### PR TITLE
[Olwen] Fix Blog Index Heading Hierarchy

### DIFF
--- a/website/templates/blog.html
+++ b/website/templates/blog.html
@@ -8,13 +8,43 @@
   <div class="container">
     <h1 class="section-title">Blog</h1>
     <p class="section-sub">Essays and hot takes on testing, AWS, and AI-assisted development.</p>
+
+    <h2 style="font-family: var(--mono); font-size: 22px; font-weight: 700; margin: 48px auto 16px; max-width: 700px;">Technical Deep Dives</h2>
     <div class="blog-list">
       {% for page in section.pages %}
-      <a href="{{ page.permalink }}" class="post" data-publish-date="{{ page.date | date(format="%Y-%m-%d") }}">
-        <div class="date">{{ page.date | date(format="%B %d, %Y") }}</div>
-        <h3>{{ page.title }}</h3>
-        <p>{{ page.description }}</p>
-      </a>
+        {% if "ai" not in page.slug and "bedrock" not in page.slug and "llm" not in page.slug and "claude" not in page.slug and "guardrails" not in page.slug and "no-list" not in page.slug and "eliminating" not in page.slug and "why-fakecloud" not in page.slug %}
+          <a href="{{ page.permalink }}" class="post" data-publish-date="{{ page.date | date(format="%Y-%m-%d") }}">
+            <div class="date">{{ page.date | date(format="%B %d, %Y") }}</div>
+            <h3>{{ page.title }}</h3>
+            <p>{{ page.description }}</p>
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <h2 style="font-family: var(--mono); font-size: 22px; font-weight: 700; margin: 48px auto 16px; max-width: 700px;">Developer Experience & AI</h2>
+    <div class="blog-list">
+      {% for page in section.pages %}
+        {% if "ai" in page.slug or "bedrock" in page.slug or "llm" in page.slug or "claude" in page.slug or "guardrails" in page.slug %}
+          <a href="{{ page.permalink }}" class="post" data-publish-date="{{ page.date | date(format="%Y-%m-%d") }}">
+            <div class="date">{{ page.date | date(format="%B %d, %Y") }}</div>
+            <h3>{{ page.title }}</h3>
+            <p>{{ page.description }}</p>
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <h2 style="font-family: var(--mono); font-size: 22px; font-weight: 700; margin: 48px auto 16px; max-width: 700px;">The 'No' List Series</h2>
+    <div class="blog-list">
+      {% for page in section.pages %}
+        {% if "no-list" in page.slug or "eliminating" in page.slug or "why-fakecloud" in page.slug %}
+          <a href="{{ page.permalink }}" class="post" data-publish-date="{{ page.date | date(format="%Y-%m-%d") }}">
+            <div class="date">{{ page.date | date(format="%B %d, %Y") }}</div>
+            <h3>{{ page.title }}</h3>
+            <p>{{ page.description }}</p>
+          </a>
+        {% endif %}
       {% endfor %}
     </div>
   </div>


### PR DESCRIPTION
This PR updates the blog index template to categorize content using H2 headings, improving the semantic structure and crawlability for search engines and AI assistants. 

The blog posts are now grouped into three logical sections:
- **Technical Deep Dives**: Performance benchmarks, API conformance reports, and infrastructure-level guides.
- **Developer Experience & AI**: Agent-assisted development, Bedrock local testing, and AI tool integration.
- **The 'No' List Series**: Friction-reduction posts focusing on why fakecloud requires no accounts, internet, or tokens.

The layout preserves the original styling while adding clear hierarchical separation between categories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the blog index to use H2 section headings and group posts into three categories. Improves heading hierarchy, accessibility, and crawlability without changing styling.

- **Refactors**
  - Added H2 sections: Technical Deep Dives, Developer Experience & AI, The 'No' List Series.
  - Populated groups via slug filters: `ai`, `bedrock`, `llm`, `claude`, `guardrails`, `no-list`, `eliminating`, `why-fakecloud`.
  - Kept post cards unchanged (date, H3 title, description, styles).
  - Defaulted non-matching posts to Technical Deep Dives.

<sup>Written for commit f61131ffdb83def68e5b33131b911659eb4b452a. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1505?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

