### PR TITLE
fix(lambda): DeleteFunction blocks versions referenced by aliases

### DIFF
--- a/crates/fakecloud-lambda/src/service/functions.rs
+++ b/crates/fakecloud-lambda/src/service/functions.rs
@@ -254,6 +254,31 @@ impl LambdaService {
                     ),
                 ));
             }
+            // AWS rejects DeleteFunction on a version still referenced
+            // by an alias; otherwise the alias dangles. Mirror that
+            // before mutating any snapshot maps.
+            let alias_targets: Vec<String> = state
+                .aliases
+                .iter()
+                .filter_map(|(k, a)| {
+                    let prefix = format!("{function_name}:");
+                    if k.starts_with(&prefix) && a.function_version == *q {
+                        Some(a.name.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if !alias_targets.is_empty() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::CONFLICT,
+                    "ResourceConflictException",
+                    format!(
+                        "Cannot delete version {q} of function {function_name}: alias(es) reference it ({})",
+                        alias_targets.join(", ")
+                    ),
+                ));
+            }
             let snap_existed = state
                 .function_version_snapshots
                 .get_mut(function_name)


### PR DESCRIPTION
Cubic P1 on PR #1496. Reject DeleteFunction for a version when any alias targets it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block deleting a Lambda function version if any alias points to it, matching AWS behavior. Returns a ResourceConflictException with the alias names and leaves state unchanged.

- **Bug Fixes**
  - Before deletion, scan aliases for the function; if any target the version, return 409 ResourceConflictException listing them.
  - Prevents dangling aliases by rejecting the delete before mutating snapshots.

<sup>Written for commit 276c6af66f90482e825c27a5cb1043f153e3fefb. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1517?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

