### PR TITLE
[Olwen] Blog: Benchmarking Local AWS Emulators

### DIFF
--- a/website/content/blog/benchmarking-local-aws-emulators-500ms-vs-15s-startup-latency.md
+++ b/website/content/blog/benchmarking-local-aws-emulators-500ms-vs-15s-startup-latency.md
@@ -1,13 +1,11 @@
 +++
 title = "Benchmarking Local AWS Emulators: 500ms vs 15s Startup Latency"
 date = 2026-05-20
-description = "A performance analysis of local AWS emulators, comparing the sub-second startup of fakecloud against industry incumbents and the impact on developer productivity."
+description = "A benchmark analysis of the performance gap between fakecloud and LocalStack, focusing on startup latency and binary footprint."
 
 [extra]
 author = "Lucas Vieira"
 +++
-
-# Benchmarking Local AWS Emulators: 500ms vs 15s Startup Latency
 
 In modern software engineering, the inner loop -- the cycle of coding, building, and testing -- is the most critical factor in developer productivity. When your local environment relies on cloud-emulation tools that introduce multi-second latencies, that inner loop breaks. As of 2026-05-20, the landscape for local AWS development has shifted significantly. With major players moving toward mandatory accounts and auth tokens, the need for a high-fidelity, zero-friction binary has never been greater.
 
@@ -19,7 +17,7 @@ Every time a developer runs a test suite, the environment must be ready. If the 
 
 Beyond the time lost, there is a cognitive cost. A 15-second delay is long enough for a human brain to switch context, often leading to distractions like checking email or messaging apps. A sub-second startup, like the ~500ms provided by fakecloud, keeps the developer in the flow state.
 
-```bash
+```sh
 # Start the entire fakecloud environment instantly
 fakecloud start
 ```
@@ -49,9 +47,9 @@ In a CI/CD environment, memory is a finite resource. Running a 400 MiB container
 
 ## Service Conformance and Radical Accuracy
 
-Speed is irrelevant if the emulator does not behave like the real AWS. As of 2026-05-20, fakecloud achieves 100% API conformance across [2,422 operations](/blog/2-422-operations-how-fakecloud-reached-100-aws-api-conformance/). This is not achieved through manual mocking, which is error-prone and difficult to maintain. Instead, fakecloud uses Smithy models -- the same modeling language AWS uses to define its own APIs.
+Speed is irrelevant if the emulator does not behave like the real AWS. As of 2026-05-20, fakecloud achieves [100% API conformance across 2,422 operations](/blog/2-422-operations-how-fakecloud-reached-100-aws-api-conformance/). This is not achieved through manual mocking, which is error-prone and difficult to maintain. Instead, fakecloud uses Smithy models -- the same modeling language AWS uses to define its own APIs.
 
-Every commit to the [fakecloud repository](https://github.com/faiscadev/fakecloud) is validated against 59,000+ generated test variants. This ensures that edge cases, such as specific error codes, header requirements, and XML/JSON serialization quirks, match the behavior of the real AWS production environment.
+Every commit to the fakecloud repository is validated against 59,000+ generated test variants. This ensures that edge cases, such as specific error codes, header requirements, and XML/JSON serialization quirks, match the behavior of the real AWS production environment.
 
 ### Supported Services (Partial List)
 
@@ -59,7 +57,7 @@ Every commit to the [fakecloud repository](https://github.com/faiscadev/fakeclou
 *   **Lambda**: Support for 23 runtimes with sub-second execution overhead.
 *   **DynamoDB**: 100% conformance on TTL, Global Secondary Indexes (GSI), and atomic increments.
 *   **SQS/SNS**: Real cross-service integration, including SNS fanout to multiple SQS queues.
-*   **Bedrock**: 111 operations supported for local AI development and agent orchestration.
+*   **Bedrock**: [111 operations supported](/blog/bedrock-local-testing/) for local AI development and agent orchestration.
 
 ## AI Development with Local Bedrock
 
@@ -83,7 +81,7 @@ One of the most difficult aspects of local AWS testing is asserting that an asyn
 
 fakecloud solves this with first-party SDKs for 6+ programming languages (Go, Python, TypeScript, Java, Rust, and .NET). These SDKs allow your tests to query the internal state of the emulator. 
 
-```typescript
+```ts
 import { FakecloudClient } from 'fakecloud';
 
 const client = new FakecloudClient();
@@ -115,11 +113,11 @@ steps:
 
 We do not use words like "seamless" or "effortless" because engineering is rarely either. Instead, we provide a binary that starts in 500ms and conforms to 2,422 operations. We provide a tool that respects your time by not requiring an account or an internet connection. We provide a high-fidelity environment that behaves like the real AWS so that your tests are meaningful.
 
-The goal of fakecloud is to shrink the gap between your local machine and the cloud. By eliminating the latency of containers and the friction of mandatory authentication, we return those lost minutes to your day. 
+The goal of [fakecloud](https://github.com/faiscadev/fakecloud) is to shrink the gap between your local machine and the cloud. By eliminating the latency of containers and the friction of mandatory authentication, we return those lost minutes to your day. 
 
 To begin using the fastest local AWS environment available as of 2026-05-20, run the installation command and start the binary. No configuration flags are required: every service is ready when you are.
 
-```bash
+```sh
 curl -fsSL https://fakecloud.dev/install.sh | bash
 fakecloud start
 ```


### PR DESCRIPTION
This PR adds a new blog post analyzing the performance metrics of fakecloud compared to LocalStack, highlighting its 500ms startup latency, 10MiB idle memory footprint, and 100% API conformance for local AWS development.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new blog post benchmarking local AWS emulators, comparing fakecloud to LocalStack with a focus on 500ms vs ~15s startup latency, binary footprint, and 100% API conformance. Also improves formatting and links for clarity.

- **Refactors**
  - Updated frontmatter description to emphasize startup latency and footprint.
  - Removed duplicate H1 (title comes from the template).
  - Standardized code fences to sh and ts.
  - Tightened copy and fixed links (API conformance, Bedrock).

<sup>Written for commit 4b6d9dc9b1fa49c0ebe8a6c3b84fef85dbf794dc. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1508?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

