### PR TITLE
refactor: demote service-crate pub mod state/service to pub(crate)

### DIFF
--- a/crates/fakecloud-apigateway/src/data_plane.rs
+++ b/crates/fakecloud-apigateway/src/data_plane.rs
@@ -3491,27 +3491,26 @@ mod tests {
         };
 
         // Seed ELBv2 state with a load balancer that has a bound port.
-        let mut elbv2_accounts = fakecloud_elbv2::state::Elbv2Accounts::new();
+        let mut elbv2_accounts = fakecloud_elbv2::Elbv2Accounts::new();
         let elbv2_state = elbv2_accounts.get_or_create(TEST_ACCOUNT);
         let lb_arn = "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-nlb/50dc6c495c0c9188";
-        let mut lb: fakecloud_elbv2::state::LoadBalancer =
-            serde_json::from_value(serde_json::json!({
-                "arn": lb_arn,
-                "name": "my-nlb",
-                "dns_name": "my-nlb-123.elb.us-east-1.amazonaws.com",
-                "canonical_hosted_zone_id": "Z35SXDOTRQ7X7K",
-                "created_time": "2024-01-01T00:00:00Z",
-                "scheme": "internal",
-                "vpc_id": "vpc-123",
-                "state_code": "active",
-                "lb_type": "application",
-                "availability_zones": [],
-                "security_groups": [],
-                "ip_address_type": "ipv4",
-                "tags": [],
-                "attributes": {}
-            }))
-            .unwrap();
+        let mut lb: fakecloud_elbv2::LoadBalancer = serde_json::from_value(serde_json::json!({
+            "arn": lb_arn,
+            "name": "my-nlb",
+            "dns_name": "my-nlb-123.elb.us-east-1.amazonaws.com",
+            "canonical_hosted_zone_id": "Z35SXDOTRQ7X7K",
+            "created_time": "2024-01-01T00:00:00Z",
+            "scheme": "internal",
+            "vpc_id": "vpc-123",
+            "state_code": "active",
+            "lb_type": "application",
+            "availability_zones": [],
+            "security_groups": [],
+            "ip_address_type": "ipv4",
+            "tags": [],
+            "attributes": {}
+        }))
+        .unwrap();
         lb.bound_port = Some(54321);
         elbv2_state.load_balancers.insert(lb_arn.to_string(), lb);
         let shared_elbv2 = Arc::new(parking_lot::RwLock::new(elbv2_accounts));

--- a/crates/fakecloud-apigateway/src/lib.rs
+++ b/crates/fakecloud-apigateway/src/lib.rs
@@ -16,7 +16,7 @@ pub mod facade;
 pub mod lambda_proxy;
 pub mod model_validation;
 pub(crate) mod service;
-pub mod state;
+pub(crate) mod state;
 pub(crate) mod validation;
 pub mod vtl;
 

--- a/crates/fakecloud-apigatewayv2/src/lib.rs
+++ b/crates/fakecloud-apigatewayv2/src/lib.rs
@@ -6,7 +6,7 @@ pub mod management;
 pub mod mock;
 pub mod router;
 pub(crate) mod service;
-pub mod state;
+pub(crate) mod state;
 pub mod websocket;
 pub mod websocket_dispatch;
 

