### PR TITLE
fix(cognito): validate ConfirmationCode in ConfirmSignUp

### DIFF
--- a/crates/fakecloud-cognito/src/service/auth/signup.rs
+++ b/crates/fakecloud-cognito/src/service/auth/signup.rs
@@ -225,6 +225,23 @@ impl CognitoService {
                 )
             })?;
 
+        // Validate confirmation code against the stored value before
+        // promoting the user to CONFIRMED. Without this check anyone
+        // calling ConfirmSignUp with the user's name + a non-empty
+        // string could activate the account. Stored code is set by
+        // SignUp (auth/signup.rs:153) and ResendConfirmationCode.
+        match user.confirmation_code.as_deref() {
+            Some(stored) if stored == code => {}
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "CodeMismatchException",
+                    "Invalid verification code provided, please try again.",
+                ));
+            }
+        }
+        user.confirmation_code = None;
+
         user.user_status = user_status::CONFIRMED.to_string();
         user.user_last_modified_date = Utc::now();
 

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -3015,7 +3015,7 @@ fn admin_initiate_auth_unsupported_flow() {
 
 #[test]
 fn sign_up_and_confirm() {
-    let (svc, _) = make_svc();
+    let (svc, state) = make_svc();
     let pool_id = create_pool(&svc);
     let client_id = create_client(&svc, &pool_id);
 
@@ -3031,11 +3031,35 @@ fn sign_up_and_confirm() {
     assert!(!b["UserConfirmed"].as_bool().unwrap());
     assert!(b["UserSub"].as_str().is_some());
 
-    // Confirm via ConfirmSignUp (accepts any code in current impl)
+    // Confirm with wrong code first — should be rejected with CodeMismatchException.
     let body = json!({
         "ClientId": client_id,
         "Username": "selfuser",
-        "ConfirmationCode": "123456",
+        "ConfirmationCode": "wrong",
+    });
+    let req = make_req("ConfirmSignUp", &body.to_string());
+    let err = expect_err(block_on(svc.confirm_sign_up(&req)));
+    assert_eq!(err.code(), "CodeMismatchException");
+
+    // Read stored code via state to drive a successful confirmation.
+    let code = {
+        let accounts = state.read();
+        accounts
+            .get("123456789012")
+            .unwrap()
+            .users
+            .get(&pool_id)
+            .unwrap()
+            .get("selfuser")
+            .unwrap()
+            .confirmation_code
+            .clone()
+            .expect("SignUp should have stored a confirmation code")
+    };
+    let body = json!({
+        "ClientId": client_id,
+        "Username": "selfuser",
+        "ConfirmationCode": code,
     });
     let req = make_req("ConfirmSignUp", &body.to_string());
     block_on(svc.confirm_sign_up(&req)).unwrap();

--- a/crates/fakecloud-conformance/tests/cognito.rs
+++ b/crates/fakecloud-conformance/tests/cognito.rs
@@ -977,11 +977,31 @@ async fn cognito_sign_up_and_confirm() {
     assert!(!signup.user_confirmed());
     assert!(!signup.user_sub().is_empty());
 
+    // Pull the freshly-minted confirmation code from the
+    // /_fakecloud/cognito introspection endpoint; ConfirmSignUp now
+    // validates the code so passing a literal won't work.
+    let code_url = format!(
+        "{}/_fakecloud/cognito/confirmation-codes/{}/signupuser",
+        server.endpoint(),
+        pool_id
+    );
+    let code = reqwest::Client::new()
+        .get(&code_url)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()["confirmationCode"]
+        .as_str()
+        .expect("introspection should expose the stored confirmation code")
+        .to_string();
+
     client
         .confirm_sign_up()
         .client_id(&client_id)
         .username("signupuser")
-        .confirmation_code("123456")
+        .confirmation_code(code)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -1,6 +1,26 @@
 mod helpers;
 use helpers::TestServer;
 
+async fn fetch_confirmation_code(server: &TestServer, pool_id: &str, username: &str) -> String {
+    let url = format!(
+        "{}/_fakecloud/cognito/confirmation-codes/{}/{}",
+        server.endpoint(),
+        pool_id,
+        username
+    );
+    reqwest::Client::new()
+        .get(&url)
+        .send()
+        .await
+        .expect("introspection fetch")
+        .json::<serde_json::Value>()
+        .await
+        .expect("introspection json")["confirmationCode"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no confirmationCode for {pool_id}/{username}"))
+        .to_string()
+}
+
 use aws_sdk_cognitoidentityprovider::types::{
     AccountRecoverySettingType, AttributeType, ChallengeNameType, DeliveryMediumType,
     DeviceRememberedStatusType, DomainStatusType, ExplicitAuthFlowsType, IdentityProviderTypeType,
@@ -1312,7 +1332,7 @@ async fn cognito_sign_up_and_confirm() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("signupuser")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "signupuser").await)
         .send()
         .await
         .expect("confirm sign up");
@@ -1467,7 +1487,7 @@ async fn cognito_refresh_token_flow() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("refreshuser")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "refreshuser").await)
         .send()
         .await
         .expect("confirm sign up");
@@ -2963,7 +2983,7 @@ async fn cognito_resend_confirmation_code() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("resenduser")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "resenduser").await)
         .send()
         .await
         .expect("confirm sign up");
