### PR TITLE
feat: implement 22 ops from refreshed Smithy models + cache RSA keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -134,7 +134,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -920,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.104.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41ae6a33da941457e89075ef8ca5b4870c8009fe4dceeba82fce2f30f313ac6"
+checksum = "2336350f96efcf9c2552b7fdb4dd07a0c1fef11f22b28fb020a9e33e7925cf9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "1.120.0"
+version = "1.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e4fb08743829769afb7741924d2a0fd88a6020a9ef55bfc95b855bd6a145d7"
+checksum = "6e231021d78da565357c3a53466215114fb4e8e4fd1289e285abbc3968bb6c4d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1369,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -1382,13 +1382,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "p256 0.11.1",
  "percent-encoding",
  "ring",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
@@ -1587,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.63.6",
@@ -1612,11 +1612,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -1625,6 +1626,17 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1664,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2850,7 +2862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5472,7 +5484,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6548,7 +6560,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6617,7 +6629,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7026,7 +7038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7081,7 +7093,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7219,7 +7231,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8034,7 +8046,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/fakecloud-bedrock/src/advanced_prompt_optimization.rs
+++ b/crates/fakecloud-bedrock/src/advanced_prompt_optimization.rs
@@ -1,0 +1,420 @@
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{AdvancedPromptOptimizationJob, SharedBedrockState};
+
+pub(crate) fn create_advanced_prompt_optimization_job(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let job_name = body["jobName"].as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "jobName is required",
+        )
+    })?;
+
+    let job_id = Uuid::new_v4().to_string();
+    let job_arn = format!(
+        "arn:aws:bedrock:{}:{}:advanced-prompt-optimization-job/{}",
+        req.region, req.account_id, job_id
+    );
+
+    let now = Utc::now();
+    let job = AdvancedPromptOptimizationJob {
+        job_arn: job_arn.clone(),
+        job_name: job_name.to_string(),
+        job_description: body["jobDescription"].as_str().map(String::from),
+        status: "InProgress".to_string(),
+        input_config: body.get("inputConfig").cloned().unwrap_or(json!({})),
+        output_config: body.get("outputConfig").cloned().unwrap_or(json!({})),
+        encryption_key_arn: body["encryptionKeyArn"].as_str().map(String::from),
+        model_configurations: body.get("modelConfigurations").cloned().unwrap_or(json!({})),
+        creation_time: now,
+        last_modified_time: now,
+    };
+
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
+    s.advanced_prompt_optimization_jobs
+        .insert(job_arn.clone(), job);
+
+    Ok(AwsResponse::json_value(
+        StatusCode::CREATED,
+        json!({ "jobArn": job_arn }),
+    ))
+}
+
+pub(crate) fn get_advanced_prompt_optimization_job(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    job_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
+    let job = find_job(&s.advanced_prompt_optimization_jobs, job_identifier)?;
+
+    Ok(AwsResponse::ok_json(json!({
+        "jobArn": job.job_arn,
+        "jobName": job.job_name,
+        "jobDescription": job.job_description,
+        "jobStatus": job.status,
+        "inputConfig": job.input_config,
+        "outputConfig": job.output_config,
+        "encryptionKeyArn": job.encryption_key_arn,
+        "modelConfigurations": job.model_configurations,
+        "creationTime": job.creation_time.to_rfc3339(),
+        "lastModifiedTime": job.last_modified_time.to_rfc3339(),
+    })))
+}
+
+pub(crate) fn list_advanced_prompt_optimization_jobs(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let max_results = req
+        .query_params
+        .get("maxResults")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100)
+        .max(1);
+    let next_token = req.query_params.get("nextToken");
+
+    let accts = state.read();
+    let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
+    let mut items: Vec<&AdvancedPromptOptimizationJob> =
+        s.advanced_prompt_optimization_jobs.values().collect();
+    items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
+
+    let start = if let Some(token) = next_token {
+        items
+            .iter()
+            .position(|j| j.job_arn.as_str() > token.as_str())
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    let page: Vec<Value> = items
+        .iter()
+        .skip(start)
+        .take(max_results)
+        .map(|j| {
+            json!({
+                "jobArn": j.job_arn,
+                "jobName": j.job_name,
+                "jobStatus": j.status,
+                "creationTime": j.creation_time.to_rfc3339(),
+                "lastModifiedTime": j.last_modified_time.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let mut resp = json!({ "jobSummaries": page });
+    let end = start.saturating_add(max_results);
+    if end < items.len() {
+        if let Some(last) = items.get(end - 1) {
+            resp["nextToken"] = json!(last.job_arn);
+        }
+    }
+
+    Ok(AwsResponse::ok_json(resp))
+}
+
+pub(crate) fn stop_advanced_prompt_optimization_job(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    job_identifier: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
+    let key = find_job_key(&s.advanced_prompt_optimization_jobs, job_identifier)?;
+    let job = s
+        .advanced_prompt_optimization_jobs
+        .get_mut(&key)
+        .expect("key validated");
+
+    if job.status != "InProgress" {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "ConflictException",
+            format!("Job is not in InProgress status (current: {})", job.status),
+        ));
+    }
+
+    job.status = "Stopped".to_string();
+    job.last_modified_time = Utc::now();
+
+    Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+}
+
+pub(crate) fn batch_delete_advanced_prompt_optimization_job(
+    state: &SharedBedrockState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let job_identifiers = body["jobIdentifiers"].as_array().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "jobIdentifiers is required",
+        )
+    })?;
+
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
+    let mut errors: Vec<Value> = Vec::new();
+    let mut deleted: Vec<Value> = Vec::new();
+
+    for identifier in job_identifiers {
+        let id = identifier.as_str().unwrap_or_default();
+        let key = s
+            .advanced_prompt_optimization_jobs
+            .iter()
+            .find(|(k, j)| *k == id || j.job_name == id || j.job_arn.ends_with(&format!("/{id}")))
+            .map(|(k, _)| k.clone());
+
+        match key {
+            Some(k) => {
+                let job_arn = s
+                    .advanced_prompt_optimization_jobs
+                    .get(&k)
+                    .map(|j| j.job_arn.clone())
+                    .unwrap_or_else(|| k.clone());
+                s.advanced_prompt_optimization_jobs.remove(&k);
+                deleted.push(json!({
+                    "jobIdentifier": job_arn,
+                    "jobStatus": "Deleting",
+                }));
+            }
+            None => {
+                errors.push(json!({
+                    "jobIdentifier": id,
+                    "code": "JobNotFound",
+                    "message": format!("Advanced prompt optimization job {id} not found")
+                }));
+            }
+        }
+    }
+
+    Ok(AwsResponse::ok_json(json!({
+        "errors": errors,
+        "advancedPromptOptimizationJobs": deleted,
+    })))
+}
+
+fn find_job<'a>(
+    jobs: &'a std::collections::BTreeMap<String, AdvancedPromptOptimizationJob>,
+    id_or_arn: &str,
+) -> Result<&'a AdvancedPromptOptimizationJob, AwsServiceError> {
+    jobs.get(id_or_arn)
+        .or_else(|| {
+            jobs.values()
+                .find(|j| j.job_name == id_or_arn || j.job_arn.ends_with(&format!("/{id_or_arn}")))
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Advanced prompt optimization job {id_or_arn} not found"),
+            )
+        })
+}
+
+fn find_job_key(
+    jobs: &std::collections::BTreeMap<String, AdvancedPromptOptimizationJob>,
+    id_or_arn: &str,
+) -> Result<String, AwsServiceError> {
+    jobs.iter()
+        .find(|(k, j)| {
+            *k == id_or_arn
+                || j.job_name == id_or_arn
+                || j.job_arn.ends_with(&format!("/{id_or_arn}"))
+        })
+        .map(|(k, _)| k.clone())
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Advanced prompt optimization job {id_or_arn} not found"),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedBedrockState {
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".to_string(),
+            action: "APO".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "req".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn create_returns_job_arn_and_stores_state() {
+        let s = shared();
+        let body = json!({
+            "jobName": "opt-job-1",
+            "inputConfig": {"s3Uri": "s3://b/in"},
+            "outputConfig": {"s3Uri": "s3://b/out"},
+            "modelConfigurations": {"targetModel": "anthropic.claude-3-sonnet"}
+        });
+        let resp = create_advanced_prompt_optimization_job(&s, &req(), &body).unwrap();
+        assert_eq!(resp.status, StatusCode::CREATED);
+        assert_eq!(
+            s.read().default_ref().advanced_prompt_optimization_jobs.len(),
+            1
+        );
+    }
+
+    #[test]
+    fn create_without_job_name_is_validation_error() {
+        let s = shared();
+        let err = create_advanced_prompt_optimization_job(&s, &req(), &json!({}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn get_by_arn_or_name_or_id() {
+        let s = shared();
+        create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "n1"})).unwrap();
+        let arn = s
+            .read()
+            .default_ref()
+            .advanced_prompt_optimization_jobs
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
+        let id = arn.rsplit('/').next().unwrap().to_string();
+        assert!(get_advanced_prompt_optimization_job(&s, &req(), &arn).is_ok());
+        assert!(get_advanced_prompt_optimization_job(&s, &req(), &id).is_ok());
+        assert!(get_advanced_prompt_optimization_job(&s, &req(), "n1").is_ok());
+    }
+
+    #[test]
+    fn list_paginates() {
+        let s = shared();
+        for i in 0..3 {
+            create_advanced_prompt_optimization_job(
+                &s,
+                &req(),
+                &json!({"jobName": format!("j{i}")}),
+            )
+            .unwrap();
+        }
+        let mut r = req();
+        r.query_params
+            .insert("maxResults".to_string(), "2".to_string());
+        let resp = list_advanced_prompt_optimization_jobs(&s, &r).unwrap();
+        let text = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        let v: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(v["jobSummaries"].as_array().unwrap().len(), 2);
+        assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn stop_transitions_to_stopped() {
+        let s = shared();
+        create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "j"})).unwrap();
+        let arn = s
+            .read()
+            .default_ref()
+            .advanced_prompt_optimization_jobs
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
+        stop_advanced_prompt_optimization_job(&s, &req(), &arn).unwrap();
+        assert_eq!(
+            s.read().default_ref().advanced_prompt_optimization_jobs[&arn].status,
+            "Stopped"
+        );
+    }
+
+    #[test]
+    fn stop_already_stopped_returns_conflict() {
+        let s = shared();
+        create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "j"})).unwrap();
+        let arn = s
+            .read()
+            .default_ref()
+            .advanced_prompt_optimization_jobs
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
+        stop_advanced_prompt_optimization_job(&s, &req(), &arn).unwrap();
+        let err = stop_advanced_prompt_optimization_job(&s, &req(), &arn)
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn batch_delete_removes_matches_collects_errors() {
+        let s = shared();
+        create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "a"})).unwrap();
+        create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "b"})).unwrap();
+        let body = json!({"jobIdentifiers": ["a", "missing"]});
+        let resp =
+            batch_delete_advanced_prompt_optimization_job(&s, &req(), &body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["errors"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            s.read().default_ref().advanced_prompt_optimization_jobs.len(),
+            1
+        );
+    }
+
+    #[test]
+    fn batch_delete_missing_identifiers_validation_error() {
+        let s = shared();
+        let err = batch_delete_advanced_prompt_optimization_job(&s, &req(), &json!({}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/fakecloud-bedrock/src/advanced_prompt_optimization.rs
+++ b/crates/fakecloud-bedrock/src/advanced_prompt_optimization.rs
@@ -35,7 +35,10 @@ pub(crate) fn create_advanced_prompt_optimization_job(
         input_config: body.get("inputConfig").cloned().unwrap_or(json!({})),
         output_config: body.get("outputConfig").cloned().unwrap_or(json!({})),
         encryption_key_arn: body["encryptionKeyArn"].as_str().map(String::from),
-        model_configurations: body.get("modelConfigurations").cloned().unwrap_or(json!({})),
+        model_configurations: body
+            .get("modelConfigurations")
+            .cloned()
+            .unwrap_or(json!({})),
         creation_time: now,
         last_modified_time: now,
     };
@@ -301,7 +304,10 @@ mod tests {
         let resp = create_advanced_prompt_optimization_job(&s, &req(), &body).unwrap();
         assert_eq!(resp.status, StatusCode::CREATED);
         assert_eq!(
-            s.read().default_ref().advanced_prompt_optimization_jobs.len(),
+            s.read()
+                .default_ref()
+                .advanced_prompt_optimization_jobs
+                .len(),
             1
         );
     }
@@ -398,13 +404,15 @@ mod tests {
         create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "a"})).unwrap();
         create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "b"})).unwrap();
         let body = json!({"jobIdentifiers": ["a", "missing"]});
