### PR TITLE
fix(conformance): close last 71-variant gap to hit 100%

### DIFF
--- a/crates/fakecloud-bedrock/src/advanced_prompt_optimization.rs
+++ b/crates/fakecloud-bedrock/src/advanced_prompt_optimization.rs
@@ -185,7 +185,26 @@ pub(crate) fn list_advanced_prompt_optimization_jobs(
     let s = accts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<&AdvancedPromptOptimizationJob> =
         s.advanced_prompt_optimization_jobs.values().collect();
-    items.sort_by(|a, b| a.job_arn.cmp(&b.job_arn));
+    let sort_by = req
+        .query_params
+        .get("sortBy")
+        .map(|s| s.as_str())
+        .unwrap_or("CreationTime");
+    let descending = matches!(
+        req.query_params.get("sortOrder").map(|s| s.as_str()),
+        Some("Descending")
+    );
+    items.sort_by(|a, b| {
+        let ord = match sort_by {
+            "CreationTime" => a.creation_time.cmp(&b.creation_time),
+            _ => a.job_arn.cmp(&b.job_arn),
+        };
+        if descending {
+            ord.reverse()
+        } else {
+            ord
+        }
+    });
 
     let start = if let Some(token) = next_token {
         items

--- a/crates/fakecloud-bedrock/src/advanced_prompt_optimization.rs
+++ b/crates/fakecloud-bedrock/src/advanced_prompt_optimization.rs
@@ -7,18 +7,81 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{AdvancedPromptOptimizationJob, SharedBedrockState};
 
+fn validation(msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationException", msg)
+}
+
+fn check_str_len(field: &str, val: &str, min: usize, max: usize) -> Result<(), AwsServiceError> {
+    if val.len() < min || val.len() > max {
+        return Err(validation(format!(
+            "{field} length must be in [{min},{max}], got {}",
+            val.len()
+        )));
+    }
+    Ok(())
+}
+
+fn check_optional_str_len(
+    field: &str,
+    v: Option<&str>,
+    min: usize,
+    max: usize,
+) -> Result<(), AwsServiceError> {
+    if let Some(s) = v {
+        check_str_len(field, s, min, max)?;
+    }
+    Ok(())
+}
+
+fn check_optional_enum(
+    field: &str,
+    v: Option<&str>,
+    allowed: &[&str],
+) -> Result<(), AwsServiceError> {
+    if let Some(s) = v {
+        if !allowed.contains(&s) {
+            return Err(validation(format!(
+                "{field} must be one of {allowed:?}, got '{s}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn create_advanced_prompt_optimization_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let job_name = body["jobName"].as_str().ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            "jobName is required",
-        )
-    })?;
+    let job_name = body["jobName"]
+        .as_str()
+        .ok_or_else(|| validation("jobName is required"))?;
+    check_str_len("jobName", job_name, 1, 100)?;
+    check_optional_str_len("jobDescription", body["jobDescription"].as_str(), 1, 500)?;
+    check_optional_str_len("clientToken", body["clientToken"].as_str(), 1, 256)?;
+    check_optional_str_len(
+        "encryptionKeyArn",
+        body["encryptionKeyArn"].as_str(),
+        1,
+        2048,
+    )?;
+    if body.get("inputConfig").map(|v| v.is_null()).unwrap_or(true) {
+        return Err(validation("inputConfig is required"));
+    }
+    if body
+        .get("outputConfig")
+        .map(|v| v.is_null())
+        .unwrap_or(true)
+    {
+        return Err(validation("outputConfig is required"));
+    }
+    if body
+        .get("modelConfigurations")
+        .map(|v| v.is_null())
+        .unwrap_or(true)
+    {
+        return Err(validation("modelConfigurations is required"));
+    }
 
     let job_id = Uuid::new_v4().to_string();
     let job_arn = format!(
@@ -82,6 +145,33 @@ pub(crate) fn list_advanced_prompt_optimization_jobs(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    if let Some(s) = req.query_params.get("maxResults") {
+        let n: i64 = s
+            .parse()
+            .map_err(|_| validation("maxResults must be int"))?;
+        if !(1..=1000).contains(&n) {
+            return Err(validation(format!(
+                "maxResults must be in [1,1000], got {n}"
+            )));
+        }
+    }
+    check_optional_str_len(
+        "nextToken",
+        req.query_params.get("nextToken").map(|s| s.as_str()),
+        1,
+        2048,
+    )?;
+    check_optional_enum(
+        "sortBy",
+        req.query_params.get("sortBy").map(|s| s.as_str()),
+        &["CreationTime"],
+    )?;
+    check_optional_enum(
+        "sortOrder",
+        req.query_params.get("sortOrder").map(|s| s.as_str()),
+        &["Ascending", "Descending"],
+    )?;
+
     let max_results = req
         .query_params
         .get("maxResults")
@@ -261,6 +351,15 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    fn full_body(name: &str) -> Value {
+        json!({
+            "jobName": name,
+            "inputConfig": {"s3Uri": "s3://b/in"},
+            "outputConfig": {"s3Uri": "s3://b/out"},
+            "modelConfigurations": {"targetModel": "anthropic.claude-3-sonnet"}
+        })
+    }
+
     fn shared() -> SharedBedrockState {
         Arc::new(RwLock::new(
             fakecloud_core::multi_account::MultiAccountState::new(
@@ -324,7 +423,7 @@ mod tests {
     #[test]
     fn get_by_arn_or_name_or_id() {
         let s = shared();
-        create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "n1"})).unwrap();
+        create_advanced_prompt_optimization_job(&s, &req(), &full_body("n1")).unwrap();
         let arn = s
             .read()
             .default_ref()
@@ -343,12 +442,8 @@ mod tests {
     fn list_paginates() {
         let s = shared();
         for i in 0..3 {
-            create_advanced_prompt_optimization_job(
-                &s,
-                &req(),
-                &json!({"jobName": format!("j{i}")}),
-            )
-            .unwrap();
+            create_advanced_prompt_optimization_job(&s, &req(), &full_body(&format!("j{i}")))
+                .unwrap();
         }
         let mut r = req();
         r.query_params
@@ -363,7 +458,7 @@ mod tests {
     #[test]
     fn stop_transitions_to_stopped() {
         let s = shared();
-        create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "j"})).unwrap();
+        create_advanced_prompt_optimization_job(&s, &req(), &full_body("j")).unwrap();
         let arn = s
             .read()
             .default_ref()
@@ -382,7 +477,7 @@ mod tests {
     #[test]
     fn stop_already_stopped_returns_conflict() {
         let s = shared();
-        create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "j"})).unwrap();
+        create_advanced_prompt_optimization_job(&s, &req(), &full_body("j")).unwrap();
         let arn = s
             .read()
             .default_ref()
@@ -401,8 +496,8 @@ mod tests {
     #[test]
     fn batch_delete_removes_matches_collects_errors() {
         let s = shared();
-        create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "a"})).unwrap();
-        create_advanced_prompt_optimization_job(&s, &req(), &json!({"jobName": "b"})).unwrap();
+        create_advanced_prompt_optimization_job(&s, &req(), &full_body("a")).unwrap();
+        create_advanced_prompt_optimization_job(&s, &req(), &full_body("b")).unwrap();
         let body = json!({"jobIdentifiers": ["a", "missing"]});
         let resp = batch_delete_advanced_prompt_optimization_job(&s, &req(), &body).unwrap();
         let v: Value =

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -789,6 +789,84 @@ fn rest_request_config(
                 format!("/2025-11-30/functions/{}/function-scaling-config", FUNC),
                 None,
             ),
+            // Lambda Workflows: capacity providers (2025-11-30 API).
+            "CreateCapacityProvider" => (
+                reqwest::Method::POST,
+                "/2025-11-30/capacity-providers".to_string(),
+                None,
+            ),
+            "ListCapacityProviders" => (
+                reqwest::Method::GET,
+                "/2025-11-30/capacity-providers".to_string(),
+                None,
+            ),
+            "GetCapacityProvider" => (
+                reqwest::Method::GET,
+                "/2025-11-30/capacity-providers/test-capacity-provider".to_string(),
+                None,
+            ),
+            "UpdateCapacityProvider" => (
+                reqwest::Method::PUT,
+                "/2025-11-30/capacity-providers/test-capacity-provider".to_string(),
+                None,
+            ),
+            "DeleteCapacityProvider" => (
+                reqwest::Method::DELETE,
+                "/2025-11-30/capacity-providers/test-capacity-provider".to_string(),
+                None,
+            ),
+            "ListFunctionVersionsByCapacityProvider" => (
+                reqwest::Method::GET,
+                "/2025-11-30/capacity-providers/test-capacity-provider/function-versions"
+                    .to_string(),
+                None,
+            ),
+            // Lambda Workflows: durable executions (2025-12-01 API).
+            "GetDurableExecution" => (
+                reqwest::Method::GET,
+                "/2025-12-01/durable-executions/test-durable-execution".to_string(),
+                None,
+            ),
+            "GetDurableExecutionHistory" => (
+                reqwest::Method::GET,
+                "/2025-12-01/durable-executions/test-durable-execution/history".to_string(),
+                None,
+            ),
+            "GetDurableExecutionState" => (
+                reqwest::Method::GET,
+                "/2025-12-01/durable-executions/test-durable-execution/state".to_string(),
+                None,
+            ),
+            "CheckpointDurableExecution" => (
+                reqwest::Method::POST,
+                "/2025-12-01/durable-executions/test-durable-execution/checkpoint".to_string(),
+                None,
+            ),
+            "StopDurableExecution" => (
+                reqwest::Method::POST,
+                "/2025-12-01/durable-executions/test-durable-execution/stop".to_string(),
+                None,
+            ),
+            "ListDurableExecutionsByFunction" => (
+                reqwest::Method::GET,
+                format!("/2025-12-01/functions/{}/durable-executions", FUNC),
+                None,
+            ),
+            "SendDurableExecutionCallbackSuccess" => (
+                reqwest::Method::POST,
+                "/2025-12-01/durable-execution-callbacks/test-callback/succeed".to_string(),
+                None,
+            ),
+            "SendDurableExecutionCallbackFailure" => (
+                reqwest::Method::POST,
+                "/2025-12-01/durable-execution-callbacks/test-callback/fail".to_string(),
+                None,
+            ),
+            "SendDurableExecutionCallbackHeartbeat" => (
+                reqwest::Method::POST,
+                "/2025-12-01/durable-execution-callbacks/test-callback/heartbeat".to_string(),
+                None,
+            ),
             // Default: POST to functions path
             _ => (
                 reqwest::Method::POST,
@@ -1216,6 +1294,10 @@ fn legacy_substitute_identifiers(
             // Alias ops use `LATEST` as the path placeholder. Drive
             // negative variants through the same slot.
             ("LATEST", "Name"),
+            // Lambda Workflows path labels (2025-11-30 + 2025-12-01).
+            ("test-capacity-provider", "CapacityProviderName"),
+            ("test-durable-execution", "DurableExecutionArn"),
+            ("test-callback", "CallbackId"),
         ],
         "s3" => &[("test-conformance-bucket", "Bucket"), ("test-key", "Key")],
         _ => &[],

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -132,11 +132,13 @@ impl KmsService {
         // with that bit width; doing it here off a blocking thread keeps
         // the first concurrent CreateKey from racing N tokio workers into
         // a 30s read-timeout cliff (see `asym::generate_keypair`).
-        tokio::task::spawn_blocking(|| {
-            let _ = self::asym::generate_keypair("RSA_2048");
-            let _ = self::asym::generate_keypair("RSA_3072");
-            let _ = self::asym::generate_keypair("RSA_4096");
-        });
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::task::spawn_blocking(|| {
+                let _ = self::asym::generate_keypair("RSA_2048");
+                let _ = self::asym::generate_keypair("RSA_3072");
+                let _ = self::asym::generate_keypair("RSA_4096");
+            });
+        }
         Self {
             state,
             snapshot_store: None,

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -127,6 +127,16 @@ pub struct KmsService {
 
 impl KmsService {
     pub fn new(state: SharedKmsState) -> Self {
+        // Warm the RSA keypair cache in the background. Generation is
+        // CPU-bound (~20s for RSA-4096) and reused across every CreateKey
+        // with that bit width; doing it here off a blocking thread keeps
+        // the first concurrent CreateKey from racing N tokio workers into
+        // a 30s read-timeout cliff (see `asym::generate_keypair`).
+        tokio::task::spawn_blocking(|| {
+            let _ = self::asym::generate_keypair("RSA_2048");
+            let _ = self::asym::generate_keypair("RSA_3072");
+            let _ = self::asym::generate_keypair("RSA_4096");
+        });
         Self {
             state,
             snapshot_store: None,

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -17,6 +17,155 @@ use crate::state::{
     LAMBDA_SNAPSHOT_SCHEMA_VERSION,
 };
 
+fn invalid_param(msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidParameterValueException",
+        msg,
+    )
+}
+
+fn check_len(field: &str, v: &str, min: usize, max: usize) -> Result<(), AwsServiceError> {
+    if v.len() < min || v.len() > max {
+        return Err(invalid_param(format!(
+            "{field} length must be in [{min},{max}], got {}",
+            v.len()
+        )));
+    }
+    Ok(())
+}
+
+fn check_optional_len(
+    field: &str,
+    v: Option<&str>,
+    min: usize,
+    max: usize,
+) -> Result<(), AwsServiceError> {
+    if let Some(s) = v {
+        check_len(field, s, min, max)?;
+    }
+    Ok(())
+}
+
+fn check_optional_int_range(
+    field: &str,
+    v: Option<i64>,
+    min: i64,
+    max: i64,
+) -> Result<(), AwsServiceError> {
+    if let Some(n) = v {
+        if n < min || n > max {
+            return Err(invalid_param(format!(
+                "{field} must be in [{min},{max}], got {n}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+const LAMBDA_PUBLISH_TO_VALUES: &[&str] = &["LATEST_PUBLISHED"];
+
+// Trimmed to runtimes the SDK still mints; the full Smithy enum has 46
+// entries but only these are emitted by `aws-sdk-lambda` since the
+// older ones are deprecation-only and never surfaced via CreateFunction
+// in practice. Conformance probes use the model enum exhaustively, so
+// keep this list in sync with the Smithy model.
+const LAMBDA_RUNTIMES: &[&str] = &[
+    "nodejs",
+    "nodejs4.3",
+    "nodejs4.3-edge",
+    "nodejs6.10",
+    "nodejs8.10",
+    "nodejs10.x",
+    "nodejs12.x",
+    "nodejs14.x",
+    "nodejs16.x",
+    "nodejs18.x",
+    "nodejs20.x",
+    "nodejs22.x",
+    "nodejs24.x",
+    "java8",
+    "java8.al2",
+    "java11",
+    "java17",
+    "java21",
+    "java25",
+    "python2.7",
+    "python3.6",
+    "python3.7",
+    "python3.8",
+    "python3.9",
+    "python3.10",
+    "python3.11",
+    "python3.12",
+    "python3.13",
+    "python3.14",
+    "dotnetcore1.0",
+    "dotnetcore2.0",
+    "dotnetcore2.1",
+    "dotnetcore3.1",
+    "dotnet6",
+    "dotnet8",
+    "dotnet10",
+    "go1.x",
+    "ruby2.5",
+    "ruby2.7",
+    "ruby3.2",
+    "ruby3.3",
+    "ruby3.4",
+    "provided",
+    "provided.al2",
+    "provided.al2023",
+];
+
+fn check_optional_enum(
+    field: &str,
+    v: Option<&str>,
+    allowed: &[&str],
+) -> Result<(), AwsServiceError> {
+    if let Some(s) = v {
+        if !allowed.contains(&s) {
+            return Err(invalid_param(format!(
+                "{field} must be one of the enum values, got '{s}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn prevalidate_lambda(action: &str, req: &AwsRequest) -> Result<(), AwsServiceError> {
+    let body: Value = serde_json::from_slice(&req.body).unwrap_or(Value::Null);
+    match action {
+        "PublishVersion" => {
+            check_optional_len("Description", body["Description"].as_str(), 0, 256)?;
+            check_optional_enum(
+                "PublishTo",
+                body["PublishTo"].as_str(),
+                LAMBDA_PUBLISH_TO_VALUES,
+            )?;
+        }
+        "UpdateFunctionCode" => {
+            check_optional_enum(
+                "PublishTo",
+                body["PublishTo"].as_str(),
+                LAMBDA_PUBLISH_TO_VALUES,
+            )?;
+            check_optional_len("S3Bucket", body["S3Bucket"].as_str(), 3, 63)?;
+            check_optional_len("S3Key", body["S3Key"].as_str(), 1, 1024)?;
+            check_optional_len("S3ObjectVersion", body["S3ObjectVersion"].as_str(), 1, 1024)?;
+        }
+        "UpdateFunctionConfiguration" => {
+            check_optional_len("Description", body["Description"].as_str(), 0, 256)?;
+            check_optional_len("Handler", body["Handler"].as_str(), 0, 128)?;
+            check_optional_int_range("MemorySize", body["MemorySize"].as_i64(), 128, 32768)?;
+            check_optional_int_range("Timeout", body["Timeout"].as_i64(), 1, i64::MAX)?;
+            check_optional_enum("Runtime", body["Runtime"].as_str(), LAMBDA_RUNTIMES)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 /// Lambda actions whose URL `resource_name` slot is a `FunctionName`
 /// (and therefore accepts ARN / partial ARN / `name:qualifier` forms).
 /// Layer / event-source-mapping / code-signing-config actions key off
@@ -2255,6 +2404,11 @@ impl AwsService for LambdaService {
         );
 
         let aid = &req.account_id;
+        // Smithy-aligned validation for the handful of input fields whose
+        // refreshed @length / @range / enum constraints surface as new
+        // conformance variants. Centralised here so the body parser in each
+        // handler stays focused on shape transforms.
+        prevalidate_lambda(action, &req)?;
         let result = match action {
             "CreateFunction" => self.create_function(&req),
             "ListFunctions" => self.list_functions(

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1112,6 +1112,29 @@ impl LambdaService {
         // /2025-11-30/capacity-providers — Lambda Workflows.
         if prefix == "2025-11-30" && segs.get(1).map(|s| s.as_str()) == Some("capacity-providers") {
             let name = segs.get(2).map(|s| s.to_string());
+            // Empty CapacityProviderName label (negative-omit probe) reaches
+            // here with one fewer segment than the model URI implies. Route
+            // each method to its real op with an empty name so the validation
+            // layer surfaces a declared InvalidParameterValueException
+            // rather than degrading silently into List or returning 501.
+            if segs.len() == 2 && req.raw_path.ends_with("/capacity-providers/") {
+                return match req.method {
+                    Method::GET => Some(("GetCapacityProvider", Some(String::new()))),
+                    Method::PUT => Some(("UpdateCapacityProvider", Some(String::new()))),
+                    Method::DELETE => Some(("DeleteCapacityProvider", Some(String::new()))),
+                    _ => None,
+                };
+            }
+            if segs.len() == 3
+                && req.method == Method::GET
+                && req.raw_path.ends_with("/function-versions")
+                && segs.get(2).map(|s| s.as_str()) == Some("function-versions")
+            {
+                return Some((
+                    "ListFunctionVersionsByCapacityProvider",
+                    Some(String::new()),
+                ));
+            }
             return match (
                 req.method.clone(),
                 segs.len(),
@@ -1134,6 +1157,53 @@ impl LambdaService {
             let collection = segs.get(1).map(|s| s.as_str());
             let arn = segs.get(2).map(|s| s.to_string());
             let action = segs.get(3).map(|s| s.as_str());
+            // Empty path label (negative-omit / negative-too-short probes
+            // substitute an empty string into the URI template). Without
+            // these recoveries the request falls through to None and
+            // returns 501, but the Smithy contract declares only
+            // InvalidParameterValueException — so route to the right
+            // handler with an empty identifier and let the validation
+            // layer surface a 400 with the declared shape.
+            //
+            // The pattern matches both the trailing-slash collapse
+            // (`/durable-executions/`) and the empty-middle collapse
+            // (`/durable-executions//stop`) — filtered segments hide
+            // either form behind the same shortened `segs` vector.
+            if req.raw_path.contains("/durable-executions/") && segs.len() < 4 {
+                if req.raw_path.ends_with("/checkpoint") && req.method == Method::POST {
+                    return Some(("CheckpointDurableExecution", Some(String::new())));
+                }
+                if req.raw_path.ends_with("/stop") && req.method == Method::POST {
+                    return Some(("StopDurableExecution", Some(String::new())));
+                }
+                if req.raw_path.ends_with("/history") && req.method == Method::GET {
+                    return Some(("GetDurableExecutionHistory", Some(String::new())));
+                }
+                if req.raw_path.ends_with("/state") && req.method == Method::GET {
+                    return Some(("GetDurableExecutionState", Some(String::new())));
+                }
+                if req.raw_path.ends_with("/durable-executions/") && req.method == Method::GET {
+                    return Some(("GetDurableExecution", Some(String::new())));
+                }
+            }
+            if req.raw_path.contains("/durable-execution-callbacks/") && segs.len() < 4 {
+                if req.raw_path.ends_with("/succeed") && req.method == Method::POST {
+                    return Some(("SendDurableExecutionCallbackSuccess", Some(String::new())));
+                }
+                if req.raw_path.ends_with("/fail") && req.method == Method::POST {
+                    return Some(("SendDurableExecutionCallbackFailure", Some(String::new())));
+                }
+                if req.raw_path.ends_with("/heartbeat") && req.method == Method::POST {
+                    return Some(("SendDurableExecutionCallbackHeartbeat", Some(String::new())));
+                }
+            }
+            if req.raw_path.contains("/functions/")
+                && req.raw_path.ends_with("/durable-executions")
+                && req.method == Method::GET
+                && segs.len() == 3
+            {
+                return Some(("ListDurableExecutionsByFunction", Some(String::new())));
+            }
             match (req.method.clone(), collection, segs.len(), action) {
                 (Method::GET, Some("durable-executions"), 3, _) => {
                     return Some(("GetDurableExecution", arn));

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1125,10 +1125,14 @@ impl LambdaService {
                     _ => None,
                 };
             }
-            if segs.len() == 3
+            // Empty-name recovery: only when the wire path literally has
+            // `//function-versions` (collapsed middle segment), not when
+            // a provider is genuinely named "function-versions" — see
+            // Cubic on PR #1474.
+            if req
+                .raw_path
+                .contains("/capacity-providers//function-versions")
                 && req.method == Method::GET
-                && req.raw_path.ends_with("/function-versions")
-                && segs.get(2).map(|s| s.as_str()) == Some("function-versions")
             {
                 return Some((
                     "ListFunctionVersionsByCapacityProvider",
@@ -1157,19 +1161,17 @@ impl LambdaService {
             let collection = segs.get(1).map(|s| s.as_str());
             let arn = segs.get(2).map(|s| s.to_string());
             let action = segs.get(3).map(|s| s.as_str());
-            // Empty path label (negative-omit / negative-too-short probes
-            // substitute an empty string into the URI template). Without
-            // these recoveries the request falls through to None and
-            // returns 501, but the Smithy contract declares only
-            // InvalidParameterValueException — so route to the right
-            // handler with an empty identifier and let the validation
-            // layer surface a 400 with the declared shape.
-            //
-            // The pattern matches both the trailing-slash collapse
-            // (`/durable-executions/`) and the empty-middle collapse
-            // (`/durable-executions//stop`) — filtered segments hide
-            // either form behind the same shortened `segs` vector.
-            if req.raw_path.contains("/durable-executions/") && segs.len() < 4 {
+            // Empty path label recovery: a negative-omit / negative-too-short
+            // probe substituted an empty string into the URI template,
+            // leaving a literal `//` in the wire path. The dispatcher's
+            // segment splitter filters those out, hiding the bug behind a
+            // shortened `segs` vector and a 501 ActionNotImplemented. We
+            // catch the literal `//` form so the request reaches the right
+            // handler with an empty identifier and the validation layer
+            // surfaces a declared 400 InvalidParameterValueException —
+            // without shadowing legitimate identifiers like "history" or
+            // "state" (an ARN named "history" is rare but allowed).
+            if req.raw_path.contains("/durable-executions//") {
                 if req.raw_path.ends_with("/checkpoint") && req.method == Method::POST {
                     return Some(("CheckpointDurableExecution", Some(String::new())));
                 }
@@ -1182,11 +1184,11 @@ impl LambdaService {
                 if req.raw_path.ends_with("/state") && req.method == Method::GET {
                     return Some(("GetDurableExecutionState", Some(String::new())));
                 }
-                if req.raw_path.ends_with("/durable-executions/") && req.method == Method::GET {
-                    return Some(("GetDurableExecution", Some(String::new())));
-                }
             }
-            if req.raw_path.contains("/durable-execution-callbacks/") && segs.len() < 4 {
+            if req.raw_path.ends_with("/durable-executions/") && req.method == Method::GET {
+                return Some(("GetDurableExecution", Some(String::new())));
+            }
+            if req.raw_path.contains("/durable-execution-callbacks//") {
                 if req.raw_path.ends_with("/succeed") && req.method == Method::POST {
                     return Some(("SendDurableExecutionCallbackSuccess", Some(String::new())));
                 }
@@ -1197,10 +1199,7 @@ impl LambdaService {
                     return Some(("SendDurableExecutionCallbackHeartbeat", Some(String::new())));
                 }
             }
-            if req.raw_path.contains("/functions/")
-                && req.raw_path.ends_with("/durable-executions")
-                && req.method == Method::GET
-                && segs.len() == 3
+            if req.raw_path.contains("/functions//durable-executions") && req.method == Method::GET
             {
                 return Some(("ListDurableExecutionsByFunction", Some(String::new())));
             }

--- a/crates/fakecloud-lambda/src/workflows.rs
+++ b/crates/fakecloud-lambda/src/workflows.rs
@@ -63,6 +63,7 @@ pub(crate) fn create_capacity_provider(
         .as_str()
         .ok_or_else(|| validation("CapacityProviderName is required"))?
         .to_string();
+    check_len("CapacityProviderName", &name, 1, 140)?;
     let vpc = body
         .get("VpcConfig")
         .filter(|v| !v.is_null())
@@ -139,6 +140,17 @@ pub(crate) fn list_capacity_providers(
     state: &SharedLambdaState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    if let Some(s) = req.query_params.get("MaxItems") {
+        let n: i64 = s.parse().map_err(|_| validation("MaxItems must be int"))?;
+        if !(1..=50).contains(&n) {
+            return Err(validation(format!("MaxItems must be in [1,50], got {n}")));
+        }
+    }
+    if let Some(st) = req.query_params.get("State") {
+        if !matches!(st.as_str(), "Pending" | "Active" | "Failed" | "Deleting") {
+            return Err(validation(format!("State enum invalid: {st}")));
+        }
+    }
     let accts = state.read();
     let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
     let s = accts.get(&req.account_id).unwrap_or(&empty);
@@ -198,10 +210,17 @@ pub(crate) fn delete_capacity_provider(
     check_len("CapacityProviderName", name, 1, 140)?;
     let mut accts = state.write();
     let s = accts.get_or_create(&req.account_id);
-    s.capacity_providers
+    let cp = s
+        .capacity_providers
         .remove(name)
         .ok_or_else(|| not_found(format!("Capacity provider {name} not found")))?;
-    Ok(AwsResponse::json(StatusCode::ACCEPTED, "{}".to_string()))
+    let mut deleted = cp;
+    deleted.state = "Deleting".to_string();
+    deleted.last_modified = Utc::now();
+    Ok(AwsResponse::json_value(
+        StatusCode::ACCEPTED,
+        json!({ "CapacityProvider": capacity_provider_json(&deleted) }),
+    ))
 }
 
 pub(crate) fn list_function_versions_by_capacity_provider(
@@ -251,6 +270,15 @@ pub(crate) fn list_durable_executions_by_function(
     function_name: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
     check_len("FunctionName", function_name, 1, 170)?;
+    if let Some(n) = req.query_params.get("DurableExecutionName") {
+        check_len("DurableExecutionName", n, 1, 64)?;
+    }
+    if let Some(s) = req.query_params.get("MaxItems") {
+        let n: i64 = s.parse().map_err(|_| validation("MaxItems must be int"))?;
+        if !(0..=1000).contains(&n) {
+            return Err(validation(format!("MaxItems must be in [0,1000], got {n}")));
+        }
+    }
     let accts = state.read();
     let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
     let s = accts.get(&req.account_id).unwrap_or(&empty);

--- a/crates/fakecloud-lambda/src/workflows.rs
+++ b/crates/fakecloud-lambda/src/workflows.rs
@@ -27,6 +27,16 @@ fn not_found(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::NOT_FOUND, "ResourceNotFoundException", msg)
 }
 
+fn check_len(field: &str, v: &str, min: usize, max: usize) -> Result<(), AwsServiceError> {
+    if v.len() < min || v.len() > max {
+        return Err(validation(format!(
+            "{field} length must be in [{min},{max}], got {}",
+            v.len()
+        )));
+    }
+    Ok(())
+}
+
 fn arn_for_capacity_provider(region: &str, account: &str, name: &str) -> String {
     format!("arn:aws:lambda:{region}:{account}:capacity-provider/{name}")
 }
@@ -111,6 +121,7 @@ pub(crate) fn get_capacity_provider(
     req: &AwsRequest,
     name: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("CapacityProviderName", name, 1, 140)?;
     let accts = state.read();
     let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
     let s = accts.get(&req.account_id).unwrap_or(&empty);
@@ -148,6 +159,7 @@ pub(crate) fn update_capacity_provider(
     name: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("CapacityProviderName", name, 1, 140)?;
     let mut accts = state.write();
     let s = accts.get_or_create(&req.account_id);
     let cp = s
@@ -183,6 +195,7 @@ pub(crate) fn delete_capacity_provider(
     req: &AwsRequest,
     name: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("CapacityProviderName", name, 1, 140)?;
     let mut accts = state.write();
     let s = accts.get_or_create(&req.account_id);
     s.capacity_providers
@@ -196,6 +209,7 @@ pub(crate) fn list_function_versions_by_capacity_provider(
     req: &AwsRequest,
     name: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("CapacityProviderName", name, 1, 140)?;
     let accts = state.read();
     let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
     let s = accts.get(&req.account_id).unwrap_or(&empty);
@@ -236,6 +250,7 @@ pub(crate) fn list_durable_executions_by_function(
     req: &AwsRequest,
     function_name: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("FunctionName", function_name, 1, 170)?;
     let accts = state.read();
     let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
     let s = accts.get(&req.account_id).unwrap_or(&empty);
@@ -269,6 +284,7 @@ pub(crate) fn get_durable_execution(
     req: &AwsRequest,
     arn: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("DurableExecutionArn", arn, 1, 1024)?;
     let accts = state.read();
     let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
     let s = accts.get(&req.account_id).unwrap_or(&empty);
@@ -283,6 +299,7 @@ pub(crate) fn get_durable_execution_history(
     req: &AwsRequest,
     arn: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("DurableExecutionArn", arn, 1, 1024)?;
     let accts = state.read();
     let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
     let s = accts.get(&req.account_id).unwrap_or(&empty);
@@ -297,10 +314,16 @@ pub(crate) fn get_durable_execution_state(
     req: &AwsRequest,
     arn: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("DurableExecutionArn", arn, 1, 1024)?;
+    // GetDurableExecutionState's Smithy declares only InvalidParameterValueException
+    // for client errors (no ResourceNotFoundException), so map missing arn there.
     let accts = state.read();
     let empty = crate::state::LambdaState::new(&req.account_id, &req.region);
     let s = accts.get(&req.account_id).unwrap_or(&empty);
-    let exec = ensure_execution(s, arn)?;
+    let exec = s
+        .durable_executions
+        .get(arn)
+        .ok_or_else(|| validation(format!("Durable execution {arn} not found")))?;
     Ok(AwsResponse::ok_json(json!({
         "State": exec.state.clone(),
     })))
@@ -312,12 +335,18 @@ pub(crate) fn checkpoint_durable_execution(
     arn: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("DurableExecutionArn", arn, 1, 1024)?;
+    if let Some(token) = body.get("CheckpointToken").and_then(|v| v.as_str()) {
+        check_len("CheckpointToken", token, 1, 2048)?;
+    }
+    // CheckpointDurableExecution Smithy doesn't declare ResourceNotFoundException;
+    // map missing arn to InvalidParameterValueException.
     let mut accts = state.write();
     let s = accts.get_or_create(&req.account_id);
     let exec = s
         .durable_executions
         .get_mut(arn)
-        .ok_or_else(|| not_found(format!("Durable execution {arn} not found")))?;
+        .ok_or_else(|| validation(format!("Durable execution {arn} not found")))?;
     if exec.status != "Running" && exec.status != "Pending" {
         return Err(AwsServiceError::aws_error(
             StatusCode::CONFLICT,
@@ -340,6 +369,7 @@ pub(crate) fn stop_durable_execution(
     req: &AwsRequest,
     arn: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("DurableExecutionArn", arn, 1, 1024)?;
     let mut accts = state.write();
     let s = accts.get_or_create(&req.account_id);
     let exec = s
@@ -366,6 +396,7 @@ fn record_callback(
     callback_id: &str,
     outcome: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    check_len("CallbackId", callback_id, 1, 1024)?;
     let mut accts = state.write();
     let s = accts.get_or_create(&req.account_id);
     let existing_execution = s


### PR DESCRIPTION
## Summary

Follow-up to #1471 — chases the 71 remaining conformance variants from the post-refresh report (99.9% → 100%).

**probe.rs routing** — Added `rest_request_config` entries for all 15 Lambda Workflows ops. Lambda is in `SERVICES_WITH_HARDCODED_REST`, so the harness ignores the Smithy `@http` URI template and uses this table. Without entries, the default case routed everything to `POST /functions` (= CreateFunction → 201 + Function shape). This single fix unblocks the 38 ListDurableExecutionsByFunction variants and the other capacity-provider / durable-execution / callback ops.

**Bedrock APO validation** — `create_advanced_prompt_optimization_job` + `list_*` now enforce the @length / @range / @enum traits from the model (jobName 1-100, jobDescription 1-500, clientToken 1-256, encryptionKeyArn 1-2048, inputConfig/outputConfig/modelConfigurations required; maxResults 1-1000, nextToken 1-2048, sortBy + sortOrder enum). Closes 16 negative variants.

**Lambda prevalidate** — New `prevalidate_lambda()` for the three legacy ops whose existing fields gained constraint annotations: PublishVersion (Description, PublishTo), UpdateFunctionCode (S3Bucket/Key/ObjectVersion, PublishTo), UpdateFunctionConfiguration (Description, Handler, MemorySize, Runtime, Timeout). Closes 15 variants.

**KMS RSA pre-warm** — `spawn_blocking` the RSA-2048/3072/4096 keypair generation at `KmsService::new` so the cache is hot before the first CreateKey enum-exhaustion variant arrives. The earlier OnceLock cache fixed 30/32 crashes but the cold-start variant still paid 20s and tripped the 30s harness timeout under parallel load. Closes the 2 final crashes (HMAC_512, RSA_4096).

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] All existing unit tests pass (151 lambda, 350 bedrock)
- [ ] Wait for CI conformance to confirm 87315/87315

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the final 71 conformance variants to reach 100% by fixing Lambda Workflows routing and validation, tightening Bedrock APO and Lambda input checks, honoring APO list sorting, and removing KMS RSA cold-start timeouts. Empty-label recovery now triggers only on literal `//` path segments to avoid shadowing real identifiers.

- Bug Fixes
  - Fix Lambda Workflows routing and validation in `fakecloud-conformance` and `fakecloud-lambda`: route all 15 ops to correct paths; recover empty path labels only on literal `//`; validate `CapacityProviderName` (1–140), `FunctionName`, `DurableExecutionArn`, `CallbackId`, `CheckpointToken` lengths; validate `ListCapacityProviders` (`MaxItems` 1–50, `State` enum) and `ListDurableExecutionsByFunction` (`DurableExecutionName` 1–64, `MaxItems` 0–1000); return required `CapacityProvider` in `DeleteCapacityProvider` response; map missing ARNs in Checkpoint/GetState/Callbacks to `InvalidParameterValueException`.
  - Enforce Bedrock APO `create_*` and `list_*` input constraints (length/range/enums) in `fakecloud-bedrock`, matching the model.
  - Honor `sortBy`/`sortOrder` in `ListAdvancedPromptOptimizationJobs` (default `CreationTime`; reverse when `Descending`) in `fakecloud-bedrock`.
  - Add `prevalidate_lambda()` in `fakecloud-lambda` for `PublishVersion`, `UpdateFunctionCode`, and `UpdateFunctionConfiguration` to validate new length/range/enum fields.

- Performance
  - Pre-warm RSA-2048/3072/4096 keypairs in `fakecloud-kms` at service init to remove first-call delays; guard behind a Tokio runtime check to avoid unit-test panics.

<sup>Written for commit 4cc987a4a2bc3a1abb21575d03af9fa3ecacd51e. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1474?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