@@ -5054,7 +5074,7 @@ async fn cognito_oauth2_token_refresh_grant() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("alice")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "alice").await)
         .send()
         .await
         .expect("confirm");
@@ -5287,7 +5307,7 @@ async fn cognito_oauth2_token_authorization_code_grant_issues_tokens() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("alice")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "alice").await)
         .send()
         .await
         .expect("confirm");
@@ -5419,7 +5439,7 @@ async fn cognito_oauth2_token_authorization_code_redirect_uri_mismatch() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("bob")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "bob").await)
         .send()
         .await
         .expect("confirm");
@@ -5524,7 +5544,7 @@ async fn cognito_oauth2_token_authorization_code_with_pkce_s256() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("carol")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "carol").await)
         .send()
         .await
         .expect("confirm");
@@ -5926,7 +5946,7 @@ async fn cognito_oauth2_userinfo_returns_user_attrs() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("bob")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "bob").await)
         .send()
         .await
         .expect("confirm");
@@ -6041,7 +6061,7 @@ async fn cognito_oauth2_revoke_refresh_token() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("carol")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "carol").await)
         .send()
         .await
         .expect("confirm");
@@ -6208,7 +6228,7 @@ async fn cognito_refresh_token_rotation_enabled_rotates() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("dave")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "dave").await)
         .send()
         .await
         .expect("confirm");
@@ -6303,7 +6323,7 @@ async fn cognito_refresh_token_rotation_disabled_no_new_token() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("eve")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "eve").await)
         .send()
         .await
         .expect("confirm");
@@ -6405,7 +6425,7 @@ async fn cognito_oauth2_token_rotates_refresh_when_enabled() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("frank")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "frank").await)
         .send()
         .await
         .expect("confirm");

--- a/crates/fakecloud-e2e/tests/cognito_authorize.rs
+++ b/crates/fakecloud-e2e/tests/cognito_authorize.rs
@@ -9,6 +9,26 @@ use helpers::TestServer;
 
 use aws_sdk_cognitoidentityprovider::types::{PasswordPolicyType, UserPoolPolicyType};
 
+async fn fetch_confirmation_code(server: &TestServer, pool_id: &str, username: &str) -> String {
+    let url = format!(
+        "{}/_fakecloud/cognito/confirmation-codes/{}/{}",
+        server.endpoint(),
+        pool_id,
+        username,
+    );
+    reqwest::Client::new()
+        .get(&url)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()["confirmationCode"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no confirmationCode for {pool_id}/{username}"))
+        .to_string()
+}
+
 /// Percent-encode a URL component for inline query-string assembly.
 /// We don't pull in the `urlencoding` crate just for tests — RFC 3986
 /// unreserved set is enough for the values we care about (URLs, JWTs,
@@ -106,7 +126,7 @@ async fn cognito_oauth2_authorize_code_flow_round_trip() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("alice")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "alice").await)
         .send()
         .await
         .expect("confirm");
@@ -235,7 +255,7 @@ async fn cognito_oauth2_authorize_implicit_flow_returns_fragment_tokens() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("bob")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "bob").await)
         .send()
         .await
         .expect("confirm");
@@ -491,7 +511,7 @@ async fn cognito_oauth2_authorize_bad_password_redirects_access_denied() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("carol")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "carol").await)
         .send()
         .await
         .expect("confirm");
@@ -577,7 +597,7 @@ async fn cognito_oauth2_authorize_with_pkce_round_trips_to_token() {
         .confirm_sign_up()
         .client_id(&client_id)
         .username("dave")
-        .confirmation_code("123456")
+        .confirmation_code(fetch_confirmation_code(&server, &pool_id, "dave").await)
         .send()
         .await
         .expect("confirm");


### PR DESCRIPTION
Cubic P1 on PR #1500. confirm_sign_up was accepting any non-empty code. Now validates against stored confirmation_code and rejects mismatches with CodeMismatchException.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a security gap in Cognito ConfirmSignUp by validating the provided ConfirmationCode against the stored code. Prevents unauthorized account activation, returns CodeMismatchException on mismatch, and clears the code after success.

- **Bug Fixes**
  - Compare input code with `user.confirmation_code`; reject mismatches with `CodeMismatchException` (400).
  - Clear `confirmation_code` after successful confirmation to prevent reuse.
  - Update unit tests to read the stored code from service state; update conformance and e2e tests (including authorize flows) to fetch it via `/_fakecloud/cognito/confirmation-codes/{pool}/{user}`, and assert mismatch before a successful confirm.

<sup>Written for commit 2353152136a2c2e7eeee7231e6c395c25b7a1699. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1510?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

