### PR TITLE
[Olwen] Add Local Bedrock feature page

### DIFF
--- a/website/content/features/local-bedrock.md
+++ b/website/content/features/local-bedrock.md
@@ -1,0 +1,19 @@
++++
+title = "Local Bedrock Emulation for AI Development"
+description = "Develop and test LLM-powered applications locally with fakecloud's high-fidelity Bedrock emulation. Eliminate cloud costs and latency during the 'Inner Loop' of AI agent development."
+template = "page.html"
++++
+
+## Performance & Coverage
+- **111 Bedrock Operations:** 100% API conformance for model invocation, agent orchestration, and knowledge bases.
+- **Zero Latency:** Sub-millisecond response times for local API calls, bypassing internet round-trips.
+- **Lightweight & Fast:** ~19MB standalone binary with ~500ms startup time.
+
+## Supported AI Tools
+- **Claude Code & Cursor:** Seamlessly integrate local Bedrock endpoints into your AI-assisted coding workflow. [Read the guide](/blog/aws-integration-tests-with-claude-code-cursor/).
+- **LangChain & LlamaIndex:** Use standard AWS SDKs to point your RAG pipelines at `http://localhost:4566`.
+
+## Why Local Bedrock?
+- **Cost Control:** Zero per-token costs during development and integration testing.
+- **Offline Ready:** Develop AI features on planes or in air-gapped environments.
+- **Deterministic Testing:** Use fakecloud SDKs to assert on model invocations and agent steps.


### PR DESCRIPTION
This PR adds a new dedicated feature page for Local Bedrock emulation at `/features/local-bedrock/`. 

The page targets AI Engineers by highlighting fakecloud's performance metrics (111 Bedrock operations, 19MB binary, 500ms startup) and integration with popular AI coding tools like Claude Code and Cursor. This content aligns with the brand strategy to emphasize local, deterministic LLM application development without cloud costs or latency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated Local Bedrock feature page at /features/local-bedrock/ for local AI development with fakecloud. It highlights 111 Bedrock operations, a ~19MB binary, ~500ms startup, and integrations with Claude Code, Cursor, LangChain, and LlamaIndex to enable deterministic workflows without cloud cost or latency.

<sup>Written for commit ebebb2ab28678ad84d3e942fe86eee88d6dd8203. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1503?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

