### PR TITLE
chore: remove remaining dead_code allows

### DIFF
--- a/crates/fakecloud-cognito/src/jwt.rs
+++ b/crates/fakecloud-cognito/src/jwt.rs
@@ -167,18 +167,6 @@ pub fn verify_rs256(token: &str, private_key_pem: &str) -> Result<(Value, Value)
     Ok((header, payload))
 }
 
-/// SubjectPublicKeyInfo PEM for callers that want the raw public half
-/// without parsing the JWKS document.
-#[allow(dead_code)]
-pub(crate) fn public_key_pem(private_key_pem: &str) -> Option<String> {
-    use rsa::pkcs8::DecodePrivateKey;
-    let private_key = RsaPrivateKey::from_pkcs8_pem(private_key_pem).ok()?;
-    let public_key = RsaPublicKey::from(&private_key);
-    public_key
-        .to_public_key_pem(rsa::pkcs8::LineEnding::LF)
-        .ok()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -367,10 +367,6 @@ pub(crate) fn parse_query_list_param(
 /// `ReplicaConfiguration.ConfigureShard.N.{NodeGroupId,NewReplicaCount}`.
 /// Used by IncreaseReplicaCount + DecreaseReplicaCount.
 pub(crate) struct ConfigureShard {
-    /// Captured from the request so future per-shard placement can target a
-    /// specific NodeGroupId; today we apply NewReplicaCount uniformly.
-    #[allow(dead_code)]
-    pub node_group_id: String,
     pub new_replica_count: i32,
 }
 
@@ -394,7 +390,7 @@ pub(crate) fn parse_replica_configuration(
     for idx in indices {
         let id_key = format!("{prefix}{idx}.NodeGroupId");
         let count_key = format!("{prefix}{idx}.NewReplicaCount");
-        let node_group_id = req.query_params.get(&id_key).ok_or_else(|| {
+        req.query_params.get(&id_key).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "MissingParameter",
@@ -417,10 +413,7 @@ pub(crate) fn parse_replica_configuration(
                 ),
             )
         })?;
-        out.push(ConfigureShard {
-            node_group_id: node_group_id.clone(),
-            new_replica_count,
-        });
+        out.push(ConfigureShard { new_replica_count });
     }
     Ok(out)
 }

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -15,24 +15,17 @@ use super::{
     s3_xml, validate_lifecycle_xml, validate_tags, xml_escape, S3Service,
 };
 
-/// Decoded `PublicAccessBlockConfiguration` flags. Each flag defaults
-/// to `false` when missing from the stored XML, matching AWS's
-/// `GetPublicAccessBlock` echo path.
-///
-/// `ignore_public_acls` and `restrict_public_buckets` gate
-/// **read-time** evaluation (effective ACL / effective policy lookup)
-/// — fakecloud doesn't yet evaluate effective access at GetObject
-/// time, so we parse and store them but they are not read from on
-/// the request path. Removing them would silently drop the values
-/// from `GetPublicAccessBlock` round-trips.
+/// Decoded `PublicAccessBlockConfiguration` flags read by the request
+/// path. `GetPublicAccessBlock` echoes the bucket's stored XML directly
+/// (see `get_public_access_block`), so flags absent here still
+/// round-trip — they just aren't enforced. `RestrictPublicBuckets`
+/// is intentionally omitted until the effective-policy evaluator
+/// lands; it's a feature gap, not a parse gap.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct PublicAccessBlockFlags {
     pub block_public_acls: bool,
-    #[allow(dead_code)]
     pub ignore_public_acls: bool,
     pub block_public_policy: bool,
-    #[allow(dead_code)]
-    pub restrict_public_buckets: bool,
 }
 
 impl PublicAccessBlockFlags {
@@ -55,7 +48,6 @@ impl PublicAccessBlockFlags {
             block_public_acls: flag(xml, "BlockPublicAcls"),
             ignore_public_acls: flag(xml, "IgnorePublicAcls"),
             block_public_policy: flag(xml, "BlockPublicPolicy"),
-            restrict_public_buckets: flag(xml, "RestrictPublicBuckets"),
         }
     }
 }

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -345,10 +345,6 @@ mod tests {
         struct Call {
             queue_arn: String,
             body: String,
-            #[allow(dead_code)]
-            group: Option<String>,
-            #[allow(dead_code)]
-            dedup: Option<String>,
         }
 
         #[derive(Default)]
@@ -366,8 +362,6 @@ mod tests {
                 self.calls.lock().unwrap().push(Call {
                     queue_arn: queue_arn.to_string(),
                     body: message_body.to_string(),
-                    group: None,
-                    dedup: None,
                 });
             }
 
@@ -376,14 +370,12 @@ mod tests {
                 queue_arn: &str,
                 message_body: &str,
                 _attrs: &HashMap<String, fakecloud_core::delivery::SqsMessageAttribute>,
-                group: Option<&str>,
-                dedup: Option<&str>,
+                _group: Option<&str>,
+                _dedup: Option<&str>,
             ) {
                 self.calls.lock().unwrap().push(Call {
                     queue_arn: queue_arn.to_string(),
                     body: message_body.to_string(),
-                    group: group.map(|s| s.to_string()),
-                    dedup: dedup.map(|s| s.to_string()),
                 });
             }
         }


### PR DESCRIPTION
## Summary

Second wave of audit 2026-05-19 dead_code cleanup — cleared the six remaining `#[allow(dead_code)]` sites by removing genuinely unused state:

- **sns/delivery.rs**: dropped `group`/`dedup` fields from test `Call` struct — never asserted on.
- **s3/service/config.rs**: removed `ignore_public_acls` `#[allow]` (the field IS read in `objects.rs`) and dropped `restrict_public_buckets` entirely — never enforced, never read, and `GetPublicAccessBlock` echoes raw stored XML so round-trip is preserved at the XML level. Doc comment updated to flag RestrictPublicBuckets as a deliberate enforcement gap (not a parse gap), to be addressed when the effective-policy evaluator lands.
- **elasticache/helpers.rs**: dropped `node_group_id` from `ConfigureShard` — captured for hypothetical future per-shard placement that never materialized; still validated as required at parse time.
- **cognito/jwt.rs**: removed `public_key_pem` helper — zero callers, JWKS path bypassed it.

Combined with PR #1476, this closes all 9 `#[allow(dead_code)]` sites from the audit.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` all pass
- [x] `GetPublicAccessBlock` round-trip preserved (XML echo path unchanged)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the remaining `#[allow(dead_code)]` by deleting unused fields and a helper across `fakecloud-sns`, `fakecloud-s3`, `fakecloud-elasticache`, and `fakecloud-cognito`. No runtime behavior changes; S3 `PublicAccessBlock` XML round-trips remain unchanged.

- **Refactors**
  - `fakecloud-sns`: Removed `group`/`dedup` fields from test `Call` struct.
  - `fakecloud-s3`: Dropped `restrict_public_buckets`; kept `ignore_public_acls` (it’s read). Updated docs to note the enforcement gap until the effective-policy evaluator lands.
  - `fakecloud-elasticache`: Removed `node_group_id` from `ConfigureShard`; still validated at parse time.
  - `fakecloud-cognito`: Removed unused `public_key_pem` helper.

<sup>Written for commit faef79b0aac5428f56ee97e7bdea668a06da83f7. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1477?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

