### PR TITLE
docs(website): add URL aliases for guessable LocalStack/Bedrock paths

### DIFF
--- a/website/content/bedrock-emulator.md
+++ b/website/content/bedrock-emulator.md
@@ -2,6 +2,12 @@
 title = "Bedrock emulator"
 description = "Bedrock emulator for tests: 214 operations across Bedrock, Bedrock Runtime, Bedrock Agent, and Bedrock Agent Runtime. Real wire protocol, fault injection, configurable responses. Deterministic, offline, free. Not a mock library, not a real LLM."
 template = "page.html"
+aliases = [
+    "/features/local-bedrock/",
+    "/features/bedrock/",
+    "/local-bedrock/",
+    "/bedrock-local/",
+]
 +++
 
 Need a Bedrock emulator? Use [fakecloud](https://github.com/faiscadev/fakecloud). Not a mock library. Not a real LLM. A real server that speaks the Bedrock wire protocol and returns exactly what you tell it to.

--- a/website/content/docs/migration-from-localstack.md
+++ b/website/content/docs/migration-from-localstack.md
@@ -4,7 +4,7 @@ description = "Technical path for migrating from LocalStack to fakecloud, target
 weight = 2
 +++
 
-If your local development workflow is blocked by LocalStack's account requirements or proprietary tier shifts, fakecloud offers a drop-in replacement for core services with zero internet dependency.
+If your local development workflow is blocked by LocalStack's account requirements or proprietary tier shifts, fakecloud offers a drop-in replacement for core services with zero internet dependency. This page is the technical reference card; for the full step-by-step walkthrough with docker-compose, CI, Terraform, CDK, and Serverless snippets, see [Migrating from LocalStack to fakecloud in 10 minutes](@/blog/migrate-from-localstack.md).
 
 ## Key Differences
 - **No API Key**: fakecloud is fully functional offline. No `ACTIVATE_PRO` or account login required.

--- a/website/content/localstack-alternative.md
+++ b/website/content/localstack-alternative.md
@@ -2,6 +2,11 @@
 title = "Free, open-source LocalStack alternative"
 description = "fakecloud is a free, open-source local AWS emulator: 39 services, 2,592 operations, 86,327/86,327 Smithy variants pass (true 100% conformance), 6 test-assertion SDKs. No account, no token, no paid tier. Drop-in replacement for LocalStack Community."
 template = "page.html"
+aliases = [
+    "/alternative/localstack/",
+    "/free-localstack-alternative/",
+    "/localstack-free-alternative/",
+]
 +++
 
 LocalStack replaced its open-source Community Edition with a proprietary image in March 2026. Running `localstack:latest` now requires an account and an auth token, and several previously-free services (RDS, ElastiCache, Cognito User Pools, SES v2, API Gateway v2, ECS/ECR) moved behind a paywall.

--- a/website/content/vs/localstack.md
+++ b/website/content/vs/localstack.md
@@ -2,6 +2,11 @@
 title = "fakecloud vs LocalStack"
 description = "How fakecloud compares to LocalStack Community (post-March 2026) and LocalStack Pro. Honest positioning, feature table, migration path."
 template = "page.html"
+aliases = [
+    "/compare/localstack/",
+    "/comparison/localstack/",
+    "/alternatives/localstack/",
+]
 +++
 
 Since LocalStack replaced its open-source Community Edition with a proprietary image in March 2026, `localstack:latest` now requires an account + auth token, and several previously-free services (Cognito, SES v2, RDS, ElastiCache, API Gateway v2, ECS/ECR) moved to the paid LocalStack Pro tier.


### PR DESCRIPTION
## Summary

Closes the gap that lets agents (Olwen and future others) land on 404s when they guess at site URL conventions. Each alias renders as an HTML redirect to the canonical page via Zola's `aliases` frontmatter field.

- `/vs/localstack/` answers `/compare/localstack/`, `/comparison/localstack/`, `/alternatives/localstack/` — Olwen's PR #1502 used `/compare/`
- `/localstack-alternative/` answers `/alternative/localstack/`, `/free-localstack-alternative/`, `/localstack-free-alternative/`
- `/bedrock-emulator/` answers `/features/local-bedrock/`, `/features/bedrock/`, `/local-bedrock/`, `/bedrock-local/` — Olwen's PR #1503 used `/features/`

Also adds a cross-link from `/docs/migration-from-localstack/` (the technical reference card) to `/blog/migrate-from-localstack/` (the full walkthrough), so readers landing on the doc are surfaced to the deeper guide.

Final batch in the post-Olwen guardrail series (#1511 doc-counts checks, #1512 AGENTS.md, #1513 operations index, this one).

## Test plan

- [x] `bash scripts/check-doc-counts.sh` passes (no number drift)
- [ ] Zola build succeeds
- [ ] Aliases redirect correctly when site deploys
- [ ] Cubic review clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add URL aliases for common, guessable paths to prevent 404s and help agents find the right pages. Implemented via Zola `aliases` redirects and added a cross-link from the LocalStack migration doc to the full blog guide.

- **New Features**
  - /vs/localstack/ redirects from: /compare/localstack/, /comparison/localstack/, /alternatives/localstack/
  - /localstack-alternative/ redirects from: /alternative/localstack/, /free-localstack-alternative/, /localstack-free-alternative/
  - /bedrock-emulator/ redirects from: /features/local-bedrock/, /features/bedrock/, /local-bedrock/, /bedrock-local/
  - /docs/migration-from-localstack/ links to /blog/migrate-from-localstack/ for the step-by-step walkthrough

<sup>Written for commit 155930a357b4b6c5f856ffbb5450f8b21e338df9. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1514?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

