### PR TITLE
docs(sdks): bring all SDK docs + READMEs to v0.15.0 parity

### DIFF
--- a/crates/fakecloud-sdk/README.md
+++ b/crates/fakecloud-sdk/README.md
@@ -4,11 +4,15 @@ Rust client SDK for [fakecloud](https://github.com/faiscadev/fakecloud), a local
 
 The crate wraps fakecloud's introspection and simulation API (`/_fakecloud/*`) so Rust tests can inspect emulator state, reset services, and trigger time-based processors without going through raw HTTP calls.
 
+As of v0.15.0 the Rust SDK covers all 111 introspection routes across 31 sub-clients, matching the TypeScript / Python / Go / Java / PHP SDKs.
+
 ## Installation
 
 ```bash
 cargo add fakecloud-sdk
 ```
+
+Rust 1.75+. Async-only, built on `reqwest` + `tokio`.
 
 ## Quick Start
 
@@ -31,21 +35,281 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-## What It Covers
+## Top-level
 
-- health and reset endpoints
-- SES email inspection and inbound simulation
-- SNS and SQS message inspection
-- EventBridge history and manual rule firing
-- S3 notifications and lifecycle ticks
-- DynamoDB TTL and Secrets Manager rotation ticks
-- Lambda invocation and warm-container inspection
-- Cognito confirmation codes, token inspection, and auth event access
-- RDS instance inspection with runtime metadata
-- ElastiCache cluster, replication group, and serverless cache inspection
-- Step Functions execution history
-- API Gateway v2 HTTP API request history
-- Bedrock runtime invocation inspection, prompt-conditional response rules, and fault injection
+| Method                                              | Description                              |
+| --------------------------------------------------- | ---------------------------------------- |
+| `health().await`                                    | Server health check                      |
+| `reset().await`                                     | Reset all service state                  |
+| `reset_service(service).await`                      | Reset a single service                   |
+| `reset_service_for_account(service, account).await` | Reset one service in one account         |
+| `create_admin(req).await`                           | Create an admin user in another account  |
+
+## Sub-clients
+
+### `fc.acm()`
+
+| Method                                          | Description                                                  |
+| ----------------------------------------------- | ------------------------------------------------------------ |
+| `set_certificate_status(arn_or_id, req).await`  | Flip a stored certificate's status (and optional failure reason) |
+| `get_certificate_chain_info(arn_or_id).await`   | Inspect PEM block counts and byte sizes of a stored chain    |
+| `approve_certificate(arn_or_id).await`          | Approve a `PENDING_VALIDATION` certificate                   |
+
+### `fc.apigatewayv2()`
+
+| Method                    | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `get_requests().await`    | List recorded HTTP API requests                      |
+| `connections().await`     | List WebSocket connections                           |
+| `mtls_info(name).await`   | Inspect mTLS trust-store status for a domain name    |
+| `ws_url(api_id, stage)`   | Build a `ws://` URL for a WebSocket API (sync)       |
+
+### `fc.application_autoscaling()`
+
+| Method                   | Description                                                   |
+| ------------------------ | ------------------------------------------------------------- |
+| `tick().await`           | Re-evaluate target-tracking policies and emit scaling actions |
+| `scheduled_tick().await` | Fire any scheduled actions whose time has arrived             |
+
+### `fc.athena()`
+
+| Method                      | Description                          |
+| --------------------------- | ------------------------------------ |
+| `get_named_queries().await` | List recorded Athena named queries   |
+
+### `fc.bedrock()`
+
+| Method                                       | Description                                                  |
+| -------------------------------------------- | ------------------------------------------------------------ |
+| `get_invocations().await`                    | List recorded Bedrock runtime invocations                    |
+| `set_model_response(model_id, text).await`   | Configure a single canned response for a model               |
+| `set_response_rules(model_id, rules).await`  | Replace prompt-conditional response rules for a model        |
+| `clear_response_rules(model_id).await`       | Clear all prompt-conditional response rules for a model      |
+| `queue_fault(rule).await`                    | Queue a fault rule for the next N calls                      |
+| `get_faults().await`                         | List currently queued fault rules                            |
+| `clear_faults().await`                       | Clear all queued fault rules                                 |
+
+### `fc.bedrock_agent()`
+
+| Method                | Description                       |
+| --------------------- | --------------------------------- |
+| `get_agents().await`  | List configured Bedrock agents    |
+
+### `fc.bedrock_agent_runtime()`
+
+| Method                    | Description                                     |
+| ------------------------- | ----------------------------------------------- |
+| `get_invocations().await` | List recorded Bedrock Agent runtime invocations |
+
+### `fc.cloudfront()`
+
+| Method                                   | Description                                              |
+| ---------------------------------------- | -------------------------------------------------------- |
+| `set_distribution_status(id, req).await` | Override a CloudFront distribution's deployment status   |
+
+### `fc.cognito()`
+
+| Method                                    | Description                                                |
+| ----------------------------------------- | ---------------------------------------------------------- |
+| `get_user_codes(pool_id, username).await` | Pending confirmation codes for a specific user             |
+| `get_confirmation_codes().await`          | List all pending confirmation codes                        |
+| `confirm_user(pool_id, username).await`   | Force-confirm a user                                       |
+| `get_tokens().await`                      | List currently active tokens                               |
+| `expire_tokens(req).await`                | Expire tokens for a pool/user                              |
+| `get_auth_events().await`                 | List recorded auth events                                  |
+| `get_pre_token_gen_invocations().await`   | List Pre-Token-Generation Lambda invocations               |
+| `mint_authorization_code(req).await`      | Mint an OAuth2 authorization code without a real browser   |
+| `set_compromised_passwords(req).await`    | Seed the compromised-credentials list                      |
+| `get_webauthn_credentials().await`        | List registered WebAuthn credentials                       |
+
+### `fc.dynamodb()`
+
+| Method             | Description                     |
+| ------------------ | ------------------------------- |
+| `tick_ttl().await` | Tick the DynamoDB TTL processor |
+
+### `fc.ecr()`
+
+| Method                              | Description                       |
+| ----------------------------------- | --------------------------------- |
+| `get_images().await`                | List stored ECR images            |
+| `get_repositories().await`          | List ECR repositories             |
+| `get_pull_through_rules().await`    | List pull-through cache rules     |
+
+### `fc.ecs()`
+
+| Method                                  | Description                                                  |
+| --------------------------------------- | ------------------------------------------------------------ |
+| `get_clusters().await`                  | List ECS clusters with task counts                           |
+| `get_tasks(filter).await`               | List tasks, optionally filtered by cluster / family / status |
+| `get_task_logs(task_id).await`          | Fetch captured stdout/stderr for a task                      |
+| `force_stop_task(task_id).await`        | Force a task into `STOPPED`                                  |
+| `mark_task_failed(task_id, req).await`  | Mark a task failed with a custom reason / exit code          |
+| `get_events().await`                    | List ECS service / task lifecycle events                     |
+| `get_metadata_by_arn(task_arn).await`   | Fetch task metadata by full ARN                              |
+| `task_credentials(task_id).await`       | Fetch IAM credentials served to the task                     |
+| `task_metadata_v3(task_id).await`       | Task Metadata Endpoint v3 payload                            |
+| `task_metadata_v4(task_id).await`       | Task Metadata Endpoint v4 payload                            |
+
+### `fc.elasticache()`
+
+| Method                                  | Description                  |
+| --------------------------------------- | ---------------------------- |
+| `get_clusters().await`                  | List ElastiCache clusters    |
+| `get_replication_groups().await`        | List replication groups      |
+| `get_serverless_caches().await`         | List serverless caches       |
+| `get_acls().await`                      | List RBAC ACLs               |
+
+### `fc.elbv2()`
+
+| Method                       | Description                          |
+| ---------------------------- | ------------------------------------ |
+| `get_load_balancers().await` | List ALB / NLB / GWLB load balancers |
+| `get_listeners().await`      | List listeners across load balancers |
+| `get_rules().await`          | List listener rules                  |
+| `get_target_groups().await`  | List target groups                   |
+| `flush_access_logs().await`  | Flush buffered access-log entries    |
+| `waf_counts().await`         | Inspect WAF allow/block counters     |
+
+### `fc.events()`
+
+| Method                  | Description                            |
+| ----------------------- | -------------------------------------- |
+| `get_history().await`   | Get event history and delivery records |
+| `fire_rule(req).await`  | Fire an EventBridge rule manually      |
+
+### `fc.glue()`
+
+| Method                              | Description                              |
+| ----------------------------------- | ---------------------------------------- |
+| `get_jobs().await`                  | List configured Glue jobs                |
+| `get_job_runs(job_name).await`      | List job runs, optionally for one job    |
+
+### `fc.kms()`
+
+| Method            | Description                                       |
+| ----------------- | ------------------------------------------------- |
+| `usage().await`   | KMS key usage counters (encrypt/decrypt/sign/etc) |
+
+### `fc.lambda()`
+
+| Method                                          | Description                          |
+| ----------------------------------------------- | ------------------------------------ |
+| `get_invocations().await`                       | List recorded Lambda invocations     |
+| `get_warm_containers().await`                   | List warm (cached) Lambda containers |
+| `evict_container(function_name).await`          | Evict a warm container               |
+| `download_function_code(function_name).await`   | Download the uploaded function zip   |
+| `download_layer_content(layer_name, ver).await` | Download a layer version's content   |
+
+### `fc.logs()`
+
+| Method                              | Description                                       |
+| ----------------------------------- | ------------------------------------------------- |
+| `inject_anomaly(req).await`         | Inject a synthetic CloudWatch Logs anomaly        |
+| `get_delivery_config().await`       | Inspect log-delivery configuration                |
+| `get_field_indexes(group).await`    | Inspect field indexes for a log group             |
+
+### `fc.organizations()`
+
+| Method                  | Description                        |
+| ----------------------- | ---------------------------------- |
+| `get_accounts().await`  | List Organizations member accounts |
+
+### `fc.rds()`
+
+| Method                              | Description                                                 |
+| ----------------------------------- | ----------------------------------------------------------- |
+| `get_instances().await`             | List managed RDS instances with runtime metadata            |
+| `lambda_invoke(req).await`          | Invoke a Lambda via the `aws_lambda` PG extension bridge    |
+| `s3_import(req).await`              | Simulate the `aws_s3.table_import_from_s3` extension call   |
+| `s3_export(req).await`              | Simulate the `aws_s3.query_export_to_s3` extension call     |
+
+### `fc.route53()`
+
+| Method                                       | Description                          |
+| -------------------------------------------- | ------------------------------------ |
+| `dnssec_material(hosted_zone_id).await`      | Inspect DNSSEC key-signing material  |
+| `dnssec_sign(hosted_zone_id, req).await`     | Sign a payload with the zone's KSK   |
+| `set_health_check_status(id, req).await`     | Override a health check's status     |
+
+### `fc.s3()`
+
+| Method                                  | Description                              |
+| --------------------------------------- | ---------------------------------------- |
+| `get_notifications().await`             | List S3 notification events              |
+| `tick_lifecycle().await`                | Tick the lifecycle processor             |
+| `get_access_points().await`             | List S3 access points                    |
+| `get_object_lambda_responses().await`   | List Object Lambda transformed responses |
+
+### `fc.scheduler()`
+
+| Method                              | Description                          |
+| ----------------------------------- | ------------------------------------ |
+| `get_schedules().await`             | List EventBridge Scheduler schedules |
+| `fire_schedule(name, group).await`  | Fire a schedule immediately          |
+
+### `fc.secretsmanager()`
+
+| Method                  | Description                  |
+| ----------------------- | ---------------------------- |
+| `tick_rotation().await` | Tick the rotation scheduler  |
+
+### `fc.ses()`
+
+| Method                                              | Description                                         |
+| --------------------------------------------------- | --------------------------------------------------- |
+| `get_emails().await`                                | List all sent emails                                |
+| `simulate_inbound(req).await`                       | Simulate an inbound email (receipt rules)           |
+| `get_metrics().await`                               | Aggregate send / bounce / complaint counters        |
+| `get_bounces().await`                               | List recorded bounces                               |
+| `set_sandbox(enabled).await`                        | Toggle SES sandbox mode                             |
+| `get_event_destination_deliveries().await`          | List event-destination delivery records             |
+| `get_dkim_public_key(domain).await`                 | Fetch the public DKIM key for a domain              |
+| `set_mail_from_status(req).await`                   | Override a domain's MAIL-FROM verification status   |
+| `get_message_insights(message_id).await`            | Fetch message-insights breakdown for a message      |
+| `get_smtp_submissions().await`                      | List inbound SMTP submission records                |
+
+### `fc.sns()`
+
+| Method                              | Description                                       |
+| ----------------------------------- | ------------------------------------------------- |
+| `get_messages().await`              | List all published messages                       |
+| `get_pending_confirmations().await` | List subscriptions pending confirmation           |
+| `confirm_subscription(req).await`   | Confirm a pending subscription                    |
+| `cert_pem().await`                  | Fetch the PEM used to sign SNS HTTP/S deliveries  |
+| `sms().await`                       | List recorded SMS deliveries                      |
+
+### `fc.sqs()`
+
+| Method                          | Description                            |
+| ------------------------------- | -------------------------------------- |
+| `get_messages().await`          | List all messages across all queues    |
+| `tick_expiration().await`       | Tick the message expiration processor  |
+| `force_dlq(queue_name).await`   | Force all messages to the queue's DLQ  |
+
+### `fc.ssm()`
+
+| Method                                          | Description                                            |
+| ----------------------------------------------- | ------------------------------------------------------ |
+| `set_command_status(command_id, req).await`     | Override an SSM Run Command's status                   |
+| `fail_command(command_id, req).await`           | Mark an SSM Run Command failed with a reason           |
+| `parameter_policy_events().await`               | List parameter-policy expiration / notification events |
+| `inject_session(req).await`                     | Inject a synthetic SSM Session                         |
+
+### `fc.stepfunctions()`
+
+| Method                                    | Description                              |
+| ----------------------------------------- | ---------------------------------------- |
+| `get_executions().await`                  | List standard executions                 |
+| `get_sync_executions().await`             | List Express sync executions             |
+| `enqueue_activity_task(req).await`        | Enqueue a task for an activity worker    |
+| `get_execution_tree(execution_arn).await` | Fetch a nested execution tree            |
+
+### `fc.wafv2()`
+
+| Method                       | Description                                       |
+| ---------------------------- | ------------------------------------------------- |
+| `evaluate(body).await`       | Evaluate a request against configured WAFv2 rules |
 
 ## Testing Bedrock-calling code
 
@@ -113,6 +377,13 @@ async fn retries_on_throttling() {
     assert!(invs.invocations[1].error.is_none());
 }
 ```
+
+## Error handling
+
+All methods return `Result<T, fakecloud_sdk::Error>`. `Error` has two variants:
+
+- `Error::Api { status, body }` — fakecloud returned a non-2xx response
+- `Error::Http(reqwest::Error)` — transport-level failure
 
 ## Repository
 

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -65,6 +65,7 @@ func main() {
 | `Health(ctx)` | Check server health |
 | `Reset(ctx)` | Reset all service state |
 | `ResetService(ctx, service)` | Reset a single service |
+| `CreateAdmin(ctx, accountID, userName)` | Bootstrap an admin user in a secondary account |
 
 ### SES - `fc.SES()`
 
@@ -72,6 +73,14 @@ func main() {
 |--------|-------------|
 | `GetEmails(ctx)` | List all sent emails |
 | `SimulateInbound(ctx, req)` | Simulate an inbound email |
+| `GetMetrics(ctx)` | Aggregate send/delivery metrics |
+| `SetMailFromStatus(ctx, req)` | Drive custom MAIL FROM verification state |
+| `GetDkimPublicKey(ctx, identity)` | Fetch the synthetic DKIM public key for an identity |
+| `GetBounces(ctx)` | List simulated bounce/complaint events |
+| `GetMessageInsights(ctx)` | Per-message insights (placements, engagement) |
+| `GetSmtpSubmissions(ctx)` | List submissions made through the SMTP endpoint |
+| `GetEventDestinationDeliveries(ctx)` | List event-destination delivery attempts |
+| `SetSandbox(ctx, req)` | Toggle SES sandbox mode |
 
 ### SNS - `fc.SNS()`
 
@@ -80,6 +89,8 @@ func main() {
 | `GetMessages(ctx)` | List published messages |
 | `GetPendingConfirmations(ctx)` | List pending subscription confirmations |
 | `ConfirmSubscription(ctx, req)` | Confirm a subscription |
+| `GetCertPEM(ctx)` | Fetch the PEM used to sign SNS HTTP/S notifications |
+| `GetSMSMessages(ctx)` | List SMS messages delivered to phone numbers |
 
 ### SQS - `fc.SQS()`
 
@@ -96,12 +107,28 @@ func main() {
 | `GetHistory(ctx)` | Get event history and deliveries |
 | `FireRule(ctx, req)` | Manually fire a rule |
 
+### Scheduler - `fc.Scheduler()`
+
+| Method | Description |
+|--------|-------------|
+| `GetSchedules(ctx)` | List EventBridge Scheduler schedules with next-fire metadata |
+| `FireSchedule(ctx, req)` | Manually fire a schedule once |
+
+### Glue - `fc.Glue()`
+
+| Method | Description |
+|--------|-------------|
+| `GetJobs(ctx)` | List Glue job definitions |
+| `GetJobRuns(ctx)` | List Glue job runs with status |
+
 ### S3 - `fc.S3()`
 
 | Method | Description |
 |--------|-------------|
 | `GetNotifications(ctx)` | List notification events |
 | `TickLifecycle(ctx)` | Tick the lifecycle processor |
+| `GetAccessPoints(ctx)` | List S3 access points |
+| `GetObjectLambdaResponses(ctx)` | List Object Lambda transformed responses |
 
 ### Lambda - `fc.Lambda()`
 
@@ -109,7 +136,41 @@ func main() {
 |--------|-------------|
 | `GetInvocations(ctx)` | List recorded invocations |
 | `GetWarmContainers(ctx)` | List warm containers |
+| `DownloadFunctionCode(ctx, functionName)` | Download a function's deployment package |
+| `DownloadLayerContent(ctx, layerName, versionNumber)` | Download a layer version's zip content |
 | `EvictContainer(ctx, functionName)` | Evict a warm container |
+
+### RDS - `fc.RDS()`
+
+| Method | Description |
+|--------|-------------|
+| `GetInstances(ctx)` | List RDS instances with runtime metadata |
+| `LambdaInvoke(ctx, req)` | Drive the `aws_lambda` Postgres extension bridge |
+| `S3Import(ctx, req)` | Drive the `aws_s3.table_import_from_s3` bridge |
+| `S3Export(ctx, req)` | Drive the `aws_s3.query_export_to_s3` bridge |
+
+### ElastiCache - `fc.ElastiCache()`
+
+| Method | Description |
+|--------|-------------|
+| `GetClusters(ctx)` | List cache clusters |
+| `GetReplicationGroups(ctx)` | List replication groups |
+| `GetServerlessCaches(ctx)` | List serverless caches |
+| `GetElastiCacheAcls(ctx)` | List RBAC users and ACLs |
+
+### Athena - `fc.Athena()`
+
+| Method | Description |
+|--------|-------------|
+| `GetNamedQueries(ctx)` | List saved named queries |
+
+### ECR - `fc.ECR()`
+
+| Method | Description |
+|--------|-------------|
+| `GetRepositories(ctx)` | List ECR repositories |
+| `GetImages(ctx)` | List images across repositories |
+| `GetPullThroughRules(ctx)` | List pull-through cache rules |
 
 ### DynamoDB - `fc.DynamoDB()`
 
@@ -134,32 +195,27 @@ func main() {
 | `ExpireTokens(ctx, req)` | Expire tokens |
 | `GetAuthEvents(ctx)` | List auth events |
 | `MintAuthorizationCode(ctx, req)` | Mint a single-use OAuth2 authorization code (programmatic alternative to driving /oauth2/authorize) |
-
-### RDS - `fc.RDS()`
-
-| Method | Description |
-|--------|-------------|
-| `GetInstances(ctx)` | List RDS instances with runtime metadata |
-
-### ElastiCache - `fc.ElastiCache()`
-
-| Method | Description |
-|--------|-------------|
-| `GetClusters(ctx)` | List cache clusters |
-| `GetReplicationGroups(ctx)` | List replication groups |
-| `GetServerlessCaches(ctx)` | List serverless caches |
-
-### Step Functions - `fc.StepFunctions()`
-
-| Method | Description |
-|--------|-------------|
-| `GetExecutions(ctx)` | List all state machine execution history |
+| `SetCompromisedPasswords(ctx, req)` | Mark a set of passwords as compromised to drive advanced security |
+| `GetPreTokenGenInvocations(ctx)` | List pre-token-generation Lambda invocations |
+| `GetWebAuthnCredentials(ctx)` | List registered WebAuthn credentials |
 
 ### API Gateway v2 - `fc.ApiGatewayV2()`
 
 | Method | Description |
 |--------|-------------|
 | `GetRequests(ctx)` | List all HTTP API requests received |
+| `GetConnections(ctx)` | List active WebSocket connections |
+| `GetDomainNameMtlsInfo(ctx, domainName)` | Inspect mTLS trust-store config for a custom domain |
+| `WsURL(stage, apiID)` | Build a `ws://` URL for a WebSocket stage |
+
+### Step Functions - `fc.StepFunctions()`
+
+| Method | Description |
+|--------|-------------|
+| `GetExecutions(ctx)` | List all state machine execution history |
+| `GetSyncExecutions(ctx)` | List `StartSyncExecution` results (Express workflows) |
+| `GetExecutionTree(ctx, executionArn)` | Get the parent/child execution tree |
+| `EnqueueActivityTask(ctx, req)` | Enqueue an activity-task heartbeat/result for a worker |
 
 ### Bedrock - `fc.Bedrock()`
 
@@ -173,11 +229,103 @@ func main() {
 | `GetFaults(ctx)` | List currently queued fault rules |
 | `ClearFaults(ctx)` | Clear all queued fault rules |
 
+### Bedrock Agent - `fc.BedrockAgent()` / `fc.BedrockAgentRuntime()`
+
+| Method | Description |
+|--------|-------------|
+| `BedrockAgent().GetAgents(ctx)` | List configured Bedrock agents |
+| `BedrockAgentRuntime().GetInvocations(ctx)` | List recorded agent runtime invocations |
+
+### ECS - `fc.ECS()`
+
+| Method | Description |
+|--------|-------------|
+| `GetClusters(ctx)` | List ECS clusters |
+| `GetTasks(ctx)` | List tasks |
+| `GetTask(ctx, taskArn)` | Get a single task |
+| `GetTaskLogs(ctx, taskArn)` | Get logs for a task |
+| `ForceStopTask(ctx, taskArn)` | Forcibly stop a task |
+| `MarkTaskFailed(ctx, taskArn, req)` | Inject a failure into a task |
+| `GetEvents(ctx)` | List ECS lifecycle events |
+| `GetTaskMetadata(ctx, taskArn)` | Container-agent task metadata |
+| `GetTaskCredentials(ctx, credentialID)` | Task-role credentials served to containers |
+| `GetTaskMetadataV3(ctx, taskArn)` | Task metadata endpoint v3 |
+| `GetTaskMetadataV4(ctx, taskArn)` | Task metadata endpoint v4 |
+
+### ELBv2 - `fc.ELBv2()`
+
+| Method | Description |
+|--------|-------------|
+| `GetLoadBalancers(ctx)` | List load balancers (ALB/NLB/GWLB) |
+| `GetTargetGroups(ctx)` | List target groups |
+| `GetListeners(ctx)` | List listeners |
+| `GetRules(ctx)` | List listener rules |
+| `GetWafCounts(ctx)` | WAF allow/block counters per listener |
+| `FlushAccessLogs(ctx)` | Flush buffered access logs to S3 |
+
 ### Route 53 - `fc.Route53()`
 
 | Method | Description |
 |--------|-------------|
 | `SetHealthCheckStatus(ctx, id, req)` | Flip a health check between `Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown` to drive failover routing in tests; reason is appended to the `<Status>` element for failure-flavoured statuses |
+| `GetDnssecMaterial(ctx, hostedZoneID)` | Fetch DNSSEC KSK/ZSK material for a hosted zone |
+| `SignRRset(ctx, req)` | Produce an RRSIG over an RRset for offline verification |
+
+### ACM - `fc.ACM()`
+
+| Method | Description |
+|--------|-------------|
+| `SetCertificateStatus(ctx, arn, req)` | Force a certificate into `ISSUED`/`FAILED`/etc. |
+| `ApproveCertificate(ctx, arn)` | Approve a pending certificate |
+| `GetCertificateChainInfo(ctx, arn)` | Inspect issuer and chain metadata |
+
+### Logs - `fc.Logs()`
+
+| Method | Description |
+|--------|-------------|
+| `InjectAnomaly(ctx, req)` | Inject a Log Anomaly Detection finding |
+| `GetDeliveryConfig(ctx)` | Inspect log-delivery configurations |
+| `GetFieldIndexes(ctx)` | List configured field indexes |
+
+### Application Auto Scaling - `fc.ApplicationAutoScaling()`
+
+| Method | Description |
+|--------|-------------|
+| `Tick(ctx)` | Run scaling evaluation once |
+| `ScheduledTick(ctx)` | Run scheduled-action evaluation once |
+
+### Organizations - `fc.Organizations()`
+
+| Method | Description |
+|--------|-------------|
+| `GetAccounts(ctx)` | List accounts in the organization |
+
+### SSM - `fc.SSM()`
+
+| Method | Description |
+|--------|-------------|
+| `SetCommandStatus(ctx, commandID, req)` | Drive a Run Command to `Success`/`Failed`/etc. |
+| `FailCommand(ctx, commandID, req)` | Convenience helper to fail a command with a reason |
+| `GetParameterPolicyEvents(ctx)` | List parameter-policy expiration/notification events |
+| `InjectSession(ctx, req)` | Inject a Session Manager session record |
+
+### KMS - `fc.KMS()`
+
+| Method | Description |
+|--------|-------------|
+| `GetUsage(ctx)` | Per-key usage counters (encrypt/decrypt/sign/verify) |
+
+### WAFv2 - `fc.WAFv2()`
+
+| Method | Description |
+|--------|-------------|
+| `Evaluate(ctx, req)` | Evaluate a request against a Web ACL and return the verdict |
+
+### CloudFront - `fc.CloudFront()`
+
+| Method | Description |
+|--------|-------------|
+| `SetDistributionStatus(ctx, id, req)` | Force a distribution into `Deployed`/`InProgress` |
 
 #### Testing Bedrock-calling code end-to-end
 

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.12.0")
+    testImplementation("dev.fakecloud:fakecloud:0.15.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.12.0</version>
+    <version>0.15.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -64,38 +64,51 @@ int expiredObjects = fc.s3().tickLifecycle().expiredObjects();
 ### `FakeCloud`
 
 ```java
-FakeCloud fc = new FakeCloud();                       // defaults to http://localhost:4566
+FakeCloud fc = new FakeCloud();                        // defaults to http://localhost:4566
 FakeCloud fc = new FakeCloud("http://localhost:4566"); // explicit base URL
 ```
 
-| Method                   | Description             |
-| ------------------------ | ----------------------- |
-| `health()`               | Server health check     |
-| `reset()`                | Reset all service state |
-| `resetService(service)`  | Reset a single service  |
+| Method                              | Description                                |
+| ----------------------------------- | ------------------------------------------ |
+| `health()`                          | Server health check                        |
+| `reset()`                           | Reset all service state                    |
+| `resetService(service)`             | Reset a single service                     |
+| `createAdmin(accountId, userName)`  | Bootstrap an admin IAM user in an account  |
 
 ### `fc.lambda()`
 
-| Method                          | Description                          |
-| ------------------------------- | ------------------------------------ |
-| `getInvocations()`              | List recorded Lambda invocations     |
-| `getWarmContainers()`           | List warm (cached) Lambda containers |
-| `evictContainer(functionName)`  | Evict a warm container               |
+| Method                                                       | Description                                                              |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| `getInvocations()`                                           | List recorded Lambda invocations                                         |
+| `getWarmContainers()`                                        | List warm (cached) Lambda containers                                     |
+| `evictContainer(functionName)`                               | Evict a warm container                                                   |
+| `downloadFunctionCode(accountId, functionName, qualifier)`   | Download the stored zip for a function version (`"latest"` or version)   |
+| `downloadLayerContent(accountId, layerName, version)`        | Download the stored zip for a layer version                              |
 
 ### `fc.ses()`
 
-| Method                 | Description                               |
-| ---------------------- | ----------------------------------------- |
-| `getEmails()`          | List all sent emails                      |
-| `simulateInbound(req)` | Simulate an inbound email (receipt rules) |
+| Method                                | Description                                       |
+| ------------------------------------- | ------------------------------------------------- |
+| `getEmails()`                         | List all sent emails                              |
+| `simulateInbound(req)`                | Simulate an inbound email (receipt rules)         |
+| `getMetrics()`                        | Return aggregated send/bounce/complaint counters  |
+| `setMailFromStatus(identity, status)` | Force a MAIL FROM verification status             |
+| `getDkimPublicKey(identity)`          | Fetch the DKIM public key for an identity         |
+| `setSandbox(sandbox)`                 | Toggle the account-level sandbox flag             |
+| `getBounces()`                        | List captured bounce events                       |
+| `getMessageInsights(messageId)`       | Fetch Message Insights for a sent message         |
+| `getSmtpSubmissions()`                | List SMTP submission attempts                     |
+| `getEventDestinationDeliveries()`     | List event-destination delivery records           |
 
 ### `fc.sns()`
 
-| Method                       | Description                             |
-| ---------------------------- | --------------------------------------- |
-| `getMessages()`              | List all published messages             |
-| `getPendingConfirmations()`  | List subscriptions pending confirmation |
-| `confirmSubscription(req)`   | Confirm a pending subscription          |
+| Method                       | Description                                                                                  |
+| ---------------------------- | -------------------------------------------------------------------------------------------- |
+| `getMessages()`              | List all published messages                                                                  |
+| `getPendingConfirmations()`  | List subscriptions pending confirmation                                                      |
+| `confirmSubscription(req)`   | Confirm a pending subscription                                                               |
+| `getCertPem()`               | Return the PEM-encoded SNS signing cert used by message signature validators                 |
+| `getSmsMessages()`           | List captured SMS messages SNS has "delivered"                                               |
 
 ### `fc.sqs()`
 
@@ -112,12 +125,29 @@ FakeCloud fc = new FakeCloud("http://localhost:4566"); // explicit base URL
 | `getHistory()`   | Get event history and delivery records |
 | `fireRule(req)`  | Fire an EventBridge rule manually      |
 
+### `fc.scheduler()`
+
+| Method                          | Description                                  |
+| ------------------------------- | -------------------------------------------- |
+| `getSchedules()`                | List EventBridge Scheduler schedules         |
+| `fireSchedule(group, name)`     | Fire a single schedule immediately           |
+
+### `fc.glue()`
+
+| Method                   | Description                                  |
+| ------------------------ | -------------------------------------------- |
+| `getJobs()`              | List registered Glue jobs                    |
+| `getJobRuns()`           | List all Glue job runs                       |
+| `getJobRuns(jobName)`    | Filter job runs by job name                  |
+
 ### `fc.s3()`
 
-| Method                | Description                  |
-| --------------------- | ---------------------------- |
-| `getNotifications()`  | List S3 notification events  |
-| `tickLifecycle()`     | Tick the lifecycle processor |
+| Method                          | Description                                  |
+| ------------------------------- | -------------------------------------------- |
+| `getNotifications()`            | List S3 notification events                  |
+| `tickLifecycle()`               | Tick the lifecycle processor                 |
+| `getAccessPoints()`             | List S3 access points                        |
+| `getObjectLambdaResponses()`    | List S3 Object Lambda responses captured     |
 
 ### `fc.dynamodb()`
 
@@ -133,41 +163,72 @@ FakeCloud fc = new FakeCloud("http://localhost:4566"); // explicit base URL
 
 ### `fc.cognito()`
 
-| Method                            | Description                          |
-| --------------------------------- | ------------------------------------ |
-| `getUserCodes(poolId, username)`  | Get confirmation codes for a user    |
-| `getConfirmationCodes()`          | List all confirmation codes          |
-| `confirmUser(req)`                | Confirm a user (bypass verification) |
-| `getTokens()`                     | List all active tokens               |
-| `expireTokens(req)`               | Expire tokens (optionally filtered)  |
-| `getAuthEvents()`                 | List auth events                     |
-| `mintAuthorizationCode(req)`      | Mint a single-use OAuth2 authorization code (programmatic alternative to driving /oauth2/authorize) |
+| Method                                | Description                                                                                  |
+| ------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `getUserCodes(poolId, username)`      | Get confirmation codes for a user                                                            |
+| `getConfirmationCodes()`              | List all confirmation codes                                                                  |
+| `confirmUser(req)`                    | Confirm a user (bypass verification)                                                         |
+| `getTokens()`                         | List all active tokens                                                                       |
+| `expireTokens(req)`                   | Expire tokens (optionally filtered)                                                          |
+| `getAuthEvents()`                     | List auth events                                                                             |
+| `getPreTokenGenInvocations()`         | List PreTokenGeneration Lambda trigger invocations recorded by `InitiateAuth`                |
+| `mintAuthorizationCode(req)`          | Mint a single-use OAuth2 authorization code (programmatic alternative to `/oauth2/authorize`) |
+| `setCompromisedPasswords(req)`        | Seed the compromised-password list used by Advanced Security                                 |
+| `getWebAuthnCredentials()`            | List stored WebAuthn credentials                                                             |
 
 ### `fc.rds()`
 
-| Method            | Description                              |
-| ----------------- | ---------------------------------------- |
-| `getInstances()`  | List RDS instances with runtime metadata |
+| Method                | Description                                                                  |
+| --------------------- | ---------------------------------------------------------------------------- |
+| `getInstances()`      | List RDS instances with runtime metadata                                     |
+| `lambdaInvoke(req)`   | Bridge endpoint for the PostgreSQL `aws_lambda` extension                    |
+| `s3Import(req)`       | Bridge endpoint for the PostgreSQL `aws_s3` extension (fetch object)         |
+| `s3Export(req)`       | Bridge equivalent of `S3:PutObject` from inside the DB container             |
 
 ### `fc.elasticache()`
 
-| Method                    | Description                         |
-| ------------------------- | ----------------------------------- |
-| `getClusters()`           | List ElastiCache cache clusters     |
-| `getReplicationGroups()`  | List ElastiCache replication groups |
-| `getServerlessCaches()`   | List ElastiCache serverless caches  |
+| Method                    | Description                          |
+| ------------------------- | ------------------------------------ |
+| `getClusters()`           | List ElastiCache cache clusters      |
+| `getReplicationGroups()`  | List ElastiCache replication groups  |
+| `getServerlessCaches()`   | List ElastiCache serverless caches   |
+| `getElastiCacheAcls()`    | List ElastiCache (Valkey/Redis) ACLs |
+
+### `fc.ecr()`
+
+| Method                                    | Description                                  |
+| ----------------------------------------- | -------------------------------------------- |
+| `getRepositories()`                       | List ECR repositories                        |
+| `getImages()`                             | List all ECR images                          |
+| `getImagesForRepository(repositoryName)`  | Filter images by repository                  |
+| `getPullThroughRules()`                   | List configured pull-through cache rules     |
+
+### `fc.logs()`
+
+| Method                            | Description                                       |
+| --------------------------------- | ------------------------------------------------- |
+| `injectAnomaly(req)`              | Inject a Log Anomaly Detector anomaly             |
+| `getDeliveryConfig()`             | Persisted CloudWatch Logs delivery configurations |
+| `getFieldIndexes(logGroupName)`   | Parsed `Fields` from index policies on a log group |
 
 ### `fc.stepfunctions()`
 
-| Method             | Description                              |
-| ------------------ | ---------------------------------------- |
-| `getExecutions()`  | List all state machine execution history |
+| Method                       | Description                                                                  |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| `getExecutions()`            | List all state machine execution history                                     |
+| `getSyncExecutions()`        | List synchronous (`StartSyncExecution`) results                              |
+| `getExecutionTree(arn)`      | Full parent/child execution tree under an execution ARN                      |
+| `enqueueActivityTask(req)`   | Push a synthetic activity task onto an activity worker queue                 |
 
 ### `fc.apigatewayv2()`
 
-| Method           | Description                         |
-| ---------------- | ----------------------------------- |
-| `getRequests()`  | List all HTTP API requests received |
+| Method                              | Description                                                                                  |
+| ----------------------------------- | -------------------------------------------------------------------------------------------- |
+| `getRequests()`                     | List all HTTP API requests received                                                          |
+| `getConnections()`                  | List every active WebSocket connection tracked by API Gateway v2                             |
+| `getDomainNameMtlsInfo(domainName)` | Fetch the mTLS truststore info for a custom domain (free-form JSON map)                      |
+| `wsUrl(apiId)`                      | Build the WebSocket URL for the given API id on the default `$default` stage                 |
+| `wsUrl(apiId, stage)`               | Build the WebSocket URL for the given API id and stage                                       |
 
 ### `fc.bedrock()`
 
@@ -181,11 +242,106 @@ FakeCloud fc = new FakeCloud("http://localhost:4566"); // explicit base URL
 | `getFaults()`                       | List currently queued fault rules                                    |
 | `clearFaults()`                     | Clear all queued fault rules                                         |
 
+### `fc.bedrockAgent()`
+
+| Method        | Description                                  |
+| ------------- | -------------------------------------------- |
+| `getAgents()` | List Bedrock Agent (control plane) agents    |
+
+### `fc.bedrockAgentRuntime()`
+
+| Method             | Description                            |
+| ------------------ | -------------------------------------- |
+| `getInvocations()` | List Bedrock Agent Runtime invocations |
+
+### `fc.ecs()`
+
+| Method                              | Description                                                                                  |
+| ----------------------------------- | -------------------------------------------------------------------------------------------- |
+| `getClusters()`                     | List ECS clusters                                                                            |
+| `getTasks(cluster, status)`         | List tracked tasks, optionally filtered by cluster and status                                |
+| `getTask(taskId)`                   | Fetch a single task snapshot by task ID                                                      |
+| `getTaskLogs(taskId)`               | Captured stdout/stderr for a task plus its exit code if known                                |
+| `forceStopTask(taskId)`             | SIGTERM (then SIGKILL after 10s) the task's running container                                |
+| `markTaskFailed(taskId, req)`       | Flip a task to `STOPPED` without killing the container                                       |
+| `getEvents()`                       | Replay the lifecycle event log                                                               |
+| `getTaskMetadata(taskArn)`          | Aggregated v4 metadata dump for a task (by full ARN)                                         |
+| `getCredentials(taskId)`            | Return short-lived IAM credentials for a task (matches the wire shape ECS exposes)           |
+| `getMetadataV3(taskId)`             | Raw v3 task metadata document (free-form `Map<String, Object>`)                              |
+| `getMetadataV4(taskId)`             | Raw v4 task metadata document (free-form `Map<String, Object>`)                              |
+
+### `fc.elbv2()`
+
+| Method               | Description                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------- |
+| `getLoadBalancers()` | List ELBv2 load balancers (ALB/NLB/GWLB)                                                     |
+| `getTargetGroups()`  | List ELBv2 target groups                                                                     |
+| `getListeners()`     | List ELBv2 listeners                                                                         |
+| `getRules()`         | List ELBv2 listener rules                                                                    |
+| `flushAccessLogs()`  | Force every buffered access-log + connection-log line to flush to S3 immediately             |
+| `getWafCounts()`     | Return WAFv2 association/evaluation counts the ELBv2 service has accumulated                 |
+
 ### `fc.route53()`
 
 | Method                                              | Description                                                                                                                          |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `setHealthCheckStatus(id, status, reason)`          | Flip a health check between `Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown` to drive failover routing in tests; reason is appended to the `<Status>` element for failure-flavoured statuses (pass `null` to omit) |
+| `setHealthCheckStatus(id, status, reason)`          | Flip a health check between `Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown`; reason is appended to the `<Status>` element for failure-flavoured statuses (pass `null` to omit) |
+| `getDnssecMaterial(zoneId)`                         | Fetch DNSSEC material (DNSKEY + DS digest) for a hosted zone with at least one ACTIVE KSK                                            |
+| `signDnssec(zoneId, req)`                           | Sign an RRset under the zone's first ACTIVE KSK and return raw RRSIG fields                                                          |
+
+### `fc.acm()`
+
+| Method                                          | Description                                                                                  |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `setCertificateStatus(arnOrId, status, reason)` | Flip an ACM certificate's status synchronously (`ISSUED` / `FAILED` / `VALIDATION_TIMED_OUT`) |
+| `approveCertificate(arnOrId)`                   | Approve a `PENDING_VALIDATION` certificate (simulates the email click)                       |
+| `getCertificateChainInfo(arnOrId)`              | Inspect a stored cert's PEM block counts and byte sizes                                      |
+
+### `fc.applicationAutoscaling()`
+
+| Method            | Description                                            |
+| ----------------- | ------------------------------------------------------ |
+| `tick()`          | Tick the Application Auto Scaling alarm evaluator      |
+| `scheduledTick()` | Tick the scheduled-action processor                    |
+
+### `fc.athena()`
+
+| Method               | Description                                  |
+| -------------------- | -------------------------------------------- |
+| `getNamedQueries()`  | List every named query stored in the registry |
+
+### `fc.organizations()`
+
+| Method            | Description                                                                                  |
+| ----------------- | -------------------------------------------------------------------------------------------- |
+| `getAccounts()`   | List every member account in the org (state, parent OU, tags, directly-attached SCPs)        |
+
+### `fc.ssm()`
+
+| Method                                                  | Description                                                                                  |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `setCommandStatus(commandId, accountId, status)`        | Flip the status of every invocation under a `SendCommand` command id                         |
+| `failCommand(commandId, req)`                           | Force a command (or specific invocation) into `Failed`                                       |
+| `getParameterPolicyEvents(accountId)`                   | Return every parameter-policy event recorded for the account                                 |
+| `injectSession(req)`                                    | Drop a fake Session Manager session into state (bypassing `StartSession`)                    |
+
+### `fc.kms()`
+
+| Method        | Description                                  |
+| ------------- | -------------------------------------------- |
+| `getUsage()`  | Return every recorded KMS data-plane invocation |
+
+### `fc.wafv2()`
+
+| Method              | Description                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------- |
+| `evaluate(request)` | Evaluate an arbitrary request payload against the stored WAFv2 rule set (free-form JSON)     |
+
+### `fc.cloudfront()`
+
+| Method                                          | Description                                                                                  |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `setDistributionStatus(distributionId, status)` | Flip a stored CloudFront Distribution's status (`Deployed` / `InProgress`) without waiting   |
 
 #### Full test loop — asserting on Bedrock calls
 

--- a/sdks/php/README.md
+++ b/sdks/php/README.md
@@ -48,38 +48,86 @@ $expiredObjects = $fc->s3()->tickLifecycle()->expiredObjects;
 ### `FakeCloud`
 
 ```php
-$fc = new FakeCloud();                       // defaults to http://localhost:4566
+$fc = new FakeCloud();                        // defaults to http://localhost:4566
 $fc = new FakeCloud('http://localhost:4566'); // explicit base URL
 ```
 
-| Method                   | Description             |
-| ------------------------ | ----------------------- |
-| `health()`               | Server health check     |
-| `reset()`                | Reset all service state |
-| `resetService($service)` | Reset a single service  |
+| Method                                | Description                                         |
+| ------------------------------------- | --------------------------------------------------- |
+| `baseUrl()`                           | Return the configured base URL                      |
+| `health()`                            | Server health check                                 |
+| `reset()`                             | Reset all service state                             |
+| `resetService($service)`              | Reset a single service                              |
+| `createAdmin($accountId, $userName)`  | Bootstrap an admin IAM user in an additional account |
 
 ### `$fc->lambda()`
 
-| Method                          | Description                          |
-| ------------------------------- | ------------------------------------ |
-| `getInvocations()`              | List recorded Lambda invocations     |
-| `getWarmContainers()`           | List warm (cached) Lambda containers |
-| `evictContainer($functionName)` | Evict a warm container               |
+| Method                                                          | Description                                       |
+| --------------------------------------------------------------- | ------------------------------------------------- |
+| `getInvocations()`                                              | List recorded Lambda invocations                  |
+| `getWarmContainers()`                                           | List warm (cached) Lambda containers              |
+| `evictContainer($functionName)`                                 | Evict a warm container                            |
+| `downloadFunctionCode($accountId, $functionName, $qualifier)`   | Download a function's stored zip bundle (raw bytes) |
+| `downloadLayerContent($accountId, $layerName, $version)`        | Download a layer version's stored zip (raw bytes) |
+
+### `$fc->rds()`
+
+| Method                  | Description                                                              |
+| ----------------------- | ------------------------------------------------------------------------ |
+| `getInstances()`        | List RDS instances with runtime metadata                                 |
+| `lambdaInvoke($req)`    | Bridge endpoint for the PostgreSQL `aws_lambda` extension                |
+| `s3Import($req)`        | Bridge endpoint for the PostgreSQL `aws_s3` extension (S3 -> DB)         |
+| `s3Export($req)`        | Bridge endpoint for the PostgreSQL `aws_s3` extension (DB -> S3 PutObject) |
+
+### `$fc->elasticache()`
+
+| Method                    | Description                         |
+| ------------------------- | ----------------------------------- |
+| `getClusters()`           | List ElastiCache cache clusters     |
+| `getReplicationGroups()`  | List ElastiCache replication groups |
+| `getServerlessCaches()`   | List ElastiCache serverless caches  |
+| `getElastiCacheAcls()`    | List ElastiCache user ACLs          |
+
+### `$fc->ecr()`
+
+| Method                              | Description                          |
+| ----------------------------------- | ------------------------------------ |
+| `getRepositories()`                 | List ECR repositories                |
+| `getImages($repositoryName = null)` | List ECR images (optionally per repo) |
+| `getPullThroughRules()`             | List ECR pull-through cache rules    |
+
+### `$fc->logs()`
+
+| Method                          | Description                                          |
+| ------------------------------- | ---------------------------------------------------- |
+| `injectAnomaly($req)`           | Inject a CloudWatch Logs anomaly for tests           |
+| `getDeliveryConfig()`           | Get the current Logs delivery config snapshot        |
+| `getFieldIndexes($logGroupName)` | Get configured field indexes for a log group         |
 
 ### `$fc->ses()`
 
-| Method                 | Description                               |
-| ---------------------- | ----------------------------------------- |
-| `getEmails()`          | List all sent emails                      |
-| `simulateInbound($req)` | Simulate an inbound email (receipt rules) |
+| Method                              | Description                                                     |
+| ----------------------------------- | --------------------------------------------------------------- |
+| `getEmails()`                       | List all sent emails                                            |
+| `simulateInbound($req)`             | Simulate an inbound email (drive receipt rules)                 |
+| `getMetrics()`                      | Get SES send/bounce/complaint metrics                           |
+| `setMailFromStatus($identity, $status)` | Force a MAIL FROM domain verification status                |
+| `getDkimPublicKey($identity)`       | Get the simulated DKIM public key for an identity               |
+| `setSandbox($sandbox)`              | Toggle sandbox mode for the account                             |
+| `getBounces()`                      | List recorded SES bounce events                                 |
+| `getMessageInsights($messageId)`    | Get SES message insights for a sent message                     |
+| `getSmtpSubmissions()`              | List messages submitted via the SMTP submission endpoint        |
+| `getEventDestinationDeliveries()`   | List deliveries fanned out to configuration set destinations    |
 
 ### `$fc->sns()`
 
-| Method                       | Description                             |
-| ---------------------------- | --------------------------------------- |
-| `getMessages()`              | List all published messages             |
-| `getPendingConfirmations()`  | List subscriptions pending confirmation |
-| `confirmSubscription($req)`  | Confirm a pending subscription          |
+| Method                       | Description                                              |
+| ---------------------------- | -------------------------------------------------------- |
+| `getMessages()`              | List all published messages                              |
+| `getPendingConfirmations()`  | List subscriptions pending confirmation                  |
+| `confirmSubscription($req)`  | Confirm a pending subscription                           |
+| `getSigningCertPem()`        | Get the PEM body served by the SNS signing-cert endpoint |
+| `getSmsMessages()`           | List SMS messages dispatched via SNS                     |
 
 ### `$fc->sqs()`
 
@@ -87,7 +135,20 @@ $fc = new FakeCloud('http://localhost:4566'); // explicit base URL
 | ----------------------- | ------------------------------------- |
 | `getMessages()`         | List all messages across all queues   |
 | `tickExpiration()`      | Tick the message expiration processor |
-| `forceDlq($queueName)` | Force all messages to the queue's DLQ |
+| `forceDlq($queueName)`  | Force all messages to the queue's DLQ |
+
+### `$fc->applicationAutoscaling()`
+
+| Method            | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `tick()`          | Tick the Application Auto Scaling metric/policy processor |
+| `scheduledTick()` | Tick the scheduled-action processor                       |
+
+### `$fc->athena()`
+
+| Method              | Description                       |
+| ------------------- | --------------------------------- |
+| `getNamedQueries()` | List all stored Athena named queries |
 
 ### `$fc->events()`
 
@@ -96,12 +157,28 @@ $fc = new FakeCloud('http://localhost:4566'); // explicit base URL
 | `getHistory()`   | Get event history and delivery records |
 | `fireRule($req)` | Fire an EventBridge rule manually      |
 
+### `$fc->scheduler()`
+
+| Method                          | Description                                  |
+| ------------------------------- | -------------------------------------------- |
+| `getSchedules()`                | List EventBridge Scheduler schedules         |
+| `fireSchedule($group, $name)`   | Fire a scheduled invocation immediately      |
+
+### `$fc->glue()`
+
+| Method                       | Description                                |
+| ---------------------------- | ------------------------------------------ |
+| `getJobs()`                  | List all Glue jobs                         |
+| `getJobRuns($jobName = null)` | List Glue job runs (optionally per job)    |
+
 ### `$fc->s3()`
 
-| Method                | Description                  |
-| --------------------- | ---------------------------- |
-| `getNotifications()`  | List S3 notification events  |
-| `tickLifecycle()`     | Tick the lifecycle processor |
+| Method                          | Description                                            |
+| ------------------------------- | ------------------------------------------------------ |
+| `getNotifications()`            | List S3 notification events                            |
+| `tickLifecycle()`               | Tick the lifecycle processor                           |
+| `getAccessPoints()`             | List S3 access points                                  |
+| `getObjectLambdaResponses()`    | List recorded S3 Object Lambda WriteGetObjectResponse calls |
 
 ### `$fc->dynamodb()`
 
@@ -117,59 +194,136 @@ $fc = new FakeCloud('http://localhost:4566'); // explicit base URL
 
 ### `$fc->cognito()`
 
-| Method                            | Description                          |
-| --------------------------------- | ------------------------------------ |
-| `getUserCodes($poolId, $username)` | Get confirmation codes for a user    |
-| `getConfirmationCodes()`          | List all confirmation codes          |
-| `confirmUser($req)`               | Confirm a user (bypass verification) |
-| `getTokens()`                     | List all active tokens               |
-| `expireTokens($req)`              | Expire tokens (optionally filtered)  |
-| `getAuthEvents()`                 | List auth events                     |
-| `mintAuthorizationCode($req)`     | Mint a single-use OAuth2 authorization code (programmatic alternative to driving /oauth2/authorize) |
-
-### `$fc->rds()`
-
-| Method            | Description                              |
-| ----------------- | ---------------------------------------- |
-| `getInstances()`  | List RDS instances with runtime metadata |
-
-### `$fc->elasticache()`
-
-| Method                    | Description                         |
-| ------------------------- | ----------------------------------- |
-| `getClusters()`           | List ElastiCache cache clusters     |
-| `getReplicationGroups()`  | List ElastiCache replication groups |
-| `getServerlessCaches()`   | List ElastiCache serverless caches  |
-
-### `$fc->stepfunctions()`
-
-| Method             | Description                              |
-| ------------------ | ---------------------------------------- |
-| `getExecutions()`  | List all state machine execution history |
+| Method                                | Description                                                                  |
+| ------------------------------------- | ---------------------------------------------------------------------------- |
+| `getUserCodes($poolId, $username)`    | Get confirmation codes for a user                                            |
+| `getConfirmationCodes()`              | List all confirmation codes                                                  |
+| `confirmUser($req)`                   | Confirm a user (bypass verification)                                         |
+| `getTokens()`                         | List all active tokens                                                       |
+| `expireTokens($req)`                  | Expire tokens (optionally filtered)                                          |
+| `getAuthEvents()`                     | List auth events                                                             |
+| `getPreTokenGenInvocations()`         | List PreTokenGeneration Lambda trigger invocations                           |
+| `mintAuthorizationCode($req)`         | Mint a single-use OAuth2 authorization code (alternative to /oauth2/authorize) |
+| `setCompromisedPasswords($req)`       | Mark passwords as compromised for the advanced-security simulator            |
+| `getWebAuthnCredentials()`            | List enrolled WebAuthn credentials                                           |
 
 ### `$fc->apigatewayv2()`
 
-| Method           | Description                         |
-| ---------------- | ----------------------------------- |
-| `getRequests()`  | List all HTTP API requests received |
+| Method                       | Description                                                  |
+| ---------------------------- | ------------------------------------------------------------ |
+| `getRequests()`              | List all HTTP API requests received                          |
+| `getConnections()`           | List active WebSocket API connections                        |
+| `mtlsInfo($domainName)`      | Get mTLS truststore info for a custom domain                 |
+| `wsUrl($apiId, $stage = null)` | Compute the WebSocket URL for an API/stage                |
+
+### `$fc->stepfunctions()`
+
+| Method                          | Description                                                  |
+| ------------------------------- | ------------------------------------------------------------ |
+| `getExecutions()`               | List all state machine execution history                     |
+| `getSyncExecutions()`           | List `StartSyncExecution` results                            |
+| `getExecutionTree($arn)`        | Get the full parent/child execution tree for an execution    |
+| `enqueueActivityTask($req)`     | Enqueue an activity task for `GetActivityTask` consumers     |
 
 ### `$fc->bedrock()`
 
-| Method                              | Description                                                          |
-| ----------------------------------- | -------------------------------------------------------------------- |
-| `getInvocations()`                  | List recorded Bedrock runtime invocations                            |
-| `setModelResponse($modelId, $text)` | Configure a single canned response for a model                       |
-| `setResponseRules($modelId, $rules)` | Replace prompt-conditional response rules for a model               |
-| `clearResponseRules($modelId)`      | Clear all prompt-conditional response rules for a model              |
-| `queueFault($rule)`                 | Queue a fault rule for the next N calls                              |
-| `getFaults()`                       | List currently queued fault rules                                    |
-| `clearFaults()`                     | Clear all queued fault rules                                         |
+| Method                               | Description                                                          |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| `getInvocations()`                   | List recorded Bedrock runtime invocations                            |
+| `setModelResponse($modelId, $text)`  | Configure a single canned response for a model                       |
+| `setResponseRules($modelId, $rules)` | Replace prompt-conditional response rules for a model                |
+| `clearResponseRules($modelId)`       | Clear all prompt-conditional response rules for a model              |
+| `queueFault($rule)`                  | Queue a fault rule for the next N calls                              |
+| `getFaults()`                        | List currently queued fault rules                                    |
+| `clearFaults()`                      | Clear all queued fault rules                                         |
+
+### `$fc->bedrockAgent()`
+
+| Method        | Description                       |
+| ------------- | --------------------------------- |
+| `getAgents()` | List Bedrock Agent definitions    |
+
+### `$fc->bedrockAgentRuntime()`
+
+| Method             | Description                                  |
+| ------------------ | -------------------------------------------- |
+| `getInvocations()` | List Bedrock Agent runtime invocations       |
+
+### `$fc->ecs()`
+
+| Method                                       | Description                                                       |
+| -------------------------------------------- | ----------------------------------------------------------------- |
+| `getClusters()`                              | List ECS clusters                                                 |
+| `getTasks($cluster = null, $status = null)`  | List ECS tasks (optionally filtered by cluster and status)        |
+| `getTask($taskId)`                           | Get a single ECS task                                             |
+| `getTaskLogs($taskId)`                       | Get captured stdout/stderr logs for a task                        |
+| `forceStopTask($taskId)`                     | Force-stop a running task                                         |
+| `markTaskFailed($taskId, $req)`              | Mark a task as failed with the supplied reason                    |
+| `getEvents()`                                | List ECS service/task lifecycle events                            |
+| `getTaskMetadata($taskArn)`                  | Get ECS task metadata (control-plane shape)                       |
+| `getTaskCredentials($taskId)`                | Get the IAM credentials served via the task metadata endpoint     |
+| `getTaskMetadataV3($taskId)`                 | Get the task metadata v3 payload                                  |
+| `getTaskMetadataV4($taskId)`                 | Get the task metadata v4 payload                                  |
+
+### `$fc->elbv2()`
+
+| Method                | Description                                            |
+| --------------------- | ------------------------------------------------------ |
+| `getLoadBalancers()`  | List ELBv2 load balancers                              |
+| `getTargetGroups()`   | List ELBv2 target groups                               |
+| `getListeners()`      | List ELBv2 listeners                                   |
+| `getRules()`          | List ELBv2 listener rules                              |
+| `flushAccessLogs()`   | Flush buffered ELBv2 access logs to their S3 bucket    |
+| `getWafCounts()`      | Get WAF allow/block counts seen by ELBv2 listeners     |
 
 ### `$fc->route53()`
 
-| Method                                              | Description                                                                                                                                       |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setHealthCheckStatus($id, $status, $reason)`       | Flip a health check between `Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown` to drive failover routing in tests; reason is appended to the `<Status>` element for failure-flavoured statuses (omit for null) |
+| Method                                         | Description                                                                                                                                       |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setHealthCheckStatus($id, $status, $reason)`  | Flip a health check between `Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown` to drive failover routing       |
+| `getDnssecMaterial($zoneId)`                   | Get the simulated DNSSEC key material for a hosted zone                                                                                           |
+| `signDnssec($zoneId, $req)`                    | Sign a payload with the zone's DNSSEC key                                                                                                         |
+
+### `$fc->acm()`
+
+| Method                                            | Description                                                |
+| ------------------------------------------------- | ---------------------------------------------------------- |
+| `setCertificateStatus($arnOrId, $status, $reason)` | Force an ACM certificate into a specific status            |
+| `approveCertificate($arnOrId)`                    | Approve a pending ACM certificate request                  |
+| `getCertificateChainInfo($arnOrId)`               | Get parsed chain info for an ACM certificate               |
+
+### `$fc->organizations()`
+
+| Method           | Description                          |
+| ---------------- | ------------------------------------ |
+| `getAccounts()`  | List Organizations member accounts   |
+
+### `$fc->ssm()`
+
+| Method                                                              | Description                                                          |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `setCommandStatus($commandId, $status, $accountId = null)`          | Force an SSM Run Command into a specific terminal status             |
+| `failCommand($commandId, $accountId = null, $errorCode = null, ...)` | Fail an SSM Run Command with structured error metadata               |
+| `getParameterPolicyEvents($accountId = null)`                       | List Parameter Store policy expiration/notification events           |
+| `injectSession($req)`                                               | Inject a Session Manager session for inspection in tests             |
+
+### `$fc->kms()`
+
+| Method        | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `getUsage()`  | Get KMS key usage counters (encrypt/decrypt/sign) |
+
+### `$fc->wafv2()`
+
+| Method              | Description                                                       |
+| ------------------- | ----------------------------------------------------------------- |
+| `evaluate($body)`   | Evaluate a request against a WAFv2 WebACL and return the decision |
+
+### `$fc->cloudfront()`
+
+| Method                                          | Description                                          |
+| ----------------------------------------------- | ---------------------------------------------------- |
+| `setDistributionStatus($distributionId, $status)` | Force a CloudFront distribution into a status        |
 
 #### Full test loop — asserting on Bedrock calls
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -61,37 +61,293 @@ with FakeCloudSync("http://localhost:4566") as fc:
 
 ## API reference
 
-### `FakeCloud` / `FakeCloudSync`
+The SDK ships two top-level clients with identical surfaces:
 
-Top-level client. Pass `base_url` (default `http://localhost:4566`).
+- `FakeCloud` — async (`await fc.x.y()`), context-manager friendly
+- `FakeCloudSync` — sync (`fc.x.y()`)
+
+Tables below document the async API. Drop the `await` and use `FakeCloudSync` for the sync variant; method names and arguments match exactly.
+
+### Top-level
+
+Pass `base_url` (default `http://localhost:4566`).
 
 | Method | Description |
 |---|---|
 | `health()` | Server health check |
 | `reset()` | Reset all service state |
 | `reset_service(service)` | Reset a single service |
+| `create_admin(account_id, user_name)` | Create an IAM admin user in a specific account |
+| `aclose()` *(async only)* | Close the underlying `httpx.AsyncClient` (or use `async with`) |
 
-### Service sub-clients
+### `fc.lambda_`
 
-Access via properties on the main client:
+`lambda` is a Python keyword, so the attribute is `lambda_`.
 
-| Property | Service | Methods |
-|---|---|---|
-| `lambda_` | Lambda | `get_invocations()`, `get_warm_containers()`, `evict_container(name)` |
-| `ses` | SES | `get_emails()`, `simulate_inbound(req)` |
-| `sns` | SNS | `get_messages()`, `get_pending_confirmations()`, `confirm_subscription(req)` |
-| `sqs` | SQS | `get_messages()`, `tick_expiration()`, `force_dlq(queue_name)` |
-| `events` | EventBridge | `get_history()`, `fire_rule(req)` |
-| `s3` | S3 | `get_notifications()`, `tick_lifecycle()` |
-| `dynamodb` | DynamoDB | `tick_ttl()` |
-| `secretsmanager` | SecretsManager | `tick_rotation()` |
-| `cognito` | Cognito | `get_user_codes(pool_id, username)`, `get_confirmation_codes()`, `confirm_user(req)`, `get_tokens()`, `expire_tokens(req)`, `get_auth_events()`, `mint_authorization_code(req)` |
-| `rds` | RDS | `get_instances()` |
-| `elasticache` | ElastiCache | `get_clusters()`, `get_replication_groups()`, `get_serverless_caches()` |
-| `stepfunctions` | Step Functions | `get_executions()` |
-| `apigatewayv2` | API Gateway v2 | `get_requests()` |
-| `bedrock` | Bedrock Runtime | `get_invocations()`, `set_model_response(model_id, text)`, `set_response_rules(model_id, rules)`, `clear_response_rules(model_id)`, `queue_fault(rule)`, `get_faults()`, `clear_faults()` |
-| `route53` | Route 53 | `set_health_check_status(id, status, reason=None)` — flip a health check between `Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown` to drive failover routing in tests |
+| Method | Description |
+|---|---|
+| `get_invocations()` | List recorded Lambda invocations |
+| `get_warm_containers()` | List warm containers |
+| `evict_container(function_name)` | Evict a warm container |
+| `download_function_code(account_id, function_name, qualifier_or_latest="latest")` | Download function-code zip (bytes) |
+| `download_layer_content(account_id, layer_name, version)` | Download layer-version zip (bytes) |
+
+### `fc.rds`
+
+| Method | Description |
+|---|---|
+| `get_instances()` | List managed RDS instances |
+| `lambda_invoke(req)` | Invoke a Lambda via the RDS `aws_lambda` PG extension bridge |
+| `s3_import(req)` | Fetch an S3 object via the RDS `aws_s3` extension bridge |
+| `s3_export(req)` | Upload an object via the RDS `aws_s3` extension bridge |
+
+### `fc.elasticache`
+
+| Method | Description |
+|---|---|
+| `get_clusters()` | List cache clusters |
+| `get_replication_groups()` | List replication groups |
+| `get_serverless_caches()` | List serverless caches |
+| `get_elasti_cache_acls()` | List ElastiCache ACLs |
+
+### `fc.athena`
+
+| Method | Description |
+|---|---|
+| `get_named_queries()` | List every named query across workgroups (with `last_used_at`) |
+
+### `fc.ecr`
+
+| Method | Description |
+|---|---|
+| `get_repositories()` | List ECR repositories |
+| `get_images(repository_name=None)` | List images, optionally filtered by repo |
+| `get_pull_through_rules()` | List pull-through cache rules |
+
+### `fc.ecs`
+
+| Method | Description |
+|---|---|
+| `get_clusters()` | List ECS clusters |
+| `get_tasks(cluster=None, status=None)` | List tasks, optionally filtered by cluster/status |
+| `get_task(task_id)` | Get a single task |
+| `get_task_logs(task_id)` | Tail captured stdout/stderr for a task |
+| `force_stop_task(task_id)` | Force-stop a running task |
+| `mark_task_failed(task_id, req)` | Mark a task as failed with a given reason |
+| `get_events()` | List ECS service events |
+| `get_task_metadata(task_arn)` | v4 metadata-URI dump for a task by ARN |
+| `get_task_credentials(task_id)` | IAM credentials a running task would see |
+| `get_task_metadata_v3(task_id)` | v3 task metadata document (pass-through dict) |
+| `get_task_metadata_v4(task_id)` | v4 task metadata document (pass-through dict) |
+
+### `fc.elbv2`
+
+| Method | Description |
+|---|---|
+| `get_load_balancers()` | List ALBs / NLBs / GWLBs |
+| `get_target_groups()` | List target groups |
+| `get_listeners()` | List listeners |
+| `get_rules()` | List listener rules |
+| `flush_access_logs()` | Force buffered access + connection logs to S3 |
+| `get_waf_counts()` | Snapshot WAF-association counts across ALBs |
+
+### `fc.route53`
+
+| Method | Description |
+|---|---|
+| `set_health_check_status(health_check_id, status, reason=None)` | Flip a health check (`Success`/`Failure`/`Timeout`/`DnsError`/`InsufficientDataPoints`/`Unknown`) |
+| `get_dnssec_material(zone_id)` | Deterministic DNSSEC KSK material for a zone |
+| `sign_dnssec_rrset(zone_id, req)` | Sign an RRset under the zone's first ACTIVE KSK |
+
+### `fc.ssm`
+
+| Method | Description |
+|---|---|
+| `set_command_status(command_id, status, account_id=None)` | Force a stored `SendCommand` into a given status |
+| `fail_command(command_id, req=None)` | Flip every (or one) invocation on a command to `Failed` |
+| `get_parameter_policy_events(account_id=None)` | List Parameter Store policy events |
+| `inject_session(req)` | Drop a fake Session Manager record into state |
+
+### `fc.kms`
+
+| Method | Description |
+|---|---|
+| `get_usage()` | Snapshot recorded KMS usage events across services |
+
+### `fc.wafv2`
+
+| Method | Description |
+|---|---|
+| `evaluate(body)` | Run a synthetic request through the WAFv2 evaluator |
+
+### `fc.cloudfront`
+
+| Method | Description |
+|---|---|
+| `set_distribution_status(distribution_id, status)` | Force a distribution into a given status |
+
+### `fc.acm`
+
+| Method | Description |
+|---|---|
+| `set_certificate_status(arn_or_id, status, reason=None)` | Flip cert status (`ISSUED`/`FAILED`/`VALIDATION_TIMED_OUT`) |
+| `approve_certificate(arn_or_id)` | Approve a `PENDING_VALIDATION` cert (EMAIL validation flow) |
+| `get_certificate_chain_info(arn_or_id)` | PEM-block / byte counts for a stored cert + chain |
+
+### `fc.application_autoscaling`
+
+| Method | Description |
+|---|---|
+| `tick()` | Force the watcher to evaluate every scaling policy now |
+| `scheduled_tick()` | Force the scheduled-action executor to evaluate every action now |
+
+### `fc.logs`
+
+| Method | Description |
+|---|---|
+| `inject_anomaly(req)` | Seed a synthetic anomaly for ListAnomalies/UpdateAnomaly |
+| `get_delivery_config()` | Persisted CloudWatch Logs delivery configurations |
+| `get_field_indexes(log_group_name)` | Parsed `Fields` from index policies on a log group |
+
+### `fc.organizations`
+
+Called as a method on the main client: `fc.organizations()`.
+
+| Method | Description |
+|---|---|
+| `get_accounts()` | List member accounts with lifecycle state, parent OU, tags, attached SCPs |
+
+### `fc.ses`
+
+| Method | Description |
+|---|---|
+| `get_emails()` | List all sent emails |
+| `simulate_inbound(req)` | Simulate an inbound email (receipt rules) |
+| `get_metrics()` | Send/bounce/complaint metrics |
+| `set_mail_from_status(identity, status)` | Set MAIL FROM verification status for an identity |
+| `get_dkim_public_key(identity)` | Public DKIM key for an identity |
+| `set_sandbox(sandbox)` | Enable/disable account-level sandbox |
+| `get_bounces()` | List recorded bounces |
+| `get_message_insights(message_id)` | Message insights record for a sent message |
+| `get_smtp_submissions()` | List SMTP-submission events |
+| `get_event_destination_deliveries()` | Deliveries fanned out to event destinations |
+
+### `fc.sns`
+
+| Method | Description |
+|---|---|
+| `get_messages()` | List all published messages |
+| `get_pending_confirmations()` | List subscriptions pending confirmation |
+| `confirm_subscription(req)` | Confirm a pending subscription |
+| `get_cert_pem()` | Signing cert as a PEM string |
+| `get_sms()` | List SMS messages accepted by the SNS fake |
+
+### `fc.sqs`
+
+| Method | Description |
+|---|---|
+| `get_messages()` | List all messages across queues |
+| `tick_expiration()` | Tick the message-expiration processor |
+| `force_dlq(queue_name)` | Force all messages to the queue's DLQ |
+
+### `fc.events`
+
+| Method | Description |
+|---|---|
+| `get_history()` | Get EventBridge event history |
+| `fire_rule(req)` | Fire an EventBridge rule manually |
+
+### `fc.scheduler`
+
+| Method | Description |
+|---|---|
+| `get_schedules()` | List scheduler schedules |
+| `fire_schedule(group, name)` | Manually fire a schedule by group/name |
+
+### `fc.glue`
+
+| Method | Description |
+|---|---|
+| `get_jobs()` | List Glue jobs |
+| `get_job_runs(job_name=None)` | List job runs, optionally filtered by job |
+
+### `fc.s3`
+
+| Method | Description |
+|---|---|
+| `get_notifications()` | List S3 notification events |
+| `tick_lifecycle()` | Tick the lifecycle processor |
+| `get_access_points()` | List S3 access points |
+| `get_object_lambda_responses()` | List recorded Object Lambda responses |
+
+### `fc.dynamodb`
+
+| Method | Description |
+|---|---|
+| `tick_ttl()` | Tick the TTL processor |
+
+### `fc.secretsmanager`
+
+| Method | Description |
+|---|---|
+| `tick_rotation()` | Tick the rotation scheduler |
+
+### `fc.cognito`
+
+| Method | Description |
+|---|---|
+| `get_user_codes(pool_id, username)` | Confirmation codes for a specific user |
+| `get_confirmation_codes()` | List all pending confirmation codes |
+| `confirm_user(req)` | Force-confirm a user |
+| `get_tokens()` | List active tokens |
+| `expire_tokens(req)` | Expire tokens for a pool/user |
+| `get_auth_events()` | List auth events |
+| `get_pre_token_gen_invocations()` | PreTokenGeneration Lambda trigger invocation log |
+| `mint_authorization_code(req)` | Mint an OAuth authorization code |
+| `set_compromised_passwords(req)` | Seed compromised-password records |
+| `get_webauthn_credentials()` | List stored WebAuthn credentials |
+
+### `fc.apigatewayv2`
+
+| Method | Description |
+|---|---|
+| `get_requests()` | List recorded HTTP API requests |
+| `get_connections()` | List active WebSocket connections |
+| `get_mtls_info(domain_name)` | mTLS trust-store summary for a custom domain (dict) |
+| `ws_url(api_id, stage=None)` | Build the `ws(s)://` WebSocket URL for an API + stage |
+
+### `fc.stepfunctions`
+
+| Method | Description |
+|---|---|
+| `get_executions()` | List all executions |
+| `get_sync_executions()` | List sync (Express) executions |
+| `get_execution_tree(arn)` | Nested execution tree for a parent execution |
+| `enqueue_activity_task(req)` | Insert a pending task into an activity-worker queue |
+
+### `fc.bedrock`
+
+| Method | Description |
+|---|---|
+| `get_invocations()` | List recorded Bedrock runtime invocations |
+| `set_model_response(model_id, text)` | Configure a single canned response for a model |
+| `set_response_rules(model_id, rules)` | Replace prompt-conditional response rules |
+| `clear_response_rules(model_id)` | Clear all prompt-conditional response rules for a model |
+| `queue_fault(rule)` | Queue a fault rule for the next N matching calls |
+| `get_faults()` | List currently queued fault rules |
+| `clear_faults()` | Clear all queued fault rules |
+
+### `fc.bedrock_agent`
+
+| Method | Description |
+|---|---|
+| `get_agents()` | List Bedrock Agents (control plane) |
+
+### `fc.bedrock_agent_runtime`
+
+| Method | Description |
+|---|---|
+| `get_invocations()` | List Bedrock Agent runtime invocations (data plane) |
 
 ### Testing Bedrock-calling code end-to-end
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -1,6 +1,6 @@
 # fakecloud
 
-TypeScript client SDK for [fakecloud](https://github.com/faiscadev/fakecloud) — a local AWS cloud emulator.
+TypeScript client SDK for [fakecloud](https://github.com/faiscadev/fakecloud) -- a local AWS cloud emulator.
 
 Provides typed access to the fakecloud introspection and simulation API (`/_fakecloud/*` endpoints), letting you inspect emulator state and trigger time-based processors in tests.
 
@@ -51,106 +51,42 @@ const fc = new FakeCloud(baseUrl?: string);
 
 Top-level client. Defaults to `http://localhost:4566`.
 
-| Method                  | Description             |
-| ----------------------- | ----------------------- |
-| `health()`              | Server health check     |
-| `reset()`               | Reset all service state |
-| `resetService(service)` | Reset a single service  |
+| Method                              | Description                                              |
+| ----------------------------------- | -------------------------------------------------------- |
+| `health()`                          | Server health check                                      |
+| `reset()`                           | Reset all service state                                  |
+| `resetService(service)`             | Reset a single service                                   |
+| `createAdmin(accountId, userName)`  | Bootstrap an admin IAM user for an account               |
 
-### `fc.lambda`
+### `fc.acm`
 
-| Method                         | Description                          |
-| ------------------------------ | ------------------------------------ |
-| `getInvocations()`             | List recorded Lambda invocations     |
-| `getWarmContainers()`          | List warm (cached) Lambda containers |
-| `evictContainer(functionName)` | Evict a warm container               |
-
-### `fc.ses`
-
-| Method                 | Description                               |
-| ---------------------- | ----------------------------------------- |
-| `getEmails()`          | List all sent emails                      |
-| `simulateInbound(req)` | Simulate an inbound email (receipt rules) |
-
-### `fc.sns`
-
-| Method                      | Description                             |
-| --------------------------- | --------------------------------------- |
-| `getMessages()`             | List all published messages             |
-| `getPendingConfirmations()` | List subscriptions pending confirmation |
-| `confirmSubscription(req)`  | Confirm a pending subscription          |
-
-### `fc.sqs`
-
-| Method                | Description                           |
-| --------------------- | ------------------------------------- |
-| `getMessages()`       | List all messages across all queues   |
-| `tickExpiration()`    | Tick the message expiration processor |
-| `forceDlq(queueName)` | Force all messages to the queue's DLQ |
-
-### `fc.events`
-
-| Method          | Description                            |
-| --------------- | -------------------------------------- |
-| `getHistory()`  | Get event history and delivery records |
-| `fireRule(req)` | Fire an EventBridge rule manually      |
-
-### `fc.s3`
-
-| Method               | Description                  |
-| -------------------- | ---------------------------- |
-| `getNotifications()` | List S3 notification events  |
-| `tickLifecycle()`    | Tick the lifecycle processor |
-
-### `fc.dynamodb`
-
-| Method      | Description            |
-| ----------- | ---------------------- |
-| `tickTtl()` | Tick the TTL processor |
-
-### `fc.secretsmanager`
-
-| Method           | Description                 |
-| ---------------- | --------------------------- |
-| `tickRotation()` | Tick the rotation scheduler |
-
-### `fc.cognito`
-
-| Method                           | Description                                                                                         |
-| -------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `getUserCodes(poolId, username)` | Get confirmation codes for a user                                                                   |
-| `getConfirmationCodes()`         | List all confirmation codes                                                                         |
-| `confirmUser(req)`               | Confirm a user (bypass verification)                                                                |
-| `getTokens()`                    | List all active tokens                                                                              |
-| `expireTokens(req)`              | Expire tokens (optionally filtered)                                                                 |
-| `getAuthEvents()`                | List auth events                                                                                    |
-| `mintAuthorizationCode(req)`     | Mint a single-use OAuth2 authorization code (programmatic alternative to driving /oauth2/authorize) |
-
-### `fc.rds`
-
-| Method           | Description                              |
-| ---------------- | ---------------------------------------- |
-| `getInstances()` | List RDS instances with runtime metadata |
-
-### `fc.elasticache`
-
-| Method                   | Description                         |
-| ------------------------ | ----------------------------------- |
-| `getClusters()`          | List ElastiCache cache clusters     |
-| `getReplicationGroups()` | List ElastiCache replication groups |
-| `getServerlessCaches()`  | List ElastiCache serverless caches  |
-
-### `fc.stepfunctions`
-
-| Method            | Description                              |
-| ----------------- | ---------------------------------------- |
-| `getExecutions()` | List all state machine execution history |
+| Method                                       | Description                                                                  |
+| -------------------------------------------- | ---------------------------------------------------------------------------- |
+| `setCertificateStatus(arnOrId, req)`         | Flip a certificate's status (`ISSUED` / `FAILED` / `VALIDATION_TIMED_OUT`)   |
+| `approveCertificate(arnOrId)`                | Approve a `PENDING_VALIDATION` cert synchronously (email-validation bypass)  |
+| `getCertificateChainInfo(arnOrId)`           | Inspect stored PEM block counts and byte sizes for a certificate             |
 
 ### `fc.apigatewayv2`
 
-| Method          | Description                         |
-| --------------- | ----------------------------------- |
-| `getRequests()` | List all HTTP API requests received |
+| Method                       | Description                                                            |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| `getRequests()`              | List recorded HTTP API requests                                        |
+| `getConnections()`           | List every live WebSocket connection currently tracked                 |
+| `getMtlsInfo(domainName)`    | Inspect the mTLS trust store / chain configuration for a custom domain |
+| `wsUrl(apiId, stage?)`       | Build the `ws://`/`wss://` URL for a WebSocket API stage               |
+
+### `fc.applicationAutoscaling`
+
+| Method            | Description                                                       |
+| ----------------- | ----------------------------------------------------------------- |
+| `tick()`          | Force an immediate scaling-policy evaluation pass                 |
+| `scheduledTick()` | Force the scheduled-action watcher to fire due actions now        |
+
+### `fc.athena`
+
+| Method              | Description                                                          |
+| ------------------- | -------------------------------------------------------------------- |
+| `getNamedQueries()` | List every named query across all workgroups for the default account |
 
 ### `fc.bedrock`
 
@@ -164,13 +100,230 @@ Top-level client. Defaults to `http://localhost:4566`.
 | `getFaults()`                      | List currently queued fault rules                                    |
 | `clearFaults()`                    | Clear all queued fault rules                                         |
 
+### `fc.bedrockAgent`
+
+| Method        | Description                                                                                |
+| ------------- | ------------------------------------------------------------------------------------------ |
+| `getAgents()` | List every Bedrock Agent with aliases, versions, knowledge bases, and collaborators        |
+
+### `fc.bedrockAgentRuntime`
+
+| Method             | Description                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| `getInvocations()` | List recorded `InvokeAgent` / `InvokeInlineAgent` / `InvokeFlow` / `Retrieve*` calls       |
+
+### `fc.cloudfront`
+
+| Method                                | Description                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `setDistributionStatus(id, req)`      | Flip a Distribution synchronously into `Deployed` or `InProgress`        |
+
+### `fc.cognito`
+
+| Method                              | Description                                                                                   |
+| ----------------------------------- | --------------------------------------------------------------------------------------------- |
+| `getUserCodes(poolId, username)`    | Get confirmation codes for a single user                                                      |
+| `getConfirmationCodes()`            | List all pending confirmation codes                                                           |
+| `confirmUser(req)`                  | Force-confirm a user                                                                          |
+| `getTokens()`                       | List active tokens                                                                            |
+| `expireTokens(req)`                 | Expire tokens for a pool/user                                                                 |
+| `getAuthEvents()`                   | List auth events                                                                              |
+| `getPreTokenGenInvocations()`       | List PreTokenGeneration Lambda trigger invocations with parsed claim mutations                |
+| `mintAuthorizationCode(req)`        | Mint a single-use OAuth2 authorization code (programmatic alternative to `/oauth2/authorize`) |
+| `setCompromisedPasswords(req)`      | Replace the compromised-password list used by adaptive auth                                   |
+| `getWebAuthnCredentials()`          | List stored WebAuthn credentials                                                              |
+
+### `fc.dynamodb`
+
+| Method      | Description            |
+| ----------- | ---------------------- |
+| `tickTtl()` | Tick the TTL processor |
+
+### `fc.ecr`
+
+| Method                  | Description                                                       |
+| ----------------------- | ----------------------------------------------------------------- |
+| `getRepositories()`     | List every ECR repository fakecloud has seen                      |
+| `getImages(repo?)`      | List images, optionally filtered by repository name               |
+| `getPullThroughRules()` | List pull-through cache rules                                     |
+
+### `fc.ecs`
+
+| Method                          | Description                                                                |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| `getClusters()`                 | List every ECS cluster across every account                                |
+| `getTasks(opts?)`               | List tracked tasks; optional `cluster` / `status` filters                  |
+| `getTask(taskId)`               | Fetch a single task snapshot by ID                                         |
+| `getTaskLogs(taskId)`           | Captured docker stdout/stderr + exit code for a task                       |
+| `forceStopTask(taskId)`         | SIGTERM (then SIGKILL after 10s) the task's running container              |
+| `markTaskFailed(taskId, req)`   | Flip a task to STOPPED without killing the container                       |
+| `getEvents()`                   | Replay the lifecycle event log                                             |
+| `getTaskMetadata(taskArn)`      | v4 metadata dump keyed by full task ARN                                    |
+| `getTaskCredentials(taskId)`    | IMDS-style temporary credentials minted for an ECS task                    |
+| `getTaskMetadataV3(taskId)`     | v3 task metadata dump (`ECS_CONTAINER_METADATA_URI`)                       |
+| `getTaskMetadataV4(taskId)`     | v4 task metadata dump (`ECS_CONTAINER_METADATA_URI_V4`)                    |
+
+### `fc.elasticache`
+
+| Method                    | Description                                                       |
+| ------------------------- | ----------------------------------------------------------------- |
+| `getClusters()`           | List ElastiCache cache clusters                                   |
+| `getReplicationGroups()`  | List ElastiCache replication groups                               |
+| `getServerlessCaches()`   | List ElastiCache serverless caches                                |
+| `getElastiCacheAcls()`    | List Redis user-group ACLs                                        |
+
+### `fc.elbv2`
+
+| Method                | Description                                                                       |
+| --------------------- | --------------------------------------------------------------------------------- |
+| `getLoadBalancers()`  | List every ELBv2 load balancer (ALB / NLB / GWLB) across every account            |
+| `getListeners()`      | List every listener                                                               |
+| `getRules()`          | List every listener rule                                                          |
+| `getTargetGroups()`   | List every target group                                                           |
+| `flushAccessLogs()`   | Flush buffered ALB access-log + connection-log lines to S3 now                    |
+| `getWafCounts()`      | Return current WAF association / evaluation counts                                |
+
+### `fc.events`
+
+| Method          | Description                            |
+| --------------- | -------------------------------------- |
+| `getHistory()`  | Get event history and delivery records |
+| `fireRule(req)` | Fire an EventBridge rule manually      |
+
+### `fc.glue`
+
+| Method               | Description                                                  |
+| -------------------- | ------------------------------------------------------------ |
+| `getJobs()`          | List every Glue job                                          |
+| `getJobRuns(name?)`  | List job runs, optionally filtered by job name               |
+
+### `fc.kms`
+
+| Method       | Description                                                              |
+| ------------ | ------------------------------------------------------------------------ |
+| `getUsage()` | Return every recorded KMS usage record (one per server-side encrypt op)  |
+
+### `fc.lambda`
+
+| Method                                                       | Description                                                          |
+| ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `getInvocations()`                                           | List recorded Lambda invocations                                     |
+| `getWarmContainers()`                                        | List warm (cached) Lambda containers                                 |
+| `evictContainer(functionName)`                               | Evict a warm container                                               |
+| `downloadFunctionCode(accountId, functionName, qualifier?)`  | Download the raw ZIP for a function's code (default `latest`)        |
+| `downloadLayerContent(accountId, layerName, version)`        | Download the raw ZIP for a Lambda layer version                      |
+
+### `fc.logs`
+
+| Method                              | Description                                                            |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| `injectAnomaly(req)`                | Inject a synthetic anomaly into the anomaly detector                   |
+| `getDeliveryConfig()`               | Return persisted CloudWatch Logs delivery configurations               |
+| `getFieldIndexes(logGroupName)`     | Parsed `Fields` from index policies on a log group (404 when missing)  |
+
+### `fc.organizations`
+
+| Method          | Description                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------- |
+| `getAccounts()` | List every member account with lifecycle state, parent OU, tags, and directly-attached SCPs  |
+
+### `fc.rds`
+
+| Method              | Description                                                                |
+| ------------------- | -------------------------------------------------------------------------- |
+| `getInstances()`    | List RDS instances with runtime metadata                                   |
+| `lambdaInvoke(req)` | Bridge endpoint the PostgreSQL `aws_lambda` extension dispatches into      |
+| `s3Import(req)`     | Bridge for the PostgreSQL `aws_s3` extension's import path                 |
+| `s3Export(req)`     | Bridge for the PostgreSQL `aws_s3` extension's export path                 |
+
 ### `fc.route53`
 
-| Method                                          | Description                                                                                                                                                                                                                       |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setHealthCheckStatus(id, { status, reason? })` | Flip a health check between `Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown` to drive failover routing in tests; reason is appended to the `<Status>` element for failure-flavoured statuses |
+| Method                                  | Description                                                                                                       |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `setHealthCheckStatus(id, req)`         | Flip a health check status (`Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown`) |
+| `getDnssecMaterial(zoneId)`             | DNSKEY public key + DS digest derived from the zone's first ACTIVE KSK                                            |
+| `signDnssecRrset(zoneId, req)`          | Sign an RRset under the zone's first ACTIVE KSK and return the raw RRSIG fields                                   |
 
-#### Full test loop — asserting on Bedrock calls
+### `fc.s3`
+
+| Method                         | Description                                                  |
+| ------------------------------ | ------------------------------------------------------------ |
+| `getNotifications()`           | List S3 notification events                                  |
+| `tickLifecycle()`              | Tick the lifecycle processor                                 |
+| `getAccessPoints()`            | List configured S3 access points                             |
+| `getObjectLambdaResponses()`   | List recorded S3 Object Lambda `WriteGetObjectResponse` calls |
+
+### `fc.scheduler`
+
+| Method                       | Description                                                  |
+| ---------------------------- | ------------------------------------------------------------ |
+| `getSchedules()`             | List every EventBridge Scheduler schedule                    |
+| `fireSchedule(group, name)`  | Fire a schedule manually, bypassing the cron tick            |
+
+### `fc.secretsmanager`
+
+| Method           | Description                 |
+| ---------------- | --------------------------- |
+| `tickRotation()` | Tick the rotation scheduler |
+
+### `fc.ses`
+
+| Method                                | Description                                                                |
+| ------------------------------------- | -------------------------------------------------------------------------- |
+| `getEmails()`                         | List all sent emails                                                       |
+| `simulateInbound(req)`                | Simulate an inbound email (receipt rules)                                  |
+| `getMetrics()`                        | Aggregate counters for sends / bounces / complaints / deliveries           |
+| `getBounces()`                        | List recorded bounce events                                                |
+| `setSandbox(sandbox)`                 | Toggle SES account sandbox mode                                            |
+| `getEventDestinationDeliveries()`     | List event-destination delivery records (SNS / Firehose / EventBridge)     |
+| `getDkimPublicKey(identity)`          | Return the DKIM public key fakecloud minted for an identity                |
+| `setMailFromStatus(identity, status)` | Flip a custom MAIL FROM domain's verification status synchronously         |
+| `getMessageInsights(messageId)`       | Return Message Insights for a sent message                                 |
+| `getSmtpSubmissions()`                | List messages submitted via the SMTP endpoint                              |
+
+### `fc.sns`
+
+| Method                      | Description                                                          |
+| --------------------------- | -------------------------------------------------------------------- |
+| `getMessages()`             | List all published messages                                          |
+| `getPendingConfirmations()` | List subscriptions pending confirmation                              |
+| `confirmSubscription(req)`  | Confirm a pending subscription                                       |
+| `getCertPem()`              | Return the PEM-encoded SNS signing certificate (raw PEM, not JSON)   |
+| `getSms()`                  | List recorded SMS messages dispatched via `SNS Publish`              |
+
+### `fc.sqs`
+
+| Method                | Description                           |
+| --------------------- | ------------------------------------- |
+| `getMessages()`       | List all messages across all queues   |
+| `tickExpiration()`    | Tick the message expiration processor |
+| `forceDlq(queueName)` | Force all messages to the queue's DLQ |
+
+### `fc.ssm`
+
+| Method                                    | Description                                                                  |
+| ----------------------------------------- | ---------------------------------------------------------------------------- |
+| `setCommandStatus(commandId, req)`        | Flip a Run Command's status synchronously                                    |
+| `failCommand(commandId, req?)`            | Mark a Run Command's invocations as failed (all or a single instance)        |
+| `getParameterPolicyEvents(accountId?)`    | List recorded SSM parameter-policy lifecycle events                          |
+| `injectSession(req)`                      | Inject a fake Session Manager session without going through `StartSession`   |
+
+### `fc.stepfunctions`
+
+| Method                       | Description                                                              |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| `getExecutions()`            | List all state machine executions                                        |
+| `getSyncExecutions()`        | List recorded `StartSyncExecution` results                               |
+| `getExecutionTree(arn)`      | Return the full execution tree (parent + nested child workflows)         |
+| `enqueueActivityTask(req)`   | Enqueue an Activity task directly for a worker to `GetActivityTask`      |
+
+### `fc.wafv2`
+
+| Method          | Description                                                                  |
+| --------------- | ---------------------------------------------------------------------------- |
+| `evaluate(req)` | Run an arbitrary request payload against the configured WebACLs (opaque JSON) |
+
+#### Full test loop -- asserting on Bedrock calls
 
 ```typescript
 import { FakeCloud } from "fakecloud";

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -51,36 +51,36 @@ const fc = new FakeCloud(baseUrl?: string);
 
 Top-level client. Defaults to `http://localhost:4566`.
 
-| Method                              | Description                                              |
-| ----------------------------------- | -------------------------------------------------------- |
-| `health()`                          | Server health check                                      |
-| `reset()`                           | Reset all service state                                  |
-| `resetService(service)`             | Reset a single service                                   |
-| `createAdmin(accountId, userName)`  | Bootstrap an admin IAM user for an account               |
+| Method                             | Description                                |
+| ---------------------------------- | ------------------------------------------ |
+| `health()`                         | Server health check                        |
+| `reset()`                          | Reset all service state                    |
+| `resetService(service)`            | Reset a single service                     |
+| `createAdmin(accountId, userName)` | Bootstrap an admin IAM user for an account |
 
 ### `fc.acm`
 
-| Method                                       | Description                                                                  |
-| -------------------------------------------- | ---------------------------------------------------------------------------- |
-| `setCertificateStatus(arnOrId, req)`         | Flip a certificate's status (`ISSUED` / `FAILED` / `VALIDATION_TIMED_OUT`)   |
-| `approveCertificate(arnOrId)`                | Approve a `PENDING_VALIDATION` cert synchronously (email-validation bypass)  |
-| `getCertificateChainInfo(arnOrId)`           | Inspect stored PEM block counts and byte sizes for a certificate             |
+| Method                               | Description                                                                 |
+| ------------------------------------ | --------------------------------------------------------------------------- |
+| `setCertificateStatus(arnOrId, req)` | Flip a certificate's status (`ISSUED` / `FAILED` / `VALIDATION_TIMED_OUT`)  |
+| `approveCertificate(arnOrId)`        | Approve a `PENDING_VALIDATION` cert synchronously (email-validation bypass) |
+| `getCertificateChainInfo(arnOrId)`   | Inspect stored PEM block counts and byte sizes for a certificate            |
 
 ### `fc.apigatewayv2`
 
-| Method                       | Description                                                            |
-| ---------------------------- | ---------------------------------------------------------------------- |
-| `getRequests()`              | List recorded HTTP API requests                                        |
-| `getConnections()`           | List every live WebSocket connection currently tracked                 |
-| `getMtlsInfo(domainName)`    | Inspect the mTLS trust store / chain configuration for a custom domain |
-| `wsUrl(apiId, stage?)`       | Build the `ws://`/`wss://` URL for a WebSocket API stage               |
+| Method                    | Description                                                            |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `getRequests()`           | List recorded HTTP API requests                                        |
+| `getConnections()`        | List every live WebSocket connection currently tracked                 |
+| `getMtlsInfo(domainName)` | Inspect the mTLS trust store / chain configuration for a custom domain |
+| `wsUrl(apiId, stage?)`    | Build the `ws://`/`wss://` URL for a WebSocket API stage               |
 
 ### `fc.applicationAutoscaling`
 
-| Method            | Description                                                       |
-| ----------------- | ----------------------------------------------------------------- |
-| `tick()`          | Force an immediate scaling-policy evaluation pass                 |
-| `scheduledTick()` | Force the scheduled-action watcher to fire due actions now        |
+| Method            | Description                                                |
+| ----------------- | ---------------------------------------------------------- |
+| `tick()`          | Force an immediate scaling-policy evaluation pass          |
+| `scheduledTick()` | Force the scheduled-action watcher to fire due actions now |
 
 ### `fc.athena`
 
@@ -102,36 +102,36 @@ Top-level client. Defaults to `http://localhost:4566`.
 
 ### `fc.bedrockAgent`
 
-| Method        | Description                                                                                |
-| ------------- | ------------------------------------------------------------------------------------------ |
-| `getAgents()` | List every Bedrock Agent with aliases, versions, knowledge bases, and collaborators        |
+| Method        | Description                                                                         |
+| ------------- | ----------------------------------------------------------------------------------- |
+| `getAgents()` | List every Bedrock Agent with aliases, versions, knowledge bases, and collaborators |
 
 ### `fc.bedrockAgentRuntime`
 
-| Method             | Description                                                                                |
-| ------------------ | ------------------------------------------------------------------------------------------ |
-| `getInvocations()` | List recorded `InvokeAgent` / `InvokeInlineAgent` / `InvokeFlow` / `Retrieve*` calls       |
+| Method             | Description                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| `getInvocations()` | List recorded `InvokeAgent` / `InvokeInlineAgent` / `InvokeFlow` / `Retrieve*` calls |
 
 ### `fc.cloudfront`
 
-| Method                                | Description                                                              |
-| ------------------------------------- | ------------------------------------------------------------------------ |
-| `setDistributionStatus(id, req)`      | Flip a Distribution synchronously into `Deployed` or `InProgress`        |
+| Method                           | Description                                                       |
+| -------------------------------- | ----------------------------------------------------------------- |
+| `setDistributionStatus(id, req)` | Flip a Distribution synchronously into `Deployed` or `InProgress` |
 
 ### `fc.cognito`
 
-| Method                              | Description                                                                                   |
-| ----------------------------------- | --------------------------------------------------------------------------------------------- |
-| `getUserCodes(poolId, username)`    | Get confirmation codes for a single user                                                      |
-| `getConfirmationCodes()`            | List all pending confirmation codes                                                           |
-| `confirmUser(req)`                  | Force-confirm a user                                                                          |
-| `getTokens()`                       | List active tokens                                                                            |
-| `expireTokens(req)`                 | Expire tokens for a pool/user                                                                 |
-| `getAuthEvents()`                   | List auth events                                                                              |
-| `getPreTokenGenInvocations()`       | List PreTokenGeneration Lambda trigger invocations with parsed claim mutations                |
-| `mintAuthorizationCode(req)`        | Mint a single-use OAuth2 authorization code (programmatic alternative to `/oauth2/authorize`) |
-| `setCompromisedPasswords(req)`      | Replace the compromised-password list used by adaptive auth                                   |
-| `getWebAuthnCredentials()`          | List stored WebAuthn credentials                                                              |
+| Method                           | Description                                                                                   |
+| -------------------------------- | --------------------------------------------------------------------------------------------- |
+| `getUserCodes(poolId, username)` | Get confirmation codes for a single user                                                      |
+| `getConfirmationCodes()`         | List all pending confirmation codes                                                           |
+| `confirmUser(req)`               | Force-confirm a user                                                                          |
+| `getTokens()`                    | List active tokens                                                                            |
+| `expireTokens(req)`              | Expire tokens for a pool/user                                                                 |
+| `getAuthEvents()`                | List auth events                                                                              |
+| `getPreTokenGenInvocations()`    | List PreTokenGeneration Lambda trigger invocations with parsed claim mutations                |
+| `mintAuthorizationCode(req)`     | Mint a single-use OAuth2 authorization code (programmatic alternative to `/oauth2/authorize`) |
+| `setCompromisedPasswords(req)`   | Replace the compromised-password list used by adaptive auth                                   |
+| `getWebAuthnCredentials()`       | List stored WebAuthn credentials                                                              |
 
 ### `fc.dynamodb`
 
@@ -141,47 +141,47 @@ Top-level client. Defaults to `http://localhost:4566`.
 
 ### `fc.ecr`
 
-| Method                  | Description                                                       |
-| ----------------------- | ----------------------------------------------------------------- |
-| `getRepositories()`     | List every ECR repository fakecloud has seen                      |
-| `getImages(repo?)`      | List images, optionally filtered by repository name               |
-| `getPullThroughRules()` | List pull-through cache rules                                     |
+| Method                  | Description                                         |
+| ----------------------- | --------------------------------------------------- |
+| `getRepositories()`     | List every ECR repository fakecloud has seen        |
+| `getImages(repo?)`      | List images, optionally filtered by repository name |
+| `getPullThroughRules()` | List pull-through cache rules                       |
 
 ### `fc.ecs`
 
-| Method                          | Description                                                                |
-| ------------------------------- | -------------------------------------------------------------------------- |
-| `getClusters()`                 | List every ECS cluster across every account                                |
-| `getTasks(opts?)`               | List tracked tasks; optional `cluster` / `status` filters                  |
-| `getTask(taskId)`               | Fetch a single task snapshot by ID                                         |
-| `getTaskLogs(taskId)`           | Captured docker stdout/stderr + exit code for a task                       |
-| `forceStopTask(taskId)`         | SIGTERM (then SIGKILL after 10s) the task's running container              |
-| `markTaskFailed(taskId, req)`   | Flip a task to STOPPED without killing the container                       |
-| `getEvents()`                   | Replay the lifecycle event log                                             |
-| `getTaskMetadata(taskArn)`      | v4 metadata dump keyed by full task ARN                                    |
-| `getTaskCredentials(taskId)`    | IMDS-style temporary credentials minted for an ECS task                    |
-| `getTaskMetadataV3(taskId)`     | v3 task metadata dump (`ECS_CONTAINER_METADATA_URI`)                       |
-| `getTaskMetadataV4(taskId)`     | v4 task metadata dump (`ECS_CONTAINER_METADATA_URI_V4`)                    |
+| Method                        | Description                                                   |
+| ----------------------------- | ------------------------------------------------------------- |
+| `getClusters()`               | List every ECS cluster across every account                   |
+| `getTasks(opts?)`             | List tracked tasks; optional `cluster` / `status` filters     |
+| `getTask(taskId)`             | Fetch a single task snapshot by ID                            |
+| `getTaskLogs(taskId)`         | Captured docker stdout/stderr + exit code for a task          |
+| `forceStopTask(taskId)`       | SIGTERM (then SIGKILL after 10s) the task's running container |
+| `markTaskFailed(taskId, req)` | Flip a task to STOPPED without killing the container          |
+| `getEvents()`                 | Replay the lifecycle event log                                |
+| `getTaskMetadata(taskArn)`    | v4 metadata dump keyed by full task ARN                       |
+| `getTaskCredentials(taskId)`  | IMDS-style temporary credentials minted for an ECS task       |
+| `getTaskMetadataV3(taskId)`   | v3 task metadata dump (`ECS_CONTAINER_METADATA_URI`)          |
+| `getTaskMetadataV4(taskId)`   | v4 task metadata dump (`ECS_CONTAINER_METADATA_URI_V4`)       |
 
 ### `fc.elasticache`
 
-| Method                    | Description                                                       |
-| ------------------------- | ----------------------------------------------------------------- |
-| `getClusters()`           | List ElastiCache cache clusters                                   |
-| `getReplicationGroups()`  | List ElastiCache replication groups                               |
-| `getServerlessCaches()`   | List ElastiCache serverless caches                                |
-| `getElastiCacheAcls()`    | List Redis user-group ACLs                                        |
+| Method                   | Description                         |
+| ------------------------ | ----------------------------------- |
+| `getClusters()`          | List ElastiCache cache clusters     |
+| `getReplicationGroups()` | List ElastiCache replication groups |
+| `getServerlessCaches()`  | List ElastiCache serverless caches  |
+| `getElastiCacheAcls()`   | List Redis user-group ACLs          |
 
 ### `fc.elbv2`
 
-| Method                | Description                                                                       |
-| --------------------- | --------------------------------------------------------------------------------- |
-| `getLoadBalancers()`  | List every ELBv2 load balancer (ALB / NLB / GWLB) across every account            |
-| `getListeners()`      | List every listener                                                               |
-| `getRules()`          | List every listener rule                                                          |
-| `getTargetGroups()`   | List every target group                                                           |
-| `flushAccessLogs()`   | Flush buffered ALB access-log + connection-log lines to S3 now                    |
-| `getWafCounts()`      | Return current WAF association / evaluation counts                                |
+| Method               | Description                                                            |
+| -------------------- | ---------------------------------------------------------------------- |
+| `getLoadBalancers()` | List every ELBv2 load balancer (ALB / NLB / GWLB) across every account |
+| `getListeners()`     | List every listener                                                    |
+| `getRules()`         | List every listener rule                                               |
+| `getTargetGroups()`  | List every target group                                                |
+| `flushAccessLogs()`  | Flush buffered ALB access-log + connection-log lines to S3 now         |
+| `getWafCounts()`     | Return current WAF association / evaluation counts                     |
 
 ### `fc.events`
 
@@ -192,73 +192,73 @@ Top-level client. Defaults to `http://localhost:4566`.
 
 ### `fc.glue`
 
-| Method               | Description                                                  |
-| -------------------- | ------------------------------------------------------------ |
-| `getJobs()`          | List every Glue job                                          |
-| `getJobRuns(name?)`  | List job runs, optionally filtered by job name               |
+| Method              | Description                                    |
+| ------------------- | ---------------------------------------------- |
+| `getJobs()`         | List every Glue job                            |
+| `getJobRuns(name?)` | List job runs, optionally filtered by job name |
 
 ### `fc.kms`
 
-| Method       | Description                                                              |
-| ------------ | ------------------------------------------------------------------------ |
-| `getUsage()` | Return every recorded KMS usage record (one per server-side encrypt op)  |
+| Method       | Description                                                             |
+| ------------ | ----------------------------------------------------------------------- |
+| `getUsage()` | Return every recorded KMS usage record (one per server-side encrypt op) |
 
 ### `fc.lambda`
 
-| Method                                                       | Description                                                          |
-| ------------------------------------------------------------ | -------------------------------------------------------------------- |
-| `getInvocations()`                                           | List recorded Lambda invocations                                     |
-| `getWarmContainers()`                                        | List warm (cached) Lambda containers                                 |
-| `evictContainer(functionName)`                               | Evict a warm container                                               |
-| `downloadFunctionCode(accountId, functionName, qualifier?)`  | Download the raw ZIP for a function's code (default `latest`)        |
-| `downloadLayerContent(accountId, layerName, version)`        | Download the raw ZIP for a Lambda layer version                      |
+| Method                                                      | Description                                                   |
+| ----------------------------------------------------------- | ------------------------------------------------------------- |
+| `getInvocations()`                                          | List recorded Lambda invocations                              |
+| `getWarmContainers()`                                       | List warm (cached) Lambda containers                          |
+| `evictContainer(functionName)`                              | Evict a warm container                                        |
+| `downloadFunctionCode(accountId, functionName, qualifier?)` | Download the raw ZIP for a function's code (default `latest`) |
+| `downloadLayerContent(accountId, layerName, version)`       | Download the raw ZIP for a Lambda layer version               |
 
 ### `fc.logs`
 
-| Method                              | Description                                                            |
-| ----------------------------------- | ---------------------------------------------------------------------- |
-| `injectAnomaly(req)`                | Inject a synthetic anomaly into the anomaly detector                   |
-| `getDeliveryConfig()`               | Return persisted CloudWatch Logs delivery configurations               |
-| `getFieldIndexes(logGroupName)`     | Parsed `Fields` from index policies on a log group (404 when missing)  |
+| Method                          | Description                                                           |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `injectAnomaly(req)`            | Inject a synthetic anomaly into the anomaly detector                  |
+| `getDeliveryConfig()`           | Return persisted CloudWatch Logs delivery configurations              |
+| `getFieldIndexes(logGroupName)` | Parsed `Fields` from index policies on a log group (404 when missing) |
 
 ### `fc.organizations`
 
-| Method          | Description                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------- |
-| `getAccounts()` | List every member account with lifecycle state, parent OU, tags, and directly-attached SCPs  |
+| Method          | Description                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------- |
+| `getAccounts()` | List every member account with lifecycle state, parent OU, tags, and directly-attached SCPs |
 
 ### `fc.rds`
 
-| Method              | Description                                                                |
-| ------------------- | -------------------------------------------------------------------------- |
-| `getInstances()`    | List RDS instances with runtime metadata                                   |
-| `lambdaInvoke(req)` | Bridge endpoint the PostgreSQL `aws_lambda` extension dispatches into      |
-| `s3Import(req)`     | Bridge for the PostgreSQL `aws_s3` extension's import path                 |
-| `s3Export(req)`     | Bridge for the PostgreSQL `aws_s3` extension's export path                 |
+| Method              | Description                                                           |
+| ------------------- | --------------------------------------------------------------------- |
+| `getInstances()`    | List RDS instances with runtime metadata                              |
+| `lambdaInvoke(req)` | Bridge endpoint the PostgreSQL `aws_lambda` extension dispatches into |
+| `s3Import(req)`     | Bridge for the PostgreSQL `aws_s3` extension's import path            |
+| `s3Export(req)`     | Bridge for the PostgreSQL `aws_s3` extension's export path            |
 
 ### `fc.route53`
 
-| Method                                  | Description                                                                                                       |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `setHealthCheckStatus(id, req)`         | Flip a health check status (`Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown`) |
-| `getDnssecMaterial(zoneId)`             | DNSKEY public key + DS digest derived from the zone's first ACTIVE KSK                                            |
-| `signDnssecRrset(zoneId, req)`          | Sign an RRset under the zone's first ACTIVE KSK and return the raw RRSIG fields                                   |
+| Method                          | Description                                                                                                        |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `setHealthCheckStatus(id, req)` | Flip a health check status (`Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown`) |
+| `getDnssecMaterial(zoneId)`     | DNSKEY public key + DS digest derived from the zone's first ACTIVE KSK                                             |
+| `signDnssecRrset(zoneId, req)`  | Sign an RRset under the zone's first ACTIVE KSK and return the raw RRSIG fields                                    |
 
 ### `fc.s3`
 
-| Method                         | Description                                                  |
-| ------------------------------ | ------------------------------------------------------------ |
-| `getNotifications()`           | List S3 notification events                                  |
-| `tickLifecycle()`              | Tick the lifecycle processor                                 |
-| `getAccessPoints()`            | List configured S3 access points                             |
-| `getObjectLambdaResponses()`   | List recorded S3 Object Lambda `WriteGetObjectResponse` calls |
+| Method                       | Description                                                   |
+| ---------------------------- | ------------------------------------------------------------- |
+| `getNotifications()`         | List S3 notification events                                   |
+| `tickLifecycle()`            | Tick the lifecycle processor                                  |
+| `getAccessPoints()`          | List configured S3 access points                              |
+| `getObjectLambdaResponses()` | List recorded S3 Object Lambda `WriteGetObjectResponse` calls |
 
 ### `fc.scheduler`
 
-| Method                       | Description                                                  |
-| ---------------------------- | ------------------------------------------------------------ |
-| `getSchedules()`             | List every EventBridge Scheduler schedule                    |
-| `fireSchedule(group, name)`  | Fire a schedule manually, bypassing the cron tick            |
+| Method                      | Description                                       |
+| --------------------------- | ------------------------------------------------- |
+| `getSchedules()`            | List every EventBridge Scheduler schedule         |
+| `fireSchedule(group, name)` | Fire a schedule manually, bypassing the cron tick |
 
 ### `fc.secretsmanager`
 
@@ -268,28 +268,28 @@ Top-level client. Defaults to `http://localhost:4566`.
 
 ### `fc.ses`
 
-| Method                                | Description                                                                |
-| ------------------------------------- | -------------------------------------------------------------------------- |
-| `getEmails()`                         | List all sent emails                                                       |
-| `simulateInbound(req)`                | Simulate an inbound email (receipt rules)                                  |
-| `getMetrics()`                        | Aggregate counters for sends / bounces / complaints / deliveries           |
-| `getBounces()`                        | List recorded bounce events                                                |
-| `setSandbox(sandbox)`                 | Toggle SES account sandbox mode                                            |
-| `getEventDestinationDeliveries()`     | List event-destination delivery records (SNS / Firehose / EventBridge)     |
-| `getDkimPublicKey(identity)`          | Return the DKIM public key fakecloud minted for an identity                |
-| `setMailFromStatus(identity, status)` | Flip a custom MAIL FROM domain's verification status synchronously         |
-| `getMessageInsights(messageId)`       | Return Message Insights for a sent message                                 |
-| `getSmtpSubmissions()`                | List messages submitted via the SMTP endpoint                              |
+| Method                                | Description                                                            |
+| ------------------------------------- | ---------------------------------------------------------------------- |
+| `getEmails()`                         | List all sent emails                                                   |
+| `simulateInbound(req)`                | Simulate an inbound email (receipt rules)                              |
+| `getMetrics()`                        | Aggregate counters for sends / bounces / complaints / deliveries       |
+| `getBounces()`                        | List recorded bounce events                                            |
+| `setSandbox(sandbox)`                 | Toggle SES account sandbox mode                                        |
+| `getEventDestinationDeliveries()`     | List event-destination delivery records (SNS / Firehose / EventBridge) |
+| `getDkimPublicKey(identity)`          | Return the DKIM public key fakecloud minted for an identity            |
+| `setMailFromStatus(identity, status)` | Flip a custom MAIL FROM domain's verification status synchronously     |
+| `getMessageInsights(messageId)`       | Return Message Insights for a sent message                             |
+| `getSmtpSubmissions()`                | List messages submitted via the SMTP endpoint                          |
 
 ### `fc.sns`
 
-| Method                      | Description                                                          |
-| --------------------------- | -------------------------------------------------------------------- |
-| `getMessages()`             | List all published messages                                          |
-| `getPendingConfirmations()` | List subscriptions pending confirmation                              |
-| `confirmSubscription(req)`  | Confirm a pending subscription                                       |
-| `getCertPem()`              | Return the PEM-encoded SNS signing certificate (raw PEM, not JSON)   |
-| `getSms()`                  | List recorded SMS messages dispatched via `SNS Publish`              |
+| Method                      | Description                                                        |
+| --------------------------- | ------------------------------------------------------------------ |
+| `getMessages()`             | List all published messages                                        |
+| `getPendingConfirmations()` | List subscriptions pending confirmation                            |
+| `confirmSubscription(req)`  | Confirm a pending subscription                                     |
+| `getCertPem()`              | Return the PEM-encoded SNS signing certificate (raw PEM, not JSON) |
+| `getSms()`                  | List recorded SMS messages dispatched via `SNS Publish`            |
 
 ### `fc.sqs`
 
@@ -301,26 +301,26 @@ Top-level client. Defaults to `http://localhost:4566`.
 
 ### `fc.ssm`
 
-| Method                                    | Description                                                                  |
-| ----------------------------------------- | ---------------------------------------------------------------------------- |
-| `setCommandStatus(commandId, req)`        | Flip a Run Command's status synchronously                                    |
-| `failCommand(commandId, req?)`            | Mark a Run Command's invocations as failed (all or a single instance)        |
-| `getParameterPolicyEvents(accountId?)`    | List recorded SSM parameter-policy lifecycle events                          |
-| `injectSession(req)`                      | Inject a fake Session Manager session without going through `StartSession`   |
+| Method                                 | Description                                                                |
+| -------------------------------------- | -------------------------------------------------------------------------- |
+| `setCommandStatus(commandId, req)`     | Flip a Run Command's status synchronously                                  |
+| `failCommand(commandId, req?)`         | Mark a Run Command's invocations as failed (all or a single instance)      |
+| `getParameterPolicyEvents(accountId?)` | List recorded SSM parameter-policy lifecycle events                        |
+| `injectSession(req)`                   | Inject a fake Session Manager session without going through `StartSession` |
 
 ### `fc.stepfunctions`
 
-| Method                       | Description                                                              |
-| ---------------------------- | ------------------------------------------------------------------------ |
-| `getExecutions()`            | List all state machine executions                                        |
-| `getSyncExecutions()`        | List recorded `StartSyncExecution` results                               |
-| `getExecutionTree(arn)`      | Return the full execution tree (parent + nested child workflows)         |
-| `enqueueActivityTask(req)`   | Enqueue an Activity task directly for a worker to `GetActivityTask`      |
+| Method                     | Description                                                         |
+| -------------------------- | ------------------------------------------------------------------- |
+| `getExecutions()`          | List all state machine executions                                   |
+| `getSyncExecutions()`      | List recorded `StartSyncExecution` results                          |
+| `getExecutionTree(arn)`    | Return the full execution tree (parent + nested child workflows)    |
+| `enqueueActivityTask(req)` | Enqueue an Activity task directly for a worker to `GetActivityTask` |
 
 ### `fc.wafv2`
 
-| Method          | Description                                                                  |
-| --------------- | ---------------------------------------------------------------------------- |
+| Method          | Description                                                                   |
+| --------------- | ----------------------------------------------------------------------------- |
 | `evaluate(req)` | Run an arbitrary request payload against the configured WebACLs (opaque JSON) |
 
 #### Full test loop -- asserting on Bedrock calls

--- a/website/content/docs/sdks/_index.md
+++ b/website/content/docs/sdks/_index.md
@@ -19,7 +19,7 @@ These SDKs are **not** the AWS SDK. Your application code still talks to fakeclo
 | Python     | `pip install fakecloud`                         | [Python SDK](/docs/sdks/python/) |
 | Go         | `go get github.com/faiscadev/fakecloud/sdks/go` | [Go SDK](/docs/sdks/go/) |
 | PHP        | `composer require fakecloud/fakecloud`          | [PHP SDK](/docs/sdks/php/) |
-| Java       | `dev.fakecloud:fakecloud:0.12.0`                 | [Java SDK](/docs/sdks/java/) |
+| Java       | `dev.fakecloud:fakecloud:0.15.0`                 | [Java SDK](/docs/sdks/java/) |
 | Rust       | `cargo add fakecloud-sdk`                       | [Rust SDK](/docs/sdks/rust/) |
 
 ## Common surface
@@ -31,5 +31,13 @@ All six SDKs cover the same core surface:
 - **Per-service introspection:** get recorded messages, emails, invocations, events
 - **Simulation and processor ticks:** drive time-dependent behavior on demand (TTL expiration, secret rotation, S3 lifecycle)
 - **Bedrock test harness:** response configuration, fault injection, call history
+- **AWS metadata endpoints:** ECS task metadata (v3, v4), task credentials
+- **Admin state mutation:** flip CloudFront distribution status, Route53 health-check status, SSM command status, ACM certificate status, SES sandbox/mail-from status
+- **DNSSEC:** Route53 zone DNSSEC material + RRSIG signing
+- **Code/layer downloads:** Lambda function code, Lambda layer content (raw bytes)
+- **Container/cache introspection:** ECS clusters/tasks/events, ElastiCache clusters/replication-groups/serverless-caches/ACLs, ECR repositories/images/pull-through rules
+- **Logs introspection:** anomaly injection, delivery config, field indexes
+- **API Gateway v2:** recorded HTTP requests, WebSocket connections, mTLS info, ws:// URL builder
+- **RDS bridge:** aws_lambda invoke, aws_s3 import/export
 
 The method names differ across languages to match each language's idiom (camelCase for TS/JS, Java, and PHP, snake_case for Python, PascalCase for Go, snake_case for Rust), but the behavior is the same.

--- a/website/content/docs/sdks/go.md
+++ b/website/content/docs/sdks/go.md
@@ -334,7 +334,7 @@ func TestAppPublishesToSQS(t *testing.T) {
 
     cfg, _ := config.LoadDefaultConfig(ctx,
         config.WithRegion("us-east-1"),
-        config.WithCredentialsProvider(aws.AnonymousCredentialsProvider{}),
+        config.WithCredentialsProvider(aws.AnonymousCredentials{}),
     )
     sqsClient := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
         o.BaseEndpoint = aws.String("http://localhost:4566")

--- a/website/content/docs/sdks/go.md
+++ b/website/content/docs/sdks/go.md
@@ -15,61 +15,297 @@ Go 1.21+.
 ## Initialize
 
 ```go
-import "github.com/faiscadev/fakecloud/sdks/go/fakecloud"
+import fakecloud "github.com/faiscadev/fakecloud/sdks/go"
 
 fc := fakecloud.New("http://localhost:4566")
-// or with default URL:
-fc := fakecloud.NewDefault() // http://localhost:4566
 ```
+
+Sub-clients are accessed via methods: `fc.SES()`, `fc.SNS()`, `fc.Lambda()`, etc.
 
 ## Top-level
 
-| Method                      | Description             |
-| --------------------------- | ----------------------- |
-| `Health() error`            | Server health check     |
-| `Reset() error`             | Reset all service state |
-| `ResetService(svc) error`   | Reset a single service  |
+| Method | Description |
+|--------|-------------|
+| `New(baseURL)` | Create a new client |
+| `Health(ctx)` | Server health check |
+| `Reset(ctx)` | Reset all service state |
+| `ResetService(ctx, service)` | Reset a single service |
+| `CreateAdmin(ctx, accountID, userName)` | Bootstrap an admin user in a secondary account |
 
-## `fc.Bedrock`
+## `fc.SES()`
 
-| Method                                       | Description                                       |
-| -------------------------------------------- | ------------------------------------------------- |
-| `GetInvocations()`                           | List runtime invocations (with `Error` field)     |
-| `SetModelResponse(modelID, text)`            | Single canned response for a model                |
-| `SetResponseRules(modelID, rules)`           | Prompt-conditional rules                          |
-| `ClearResponseRules(modelID)`                | Clear rules for a model                           |
-| `QueueFault(rule)`                           | Queue a fault rule                                |
-| `GetFaults()`                                | List queued fault rules                           |
-| `ClearFaults()`                              | Clear all queued fault rules                      |
+| Method | Description |
+|--------|-------------|
+| `GetEmails(ctx)` | List all sent emails |
+| `SimulateInbound(ctx, req)` | Simulate an inbound email |
+| `GetMetrics(ctx)` | Aggregate send/delivery metrics |
+| `SetMailFromStatus(ctx, req)` | Drive custom MAIL FROM verification state |
+| `GetDkimPublicKey(ctx, identity)` | Fetch the synthetic DKIM public key for an identity |
+| `GetBounces(ctx)` | List simulated bounce/complaint events |
+| `GetMessageInsights(ctx)` | Per-message insights |
+| `GetSmtpSubmissions(ctx)` | List submissions made through the SMTP endpoint |
+| `GetEventDestinationDeliveries(ctx)` | List event-destination delivery attempts |
+| `SetSandbox(ctx, req)` | Toggle SES sandbox mode |
 
-## `fc.Lambda`
+## `fc.SNS()`
 
-| Method                              | Description                          |
-| ----------------------------------- | ------------------------------------ |
-| `GetInvocations()`                  | List Lambda invocations              |
-| `GetWarmContainers()`               | List warm containers                 |
-| `EvictContainer(functionName)`      | Evict a warm container               |
+| Method | Description |
+|--------|-------------|
+| `GetMessages(ctx)` | List published messages |
+| `GetPendingConfirmations(ctx)` | List pending subscription confirmations |
+| `ConfirmSubscription(ctx, req)` | Confirm a subscription |
+| `GetCertPEM(ctx)` | Fetch the PEM used to sign SNS HTTP/S notifications |
+| `GetSMSMessages(ctx)` | List SMS messages delivered to phone numbers |
 
-## `fc.SES`, `fc.SNS`, `fc.SQS`, `fc.Events`, `fc.S3`, `fc.DynamoDB`, `fc.SecretsManager`, `fc.Cognito`, `fc.StepFunctions`, `fc.RDS`, `fc.APIGatewayV2`
+## `fc.SQS()`
 
-Each mirrors the TypeScript SDK's surface with Go method naming (`GetMessages`, `TickTTL`, `FireRule`, etc.). See the [TypeScript reference](/docs/sdks/typescript/) for the full method list — the semantics are identical.
+| Method | Description |
+|--------|-------------|
+| `GetMessages(ctx)` | List all messages across queues |
+| `TickExpiration(ctx)` | Tick the expiration processor |
+| `ForceDLQ(ctx, queueName)` | Force messages to DLQ |
 
-The authoritative per-method list for Go lives in the [Go SDK source README](https://github.com/faiscadev/fakecloud/blob/main/sdks/go/README.md).
+## `fc.Events()`
+
+| Method | Description |
+|--------|-------------|
+| `GetHistory(ctx)` | Get event history and deliveries |
+| `FireRule(ctx, req)` | Manually fire a rule |
+
+## `fc.Scheduler()`
+
+| Method | Description |
+|--------|-------------|
+| `GetSchedules(ctx)` | List EventBridge Scheduler schedules with next-fire metadata |
+| `FireSchedule(ctx, req)` | Manually fire a schedule once |
+
+## `fc.Glue()`
+
+| Method | Description |
+|--------|-------------|
+| `GetJobs(ctx)` | List Glue job definitions |
+| `GetJobRuns(ctx)` | List Glue job runs with status |
+
+## `fc.S3()`
+
+| Method | Description |
+|--------|-------------|
+| `GetNotifications(ctx)` | List notification events |
+| `TickLifecycle(ctx)` | Tick the lifecycle processor |
+| `GetAccessPoints(ctx)` | List S3 access points |
+| `GetObjectLambdaResponses(ctx)` | List Object Lambda transformed responses |
+
+## `fc.Lambda()`
+
+| Method | Description |
+|--------|-------------|
+| `GetInvocations(ctx)` | List Lambda invocations |
+| `GetWarmContainers(ctx)` | List warm containers |
+| `DownloadFunctionCode(ctx, functionName)` | Download a function's deployment package |
+| `DownloadLayerContent(ctx, layerName, versionNumber)` | Download a layer version's zip content |
+| `EvictContainer(ctx, functionName)` | Evict a warm container |
+
+## `fc.RDS()`
+
+| Method | Description |
+|--------|-------------|
+| `GetInstances(ctx)` | List RDS instances with runtime metadata |
+| `LambdaInvoke(ctx, req)` | Drive the `aws_lambda` Postgres extension bridge |
+| `S3Import(ctx, req)` | Drive the `aws_s3.table_import_from_s3` bridge |
+| `S3Export(ctx, req)` | Drive the `aws_s3.query_export_to_s3` bridge |
+
+## `fc.ElastiCache()`
+
+| Method | Description |
+|--------|-------------|
+| `GetClusters(ctx)` | List cache clusters |
+| `GetReplicationGroups(ctx)` | List replication groups |
+| `GetServerlessCaches(ctx)` | List serverless caches |
+| `GetElastiCacheAcls(ctx)` | List RBAC users and ACLs |
+
+## `fc.Athena()`
+
+| Method | Description |
+|--------|-------------|
+| `GetNamedQueries(ctx)` | List saved named queries |
+
+## `fc.ECR()`
+
+| Method | Description |
+|--------|-------------|
+| `GetRepositories(ctx)` | List ECR repositories |
+| `GetImages(ctx)` | List images across repositories |
+| `GetPullThroughRules(ctx)` | List pull-through cache rules |
+
+## `fc.DynamoDB()`
+
+| Method | Description |
+|--------|-------------|
+| `TickTTL(ctx)` | Tick the TTL processor |
+
+## `fc.SecretsManager()`
+
+| Method | Description |
+|--------|-------------|
+| `TickRotation(ctx)` | Tick the rotation scheduler |
+
+## `fc.Cognito()`
+
+| Method | Description |
+|--------|-------------|
+| `GetUserCodes(ctx, poolID, username)` | Get codes for a user |
+| `GetConfirmationCodes(ctx)` | List all confirmation codes |
+| `ConfirmUser(ctx, req)` | Confirm a user |
+| `GetTokens(ctx)` | List active tokens |
+| `ExpireTokens(ctx, req)` | Expire tokens |
+| `GetAuthEvents(ctx)` | List auth events |
+| `MintAuthorizationCode(ctx, req)` | Mint a single-use OAuth2 authorization code |
+| `SetCompromisedPasswords(ctx, req)` | Mark passwords as compromised to drive advanced security |
+| `GetPreTokenGenInvocations(ctx)` | List pre-token-generation Lambda invocations |
+| `GetWebAuthnCredentials(ctx)` | List registered WebAuthn credentials |
+
+## `fc.ApiGatewayV2()`
+
+| Method | Description |
+|--------|-------------|
+| `GetRequests(ctx)` | List all HTTP API requests received |
+| `GetConnections(ctx)` | List active WebSocket connections |
+| `GetDomainNameMtlsInfo(ctx, domainName)` | Inspect mTLS trust-store config for a custom domain |
+| `WsURL(stage, apiID)` | Build a `ws://` URL for a WebSocket stage |
+
+## `fc.StepFunctions()`
+
+| Method | Description |
+|--------|-------------|
+| `GetExecutions(ctx)` | List all state machine execution history |
+| `GetSyncExecutions(ctx)` | List `StartSyncExecution` results (Express workflows) |
+| `GetExecutionTree(ctx, executionArn)` | Get the parent/child execution tree |
+| `EnqueueActivityTask(ctx, req)` | Enqueue an activity-task heartbeat/result for a worker |
+
+## `fc.Bedrock()`
+
+| Method | Description |
+|--------|-------------|
+| `GetInvocations(ctx)` | List runtime invocations (with `Error` field) |
+| `SetModelResponse(ctx, modelID, text)` | Single canned response for a model |
+| `SetResponseRules(ctx, modelID, rules)` | Prompt-conditional rules |
+| `ClearResponseRules(ctx, modelID)` | Clear rules for a model |
+| `QueueFault(ctx, rule)` | Queue a fault rule |
+| `GetFaults(ctx)` | List queued fault rules |
+| `ClearFaults(ctx)` | Clear all queued fault rules |
+
+## `fc.BedrockAgent()` / `fc.BedrockAgentRuntime()`
+
+| Method | Description |
+|--------|-------------|
+| `BedrockAgent().GetAgents(ctx)` | List configured Bedrock agents |
+| `BedrockAgentRuntime().GetInvocations(ctx)` | List recorded agent runtime invocations |
+
+## `fc.ECS()`
+
+| Method | Description |
+|--------|-------------|
+| `GetClusters(ctx)` | List ECS clusters |
+| `GetTasks(ctx)` | List tasks |
+| `GetTask(ctx, taskArn)` | Get a single task |
+| `GetTaskLogs(ctx, taskArn)` | Get logs for a task |
+| `ForceStopTask(ctx, taskArn)` | Forcibly stop a task |
+| `MarkTaskFailed(ctx, taskArn, req)` | Inject a failure into a task |
+| `GetEvents(ctx)` | List ECS lifecycle events |
+| `GetTaskMetadata(ctx, taskArn)` | Container-agent task metadata |
+| `GetTaskCredentials(ctx, credentialID)` | Task-role credentials served to containers |
+| `GetTaskMetadataV3(ctx, taskArn)` | Task metadata endpoint v3 |
+| `GetTaskMetadataV4(ctx, taskArn)` | Task metadata endpoint v4 |
+
+## `fc.ELBv2()`
+
+| Method | Description |
+|--------|-------------|
+| `GetLoadBalancers(ctx)` | List load balancers (ALB/NLB/GWLB) |
+| `GetTargetGroups(ctx)` | List target groups |
+| `GetListeners(ctx)` | List listeners |
+| `GetRules(ctx)` | List listener rules |
+| `GetWafCounts(ctx)` | WAF allow/block counters per listener |
+| `FlushAccessLogs(ctx)` | Flush buffered access logs to S3 |
+
+## `fc.Route53()`
+
+| Method | Description |
+|--------|-------------|
+| `SetHealthCheckStatus(ctx, id, req)` | Flip a health check between `Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown` |
+| `GetDnssecMaterial(ctx, hostedZoneID)` | Fetch DNSSEC KSK/ZSK material for a hosted zone |
+| `SignRRset(ctx, req)` | Produce an RRSIG over an RRset for offline verification |
+
+## `fc.ACM()`
+
+| Method | Description |
+|--------|-------------|
+| `SetCertificateStatus(ctx, arn, req)` | Force a certificate into `ISSUED`/`FAILED`/etc. |
+| `ApproveCertificate(ctx, arn)` | Approve a pending certificate |
+| `GetCertificateChainInfo(ctx, arn)` | Inspect issuer and chain metadata |
+
+## `fc.Logs()`
+
+| Method | Description |
+|--------|-------------|
+| `InjectAnomaly(ctx, req)` | Inject a Log Anomaly Detection finding |
+| `GetDeliveryConfig(ctx)` | Inspect log-delivery configurations |
+| `GetFieldIndexes(ctx)` | List configured field indexes |
+
+## `fc.ApplicationAutoScaling()`
+
+| Method | Description |
+|--------|-------------|
+| `Tick(ctx)` | Run scaling evaluation once |
+| `ScheduledTick(ctx)` | Run scheduled-action evaluation once |
+
+## `fc.Organizations()`
+
+| Method | Description |
+|--------|-------------|
+| `GetAccounts(ctx)` | List accounts in the organization |
+
+## `fc.SSM()`
+
+| Method | Description |
+|--------|-------------|
+| `SetCommandStatus(ctx, commandID, req)` | Drive a Run Command to `Success`/`Failed`/etc. |
+| `FailCommand(ctx, commandID, req)` | Convenience helper to fail a command with a reason |
+| `GetParameterPolicyEvents(ctx)` | List parameter-policy expiration/notification events |
+| `InjectSession(ctx, req)` | Inject a Session Manager session record |
+
+## `fc.KMS()`
+
+| Method | Description |
+|--------|-------------|
+| `GetUsage(ctx)` | Per-key usage counters (encrypt/decrypt/sign/verify) |
+
+## `fc.WAFv2()`
+
+| Method | Description |
+|--------|-------------|
+| `Evaluate(ctx, req)` | Evaluate a request against a Web ACL and return the verdict |
+
+## `fc.CloudFront()`
+
+| Method | Description |
+|--------|-------------|
+| `SetDistributionStatus(ctx, id, req)` | Force a distribution into `Deployed`/`InProgress` |
 
 ## Error handling
 
-Methods return `*FakeCloudError` on non-2xx responses:
+Methods return `*fakecloud.APIError` on non-2xx responses:
 
 ```go
-_, err := fc.Cognito.ConfirmUser(ConfirmUserRequest{
+_, err := fc.Cognito().ConfirmUser(ctx, fakecloud.ConfirmUserRequest{
     UserPoolID: "pool-1",
     Username:   "nobody",
 })
 if err != nil {
-    var fcErr *fakecloud.FakeCloudError
-    if errors.As(err, &fcErr) {
-        fmt.Println(fcErr.Status) // 404
-        fmt.Println(fcErr.Body)
+    var apiErr *fakecloud.APIError
+    if errors.As(err, &apiErr) {
+        fmt.Println(apiErr.StatusCode) // 404
+        fmt.Println(apiErr.Body)
     }
 }
 ```
@@ -86,24 +322,25 @@ import (
     "github.com/aws/aws-sdk-go-v2/aws"
     "github.com/aws/aws-sdk-go-v2/config"
     "github.com/aws/aws-sdk-go-v2/service/sqs"
-    "github.com/faiscadev/fakecloud/sdks/go/fakecloud"
+    fakecloud "github.com/faiscadev/fakecloud/sdks/go"
 )
 
 func TestAppPublishesToSQS(t *testing.T) {
-    fc := fakecloud.NewDefault()
-    if err := fc.Reset(); err != nil {
+    ctx := context.Background()
+    fc := fakecloud.New("http://localhost:4566")
+    if err := fc.Reset(ctx); err != nil {
         t.Fatal(err)
     }
 
-    cfg, _ := config.LoadDefaultConfig(context.TODO(),
+    cfg, _ := config.LoadDefaultConfig(ctx,
         config.WithRegion("us-east-1"),
-        config.WithCredentialsProvider(aws.AnonymousCredentials{}),
+        config.WithCredentialsProvider(aws.AnonymousCredentialsProvider{}),
     )
     sqsClient := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
         o.BaseEndpoint = aws.String("http://localhost:4566")
     })
 
-    _, err := sqsClient.SendMessage(context.TODO(), &sqs.SendMessageInput{
+    _, err := sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
         QueueUrl:    aws.String("http://localhost:4566/000000000000/my-queue"),
         MessageBody: aws.String("hello"),
     })
@@ -111,15 +348,15 @@ func TestAppPublishesToSQS(t *testing.T) {
         t.Fatal(err)
     }
 
-    messages, err := fc.SQS.GetMessages()
+    messages, err := fc.SQS().GetMessages(ctx)
     if err != nil {
         t.Fatal(err)
     }
-    if len(messages) != 1 {
-        t.Fatalf("expected 1 message, got %d", len(messages))
+    if len(messages.Messages) != 1 {
+        t.Fatalf("expected 1 message, got %d", len(messages.Messages))
     }
-    if messages[0].Body != "hello" {
-        t.Fatalf("expected body 'hello', got %q", messages[0].Body)
+    if messages.Messages[0].Body != "hello" {
+        t.Fatalf("expected body 'hello', got %q", messages.Messages[0].Body)
     }
 }
 ```

--- a/website/content/docs/sdks/java.md
+++ b/website/content/docs/sdks/java.md
@@ -10,7 +10,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.12.0")
+    testImplementation("dev.fakecloud:fakecloud:0.15.0")
 }
 ```
 
@@ -20,7 +20,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.12.0</version>
+    <version>0.15.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -38,11 +38,167 @@ FakeCloud fc2 = new FakeCloud("http://localhost:5000"); // explicit base URL
 
 ## Top-level
 
-| Method                  | Description             |
-| ----------------------- | ----------------------- |
-| `health()`              | Server health check     |
-| `reset()`               | Reset all service state |
-| `resetService(service)` | Reset a single service  |
+| Method                              | Description                              |
+| ----------------------------------- | ---------------------------------------- |
+| `health()`                          | Server health check                      |
+| `reset()`                           | Reset all service state                  |
+| `resetService(service)`             | Reset a single service                   |
+| `createAdmin(accountId, userName)`  | Bootstrap an admin IAM user in an account |
+
+## `fc.lambda()`
+
+| Method                                                       | Description                                                              |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| `getInvocations()`                                           | List recorded Lambda invocations                                         |
+| `getWarmContainers()`                                        | List warm (cached) Lambda containers                                     |
+| `evictContainer(functionName)`                               | Evict a warm container                                                   |
+| `downloadFunctionCode(accountId, functionName, qualifier)`   | Download the stored zip for a function version (`"latest"` or version)   |
+| `downloadLayerContent(accountId, layerName, version)`        | Download the stored zip for a layer version                              |
+
+## `fc.rds()`
+
+| Method                  | Description                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| `getInstances()`        | List RDS instances with runtime metadata                                     |
+| `lambdaInvoke(req)`     | Bridge endpoint for the PostgreSQL `aws_lambda` extension                    |
+| `s3Import(req)`         | Bridge endpoint for the PostgreSQL `aws_s3` extension (fetch object)         |
+| `s3Export(req)`         | Bridge equivalent of `S3:PutObject` from inside the DB container             |
+
+## `fc.elasticache()`
+
+| Method                    | Description                         |
+| ------------------------- | ----------------------------------- |
+| `getClusters()`           | List ElastiCache cache clusters     |
+| `getReplicationGroups()`  | List ElastiCache replication groups |
+| `getServerlessCaches()`   | List ElastiCache serverless caches  |
+| `getElastiCacheAcls()`    | List ElastiCache (Valkey/Redis) ACLs |
+
+## `fc.ecr()`
+
+| Method                                  | Description                                                  |
+| --------------------------------------- | ------------------------------------------------------------ |
+| `getRepositories()`                     | List ECR repositories                                        |
+| `getImages()`                           | List all ECR images                                          |
+| `getImagesForRepository(repositoryName)`| Filter images by repository                                  |
+| `getPullThroughRules()`                 | List configured pull-through cache rules                     |
+
+## `fc.logs()`
+
+| Method                            | Description                                       |
+| --------------------------------- | ------------------------------------------------- |
+| `injectAnomaly(req)`              | Inject a Log Anomaly Detector anomaly             |
+| `getDeliveryConfig()`             | Persisted CloudWatch Logs delivery configurations |
+| `getFieldIndexes(logGroupName)`   | Parsed `Fields` from index policies on a log group |
+
+## `fc.ses()`
+
+| Method                              | Description                                       |
+| ----------------------------------- | ------------------------------------------------- |
+| `getEmails()`                       | List all sent emails                              |
+| `simulateInbound(req)`              | Simulate an inbound email (receipt rules)         |
+| `getMetrics()`                      | Return aggregated send/bounce/complaint counters  |
+| `setMailFromStatus(identity, status)`| Force a MAIL FROM verification status              |
+| `getDkimPublicKey(identity)`        | Fetch the DKIM public key for an identity         |
+| `setSandbox(sandbox)`               | Toggle the account-level sandbox flag             |
+| `getBounces()`                      | List captured bounce events                       |
+| `getMessageInsights(messageId)`     | Fetch Message Insights for a sent message         |
+| `getSmtpSubmissions()`              | List SMTP submission attempts                     |
+| `getEventDestinationDeliveries()`   | List event-destination delivery records           |
+
+## `fc.sns()`
+
+| Method                       | Description                                                                                  |
+| ---------------------------- | -------------------------------------------------------------------------------------------- |
+| `getMessages()`              | List all published messages                                                                  |
+| `getPendingConfirmations()`  | List subscriptions pending confirmation                                                      |
+| `confirmSubscription(req)`   | Confirm a pending subscription                                                               |
+| `getCertPem()`               | Return the PEM-encoded SNS signing cert used by message signature validators                 |
+| `getSmsMessages()`           | List captured SMS messages SNS has "delivered"                                               |
+
+## `fc.sqs()`
+
+| Method                 | Description                           |
+| ---------------------- | ------------------------------------- |
+| `getMessages()`        | List all messages across all queues   |
+| `tickExpiration()`     | Tick the message expiration processor |
+| `forceDlq(queueName)`  | Force all messages to the queue's DLQ |
+
+## `fc.events()`
+
+| Method           | Description                            |
+| ---------------- | -------------------------------------- |
+| `getHistory()`   | Get event history and delivery records |
+| `fireRule(req)`  | Fire an EventBridge rule manually      |
+
+## `fc.scheduler()`
+
+| Method                          | Description                                  |
+| ------------------------------- | -------------------------------------------- |
+| `getSchedules()`                | List EventBridge Scheduler schedules         |
+| `fireSchedule(group, name)`     | Fire a single schedule immediately           |
+
+## `fc.glue()`
+
+| Method                   | Description                                  |
+| ------------------------ | -------------------------------------------- |
+| `getJobs()`              | List registered Glue jobs                    |
+| `getJobRuns()`           | List all Glue job runs                       |
+| `getJobRuns(jobName)`    | Filter job runs by job name                  |
+
+## `fc.s3()`
+
+| Method                          | Description                                  |
+| ------------------------------- | -------------------------------------------- |
+| `getNotifications()`            | List S3 notification events                  |
+| `tickLifecycle()`               | Tick the lifecycle processor                 |
+| `getAccessPoints()`             | List S3 access points                        |
+| `getObjectLambdaResponses()`    | List S3 Object Lambda responses captured     |
+
+## `fc.dynamodb()`
+
+| Method       | Description            |
+| ------------ | ---------------------- |
+| `tickTtl()`  | Tick the TTL processor |
+
+## `fc.secretsmanager()`
+
+| Method            | Description                 |
+| ----------------- | --------------------------- |
+| `tickRotation()`  | Tick the rotation scheduler |
+
+## `fc.cognito()`
+
+| Method                                | Description                                                                                  |
+| ------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `getUserCodes(poolId, username)`      | Get confirmation codes for a user                                                            |
+| `getConfirmationCodes()`              | List all confirmation codes                                                                  |
+| `confirmUser(req)`                    | Force-confirm a user (bypass verification)                                                   |
+| `getTokens()`                         | List all active tokens                                                                       |
+| `expireTokens(req)`                   | Expire tokens (optionally filtered)                                                          |
+| `getAuthEvents()`                     | List auth events                                                                             |
+| `getPreTokenGenInvocations()`         | List PreTokenGeneration Lambda trigger invocations recorded by `InitiateAuth`                |
+| `mintAuthorizationCode(req)`          | Mint a single-use OAuth2 authorization code (programmatic alternative to `/oauth2/authorize`) |
+| `setCompromisedPasswords(req)`        | Seed the compromised-password list used by Advanced Security                                 |
+| `getWebAuthnCredentials()`            | List stored WebAuthn credentials                                                             |
+
+## `fc.apigatewayv2()`
+
+| Method                              | Description                                                                                  |
+| ----------------------------------- | -------------------------------------------------------------------------------------------- |
+| `getRequests()`                     | List all HTTP API requests received                                                          |
+| `getConnections()`                  | List every active WebSocket connection tracked by API Gateway v2                             |
+| `getDomainNameMtlsInfo(domainName)` | Fetch the mTLS truststore info for a custom domain (free-form JSON map)                      |
+| `wsUrl(apiId)`                      | Build the WebSocket URL for the given API id on the default `$default` stage                 |
+| `wsUrl(apiId, stage)`               | Build the WebSocket URL for the given API id and stage                                       |
+
+## `fc.stepfunctions()`
+
+| Method                       | Description                                                                  |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| `getExecutions()`            | List all state machine execution history                                     |
+| `getSyncExecutions()`        | List synchronous (`StartSyncExecution`) results                              |
+| `getExecutionTree(arn)`      | Full parent/child execution tree under an execution ARN                      |
+| `enqueueActivityTask(req)`   | Push a synthetic activity task onto an activity worker queue                 |
 
 ## `fc.bedrock()`
 
@@ -56,11 +212,106 @@ FakeCloud fc2 = new FakeCloud("http://localhost:5000"); // explicit base URL
 | `getFaults()`                       | List currently queued fault rules                                    |
 | `clearFaults()`                     | Clear all queued fault rules                                         |
 
-## `fc.lambda()`, `fc.ses()`, `fc.sns()`, `fc.sqs()`, `fc.events()`, `fc.s3()`, `fc.dynamodb()`, `fc.secretsmanager()`, `fc.cognito()`, `fc.stepfunctions()`, `fc.rds()`, `fc.elasticache()`, `fc.apigatewayv2()`
+## `fc.bedrockAgent()`
 
-Each sub-client mirrors the TypeScript SDK method list 1:1. See the
-[SDK README](https://github.com/faiscadev/fakecloud/blob/main/sdks/java/README.md)
-for the full, always-current surface.
+| Method        | Description                                  |
+| ------------- | -------------------------------------------- |
+| `getAgents()` | List Bedrock Agent (control plane) agents    |
+
+## `fc.bedrockAgentRuntime()`
+
+| Method             | Description                                  |
+| ------------------ | -------------------------------------------- |
+| `getInvocations()` | List Bedrock Agent Runtime invocations       |
+
+## `fc.ecs()`
+
+| Method                              | Description                                                                                  |
+| ----------------------------------- | -------------------------------------------------------------------------------------------- |
+| `getClusters()`                     | List ECS clusters                                                                            |
+| `getTasks(cluster, status)`         | List tracked tasks, optionally filtered by cluster and status                                |
+| `getTask(taskId)`                   | Fetch a single task snapshot by task ID                                                      |
+| `getTaskLogs(taskId)`               | Captured stdout/stderr for a task plus its exit code if known                                |
+| `forceStopTask(taskId)`             | SIGTERM (then SIGKILL after 10s) the task's running container                                |
+| `markTaskFailed(taskId, req)`       | Flip a task to `STOPPED` without killing the container                                       |
+| `getEvents()`                       | Replay the lifecycle event log                                                               |
+| `getTaskMetadata(taskArn)`          | Aggregated v4 metadata dump for a task (by full ARN)                                         |
+| `getCredentials(taskId)`            | Return short-lived IAM credentials for a task (matches the wire shape ECS exposes)           |
+| `getMetadataV3(taskId)`             | Raw v3 task metadata document (free-form `Map<String, Object>`)                              |
+| `getMetadataV4(taskId)`             | Raw v4 task metadata document (free-form `Map<String, Object>`)                              |
+
+## `fc.elbv2()`
+
+| Method               | Description                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------- |
+| `getLoadBalancers()` | List ELBv2 load balancers (ALB/NLB/GWLB)                                                     |
+| `getTargetGroups()`  | List ELBv2 target groups                                                                     |
+| `getListeners()`     | List ELBv2 listeners                                                                         |
+| `getRules()`         | List ELBv2 listener rules                                                                    |
+| `flushAccessLogs()`  | Force every buffered access-log + connection-log line to flush to S3 immediately             |
+| `getWafCounts()`     | Return WAFv2 association/evaluation counts the ELBv2 service has accumulated                 |
+
+## `fc.route53()`
+
+| Method                                              | Description                                                                                                                          |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `setHealthCheckStatus(id, status, reason)`          | Flip a health check between `Success` / `Failure` to drive failover routing in tests; reason is appended to `<Status>` (pass `null` to omit) |
+| `getDnssecMaterial(zoneId)`                         | Fetch DNSSEC material (DNSKEY + DS digest) for a hosted zone with at least one ACTIVE KSK                                            |
+| `signDnssec(zoneId, req)`                           | Sign an RRset under the zone's first ACTIVE KSK and return raw RRSIG fields                                                          |
+
+## `fc.acm()`
+
+| Method                                       | Description                                                                                  |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `setCertificateStatus(arnOrId, status, reason)` | Flip an ACM certificate's status synchronously (`ISSUED` / `FAILED` / `VALIDATION_TIMED_OUT`) |
+| `approveCertificate(arnOrId)`                | Approve a `PENDING_VALIDATION` certificate (simulates the email click)                       |
+| `getCertificateChainInfo(arnOrId)`           | Inspect a stored cert's PEM block counts and byte sizes                                      |
+
+## `fc.applicationAutoscaling()`
+
+| Method            | Description                                            |
+| ----------------- | ------------------------------------------------------ |
+| `tick()`          | Tick the Application Auto Scaling alarm evaluator      |
+| `scheduledTick()` | Tick the scheduled-action processor                    |
+
+## `fc.athena()`
+
+| Method               | Description                                  |
+| -------------------- | -------------------------------------------- |
+| `getNamedQueries()`  | List every named query stored in the registry |
+
+## `fc.organizations()`
+
+| Method            | Description                                                                                  |
+| ----------------- | -------------------------------------------------------------------------------------------- |
+| `getAccounts()`   | List every member account in the org (state, parent OU, tags, directly-attached SCPs)        |
+
+## `fc.ssm()`
+
+| Method                                                  | Description                                                                                  |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `setCommandStatus(commandId, accountId, status)`        | Flip the status of every invocation under a `SendCommand` command id                         |
+| `failCommand(commandId, req)`                           | Force a command (or specific invocation) into `Failed`                                       |
+| `getParameterPolicyEvents(accountId)`                   | Return every parameter-policy event recorded for the account                                 |
+| `injectSession(req)`                                    | Drop a fake Session Manager session into state (bypassing `StartSession`)                    |
+
+## `fc.kms()`
+
+| Method        | Description                                  |
+| ------------- | -------------------------------------------- |
+| `getUsage()`  | Return every recorded KMS data-plane invocation |
+
+## `fc.wafv2()`
+
+| Method              | Description                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------- |
+| `evaluate(request)` | Evaluate an arbitrary request payload against the stored WAFv2 rule set (free-form JSON)     |
+
+## `fc.cloudfront()`
+
+| Method                                          | Description                                                                                  |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `setDistributionStatus(distributionId, status)` | Flip a stored CloudFront Distribution's status (`Deployed` / `InProgress`) without waiting   |
 
 ## Error handling
 

--- a/website/content/docs/sdks/php.md
+++ b/website/content/docs/sdks/php.md
@@ -23,29 +23,278 @@ $fc = new FakeCloud('http://localhost:5000');   // explicit base URL
 
 ## Top-level
 
-| Method                   | Description             |
-| ------------------------ | ----------------------- |
-| `health()`               | Server health check     |
-| `reset()`                | Reset all service state |
-| `resetService($service)` | Reset a single service  |
+| Method                                | Description                                          |
+| ------------------------------------- | ---------------------------------------------------- |
+| `baseUrl()`                           | Return the configured base URL                       |
+| `health()`                            | Server health check                                  |
+| `reset()`                             | Reset all service state                              |
+| `resetService($service)`              | Reset a single service                               |
+| `createAdmin($accountId, $userName)`  | Bootstrap an admin IAM user in an additional account |
+
+## `$fc->lambda()`
+
+| Method                                                        | Description                                         |
+| ------------------------------------------------------------- | --------------------------------------------------- |
+| `getInvocations()`                                            | List recorded Lambda invocations                    |
+| `getWarmContainers()`                                         | List warm (cached) Lambda containers                |
+| `evictContainer($functionName)`                               | Evict a warm container                              |
+| `downloadFunctionCode($accountId, $functionName, $qualifier)` | Download a function's stored zip bundle (raw bytes) |
+| `downloadLayerContent($accountId, $layerName, $version)`      | Download a layer version's stored zip (raw bytes)   |
+
+## `$fc->rds()`
+
+| Method                | Description                                                                |
+| --------------------- | -------------------------------------------------------------------------- |
+| `getInstances()`      | List RDS instances with runtime metadata                                   |
+| `lambdaInvoke($req)`  | Bridge endpoint for the PostgreSQL `aws_lambda` extension                  |
+| `s3Import($req)`      | Bridge endpoint for the PostgreSQL `aws_s3` extension (S3 -> DB)           |
+| `s3Export($req)`      | Bridge endpoint for the PostgreSQL `aws_s3` extension (DB -> S3 PutObject) |
+
+## `$fc->elasticache()`
+
+| Method                   | Description                         |
+| ------------------------ | ----------------------------------- |
+| `getClusters()`          | List ElastiCache cache clusters     |
+| `getReplicationGroups()` | List ElastiCache replication groups |
+| `getServerlessCaches()`  | List ElastiCache serverless caches  |
+| `getElastiCacheAcls()`   | List ElastiCache user ACLs          |
+
+## `$fc->ecr()`
+
+| Method                              | Description                           |
+| ----------------------------------- | ------------------------------------- |
+| `getRepositories()`                 | List ECR repositories                 |
+| `getImages($repositoryName = null)` | List ECR images (optionally per repo) |
+| `getPullThroughRules()`             | List ECR pull-through cache rules     |
+
+## `$fc->logs()`
+
+| Method                           | Description                                   |
+| -------------------------------- | --------------------------------------------- |
+| `injectAnomaly($req)`            | Inject a CloudWatch Logs anomaly for tests    |
+| `getDeliveryConfig()`            | Get the current Logs delivery config snapshot |
+| `getFieldIndexes($logGroupName)` | Get configured field indexes for a log group  |
+
+## `$fc->ses()`
+
+| Method                                  | Description                                                  |
+| --------------------------------------- | ------------------------------------------------------------ |
+| `getEmails()`                           | List all sent emails                                         |
+| `simulateInbound($req)`                 | Simulate an inbound email (drive receipt rules)              |
+| `getMetrics()`                          | Get SES send/bounce/complaint metrics                        |
+| `setMailFromStatus($identity, $status)` | Force a MAIL FROM domain verification status                 |
+| `getDkimPublicKey($identity)`           | Get the simulated DKIM public key for an identity            |
+| `setSandbox($sandbox)`                  | Toggle sandbox mode for the account                          |
+| `getBounces()`                          | List recorded SES bounce events                              |
+| `getMessageInsights($messageId)`        | Get SES message insights for a sent message                  |
+| `getSmtpSubmissions()`                  | List messages submitted via the SMTP submission endpoint     |
+| `getEventDestinationDeliveries()`       | List deliveries fanned out to configuration set destinations |
+
+## `$fc->sns()`
+
+| Method                      | Description                                              |
+| --------------------------- | -------------------------------------------------------- |
+| `getMessages()`             | List all published messages                              |
+| `getPendingConfirmations()` | List subscriptions pending confirmation                  |
+| `confirmSubscription($req)` | Confirm a pending subscription                           |
+| `getSigningCertPem()`       | Get the PEM body served by the SNS signing-cert endpoint |
+| `getSmsMessages()`          | List SMS messages dispatched via SNS                     |
+
+## `$fc->sqs()`
+
+| Method                 | Description                           |
+| ---------------------- | ------------------------------------- |
+| `getMessages()`        | List all messages across all queues   |
+| `tickExpiration()`     | Tick the message expiration processor |
+| `forceDlq($queueName)` | Force all messages to the queue's DLQ |
+
+## `$fc->applicationAutoscaling()`
+
+| Method            | Description                                               |
+| ----------------- | --------------------------------------------------------- |
+| `tick()`          | Tick the Application Auto Scaling metric/policy processor |
+| `scheduledTick()` | Tick the scheduled-action processor                       |
+
+## `$fc->athena()`
+
+| Method              | Description                          |
+| ------------------- | ------------------------------------ |
+| `getNamedQueries()` | List all stored Athena named queries |
+
+## `$fc->events()`
+
+| Method           | Description                            |
+| ---------------- | -------------------------------------- |
+| `getHistory()`   | Get event history and delivery records |
+| `fireRule($req)` | Fire an EventBridge rule manually      |
+
+## `$fc->scheduler()`
+
+| Method                        | Description                             |
+| ----------------------------- | --------------------------------------- |
+| `getSchedules()`              | List EventBridge Scheduler schedules    |
+| `fireSchedule($group, $name)` | Fire a scheduled invocation immediately |
+
+## `$fc->glue()`
+
+| Method                        | Description                             |
+| ----------------------------- | --------------------------------------- |
+| `getJobs()`                   | List all Glue jobs                      |
+| `getJobRuns($jobName = null)` | List Glue job runs (optionally per job) |
+
+## `$fc->s3()`
+
+| Method                       | Description                                                 |
+| ---------------------------- | ----------------------------------------------------------- |
+| `getNotifications()`         | List S3 notification events                                 |
+| `tickLifecycle()`            | Tick the lifecycle processor                                |
+| `getAccessPoints()`          | List S3 access points                                       |
+| `getObjectLambdaResponses()` | List recorded S3 Object Lambda WriteGetObjectResponse calls |
+
+## `$fc->dynamodb()`
+
+| Method      | Description            |
+| ----------- | ---------------------- |
+| `tickTtl()` | Tick the TTL processor |
+
+## `$fc->secretsmanager()`
+
+| Method           | Description                 |
+| ---------------- | --------------------------- |
+| `tickRotation()` | Tick the rotation scheduler |
+
+## `$fc->cognito()`
+
+| Method                             | Description                                                                    |
+| ---------------------------------- | ------------------------------------------------------------------------------ |
+| `getUserCodes($poolId, $username)` | Get confirmation codes for a user                                              |
+| `getConfirmationCodes()`           | List all confirmation codes                                                    |
+| `confirmUser($req)`                | Confirm a user (bypass verification)                                           |
+| `getTokens()`                      | List all active tokens                                                         |
+| `expireTokens($req)`               | Expire tokens (optionally filtered)                                            |
+| `getAuthEvents()`                  | List auth events                                                               |
+| `getPreTokenGenInvocations()`      | List PreTokenGeneration Lambda trigger invocations                             |
+| `mintAuthorizationCode($req)`      | Mint a single-use OAuth2 authorization code (alternative to /oauth2/authorize) |
+| `setCompromisedPasswords($req)`    | Mark passwords as compromised for the advanced-security simulator              |
+| `getWebAuthnCredentials()`         | List enrolled WebAuthn credentials                                             |
+
+## `$fc->apigatewayv2()`
+
+| Method                         | Description                                  |
+| ------------------------------ | -------------------------------------------- |
+| `getRequests()`                | List all HTTP API requests received          |
+| `getConnections()`             | List active WebSocket API connections        |
+| `mtlsInfo($domainName)`        | Get mTLS truststore info for a custom domain |
+| `wsUrl($apiId, $stage = null)` | Compute the WebSocket URL for an API/stage   |
+
+## `$fc->stepfunctions()`
+
+| Method                      | Description                                               |
+| --------------------------- | --------------------------------------------------------- |
+| `getExecutions()`           | List all state machine execution history                  |
+| `getSyncExecutions()`       | List `StartSyncExecution` results                         |
+| `getExecutionTree($arn)`    | Get the full parent/child execution tree for an execution |
+| `enqueueActivityTask($req)` | Enqueue an activity task for `GetActivityTask` consumers  |
 
 ## `$fc->bedrock()`
 
-| Method                                | Description                                                          |
-| ------------------------------------- | -------------------------------------------------------------------- |
-| `getInvocations()`                    | List recorded Bedrock runtime invocations                            |
-| `setModelResponse($modelId, $text)`   | Configure a single canned response for a model                       |
-| `setResponseRules($modelId, $rules)`  | Replace prompt-conditional response rules for a model                |
-| `clearResponseRules($modelId)`        | Clear all prompt-conditional response rules for a model              |
-| `queueFault($rule)`                   | Queue a fault rule for the next N calls                              |
-| `getFaults()`                         | List currently queued fault rules                                    |
-| `clearFaults()`                       | Clear all queued fault rules                                         |
+| Method                               | Description                                             |
+| ------------------------------------ | ------------------------------------------------------- |
+| `getInvocations()`                   | List recorded Bedrock runtime invocations               |
+| `setModelResponse($modelId, $text)`  | Configure a single canned response for a model          |
+| `setResponseRules($modelId, $rules)` | Replace prompt-conditional response rules for a model   |
+| `clearResponseRules($modelId)`       | Clear all prompt-conditional response rules for a model |
+| `queueFault($rule)`                  | Queue a fault rule for the next N calls                 |
+| `getFaults()`                        | List currently queued fault rules                       |
+| `clearFaults()`                      | Clear all queued fault rules                            |
 
-## `$fc->lambda()`, `$fc->ses()`, `$fc->sns()`, `$fc->sqs()`, `$fc->events()`, `$fc->s3()`, `$fc->dynamodb()`, `$fc->secretsmanager()`, `$fc->cognito()`, `$fc->stepfunctions()`, `$fc->rds()`, `$fc->elasticache()`, `$fc->apigatewayv2()`
+## `$fc->bedrockAgent()`
 
-Each sub-client mirrors the Java SDK method list 1:1. See the
-[SDK README](https://github.com/faiscadev/fakecloud/blob/main/sdks/php/README.md)
-for the full, always-current surface.
+| Method        | Description                    |
+| ------------- | ------------------------------ |
+| `getAgents()` | List Bedrock Agent definitions |
+
+## `$fc->bedrockAgentRuntime()`
+
+| Method             | Description                            |
+| ------------------ | -------------------------------------- |
+| `getInvocations()` | List Bedrock Agent runtime invocations |
+
+## `$fc->ecs()`
+
+| Method                                      | Description                                                   |
+| ------------------------------------------- | ------------------------------------------------------------- |
+| `getClusters()`                             | List ECS clusters                                             |
+| `getTasks($cluster = null, $status = null)` | List ECS tasks (optionally filtered by cluster and status)    |
+| `getTask($taskId)`                          | Get a single ECS task                                         |
+| `getTaskLogs($taskId)`                      | Get captured stdout/stderr logs for a task                    |
+| `forceStopTask($taskId)`                    | Force-stop a running task                                     |
+| `markTaskFailed($taskId, $req)`             | Mark a task as failed with the supplied reason                |
+| `getEvents()`                               | List ECS service/task lifecycle events                        |
+| `getTaskMetadata($taskArn)`                 | Get ECS task metadata (control-plane shape)                   |
+| `getTaskCredentials($taskId)`               | Get the IAM credentials served via the task metadata endpoint |
+| `getTaskMetadataV3($taskId)`                | Get the task metadata v3 payload                              |
+| `getTaskMetadataV4($taskId)`                | Get the task metadata v4 payload                              |
+
+## `$fc->elbv2()`
+
+| Method               | Description                                         |
+| -------------------- | --------------------------------------------------- |
+| `getLoadBalancers()` | List ELBv2 load balancers                           |
+| `getTargetGroups()`  | List ELBv2 target groups                            |
+| `getListeners()`     | List ELBv2 listeners                                |
+| `getRules()`         | List ELBv2 listener rules                           |
+| `flushAccessLogs()`  | Flush buffered ELBv2 access logs to their S3 bucket |
+| `getWafCounts()`     | Get WAF allow/block counts seen by ELBv2 listeners  |
+
+## `$fc->route53()`
+
+| Method                                        | Description                                                                                                                                  |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setHealthCheckStatus($id, $status, $reason)` | Flip a health check between `Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown` to drive failover routing  |
+| `getDnssecMaterial($zoneId)`                  | Get the simulated DNSSEC key material for a hosted zone                                                                                      |
+| `signDnssec($zoneId, $req)`                   | Sign a payload with the zone's DNSSEC key                                                                                                    |
+
+## `$fc->acm()`
+
+| Method                                             | Description                                     |
+| -------------------------------------------------- | ----------------------------------------------- |
+| `setCertificateStatus($arnOrId, $status, $reason)` | Force an ACM certificate into a specific status |
+| `approveCertificate($arnOrId)`                     | Approve a pending ACM certificate request       |
+| `getCertificateChainInfo($arnOrId)`                | Get parsed chain info for an ACM certificate    |
+
+## `$fc->organizations()`
+
+| Method          | Description                        |
+| --------------- | ---------------------------------- |
+| `getAccounts()` | List Organizations member accounts |
+
+## `$fc->ssm()`
+
+| Method                                                               | Description                                                |
+| -------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `setCommandStatus($commandId, $status, $accountId = null)`           | Force an SSM Run Command into a specific terminal status   |
+| `failCommand($commandId, $accountId = null, $errorCode = null, ...)` | Fail an SSM Run Command with structured error metadata     |
+| `getParameterPolicyEvents($accountId = null)`                        | List Parameter Store policy expiration/notification events |
+| `injectSession($req)`                                                | Inject a Session Manager session for inspection in tests   |
+
+## `$fc->kms()`
+
+| Method       | Description                                       |
+| ------------ | ------------------------------------------------- |
+| `getUsage()` | Get KMS key usage counters (encrypt/decrypt/sign) |
+
+## `$fc->wafv2()`
+
+| Method            | Description                                                       |
+| ----------------- | ----------------------------------------------------------------- |
+| `evaluate($body)` | Evaluate a request against a WAFv2 WebACL and return the decision |
+
+## `$fc->cloudfront()`
+
+| Method                                            | Description                                   |
+| ------------------------------------------------- | --------------------------------------------- |
+| `setDistributionStatus($distributionId, $status)` | Force a CloudFront distribution into a status |
 
 ## Error handling
 

--- a/website/content/docs/sdks/python.md
+++ b/website/content/docs/sdks/python.md
@@ -329,13 +329,17 @@ Called as a method on the main client: `fc.organizations()`.
 Methods raise `FakeCloudError` on non-2xx responses:
 
 ```python
+import asyncio
 from fakecloud import FakeCloudError
 
-try:
-    await fc.cognito.confirm_user(req)
-except FakeCloudError as err:
-    print(err.status)  # 404
-    print(err.body)
+async def main():
+    try:
+        await fc.cognito.confirm_user(req)
+    except FakeCloudError as err:
+        print(err.status)  # 404
+        print(err.body)
+
+asyncio.run(main())
 ```
 
 ## Example: pytest fixture

--- a/website/content/docs/sdks/python.md
+++ b/website/content/docs/sdks/python.md
@@ -12,134 +12,317 @@ pip install fakecloud
 
 Works with Python 3.9+. Type hints bundled (mypy-compatible).
 
-## Initialize (sync)
+## Initialize
+
+The SDK ships two top-level clients with identical surface area:
+
+- `FakeCloud` — async, returns coroutines
+- `FakeCloudSync` — sync, returns values directly
+
+Tables below document the async API. Drop the `await` and use `FakeCloudSync` for the sync variant; method names and arguments are the same.
+
+### Async
 
 ```python
+import asyncio
 from fakecloud import FakeCloud
 
-fc = FakeCloud()  # defaults to http://localhost:4566
-# or
-fc = FakeCloud("http://localhost:5000")
+async def main():
+    async with FakeCloud() as fc:  # defaults to http://localhost:4566
+        await fc.reset()
+        emails = await fc.ses.get_emails()
+
+asyncio.run(main())
 ```
 
-## Initialize (async)
+### Sync
 
 ```python
-from fakecloud import AsyncFakeCloud
+from fakecloud import FakeCloudSync
 
-async with AsyncFakeCloud() as fc:
-    await fc.reset()
+fc = FakeCloudSync("http://localhost:4566")
+fc.reset()
+emails = fc.ses.get_emails()
 ```
-
-Both clients expose the same surface; only the call form differs (`fc.x.y()` vs `await fc.x.y()`).
 
 ## Top-level
 
-| Method                   | Description             |
-| ------------------------ | ----------------------- |
-| `health()`               | Server health check     |
-| `reset()`                | Reset all service state |
-| `reset_service(service)` | Reset a single service  |
-
-## `fc.bedrock`
-
-| Method                                 | Description                                                          |
-| -------------------------------------- | -------------------------------------------------------------------- |
-| `get_invocations()`                    | List recorded Bedrock runtime invocations (each has `error` field)   |
-| `set_model_response(model_id, text)`   | Configure a single canned response for a model                       |
-| `set_response_rules(model_id, rules)`  | Replace prompt-conditional response rules                            |
-| `clear_response_rules(model_id)`       | Clear all prompt-conditional response rules for a model              |
-| `queue_fault(rule)`                    | Queue a fault rule for the next N matching calls                     |
-| `get_faults()`                         | List currently queued fault rules                                    |
-| `clear_faults()`                       | Clear all queued fault rules                                         |
+| Method                                | Description                                              |
+| ------------------------------------- | -------------------------------------------------------- |
+| `health()`                            | Server health check                                      |
+| `reset()`                             | Reset all service state                                  |
+| `reset_service(service)`              | Reset a single service                                   |
+| `create_admin(account_id, user_name)` | Create an IAM admin user in a specific account           |
+| `aclose()` (async only)               | Close the underlying `httpx.AsyncClient` (or use `async with`) |
 
 ## `fc.lambda_`
 
-Note: `lambda` is a Python keyword, so the attribute is `lambda_`.
+`lambda` is a Python keyword, so the attribute is `lambda_`.
 
-| Method                           | Description                          |
-| -------------------------------- | ------------------------------------ |
-| `get_invocations()`              | List recorded Lambda invocations     |
-| `get_warm_containers()`          | List warm containers                 |
-| `evict_container(function_name)` | Evict a warm container               |
-
-## `fc.ses`
-
-| Method                    | Description                               |
-| ------------------------- | ----------------------------------------- |
-| `get_emails()`            | List all sent emails                      |
-| `simulate_inbound(req)`   | Simulate an inbound email (receipt rules) |
-
-## `fc.sns`
-
-| Method                         | Description                             |
-| ------------------------------ | --------------------------------------- |
-| `get_messages()`               | List all published messages             |
-| `get_pending_confirmations()`  | List subscriptions pending confirmation |
-| `confirm_subscription(req)`    | Confirm a pending subscription          |
-
-## `fc.sqs`
-
-| Method                   | Description                           |
-| ------------------------ | ------------------------------------- |
-| `get_messages()`         | List all messages across all queues   |
-| `tick_expiration()`      | Tick the message expiration processor |
-| `force_dlq(queue_name)`  | Force all messages to the queue's DLQ |
-
-## `fc.events`
-
-| Method           | Description                            |
-| ---------------- | -------------------------------------- |
-| `get_history()`  | Get event history                      |
-| `fire_rule(req)` | Fire an EventBridge rule manually      |
-
-## `fc.s3`
-
-| Method                 | Description                  |
-| ---------------------- | ---------------------------- |
-| `get_notifications()`  | List S3 notification events  |
-| `tick_lifecycle()`     | Tick the lifecycle processor |
-
-## `fc.dynamodb`
-
-| Method       | Description            |
-| ------------ | ---------------------- |
-| `tick_ttl()` | Tick the TTL processor |
-
-## `fc.secretsmanager`
-
-| Method            | Description                 |
-| ----------------- | --------------------------- |
-| `tick_rotation()` | Tick the rotation scheduler |
-
-## `fc.cognito`
-
-| Method                                                        | Description                     |
-| ------------------------------------------------------------- | ------------------------------- |
-| `get_confirmation_codes()`                                    | List all pending codes          |
-| `get_confirmation_codes_for_user(pool_id, username)`          | Codes for a specific user       |
-| `confirm_user(req)`                                           | Force-confirm a user            |
-| `get_tokens()`                                                | List active tokens              |
-| `expire_tokens(req)`                                          | Expire tokens for a pool/user   |
-| `get_auth_events()`                                           | List auth events                |
-
-## `fc.stepfunctions`
-
-| Method             | Description             |
-| ------------------ | ----------------------- |
-| `get_executions()` | List all executions     |
+| Method                                                            | Description                                  |
+| ----------------------------------------------------------------- | -------------------------------------------- |
+| `get_invocations()`                                               | List recorded Lambda invocations             |
+| `get_warm_containers()`                                           | List warm containers                         |
+| `evict_container(function_name)`                                  | Evict a warm container                       |
+| `download_function_code(account_id, function_name, qualifier_or_latest="latest")` | Download a function-code zip blob (bytes) |
+| `download_layer_content(account_id, layer_name, version)`         | Download a layer-version zip blob (bytes)    |
 
 ## `fc.rds`
 
-| Method            | Description                 |
-| ----------------- | --------------------------- |
-| `get_instances()` | List managed RDS instances  |
+| Method                | Description                                                       |
+| --------------------- | ----------------------------------------------------------------- |
+| `get_instances()`     | List managed RDS instances                                        |
+| `lambda_invoke(req)`  | Invoke a Lambda via the RDS `aws_lambda` PG extension bridge      |
+| `s3_import(req)`      | Fetch an S3 object via the RDS `aws_s3` extension bridge          |
+| `s3_export(req)`      | Upload an object via the RDS `aws_s3` extension bridge            |
+
+## `fc.elasticache`
+
+| Method                     | Description                          |
+| -------------------------- | ------------------------------------ |
+| `get_clusters()`           | List cache clusters                  |
+| `get_replication_groups()` | List replication groups              |
+| `get_serverless_caches()`  | List serverless caches               |
+| `get_elasti_cache_acls()`  | List ElastiCache ACLs                |
+
+## `fc.athena`
+
+| Method                | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `get_named_queries()` | List every named query across workgroups (with `last_used_at`) |
+
+## `fc.ecr`
+
+| Method                            | Description                                  |
+| --------------------------------- | -------------------------------------------- |
+| `get_repositories()`              | List ECR repositories                        |
+| `get_images(repository_name=None)`| List images, optionally filtered by repo     |
+| `get_pull_through_rules()`        | List pull-through cache rules                |
+
+## `fc.ecs`
+
+| Method                                          | Description                                                |
+| ----------------------------------------------- | ---------------------------------------------------------- |
+| `get_clusters()`                                | List ECS clusters                                          |
+| `get_tasks(cluster=None, status=None)`          | List tasks, optionally filtered by cluster/status          |
+| `get_task(task_id)`                             | Get a single task                                          |
+| `get_task_logs(task_id)`                        | Tail captured stdout/stderr for a task                     |
+| `force_stop_task(task_id)`                      | Force-stop a running task                                  |
+| `mark_task_failed(task_id, req)`                | Mark a task as failed with a given reason                  |
+| `get_events()`                                  | List ECS service events                                    |
+| `get_task_metadata(task_arn)`                   | v4 metadata-URI dump for a task by ARN                     |
+| `get_task_credentials(task_id)`                 | IAM credentials a running task would see                   |
+| `get_task_metadata_v3(task_id)`                 | v3 task metadata document (pass-through dict)              |
+| `get_task_metadata_v4(task_id)`                 | v4 task metadata document (pass-through dict)              |
+
+## `fc.elbv2`
+
+| Method                  | Description                                            |
+| ----------------------- | ------------------------------------------------------ |
+| `get_load_balancers()`  | List ALBs / NLBs / GWLBs                               |
+| `get_target_groups()`   | List target groups                                     |
+| `get_listeners()`       | List listeners                                         |
+| `get_rules()`           | List listener rules                                    |
+| `flush_access_logs()`   | Force buffered access + connection logs to S3          |
+| `get_waf_counts()`      | Snapshot WAF-association counts across ALBs            |
+
+## `fc.route53`
+
+| Method                                                | Description                                                          |
+| ----------------------------------------------------- | -------------------------------------------------------------------- |
+| `set_health_check_status(health_check_id, status, reason=None)` | Flip a health check (`Success`/`Failure`/`Timeout`/`DnsError`/`InsufficientDataPoints`/`Unknown`) |
+| `get_dnssec_material(zone_id)`                        | Deterministic DNSSEC KSK material for a zone                         |
+| `sign_dnssec_rrset(zone_id, req)`                     | Sign an RRset with the zone's first ACTIVE KSK, return RRSIG fields  |
+
+## `fc.ssm`
+
+| Method                                                       | Description                                              |
+| ------------------------------------------------------------ | -------------------------------------------------------- |
+| `set_command_status(command_id, status, account_id=None)`    | Force a stored `SendCommand` into a given status         |
+| `fail_command(command_id, req=None)`                         | Flip every (or one) invocation on a command to `Failed`  |
+| `get_parameter_policy_events(account_id=None)`               | List Parameter Store policy events                       |
+| `inject_session(req)`                                        | Drop a fake Session Manager record into state            |
+
+## `fc.kms`
+
+| Method        | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `get_usage()` | Snapshot recorded KMS usage events across services |
+
+## `fc.wafv2`
+
+| Method           | Description                                         |
+| ---------------- | --------------------------------------------------- |
+| `evaluate(body)` | Run a synthetic request through the WAFv2 evaluator |
+
+## `fc.cloudfront`
+
+| Method                                         | Description                                          |
+| ---------------------------------------------- | ---------------------------------------------------- |
+| `set_distribution_status(distribution_id, status)` | Force a distribution into a given status (204 / `FakeCloudError`) |
+
+## `fc.acm`
+
+| Method                                                          | Description                                                            |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `set_certificate_status(arn_or_id, status, reason=None)`        | Flip a cert (`ISSUED`/`FAILED`/`VALIDATION_TIMED_OUT`)                 |
+| `approve_certificate(arn_or_id)`                                | Approve a `PENDING_VALIDATION` cert (EMAIL validation flow)            |
+| `get_certificate_chain_info(arn_or_id)`                         | PEM-block / byte counts for a stored cert + chain                      |
+
+## `fc.application_autoscaling`
+
+| Method             | Description                                                      |
+| ------------------ | ---------------------------------------------------------------- |
+| `tick()`           | Force the watcher to evaluate every scaling policy now           |
+| `scheduled_tick()` | Force the scheduled-action executor to evaluate every action now |
+
+## `fc.logs`
+
+| Method                                | Description                                          |
+| ------------------------------------- | ---------------------------------------------------- |
+| `inject_anomaly(req)`                 | Seed a synthetic anomaly for ListAnomalies/UpdateAnomaly |
+| `get_delivery_config()`               | Persisted CloudWatch Logs delivery configurations    |
+| `get_field_indexes(log_group_name)`   | Parsed `Fields` from index policies on a log group   |
+
+## `fc.organizations`
+
+Called as a method on the main client: `fc.organizations()`.
+
+| Method            | Description                                                                 |
+| ----------------- | --------------------------------------------------------------------------- |
+| `get_accounts()`  | List member accounts with lifecycle state, parent OU, tags, attached SCPs   |
+
+## `fc.ses`
+
+| Method                                  | Description                                          |
+| --------------------------------------- | ---------------------------------------------------- |
+| `get_emails()`                          | List all sent emails                                 |
+| `simulate_inbound(req)`                 | Simulate an inbound email (receipt rules)            |
+| `get_metrics()`                         | Send/bounce/complaint metrics                        |
+| `set_mail_from_status(identity, status)`| Set MAIL FROM verification status for an identity    |
+| `get_dkim_public_key(identity)`         | Public DKIM key for an identity                      |
+| `set_sandbox(sandbox)`                  | Enable/disable account-level sandbox                 |
+| `get_bounces()`                         | List recorded bounces                                |
+| `get_message_insights(message_id)`      | Message insights record for a sent message           |
+| `get_smtp_submissions()`                | List SMTP-submission events                          |
+| `get_event_destination_deliveries()`    | Deliveries fanned out to event destinations          |
+
+## `fc.sns`
+
+| Method                          | Description                                               |
+| ------------------------------- | --------------------------------------------------------- |
+| `get_messages()`                | List all published messages                               |
+| `get_pending_confirmations()`   | List subscriptions pending confirmation                   |
+| `confirm_subscription(req)`     | Confirm a pending subscription                            |
+| `get_cert_pem()`                | Signing cert as a PEM string (`application/x-pem-file`)   |
+| `get_sms()`                     | List SMS messages accepted by the SNS fake                |
+
+## `fc.sqs`
+
+| Method                  | Description                           |
+| ----------------------- | ------------------------------------- |
+| `get_messages()`        | List all messages across queues       |
+| `tick_expiration()`     | Tick the message-expiration processor |
+| `force_dlq(queue_name)` | Force all messages to the queue's DLQ |
+
+## `fc.events`
+
+| Method            | Description                       |
+| ----------------- | --------------------------------- |
+| `get_history()`   | Get EventBridge event history     |
+| `fire_rule(req)`  | Fire an EventBridge rule manually |
+
+## `fc.scheduler`
+
+| Method                            | Description                            |
+| --------------------------------- | -------------------------------------- |
+| `get_schedules()`                 | List scheduler schedules               |
+| `fire_schedule(group, name)`      | Manually fire a schedule by group/name |
+
+## `fc.glue`
+
+| Method                          | Description                                  |
+| ------------------------------- | -------------------------------------------- |
+| `get_jobs()`                    | List Glue jobs                               |
+| `get_job_runs(job_name=None)`   | List job runs, optionally filtered by job    |
+
+## `fc.s3`
+
+| Method                            | Description                                            |
+| --------------------------------- | ------------------------------------------------------ |
+| `get_notifications()`             | List S3 notification events                            |
+| `tick_lifecycle()`                | Tick the lifecycle processor                           |
+| `get_access_points()`             | List S3 access points                                  |
+| `get_object_lambda_responses()`   | List recorded Object Lambda responses                  |
+
+## `fc.dynamodb`
+
+| Method        | Description            |
+| ------------- | ---------------------- |
+| `tick_ttl()`  | Tick the TTL processor |
+
+## `fc.secretsmanager`
+
+| Method             | Description                 |
+| ------------------ | --------------------------- |
+| `tick_rotation()`  | Tick the rotation scheduler |
+
+## `fc.cognito`
+
+| Method                                               | Description                                                |
+| ---------------------------------------------------- | ---------------------------------------------------------- |
+| `get_user_codes(pool_id, username)`                  | Confirmation codes for a specific user                     |
+| `get_confirmation_codes()`                           | List all pending confirmation codes                        |
+| `confirm_user(req)`                                  | Force-confirm a user                                       |
+| `get_tokens()`                                       | List active tokens                                         |
+| `expire_tokens(req)`                                 | Expire tokens for a pool/user                              |
+| `get_auth_events()`                                  | List auth events                                           |
+| `get_pre_token_gen_invocations()`                    | PreTokenGeneration Lambda trigger invocation log           |
+| `mint_authorization_code(req)`                       | Mint an OAuth authorization code                           |
+| `set_compromised_passwords(req)`                     | Seed compromised-password records                          |
+| `get_webauthn_credentials()`                         | List stored WebAuthn credentials                           |
 
 ## `fc.apigatewayv2`
 
-| Method           | Description                     |
-| ---------------- | ------------------------------- |
-| `get_requests()` | List recorded HTTP API requests |
+| Method                              | Description                                                  |
+| ----------------------------------- | ------------------------------------------------------------ |
+| `get_requests()`                    | List recorded HTTP API requests                              |
+| `get_connections()`                 | List active WebSocket connections                            |
+| `get_mtls_info(domain_name)`        | mTLS trust-store summary for a custom domain (dict)          |
+| `ws_url(api_id, stage=None)`        | Build the `ws(s)://` WebSocket URL for an API + stage        |
+
+## `fc.stepfunctions`
+
+| Method                          | Description                                                          |
+| ------------------------------- | -------------------------------------------------------------------- |
+| `get_executions()`              | List all executions                                                  |
+| `get_sync_executions()`         | List sync (Express) executions                                       |
+| `get_execution_tree(arn)`       | Nested execution tree for a parent execution                         |
+| `enqueue_activity_task(req)`    | Insert a pending task into an activity-worker queue                  |
+
+## `fc.bedrock`
+
+| Method                                  | Description                                              |
+| --------------------------------------- | -------------------------------------------------------- |
+| `get_invocations()`                     | List recorded Bedrock runtime invocations                |
+| `set_model_response(model_id, text)`    | Configure a single canned response for a model           |
+| `set_response_rules(model_id, rules)`   | Replace prompt-conditional response rules                |
+| `clear_response_rules(model_id)`        | Clear all prompt-conditional response rules for a model  |
+| `queue_fault(rule)`                     | Queue a fault rule for the next N matching calls         |
+| `get_faults()`                          | List currently queued fault rules                        |
+| `clear_faults()`                        | Clear all queued fault rules                             |
+
+## `fc.bedrock_agent`
+
+| Method          | Description                                |
+| --------------- | ------------------------------------------ |
+| `get_agents()`  | List Bedrock Agents (control plane)        |
+
+## `fc.bedrock_agent_runtime`
+
+| Method               | Description                                              |
+| -------------------- | -------------------------------------------------------- |
+| `get_invocations()`  | List Bedrock Agent runtime invocations (data plane)      |
 
 ## Error handling
 
@@ -149,7 +332,7 @@ Methods raise `FakeCloudError` on non-2xx responses:
 from fakecloud import FakeCloudError
 
 try:
-    fc.cognito.confirm_user({"userPoolId": "pool-1", "username": "nobody"})
+    await fc.cognito.confirm_user(req)
 except FakeCloudError as err:
     print(err.status)  # 404
     print(err.body)
@@ -160,11 +343,11 @@ except FakeCloudError as err:
 ```python
 import pytest
 import boto3
-from fakecloud import FakeCloud
+from fakecloud import FakeCloudSync
 
 @pytest.fixture
 def fc():
-    client = FakeCloud()
+    client = FakeCloudSync()
     yield client
     client.reset()
 
@@ -185,8 +368,8 @@ def test_app_publishes_to_sqs(fc, sqs):
     )
 
     messages = fc.sqs.get_messages()
-    assert len(messages) == 1
-    assert messages[0].body == "hello"
+    assert len(messages.messages) == 1
+    assert messages.messages[0].body == "hello"
 ```
 
 ## Source

--- a/website/content/docs/sdks/rust.md
+++ b/website/content/docs/sdks/rust.md
@@ -10,57 +10,306 @@ weight = 4
 cargo add fakecloud-sdk
 ```
 
-Rust 1.75+.
+Rust 1.75+. Async-only, built on `reqwest` + `tokio`.
 
 ## Initialize
 
 ```rust
-use fakecloud_sdk::FakeCloudClient;
+use fakecloud_sdk::FakeCloud;
 
-let fc = FakeCloudClient::new("http://localhost:4566");
-// or default:
-let fc = FakeCloudClient::default();
+let fc = FakeCloud::new("http://localhost:4566");
 ```
+
+Every sub-client is constructed lazily via an accessor (`fc.lambda()`, `fc.sqs()`, ...). All endpoint methods are `async` and return `Result<T, fakecloud_sdk::Error>`.
 
 ## Top-level
 
-| Method                                | Description             |
-| ------------------------------------- | ----------------------- |
-| `health().await`                      | Server health check     |
-| `reset().await`                       | Reset all service state |
-| `reset_service(service).await`        | Reset a single service  |
+| Method                                            | Description                              |
+| ------------------------------------------------- | ---------------------------------------- |
+| `health().await`                                  | Server health check                      |
+| `reset().await`                                   | Reset all service state                  |
+| `reset_service(service).await`                    | Reset a single service                   |
+| `reset_service_for_account(service, account).await` | Reset one service in one account       |
+| `create_admin(req).await`                         | Create an admin user in another account  |
+
+## `fc.acm()`
+
+| Method                                              | Description                                                  |
+| --------------------------------------------------- | ------------------------------------------------------------ |
+| `set_certificate_status(arn_or_id, req).await`      | Flip a stored certificate's status (and optional failure reason) |
+| `get_certificate_chain_info(arn_or_id).await`       | Inspect PEM block counts and byte sizes of a stored chain    |
+| `approve_certificate(arn_or_id).await`              | Approve a `PENDING_VALIDATION` certificate                   |
+
+## `fc.apigatewayv2()`
+
+| Method                                | Description                                          |
+| ------------------------------------- | ---------------------------------------------------- |
+| `get_requests().await`                | List recorded HTTP API requests                      |
+| `connections().await`                 | List WebSocket connections                           |
+| `mtls_info(name).await`               | Inspect mTLS trust-store status for a domain name    |
+| `ws_url(api_id, stage)`               | Build a `ws://` URL for a WebSocket API (sync)       |
+
+## `fc.application_autoscaling()`
+
+| Method                       | Description                                                   |
+| ---------------------------- | ------------------------------------------------------------- |
+| `tick().await`               | Re-evaluate target-tracking policies and emit scaling actions |
+| `scheduled_tick().await`     | Fire any scheduled actions whose time has arrived             |
+
+## `fc.athena()`
+
+| Method                      | Description                          |
+| --------------------------- | ------------------------------------ |
+| `get_named_queries().await` | List recorded Athena named queries   |
 
 ## `fc.bedrock()`
 
-| Method                                              | Description                                       |
-| --------------------------------------------------- | ------------------------------------------------- |
-| `get_invocations().await`                           | List runtime invocations                          |
-| `set_model_response(model_id, text).await`          | Single canned response                            |
-| `set_response_rules(model_id, rules).await`         | Prompt-conditional rules                          |
-| `clear_response_rules(model_id).await`              | Clear rules for a model                           |
-| `queue_fault(rule).await`                           | Queue a fault rule                                |
-| `get_faults().await`                                | List queued fault rules                           |
-| `clear_faults().await`                              | Clear all queued fault rules                      |
+| Method                                       | Description                                                  |
+| -------------------------------------------- | ------------------------------------------------------------ |
+| `get_invocations().await`                    | List recorded Bedrock runtime invocations                    |
+| `set_model_response(model_id, text).await`   | Configure a single canned response for a model               |
+| `set_response_rules(model_id, rules).await`  | Replace prompt-conditional response rules for a model        |
+| `clear_response_rules(model_id).await`       | Clear all prompt-conditional response rules for a model      |
+| `queue_fault(rule).await`                    | Queue a fault rule (e.g. `ThrottlingException`) for the next N calls |
+| `get_faults().await`                         | List currently queued fault rules                            |
+| `clear_faults().await`                       | Clear all queued fault rules                                 |
 
-## `fc.lambda()`, `fc.ses()`, `fc.sns()`, `fc.sqs()`, `fc.events()`, `fc.s3()`, `fc.dynamodb()`, `fc.secretsmanager()`, `fc.cognito()`, `fc.stepfunctions()`, `fc.rds()`, `fc.apigatewayv2()`
+## `fc.bedrock_agent()`
 
-Each service accessor mirrors the TypeScript SDK's surface with Rust method naming (`get_messages`, `tick_ttl`, `fire_rule`, etc.). See the [TypeScript reference](/docs/sdks/typescript/) for the full method list.
+| Method                | Description                                |
+| --------------------- | ------------------------------------------ |
+| `get_agents().await`  | List configured Bedrock agents             |
 
-The authoritative per-method list for Rust lives in the [`fakecloud-sdk` crate source](https://github.com/faiscadev/fakecloud/tree/main/crates/fakecloud-sdk).
+## `fc.bedrock_agent_runtime()`
+
+| Method                       | Description                                |
+| ---------------------------- | ------------------------------------------ |
+| `get_invocations().await`    | List recorded Bedrock Agent runtime invocations |
+
+## `fc.cloudfront()`
+
+| Method                                                  | Description                                              |
+| ------------------------------------------------------- | -------------------------------------------------------- |
+| `set_distribution_status(id, req).await`                | Override a CloudFront distribution's deployment status   |
+
+## `fc.cognito()`
+
+| Method                                              | Description                                                |
+| --------------------------------------------------- | ---------------------------------------------------------- |
+| `get_user_codes(pool_id, username).await`           | Pending confirmation codes for a specific user             |
+| `get_confirmation_codes().await`                    | List all pending confirmation codes                        |
+| `confirm_user(pool_id, username).await`             | Force-confirm a user                                       |
+| `get_tokens().await`                                | List currently active tokens                               |
+| `expire_tokens(req).await`                          | Expire tokens for a pool/user                              |
+| `get_auth_events().await`                           | List recorded auth events                                  |
+| `get_pre_token_gen_invocations().await`             | List Pre-Token-Generation Lambda invocations               |
+| `mint_authorization_code(req).await`                | Mint an OAuth2 authorization code without a real browser   |
+| `set_compromised_passwords(req).await`              | Seed the compromised-credentials list                      |
+| `get_webauthn_credentials().await`                  | List registered WebAuthn credentials                       |
+
+## `fc.dynamodb()`
+
+| Method             | Description                                |
+| ------------------ | ------------------------------------------ |
+| `tick_ttl().await` | Tick the DynamoDB TTL processor            |
+
+## `fc.ecr()`
+
+| Method                              | Description                                |
+| ----------------------------------- | ------------------------------------------ |
+| `get_images().await`                | List stored ECR images                     |
+| `get_repositories().await`          | List ECR repositories                      |
+| `get_pull_through_rules().await`    | List pull-through cache rules              |
+
+## `fc.ecs()`
+
+| Method                                  | Description                                                  |
+| --------------------------------------- | ------------------------------------------------------------ |
+| `get_clusters().await`                  | List ECS clusters with task counts                           |
+| `get_tasks(filter).await`               | List tasks, optionally filtered by cluster / family / status |
+| `get_task_logs(task_id).await`          | Fetch captured stdout/stderr for a task                      |
+| `force_stop_task(task_id).await`        | Force a task into `STOPPED`                                  |
+| `mark_task_failed(task_id, req).await`  | Mark a task failed with a custom reason / exit code          |
+| `get_events().await`                    | List ECS service / task lifecycle events                     |
+| `get_metadata_by_arn(task_arn).await`   | Fetch task metadata by full ARN                              |
+| `task_credentials(task_id).await`       | Fetch IAM credentials served to the task                     |
+| `task_metadata_v3(task_id).await`       | Task Metadata Endpoint v3 payload                            |
+| `task_metadata_v4(task_id).await`       | Task Metadata Endpoint v4 payload                            |
+
+## `fc.elasticache()`
+
+| Method                                  | Description                                |
+| --------------------------------------- | ------------------------------------------ |
+| `get_clusters().await`                  | List ElastiCache clusters                  |
+| `get_replication_groups().await`        | List replication groups                    |
+| `get_serverless_caches().await`         | List serverless caches                     |
+| `get_acls().await`                      | List RBAC ACLs                             |
+
+## `fc.elbv2()`
+
+| Method                               | Description                                |
+| ------------------------------------ | ------------------------------------------ |
+| `get_load_balancers().await`         | List ALB / NLB / GWLB load balancers       |
+| `get_listeners().await`              | List listeners across load balancers       |
+| `get_rules().await`                  | List listener rules                        |
+| `get_target_groups().await`          | List target groups                         |
+| `flush_access_logs().await`          | Flush buffered access-log entries          |
+| `waf_counts().await`                 | Inspect WAF allow/block counters           |
+
+## `fc.events()`
+
+| Method                  | Description                                |
+| ----------------------- | ------------------------------------------ |
+| `get_history().await`   | Get event history and delivery records     |
+| `fire_rule(req).await`  | Fire an EventBridge rule manually          |
+
+## `fc.glue()`
+
+| Method                              | Description                                |
+| ----------------------------------- | ------------------------------------------ |
+| `get_jobs().await`                  | List configured Glue jobs                  |
+| `get_job_runs(job_name).await`      | List job runs, optionally for one job      |
+
+## `fc.kms()`
+
+| Method            | Description                                       |
+| ----------------- | ------------------------------------------------- |
+| `usage().await`   | KMS key usage counters (encrypt/decrypt/sign/etc) |
+
+## `fc.lambda()`
+
+| Method                                          | Description                                |
+| ----------------------------------------------- | ------------------------------------------ |
+| `get_invocations().await`                       | List recorded Lambda invocations           |
+| `get_warm_containers().await`                   | List warm (cached) Lambda containers       |
+| `evict_container(function_name).await`          | Evict a warm container                     |
+| `download_function_code(function_name).await`   | Download the uploaded function zip         |
+| `download_layer_content(layer_name, ver).await` | Download a layer version's content         |
+
+## `fc.logs()`
+
+| Method                              | Description                                       |
+| ----------------------------------- | ------------------------------------------------- |
+| `inject_anomaly(req).await`         | Inject a synthetic CloudWatch Logs anomaly        |
+| `get_delivery_config().await`       | Inspect log-delivery configuration                |
+| `get_field_indexes(group).await`    | Inspect field indexes for a log group             |
+
+## `fc.organizations()`
+
+| Method                  | Description                                |
+| ----------------------- | ------------------------------------------ |
+| `get_accounts().await`  | List Organizations member accounts         |
+
+## `fc.rds()`
+
+| Method                              | Description                                                 |
+| ----------------------------------- | ----------------------------------------------------------- |
+| `get_instances().await`             | List managed RDS instances with runtime metadata            |
+| `lambda_invoke(req).await`          | Invoke a Lambda via the `aws_lambda` PG extension bridge    |
+| `s3_import(req).await`              | Simulate the `aws_s3.table_import_from_s3` extension call   |
+| `s3_export(req).await`              | Simulate the `aws_s3.query_export_to_s3` extension call     |
+
+## `fc.route53()`
+
+| Method                                       | Description                                       |
+| -------------------------------------------- | ------------------------------------------------- |
+| `dnssec_material(hosted_zone_id).await`      | Inspect DNSSEC key-signing material               |
+| `dnssec_sign(hosted_zone_id, req).await`     | Sign a payload with the zone's KSK                |
+| `set_health_check_status(id, req).await`     | Override a health check's status                  |
+
+## `fc.s3()`
+
+| Method                                  | Description                                |
+| --------------------------------------- | ------------------------------------------ |
+| `get_notifications().await`             | List S3 notification events                |
+| `tick_lifecycle().await`                | Tick the lifecycle processor               |
+| `get_access_points().await`             | List S3 access points                      |
+| `get_object_lambda_responses().await`   | List Object Lambda transformed responses   |
+
+## `fc.scheduler()`
+
+| Method                              | Description                                |
+| ----------------------------------- | ------------------------------------------ |
+| `get_schedules().await`             | List EventBridge Scheduler schedules       |
+| `fire_schedule(name, group).await`  | Fire a schedule immediately                |
+
+## `fc.secretsmanager()`
+
+| Method                  | Description                                |
+| ----------------------- | ------------------------------------------ |
+| `tick_rotation().await` | Tick the rotation scheduler                |
+
+## `fc.ses()`
+
+| Method                                              | Description                                         |
+| --------------------------------------------------- | --------------------------------------------------- |
+| `get_emails().await`                                | List all sent emails                                |
+| `simulate_inbound(req).await`                       | Simulate an inbound email (receipt rules)           |
+| `get_metrics().await`                               | Aggregate send / bounce / complaint counters        |
+| `get_bounces().await`                               | List recorded bounces                               |
+| `set_sandbox(enabled).await`                        | Toggle SES sandbox mode                             |
+| `get_event_destination_deliveries().await`          | List event-destination delivery records             |
+| `get_dkim_public_key(domain).await`                 | Fetch the public DKIM key for a domain              |
+| `set_mail_from_status(req).await`                   | Override a domain's MAIL-FROM verification status   |
+| `get_message_insights(message_id).await`            | Fetch message-insights breakdown for a message      |
+| `get_smtp_submissions().await`                      | List inbound SMTP submission records                |
+
+## `fc.sns()`
+
+| Method                              | Description                                       |
+| ----------------------------------- | ------------------------------------------------- |
+| `get_messages().await`              | List all published messages                       |
+| `get_pending_confirmations().await` | List subscriptions pending confirmation           |
+| `confirm_subscription(req).await`   | Confirm a pending subscription                    |
+| `cert_pem().await`                  | Fetch the PEM used to sign SNS HTTP/S deliveries  |
+| `sms().await`                       | List recorded SMS deliveries                      |
+
+## `fc.sqs()`
+
+| Method                          | Description                                |
+| ------------------------------- | ------------------------------------------ |
+| `get_messages().await`          | List all messages across all queues        |
+| `tick_expiration().await`       | Tick the message expiration processor      |
+| `force_dlq(queue_name).await`   | Force all messages to the queue's DLQ      |
+
+## `fc.ssm()`
+
+| Method                                          | Description                                            |
+| ----------------------------------------------- | ------------------------------------------------------ |
+| `set_command_status(command_id, req).await`     | Override an SSM Run Command's status                   |
+| `fail_command(command_id, req).await`           | Mark an SSM Run Command failed with a reason           |
+| `parameter_policy_events().await`               | List parameter-policy expiration / notification events |
+| `inject_session(req).await`                     | Inject a synthetic SSM Session                         |
+
+## `fc.stepfunctions()`
+
+| Method                                  | Description                                       |
+| --------------------------------------- | ------------------------------------------------- |
+| `get_executions().await`                | List standard executions                          |
+| `get_sync_executions().await`           | List Express sync executions                      |
+| `enqueue_activity_task(req).await`      | Enqueue a task for an activity worker             |
+| `get_execution_tree(execution_arn).await` | Fetch a nested execution tree                   |
+
+## `fc.wafv2()`
+
+| Method                       | Description                                                  |
+| ---------------------------- | ------------------------------------------------------------ |
+| `evaluate(body).await`       | Evaluate a request against configured WAFv2 rules            |
 
 ## Error handling
 
-All methods return `Result<T, FakeCloudError>`:
+All methods return `Result<T, fakecloud_sdk::Error>`. `Error` has two variants:
 
 ```rust
-use fakecloud_sdk::FakeCloudError;
+use fakecloud_sdk::{FakeCloud, Error};
 
+let fc = FakeCloud::new("http://localhost:4566");
 match fc.cognito().confirm_user("pool-1", "nobody").await {
     Ok(_) => {}
-    Err(FakeCloudError::Http { status, body }) => {
-        println!("status {}, body {}", status, body);
+    Err(Error::Api { status, body }) => {
+        println!("status {status}, body {body}");
     }
-    Err(e) => eprintln!("{}", e),
+    Err(Error::Http(e)) => eprintln!("transport: {e}"),
 }
 ```
 
@@ -69,11 +318,11 @@ match fc.cognito().confirm_user("pool-1", "nobody").await {
 ```rust
 use aws_sdk_sqs::Client;
 use aws_config::BehaviorVersion;
-use fakecloud_sdk::FakeCloudClient;
+use fakecloud_sdk::FakeCloud;
 
 #[tokio::test]
 async fn app_publishes_to_sqs() {
-    let fc = FakeCloudClient::default();
+    let fc = FakeCloud::new("http://localhost:4566");
     fc.reset().await.unwrap();
 
     let config = aws_config::defaults(BehaviorVersion::latest())
@@ -90,9 +339,9 @@ async fn app_publishes_to_sqs() {
         .await
         .unwrap();
 
-    let messages = fc.sqs().get_messages().await.unwrap();
-    assert_eq!(messages.len(), 1);
-    assert_eq!(messages[0].body, "hello");
+    let resp = fc.sqs().get_messages().await.unwrap();
+    assert_eq!(resp.messages.len(), 1);
+    assert_eq!(resp.messages[0].body, "hello");
 }
 ```
 

--- a/website/content/docs/sdks/typescript.md
+++ b/website/content/docs/sdks/typescript.md
@@ -24,11 +24,42 @@ const fc = new FakeCloud("http://localhost:5000");
 
 ## Top-level
 
-| Method                  | Description             |
-| ----------------------- | ----------------------- |
-| `health()`              | Server health check     |
-| `reset()`               | Reset all service state |
-| `resetService(service)` | Reset a single service  |
+| Method                            | Description                                              |
+| --------------------------------- | -------------------------------------------------------- |
+| `health()`                        | Server health check                                      |
+| `reset()`                         | Reset all service state                                  |
+| `resetService(service)`           | Reset a single service                                   |
+| `createAdmin(accountId, userName)`| Bootstrap an admin IAM user for an account               |
+
+## `fc.acm`
+
+| Method                                       | Description                                                                  |
+| -------------------------------------------- | ---------------------------------------------------------------------------- |
+| `setCertificateStatus(arnOrId, req)`         | Flip a certificate's status (`ISSUED` / `FAILED` / `VALIDATION_TIMED_OUT`)   |
+| `approveCertificate(arnOrId)`                | Approve a `PENDING_VALIDATION` cert synchronously (email-validation bypass)  |
+| `getCertificateChainInfo(arnOrId)`           | Inspect stored PEM block counts and byte sizes for a certificate             |
+
+## `fc.apigatewayv2`
+
+| Method                       | Description                                                            |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| `getRequests()`              | List recorded HTTP API requests                                        |
+| `getConnections()`           | List every live WebSocket connection currently tracked                 |
+| `getMtlsInfo(domainName)`    | Inspect the mTLS trust store / chain configuration for a custom domain |
+| `wsUrl(apiId, stage?)`       | Build the `ws://`/`wss://` URL for a WebSocket API stage               |
+
+## `fc.applicationAutoscaling`
+
+| Method            | Description                                                       |
+| ----------------- | ----------------------------------------------------------------- |
+| `tick()`          | Force an immediate scaling-policy evaluation pass                 |
+| `scheduledTick()` | Force the scheduled-action watcher to fire due actions now        |
+
+## `fc.athena`
+
+| Method              | Description                                                          |
+| ------------------- | -------------------------------------------------------------------- |
+| `getNamedQueries()` | List every named query across all workgroups for the default account |
 
 ## `fc.bedrock`
 
@@ -42,28 +73,196 @@ const fc = new FakeCloud("http://localhost:5000");
 | `getFaults()`                      | List currently queued fault rules                                    |
 | `clearFaults()`                    | Clear all queued fault rules                                         |
 
+## `fc.bedrockAgent`
+
+| Method        | Description                                                                                |
+| ------------- | ------------------------------------------------------------------------------------------ |
+| `getAgents()` | List every Bedrock Agent with aliases, versions, knowledge bases, and collaborators        |
+
+## `fc.bedrockAgentRuntime`
+
+| Method             | Description                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| `getInvocations()` | List recorded `InvokeAgent` / `InvokeInlineAgent` / `InvokeFlow` / `Retrieve*` calls       |
+
+## `fc.cloudfront`
+
+| Method                                | Description                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `setDistributionStatus(id, req)`      | Flip a Distribution synchronously into `Deployed` or `InProgress`        |
+
+## `fc.cognito`
+
+| Method                              | Description                                                                                   |
+| ----------------------------------- | --------------------------------------------------------------------------------------------- |
+| `getUserCodes(poolId, username)`    | Get confirmation codes for a single user                                                      |
+| `getConfirmationCodes()`            | List all pending confirmation codes                                                           |
+| `confirmUser(req)`                  | Force-confirm a user                                                                          |
+| `getTokens()`                       | List active tokens                                                                            |
+| `expireTokens(req)`                 | Expire tokens for a pool/user                                                                 |
+| `getAuthEvents()`                   | List auth events                                                                              |
+| `getPreTokenGenInvocations()`       | List PreTokenGeneration Lambda trigger invocations with parsed claim mutations                |
+| `mintAuthorizationCode(req)`        | Mint a single-use OAuth2 authorization code (programmatic alternative to `/oauth2/authorize`) |
+| `setCompromisedPasswords(req)`      | Replace the compromised-password list used by adaptive auth                                   |
+| `getWebAuthnCredentials()`          | List stored WebAuthn credentials                                                              |
+
+## `fc.dynamodb`
+
+| Method      | Description            |
+| ----------- | ---------------------- |
+| `tickTtl()` | Tick the TTL processor |
+
+## `fc.ecr`
+
+| Method                  | Description                                                       |
+| ----------------------- | ----------------------------------------------------------------- |
+| `getRepositories()`     | List every ECR repository fakecloud has seen                      |
+| `getImages(repo?)`      | List images, optionally filtered by repository name               |
+| `getPullThroughRules()` | List pull-through cache rules                                     |
+
+## `fc.ecs`
+
+| Method                          | Description                                                                |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| `getClusters()`                 | List every ECS cluster across every account                                |
+| `getTasks(opts?)`               | List tracked tasks; optional `cluster` / `status` filters                  |
+| `getTask(taskId)`               | Fetch a single task snapshot by ID                                         |
+| `getTaskLogs(taskId)`           | Captured docker stdout/stderr + exit code for a task                       |
+| `forceStopTask(taskId)`         | SIGTERM (then SIGKILL after 10s) the task's running container              |
+| `markTaskFailed(taskId, req)`   | Flip a task to STOPPED without killing the container                       |
+| `getEvents()`                   | Replay the lifecycle event log                                             |
+| `getTaskMetadata(taskArn)`      | v4 metadata dump keyed by full task ARN                                    |
+| `getTaskCredentials(taskId)`    | IMDS-style temporary credentials minted for an ECS task                    |
+| `getTaskMetadataV3(taskId)`     | v3 task metadata dump (`ECS_CONTAINER_METADATA_URI`)                       |
+| `getTaskMetadataV4(taskId)`     | v4 task metadata dump (`ECS_CONTAINER_METADATA_URI_V4`)                    |
+
+## `fc.elasticache`
+
+| Method                    | Description                                                       |
+| ------------------------- | ----------------------------------------------------------------- |
+| `getClusters()`           | List ElastiCache cache clusters                                   |
+| `getReplicationGroups()`  | List ElastiCache replication groups                               |
+| `getServerlessCaches()`   | List ElastiCache serverless caches                                |
+| `getElastiCacheAcls()`    | List Redis user-group ACLs                                        |
+
+## `fc.elbv2`
+
+| Method                | Description                                                                       |
+| --------------------- | --------------------------------------------------------------------------------- |
+| `getLoadBalancers()`  | List every ELBv2 load balancer (ALB / NLB / GWLB) across every account            |
+| `getListeners()`      | List every listener                                                               |
+| `getRules()`          | List every listener rule                                                          |
+| `getTargetGroups()`   | List every target group                                                           |
+| `flushAccessLogs()`   | Flush buffered ALB access-log + connection-log lines to S3 now                    |
+| `getWafCounts()`      | Return current WAF association / evaluation counts                                |
+
+## `fc.events`
+
+| Method          | Description                            |
+| --------------- | -------------------------------------- |
+| `getHistory()`  | Get event history and delivery records |
+| `fireRule(req)` | Fire an EventBridge rule manually      |
+
+## `fc.glue`
+
+| Method               | Description                                                  |
+| -------------------- | ------------------------------------------------------------ |
+| `getJobs()`          | List every Glue job                                          |
+| `getJobRuns(name?)`  | List job runs, optionally filtered by job name               |
+
+## `fc.kms`
+
+| Method       | Description                                                              |
+| ------------ | ------------------------------------------------------------------------ |
+| `getUsage()` | Return every recorded KMS usage record (one per server-side encrypt op)  |
+
 ## `fc.lambda`
 
-| Method                         | Description                          |
-| ------------------------------ | ------------------------------------ |
-| `getInvocations()`             | List recorded Lambda invocations     |
-| `getWarmContainers()`          | List warm (cached) Lambda containers |
-| `evictContainer(functionName)` | Evict a warm container               |
+| Method                                                       | Description                                                          |
+| ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `getInvocations()`                                           | List recorded Lambda invocations                                     |
+| `getWarmContainers()`                                        | List warm (cached) Lambda containers                                 |
+| `evictContainer(functionName)`                               | Evict a warm container                                               |
+| `downloadFunctionCode(accountId, functionName, qualifier?)`  | Download the raw ZIP for a function's code (default `latest`)        |
+| `downloadLayerContent(accountId, layerName, version)`        | Download the raw ZIP for a Lambda layer version                      |
+
+## `fc.logs`
+
+| Method                              | Description                                                            |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| `injectAnomaly(req)`                | Inject a synthetic anomaly into the anomaly detector                   |
+| `getDeliveryConfig()`               | Return persisted CloudWatch Logs delivery configurations               |
+| `getFieldIndexes(logGroupName)`     | Parsed `Fields` from index policies on a log group (404 when missing)  |
+
+## `fc.organizations`
+
+| Method          | Description                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------- |
+| `getAccounts()` | List every member account with lifecycle state, parent OU, tags, and directly-attached SCPs  |
+
+## `fc.rds`
+
+| Method              | Description                                                                |
+| ------------------- | -------------------------------------------------------------------------- |
+| `getInstances()`    | List managed RDS instances                                                 |
+| `lambdaInvoke(req)` | Bridge endpoint the PostgreSQL `aws_lambda` extension dispatches into      |
+| `s3Import(req)`     | Bridge for the PostgreSQL `aws_s3` extension's import path                 |
+| `s3Export(req)`     | Bridge for the PostgreSQL `aws_s3` extension's export path                 |
+
+## `fc.route53`
+
+| Method                                  | Description                                                                                                   |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `setHealthCheckStatus(id, req)`         | Flip a health check status (`Success` / `Failure` / `Timeout` / `DnsError` / `InsufficientDataPoints` / `Unknown`) |
+| `getDnssecMaterial(zoneId)`             | DNSKEY public key + DS digest derived from the zone's first ACTIVE KSK                                        |
+| `signDnssecRrset(zoneId, req)`          | Sign an RRset under the zone's first ACTIVE KSK and return the raw RRSIG fields                               |
+
+## `fc.s3`
+
+| Method                         | Description                                                  |
+| ------------------------------ | ------------------------------------------------------------ |
+| `getNotifications()`           | List S3 notification events                                  |
+| `tickLifecycle()`              | Tick the lifecycle processor                                 |
+| `getAccessPoints()`            | List configured S3 access points                             |
+| `getObjectLambdaResponses()`   | List recorded S3 Object Lambda `WriteGetObjectResponse` calls |
+
+## `fc.scheduler`
+
+| Method                       | Description                                                  |
+| ---------------------------- | ------------------------------------------------------------ |
+| `getSchedules()`             | List every EventBridge Scheduler schedule                    |
+| `fireSchedule(group, name)`  | Fire a schedule manually, bypassing the cron tick            |
+
+## `fc.secretsmanager`
+
+| Method           | Description                 |
+| ---------------- | --------------------------- |
+| `tickRotation()` | Tick the rotation scheduler |
 
 ## `fc.ses`
 
-| Method                 | Description                               |
-| ---------------------- | ----------------------------------------- |
-| `getEmails()`          | List all sent emails                      |
-| `simulateInbound(req)` | Simulate an inbound email (receipt rules) |
+| Method                                | Description                                                                |
+| ------------------------------------- | -------------------------------------------------------------------------- |
+| `getEmails()`                         | List all sent emails                                                       |
+| `simulateInbound(req)`                | Simulate an inbound email (receipt rules)                                  |
+| `getMetrics()`                        | Aggregate counters for sends / bounces / complaints / deliveries           |
+| `getBounces()`                        | List recorded bounce events                                                |
+| `setSandbox(sandbox)`                 | Toggle SES account sandbox mode                                            |
+| `getEventDestinationDeliveries()`     | List event-destination delivery records (SNS / Firehose / EventBridge)     |
+| `getDkimPublicKey(identity)`          | Return the DKIM public key fakecloud minted for an identity                |
+| `setMailFromStatus(identity, status)` | Flip a custom MAIL FROM domain's verification status synchronously         |
+| `getMessageInsights(messageId)`       | Return Message Insights for a sent message                                 |
+| `getSmtpSubmissions()`                | List messages submitted via the SMTP endpoint                              |
 
 ## `fc.sns`
 
-| Method                      | Description                             |
-| --------------------------- | --------------------------------------- |
-| `getMessages()`             | List all published messages             |
-| `getPendingConfirmations()` | List subscriptions pending confirmation |
-| `confirmSubscription(req)`  | Confirm a pending subscription          |
+| Method                      | Description                                                          |
+| --------------------------- | -------------------------------------------------------------------- |
+| `getMessages()`             | List all published messages                                          |
+| `getPendingConfirmations()` | List subscriptions pending confirmation                              |
+| `confirmSubscription(req)`  | Confirm a pending subscription                                       |
+| `getCertPem()`              | Return the PEM-encoded SNS signing certificate (raw PEM, not JSON)   |
+| `getSms()`                  | List recorded SMS messages dispatched via `SNS Publish`              |
 
 ## `fc.sqs`
 
@@ -73,60 +272,29 @@ const fc = new FakeCloud("http://localhost:5000");
 | `tickExpiration()`    | Tick the message expiration processor |
 | `forceDlq(queueName)` | Force all messages to the queue's DLQ |
 
-## `fc.events`
+## `fc.ssm`
 
-| Method          | Description                            |
-| --------------- | -------------------------------------- |
-| `getHistory()`  | Get event history and delivery records |
-| `fireRule(req)` | Fire an EventBridge rule manually      |
-
-## `fc.s3`
-
-| Method               | Description                  |
-| -------------------- | ---------------------------- |
-| `getNotifications()` | List S3 notification events  |
-| `tickLifecycle()`    | Tick the lifecycle processor |
-
-## `fc.dynamodb`
-
-| Method      | Description            |
-| ----------- | ---------------------- |
-| `tickTtl()` | Tick the TTL processor |
-
-## `fc.secretsmanager`
-
-| Method           | Description                 |
-| ---------------- | --------------------------- |
-| `tickRotation()` | Tick the rotation scheduler |
-
-## `fc.cognito`
-
-| Method                                                      | Description                              |
-| ----------------------------------------------------------- | ---------------------------------------- |
-| `getConfirmationCodes()`                                    | List all pending confirmation codes      |
-| `getConfirmationCodesForUser(poolId, username)`             | Codes for a specific user                |
-| `confirmUser(req)`                                          | Force-confirm a user                     |
-| `getTokens()`                                               | List active tokens                       |
-| `expireTokens(req)`                                         | Expire tokens for a pool/user            |
-| `getAuthEvents()`                                           | List auth events                         |
+| Method                                    | Description                                                                  |
+| ----------------------------------------- | ---------------------------------------------------------------------------- |
+| `setCommandStatus(commandId, req)`        | Flip a Run Command's status synchronously                                    |
+| `failCommand(commandId, req?)`            | Mark a Run Command's invocations as failed (all or a single instance)        |
+| `getParameterPolicyEvents(accountId?)`    | List recorded SSM parameter-policy lifecycle events                          |
+| `injectSession(req)`                      | Inject a fake Session Manager session without going through `StartSession`   |
 
 ## `fc.stepfunctions`
 
-| Method           | Description             |
-| ---------------- | ----------------------- |
-| `getExecutions()`| List all executions     |
+| Method                       | Description                                                              |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| `getExecutions()`            | List all state machine executions                                        |
+| `getSyncExecutions()`        | List recorded `StartSyncExecution` results                               |
+| `getExecutionTree(arn)`      | Return the full execution tree (parent + nested child workflows)         |
+| `enqueueActivityTask(req)`   | Enqueue an Activity task directly for a worker to `GetActivityTask`      |
 
-## `fc.rds`
+## `fc.wafv2`
 
-| Method          | Description                       |
-| --------------- | --------------------------------- |
-| `getInstances()`| List managed RDS instances        |
-
-## `fc.apigatewayv2`
-
-| Method          | Description                       |
-| --------------- | --------------------------------- |
-| `getRequests()` | List recorded HTTP API requests   |
+| Method          | Description                                                                  |
+| --------------- | ---------------------------------------------------------------------------- |
+| `evaluate(req)` | Run an arbitrary request payload against the configured WebACLs (opaque JSON) |
 
 ## Error handling
 
@@ -175,4 +343,4 @@ test("app publishes to SQS", async () => {
 ## Source
 
 - [`sdks/typescript`](https://github.com/faiscadev/fakecloud/tree/main/sdks/typescript)
-- [Source README](https://github.com/faiscadev/fakecloud/blob/main/sdks/typescript/README.md) — always-current method list
+- [Source README](https://github.com/faiscadev/fakecloud/blob/main/sdks/typescript/README.md) -- always-current method list


### PR DESCRIPTION
## Summary

Reconciles 6 SDK website docs + 6 SDK READMEs against the actual v0.15.0 public surface (~50 methods added in PR1–PR4 were undocumented). Every sub-client now has a per-method table sourced from the language client.

| SDK | Sub-clients documented |
|---|---|
| TypeScript | 28 |
| Python | 31 (async + sync notes) |
| Go | 35 |
| PHP | 28 |
| Java | 28 |
| Rust | 31 |

## Notable corrections vs prior docs

- Java install coordinate `0.12.0` -> `0.15.0` in `_index.md`
- Cognito getters renamed to `mint*`/`set*` per actual source (no separate getters exist for authorization-codes / compromised-passwords)
- ElastiCache ACL method is `getElastiCacheAcls` (not `getAcls`)
- Rust doc was 102 lines; rewritten to 351 line per-sub-client; type was `FakeCloudClient` (doesn't exist) → `FakeCloud`
- Go doc replaced "see TypeScript" placeholder with full per-sub-client tables; error type corrected `FakeCloudError` → `*APIError`
- `_index.md` Common-surface bullets extended to cover AWS metadata endpoints, DNSSEC, admin state mutation, code/layer downloads, container/cache introspection, logs introspection, ApiGwV2, RDS bridge

## Test plan
- [x] All sub-client tables enumerated from the actual SDK source code by parallel worker agents
- [x] No code changes — docs only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates all SDK docs and READMEs to v0.15.0 parity, adding per-sub-client method tables and documenting ~50 previously missing endpoints. Ensures TypeScript, Python (async and sync), Go, PHP, Java, and Rust docs match the current public API.

- New Features
  - Per-method tables for every sub-client across all six SDKs.
  - Python docs clarify async `FakeCloud` and sync `FakeCloudSync` surfaces (identical APIs).
  - Documented admin bootstrap method: `createAdmin`/`create_admin`/`CreateAdmin`.

- Bug Fixes
  - Java install coordinate updated to `dev.fakecloud:fakecloud:0.15.0`.
  - Corrected method names: Cognito `mint*`/`set*`; ElastiCache `getElastiCacheAcls`.
  - Rust and Go docs brought to parity (Rust client is `FakeCloud`; Go error type `*APIError`; Go import path `github.com/faiscadev/fakecloud/sdks/go`); expanded common-surface list.
  - Python docs: async example wrapped in `async def main()` + `asyncio.run()`; Go docs: use `aws.AnonymousCredentials{}` (not `AnonymousCredentialsProvider{}`) in `aws-sdk-go-v2` examples.

<sup>Written for commit b7dbc38ca9ac17b0ecce97c421d737f261a3b202. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1467?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

