### PR TITLE
fix(sqs): Cubic P1 fixes on send dedup, receive decrypt, message-move

### DIFF
--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -658,7 +658,7 @@ impl SqsService {
 
         // Now swap response bodies in to plaintext.
         if !plaintext_bodies.is_empty() {
-            for (msg, plaintext) in received.iter_mut().zip(plaintext_bodies.into_iter()) {
+            for (msg, plaintext) in received.iter_mut().zip(plaintext_bodies) {
                 msg.body = plaintext;
             }
         }

--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -211,9 +211,9 @@ impl SqsService {
                         }
                         return Ok(sqs_response("SendMessage", resp, &request_id, is_query));
                     }
-                    queue
-                        .dedup_cache
-                        .insert(dedup_id.clone(), now + chrono::Duration::minutes(5));
+                    // Cache insertion deferred until after the message is
+                    // actually committed (encryption can fail), so a
+                    // KMS-denied retry isn't silently de-duplicated.
                 }
             }
 
@@ -282,13 +282,24 @@ impl SqsService {
                 visible_at,
                 receive_count: 0,
                 message_group_id,
-                message_dedup_id: effective_dedup_id,
+                message_dedup_id: effective_dedup_id.clone(),
                 created_at: now,
                 sequence_number: sequence_number.clone(),
             };
 
             let message_id = msg.message_id.clone();
             queue.messages.push_back(msg);
+
+            // Commit the dedup cache entry only after the message is on
+            // the queue. Earlier failures (encryption, size limit) leave
+            // the dedup_id un-cached so the caller's retry can succeed.
+            if queue.is_fifo {
+                if let Some(ref dedup_id) = effective_dedup_id {
+                    queue
+                        .dedup_cache
+                        .insert(dedup_id.clone(), now + chrono::Duration::minutes(5));
+                }
+            }
 
             (message_id, sequence_number)
         };
@@ -607,6 +618,23 @@ impl SqsService {
             queue.messages = remaining;
         }
 
+        // Capture queue-level encryption settings BEFORE the DLQ path
+        // re-borrows `state.queues` mutably to push into the DLQ.
+        let queue_arn = queue.arn.clone();
+        let kms_key_id = Self::effective_kms_key_id(&queue.attributes);
+
+        // Decrypt BEFORE mutating inflight/DLQ. The previous order would
+        // bump `receive_count` and stash the message in `inflight`, then
+        // bail with the decrypt error — the visibility window was
+        // already consumed even though the caller saw an error.
+        let mut plaintext_bodies: Vec<String> = Vec::with_capacity(received.len());
+        if kms_key_id.is_some() && self.kms_hook.is_some() {
+            for msg in received.iter() {
+                let plaintext = self.decrypt_message_body(account_id, &queue_arn, &msg.body)?;
+                plaintext_bodies.push(plaintext);
+            }
+        }
+
         // Push the popped messages onto inflight with their original
         // at-rest bodies (ciphertext for SendMessage-encrypted msgs,
         // plaintext for cross-service deliveries). Inflight has to
@@ -616,11 +644,6 @@ impl SqsService {
         for msg in &received {
             queue.inflight.push(msg.clone());
         }
-
-        // Capture queue-level encryption settings BEFORE the DLQ path
-        // re-borrows `state.queues` mutably to push into the DLQ.
-        let queue_arn = queue.arn.clone();
-        let kms_key_id = Self::effective_kms_key_id(&queue.attributes);
 
         // Move messages to DLQ — also with at-rest bodies untouched,
         // since the DLQ may have its own SSE settings and a downstream
@@ -633,15 +656,10 @@ impl SqsService {
             }
         }
 
