### PR TITLE
[Olwen] Blog: LocalStack vs. fakecloud Comparison (May 2026)

### DIFF
--- a/website/content/blog/localstack-vs-fakecloud-comparing-local-aws-development-in-may-2026.md
+++ b/website/content/blog/localstack-vs-fakecloud-comparing-local-aws-development-in-may-2026.md
@@ -1,7 +1,7 @@
 +++
 title = "LocalStack vs. fakecloud: Comparing Local AWS Development in May 2026"
 date = 2026-05-20
-description = "A technical comparison of LocalStack and fakecloud, detailing the 2026 shift toward account-mandatory local development and how fakecloud provides a zero-friction, high-fidelity alternative."
+description = "A technical comparison of LocalStack and fakecloud in May 2026, examining the impact of mandatory authentication on the developer inner loop and the performance benefits of Rust-based emulation."
 
 [extra]
 author = "Lucas Vieira"
@@ -44,7 +44,7 @@ When you run fakecloud, you are the owner of the infrastructure. There are no CI
 
 To start the environment, you do not need to specify which services you want to enable. Unlike older emulators that required `-s s3,lambda,dynamodb` flags to conserve memory, fakecloud activates its entire service surface by default. Because the idle memory footprint is only 10 MiB, there is no performance penalty for having all 33+ services ready to accept requests.
 
-```bash
+```sh
 # Start the entire AWS environment locally
 fakecloud start
 ```
@@ -60,11 +60,11 @@ As of May 2026, fakecloud supports 33 AWS services with 100% API conformance acr
 For teams building agentic AI applications, fakecloud provides the most comprehensive [local Bedrock implementation](/blog/bedrock-local-testing/) available. While other emulators may only mock the `InvokeModel` operation, fakecloud supports the full Bedrock surface, including 111 operations across the runtime and control plane. This includes:
 
 *   **InvokeModel and Converse:** Full support for streaming responses.
-*   **Guardrails:** Real content evaluation and PII detection logic.
+*   **Guardrails:** Real content evaluation and [PII detection logic](/blog/bedrock-guardrails-local/).
 *   **Knowledge Bases:** Integration with local OpenSearch or Vector engines.
 *   **Provisioned Throughput:** Emulated scaling and throttling behavior.
 
-This allows AI engineers to test their orchestration logic, prompt templates, and [guardrail configurations](/blog/bedrock-guardrails-local/) without incurring per-token costs or waiting for cloud deployment cycles.
+This allows AI engineers to test their orchestration logic, prompt templates, and guardrail configurations without incurring per-token costs or waiting for cloud deployment cycles.
 
 ### Real Stateful Backends
 
@@ -91,7 +91,7 @@ Testing against a local cloud often involves a lot of "polling and praying." You
 
 These SDKs allow you to make assertions directly against the emulator's internal state. Instead of calling the standard AWS SQS API to see if a message exists, you can use the fakecloud SDK to inspect the internal message bus and verify that the message was sent with the expected attributes.
 
-```typescript
+```ts
 import { FakecloudClient } from '@fakecloud/sdk-typescript';
 
 const fc = new FakecloudClient('http://localhost:4566');
@@ -115,7 +115,7 @@ If you are currently using a container-heavy setup, migrating to fakecloud is a 
 
 You can install the binary directly using a shell script or via package managers like Cargo.
 
-```bash
+```sh
 # Install the binary
 curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
 
@@ -127,7 +127,7 @@ fakecloud start
 
 To use the AWS CLI with fakecloud, simply provide the `--endpoint-url` flag. You can use any string for the access key and secret key.
 
-```bash
+```sh
 export AWS_ACCESS_KEY_ID=fake
 export AWS_SECRET_ACCESS_KEY=fake
 export AWS_DEFAULT_REGION=us-east-1

--- a/website/content/blog/localstack-vs-fakecloud-comparing-local-aws-development-in-may-2026.md
+++ b/website/content/blog/localstack-vs-fakecloud-comparing-local-aws-development-in-may-2026.md
@@ -1,7 +1,7 @@
 +++
 title = "LocalStack vs. fakecloud: Comparing Local AWS Development in May 2026"
 date = 2026-05-20
-description = "A technical comparison of LocalStack and fakecloud in May 2026, exploring the move to account-gated models and why fakecloud's zero-auth, Rust-based architecture is the preferred choice for local development."
+description = "A technical comparison of LocalStack and fakecloud, detailing the 2026 shift toward account-mandatory local development and how fakecloud provides a zero-friction, high-fidelity alternative."
 
 [extra]
 author = "Lucas Vieira"
@@ -32,7 +32,7 @@ In local development, latency is the primary enemy. A slow-starting emulator add
 | **License** | AGPL-3.0 | Proprietary |
 | **API Conformance** | 100% (per service) | Variable (Tier-dependent) |
 
-These numbers reflect a fundamental difference in architecture. LocalStack is a Python-based framework that orchestrates multiple containers and services. fakecloud is a single Rust binary that implements the AWS wire protocol directly. By removing the overhead of the Python runtime and container orchestration for the control plane, fakecloud achieves [sub-second startup times](/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks/).
+These numbers reflect a fundamental difference in architecture. LocalStack is a Python-based framework that orchestrates multiple containers and services. fakecloud is a single Rust binary that implements the AWS wire protocol directly. By removing the overhead of the Python runtime and container orchestration for the control plane, fakecloud achieves sub-second startup times.
 
 ## The Auth-Free Advantage: Removing Friction
 
@@ -44,7 +44,7 @@ When you run fakecloud, you are the owner of the infrastructure. There are no CI
 
 To start the environment, you do not need to specify which services you want to enable. Unlike older emulators that required `-s s3,lambda,dynamodb` flags to conserve memory, fakecloud activates its entire service surface by default. Because the idle memory footprint is only 10 MiB, there is no performance penalty for having all 33+ services ready to accept requests.
 
-```sh
+```bash
 # Start the entire AWS environment locally
 fakecloud start
 ```
