### PR TITLE
fix(s3): Cubic P1+P2 on objects/delete + objects/list

### DIFF
--- a/crates/fakecloud-s3/src/service/objects/delete.rs
+++ b/crates/fakecloud-s3/src/service/objects/delete.rs
@@ -136,7 +136,9 @@ impl S3Service {
                     b.objects.remove(key);
                 }
             }
-            resp_headers.insert("x-amz-version-id", vid.parse().unwrap());
+            if let Ok(hv) = vid.parse() {
+                resp_headers.insert("x-amz-version-id", hv);
+            }
             if is_dm {
                 resp_headers.insert("x-amz-delete-marker", "true".parse().unwrap());
             }
@@ -359,7 +361,11 @@ impl S3Service {
                     continue;
                 }
 
-                // Delete specific version
+                // Delete specific version. Look in object_versions first;
+                // if absent, treat b.objects as the implicit "null" version
+                // slot — otherwise unversioned-bucket batch deletes that
+                // target a vid match still report Deleted while leaving
+                // the object in place.
                 if let Some(versions) = b.object_versions.get_mut(key) {
                     versions.retain(|o| {
                         !(o.version_id.as_deref() == Some(vid)
@@ -377,6 +383,12 @@ impl S3Service {
                     if versions.is_empty() {
                         b.object_versions.remove(key);
                     }
+                } else if let Some(obj) = b.objects.get(key) {
+                    let matches = obj.version_id.as_deref() == Some(vid.as_str())
+                        || (vid == "null" && obj.version_id.is_none());
+                    if matches {
+                        b.objects.remove(key);
+                    }
                 }
                 self.store
                     .delete_object(bucket, key, Some(vid.as_str()))
@@ -389,6 +401,22 @@ impl S3Service {
                     ));
                 }
             } else if versioning_enabled {
+                // Preserve any pre-versioning object as a "null" version
+                // before stacking the delete marker on top, otherwise
+                // the existing data is shadowed by the marker and lost
+                // from the version history.
+                if !b.object_versions.contains_key(key.as_str()) {
+                    if let Some(existing) = b.objects.get(key.as_str()) {
+                        let mut preserved = existing.clone();
+                        if preserved.version_id.is_none() {
+                            preserved.version_id = Some("null".to_string());
+                        }
+                        b.object_versions
+                            .entry(key.to_string())
+                            .or_default()
+                            .push(preserved);
+                    }
+                }
                 let dm_id = Uuid::new_v4().to_string();
                 let marker = make_delete_marker(key, &dm_id);
                 b.object_versions

--- a/crates/fakecloud-s3/src/service/objects/list.rs
+++ b/crates/fakecloud-s3/src/service/objects/list.rs
@@ -18,7 +18,12 @@ impl S3Service {
             .ok_or_else(|| no_such_bucket(bucket))?;
 
         let prefix = req.query_params.get("prefix").cloned().unwrap_or_default();
-        let delimiter = req.query_params.get("delimiter").cloned();
+        // Treat empty `delimiter` as absent.
+        let delimiter = req
+            .query_params
+            .get("delimiter")
+            .filter(|s| !s.is_empty())
+            .cloned();
         let max_keys: usize = req
             .query_params
             .get("max-keys")
@@ -389,7 +394,12 @@ impl S3Service {
             .ok_or_else(|| no_such_bucket(bucket))?;
 
         let prefix = req.query_params.get("prefix").cloned().unwrap_or_default();
-        let delimiter = req.query_params.get("delimiter").cloned();
+        // Treat empty `delimiter` as absent.
+        let delimiter = req
+            .query_params
+            .get("delimiter")
+            .filter(|s| !s.is_empty())
+            .cloned();
         let key_marker = req
             .query_params
             .get("key-marker")
@@ -488,13 +498,14 @@ impl S3Service {
             all_entries = filtered_entries;
         }
 
-        // Pagination: truncate at max_keys (count versions + delete markers + common prefixes)
+        // Pagination: truncate at max_keys (count versions + delete markers + common prefixes).
+        // Both `all_entries` and `common_prefixes` count against max_keys —
+        // truncate each so the combined emit length never exceeds the cap.
         let total_items = all_entries.len() + common_prefixes.len();
         let is_truncated = total_items > max_keys;
-
-        // We need to limit versions to max_keys minus common_prefixes already counted
-        let version_limit = max_keys.saturating_sub(common_prefixes.len());
-        let truncated_entries: Vec<_> = all_entries.iter().take(version_limit).collect();
+        let truncated_entries: Vec<_> = all_entries.iter().take(max_keys).collect();
+        let remaining_slots = max_keys.saturating_sub(truncated_entries.len());
+        common_prefixes.truncate(remaining_slots);
         let next_markers = if is_truncated && !truncated_entries.is_empty() {
             let last = truncated_entries.last().unwrap();
             Some((


### PR DESCRIPTION
5 Cubic findings on PR #1495 addressed: batch-delete success without removal, unwrap-on-header panic, pre-versioning null preservation, max-keys CommonPrefixes enforcement, empty delimiter handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five S3 edge cases in `objects/delete` and `objects/list` to match AWS behavior and prevent panics or oversized pages. Batch deletes handle versions correctly, pre-versioning objects are preserved, and listing respects max-keys with CommonPrefixes; empty delimiters are ignored.

- **Bug Fixes**
  - Batch DeleteObjects with version-id now removes from `b.objects` when no `object_versions` exist.
  - Guarded insert of `x-amz-version-id` header to avoid panic on bad bytes.
  - When versioning is enabled, preserve a pre-versioning object as a "null" version before adding a delete marker.
  - list_object_versions: count both entries and CommonPrefixes toward `max-keys` and truncate both.
  - Treat `delimiter=""` as absent in list APIs to avoid collapsing all keys into one prefix.

<sup>Written for commit f9b6e00e63541721d3ad32a772882bb42a5baed7. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1515?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