-        // At-rest decryption: rewrite each delivered message's body
-        // from ciphertext to plaintext for the response. Covers both
-        // SSE-KMS (`KmsMasterKeyId`) and SSE-SQS
-        // (`SqsManagedSseEnabled=true`). Bodies that don't look like a
-        // fakecloud envelope (cross-service deliveries) are passed
-        // through unchanged inside `decrypt_message_body`.
-        if kms_key_id.is_some() && self.kms_hook.is_some() {
-            for msg in received.iter_mut() {
-                msg.body = self.decrypt_message_body(account_id, &queue_arn, &msg.body)?;
+        // Now swap response bodies in to plaintext.
+        if !plaintext_bodies.is_empty() {
+            for (msg, plaintext) in received.iter_mut().zip(plaintext_bodies.into_iter()) {
+                msg.body = plaintext;
             }
         }
 

--- a/crates/fakecloud-sqs/src/service/mod.rs
+++ b/crates/fakecloud-sqs/src/service/mod.rs
@@ -356,7 +356,37 @@ async fn run_message_move_task(
     dlq_targets: Vec<String>,
     interval: std::time::Duration,
     cancel_flag: Arc<AtomicBool>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 ) {
+    // Persist current state through the same code path SqsService::save_snapshot
+    // uses. The background loop mutates queues outside any handler, so callers
+    // can't trigger a save on its behalf — failing to checkpoint here means
+    // moved messages and task progress are silently rolled back after restart.
+    async fn checkpoint(
+        state_handle: &SharedSqsState,
+        snapshot_store: &Option<Arc<dyn SnapshotStore>>,
+        snapshot_lock: &Arc<AsyncMutex<()>>,
+    ) {
+        let Some(store) = snapshot_store.clone() else {
+            return;
+        };
+        let _guard = snapshot_lock.lock().await;
+        let snapshot = SqsSnapshot {
+            schema_version: SQS_SNAPSHOT_SCHEMA_VERSION,
+            accounts: Some(state_handle.read().clone()),
+            state: None,
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        if let Ok(Err(err)) = join {
+            tracing::warn!(%err, "background message-move snapshot save failed");
+        }
+    }
     enum Step {
         Moved,
         SourceDrained,
@@ -459,6 +489,7 @@ async fn run_message_move_task(
 
         match step {
             Step::Moved => {
+                checkpoint(&state_handle, &snapshot_store, &snapshot_lock).await;
                 tokio::time::sleep(interval).await;
             }
             Step::SourceDrained => {
@@ -469,6 +500,7 @@ async fn run_message_move_task(
                     &task_handle,
                     MessageMoveTaskStatus::Completed,
                 );
+                checkpoint(&state_handle, &snapshot_store, &snapshot_lock).await;
                 return;
             }
             Step::Failed => {
@@ -479,6 +511,7 @@ async fn run_message_move_task(
                     &task_handle,
                     MessageMoveTaskStatus::Failed,
                 );
+                checkpoint(&state_handle, &snapshot_store, &snapshot_lock).await;
                 return;
             }
         }

--- a/crates/fakecloud-sqs/src/service/moves.rs
+++ b/crates/fakecloud-sqs/src/service/moves.rs
@@ -80,12 +80,17 @@ impl SqsService {
             }
         }
 
-        // Reject if there's already a RUNNING task for this source.
-        if state
-            .message_move_tasks
-            .iter()
-            .any(|t| t.source_arn == source_arn && t.status == MessageMoveTaskStatus::Running)
-        {
+        // Reject if there's already an active task for this source —
+        // RUNNING or CANCELLING. CANCELLING is still actively moving
+        // (or finishing the in-flight batch), so a second task starting
+        // alongside it would double-drain the source queue.
+        if state.message_move_tasks.iter().any(|t| {
+            t.source_arn == source_arn
+                && matches!(
+                    t.status,
+                    MessageMoveTaskStatus::Running | MessageMoveTaskStatus::Cancelling
+                )
+        }) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "AWS.SimpleQueueService.UnsupportedOperation",
@@ -105,14 +110,13 @@ impl SqsService {
         // The async path below is only useful when the caller wants real
         // backpressure (rate limit) or the ability to observe / cancel mid-flight.
         if max_per_sec.is_none() {
+            // Drain visible messages only. Inflight messages are
+            // received-but-unacked — clearing them would silently lose
+            // data on every move task.
             let source_messages: Vec<SqsMessage> = state
                 .queues
                 .get_mut(&source_url)
-                .map(|q| {
-                    let drained: Vec<_> = q.messages.drain(..).collect();
-                    q.inflight.clear();
-                    drained
-                })
+                .map(|q| q.messages.drain(..).collect())
                 .unwrap_or_default();
             let mut moved: u64 = 0;
             if let Some(ref dest) = destination_arn {
@@ -188,6 +192,8 @@ impl SqsService {
         drop(accounts);
 
         let state_handle = self.state.clone();
+        let snapshot_store = self.snapshot_store.clone();
+        let snapshot_lock = self.snapshot_lock.clone();
         let account_id = req.account_id.clone();
         let region = req.region.clone();
         let handle_for_task = task_handle.clone();
@@ -206,6 +212,8 @@ impl SqsService {
                 dlq_targets,
                 interval,
                 cancel_flag,
+                snapshot_store,
+                snapshot_lock,
             )
             .await;
         });


### PR DESCRIPTION
5 Cubic P1 fixes addressing state corruption / data loss on PR #1492.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five P1 issues in SQS send, receive, and message-move flows to prevent data loss and state corruption. Improves deduplication, decrypt ordering, task exclusivity, inflight safety, and snapshot persistence.

- **Bug Fixes**
  - SendMessage: defer `dedup_cache` insert until after the message is committed to avoid false dedup on KMS/size failures.
  - ReceiveMessage: decrypt bodies before inflight/DLQ updates; on decrypt error, no visibility is consumed. Response now swaps in plaintext after successful decrypt.
  - StartMessageMoveTask: reject when an existing task is Running or Cancelling to prevent double-draining a source queue.
  - Fast-path move: move only visible messages; do not clear `inflight` to avoid losing unacked messages.
  - Background message-move: snapshot state after each step and on completion/failure so moved messages and task status survive restarts.

<sup>Written for commit e28051696f956b3aa4bea7b4352f596e919d93e5. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1516?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

