### PR TITLE
fix(lambda): stream-invoke terminal error + percent-decode FunctionName

### DIFF
--- a/crates/fakecloud-lambda/src/extras/mod.rs
+++ b/crates/fakecloud-lambda/src/extras/mod.rs
@@ -1035,6 +1035,12 @@ fn extract_csc_id(input: &str) -> String {
     decoded.rsplit(':').next().unwrap_or(&decoded).to_string()
 }
 
+/// Re-export of `percent_decode` for the service-mod length check.
+/// Wraps the private helper without changing its signature.
+pub(crate) fn percent_decode_for_length(input: &str) -> String {
+    percent_decode(input)
+}
+
 fn percent_decode(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();

--- a/crates/fakecloud-lambda/src/extras/stream.rs
+++ b/crates/fakecloud-lambda/src/extras/stream.rs
@@ -119,12 +119,23 @@ impl LambdaService {
                         }
                         Ok(None) => break,
                         Err(e) => {
+                            // Stream-invoke contract: errors are encoded
+                            // in-stream as a terminal InvokeComplete frame
+                            // with HTTP 200. Returning HTTP 500 here breaks
+                            // SDK parsers expecting that envelope.
                             tracing::error!(function = %function_name, error = %e, "Lambda streaming chunk read failed");
-                            return Err(AwsServiceError::aws_error(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "ServiceException",
-                                format!("Lambda streaming read failed: {e}"),
+                            let detail = format!("Lambda streaming read failed: {e}");
+                            frames.extend_from_slice(&crate::eventstream::invoke_complete_frame(
+                                Some("Runtime.StreamReadFailure"),
+                                Some(&detail),
+                                "",
                             ));
+                            return Ok(AwsResponse {
+                                status: StatusCode::OK,
+                                headers: http::HeaderMap::new(),
+                                body: bytes::Bytes::from(frames).into(),
+                                content_type: "application/vnd.amazon.eventstream".to_string(),
+                            });
                         }
                     }
                 }

--- a/crates/fakecloud-lambda/src/service/mod.rs
+++ b/crates/fakecloud-lambda/src/service/mod.rs
@@ -893,7 +893,12 @@ impl AwsService for LambdaService {
             // could never have been created. The 170-char ceiling tracks
             // the documented ARN-form upper bound.
             if let Some(raw) = resource_name.as_ref() {
-                let len = raw.chars().count();
+                // Percent-decode the path label before length-checking;
+                // SDK clients escape `:` to `%3A` for ARN-form names, so
+                // the raw count overruns the 200-char ARN ceiling on
+                // valid inputs.
+                let decoded = crate::extras::percent_decode_for_length(raw);
+                let len = decoded.chars().count();
                 // Bare-name form caps at 140. ARN form
                 // (`arn:aws:lambda:<region>:<acct>:function:<name>`)
                 // adds ~60 chars of prefix → up to ~200 total. Reject
@@ -904,8 +909,12 @@ impl AwsService for LambdaService {
                 // too-long inputs through `ResourceNotFoundException`
                 // instead — which is declared, and also reflects
                 // the practical outcome of looking up a 141-char name.
-                let limit = if raw.starts_with("arn:") { 200 } else { 140 };
-                if raw.is_empty() || len > limit {
+                let limit = if decoded.starts_with("arn:") {
+                    200
+                } else {
+                    140
+                };
+                if decoded.is_empty() || len > limit {
                     let (code, msg) = if action == "InvokeAsync" {
                         (
                             "ResourceNotFoundException",


### PR DESCRIPTION
2 Cubic P1 fixes on PRs #1493 / #1496.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Lambda stream-invoke to send a terminal InvokeComplete frame inside an HTTP 200 response on chunk read errors (instead of HTTP 500), matching the AWS eventstream contract and unblocking SDK parsers. Also percent-decode the FunctionName label before enforcing the 140/200-char limits so valid percent-encoded ARNs are accepted.

<sup>Written for commit 6016126fefe28f7cbbcf5ac956f763214f62ed96. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1521?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