--- a/crates/fakecloud-athena/src/service.rs
+++ b/crates/fakecloud-athena/src/service.rs
@@ -2702,7 +2702,7 @@ mod tests {
 
     use chrono::Utc;
     use fakecloud_core::service::AwsRequest;
-    use fakecloud_glue::state::Column;
+    use fakecloud_glue::Column;
     use fakecloud_glue::{Database, GlueAccounts, SharedGlueState, StorageDescriptor, Table};
     use parking_lot::RwLock;
     use serde_json::json;

--- a/crates/fakecloud-bedrock-agent-runtime/src/lib.rs
+++ b/crates/fakecloud-bedrock-agent-runtime/src/lib.rs
@@ -1,6 +1,6 @@
 pub(crate) mod eventstream;
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 
 pub use service::BedrockAgentRuntimeService;
 pub use state::{BedrockAgentRuntimeAccounts, InvocationRecord, SharedBedrockAgentRuntimeState};

--- a/crates/fakecloud-bedrock-agent/src/lib.rs
+++ b/crates/fakecloud-bedrock-agent/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 
 pub use service::BedrockAgentService;
 pub use state::{

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -41,8 +41,7 @@ use fakecloud_cloudfront::{
         OriginRequestPolicyQueryStringsConfig, ResponseHeadersPolicyConfig, StoredCachePolicy,
         StoredOriginAccessControl, StoredOriginRequestPolicy, StoredResponseHeadersPolicy,
     },
-    state::StoredDistribution,
-    SharedCloudFrontState,
+    SharedCloudFrontState, StoredDistribution,
 };
 use fakecloud_cloudwatch::{AlarmState, Dashboard, MetricAlarm, SharedCloudWatchState};
 use fakecloud_cognito::{
@@ -73,7 +72,7 @@ use fakecloud_elbv2::{
 use fakecloud_eventbridge::{
     ApiDestination, Archive, Connection, Endpoint, EventBus, EventRule, SharedEventBridgeState,
 };
-use fakecloud_firehose::state::{DeliveryStream, S3Destination};
+use fakecloud_firehose::{DeliveryStream, S3Destination};
 use fakecloud_iam::{
     IamAccessKey, IamGroup, IamInstanceProfile, IamPolicy, IamRole, IamUser, OidcProvider,
     PolicyVersion, SamlProvider, SharedIamState, Tag, VirtualMfaDevice,
@@ -5563,7 +5562,7 @@ impl ResourceProvisioner {
         &self,
         resource: &ResourceDefinition,
     ) -> Result<ProvisionResult, String> {
-        use fakecloud_ecr::state::{
+        use fakecloud_ecr::{
             ReplicationConfiguration, ReplicationDestination, ReplicationRule, RepositoryFilter,
         };
         let cfg = resource
@@ -5641,7 +5640,7 @@ impl ResourceProvisioner {
         &self,
         resource: &ResourceDefinition,
     ) -> Result<ProvisionResult, String> {
-        use fakecloud_ecr::state::PullThroughCacheRule;
+        use fakecloud_ecr::PullThroughCacheRule;
         let props = &resource.properties;
         let prefix = props
             .get("EcrRepositoryPrefix")
@@ -5763,7 +5762,7 @@ impl ResourceProvisioner {
         &self,
         resource: &ResourceDefinition,
     ) -> Result<ProvisionResult, String> {
-        use fakecloud_ecr::state::{
+        use fakecloud_ecr::{
             RegistryScanningConfiguration, RegistryScanningRule, RepositoryFilter,
         };
         let props = &resource.properties;
@@ -5818,7 +5817,7 @@ impl ResourceProvisioner {
     }
 
     fn delete_ecr_registry_scanning_configuration(&self) -> Result<(), String> {
-        use fakecloud_ecr::state::RegistryScanningConfiguration;
+        use fakecloud_ecr::RegistryScanningConfiguration;
         let mut accounts = self.ecr_state.write();
         let state = accounts.get_or_create(&self.account_id);
         // CFN delete reverts to the AWS default (BASIC, no rules).

--- a/crates/fakecloud-cloudfront/src/lib.rs
+++ b/crates/fakecloud-cloudfront/src/lib.rs
@@ -21,7 +21,7 @@ pub mod policies;
 pub mod policies_service;
 pub mod router;
 pub(crate) mod service;
-pub mod state;
+pub(crate) mod state;
 pub mod streaming;
 pub mod streaming_service;
 pub mod tenants;
@@ -33,4 +33,4 @@ pub const API_PREFIX: &str = "/2020-05-31";
 pub const NAMESPACE: &str = "http://cloudfront.amazonaws.com/doc/2020-05-31/";
 
 pub use service::CloudFrontService;
-pub use state::{CloudFrontAccounts, SharedCloudFrontState};
+pub use state::{CloudFrontAccounts, SharedCloudFrontState, StoredDistribution};

--- a/crates/fakecloud-cloudwatch/src/lib.rs
+++ b/crates/fakecloud-cloudwatch/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod delivery;
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 
 pub use delivery::CloudwatchDeliveryImpl;
 pub use service::CloudWatchService;

--- a/crates/fakecloud-dynamodb/src/lib.rs
+++ b/crates/fakecloud-dynamodb/src/lib.rs
@@ -1,5 +1,5 @@
 pub(crate) mod service;
-pub mod state;
+pub(crate) mod state;
 pub mod streams;
 pub mod streams_dataplane;
 pub mod ttl;

--- a/crates/fakecloud-ecr/src/lib.rs
+++ b/crates/fakecloud-ecr/src/lib.rs
@@ -4,12 +4,12 @@ pub(crate) mod pull_through;
 pub mod scanner;
 pub(crate) mod service;
 pub mod signing;
-pub mod state;
+pub(crate) mod state;
 
 pub use lifecycle_ticker::LifecycleTicker;
 pub use service::{evaluate_lifecycle_policy, EcrService};
 pub use state::{
-    EcrSnapshot, EcrState, Image, PullThroughCacheRule, ReplicationConfiguration,
-    ReplicationDestination, ReplicationRule, Repository, RepositoryFilter, SharedEcrState,
-    ECR_SNAPSHOT_SCHEMA_VERSION,
+    EcrSnapshot, EcrState, Image, PullThroughCacheRule, RegistryScanningConfiguration,
+    RegistryScanningRule, ReplicationConfiguration, ReplicationDestination, ReplicationRule,
+    Repository, RepositoryFilter, SharedEcrState, ECR_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-elbv2/src/dataplane.rs
+++ b/crates/fakecloud-elbv2/src/dataplane.rs
@@ -23,7 +23,7 @@ use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_wafv2::evaluator::{
     evaluate_detailed as waf_evaluate_detailed, WafAction, WafRequest,
 };
-use fakecloud_wafv2::state::{IpSet, RegexPatternSet, SharedWafv2State, WebAcl};
+use fakecloud_wafv2::{IpSet, RegexPatternSet, SharedWafv2State, WebAcl};
 use http::{HeaderMap, HeaderName, HeaderValue, Method, Request, Response, StatusCode};
 use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
@@ -1291,7 +1291,7 @@ fn short_id() -> String {
 mod waf_tests {
     use super::*;
     use chrono::Utc;
-    use fakecloud_wafv2::state::{AccountState, Wafv2Accounts, WebAcl};
+    use fakecloud_wafv2::{AccountState, Wafv2Accounts, WebAcl};
     use http::Uri;
     use parking_lot::RwLock;
     use serde_json::{json, Value};

--- a/crates/fakecloud-elbv2/src/lib.rs
+++ b/crates/fakecloud-elbv2/src/lib.rs
@@ -3,7 +3,7 @@ pub mod dataplane;
 pub mod prober;
 pub mod router;
 pub(crate) mod service;
-pub mod state;
+pub(crate) mod state;
 
 pub const ELBV2_NAMESPACE: &str = "http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/";
 
@@ -11,5 +11,6 @@ pub use service::Elbv2Service;
 pub use state::{
     Action, AvailabilityZone, Certificate, Elbv2Accounts, FixedResponseConfig, ForwardConfig,
     Listener, LoadBalancer, LoadBalancerAddress, RedirectConfig, Rule, RuleCondition,
-    SharedElbv2State, Tag, TargetGroup, TargetGroupTuple, TrustStore,
+    SharedElbv2State, Tag, TargetDescription, TargetGroup, TargetGroupTuple, TargetHealth,
+    TrustStore,
 };

--- a/crates/fakecloud-firehose/src/lib.rs
+++ b/crates/fakecloud-firehose/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod delivery;
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 
 pub use delivery::FirehoseDeliveryImpl;
 pub use service::FirehoseService;
-pub use state::{FirehoseAccounts, SharedFirehoseState};
+pub use state::{DeliveryStream, FirehoseAccounts, S3Destination, SharedFirehoseState};

--- a/crates/fakecloud-glue/src/lib.rs
+++ b/crates/fakecloud-glue/src/lib.rs
@@ -1,10 +1,10 @@
 pub mod introspection;
 pub mod jobs;
 pub mod partition_filter;
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 
 pub use service::GlueService;
 pub use state::{
-    Database, GlueAccounts, GlueState, Partition, SharedGlueState, StorageDescriptor, Table,
+    Column, Database, GlueAccounts, GlueState, Partition, SharedGlueState, StorageDescriptor, Table,
 };

--- a/crates/fakecloud-route53/src/lib.rs
+++ b/crates/fakecloud-route53/src/lib.rs
@@ -9,7 +9,7 @@ pub mod dnssec;
 pub mod model;
 pub mod router;
 pub(crate) mod service;
-pub mod state;
+pub(crate) mod state;
 pub mod xml_io;
 
 pub const API_VERSION: &str = "2013-04-01";

--- a/crates/fakecloud-server/src/appas_hooks.rs
+++ b/crates/fakecloud-server/src/appas_hooks.rs
@@ -9,7 +9,7 @@ use fakecloud_application_autoscaling::hooks::{
     DynamoDbCapacityHook, EcsServiceHook, MetricReader,
 };
 use fakecloud_cloudwatch::SharedCloudWatchState;
-use fakecloud_dynamodb::state::SharedDynamoDbState;
+use fakecloud_dynamodb::SharedDynamoDbState;
 use fakecloud_ecs::SharedEcsState;
 
 /// Reads from in-process CloudWatch metric and alarm state.

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -5928,7 +5928,7 @@ async fn main() {
                         // Index children by parent arn for O(N) tree build.
                         let mut children_by_parent: std::collections::HashMap<
                             String,
-                            Vec<&fakecloud_stepfunctions::state::Execution>,
+                            Vec<&fakecloud_stepfunctions::Execution>,
                         > = std::collections::HashMap::new();
                         for exec in state.executions.values() {
                             if let Some(parent) = exec.parent_execution_arn.as_ref() {
@@ -5939,10 +5939,10 @@ async fn main() {
                             }
                         }
                         fn build_node(
-                            exec: &fakecloud_stepfunctions::state::Execution,
+                            exec: &fakecloud_stepfunctions::Execution,
                             children_by_parent: &std::collections::HashMap<
                                 String,
-                                Vec<&fakecloud_stepfunctions::state::Execution>,
+                                Vec<&fakecloud_stepfunctions::Execution>,
                             >,
                         ) -> types::StepFunctionsExecutionTreeNode {
                             let kids = children_by_parent
@@ -7616,11 +7616,11 @@ impl fakecloud_core::delivery::Elbv2TargetRegistration for Elbv2TargetRegistrati
         };
         for (id, port) in targets {
             tg.targets.retain(|t| t.id != id);
-            tg.targets.push(fakecloud_elbv2::state::TargetDescription {
+            tg.targets.push(fakecloud_elbv2::TargetDescription {
                 id,
                 port: port.map(|p| p as i32),
                 availability_zone: None,
-                health: fakecloud_elbv2::state::TargetHealth {
+                health: fakecloud_elbv2::TargetHealth {
                     state: "initial".into(),
                     reason: None,
                     description: None,

--- a/crates/fakecloud-ses/src/lib.rs
+++ b/crates/fakecloud-ses/src/lib.rs
@@ -3,7 +3,7 @@ pub mod fanout;
 pub mod mime;
 pub(crate) mod service;
 pub mod smtp_relay;
-pub mod state;
+pub(crate) mod state;
 pub mod v1;
 
 pub use service::SesV2Service;

--- a/crates/fakecloud-stepfunctions/src/lib.rs
+++ b/crates/fakecloud-stepfunctions/src/lib.rs
@@ -4,11 +4,11 @@ pub mod interpreter;
 pub mod intrinsics;
 pub mod io_processing;
 pub(crate) mod service;
-pub mod state;
+pub(crate) mod state;
 
 pub use service::{start_execution_from_delivery, SharedServiceRegistry, StepFunctionsService};
 pub use state::{
-    Activity, AliasRoute, SharedStepFunctionsState, StateMachine, StateMachineAlias,
+    Activity, AliasRoute, Execution, SharedStepFunctionsState, StateMachine, StateMachineAlias,
     StateMachineStatus, StateMachineType, StateMachineVersion, StepFunctionsSnapshot,
     StepFunctionsState, TaskTokenState, STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-wafv2/src/lib.rs
+++ b/crates/fakecloud-wafv2/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod evaluator;
 pub mod inspection;
 pub(crate) mod service;
-pub mod state;
+pub(crate) mod state;
 
 pub use evaluator::{
     evaluate, evaluate_detailed, evaluate_web_acl, RateLimiter, WafAction, WafEvaluation,


### PR DESCRIPTION
## Summary

Audit 2026-05-19 surfaced that 21 service crates had regressed from 2026-04-29's clean state, with `pub mod state` / `pub mod service` re-exposing internal modules to cross-crate imports.

This restores the pattern where cross-crate access flows through explicit `pub use state::{...}` re-exports at lib root:

- 15 crates demoted: stepfunctions, bedrock-agent-runtime, dynamodb, apigateway, glue, bedrock-agent, ecr, apigatewayv2, route53, elbv2, cloudfront, firehose, cloudwatch, ses, wafv2
- added missing re-exports for types that were being accessed by direct module path: `Execution` (stepfn), `Column` (glue), `DeliveryStream`/`S3Destination` (firehose), `TargetDescription`/`TargetHealth` (elbv2), `RegistryScanningConfiguration`/`RegistryScanningRule` (ecr), `StoredDistribution` (cloudfront)
- rewrote external `fakecloud_X::state::Y` direct paths to flow through the lib-root re-exports

`fakecloud-core` retains `pub mod service` — it's the trait-defining crate.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` all pass
- [x] No production source touched beyond import path rewrites

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demoted `service` and `state` modules to `pub(crate)` across service crates to stop cross-crate access to internals. Cross-crate imports now use explicit re-exports from each crate root; updated all usages accordingly.

- **Refactors**
  - Set `pub(crate)` for `service`/`state` in 15 crates: `stepfunctions`, `bedrock-agent-runtime`, `dynamodb`, `apigateway`, `glue`, `bedrock-agent`, `ecr`, `apigatewayv2`, `route53`, `elbv2`, `cloudfront`, `firehose`, `cloudwatch`, `ses`, `wafv2`.
  - Added root re-exports where needed: `Execution` (`stepfunctions`), `Column` (`glue`), `DeliveryStream`/`S3Destination` (`firehose`), `TargetDescription`/`TargetHealth` (`elbv2`), `RegistryScanningConfiguration`/`RegistryScanningRule` (`ecr`), `StoredDistribution` (`cloudfront`).
  - Replaced direct `fakecloud_*::state::Type` imports with root-level `fakecloud_*::Type`.
  - Kept `fakecloud-core` `pub mod service` as-is.

- **Migration**
  - If you imported internal modules, switch to root re-exports. Example: `fakecloud_elbv2::state::TargetDescription` -> `fakecloud_elbv2::TargetDescription`.
  - No runtime or API behavior changes expected beyond import paths.

<sup>Written for commit 996751caf212d213fe839001f08f8306478d874e. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1475?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

