### PR TITLE
fix: Cubic P1s on conformance probe + apigateway authorizers/integrations

### DIFF
--- a/crates/fakecloud-apigateway/src/data_plane/authorizers.rs
+++ b/crates/fakecloud-apigateway/src/data_plane/authorizers.rs
@@ -180,14 +180,20 @@ pub(super) fn parse_policy_effect(response: &serde_json::Value, method_arn: &str
     for stmt in stmts {
         let effect = stmt.get("Effect").and_then(|v| v.as_str()).unwrap_or("");
         // Resource matching: explicit ARN match, wildcard `*`, or
-        // missing Resource (treat as `*`).
+        // missing Resource (treat as `*`). Invalid Resource types
+        // (number, bool, null) are NOT treated as wildcard — that would
+        // let a malformed policy authorize requests instead of failing
+        // safe.
         let matches = match stmt.get("Resource") {
             Some(serde_json::Value::String(s)) => arn_matches(s, method_arn),
             Some(serde_json::Value::Array(arr)) => arr
                 .iter()
                 .filter_map(|v| v.as_str())
                 .any(|s| arn_matches(s, method_arn)),
-            _ => true,
+            // Missing Resource is interpreted as `*` (AWS default).
+            None => true,
+            // Wrong type — refuse to match. Caller sees Deny.
+            _ => false,
         };
         if !matches {
             continue;

--- a/crates/fakecloud-apigateway/src/data_plane/integrations.rs
+++ b/crates/fakecloud-apigateway/src/data_plane/integrations.rs
@@ -296,7 +296,11 @@ pub(super) async fn aws_direct_integration(
         bad_gateway("AWS direct integration not available: service registry not yet populated")
     })?;
 
-    let parts: Vec<&str> = uri.split(':').collect();
+    // Split only the first 6 segments — the trailing one is `action/...`
+    // or `path/...` and can carry embedded `:` (e.g. Lambda ARNs). Naive
+    // `split(':').collect()` truncated those at the first colon and
+    // mis-routed the integration.
+    let parts: Vec<&str> = uri.splitn(6, ':').collect();
     if parts.len() < 6 || parts[0] != "arn" || parts[1] != "aws" || parts[2] != "apigateway" {
         return Err(bad_gateway(format!(
             "AWS integration uri not in expected ARN format: {uri}"

--- a/crates/fakecloud-apigatewayv2/src/service/authorizers.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/authorizers.rs
@@ -316,6 +316,7 @@ impl ApiGatewayV2Service {
         &self,
         req: &AwsRequest,
         api_id: &str,
+        stage: &str,
         route: &Route,
     ) -> Result<Option<AuthorizerInfo>, AwsServiceError> {
         let authorizer_id = match &route.authorizer_id {
@@ -345,7 +346,7 @@ impl ApiGatewayV2Service {
         match authorizer.authorizer_type.as_str() {
             "JWT" => self.enforce_jwt_authorizer(req, &authorizer).await,
             "REQUEST" => {
-                self.enforce_lambda_authorizer(req, api_id, &authorizer)
+                self.enforce_lambda_authorizer(req, api_id, stage, &authorizer)
                     .await
             }
             _ => Err(AwsServiceError::aws_error(
@@ -475,6 +476,7 @@ impl ApiGatewayV2Service {
         &self,
         req: &AwsRequest,
         api_id: &str,
+        stage: &str,
         authorizer: &Authorizer,
     ) -> Result<Option<AuthorizerInfo>, AwsServiceError> {
         // Identity sources are optional for REQUEST authorizers.
@@ -509,7 +511,7 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        let method_arn = build_method_arn(req, api_id);
+        let method_arn = build_method_arn(req, api_id, stage);
 
         let mut headers = serde_json::Map::new();
         for (k, v) in req.headers.iter() {

--- a/crates/fakecloud-apigatewayv2/src/service/execute.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/execute.rs
@@ -378,7 +378,7 @@ impl ApiGatewayV2Service {
 
             // Authorizer enforcement
             let authorizer_info = self
-                .enforce_authorizer(&req, &api_id, &route_match.route)
+                .enforce_authorizer(&req, &api_id, &stage_name, &route_match.route)
                 .await?;
 
             // Get the integration for this route

--- a/crates/fakecloud-apigatewayv2/src/service/mod.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/mod.rs
@@ -365,19 +365,29 @@ fn extract_lambda_arn(uri: &str) -> Option<String> {
 
 /// Build the method ARN used in Lambda-authorizer policy documents.
 /// AWS format: `arn:aws:execute-api:<region>:<account-id>:<api-id>/<stage>/<method>/<path>`.
-fn build_method_arn(req: &AwsRequest, api_id: &str) -> String {
-    let stage = req
-        .path_segments
-        .first()
-        .map(|s| s.as_str())
-        .unwrap_or("$default");
-    let path = req
-        .path_segments
-        .iter()
-        .skip(1)
-        .map(|s| s.as_str())
-        .collect::<Vec<_>>()
-        .join("/");
+/// `stage` is passed in explicitly because the execute-api path
+/// (`/{stage}/{path}`) and the custom-domain path
+/// (`/{base-path}/{path}` -> resolved stage) need different sources of
+/// truth — falling back to `req.path_segments[0]` for custom domains
+/// would surface the route's first path segment as the stage.
+fn build_method_arn(req: &AwsRequest, api_id: &str, stage: &str) -> String {
+    let segments = if req.path_segments.first().map(|s| s.as_str()) == Some(stage) {
+        // execute-api: stage IS path_segments[0], so the remaining
+        // segments are the resource path.
+        req.path_segments
+            .iter()
+            .skip(1)
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+    } else {
+        // custom-domain: path_segments already contains only the
+        // resource path; stage was stripped before this fn ran.
+        req.path_segments
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+    };
+    let path = segments.join("/");
     format!(
         "arn:aws:execute-api:{}:{}:{}/{}/{}/{}",
         req.region,

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -1981,7 +1981,7 @@ async fn execute_api_lambda_authorizer_malformed_policy_no_resource() {
 #[test]
 fn build_method_arn_includes_method_and_no_double_slash() {
     let req = make_request(Method::GET, "/prod/pets", "");
-    let arn = build_method_arn(&req, "abc123");
+    let arn = build_method_arn(&req, "abc123", "prod");
     assert_eq!(
         arn,
         "arn:aws:execute-api:us-east-1:123456789012:abc123/prod/GET/pets"
@@ -1989,7 +1989,7 @@ fn build_method_arn_includes_method_and_no_double_slash() {
 
     // Empty path after stage should not produce trailing slash.
     let req2 = make_request(Method::GET, "/prod", "");
-    let arn2 = build_method_arn(&req2, "abc123");
+    let arn2 = build_method_arn(&req2, "abc123", "prod");
     assert_eq!(
         arn2,
         "arn:aws:execute-api:us-east-1:123456789012:abc123/prod/GET/"

--- a/crates/fakecloud-conformance/src/audit.rs
+++ b/crates/fakecloud-conformance/src/audit.rs
@@ -97,7 +97,7 @@ fn service_source_files(project_root: &Path) -> Vec<AuditMapping> {
         (
             "states",
             "stepfunctions",
-            &["service.rs"],
+            &["service/mod.rs", "service.rs"],
             &["states", "sfn"],
         ),
         ("scheduler", "scheduler", &["service.rs"], &["scheduler"]),

--- a/crates/fakecloud-conformance/src/probe/mod.rs
+++ b/crates/fakecloud-conformance/src/probe/mod.rs
@@ -864,8 +864,9 @@ mod tests {
     }
 
     #[test]
-    fn classify_4xx_empty_error_shapes_lenient() {
-        // Op declares no errors (rare). Treat any AWS-shaped error as Pass.
+    fn classify_4xx_empty_error_shapes_strict() {
+        // Op declares NO errors. Any 4xx is undeclared, so surface it
+        // rather than silently passing.
         let body = r#"{"__type":"SomeException"}"#;
         let declared: Vec<String> = Vec::new();
         let result = classify_response(
@@ -877,7 +878,11 @@ mod tests {
             Some(&declared),
             "",
         );
-        assert_eq!(result.status, ProbeStatus::Pass);
+        assert!(
+            matches!(result.status, ProbeStatus::UnexpectedResult(_)),
+            "expected UnexpectedResult, got {:?}",
+            result.status
+        );
     }
 
     #[test]

--- a/crates/fakecloud-conformance/src/probe/response.rs
+++ b/crates/fakecloud-conformance/src/probe/response.rs
@@ -70,7 +70,10 @@ pub(super) fn classify_success_expectation(
     // Op model unavailable (no model for this service or unknown op) -> any
     // AWS-shaped error counts as a handler response.
     if let Some(declared) = op_error_shapes {
-        if declared.is_empty() || matches_declared_error(&code, declared) {
+        // Empty declared list means the op declares *no* errors in its
+        // Smithy contract — anything 4xx/5xx is undeclared, so don't
+        // silently mark these as Pass.
+        if !declared.is_empty() && matches_declared_error(&code, declared) {
             ProbeStatus::Pass
         } else {
             ProbeStatus::UnexpectedResult(format!(
@@ -251,7 +254,10 @@ pub(super) fn classify_response(
             }
         }
         Expectation::Error(expected_code) => {
-            if body.contains(expected_code) {
+            // Don't accept a 2xx body that happens to contain the expected
+            // error string — the response is only valid as Error if the
+            // status code is actually an error status.
+            if http_status >= 400 && body.contains(expected_code) {
                 ProbeStatus::Pass
             } else if http_status >= 400 {
                 ProbeStatus::UnexpectedResult(format!(


### PR DESCRIPTION
6 Cubic P1 fixes across PRs #1498 / #1490 / #1497 / #1500.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes six P1 issues in API Gateway authorizers/integrations and the conformance probe. Tightens policy evaluation, corrects method ARN building for custom domains, preserves embedded colons in integration URIs, and makes probe error checks strict.

- **Bug Fixes**
  - `fakecloud-apigateway`: Authorizer policy Resource must be a string or array; invalid types no longer match as wildcard (fail closed).
  - `fakecloud-apigateway`: Parse AWS integration `uri` with `splitn(6, ':')` to keep embedded colons in `action/...` or `path/...`.
  - `fakecloud-apigatewayv2`: Build method ARN with the resolved `stage` passed explicitly; fixes custom-domain authorizer evaluation. Thread `stage` through enforcement and tests.
  - `fakecloud-conformance`: Treat ops with no declared errors as strict; any 4xx/5xx is UnexpectedResult. Require `http_status >= 400` when matching `Expectation::Error`.
  - `fakecloud-conformance`: Include `service/mod.rs` in Step Functions audit fallback.

<sup>Written for commit fdf91abe6d5f97c9697036c3ab6e720bd1b5a796. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1519?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

