### PR TITLE
chore: remove dead keepalive helpers and unused imports

### DIFF
--- a/crates/fakecloud-application-autoscaling/src/scheduled_executor.rs
+++ b/crates/fakecloud-application-autoscaling/src/scheduled_executor.rs
@@ -517,7 +517,6 @@ mod tests {
         ApplicationAutoScalingAccounts, ScalableTarget, ScalableTargetAction, ScheduledAction,
     };
     use parking_lot::RwLock;
-    use std::collections::BTreeMap;
     use std::sync::atomic::{AtomicI64, Ordering};
     use std::sync::Mutex;
 
@@ -746,9 +745,4 @@ mod tests {
         let exec = ScheduledActionExecutor::new(state.clone(), ddb.clone(), "us-east-1");
         assert_eq!(exec.tick_once(), 0);
     }
-
-    // Dummy use of BTreeMap to silence unused-import warning if the
-    // test fixtures stop needing it.
-    #[allow(dead_code)]
-    fn _btreemap_used(_: BTreeMap<String, String>) {}
 }

--- a/crates/fakecloud-cognito/src/service/identity_pools.rs
+++ b/crates/fakecloud-cognito/src/service/identity_pools.rs
@@ -272,12 +272,6 @@ fn identity_to_json(identity: &FederatedIdentity) -> Value {
     })
 }
 
-/// Compose the `IdentityPoolId` ARN that tag operations use.
-/// Format: `arn:aws:cognito-identity:<region>:<account>:identitypool/<pool-id>`.
-fn identity_pool_arn(region: &str, account_id: &str, pool_id: &str) -> String {
-    format!("arn:aws:cognito-identity:{region}:{account_id}:identitypool/{pool_id}")
-}
-
 impl CognitoIdentityService {
     // --- pool CRUD ---------------------------------------------------------
 
@@ -1245,12 +1239,4 @@ impl CognitoIdentityService {
             "PrincipalTags": principal_tags,
         })))
     }
-}
-
-// `identity_pool_arn` is exposed for future ops (CFN tag inheritance,
-// SCP scoping) but isn't called yet — keep it warning-free without
-// stripping it from the API surface.
-#[allow(dead_code)]
-fn _identity_pool_arn_keepalive(region: &str, account_id: &str, pool_id: &str) -> String {
-    identity_pool_arn(region, account_id, pool_id)
 }

--- a/crates/fakecloud-kms/src/asym_ecdsa.rs
+++ b/crates/fakecloud-kms/src/asym_ecdsa.rs
@@ -6,7 +6,6 @@
 //! legacy fake-bytes path. SM2 is not currently supported and is
 //! refused at CreateKey.
 
-use rsa::sha2::{Sha256, Sha384};
 use signature::{Signer, Verifier};
 
 #[derive(Debug, thiserror::Error)]
@@ -287,12 +286,6 @@ fn digest_to_array_48(d: &[u8]) -> Result<[u8; 48], EcdsaError> {
     d.try_into().map_err(|_| {
         EcdsaError::CryptoFailure("MessageType=DIGEST requires 48-byte digest for SHA-384".into())
     })
-}
-
-#[allow(dead_code)]
-fn _unused_imports_keepalive() {
-    let _ = Sha256::default();
-    let _ = Sha384::default();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Three of the nine `#[allow(dead_code)]` sites that audit 2026-05-19 flagged were keepalive shims existing purely to silence `unused` warnings on code that was effectively dead:

- `fakecloud-kms/src/asym_ecdsa.rs`: dropped `sha2::{Sha256, Sha384}` imports and `_unused_imports_keepalive` — ECDSA paths use the curve-specific signing keys directly; sha2 was never wired in.
- `fakecloud-application-autoscaling/src/scheduled_executor.rs`: dropped `BTreeMap` test import and `_btreemap_used` keepalive.
- `fakecloud-cognito/src/service/identity_pools.rs`: dropped `identity_pool_arn` helper + its keepalive — zero callers, comment claimed "future ops" but those never landed; trivially reconstructable inline if a future op needs it.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` all pass
- [x] No behavioral change — only dead code removal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead keepalive helpers and unused imports across three crates to reduce `#[allow(dead_code)]` noise. No behavior or API changes.

- **Refactors**
  - `fakecloud-kms/src/asym_ecdsa.rs`: drop `rsa::sha2::{Sha256, Sha384}` imports and `_unused_imports_keepalive`.
  - `fakecloud-application-autoscaling/src/scheduled_executor.rs`: remove `BTreeMap` test import and `_btreemap_used`.
  - `fakecloud-cognito/src/service/identity_pools.rs`: remove `identity_pool_arn` helper and its keepalive (no callers).

<sup>Written for commit e23d81acdafed7e56c9754479ef074cffc2b8cd4. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1476?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

