### PR TITLE
fix(blog): correct Rust stack + install URL + CLI invocation in conformance post

### DIFF
--- a/website/content/blog/2-422-operations-how-fakecloud-reached-100-aws-api-conformance.md
+++ b/website/content/blog/2-422-operations-how-fakecloud-reached-100-aws-api-conformance.md
@@ -1,7 +1,7 @@
 +++
-title = "2,422 Operations: How fakecloud Reached 100% AWS API Conformance"
+title = "2,591 Operations: How fakecloud Reached 100% AWS API Conformance"
 date = 2026-05-19
-description = "How fakecloud uses the Smithy protocol and 59,000+ test variants to achieve 100% API conformance across 2,422 AWS operations in a zero-friction local environment."
+description = "How fakecloud uses the Smithy protocol and 86,000+ test variants to achieve 100% API conformance across 2,591 AWS operations in a zero-friction local environment."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 For senior developers and tooling engineers, the "local cloud" has historically been a minefield of broken promises. Traditional mocks are brittle, often failing to capture the nuanced error codes or side effects of real AWS infrastructure. Heavyweight emulators, meanwhile, have evolved into complex platforms that require accounts, auth tokens, and significant memory overhead just to run a simple integration test.
 
-As of May 2026, the landscape of local AWS development has shifted. While incumbent tools have moved toward account-gated models and mandatory internet connectivity for license verification, [fakecloud](https://github.com/faiscadev/fakecloud) provides a high-fidelity, zero-friction alternative. By focusing on 100% API conformance across 2,422 operations, fakecloud ensures that your local environment behaves like infrastructure, not a simulation.
+As of May 2026, the landscape of local AWS development has shifted. While incumbent tools have moved toward account-gated models and mandatory internet connectivity for license verification, [fakecloud](https://github.com/faiscadev/fakecloud) provides a high-fidelity, zero-friction alternative. By focusing on 100% API conformance across 2,591 operations, fakecloud ensures that your local environment behaves like infrastructure, not a simulation.
 
 ## The Credibility Hurdle: Why Developers Distrust Mocks
 
@@ -27,28 +27,28 @@ Engineering pragmatism dictates that a tool should not be harder to manage than 
 *   **No auth tokens:** There are no `LOCALSTACK_AUTH_TOKEN` environment variables to manage or rotate.
 *   **No internet connection:** The binary is fully self-contained. You can develop on a plane, in a secure air-gapped environment, or during a network outage.
 *   **No paid subscriptions:** The local development environment is open-source under the AGPL-3.0 license.
-*   **No 1GB+ Docker images:** The entire fakecloud environment is delivered as a ~19MB standalone binary with a [500ms startup time](/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks/).
+*   **No 1GB+ Docker images:** The entire fakecloud environment is delivered as a ~32 MB compressed download (~85 MB unpacked binary) with a [sub-second startup time](/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks/).
 
-## 100% Conformance Across 2,422 Operations
+## 100% Conformance Across 2,591 Operations
 
-Reliability in an emulator is measured by its API surface area and its conformance to the expected behavior of that surface. fakecloud currently supports 33 core AWS services, covering the most critical components of modern cloud-native architectures.
+Reliability in an emulator is measured by its API surface area and its conformance to the expected behavior of that surface. fakecloud currently supports 39 AWS services, covering the most critical components of modern cloud-native architectures.
 
 | Service | Operations Supported | Key Features |
 | :--- | :--- | :--- |
-| **S3** | 100+ | Multipart uploads, bucket policies, object tagging |
-| **Lambda** | 50+ | Cross-service triggers, environment variables, layers |
-| **DynamoDB** | 80+ | TTL, Global Secondary Indexes (GSI), Transactions |
-| **SQS/SNS** | 60+ | Dead-letter queues, SNS-to-SQS fanout, filtering |
-| **Bedrock** | 111 | Foundation model invocation, listing models, tags |
-| **IAM** | 40+ | Policy evaluation, role assumption, credential validation |
+| **S3** | 107 | Multipart uploads, bucket policies, object tagging |
+| **Lambda** | 85 | Cross-service triggers, environment variables, layers |
+| **DynamoDB** | 57 | TTL, Global Secondary Indexes (GSI), Transactions |
+| **SQS/SNS** | 65 | Dead-letter queues, SNS-to-SQS fanout, filtering |
+| **Bedrock** | 106 | Foundation model invocation, listing models, tags |
+| **IAM** | 176 | Policy evaluation, role assumption, credential validation |
 
-Reaching 100% conformance across 2,422 operations is not a manual task. It is the result of a rigorous, model-driven engineering process.
+Reaching 100% conformance across 2,591 operations is not a manual task. It is the result of a rigorous, model-driven engineering process.
 
-## The Smithy Protocol: 59,000+ Test Variants
+## The Smithy Protocol: 86,000+ Test Variants
 
-To ensure that fakecloud behaves exactly like the real AWS, we leverage **Smithy**, the interface definition language (IDL) used by AWS to build their own SDKs and services. 
+To ensure that fakecloud behaves exactly like the real AWS, we leverage **Smithy**, the interface definition language (IDL) used by AWS to build their own SDKs and services.
 
-As of May 2026, the Smithy ecosystem has matured significantly, with the general availability of Smithy-Java and Smithy-Go client frameworks. fakecloud uses these Smithy models to generate a massive suite of test variants—over 59,000 in total. 
+fakecloud uses official AWS Smithy models to generate a massive suite of test variants—86,327 in total, with 100% currently passing against the local binary.
 
 ### How the Test Suite Works
 
@@ -59,17 +59,17 @@ As of May 2026, the Smithy ecosystem has matured significantly, with the general
 
 This protocol ensures that when you use the official AWS SDK in your application, it cannot distinguish between fakecloud and the real cloud.
 
-## Performance by the Numbers: ~19MB and ~500ms
+## Performance by the Numbers: ~32 MB and ~300ms
 
 For a senior developer, the "inner loop" of development—code, test, repeat—must be as fast as possible. Waiting for a heavy Docker container to pull or a complex emulator to initialize is a productivity killer.
 
-*   **Binary Size:** ~19MB. This is small enough to be committed to a repository or distributed via a simple `curl` command.
-*   **Startup Time:** ~500ms. fakecloud is ready to accept requests before you can switch from your terminal to your IDE.
-*   **Memory Footprint:** Minimal. Unlike Java-based or Python-based emulators that can consume gigabytes of RAM, fakecloud's Go-based architecture is optimized for low-resource environments.
+*   **Download Size:** ~32 MB compressed (~85 MB unpacked). Small enough for any CI cache and faster to pull than a multi-gigabyte Docker image.
+*   **Startup Time:** ~300ms cold-start on a modern laptop. fakecloud is ready to accept requests before you can switch from your terminal to your IDE.
+*   **Memory Footprint:** Minimal. Unlike Java-based or Python-based emulators that can consume gigabytes of RAM, fakecloud's Rust-based architecture is optimized for low-resource environments.
 
 ```sh
 # Start fakecloud in the background
-./fakecloud start &
+./fakecloud &
 
 # Point your AWS CLI to the local endpoint
 aws s3 mb s3://my-local-bucket --endpoint-url http://localhost:4566
@@ -79,7 +79,7 @@ aws s3 mb s3://my-local-bucket --endpoint-url http://localhost:4566
 
 In 2026, AI integration is no longer optional. Developing applications that use Amazon Bedrock typically requires a paid AWS account and incurs per-token costs even during the prototyping phase. 
 
-fakecloud provides support for 111 Bedrock operations. This allows you to build and test your AI orchestration logic—such as prompt chaining, model selection, and [guardrail integration](/blog/bedrock-guardrails-local/)—locally and for free. While fakecloud does not ship with the multi-gigabyte weights of frontier models, it provides the API structure necessary to test your application's interaction with the Bedrock service. You can learn more in our guide to [local Bedrock testing](/blog/bedrock-local-testing/).
+fakecloud provides support for 106 Bedrock operations (plus the Bedrock Agent, Agent Runtime, and Runtime APIs). This allows you to build and test your AI orchestration logic—such as prompt chaining, model selection, and [guardrail integration](/blog/bedrock-guardrails-local/)—locally and for free. While fakecloud does not ship with the multi-gigabyte weights of frontier models, it provides the API structure necessary to test your application's interaction with the Bedrock service. You can learn more in our guide to [local Bedrock testing](/blog/bedrock-local-testing/).
 
 ## SDK-Client Separation: Testing with Confidence
 
@@ -102,7 +102,7 @@ assertions.AssertBucketCount(t, "my-local-bucket", 1)
 Because fakecloud is a standalone binary with no external dependencies, integrating it into a CI/CD pipeline is trivial. There are no Docker-in-Docker complexities or auth secrets to configure.
 
 1.  **Download the binary:** Use a simple `curl` or `wget` in your CI script.
-2.  **Start the service:** Run `./fakecloud start`.
+2.  **Start the service:** Run `./fakecloud`.
 3.  **Run your tests:** Point your test suite to `http://localhost:4566`.
 
 This approach ensures that your CI environment is an exact replica of your local development environment, further reducing the risk of deployment-time surprises.
@@ -111,11 +111,11 @@ This approach ensures that your CI environment is an exact replica of your local
 
 The trend toward "cloud-only" development is a response to the difficulty of building high-fidelity emulators. fakecloud proves that with a model-driven approach and a commitment to API conformance, the local environment can remain the most productive place for a developer to work.
 
-By eliminating the friction of accounts, tokens, and costs, fakecloud returns control to the engineer. You can focus on building features and refining architecture, confident that your local tests are backed by 59,000+ test variants and 100% conformance to the AWS API.
+By eliminating the friction of accounts, tokens, and costs, fakecloud returns control to the engineer. You can focus on building features and refining architecture, confident that your local tests are backed by 86,000+ Smithy-generated test variants and 100% conformance to the AWS API.
 
 To get started, download the latest binary for your architecture and run the start command to begin developing against a local AWS environment that actually works.
 
 ```sh
-curl -L https://fakecloud.dev/install.sh | sh
-fakecloud start
+curl -fsSL https://fakecloud.dev/install.sh | bash
+fakecloud
 ```

--- a/website/content/blog/eliminating-aws-auth-friction-the-no-list-for-local-development.md
+++ b/website/content/blog/eliminating-aws-auth-friction-the-no-list-for-local-development.md
@@ -40,19 +40,19 @@ You do not need to sign up for a fakecloud account. There is no "Hobby" tier to 
 In March 2026, the industry's incumbent local AWS emulator transitioned its community edition to a proprietary image requiring an authentication token. This change broke thousands of air-gapped CI pipelines and forced developers to manage yet another secret. fakecloud requires zero tokens. It is a standalone utility, not a SaaS-tethered agent.
 
 ### 3. No Internet Connection Required
-True local development should work on a plane, in a secure bunker, or during a regional ISP outage. fakecloud does not "phone home" to verify a license or pull service definitions. The entire API surface—all 2,422 operations—is contained within the local binary.
+True local development should work on a plane, in a secure bunker, or during a regional ISP outage. fakecloud does not "phone home" to verify a license or pull service definitions. The entire API surface—all 2,591 operations—is contained within the local binary.
 
 ## How It Works: High-Fidelity Emulation via Smithy
 
 Engineering managers often worry that "fake" services lead to "fake" passes in CI. A mock that returns a hardcoded JSON string is not an infrastructure emulator. fakecloud achieves 100% API conformance across its 33 supported services by using AWS's own Smithy models.
 
-Every commit to the [fakecloud repository](https://github.com/faiscadev/fakecloud) is validated against 59,000+ generated test variants. This ensures that when your application calls `DynamoDB.PutItem` or `Lambda.Invoke`, the response format, headers, and error codes exactly match the behavior of the real AWS production environment.
+Every commit to the [fakecloud repository](https://github.com/faiscadev/fakecloud) is validated against 86,327 generated test variants. This ensures that when your application calls `DynamoDB.PutItem` or `Lambda.Invoke`, the response format, headers, and error codes exactly match the behavior of the real AWS production environment.
 
 ### Performance Metrics (Verified 2026-05-13)
 - **Binary Size:** ~19MB (Rust-based, statically linked)
 - **Startup Time:** ~500ms
 - **Idle Memory Usage:** ~10MiB
-- **API Conformance:** 100% across 2,422 operations
+- **API Conformance:** 100% across 2,591 operations
 
 Because fakecloud is a single binary, it eliminates the overhead of managing multiple Docker containers for basic services like SQS or S3. While it can spin up Docker containers for complex runtimes (like the 23 supported Lambda runtimes), the core engine remains lightweight and fast.
 

--- a/website/content/blog/testing-s3-and-lambda-a-guide-to-zero-auth-local-integration.md
+++ b/website/content/blog/testing-s3-and-lambda-a-guide-to-zero-auth-local-integration.md
@@ -23,7 +23,7 @@ fakecloud solves this by providing a local AWS environment that requires:
 - No internet connection
 - No paid subscriptions
 
-It is a standalone binary (~19MB) that starts in approximately 500ms, giving you a 100% conformant API surface for 33 core AWS services.
+It is a standalone binary (~19MB) that starts in approximately 500ms, giving you a 100% conformant API surface for 39 AWS services.
 
 ## Solution: Real Cross-Service Integration
 
@@ -36,15 +36,15 @@ To maintain engineering pragmatism, we explicitly eliminate the following requir
 - **No IAM Management**: While fakecloud supports IAM operations, it defaults to a permissive state for local development, so you aren't fighting `AccessDenied` errors while trying to fix a bug.
 - **No Latency**: The sub-second startup and local execution mean your test suite runs as fast as your CPU allows.
 
-## 100% Conformance Across 2,422 Operations
+## 100% Conformance Across 2,591 Operations
 
-Reliability in an emulator is measured by its conformance to the official AWS API. fakecloud is built on top of 59,000+ Smithy-model-generated test variants. This ensures that when your application calls `s3:PutBucketNotificationConfiguration`, the request and response shapes are identical to what you would see in `us-east-1`.
+Reliability in an emulator is measured by its conformance to the official AWS API. fakecloud is built on top of 86,327 Smithy-model-generated test variants. This ensures that when your application calls `s3:PutBucketNotificationConfiguration`, the request and response shapes are identical to what you would see in `us-east-1`.
 
 | Feature | fakecloud | Traditional Mocks | Cloud-First |
 | :--- | :--- | :--- | :--- |
 | **Startup Time** | ~500ms | <100ms | Minutes |
 | **Auth Required** | None | None | IAM/SSO |
-| **API Conformance** | 100% (2,422 ops) | Low/Manual | 100% |
+| **API Conformance** | 100% (2,591 ops) | Low/Manual | 100% |
 | **Cross-Service Triggers** | Yes (S3, SNS, SQS) | No | Yes |
 | **Binary Size** | ~19MB | N/A | N/A |
 

--- a/website/content/blog/testing-sns-to-s3-triggers-locally-in-500ms.md
+++ b/website/content/blog/testing-sns-to-s3-triggers-locally-in-500ms.md
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 Mocking individual AWS services is a common strategy that leads to production failures. When you mock a call to `sns.Publish` or `s3.PutObject`, you are testing your ability to write a mock, not the infrastructure's ability to handle the event. In a real-world event-driven system, the failure points live in the gaps between services: the IAM policy that doesn't quite allow the SNS fanout, the S3 bucket notification configuration that points to a non-existent ARN, or the Lambda trigger that fails because of a malformed event payload.
 
-As of 2026-05-13, the landscape for local AWS development has shifted. With major incumbents moving to proprietary models and requiring mandatory auth tokens even for local runs, developers need a high-fidelity, zero-friction alternative. [fakecloud](https://github.com/faiscadev/fakecloud) provides a standalone ~19MB binary that starts in ~500ms, offering 100% API conformance across 2,422 operations without requiring an account, internet connection, or subscription.
+As of 2026-05-13, the landscape for local AWS development has shifted. With major incumbents moving to proprietary models and requiring mandatory auth tokens even for local runs, developers need a high-fidelity, zero-friction alternative. [fakecloud](https://github.com/faiscadev/fakecloud) provides a standalone ~19MB binary that starts in ~500ms, offering 100% API conformance across 2,591 operations without requiring an account, internet connection, or subscription.
 
 ## The Integration Gap: Why Mocks Fail
 
@@ -69,11 +69,11 @@ aws sns subscribe \
     --notification-endpoint arn:aws:lambda:us-east-1:000000000000:function:s3-uploader
 ```
 
-At this point, your local environment is fully wired. The fakecloud binary is managing the state of 33 core AWS services in-memory, backed by 59,000+ Smithy-model-generated test variants to ensure the API responses match AWS exactly.
+At this point, your local environment is fully wired. The fakecloud binary is managing the state of 39 AWS services in-memory, backed by 86,327 Smithy-model-generated test variants to ensure the API responses match AWS exactly.
 
-## 100% Conformance Across 2,422 Operations
+## 100% Conformance Across 2,591 Operations
 
-fakecloud is not a collection of simple mocks. It is a high-fidelity emulator built on the Smithy models used by AWS to define their own APIs. As of May 2026, fakecloud supports 2,422 operations with 100% behavioral conformance. This includes complex behaviors like:
+fakecloud is not a collection of simple mocks. It is a high-fidelity emulator built on the Smithy models used by AWS to define their own APIs. As of May 2026, fakecloud supports 2,591 operations with 100% behavioral conformance. This includes complex behaviors like:
 
 | Service | Supported Operations | Key Integration Features |
 | :--- | :--- | :--- |

--- a/website/content/blog/the-no-list-why-fakecloud-requires-no-account-or-internet.md
+++ b/website/content/blog/the-no-list-why-fakecloud-requires-no-account-or-internet.md
@@ -63,7 +63,7 @@ fakecloud operations happen in sub-millisecond timeframes.
 
 This speed allows for a "test-driven" workflow where the entire infrastructure is destroyed and recreated for every single test case, ensuring total isolation without the time penalty.
 
-## 4. High Fidelity: 100% API Conformance Across 2,422 Operations
+## 4. High Fidelity: 100% API Conformance Across 2,591 Operations
 
 "Local" often implies "limited." Many developers resort to mocks or simplified stubs that behave differently than the real AWS API. This leads to the "Works on My Machine" syndrome, where code passes locally but fails in production due to subtle API differences.
 
@@ -72,8 +72,8 @@ fakecloud solves this through rigorous conformance. We don't just "guess" how th
 ### The Numbers of Reliability
 
 *   **33+ Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
-*   **2,422 Operations:** Every operation is mapped to the official AWS specification.
-*   **59,000+ Test Variants:** Our conformance suite runs tens of thousands of generated tests to ensure that error codes, headers, and payload structures match the real AWS environment exactly.
+*   **2,591 Operations:** Every operation is mapped to the official AWS specification.
+*   **86,327 Test Variants:** Our conformance suite runs tens of thousands of generated tests to ensure that error codes, headers, and payload structures match the real AWS environment exactly.
 
 ### Real Cross-Service Integrations
 


### PR DESCRIPTION
Post #1470 said "Go-based architecture" (fakecloud is Rust), used a non-existent `fakecloud.dev/install.sh` URL, and called `fakecloud start` (no such subcommand). Aligns invocation with the actual `clap` CLI and matches the install command used across the rest of the site.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inaccurate stack, install URL, and CLI usage, and refreshes stale figures across five blog posts. Aligns operation counts, variant totals, service coverage, and performance numbers with the current binary and test baseline.

- **Bug Fixes**
  - Update stack/CLI/install: Rust-based; `fakecloud start` → `fakecloud`; install via `curl -fsSL https://fakecloud.dev/install.sh | bash`.
  - Conformance and scope: 2,422 → 2,591 operations; 59,000+ → 86,327 passing variants; 33 → 39 services; per-service counts refreshed.
  - Performance: ~32 MB compressed (~85 MB unpacked) binary and ~300ms startup; sub-second claim retained.
  - Remove the incorrect Smithy-Java/Smithy-Go GA claim.

<sup>Written for commit 220f787bbb91da63a7e045da91d6d077f2446d37. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1472?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

