### PR TITLE
refactor: use Arn::new for kms/bedrock-agent/firehose ARN construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,6 +3095,7 @@ version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "fakecloud-aws",
  "fakecloud-core",
  "http 1.4.0",
  "parking_lot",

--- a/crates/fakecloud-bedrock-agent/Cargo.toml
+++ b/crates/fakecloud-bedrock-agent/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 version.workspace = true
 
 [dependencies]
+fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-bedrock-agent/src/service.rs
+++ b/crates/fakecloud-bedrock-agent/src/service.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use fakecloud_aws::arn::Arn;
 use http::{Method, StatusCode};
 use parking_lot::RwLock;
 use serde_json::{json, Value};
@@ -1128,11 +1129,17 @@ fn prompt_summary_json(p: &Prompt, region: &str, account_id: &str) -> Value {
 }
 
 fn flow_arn(flow_id: &str, region: &str, account_id: &str) -> String {
-    format!("arn:aws:bedrock:{region}:{account_id}:flow/{flow_id}")
+    Arn::new("bedrock", region, account_id, &format!("flow/{flow_id}")).to_string()
 }
 
 fn prompt_arn(prompt_id: &str, region: &str, account_id: &str) -> String {
-    format!("arn:aws:bedrock:{region}:{account_id}:prompt/{prompt_id}")
+    Arn::new(
+        "bedrock",
+        region,
+        account_id,
+        &format!("prompt/{prompt_id}"),
+    )
+    .to_string()
 }
 
 fn flow_json(f: &Flow) -> Value {

--- a/crates/fakecloud-firehose/src/service.rs
+++ b/crates/fakecloud-firehose/src/service.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use base64::Engine;
 use bytes::Bytes;
 use chrono::Utc;
+use fakecloud_aws::arn::Arn;
 use http::StatusCode;
 use parking_lot::RwLock;
 use serde_json::{json, Value};
@@ -170,7 +171,13 @@ fn s3_destination_json(dest: &S3Destination) -> Value {
 }
 
 fn arn_for(region: &str, account: &str, name: &str) -> String {
-    format!("arn:aws:firehose:{region}:{account}:deliverystream/{name}")
+    Arn::new(
+        "firehose",
+        region,
+        account,
+        &format!("deliverystream/{name}"),
+    )
+    .to_string()
 }
 
 fn bucket_name_from_arn(arn: &str) -> Option<&str> {

--- a/crates/fakecloud-kms/src/provisioner.rs
+++ b/crates/fakecloud-kms/src/provisioner.rs
@@ -16,6 +16,7 @@
 use std::collections::BTreeMap;
 
 use chrono::Utc;
+use fakecloud_aws::arn::Arn;
 use uuid::Uuid;
 
 use super::asym;
@@ -156,7 +157,7 @@ pub fn build_kms_key(
     } else {
         Uuid::new_v4().to_string()
     };
-    let arn = format!("arn:aws:kms:{region}:{account_id}:key/{key_id}");
+    let arn = Arn::new("kms", region, account_id, &format!("key/{key_id}")).to_string();
     let now = Utc::now().timestamp() as f64;
 
     let signing_algs = if input.key_usage == "SIGN_VERIFY" {
@@ -280,7 +281,8 @@ pub fn provision_replica_key(
     }
 
     let replica_key_id = format!("mrk-replica-{}", Uuid::new_v4().as_simple());
-    let replica_arn = format!("arn:aws:kms:{region}:{account_id}:key/{replica_key_id}");
+    let replica_arn =
+        Arn::new("kms", &region, account_id, &format!("key/{replica_key_id}")).to_string();
     let mut replica = source;
     replica.key_id = replica_key_id.clone();
     replica.arn = replica_arn.clone();
@@ -342,7 +344,7 @@ pub fn provision_alias(
     } else {
         return Err(format!("KMS key '{target_input}' does not exist"));
     };
-    let alias_arn = format!("arn:aws:kms:{}:{}:{}", s.region, s.account_id, alias_name);
+    let alias_arn = Arn::new("kms", &s.region, &s.account_id, alias_name).to_string();
     let alias = KmsAlias {
         alias_name: alias_name.to_string(),
         alias_arn,


### PR DESCRIPTION
## Summary

First pass on audit 2026-05-19's 37-site inline `format!("arn:aws:...)` finding. Picked the cleanest, standard-shape ARNs across three crates:

- **fakecloud-kms/src/provisioner.rs**: key, replica key, and alias ARNs go through `Arn::new("kms", ...)`.
- **fakecloud-bedrock-agent/src/service.rs**: `flow_arn` / `prompt_arn` helpers — adds `fakecloud-aws` as a dep (other splits already had it).
- **fakecloud-firehose/src/service.rs**: `arn_for` delivery-stream helper.

Remaining 33 sites have non-standard shapes (empty `account_id`, leading slashes, triple-colon variants, etc) — they'll need either targeted `Arn::*` helpers or to stay inline; not worth shoehorning through `Arn::new`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` all pass
- [x] ARN string outputs unchanged (`Arn::new("kms", region, account_id, "key/id").to_string()` produces identical bytes to the prior `format!`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced inline ARN string building with `Arn::new` for KMS, Bedrock Agent, and Firehose to standardize construction and reduce errors. No behavior change; ARN outputs are identical.

- **Refactors**
  - `fakecloud-kms/src/provisioner.rs`: use `Arn::new("kms", ...)` for key, replica key, and alias ARNs.
  - `fakecloud-bedrock-agent/src/service.rs`: `flow_arn` and `prompt_arn` now use `Arn::new("bedrock", ...)`.
  - `fakecloud-firehose/src/service.rs`: `arn_for` uses `Arn::new("firehose", ...)`.
  - Limited to standard-shaped ARNs; irregular cases remain inline for now.

- **Dependencies**
  - Added `fakecloud-aws` to `fakecloud-bedrock-agent`.

<sup>Written for commit dbd31258e39b0de9fb91b7fe3b41e19a5afc6209. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1478?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