@@ -57,14 +57,14 @@ As of May 2026, fakecloud supports 33 AWS services with 100% API conformance acr
 
 ### Bedrock and AI Development
 
-For teams building agentic AI applications, fakecloud provides the most comprehensive local Bedrock implementation available. While other emulators may only mock the `InvokeModel` operation, fakecloud supports the full Bedrock surface, including 111 operations across the runtime and control plane. This includes:
+For teams building agentic AI applications, fakecloud provides the most comprehensive [local Bedrock implementation](/blog/bedrock-local-testing/) available. While other emulators may only mock the `InvokeModel` operation, fakecloud supports the full Bedrock surface, including 111 operations across the runtime and control plane. This includes:
 
 *   **InvokeModel and Converse:** Full support for streaming responses.
-*   **Guardrails:** Real content evaluation and [PII detection logic](/blog/bedrock-guardrails-local/).
+*   **Guardrails:** Real content evaluation and PII detection logic.
 *   **Knowledge Bases:** Integration with local OpenSearch or Vector engines.
 *   **Provisioned Throughput:** Emulated scaling and throttling behavior.
 
-This allows AI engineers to test their orchestration logic, prompt templates, and guardrail configurations without incurring per-token costs or waiting for cloud deployment cycles. Learn more in our guide to [local Bedrock testing](/blog/bedrock-local-testing/).
+This allows AI engineers to test their orchestration logic, prompt templates, and [guardrail configurations](/blog/bedrock-guardrails-local/) without incurring per-token costs or waiting for cloud deployment cycles.
 
 ### Real Stateful Backends
 
@@ -91,7 +91,7 @@ Testing against a local cloud often involves a lot of "polling and praying." You
 
 These SDKs allow you to make assertions directly against the emulator's internal state. Instead of calling the standard AWS SQS API to see if a message exists, you can use the fakecloud SDK to inspect the internal message bus and verify that the message was sent with the expected attributes.
 
-```ts
+```typescript
 import { FakecloudClient } from '@fakecloud/sdk-typescript';
 
 const fc = new FakecloudClient('http://localhost:4566');
@@ -115,7 +115,7 @@ If you are currently using a container-heavy setup, migrating to fakecloud is a 
 
 You can install the binary directly using a shell script or via package managers like Cargo.
 
