### PR TITLE
fix: Cubic P1s on dynamodb partiql/paths + rds cluster rename

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -268,6 +268,17 @@ pub(crate) fn find_partiql_where_indices(
 
     let conditions = split_partiql_and_clauses(where_clause);
     let parsed_conditions = parse_partiql_conditions(&conditions, parameters);
+    // If any clause failed to parse, fall back to the structured parser
+    // instead of running a `.all([])` -> match-all evaluation. AWS
+    // rejects unparseable PartiQL with ValidationException; mirror that
+    // rather than silently UPDATE/DELETE every row in the table.
+    if parsed_conditions.len() != conditions.len() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "Statement contains unsupported predicate(s); refusing match-all fallback",
+        ));
+    }
 
     let mut indices = Vec::new();
     for (i, item) in table.items.iter().enumerate() {

--- a/crates/fakecloud-dynamodb/src/service/helpers/paths.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/paths.rs
@@ -226,6 +226,11 @@ pub(crate) fn wrap_value_in_path(segments: &[PathSegment], value: Value) -> Valu
 }
 
 /// Merge two attribute values (for overlapping projections).
+///
+/// Handles both `M` (map) and `L` (list) merging. Without the list
+/// branch, two list-indexed projections (`list[0]` and `list[1]`)
+/// would overwrite each other because the second projection's `L`
+/// value replaced the first wholesale.
 pub(crate) fn merge_attribute_values(a: Value, b: Value) -> Value {
     if let (Some(a_map), Some(b_map)) = (
         a.get("M").and_then(|v| v.as_object()),
@@ -242,8 +247,30 @@ pub(crate) fn merge_attribute_values(a: Value, b: Value) -> Value {
                 merged.insert(k.clone(), v.clone());
             }
         }
-        json!({"M": merged})
-    } else {
-        b
+        return json!({"M": merged});
     }
+    if let (Some(a_list), Some(b_list)) = (
+        a.get("L").and_then(|v| v.as_array()),
+        b.get("L").and_then(|v| v.as_array()),
+    ) {
+        let len = a_list.len().max(b_list.len());
+        let mut out = Vec::with_capacity(len);
+        for i in 0..len {
+            let lhs = a_list.get(i).cloned().unwrap_or(Value::Null);
+            let rhs = b_list.get(i).cloned().unwrap_or(Value::Null);
+            // Null is the wrap_value_in_path placeholder for "no
+            // projection touched this index" — prefer the non-null
+            // side, recurse when both contributed a real value.
+            let picked = if lhs.is_null() {
+                rhs
+            } else if rhs.is_null() {
+                lhs
+            } else {
+                merge_attribute_values(lhs, rhs)
+            };
+            out.push(picked);
+        }
+        return json!({"L": out});
+    }
+    b
 }

--- a/crates/fakecloud-rds/src/extras/cluster_actions.rs
+++ b/crates/fakecloud-rds/src/extras/cluster_actions.rs
@@ -30,6 +30,14 @@ pub(super) fn cluster_not_found(id: &str) -> AwsServiceError {
     )
 }
 
+pub(super) fn cluster_already_exists(id: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "DBClusterAlreadyExistsFault",
+        format!("DBCluster {id} already exists."),
+    )
+}
+
 pub(super) fn invalid_cluster_state(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,
@@ -250,9 +258,15 @@ pub(super) fn modify_db_cluster_action(
         }
 
         // NewDBClusterIdentifier: rename the cluster key + ARN.
+        // Reject when the target identifier already names another cluster —
+        // otherwise the rename silently overwrites real data instead of
+        // surfacing DBClusterAlreadyExistsFault.
         if let Some(new_id) = new_id.as_ref() {
             if new_id != &id {
                 if let Some(map) = state.extras.get_mut("clusters") {
+                    if map.contains_key(new_id) {
+                        return Err(cluster_already_exists(new_id));
+                    }
                     if let Some(mut entry) = map.remove(&id) {
                         let new_arn =
                             Arn::new("rds", region, account_id, &format!("cluster:{new_id}"))


### PR DESCRIPTION
3 Cubic P1 fixes across PRs #1491 / #1488.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three P1s in DynamoDB and RDS simulators. Rejects invalid PartiQL WHERE instead of matching all rows, correctly merges overlapping list projections, and prevents RDS cluster rename collisions.

- **Bug Fixes**
  - DynamoDB PartiQL: Return ValidationException when any WHERE clause is unparseable; no match-all fallback on UPDATE/DELETE/SELECT.
  - DynamoDB attribute paths: Element-wise merge for `L` (list) values to preserve multiple list-index projections; recurse for nested values.
  - RDS ModifyDBCluster: On `NewDBClusterIdentifier`, return `DBClusterAlreadyExistsFault` if the target ID exists; no silent overwrite.

<sup>Written for commit e7aecbbd996af2cb59eeed42cd3fb0fee393ad66. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1522?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

