### PR TITLE
refactor: convert 9 more ARN format! sites to Arn helpers

### DIFF
--- a/crates/fakecloud-bedrock/src/customization.rs
+++ b/crates/fakecloud-bedrock/src/customization.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use fakecloud_aws::arn::Arn;
 use http::StatusCode;
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -186,7 +187,13 @@ fn base_model_arn(base_model_identifier: &str, region: &str) -> String {
     if base_model_identifier.starts_with("arn:") {
         base_model_identifier.to_string()
     } else {
-        format!("arn:aws:bedrock:{region}::foundation-model/{base_model_identifier}")
+        Arn::new(
+            "bedrock",
+            region,
+            "",
+            &format!("foundation-model/{base_model_identifier}"),
+        )
+        .to_string()
     }
 }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/iam.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/iam.rs
@@ -744,7 +744,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .ok_or("SamlMetadataDocument is required")?
             .to_string();
-        let arn = format!("arn:aws:iam::{}:saml-provider/{name}", self.account_id);
+        let arn =
+            Arn::global("iam", &self.account_id, &format!("saml-provider/{name}")).to_string();
         let now = Utc::now();
         let valid_until = now + chrono::Duration::days(365 * 10);
         let provider = SamlProvider {
@@ -794,7 +795,8 @@ impl ResourceProvisioner {
             None => format!("AWSServiceRoleFor{service_short}"),
         };
         let path = format!("/aws-service-role/{aws_service_name}/");
-        let arn = format!("arn:aws:iam::{}:role{path}{role_name}", self.account_id);
+        let arn =
+            Arn::global("iam", &self.account_id, &format!("role{path}{role_name}")).to_string();
         // Service-linked roles get a trust policy specific to the service.
         let assume_role_policy_document = serde_json::json!({
             "Version": "2012-10-17",
@@ -848,7 +850,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .unwrap_or("/")
             .to_string();
-        let serial_number = format!("arn:aws:iam::{}:mfa{}{name}", self.account_id, path);
+        let serial_number =
+            Arn::global("iam", &self.account_id, &format!("mfa{path}{name}")).to_string();
         // Real AWS returns a base32 seed + a PNG QR code; we synthesize
         // deterministic placeholders so callers can read them back.
         let seed = format!("BASE32SEED{}", Uuid::new_v4().simple());

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -26,6 +26,7 @@ use fakecloud_application_autoscaling::{
     SharedApplicationAutoScalingState as AppasState, SuspendedState as AppasSuspendedState,
 };
 use fakecloud_athena::{DataCatalog, NamedQuery, PreparedStatement, SharedAthenaState, WorkGroup};
+use fakecloud_aws::arn::Arn;
 use fakecloud_cloudfront::{
     functions::{
         CloudFrontOriginAccessIdentityConfig, FunctionConfig, KeyGroupConfig, KeyGroupItems,
@@ -4936,7 +4937,8 @@ impl ResourceProvisioner {
             "E{}",
             Uuid::new_v4().simple().to_string()[..7].to_uppercase()
         );
-        let function_arn = format!("arn:aws:cloudfront::{}:function/{}", self.account_id, name);
+        let function_arn =
+            Arn::global("cloudfront", &self.account_id, &format!("function/{name}")).to_string();
 
         let now = Utc::now();
         let func = StoredFunction {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/s3.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/s3.rs
@@ -11,7 +11,7 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         let bucket = state.buckets.get(physical_id)?;
         match attribute {
-            "Arn" => Some(format!("arn:aws:s3:::{}", bucket.name)),
+            "Arn" => Some(Arn::s3(&bucket.name).to_string()),
             "DomainName" => Some(format!("{}.s3.amazonaws.com", bucket.name)),
             "RegionalDomainName" => {
                 Some(format!("{}.s3.{}.amazonaws.com", bucket.name, self.region))
@@ -46,7 +46,7 @@ impl ResourceProvisioner {
         let bucket = S3Bucket::new(bucket_name, &state.region, &state.account_id);
         state.buckets.insert(bucket_name.to_string(), bucket);
 
-        let arn = format!("arn:aws:s3:::{bucket_name}");
+        let arn = Arn::s3(&bucket_name).to_string();
         let domain_name = format!("{bucket_name}.s3.amazonaws.com");
         let regional_domain_name = format!("{bucket_name}.s3.{region}.amazonaws.com");
         let dual_stack_domain_name = format!("{bucket_name}.s3.dualstack.{region}.amazonaws.com");

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/s3.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/s3.rs
@@ -46,7 +46,7 @@ impl ResourceProvisioner {
         let bucket = S3Bucket::new(bucket_name, &state.region, &state.account_id);
         state.buckets.insert(bucket_name.to_string(), bucket);
 
-        let arn = Arn::s3(&bucket_name).to_string();
+        let arn = Arn::s3(bucket_name).to_string();
         let domain_name = format!("{bucket_name}.s3.amazonaws.com");
         let regional_domain_name = format!("{bucket_name}.s3.{region}.amazonaws.com");
         let dual_stack_domain_name = format!("{bucket_name}.s3.dualstack.{region}.amazonaws.com");

--- a/crates/fakecloud-cognito/src/service/auth.rs
+++ b/crates/fakecloud-cognito/src/service/auth.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use chrono::Utc;
+use fakecloud_aws::arn::Arn;
 use http::StatusCode;
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -2447,7 +2448,13 @@ fn record_pre_token_gen_invocation(
     invoked_at: chrono::DateTime<Utc>,
     duration_ms: u64,
 ) {
-    let user_pool_arn = format!("arn:aws:cognito-idp:{region}:{account_id}:userpool/{pool_id}");
+    let user_pool_arn = Arn::new(
+        "cognito-idp",
+        region,
+        account_id,
+        &format!("userpool/{pool_id}"),
+    )
+    .to_string();
 
     let mut claims_added: Vec<String> = Vec::new();
     let mut claims_overridden: Vec<String> = Vec::new();

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -727,7 +727,9 @@ impl StsService {
             .as_ref()
             .map(|(_iss, p)| p.arn.clone())
             .or(provider_id_param.clone())
-            .unwrap_or_else(|| format!("arn:aws:iam::{}:oidc-provider/web-identity", account_id));
+            .unwrap_or_else(|| {
+                Arn::global("iam", &account_id, "oidc-provider/web-identity").to_string()
+            });
 
         // Trust-policy gate: same shape as AssumeRole, but the caller
         // principal is the federated provider and the action is

--- a/crates/fakecloud-lambda/src/workflows.rs
+++ b/crates/fakecloud-lambda/src/workflows.rs
@@ -9,6 +9,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{
@@ -38,7 +39,13 @@ fn check_len(field: &str, v: &str, min: usize, max: usize) -> Result<(), AwsServ
 }
 
 fn arn_for_capacity_provider(region: &str, account: &str, name: &str) -> String {
-    format!("arn:aws:lambda:{region}:{account}:capacity-provider/{name}")
+    Arn::new(
+        "lambda",
+        region,
+        account,
+        &format!("capacity-provider/{name}"),
+    )
+    .to_string()
 }
 
 fn capacity_provider_json(cp: &CapacityProvider) -> Value {
@@ -245,7 +252,13 @@ pub(crate) fn list_function_versions_by_capacity_provider(
 // ─── Durable executions ───────────────────────────────────────────────────
 
 fn execution_arn(region: &str, account: &str, id: &str) -> String {
-    format!("arn:aws:lambda:{region}:{account}:durable-execution/{id}")
+    Arn::new(
+        "lambda",
+        region,
+        account,
+        &format!("durable-execution/{id}"),
+    )
+    .to_string()
 }
 
 fn execution_json(e: &DurableExecution) -> Value {


### PR DESCRIPTION
Audit P10 batch 3. Standard-shape ARN construction moved to Arn::new/global/s3. Remaining 16 sites have non-standard shapes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced manual ARN string formatting with `Arn::new`, `Arn::global`, and `Arn::s3` across nine standard-shape sites to centralize construction and prevent inconsistencies. No behavior change; generated ARNs remain the same.

- **Refactors**
  - `fakecloud-cloudformation`: IAM (SAML provider, service-linked role, MFA) and CloudFront function → `Arn::global`; S3 bucket → `Arn::s3` (drop needless borrow).
  - `fakecloud-bedrock`: foundation-model ARN with empty account → `Arn::new("bedrock", ...)`.
  - `fakecloud-cognito`: user pool ARN → `Arn::new("cognito-idp", ...)`.
  - `fakecloud-lambda`: capacity-provider and durable-execution ARNs → `Arn::new("lambda", ...)`.
  - `fakecloud-iam`: STS fallback OIDC provider ARN → `Arn::global("iam", ...)`.
  - 16 non-standard ARN sites remain unchanged (nonstandard shapes).

<sup>Written for commit 2683c271a744380ed23a0f7be6f1ddbdc4e03ef3. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1487?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