-```sh
+```bash
 # Install the binary
 curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
 
@@ -127,7 +127,7 @@ fakecloud start
 
 To use the AWS CLI with fakecloud, simply provide the `--endpoint-url` flag. You can use any string for the access key and secret key.
 
-```sh
+```bash
 export AWS_ACCESS_KEY_ID=fake
 export AWS_SECRET_ACCESS_KEY=fake
 export AWS_DEFAULT_REGION=us-east-1
@@ -139,8 +139,8 @@ aws --endpoint-url http://localhost:4566 s3 mb s3://my-test-bucket
 aws --endpoint-url http://localhost:4566 s3 ls
 ```
 
-For more permanent configurations, you can use the `aws-local` wrapper or set the `AWS_ENDPOINT_URL" environment variable, which is supported by most modern AWS SDKs as of 2025.
+For more permanent configurations, you can use the `aws-local` wrapper or set the `AWS_ENDPOINT_URL` environment variable, which is supported by most modern AWS SDKs as of 2025.
 
 ## Conclusion
 
-The shift toward proprietary, account-gated local development tools has created a clear need for open-source, high-performance alternatives. [fakecloud](https://github.com/faiscadev/fakecloud) meets this need by providing a standalone, 19MB binary that delivers 100% API conformance for 33+ AWS services without the friction of accounts or internet requirements. By focusing on the inner loop and providing sub-second startup times, fakecloud allows developers to reclaim their productivity and maintain fully local, deterministic testing workflows. To begin your migration, visit the [official documentation](https://github.com/faiscadev/fakecloud) and run the quick-start command to see the performance difference in your own environment.
+The shift toward proprietary, account-gated local development tools has created a clear need for open-source, high-performance alternatives. fakecloud meets this need by providing a standalone, 19MB binary that delivers 100% API conformance for 33+ AWS services without the friction of accounts or internet requirements. By focusing on the inner loop and providing sub-second startup times, fakecloud allows developers to reclaim their productivity and maintain fully local, deterministic testing workflows. To begin your migration, visit the [official documentation](https://github.com/faiscadev/fakecloud) and run the quick-start command to see the performance difference in your own environment.

--- a/website/content/blog/localstack-vs-fakecloud-comparing-local-aws-development-in-may-2026.md
+++ b/website/content/blog/localstack-vs-fakecloud-comparing-local-aws-development-in-may-2026.md
@@ -1,0 +1,146 @@
++++
+title = "LocalStack vs. fakecloud: Comparing Local AWS Development in May 2026"
+date = 2026-05-20
+description = "A technical comparison of LocalStack and fakecloud in 2026, focusing on performance metrics, authentication friction, and API conformance."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+As of May 20, 2026, the landscape for local AWS emulation has fundamentally shifted. For years, developers relied on a bifurcated model of open source community editions and proprietary pro tiers. That model ended in March 2026 when LocalStack consolidated its distribution into a single, unified image requiring mandatory authentication and account registration. This change introduced significant friction into the inner loop of software development, particularly for ephemeral CI/CD environments and air-gapped local workflows.
+
+In response, fakecloud emerged as a high-fidelity, zero-friction alternative. Built in Rust and distributed as a standalone binary, fakecloud prioritizes execution speed and protocol conformance over platform features. This article provides a technical comparison of these two environments to help engineering teams decide where to host their local infrastructure.
+
+## The March 2026 Shift: Why Local Development Requires a New Approach
+
+The transition of LocalStack to an account-mandatory model in March 2026 created a bottleneck for teams using automated testing pipelines. Previously, a developer could pull a Docker image and run integration tests without external dependencies. Today, that same workflow requires an auth token, an active internet connection for initial validation, and a subscription to manage CI credits.
+
+For many DevOps engineers, this represents a regression in the "Inner Loop": the cycle of coding, building, and testing. When your local environment requires a login, it is no longer truly local. It becomes a managed service that happens to run on your hardware. fakecloud was designed to reverse this trend by providing a 19MB binary that requires no account, no auth token, and zero internet connectivity.
+
+## Performance Metrics: fakecloud vs. LocalStack
+
+In local development, latency is the primary enemy. A slow-starting emulator adds seconds to every test run, which compounds into minutes of lost productivity per day. The following table compares the core operational metrics of fakecloud and LocalStack as of May 2026.
+
+| Metric | fakecloud (v-next) | LocalStack (2026.05.0) |
+| :--- | :--- | :--- |
+| **Binary Size** | ~19 MiB | ~1.2 GiB (Docker Image) |
+| **Startup Time** | ~500 ms | 5,000 to 15,000 ms |
+| **Idle Memory** | ~10 MiB | ~140 MiB |
+| **Account Required** | No | Yes |
+| **Auth Token** | Not Required | Mandatory |
+| **Internet Required** | No | Yes (for Auth/License) |
+| **License** | AGPL-3.0 | Proprietary |
+| **API Conformance** | 100% (per service) | Variable (Tier-dependent) |
+
+These numbers reflect a fundamental difference in architecture. LocalStack is a Python-based framework that orchestrates multiple containers and services. fakecloud is a single Rust binary that implements the AWS wire protocol directly. By removing the overhead of the Python runtime and container orchestration for the control plane, fakecloud achieves sub-second startup times.
+
+## The Auth-Free Advantage: Removing Friction
+
+The most immediate difference when running `fakecloud start` is the absence of a login prompt. In the current development environment, authentication is often treated as a security feature, but for local emulation, it acts as a gatekeeper. 
+
+When you run fakecloud, you are the owner of the infrastructure. There are no CI credits to track and no seat licenses to manage. This is critical for organizations with strict data sovereignty requirements or those operating in air-gapped environments where reaching an external licensing server is impossible.
+
+### Zero-Config Execution
+
+To start the environment, you do not need to specify which services you want to enable. Unlike older emulators that required `-s s3,lambda,dynamodb` flags to conserve memory, fakecloud activates its entire service surface by default. Because the idle memory footprint is only 10 MiB, there is no performance penalty for having all 33+ services ready to accept requests.
+
+```bash
+# Start the entire AWS environment locally
+fakecloud start
+```
+
+Once started, the emulator listens on port 4566. You can point any standard AWS SDK or CLI at this endpoint using dummy credentials. The emulator does not validate the keys, it only validates the SigV4 signature if you explicitly enable IAM enforcement.
+
+## Service Coverage and API Conformance
+
+As of May 2026, fakecloud supports 33 AWS services with 100% API conformance across 2,422 operations. This conformance is not a marketing claim, it is a technical guarantee backed by AWS's own Smithy models. Every commit to the [fakecloud repository](https://github.com/faiscadev/fakecloud) is validated against 59,000+ generated test variants to ensure that the response shapes, headers, and error codes exactly match the behavior of the real AWS cloud.
+
+### Bedrock and AI Development
+
+For teams building agentic AI applications, fakecloud provides the most comprehensive local Bedrock implementation available. While other emulators may only mock the `InvokeModel` operation, fakecloud supports the full Bedrock surface, including 111 operations across the runtime and control plane. This includes:
+
+*   **InvokeModel and Converse:** Full support for streaming responses.
+*   **Guardrails:** Real content evaluation and PII detection logic.
+*   **Knowledge Bases:** Integration with local OpenSearch or Vector engines.
+*   **Provisioned Throughput:** Emulated scaling and throttling behavior.
+
+This allows AI engineers to test their orchestration logic, prompt templates, and guardrail configurations without incurring per-token costs or waiting for cloud deployment cycles.
+
+### Real Stateful Backends
+
+One common failure point in local emulation is the use of "mocks" for stateful services like RDS or ElastiCache. A mock might accept a SQL query but it won't enforce the same constraints as a real database. fakecloud takes a different approach by using real infrastructure for stateful backends. 
+
+When you call the RDS API to create a PostgreSQL instance, fakecloud spins up a real PostgreSQL container. When you use ElastiCache, it uses real Valkey or Redis. This ensures that your integration tests catch actual database errors, such as syntax incompatibilities or constraint violations, before they reach production.
+
+## Cross-Service Integrations: Testing the Architecture
+
+Modern AWS applications are rarely composed of a single service. They rely on complex event-driven architectures where an S3 upload triggers a Lambda function, which then publishes a message to an SNS topic, which finally fans out to multiple SQS queues. 
+
+fakecloud supports 30+ real cross-service integrations. These are not simulated, they are wired together at the protocol level. 
+
+1.  **S3 Triggers:** Uploading a file to a bucket immediately triggers the configured Lambda function or SQS queue.
+2.  **SNS Fanout:** A single message published to an SNS topic is delivered to all subscribed SQS queues, Lambda functions, or HTTP endpoints.
+3.  **DynamoDB Streams:** Changes to a table are captured and pushed to Kinesis or Lambda in real-time.
+4.  **Step Functions:** Full state machine execution with task integrations for all supported services.
+
+This level of integration allows you to test the "glue" of your architecture. You can verify that your SNS filter policies are correct or that your Lambda function has the right permissions to write to a specific S3 bucket, all within a sub-second local environment.
+
+## First-Party SDKs for Assertions
+
+Testing against a local cloud often involves a lot of "polling and praying." You run your code, then you write a loop to check if a message arrived in a queue or if a file was created in a bucket. fakecloud eliminates this pattern with first-party test SDKs for TypeScript, Python, Go, PHP, Java, and Rust.
+
+These SDKs allow you to make assertions directly against the emulator's internal state. Instead of calling the standard AWS SQS API to see if a message exists, you can use the fakecloud SDK to inspect the internal message bus and verify that the message was sent with the expected attributes.
+
+```ts
+import { FakecloudClient } from '@fakecloud/sdk-typescript';
+
+const fc = new FakecloudClient('http://localhost:4566');
+
+// Run your application code
+await myApp.processOrder(orderId);
+
+// Assert on the side effects
+const invocations = await fc.lambda.getInvocations('order-processor');
+expect(invocations).toHaveLength(1);
+expect(invocations[0].payload.orderId).toBe(orderId);
+```
+
+This approach makes tests deterministic. You no longer need to add `sleep(5000)` to your test suite to wait for asynchronous cloud events to settle.
+
+## Quick Start: Moving from Containers to a Binary
+
+If you are currently using a container-heavy setup, migrating to fakecloud is a matter of replacing your startup command. Because fakecloud implements the same API surface on the same default port (4566), most tools like Terraform, CDK, and the AWS CLI require no changes other than the endpoint URL.
+
+### Installation
+
+You can install the binary directly using a shell script or via package managers like Cargo.
+
+```bash
+# Install the binary
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+
+# Start the environment
+fakecloud start
+```
+
+### Configuring the CLI
+
+To use the AWS CLI with fakecloud, simply provide the `--endpoint-url` flag. You can use any string for the access key and secret key.
+
+```bash
+export AWS_ACCESS_KEY_ID=fake
+export AWS_SECRET_ACCESS_KEY=fake
+export AWS_DEFAULT_REGION=us-east-1
+
+# Create an S3 bucket
+aws --endpoint-url http://localhost:4566 s3 mb s3://my-test-bucket
+
+# List the buckets
+aws --endpoint-url http://localhost:4566 s3 ls
+```
+
+For more permanent configurations, you can use the `aws-local` wrapper or set the `AWS_ENDPOINT_URL` environment variable, which is supported by most modern AWS SDKs as of 2025.
+
+## Conclusion
+
+The shift toward proprietary, account-gated local development tools has created a clear need for open-source, high-performance alternatives. fakecloud meets this need by providing a standalone, 19MB binary that delivers 100% API conformance for 33+ AWS services without the friction of accounts or internet requirements. By focusing on the inner loop and providing sub-second startup times, fakecloud allows developers to reclaim their productivity and maintain fully local, deterministic testing workflows. To begin your migration, visit the [official documentation](https://github.com/faiscadev/fakecloud) and run the quick-start command to see the performance difference in your own environment.

--- a/website/content/blog/localstack-vs-fakecloud-comparing-local-aws-development-in-may-2026.md
+++ b/website/content/blog/localstack-vs-fakecloud-comparing-local-aws-development-in-may-2026.md
@@ -1,7 +1,7 @@
 +++
 title = "LocalStack vs. fakecloud: Comparing Local AWS Development in May 2026"
 date = 2026-05-20
-description = "A technical comparison of LocalStack and fakecloud in 2026, focusing on performance metrics, authentication friction, and API conformance."
+description = "A technical comparison of LocalStack and fakecloud in May 2026, exploring the move to account-gated models and why fakecloud's zero-auth, Rust-based architecture is the preferred choice for local development."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 As of May 20, 2026, the landscape for local AWS emulation has fundamentally shifted. For years, developers relied on a bifurcated model of open source community editions and proprietary pro tiers. That model ended in March 2026 when LocalStack consolidated its distribution into a single, unified image requiring mandatory authentication and account registration. This change introduced significant friction into the inner loop of software development, particularly for ephemeral CI/CD environments and air-gapped local workflows.
 
-In response, fakecloud emerged as a high-fidelity, zero-friction alternative. Built in Rust and distributed as a standalone binary, fakecloud prioritizes execution speed and protocol conformance over platform features. This article provides a technical comparison of these two environments to help engineering teams decide where to host their local infrastructure.
+In response, [fakecloud](https://github.com/faiscadev/fakecloud) emerged as a high-fidelity, zero-friction alternative. Built in Rust and distributed as a standalone binary, fakecloud prioritizes execution speed and protocol conformance over platform features. This article provides a technical comparison of these two environments to help engineering teams decide where to host their local infrastructure.
 
 ## The March 2026 Shift: Why Local Development Requires a New Approach
 
@@ -32,7 +32,7 @@ In local development, latency is the primary enemy. A slow-starting emulator add
 | **License** | AGPL-3.0 | Proprietary |
 | **API Conformance** | 100% (per service) | Variable (Tier-dependent) |
 
-These numbers reflect a fundamental difference in architecture. LocalStack is a Python-based framework that orchestrates multiple containers and services. fakecloud is a single Rust binary that implements the AWS wire protocol directly. By removing the overhead of the Python runtime and container orchestration for the control plane, fakecloud achieves sub-second startup times.
+These numbers reflect a fundamental difference in architecture. LocalStack is a Python-based framework that orchestrates multiple containers and services. fakecloud is a single Rust binary that implements the AWS wire protocol directly. By removing the overhead of the Python runtime and container orchestration for the control plane, fakecloud achieves [sub-second startup times](/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks/).
 
 ## The Auth-Free Advantage: Removing Friction
 
@@ -44,7 +44,7 @@ When you run fakecloud, you are the owner of the infrastructure. There are no CI
 
 To start the environment, you do not need to specify which services you want to enable. Unlike older emulators that required `-s s3,lambda,dynamodb` flags to conserve memory, fakecloud activates its entire service surface by default. Because the idle memory footprint is only 10 MiB, there is no performance penalty for having all 33+ services ready to accept requests.
 
-```bash
+```sh
 # Start the entire AWS environment locally
 fakecloud start
 ```
@@ -53,18 +53,18 @@ Once started, the emulator listens on port 4566. You can point any standard AWS 
 
 ## Service Coverage and API Conformance
 
-As of May 2026, fakecloud supports 33 AWS services with 100% API conformance across 2,422 operations. This conformance is not a marketing claim, it is a technical guarantee backed by AWS's own Smithy models. Every commit to the [fakecloud repository](https://github.com/faiscadev/fakecloud) is validated against 59,000+ generated test variants to ensure that the response shapes, headers, and error codes exactly match the behavior of the real AWS cloud.
+As of May 2026, fakecloud supports 33 AWS services with 100% API conformance across 2,422 operations. This conformance is not a marketing claim, it is a technical guarantee backed by AWS's own Smithy models. Every commit to the fakecloud repository is validated against 59,000+ generated test variants to ensure that the response shapes, headers, and error codes exactly match the behavior of the real AWS cloud.
 
 ### Bedrock and AI Development
 
 For teams building agentic AI applications, fakecloud provides the most comprehensive local Bedrock implementation available. While other emulators may only mock the `InvokeModel` operation, fakecloud supports the full Bedrock surface, including 111 operations across the runtime and control plane. This includes:
 
 *   **InvokeModel and Converse:** Full support for streaming responses.
-*   **Guardrails:** Real content evaluation and PII detection logic.
+*   **Guardrails:** Real content evaluation and [PII detection logic](/blog/bedrock-guardrails-local/).
 *   **Knowledge Bases:** Integration with local OpenSearch or Vector engines.
 *   **Provisioned Throughput:** Emulated scaling and throttling behavior.
 
-This allows AI engineers to test their orchestration logic, prompt templates, and guardrail configurations without incurring per-token costs or waiting for cloud deployment cycles.
+This allows AI engineers to test their orchestration logic, prompt templates, and guardrail configurations without incurring per-token costs or waiting for cloud deployment cycles. Learn more in our guide to [local Bedrock testing](/blog/bedrock-local-testing/).
 
 ### Real Stateful Backends
 
@@ -115,7 +115,7 @@ If you are currently using a container-heavy setup, migrating to fakecloud is a 
 
 You can install the binary directly using a shell script or via package managers like Cargo.
 
-```bash
+```sh
 # Install the binary
 curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
 
@@ -127,7 +127,7 @@ fakecloud start
 
 To use the AWS CLI with fakecloud, simply provide the `--endpoint-url` flag. You can use any string for the access key and secret key.
 
-```bash
+```sh
 export AWS_ACCESS_KEY_ID=fake
 export AWS_SECRET_ACCESS_KEY=fake
 export AWS_DEFAULT_REGION=us-east-1
@@ -139,8 +139,8 @@ aws --endpoint-url http://localhost:4566 s3 mb s3://my-test-bucket
 aws --endpoint-url http://localhost:4566 s3 ls
 ```
 
-For more permanent configurations, you can use the `aws-local` wrapper or set the `AWS_ENDPOINT_URL` environment variable, which is supported by most modern AWS SDKs as of 2025.
+For more permanent configurations, you can use the `aws-local` wrapper or set the `AWS_ENDPOINT_URL" environment variable, which is supported by most modern AWS SDKs as of 2025.
 
 ## Conclusion
 
-The shift toward proprietary, account-gated local development tools has created a clear need for open-source, high-performance alternatives. fakecloud meets this need by providing a standalone, 19MB binary that delivers 100% API conformance for 33+ AWS services without the friction of accounts or internet requirements. By focusing on the inner loop and providing sub-second startup times, fakecloud allows developers to reclaim their productivity and maintain fully local, deterministic testing workflows. To begin your migration, visit the [official documentation](https://github.com/faiscadev/fakecloud) and run the quick-start command to see the performance difference in your own environment.
+The shift toward proprietary, account-gated local development tools has created a clear need for open-source, high-performance alternatives. [fakecloud](https://github.com/faiscadev/fakecloud) meets this need by providing a standalone, 19MB binary that delivers 100% API conformance for 33+ AWS services without the friction of accounts or internet requirements. By focusing on the inner loop and providing sub-second startup times, fakecloud allows developers to reclaim their productivity and maintain fully local, deterministic testing workflows. To begin your migration, visit the [official documentation](https://github.com/faiscadev/fakecloud) and run the quick-start command to see the performance difference in your own environment.


### PR DESCRIPTION
This PR adds a new blog post comparing the technical merits of LocalStack and fakecloud following the March 2026 shift in LocalStack's distribution model. It highlights performance gains, zero-friction authentication, and the advantages of fakecloud's standalone Rust binary for local AWS emulation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new blog post comparing LocalStack and `fakecloud` in May 2026 after LocalStack’s account‑mandatory change. Covers measured performance (19 MiB binary, ~500 ms startup), 100% API conformance across 33+ services, zero‑auth/zero‑config, full Bedrock (111 ops), real RDS/ElastiCache backends, 30+ cross‑service integrations, first‑party test SDKs, and a quick migration guide.

<sup>Written for commit 2e6cf204f05c425a30b1bd7cb225f8c4c006c25b. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1506?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

