### PR TITLE
[Olwen] Add Structured 'fakecloud vs. LocalStack' Comparison Page

### DIFF
--- a/website/content/compare/localstack.md
+++ b/website/content/compare/localstack.md
@@ -1,0 +1,21 @@
++++
+title = "fakecloud vs. LocalStack: 2026 Comparison"
+description = "For developers optimizing their 'Inner Loop,' the choice of local AWS emulator impacts startup time, CI costs, and security."
+template = "page.html"
++++
+
+For developers optimizing their 'Inner Loop,' the choice of local AWS emulator impacts startup time, CI costs, and security. 
+
+| Feature | fakecloud | LocalStack (Community) |
+| :--- | :--- | :--- |
+| **Account Required** | **No** | Yes (as of 2026) |
+| **Auth Token** | **No** | Required for latest images |
+| **Binary Size** | **~19MB** (Standalone) | ~1.2GB (Docker Image) |
+| **Startup Time** | **~500ms** | 10s - 30s |
+| **Internet Required** | **No** | Yes (for license/auth) |
+| **API Conformance** | **100% (2,591 ops)** | Partial (Community tier) |
+| **Bedrock (AI) Support** | **Full (111 ops)** | Limited / Pro-only |
+| **License** | AGPL-3.0 | Proprietary/Mixed |
+
+## Why fakecloud is the zero-friction choice
+Unlike incumbents that have moved toward account-gated models, fakecloud remains a standalone utility. This eliminates 'Token Fatigue' and ensures your CI pipelines never fail due to external auth provider downtime. By providing full support for 111 Bedrock operations locally, fakecloud allows for high-velocity AI development without the latency or cost of cloud-based LLM testing.


### PR DESCRIPTION
This PR adds a new structured comparison page at `https://fakecloud.dev/compare/localstack/` to target high-intent search queries.

### Key Changes
- Created `website/content/compare/localstack.md` with the requested 2026 comparison metrics.
- Included a feature table comparing fakecloud against LocalStack Community on account requirements, startup time, binary size, and Bedrock AI support.
- Highlighted the zero-friction nature of fakecloud (no token/account required) and its full support for 111 Bedrock operations.

### Why this matters
As of 2026, many developers are seeking alternatives to account-gated local emulators. This page provides a factual, metric-heavy breakdown that helps developers evaluate fakecloud for their local AWS development needs, particularly for AI-driven workflows using Bedrock.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a structured comparison page at /compare/localstack/ to help developers evaluate `fakecloud` vs LocalStack and capture “vs” search traffic. Highlights zero-account setup, fast startup, small binary, offline mode, and full Bedrock coverage with 2026 metrics.

- **New Features**
  - New page at website/content/compare/localstack.md with a feature table covering: account/token requirements, binary size (~19MB vs ~1.2GB), startup time (~500ms vs 10–30s), internet needed, API conformance (100% / 2,591 ops), Bedrock support (111 ops), and license.

<sup>Written for commit ca15406469c6468be5e1176b703a7beff6233ba9. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1502?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

