### PR TITLE
fix: Cubic P1s on dynamodb keys, stepfunctions aliases, athena sessions

### DIFF
--- a/crates/fakecloud-athena/src/service/notebooks.rs
+++ b/crates/fakecloud-athena/src/service/notebooks.rs
@@ -198,6 +198,10 @@ impl AthenaService {
             .get("Description")
             .and_then(Value::as_str)
             .map(str::to_owned);
+        let notebook_id = body
+            .get("NotebookId")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
         let configuration = body.get("EngineConfiguration").cloned();
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
@@ -210,6 +214,7 @@ impl AthenaService {
             Session {
                 session_id: id.clone(),
                 work_group,
+                notebook_id,
                 description,
                 engine_version: Some("PySpark engine version 3".to_string()),
                 state: "IDLE".to_string(),
@@ -335,6 +340,7 @@ impl AthenaService {
         let summaries: Vec<Value> = account
             .sessions
             .values()
+            .filter(|s| s.notebook_id.as_deref() == Some(notebook_id.as_str()))
             .map(session_summary_json)
             .collect();
         Ok(AwsResponse::ok_json(json!({

--- a/crates/fakecloud-athena/src/state.rs
+++ b/crates/fakecloud-athena/src/state.rs
@@ -151,6 +151,10 @@ pub struct Notebook {
 pub struct Session {
     pub session_id: String,
     pub work_group: String,
+    /// Notebook that started this session, when StartSession was called
+    /// with a NotebookId. `None` for ad-hoc work-group sessions.
+    #[serde(default)]
+    pub notebook_id: Option<String>,
     pub description: Option<String>,
     pub engine_version: Option<String>,
     pub state: String,

--- a/crates/fakecloud-dynamodb/src/service/helpers/keys.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/keys.rs
@@ -106,5 +106,17 @@ pub(crate) fn validate_key_attributes_in_key(
             format!("Missing the key {hash_key} in the item"),
         ));
     }
+    // Composite-key tables require BOTH hash and range in the Key map;
+    // omitting the range key would otherwise let GetItem / DeleteItem
+    // succeed with an under-specified key.
+    if let Some(range_key) = table.range_key_name() {
+        if !key.contains_key(range_key) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!("Missing the key {range_key} in the item"),
+            ));
+        }
+    }
     Ok(())
 }

--- a/crates/fakecloud-stepfunctions/src/service/state_machines.rs
+++ b/crates/fakecloud-stepfunctions/src/service/state_machines.rs
@@ -386,6 +386,23 @@ impl StepFunctionsService {
             .rsplit_once(':')
             .map(|(parent, _)| parent.to_string())
             .unwrap_or_default();
+        // All routed versions must belong to the same state machine.
+        // Otherwise an alias could mix versions of two different
+        // workflows, which AWS rejects with InvalidArn.
+        for route in &routes[1..] {
+            let other_parent = route
+                .state_machine_version_arn
+                .rsplit_once(':')
+                .map(|(p, _)| p.to_string())
+                .unwrap_or_default();
+            if other_parent != parent_arn {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidArn",
+                    "routingConfiguration entries must all reference versions of the same state machine",
+                ));
+            }
+        }
         let alias_arn = format!("{parent_arn}:{name}");
         let now = chrono::Utc::now();
         let alias = crate::state::StateMachineAlias {


### PR DESCRIPTION
3 Cubic P1 fixes across PRs #1491 / #1492 / #1483.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three P1 issues to match AWS behavior: enforce composite keys in DynamoDB, validate Step Functions alias routes, and scope Athena notebook sessions by NotebookId.

- **Bug Fixes**
  - `fakecloud-dynamodb`: For composite-key tables, require both hash and range keys in Key for GetItem/DeleteItem. Returns ValidationException when missing.
  - `fakecloud-stepfunctions`: CreateStateMachineAlias now rejects routingConfiguration entries that reference versions from different state machines. Returns InvalidArn.
  - `fakecloud-athena`: Sessions record NotebookId on StartSession and ListNotebookSessions filters by it. New optional field is serde-default for back-compat.

<sup>Written for commit 008b569ed226db607e858f97d084bf11d95a2f4b. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1520?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