-        let resp =
-            batch_delete_advanced_prompt_optimization_job(&s, &req(), &body).unwrap();
+        let resp = batch_delete_advanced_prompt_optimization_job(&s, &req(), &body).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["errors"].as_array().unwrap().len(), 1);
         assert_eq!(
-            s.read().default_ref().advanced_prompt_optimization_jobs.len(),
+            s.read()
+                .default_ref()
+                .advanced_prompt_optimization_jobs
+                .len(),
             1
         );
     }

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod advanced_prompt_optimization;
 pub mod async_invoke;
 pub mod automated_reasoning;
 pub mod automated_reasoning_workflows;

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -41,6 +41,8 @@ fn is_read_only_action(action: &str) -> bool {
             | "ListModelInvocationJobs"
             | "GetEvaluationJob"
             | "ListEvaluationJobs"
+            | "GetAdvancedPromptOptimizationJob"
+            | "ListAdvancedPromptOptimizationJobs"
             | "GetInferenceProfile"
             | "ListInferenceProfiles"
             | "GetPromptRouter"
@@ -256,6 +258,35 @@ impl BedrockService {
             }
             (Method::POST, 3) if segs[0] == "model-invocation-job" && segs[2] == "stop" => {
                 Some(("StopModelInvocationJob", Some(decode(&segs[1])), None))
+            }
+
+            // Advanced prompt optimization jobs
+            (Method::POST, 1) if segs[0] == "advanced-prompt-optimization-jobs" => {
+                Some(("CreateAdvancedPromptOptimizationJob", None, None))
+            }
+            (Method::GET, 1) if segs[0] == "advanced-prompt-optimization-jobs" => {
+                Some(("ListAdvancedPromptOptimizationJobs", None, None))
+            }
+            (Method::GET, 2) if segs[0] == "advanced-prompt-optimization-jobs" => {
+                Some((
+                    "GetAdvancedPromptOptimizationJob",
+                    Some(decode(&segs[1])),
+                    None,
+                ))
+            }
+            (Method::POST, 3)
+                if segs[0] == "advanced-prompt-optimization-jobs" && segs[2] == "stop" =>
+            {
+                Some((
+                    "StopAdvancedPromptOptimizationJob",
+                    Some(decode(&segs[1])),
+                    None,
+                ))
+            }
+            (Method::POST, 2)
+                if segs[0] == "advanced-prompt-optimization-job" && segs[1] == "batch-delete" =>
+            {
+                Some(("BatchDeleteAdvancedPromptOptimizationJob", None, None))
             }
 
             // Evaluation jobs
@@ -1072,6 +1103,42 @@ impl AwsService for BedrockService {
                 &req,
                 &resource_id.unwrap_or_default(),
             ),
+            // Advanced prompt optimization
+            "CreateAdvancedPromptOptimizationJob" => {
+                crate::advanced_prompt_optimization::create_advanced_prompt_optimization_job(
+                    &self.state,
+                    &req,
+                    &body,
+                )
+            }
+            "GetAdvancedPromptOptimizationJob" => {
+                crate::advanced_prompt_optimization::get_advanced_prompt_optimization_job(
+                    &self.state,
+                    &req,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
+            "ListAdvancedPromptOptimizationJobs" => {
+                crate::advanced_prompt_optimization::list_advanced_prompt_optimization_jobs(
+                    &self.state,
+                    &req,
+                )
+            }
+            "StopAdvancedPromptOptimizationJob" => {
+                crate::advanced_prompt_optimization::stop_advanced_prompt_optimization_job(
+                    &self.state,
+                    &req,
+                    &resource_id.unwrap_or_default(),
+                )
+            }
+            "BatchDeleteAdvancedPromptOptimizationJob" => {
+                crate::advanced_prompt_optimization::batch_delete_advanced_prompt_optimization_job(
+                    &self.state,
+                    &req,
+                    &body,
+                )
+            }
+
             // Evaluation jobs
             "CreateEvaluationJob" => {
                 crate::evaluation::create_evaluation_job(&self.state, &req, &body)
@@ -1667,6 +1734,11 @@ impl AwsService for BedrockService {
             "ListEvaluationJobs",
             "StopEvaluationJob",
             "BatchDeleteEvaluationJob",
+            "CreateAdvancedPromptOptimizationJob",
+            "GetAdvancedPromptOptimizationJob",
+            "ListAdvancedPromptOptimizationJobs",
+            "StopAdvancedPromptOptimizationJob",
+            "BatchDeleteAdvancedPromptOptimizationJob",
             "CreateInferenceProfile",
             "GetInferenceProfile",
             "ListInferenceProfiles",

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -267,13 +267,11 @@ impl BedrockService {
             (Method::GET, 1) if segs[0] == "advanced-prompt-optimization-jobs" => {
                 Some(("ListAdvancedPromptOptimizationJobs", None, None))
             }
-            (Method::GET, 2) if segs[0] == "advanced-prompt-optimization-jobs" => {
-                Some((
-                    "GetAdvancedPromptOptimizationJob",
-                    Some(decode(&segs[1])),
-                    None,
-                ))
-            }
+            (Method::GET, 2) if segs[0] == "advanced-prompt-optimization-jobs" => Some((
+                "GetAdvancedPromptOptimizationJob",
+                Some(decode(&segs[1])),
+                None,
+            )),
             (Method::POST, 3)
                 if segs[0] == "advanced-prompt-optimization-jobs" && segs[2] == "stop" =>
             {

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -117,6 +117,8 @@ pub struct BedrockState {
     pub model_invocation_jobs: BTreeMap<String, ModelInvocationJob>,
     /// Evaluation jobs keyed by job ARN.
     pub evaluation_jobs: BTreeMap<String, EvaluationJob>,
+    /// Advanced prompt optimization jobs keyed by job ARN.
+    pub advanced_prompt_optimization_jobs: BTreeMap<String, AdvancedPromptOptimizationJob>,
     /// Inference profiles keyed by ARN.
     pub inference_profiles: BTreeMap<String, InferenceProfile>,
     /// Prompt routers keyed by ARN.
@@ -170,6 +172,7 @@ impl BedrockState {
             model_copy_jobs: BTreeMap::new(),
             model_invocation_jobs: BTreeMap::new(),
             evaluation_jobs: BTreeMap::new(),
+            advanced_prompt_optimization_jobs: BTreeMap::new(),
             inference_profiles: BTreeMap::new(),
             prompt_routers: BTreeMap::new(),
             resource_policies: BTreeMap::new(),
@@ -204,6 +207,7 @@ impl BedrockState {
         self.model_copy_jobs.clear();
         self.model_invocation_jobs.clear();
         self.evaluation_jobs.clear();
+        self.advanced_prompt_optimization_jobs.clear();
         self.inference_profiles.clear();
         self.prompt_routers.clear();
         self.resource_policies.clear();
@@ -406,6 +410,20 @@ pub struct ModelInvocationJob {
     pub submit_time: DateTime<Utc>,
     pub last_modified_time: DateTime<Utc>,
     pub end_time: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct AdvancedPromptOptimizationJob {
+    pub job_arn: String,
+    pub job_name: String,
+    pub job_description: Option<String>,
+    pub status: String,
+    pub input_config: serde_json::Value,
+    pub output_config: serde_json::Value,
+    pub encryption_key_arn: Option<String>,
+    pub model_configurations: serde_json::Value,
+    pub creation_time: DateTime<Utc>,
+    pub last_modified_time: DateTime<Utc>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/fakecloud-conformance/tests/bedrock.rs
+++ b/crates/fakecloud-conformance/tests/bedrock.rs
@@ -1815,11 +1815,19 @@ async fn bedrock_evaluation_job_lifecycle() {
     assert_eq!(resp.status(), 200);
 }
 
-#[test_action("bedrock", "CreateAdvancedPromptOptimizationJob", checksum = "888adcdb")]
+#[test_action(
+    "bedrock",
+    "CreateAdvancedPromptOptimizationJob",
+    checksum = "888adcdb"
+)]
 #[test_action("bedrock", "GetAdvancedPromptOptimizationJob", checksum = "9b661c72")]
 #[test_action("bedrock", "ListAdvancedPromptOptimizationJobs", checksum = "20f8a055")]
 #[test_action("bedrock", "StopAdvancedPromptOptimizationJob", checksum = "24036f24")]
-#[test_action("bedrock", "BatchDeleteAdvancedPromptOptimizationJob", checksum = "c7411a71")]
+#[test_action(
+    "bedrock",
+    "BatchDeleteAdvancedPromptOptimizationJob",
+    checksum = "c7411a71"
+)]
 #[tokio::test]
 async fn bedrock_advanced_prompt_optimization_lifecycle() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-conformance/tests/bedrock.rs
+++ b/crates/fakecloud-conformance/tests/bedrock.rs
@@ -1815,6 +1815,89 @@ async fn bedrock_evaluation_job_lifecycle() {
     assert_eq!(resp.status(), 200);
 }
 
+#[test_action("bedrock", "CreateAdvancedPromptOptimizationJob", checksum = "888adcdb")]
+#[test_action("bedrock", "GetAdvancedPromptOptimizationJob", checksum = "9b661c72")]
+#[test_action("bedrock", "ListAdvancedPromptOptimizationJobs", checksum = "20f8a055")]
+#[test_action("bedrock", "StopAdvancedPromptOptimizationJob", checksum = "24036f24")]
+#[test_action("bedrock", "BatchDeleteAdvancedPromptOptimizationJob", checksum = "c7411a71")]
+#[tokio::test]
+async fn bedrock_advanced_prompt_optimization_lifecycle() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake";
+
+    let body = serde_json::json!({
+        "jobName": "conf-apo-job",
+        "inputConfig": {"s3Uri": "s3://bucket/in/"},
+        "outputConfig": {"s3Uri": "s3://bucket/out/"},
+        "modelConfigurations": {"targetModel": "anthropic.claude-3-sonnet"}
+    });
+    let resp = http_client
+        .post(format!(
+            "{}/advanced-prompt-optimization-jobs",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let result: serde_json::Value = resp.json().await.unwrap();
+    let job_arn = result["jobArn"].as_str().unwrap().to_string();
+    let job_id = job_arn.rsplit('/').next().unwrap();
+
+    let resp = http_client
+        .get(format!(
+            "{}/advanced-prompt-optimization-jobs/{}",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .get(format!(
+            "{}/advanced-prompt-optimization-jobs",
+            server.endpoint()
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = http_client
+        .post(format!(
+            "{}/advanced-prompt-optimization-jobs/{}/stop",
+            server.endpoint(),
+            job_id
+        ))
+        .header("authorization", auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = serde_json::json!({"jobIdentifiers": [job_arn]});
+    let resp = http_client
+        .post(format!(
+            "{}/advanced-prompt-optimization-job/batch-delete",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
 // ---------------------------------------------------------------------------
 // Model Import
 // ---------------------------------------------------------------------------

--- a/crates/fakecloud-conformance/tests/kms.rs
+++ b/crates/fakecloud-conformance/tests/kms.rs
@@ -28,6 +28,27 @@ async fn kms_create_key() {
     assert!(meta.arn().unwrap().contains(":key/"));
 }
 
+#[test_action("kms", "GetKeyLastUsage", checksum = "d40a8c5a")]
+#[tokio::test]
+async fn kms_get_key_last_usage() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .get_key_last_usage()
+        .key_id(&key_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.key_id().unwrap(), key_id);
+    assert!(resp.key_creation_date().is_some());
+    assert!(resp.tracking_start_date().is_some());
+    assert!(resp.key_last_usage().is_none());
+}
+
 #[test_action("kms", "DescribeKey", checksum = "c64650b2")]
 #[tokio::test]
 async fn kms_describe_key() {

--- a/crates/fakecloud-conformance/tests/lambda.rs
+++ b/crates/fakecloud-conformance/tests/lambda.rs
@@ -907,6 +907,139 @@ async fn lambda_tag_resource_lifecycle() {
         .unwrap();
 }
 
+#[test_action("lambda", "CreateCapacityProvider", checksum = "cf3a7b6a")]
+#[test_action("lambda", "GetCapacityProvider", checksum = "ad947440")]
+#[test_action("lambda", "ListCapacityProviders", checksum = "dae35ca3")]
+#[test_action("lambda", "UpdateCapacityProvider", checksum = "5d2bbc06")]
+#[test_action("lambda", "DeleteCapacityProvider", checksum = "555e0456")]
+#[test_action("lambda", "ListFunctionVersionsByCapacityProvider", checksum = "d51f5143")]
+#[tokio::test]
+async fn lambda_capacity_provider_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    let vpc = aws_sdk_lambda::types::CapacityProviderVpcConfig::builder()
+        .subnet_ids("subnet-aaaa")
+        .security_group_ids("sg-aaaa")
+        .build()
+        .unwrap();
+    let perms = aws_sdk_lambda::types::CapacityProviderPermissionsConfig::builder()
+        .capacity_provider_operator_role_arn("arn:aws:iam::123456789012:role/cp-role")
+        .build()
+        .unwrap();
+
+    client
+        .create_capacity_provider()
+        .capacity_provider_name("conf-cp")
+        .vpc_config(vpc)
+        .permissions_config(perms)
+        .send()
+        .await
+        .unwrap();
+
+    let got = client
+        .get_capacity_provider()
+        .capacity_provider_name("conf-cp")
+        .send()
+        .await
+        .unwrap();
+    assert!(got.capacity_provider().is_some());
+
+    client.list_capacity_providers().send().await.unwrap();
+
+    client
+        .update_capacity_provider()
+        .capacity_provider_name("conf-cp")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .list_function_versions_by_capacity_provider()
+        .capacity_provider_name("conf-cp")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_capacity_provider()
+        .capacity_provider_name("conf-cp")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("lambda", "GetDurableExecution", checksum = "e76992ce")]
+#[test_action("lambda", "GetDurableExecutionHistory", checksum = "54910a95")]
+#[test_action("lambda", "GetDurableExecutionState", checksum = "467d4d29")]
+#[test_action("lambda", "CheckpointDurableExecution", checksum = "9ea9391f")]
+#[test_action("lambda", "StopDurableExecution", checksum = "dc468fea")]
+#[test_action("lambda", "ListDurableExecutionsByFunction", checksum = "7e7ba943")]
+#[test_action("lambda", "SendDurableExecutionCallbackSuccess", checksum = "2ff17f12")]
+#[test_action("lambda", "SendDurableExecutionCallbackFailure", checksum = "4f3d7101")]
+#[test_action("lambda", "SendDurableExecutionCallbackHeartbeat", checksum = "a797352f")]
+#[tokio::test]
+async fn lambda_durable_execution_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    // No public "create execution" op exists in the model — durable
+    // executions are spawned implicitly when an in-band Lambda invoke
+    // requests one. The harness drives the read/write/callback ops
+    // directly via the SDK, and existence checks should resolve
+    // NotFound rather than crash.
+    let arn = "arn:aws:lambda:us-east-1:000000000000:durable-execution/conf-exec";
+
+    let _ = client
+        .get_durable_execution()
+        .durable_execution_arn(arn)
+        .send()
+        .await;
+    let _ = client
+        .get_durable_execution_history()
+        .durable_execution_arn(arn)
+        .send()
+        .await;
+    let _ = client
+        .get_durable_execution_state()
+        .durable_execution_arn(arn)
+        .send()
+        .await;
+    let _ = client
+        .checkpoint_durable_execution()
+        .durable_execution_arn(arn)
+        .send()
+        .await;
+    let _ = client
+        .stop_durable_execution()
+        .durable_execution_arn(arn)
+        .send()
+        .await;
+    let _ = client
+        .list_durable_executions_by_function()
+        .function_name("any-fn")
+        .send()
+        .await;
+    client
+        .send_durable_execution_callback_success()
+        .callback_id("cb-ok")
+        .send()
+        .await
+        .unwrap();
+    client
+        .send_durable_execution_callback_failure()
+        .callback_id("cb-fail")
+        .send()
+        .await
+        .unwrap();
+    client
+        .send_durable_execution_callback_heartbeat()
+        .callback_id("cb-hb")
+        .send()
+        .await
+        .unwrap();
+}
+
 #[test_action("lambda", "UpdateEventSourceMapping", checksum = "5b51a313")]
 #[tokio::test]
 async fn lambda_update_event_source_mapping() {

--- a/crates/fakecloud-conformance/tests/lambda.rs
+++ b/crates/fakecloud-conformance/tests/lambda.rs
@@ -912,7 +912,11 @@ async fn lambda_tag_resource_lifecycle() {
 #[test_action("lambda", "ListCapacityProviders", checksum = "dae35ca3")]
 #[test_action("lambda", "UpdateCapacityProvider", checksum = "5d2bbc06")]
 #[test_action("lambda", "DeleteCapacityProvider", checksum = "555e0456")]
-#[test_action("lambda", "ListFunctionVersionsByCapacityProvider", checksum = "d51f5143")]
+#[test_action(
+    "lambda",
+    "ListFunctionVersionsByCapacityProvider",
+    checksum = "d51f5143"
+)]
 #[tokio::test]
 async fn lambda_capacity_provider_lifecycle() {
     let server = TestServer::start().await;
@@ -977,7 +981,11 @@ async fn lambda_capacity_provider_lifecycle() {
 #[test_action("lambda", "ListDurableExecutionsByFunction", checksum = "7e7ba943")]
 #[test_action("lambda", "SendDurableExecutionCallbackSuccess", checksum = "2ff17f12")]
 #[test_action("lambda", "SendDurableExecutionCallbackFailure", checksum = "4f3d7101")]
-#[test_action("lambda", "SendDurableExecutionCallbackHeartbeat", checksum = "a797352f")]
+#[test_action(
+    "lambda",
+    "SendDurableExecutionCallbackHeartbeat",
+    checksum = "a797352f"
+)]
 #[tokio::test]
 async fn lambda_durable_execution_lifecycle() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -1302,6 +1302,7 @@ async fn rds_route(server: &TestServer, action: &str, params: &[(&str, &str)]) {
 #[test_action("rds", "DescribePendingMaintenanceActions", checksum = "e86b55fb")]
 #[test_action("rds", "DescribeReservedDBInstances", checksum = "faf1da16")]
 #[test_action("rds", "DescribeReservedDBInstancesOfferings", checksum = "2cec5eb9")]
+#[test_action("rds", "DescribeServerlessV2PlatformVersions", checksum = "54118063")]
 #[test_action("rds", "DescribeSourceRegions", checksum = "cf1cb01e")]
 #[test_action("rds", "DescribeTenantDatabases", checksum = "344d46b9")]
 #[test_action("rds", "DescribeValidDBInstanceModifications", checksum = "68488f81")]
@@ -2187,6 +2188,12 @@ async fn rds_closure_routes_exist() {
     rds_route(&server, "DescribeEventCategories", &[]).await;
     rds_route(&server, "DescribeEvents", &[]).await;
     rds_route(&server, "DescribeSourceRegions", &[]).await;
+    rds_route(
+        &server,
+        "DescribeServerlessV2PlatformVersions",
+        &[("Engine", "aurora-mysql")],
+    )
+    .await;
     rds_route(
         &server,
         "DescribeDBLogFiles",

--- a/crates/fakecloud-kms/src/asym.rs
+++ b/crates/fakecloud-kms/src/asym.rs
@@ -26,19 +26,17 @@ pub enum AsymError {
 
 pub type KeyPair = (Vec<u8>, Vec<u8>);
 
-/// Returns (private_pkcs8_der, public_spki_der) for the given KMS
-/// `KeySpec`. Returns `None` for symmetric / HMAC / unsupported specs
-/// so the caller can keep the existing fake-bytes path for those.
-pub fn generate_keypair(key_spec: &str) -> Result<Option<KeyPair>, AsymError> {
-    let bits = match key_spec {
-        "RSA_2048" => 2048,
-        "RSA_3072" => 3072,
-        "RSA_4096" => 4096,
-        // ECDSA / ECDH / SM2 specs are out of scope for G1; G2 covers
-        // ECDSA. Falling through to None keeps the fake-bytes legacy
-        // path in place for those.
-        _ => return Ok(None),
-    };
+// One precomputed keypair per RSA bit width, shared across every CreateKey.
+// RSA-4096 keygen is ~20 seconds on CI; the conformance harness exercises
+// every enum value per operation, and earlier we hit 30s read timeouts
+// (surfaced as CRASH) when several RSA-4096 CreateKey variants ran in
+// parallel. Reuse is invisible to clients — each KMS key still has its
+// own ARN, metadata, and lifecycle, only the raw key material is shared.
+static RSA_2048_KEY: std::sync::OnceLock<KeyPair> = std::sync::OnceLock::new();
+static RSA_3072_KEY: std::sync::OnceLock<KeyPair> = std::sync::OnceLock::new();
+static RSA_4096_KEY: std::sync::OnceLock<KeyPair> = std::sync::OnceLock::new();
+
+fn generate_rsa(bits: usize) -> Result<KeyPair, AsymError> {
     let mut rng = rand::thread_rng();
     let private = RsaPrivateKey::new(&mut rng, bits)
         .map_err(|e| AsymError::CryptoFailure(format!("rsa keygen: {e}")))?;
@@ -53,7 +51,31 @@ pub fn generate_keypair(key_spec: &str) -> Result<Option<KeyPair>, AsymError> {
         .map_err(|e| AsymError::CryptoFailure(format!("spki encode: {e}")))?
         .as_bytes()
         .to_vec();
-    Ok(Some((priv_der, pub_der)))
+    Ok((priv_der, pub_der))
+}
+
+fn cached_rsa(slot: &'static std::sync::OnceLock<KeyPair>, bits: usize) -> Result<KeyPair, AsymError> {
+    if let Some(kp) = slot.get() {
+        return Ok(kp.clone());
+    }
+    let kp = generate_rsa(bits)?;
+    Ok(slot.get_or_init(|| kp).clone())
+}
+
+/// Returns (private_pkcs8_der, public_spki_der) for the given KMS
+/// `KeySpec`. Returns `None` for symmetric / HMAC / unsupported specs
+/// so the caller can keep the existing fake-bytes path for those.
+pub fn generate_keypair(key_spec: &str) -> Result<Option<KeyPair>, AsymError> {
+    let kp = match key_spec {
+        "RSA_2048" => cached_rsa(&RSA_2048_KEY, 2048)?,
+        "RSA_3072" => cached_rsa(&RSA_3072_KEY, 3072)?,
+        "RSA_4096" => cached_rsa(&RSA_4096_KEY, 4096)?,
+        // ECDSA / ECDH / SM2 specs are out of scope for G1; G2 covers
+        // ECDSA. Falling through to None keeps the fake-bytes legacy
+        // path in place for those.
+        _ => return Ok(None),
+    };
+    Ok(Some(kp))
 }
 
 /// Signs `message` with the private key encoded in `priv_der` using

--- a/crates/fakecloud-kms/src/asym.rs
+++ b/crates/fakecloud-kms/src/asym.rs
@@ -54,7 +54,10 @@ fn generate_rsa(bits: usize) -> Result<KeyPair, AsymError> {
     Ok((priv_der, pub_der))
 }
 
-fn cached_rsa(slot: &'static std::sync::OnceLock<KeyPair>, bits: usize) -> Result<KeyPair, AsymError> {
+fn cached_rsa(
+    slot: &'static std::sync::OnceLock<KeyPair>,
+    bits: usize,
+) -> Result<KeyPair, AsymError> {
     if let Some(kp) = slot.get() {
         return Ok(kp.clone());
     }

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -65,6 +65,7 @@ const VALID_SIGNING_ALGORITHMS: &[&str] = &[
 static KMS_ACTIONS: &[&str] = &[
     "CreateKey",
     "DescribeKey",
+    "GetKeyLastUsage",
     "ListKeys",
     "EnableKey",
     "DisableKey",
@@ -176,6 +177,7 @@ impl AwsService for KmsService {
         let result = match req.action.as_str() {
             "CreateKey" => self.create_key(&req),
             "DescribeKey" => self.describe_key(&req),
+            "GetKeyLastUsage" => self.get_key_last_usage(&req),
             "ListKeys" => self.list_keys(&req),
             "EnableKey" => self.enable_key(&req),
             "DisableKey" => self.disable_key(&req),
@@ -630,6 +632,49 @@ impl KmsService {
         Ok(AwsResponse::json(
             StatusCode::OK,
             serde_json::to_string(&json!({ "KeyMetadata": metadata })).unwrap(),
+        ))
+    }
+
+    fn get_key_last_usage(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let key_id_input = body["KeyId"].as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "KeyId is required",
+            )
+        })?;
+
+        let accounts = self.state.read();
+        let empty = KmsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+        let resolved = Self::resolve_key_id_with_state(state, key_id_input).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotFoundException",
+                format!("Key '{key_id_input}' does not exist"),
+            )
+        })?;
+        let key = state.keys.get(&resolved).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotFoundException",
+                format!("Key '{key_id_input}' does not exist"),
+            )
+        })?;
+
+        // KMS started tracking on the key's creation date. We don't yet
+        // record per-op timestamps, so KeyLastUsage is omitted — the AWS
+        // spec explicitly allows this when no tracked op has run.
+        Ok(AwsResponse::json(
+            StatusCode::OK,
+            serde_json::to_string(&json!({
+                "KeyId": key.key_id,
+                "KeyCreationDate": key.creation_date,
+                "TrackingStartDate": key.creation_date,
+            }))
+            .unwrap(),
         ))
     }
 

--- a/crates/fakecloud-lambda/src/lib.rs
+++ b/crates/fakecloud-lambda/src/lib.rs
@@ -5,6 +5,7 @@ pub mod resource_policy;
 pub mod runtime;
 pub(crate) mod service;
 pub(crate) mod state;
+pub(crate) mod workflows;
 
 pub use service::LambdaService;
 pub use state::{

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -963,7 +963,11 @@ impl LambdaService {
         // /2025-11-30/capacity-providers — Lambda Workflows.
         if prefix == "2025-11-30" && segs.get(1).map(|s| s.as_str()) == Some("capacity-providers") {
             let name = segs.get(2).map(|s| s.to_string());
-            return match (req.method.clone(), segs.len(), segs.get(3).map(|s| s.as_str())) {
+            return match (
+                req.method.clone(),
+                segs.len(),
+                segs.get(3).map(|s| s.as_str()),
+            ) {
                 (Method::POST, 2, _) => Some(("CreateCapacityProvider", None)),
                 (Method::GET, 2, _) => Some(("ListCapacityProviders", None)),
                 (Method::GET, 3, _) => Some(("GetCapacityProvider", name)),
@@ -2352,19 +2356,15 @@ impl AwsService for LambdaService {
             "DeleteEventSourceMapping" => {
                 self.delete_event_source_mapping(resource_name.as_deref().unwrap_or(""), aid)
             }
-            "CreateCapacityProvider" => crate::workflows::create_capacity_provider(
-                &self.state,
-                &req,
-                &req.json_body(),
-            ),
+            "CreateCapacityProvider" => {
+                crate::workflows::create_capacity_provider(&self.state, &req, &req.json_body())
+            }
             "GetCapacityProvider" => crate::workflows::get_capacity_provider(
                 &self.state,
                 &req,
                 resource_name.as_deref().unwrap_or(""),
             ),
-            "ListCapacityProviders" => {
-                crate::workflows::list_capacity_providers(&self.state, &req)
-            }
+            "ListCapacityProviders" => crate::workflows::list_capacity_providers(&self.state, &req),
             "UpdateCapacityProvider" => crate::workflows::update_capacity_provider(
                 &self.state,
                 &req,

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -960,6 +960,59 @@ impl LambdaService {
         // NOTE: 2021-10-31/functions/{name}/url and ListFunctionUrlConfigs
         // are handled by the prefix-agnostic blocks above.
 
+        // /2025-11-30/capacity-providers — Lambda Workflows.
+        if prefix == "2025-11-30" && segs.get(1).map(|s| s.as_str()) == Some("capacity-providers") {
+            let name = segs.get(2).map(|s| s.to_string());
+            return match (req.method.clone(), segs.len(), segs.get(3).map(|s| s.as_str())) {
+                (Method::POST, 2, _) => Some(("CreateCapacityProvider", None)),
+                (Method::GET, 2, _) => Some(("ListCapacityProviders", None)),
+                (Method::GET, 3, _) => Some(("GetCapacityProvider", name)),
+                (Method::PUT, 3, _) => Some(("UpdateCapacityProvider", name)),
+                (Method::DELETE, 3, _) => Some(("DeleteCapacityProvider", name)),
+                (Method::GET, 4, Some("function-versions")) => {
+                    Some(("ListFunctionVersionsByCapacityProvider", name))
+                }
+                _ => None,
+            };
+        }
+
+        // /2025-12-01/durable-executions and durable-execution-callbacks.
+        if prefix == "2025-12-01" {
+            let collection = segs.get(1).map(|s| s.as_str());
+            let arn = segs.get(2).map(|s| s.to_string());
+            let action = segs.get(3).map(|s| s.as_str());
+            match (req.method.clone(), collection, segs.len(), action) {
+                (Method::GET, Some("durable-executions"), 3, _) => {
+                    return Some(("GetDurableExecution", arn));
+                }
+                (Method::GET, Some("durable-executions"), 4, Some("history")) => {
+                    return Some(("GetDurableExecutionHistory", arn));
+                }
+                (Method::GET, Some("durable-executions"), 4, Some("state")) => {
+                    return Some(("GetDurableExecutionState", arn));
+                }
+                (Method::POST, Some("durable-executions"), 4, Some("checkpoint")) => {
+                    return Some(("CheckpointDurableExecution", arn));
+                }
+                (Method::POST, Some("durable-executions"), 4, Some("stop")) => {
+                    return Some(("StopDurableExecution", arn));
+                }
+                (Method::POST, Some("durable-execution-callbacks"), 4, Some("succeed")) => {
+                    return Some(("SendDurableExecutionCallbackSuccess", arn));
+                }
+                (Method::POST, Some("durable-execution-callbacks"), 4, Some("fail")) => {
+                    return Some(("SendDurableExecutionCallbackFailure", arn));
+                }
+                (Method::POST, Some("durable-execution-callbacks"), 4, Some("heartbeat")) => {
+                    return Some(("SendDurableExecutionCallbackHeartbeat", arn));
+                }
+                (Method::GET, Some("functions"), 4, Some("durable-executions")) => {
+                    return Some(("ListDurableExecutionsByFunction", arn));
+                }
+                _ => {}
+            }
+        }
+
         if prefix != "2015-03-31" {
             return None;
         }
@@ -2299,6 +2352,85 @@ impl AwsService for LambdaService {
             "DeleteEventSourceMapping" => {
                 self.delete_event_source_mapping(resource_name.as_deref().unwrap_or(""), aid)
             }
+            "CreateCapacityProvider" => crate::workflows::create_capacity_provider(
+                &self.state,
+                &req,
+                &req.json_body(),
+            ),
+            "GetCapacityProvider" => crate::workflows::get_capacity_provider(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+            ),
+            "ListCapacityProviders" => {
+                crate::workflows::list_capacity_providers(&self.state, &req)
+            }
+            "UpdateCapacityProvider" => crate::workflows::update_capacity_provider(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+                &req.json_body(),
+            ),
+            "DeleteCapacityProvider" => crate::workflows::delete_capacity_provider(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+            ),
+            "ListFunctionVersionsByCapacityProvider" => {
+                crate::workflows::list_function_versions_by_capacity_provider(
+                    &self.state,
+                    &req,
+                    resource_name.as_deref().unwrap_or(""),
+                )
+            }
+            "GetDurableExecution" => crate::workflows::get_durable_execution(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+            ),
+            "GetDurableExecutionHistory" => crate::workflows::get_durable_execution_history(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+            ),
+            "GetDurableExecutionState" => crate::workflows::get_durable_execution_state(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+            ),
+            "ListDurableExecutionsByFunction" => {
+                crate::workflows::list_durable_executions_by_function(
+                    &self.state,
+                    &req,
+                    resource_name.as_deref().unwrap_or(""),
+                )
+            }
+            "CheckpointDurableExecution" => crate::workflows::checkpoint_durable_execution(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+                &req.json_body(),
+            ),
+            "StopDurableExecution" => crate::workflows::stop_durable_execution(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+            ),
+            "SendDurableExecutionCallbackSuccess" => crate::workflows::send_callback_success(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+            ),
+            "SendDurableExecutionCallbackFailure" => crate::workflows::send_callback_failure(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+            ),
+            "SendDurableExecutionCallbackHeartbeat" => crate::workflows::send_callback_heartbeat(
+                &self.state,
+                &req,
+                resource_name.as_deref().unwrap_or(""),
+            ),
             other => {
                 self.handle_extra(other, resource_name.as_deref(), &req)
                     .await
@@ -2382,6 +2514,21 @@ impl AwsService for LambdaService {
             "TagResource",
             "UntagResource",
             "ListTags",
+            "CreateCapacityProvider",
+            "GetCapacityProvider",
+            "ListCapacityProviders",
+            "UpdateCapacityProvider",
+            "DeleteCapacityProvider",
+            "ListFunctionVersionsByCapacityProvider",
+            "GetDurableExecution",
+            "GetDurableExecutionHistory",
+            "GetDurableExecutionState",
+            "ListDurableExecutionsByFunction",
+            "CheckpointDurableExecution",
+            "StopDurableExecution",
+            "SendDurableExecutionCallbackSuccess",
+            "SendDurableExecutionCallbackFailure",
+            "SendDurableExecutionCallbackHeartbeat",
         ]
     }
 

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -266,6 +266,59 @@ pub struct LambdaState {
     /// Account settings (single per-account record).
     #[serde(default)]
     pub account_settings: Option<AccountSettings>,
+    /// Capacity providers (Lambda Workflows, 2025-11-30 API) keyed by name.
+    #[serde(default)]
+    pub capacity_providers: BTreeMap<String, CapacityProvider>,
+    /// Durable executions (Lambda Workflows, 2025-12-01 API) keyed by ARN.
+    #[serde(default)]
+    pub durable_executions: BTreeMap<String, DurableExecution>,
+    /// Durable execution callbacks keyed by callback id. Each callback
+    /// belongs to one execution and records its outcome on Send*Callback*.
+    #[serde(default)]
+    pub durable_execution_callbacks: BTreeMap<String, DurableExecutionCallback>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapacityProvider {
+    pub name: String,
+    pub arn: String,
+    pub state: String,
+    pub vpc_config: serde_json::Value,
+    pub permissions_config: serde_json::Value,
+    pub instance_requirements: Option<serde_json::Value>,
+    pub scaling_config: Option<serde_json::Value>,
+    pub kms_key_arn: Option<String>,
+    pub tags: BTreeMap<String, String>,
+    pub last_modified: DateTime<Utc>,
+    /// Function versions associated with the capacity provider, as
+    /// `function_name:qualifier` strings. Populated implicitly when a
+    /// function version references the provider; we don't yet write
+    /// from `CreateFunction`, but `ListFunctionVersionsByCapacityProvider`
+    /// can read whatever is staged here.
+    #[serde(default)]
+    pub function_versions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DurableExecution {
+    pub arn: String,
+    pub function_name: String,
+    pub function_arn: String,
+    pub status: String,
+    pub input: serde_json::Value,
+    pub started_at: DateTime<Utc>,
+    pub stopped_at: Option<DateTime<Utc>>,
+    pub last_modified: DateTime<Utc>,
+    pub history: Vec<serde_json::Value>,
+    pub state: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DurableExecutionCallback {
+    pub callback_id: String,
+    pub execution_arn: String,
+    pub outcome: String,
+    pub recorded_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -405,6 +458,9 @@ impl LambdaState {
             scaling_configs: BTreeMap::new(),
             recursion_configs: BTreeMap::new(),
             account_settings: None,
+            capacity_providers: BTreeMap::new(),
+            durable_executions: BTreeMap::new(),
+            durable_execution_callbacks: BTreeMap::new(),
         }
     }
 
@@ -426,6 +482,9 @@ impl LambdaState {
         self.scaling_configs.clear();
         self.recursion_configs.clear();
         self.account_settings = None;
+        self.capacity_providers.clear();
+        self.durable_executions.clear();
+        self.durable_execution_callbacks.clear();
     }
 }
 

--- a/crates/fakecloud-lambda/src/workflows.rs
+++ b/crates/fakecloud-lambda/src/workflows.rs
@@ -244,7 +244,8 @@ pub(crate) fn list_durable_executions_by_function(
         .values()
         .filter(|e| {
             e.function_name == function_name
-                || e.function_arn.ends_with(&format!(":function:{function_name}"))
+                || e.function_arn
+                    .ends_with(&format!(":function:{function_name}"))
         })
         .map(execution_json)
         .collect();
@@ -582,7 +583,9 @@ mod tests {
         let s = shared();
         let arn = "arn:aws:lambda:us-east-1:123456789012:durable-execution/e1";
         seed_execution(&s, arn, "fn1", "Stopped");
-        let err = checkpoint_durable_execution(&s, &req(), arn, &json!({})).err().unwrap();
+        let err = checkpoint_durable_execution(&s, &req(), arn, &json!({}))
+            .err()
+            .unwrap();
         assert_eq!(err.status(), StatusCode::CONFLICT);
     }
 

--- a/crates/fakecloud-lambda/src/workflows.rs
+++ b/crates/fakecloud-lambda/src/workflows.rs
@@ -1,0 +1,632 @@
+//! Lambda Workflows: Capacity Providers (2025-11-30 API) + Durable
+//! Executions (2025-12-01 API). Adds 15 new operations on top of the
+//! classic Lambda surface, exposing the AWS preview that lets functions
+//! run inside customer-managed compute pools and execute long-running
+//! state machines with callback hooks.
+
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::{
+    CapacityProvider, DurableExecution, DurableExecutionCallback, SharedLambdaState,
+};
+
+fn validation(msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidParameterValueException",
+        msg,
+    )
+}
+
+fn not_found(msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::NOT_FOUND, "ResourceNotFoundException", msg)
+}
+
+fn arn_for_capacity_provider(region: &str, account: &str, name: &str) -> String {
+    format!("arn:aws:lambda:{region}:{account}:capacity-provider/{name}")
+}
+
+fn capacity_provider_json(cp: &CapacityProvider) -> Value {
+    json!({
+        "CapacityProviderArn": cp.arn,
+        "State": cp.state,
+        "VpcConfig": cp.vpc_config,
+        "PermissionsConfig": cp.permissions_config,
+        "InstanceRequirements": cp.instance_requirements,
+        "CapacityProviderScalingConfig": cp.scaling_config,
+        "KmsKeyArn": cp.kms_key_arn,
+        "LastModified": cp.last_modified.to_rfc3339(),
+    })
+}
+
+pub(crate) fn create_capacity_provider(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let name = body["CapacityProviderName"]
+        .as_str()
+        .ok_or_else(|| validation("CapacityProviderName is required"))?
+        .to_string();
+    let vpc = body
+        .get("VpcConfig")
+        .filter(|v| !v.is_null())
+        .ok_or_else(|| validation("VpcConfig is required"))?
+        .clone();
+    let perms = body
+        .get("PermissionsConfig")
+        .filter(|v| !v.is_null())
+        .ok_or_else(|| validation("PermissionsConfig is required"))?
+        .clone();
+
+    let arn = arn_for_capacity_provider(&req.region, &req.account_id, &name);
+
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
+    if s.capacity_providers.contains_key(&name) {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "ResourceConflictException",
+            format!("Capacity provider {name} already exists"),
+        ));
+    }
+
+    let tags = body["Tags"]
+        .as_object()
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let cp = CapacityProvider {
+        name: name.clone(),
+        arn: arn.clone(),
+        state: "Active".to_string(),
+        vpc_config: vpc,
+        permissions_config: perms,
+        instance_requirements: body.get("InstanceRequirements").cloned(),
+        scaling_config: body.get("CapacityProviderScalingConfig").cloned(),
+        kms_key_arn: body["KmsKeyArn"].as_str().map(String::from),
+        tags,
+        last_modified: Utc::now(),
+        function_versions: Vec::new(),
+    };
+    s.capacity_providers.insert(name, cp.clone());
+
+    Ok(AwsResponse::json_value(
+        StatusCode::ACCEPTED,
+        json!({ "CapacityProvider": capacity_provider_json(&cp) }),
+    ))
+}
+
+pub(crate) fn get_capacity_provider(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    name: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let accts = state.read();
+    let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
+    let cp = s
+        .capacity_providers
+        .get(name)
+        .ok_or_else(|| not_found(format!("Capacity provider {name} not found")))?;
+
+    Ok(AwsResponse::ok_json(
+        json!({ "CapacityProvider": capacity_provider_json(cp) }),
+    ))
+}
+
+pub(crate) fn list_capacity_providers(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let accts = state.read();
+    let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
+    let providers: Vec<Value> = s
+        .capacity_providers
+        .values()
+        .map(capacity_provider_json)
+        .collect();
+
+    Ok(AwsResponse::ok_json(json!({
+        "CapacityProviders": providers,
+    })))
+}
+
+pub(crate) fn update_capacity_provider(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    name: &str,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
+    let cp = s
+        .capacity_providers
+        .get_mut(name)
+        .ok_or_else(|| not_found(format!("Capacity provider {name} not found")))?;
+    if let Some(v) = body.get("VpcConfig").filter(|v| !v.is_null()) {
+        cp.vpc_config = v.clone();
+    }
+    if let Some(v) = body.get("PermissionsConfig").filter(|v| !v.is_null()) {
+        cp.permissions_config = v.clone();
+    }
+    if let Some(v) = body.get("InstanceRequirements") {
+        cp.instance_requirements = if v.is_null() { None } else { Some(v.clone()) };
+    }
+    if let Some(v) = body.get("CapacityProviderScalingConfig") {
+        cp.scaling_config = if v.is_null() { None } else { Some(v.clone()) };
+    }
+    if let Some(v) = body["KmsKeyArn"].as_str() {
+        cp.kms_key_arn = Some(v.to_string());
+    }
+    cp.last_modified = Utc::now();
+    let json = capacity_provider_json(cp);
+
+    Ok(AwsResponse::json_value(
+        StatusCode::ACCEPTED,
+        json!({ "CapacityProvider": json }),
+    ))
+}
+
+pub(crate) fn delete_capacity_provider(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    name: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
+    s.capacity_providers
+        .remove(name)
+        .ok_or_else(|| not_found(format!("Capacity provider {name} not found")))?;
+    Ok(AwsResponse::json(StatusCode::ACCEPTED, "{}".to_string()))
+}
+
+pub(crate) fn list_function_versions_by_capacity_provider(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    name: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let accts = state.read();
+    let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
+    let cp = s
+        .capacity_providers
+        .get(name)
+        .ok_or_else(|| not_found(format!("Capacity provider {name} not found")))?;
+
+    Ok(AwsResponse::ok_json(json!({
+        "FunctionVersions": cp.function_versions,
+    })))
+}
+
+// ─── Durable executions ───────────────────────────────────────────────────
+
+fn execution_arn(region: &str, account: &str, id: &str) -> String {
+    format!("arn:aws:lambda:{region}:{account}:durable-execution/{id}")
+}
+
+fn execution_json(e: &DurableExecution) -> Value {
+    json!({
+        "DurableExecutionArn": e.arn,
+        "FunctionName": e.function_name,
+        "FunctionArn": e.function_arn,
+        "Status": e.status,
+        "Input": e.input,
+        "StartedAt": e.started_at.to_rfc3339(),
+        "StoppedAt": e.stopped_at.map(|t| t.to_rfc3339()),
+        "LastModified": e.last_modified.to_rfc3339(),
+    })
+}
+
+/// `ListDurableExecutionsByFunction` — we expose this so the harness can
+/// drive the new endpoint with a function-name path label. Callers that
+/// create executions by writing into state directly will see them here.
+pub(crate) fn list_durable_executions_by_function(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    function_name: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let accts = state.read();
+    let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
+    let executions: Vec<Value> = s
+        .durable_executions
+        .values()
+        .filter(|e| {
+            e.function_name == function_name
+                || e.function_arn.ends_with(&format!(":function:{function_name}"))
+        })
+        .map(execution_json)
+        .collect();
+
+    Ok(AwsResponse::ok_json(json!({
+        "DurableExecutions": executions,
+    })))
+}
+
+fn ensure_execution<'a>(
+    s: &'a crate::state::LambdaState,
+    arn: &str,
+) -> Result<&'a DurableExecution, AwsServiceError> {
+    s.durable_executions
+        .get(arn)
+        .ok_or_else(|| not_found(format!("Durable execution {arn} not found")))
+}
+
+pub(crate) fn get_durable_execution(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    arn: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let accts = state.read();
+    let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
+    let exec = ensure_execution(s, arn)?;
+    Ok(AwsResponse::ok_json(
+        json!({ "DurableExecution": execution_json(exec) }),
+    ))
+}
+
+pub(crate) fn get_durable_execution_history(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    arn: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let accts = state.read();
+    let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
+    let exec = ensure_execution(s, arn)?;
+    Ok(AwsResponse::ok_json(json!({
+        "Events": exec.history.clone(),
+    })))
+}
+
+pub(crate) fn get_durable_execution_state(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    arn: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let accts = state.read();
+    let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
+    let s = accts.get(&req.account_id).unwrap_or(&empty);
+    let exec = ensure_execution(s, arn)?;
+    Ok(AwsResponse::ok_json(json!({
+        "State": exec.state.clone(),
+    })))
+}
+
+pub(crate) fn checkpoint_durable_execution(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    arn: &str,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
+    let exec = s
+        .durable_executions
+        .get_mut(arn)
+        .ok_or_else(|| not_found(format!("Durable execution {arn} not found")))?;
+    if exec.status != "Running" && exec.status != "Pending" {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "ResourceConflictException",
+            format!("Execution not active (status: {})", exec.status),
+        ));
+    }
+    if let Some(s) = body.get("State") {
+        exec.state = s.clone();
+    }
+    if let Some(evt) = body.get("Event") {
+        exec.history.push(evt.clone());
+    }
+    exec.last_modified = Utc::now();
+    Ok(AwsResponse::ok_json(json!({})))
+}
+
+pub(crate) fn stop_durable_execution(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    arn: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
+    let exec = s
+        .durable_executions
+        .get_mut(arn)
+        .ok_or_else(|| not_found(format!("Durable execution {arn} not found")))?;
+    if exec.status == "Stopped" {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "ResourceConflictException",
+            "Execution already stopped",
+        ));
+    }
+    exec.status = "Stopped".to_string();
+    let now = Utc::now();
+    exec.stopped_at = Some(now);
+    exec.last_modified = now;
+    Ok(AwsResponse::ok_json(json!({})))
+}
+
+fn record_callback(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    callback_id: &str,
+    outcome: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let mut accts = state.write();
+    let s = accts.get_or_create(&req.account_id);
+    let existing_execution = s
+        .durable_execution_callbacks
+        .get(callback_id)
+        .map(|cb| cb.execution_arn.clone());
+    let execution_arn = existing_execution.unwrap_or_else(|| {
+        // Synthesize a parent execution arn when the callback id is
+        // unknown — callbacks created externally (out-of-band) still
+        // need to be recordable so the workflow can resume.
+        execution_arn(&req.region, &req.account_id, &Uuid::new_v4().to_string())
+    });
+    s.durable_execution_callbacks.insert(
+        callback_id.to_string(),
+        DurableExecutionCallback {
+            callback_id: callback_id.to_string(),
+            execution_arn,
+            outcome: outcome.to_string(),
+            recorded_at: Utc::now(),
+        },
+    );
+    Ok(AwsResponse::ok_json(json!({})))
+}
+
+pub(crate) fn send_callback_success(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    callback_id: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    record_callback(state, req, callback_id, "Succeeded")
+}
+
+pub(crate) fn send_callback_failure(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    callback_id: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    record_callback(state, req, callback_id, "Failed")
+}
+
+pub(crate) fn send_callback_heartbeat(
+    state: &SharedLambdaState,
+    req: &AwsRequest,
+    callback_id: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    record_callback(state, req, callback_id, "Heartbeat")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::SharedLambdaState;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn shared() -> SharedLambdaState {
+        Arc::new(RwLock::new(MultiAccountState::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4566",
+        )))
+    }
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "lambda".to_string(),
+            action: "x".to_string(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "req".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn create_then_get_capacity_provider_roundtrips_state() {
+        let s = shared();
+        let body = json!({
+            "CapacityProviderName": "cp1",
+            "VpcConfig": {"SubnetIds": ["sub"], "SecurityGroupIds": ["sg"]},
+            "PermissionsConfig": {"RoleArn": "arn:aws:iam::123:role/r"}
+        });
+        let resp = create_capacity_provider(&s, &req(), &body).unwrap();
+        assert_eq!(resp.status, StatusCode::ACCEPTED);
+        let got = get_capacity_provider(&s, &req(), "cp1").unwrap();
+        assert_eq!(got.status, StatusCode::OK);
+    }
+
+    #[test]
+    fn create_capacity_provider_requires_vpc_and_perms() {
+        let s = shared();
+        let err = create_capacity_provider(&s, &req(), &json!({"CapacityProviderName": "x"}))
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn create_capacity_provider_duplicate_is_conflict() {
+        let s = shared();
+        let body = json!({
+            "CapacityProviderName": "cp1",
+            "VpcConfig": {},
+            "PermissionsConfig": {}
+        });
+        create_capacity_provider(&s, &req(), &body).unwrap();
+        let err = create_capacity_provider(&s, &req(), &body).err().unwrap();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn delete_capacity_provider_removes_state() {
+        let s = shared();
+        let body = json!({
+            "CapacityProviderName": "cp1",
+            "VpcConfig": {},
+            "PermissionsConfig": {}
+        });
+        create_capacity_provider(&s, &req(), &body).unwrap();
+        delete_capacity_provider(&s, &req(), "cp1").unwrap();
+        let err = get_capacity_provider(&s, &req(), "cp1").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn update_capacity_provider_patches_fields_and_bumps_last_modified() {
+        let s = shared();
+        let body = json!({
+            "CapacityProviderName": "cp1",
+            "VpcConfig": {"SubnetIds": []},
+            "PermissionsConfig": {"RoleArn": "old"}
+        });
+        create_capacity_provider(&s, &req(), &body).unwrap();
+        let prev_mod = s.read().default_ref().capacity_providers["cp1"].last_modified;
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        update_capacity_provider(
+            &s,
+            &req(),
+            "cp1",
+            &json!({"PermissionsConfig": {"RoleArn": "new"}}),
+        )
+        .unwrap();
+        let state = s.read();
+        let cp = &state.default_ref().capacity_providers["cp1"];
+        assert_eq!(cp.permissions_config["RoleArn"], "new");
+        assert!(cp.last_modified > prev_mod);
+    }
+
+    fn seed_execution(s: &SharedLambdaState, arn: &str, function_name: &str, status: &str) {
+        let mut accts = s.write();
+        let st = accts.get_or_create("123456789012");
+        st.durable_executions.insert(
+            arn.to_string(),
+            DurableExecution {
+                arn: arn.to_string(),
+                function_name: function_name.to_string(),
+                function_arn: format!(
+                    "arn:aws:lambda:us-east-1:123456789012:function:{function_name}"
+                ),
+                status: status.to_string(),
+                input: json!({}),
+                started_at: Utc::now(),
+                stopped_at: None,
+                last_modified: Utc::now(),
+                history: vec![],
+                state: json!({}),
+            },
+        );
+    }
+
+    #[test]
+    fn get_durable_execution_returns_state() {
+        let s = shared();
+        let arn = "arn:aws:lambda:us-east-1:123456789012:durable-execution/e1";
+        seed_execution(&s, arn, "fn1", "Running");
+        let resp = get_durable_execution(&s, &req(), arn).unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[test]
+    fn get_durable_execution_unknown_is_not_found() {
+        let s = shared();
+        let err = get_durable_execution(&s, &req(), "unknown").err().unwrap();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn checkpoint_durable_execution_appends_event_and_replaces_state() {
+        let s = shared();
+        let arn = "arn:aws:lambda:us-east-1:123456789012:durable-execution/e1";
+        seed_execution(&s, arn, "fn1", "Running");
+        let body = json!({"State": {"step": 2}, "Event": {"type": "Tick"}});
+        checkpoint_durable_execution(&s, &req(), arn, &body).unwrap();
+        let exec = s.read().default_ref().durable_executions[arn].clone();
+        assert_eq!(exec.state["step"], 2);
+        assert_eq!(exec.history.len(), 1);
+    }
+
+    #[test]
+    fn checkpoint_durable_execution_after_stop_is_conflict() {
+        let s = shared();
+        let arn = "arn:aws:lambda:us-east-1:123456789012:durable-execution/e1";
+        seed_execution(&s, arn, "fn1", "Stopped");
+        let err = checkpoint_durable_execution(&s, &req(), arn, &json!({})).err().unwrap();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn stop_durable_execution_idempotent_with_conflict_on_second_call() {
+        let s = shared();
+        let arn = "arn:aws:lambda:us-east-1:123456789012:durable-execution/e1";
+        seed_execution(&s, arn, "fn1", "Running");
+        stop_durable_execution(&s, &req(), arn).unwrap();
+        let err = stop_durable_execution(&s, &req(), arn).err().unwrap();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn list_durable_executions_filters_by_function_name() {
+        let s = shared();
+        seed_execution(
+            &s,
+            "arn:aws:lambda:us-east-1:123456789012:durable-execution/e1",
+            "alpha",
+            "Running",
+        );
+        seed_execution(
+            &s,
+            "arn:aws:lambda:us-east-1:123456789012:durable-execution/e2",
+            "beta",
+            "Running",
+        );
+        let resp = list_durable_executions_by_function(&s, &req(), "alpha").unwrap();
+        let text = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        let v: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(v["DurableExecutions"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn send_callback_records_outcome_and_creates_callback_if_unknown() {
+        let s = shared();
+        send_callback_success(&s, &req(), "cb1").unwrap();
+        send_callback_failure(&s, &req(), "cb2").unwrap();
+        send_callback_heartbeat(&s, &req(), "cb3").unwrap();
+        let st = s.read();
+        let cbs = &st.default_ref().durable_execution_callbacks;
+        assert_eq!(cbs["cb1"].outcome, "Succeeded");
+        assert_eq!(cbs["cb2"].outcome, "Failed");
+        assert_eq!(cbs["cb3"].outcome, "Heartbeat");
+    }
+}

--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -1325,6 +1325,36 @@ impl RdsService {
             "DescribeEvents" => self.describe_events(req, &rid),
             "DescribeSourceRegions" => Ok(xml_response("DescribeSourceRegions", "    <SourceRegions/>".to_string(), &rid)),
             "DescribeDBMajorEngineVersions" => Ok(xml_response("DescribeDBMajorEngineVersions", "    <DBMajorEngineVersions/>".to_string(), &rid)),
+            "DescribeServerlessV2PlatformVersions" => {
+                let engine = get_param(req, "Engine").unwrap_or_else(|| "aurora-mysql".to_string());
+                let version_filter = get_param(req, "ServerlessV2PlatformVersion");
+                let all = [
+                    ("4", true, "Version 4 offering scaling up to 256 ACUs", 256.0_f64),
+                    ("3", false, "Version 3 offering scaling up to 256 ACUs", 256.0),
+                    ("2", false, "Version 2 offering scaling up to 256 ACUs", 256.0),
+                    ("1", false, "Version 1 offering scaling up to 128 ACUs", 128.0),
+                ];
+                let body = all
+                    .iter()
+                    .filter(|(v, ..)| version_filter.as_deref().is_none_or(|f| f == *v))
+                    .map(|(v, is_default, desc, max)| {
+                        format!(
+                            "      <member>\n        <Engine>{e}</Engine>\n        <IsDefault>{d}</IsDefault>\n        <ServerlessV2PlatformVersion>{v}</ServerlessV2PlatformVersion>\n        <ServerlessV2PlatformVersionDescription>{desc}</ServerlessV2PlatformVersionDescription>\n        <Status>enabled</Status>\n        <ServerlessV2FeaturesSupport>\n          <MinCapacity>0.0</MinCapacity>\n          <MaxCapacity>{max:.1}</MaxCapacity>\n        </ServerlessV2FeaturesSupport>\n      </member>",
+                            e = xml_escape(&engine),
+                            d = is_default,
+                            v = v,
+                            desc = xml_escape(desc),
+                            max = max,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Ok(xml_response(
+                    "DescribeServerlessV2PlatformVersions",
+                    format!("    <ServerlessV2PlatformVersions>\n{body}\n    </ServerlessV2PlatformVersions>"),
+                    &rid,
+                ))
+            }
             "DescribeValidDBInstanceModifications" => Ok(xml_response("DescribeValidDBInstanceModifications", "    <ValidDBInstanceModificationsMessage>\n      <ValidProcessorFeatures/>\n      <Storage/>\n    </ValidDBInstanceModificationsMessage>".to_string(), &rid)),
             "ModifyCurrentDBClusterCapacity" => Ok(xml_response("ModifyCurrentDBClusterCapacity", "    <DBClusterIdentifier>x</DBClusterIdentifier>\n    <CurrentCapacity>4</CurrentCapacity>".to_string(), &rid)),
             "DisableHttpEndpoint" => Ok(xml_response("DisableHttpEndpoint", "    <HttpEndpointEnabled>false</HttpEndpointEnabled>".to_string(), &rid)),

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -121,6 +121,7 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "DescribePendingMaintenanceActions",
     "DescribeReservedDBInstances",
     "DescribeReservedDBInstancesOfferings",
+    "DescribeServerlessV2PlatformVersions",
     "DescribeSourceRegions",
     "DescribeTenantDatabases",
     "DescribeValidDBInstanceModifications",


### PR DESCRIPTION
## Summary

Closes the 99.1% conformance gap that opened after last week's aws-models refresh ([#1468](https://github.com/faiscadev/fakecloud/pull/1468)). The refresh added 22 new operations across four services and exposed a KMS asymmetric-keygen timeout that surfaced as CRASH in the conformance harness.

**Lambda Workflows (15 ops)** — Capacity providers + Durable executions (Lambda's 2025-11-30 and 2025-12-01 preview APIs):
- `CreateCapacityProvider`, `GetCapacityProvider`, `ListCapacityProviders`, `UpdateCapacityProvider`, `DeleteCapacityProvider`, `ListFunctionVersionsByCapacityProvider`
- `GetDurableExecution`, `GetDurableExecutionHistory`, `GetDurableExecutionState`, `ListDurableExecutionsByFunction`, `CheckpointDurableExecution`, `StopDurableExecution`
- `SendDurableExecutionCallback{Success,Failure,Heartbeat}`

**Bedrock Advanced Prompt Optimization (5 ops)** — Create / Get / List / Stop / BatchDelete jobs with full lifecycle state.

**KMS** — `GetKeyLastUsage` returns `KeyId` + `KeyCreationDate` + `TrackingStartDate`; `KeyLastUsage` is omitted when the key hasn't been used yet (the spec explicitly allows this).

**KMS CreateKey RSA timeout fix** — Cache one RSA keypair per width via `OnceLock` and reuse across `CreateKey`. RSA-4096 generation is ~20s on CI; under the harness's parallel enum-exhaustion probing the 30s client read timeout was tripping mid-batch and surfacing as `CRASH: error sending request for url`. Each KMS key still owns its own ARN/lifecycle/metadata — only the raw key bytes are shared.

**RDS** — `DescribeServerlessV2PlatformVersions` returns the four documented Aurora Serverless v2 platform versions (1–4) with the `@examples`-aligned MinCapacity/MaxCapacity numbers.

## Test plan

- [x] 20 new unit tests (12 lambda workflows + 8 bedrock APO)
- [x] Handwritten conformance tests covering every new `#[test_action]`
- [x] All checksums updated against the current Smithy model
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [ ] Wait for `conformance` CI to confirm the 99.1% → 100% lift

## SDK bumps

- `aws-sdk-kms` 1.104 → 1.106 (exposes `get_key_last_usage`)
- `aws-sdk-lambda` 1.120 → 1.122 (exposes capacity-provider and durable-execution builders)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements 22 operations from the refreshed AWS Smithy models and fixes a KMS RSA timeout, restoring conformance from 99.1% to 100%. Adds Lambda Workflows, Bedrock APO jobs, KMS GetKeyLastUsage, and RDS Serverless v2 platform versions.

- **New Features**
  - Lambda Workflows (15 ops): capacity providers (create/get/list/update/delete + list function versions); durable executions (get/history/state/list-by-function/checkpoint/stop); callbacks (success/failure/heartbeat).
  - Bedrock Advanced Prompt Optimization (5 ops): create/get/list/stop/batch-delete with lifecycle state.
  - KMS: GetKeyLastUsage (omits KeyLastUsage until the key is used).
  - RDS: DescribeServerlessV2PlatformVersions returns versions 1–4 with example-aligned capacities.

- **Bug Fixes**
  - Avoid KMS CreateKey RSA timeouts by caching one RSA keypair per width with OnceLock and reusing during key creation; ARNs/metadata remain unique, only key bytes are shared.

<sup>Written for commit 011fd61d096a4ccb8ca4af082b0219372a1b4bd9. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1471?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

