### PR TITLE
fix(wafv2): 8 Cubic P2 fixes on validation + pagination + lock-token

### DIFF
--- a/crates/fakecloud-wafv2/src/service/api_keys.rs
+++ b/crates/fakecloud-wafv2/src/service/api_keys.rs
@@ -41,11 +41,16 @@ impl Wafv2Service {
     pub(super) fn delete_api_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let api_key = require_str(&body, "APIKey")?;
-        let _scope = require_scope(&body)?;
+        let scope = require_scope(&body)?;
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
-        if account.api_keys.remove(&api_key).is_none() {
-            return Err(not_found("APIKey"));
+        // Check the stored key's scope matches BEFORE removal. A
+        // CLOUDFRONT-scoped request shouldn't delete a REGIONAL key.
+        match account.api_keys.get(&api_key) {
+            Some(k) if k.scope == scope => {
+                account.api_keys.remove(&api_key);
+            }
+            _ => return Err(not_found("APIKey")),
         }
         Ok(AwsResponse::ok_json(json!({})))
     }

--- a/crates/fakecloud-wafv2/src/service/ip_sets.rs
+++ b/crates/fakecloud-wafv2/src/service/ip_sets.rs
@@ -47,7 +47,7 @@ impl Wafv2Service {
         let name = require_str_len(&body, "Name", 1, 128)?;
         let scope = require_scope(&body)?;
         // Id is required (Smithy @required) and must be a length(1, 36) string.
-        let _id = require_str_len(&body, "Id", 1, 36)?;
+        let id = require_str_len(&body, "Id", 1, 36)?;
         let state = self.state.read();
         let set = state
             .accounts
@@ -55,6 +55,9 @@ impl Wafv2Service {
             .and_then(|a| a.ip_sets.get(&(scope, name)))
             .ok_or_else(|| not_found("IPSet"))?
             .clone();
+        if set.id != id {
+            return Err(not_found("IPSet"));
+        }
         Ok(AwsResponse::ok_json(json!({
             "IPSet": ip_set_detail_json(&set),
             "LockToken": set.lock_token,

--- a/crates/fakecloud-wafv2/src/service/logging.rs
+++ b/crates/fakecloud-wafv2/src/service/logging.rs
@@ -79,8 +79,10 @@ impl Wafv2Service {
                 "LogScope",
             )?;
         }
+        let limit = body.get("Limit").and_then(Value::as_u64).unwrap_or(100) as usize;
+        let next_marker = body.get("NextMarker").and_then(Value::as_str).unwrap_or("");
         let state = self.state.read();
-        let configs: Vec<Value> = state
+        let mut all: Vec<Value> = state
             .accounts
             .get(&req.account_id)
             .map(|a| {
@@ -96,8 +98,32 @@ impl Wafv2Service {
                     .collect()
             })
             .unwrap_or_default();
-        Ok(AwsResponse::ok_json(json!({
-            "LoggingConfigurations": configs,
-        })))
+        all.sort_by(|a, b| {
+            let a_arn = a.get("ResourceArn").and_then(Value::as_str).unwrap_or("");
+            let b_arn = b.get("ResourceArn").and_then(Value::as_str).unwrap_or("");
+            a_arn.cmp(b_arn)
+        });
+        let start = if next_marker.is_empty() {
+            0
+        } else {
+            all.iter()
+                .position(|c| c.get("ResourceArn").and_then(Value::as_str) == Some(next_marker))
+                .map(|p| p + 1)
+                .unwrap_or(0)
+        };
+        let page: Vec<Value> = all.iter().skip(start).take(limit).cloned().collect();
+        let next = if start + page.len() < all.len() {
+            page.last()
+                .and_then(|c| c.get("ResourceArn"))
+                .and_then(Value::as_str)
+                .map(|s| s.to_string())
+        } else {
+            None
+        };
+        let mut out = json!({ "LoggingConfigurations": page });
+        if let Some(n) = next {
+            out["NextMarker"] = json!(n);
+        }
+        Ok(AwsResponse::ok_json(out))
     }
 }

--- a/crates/fakecloud-wafv2/src/service/mobile_sdk.rs
+++ b/crates/fakecloud-wafv2/src/service/mobile_sdk.rs
@@ -43,11 +43,33 @@ impl Wafv2Service {
         validate_enum(&platform, &["IOS", "ANDROID"], "Platform")?;
         validate_opt_limit(&body)?;
         validate_opt_next_marker(&body)?;
-        Ok(AwsResponse::ok_json(json!({
-            "ReleaseSummaries": [
-                {"ReleaseVersion": "1.0.0", "Timestamp": Utc::now().timestamp() as f64},
-                {"ReleaseVersion": "1.1.0", "Timestamp": Utc::now().timestamp() as f64},
-            ],
-        })))
+        let limit = body.get("Limit").and_then(Value::as_u64).unwrap_or(100) as usize;
+        let next_marker = body.get("NextMarker").and_then(Value::as_str).unwrap_or("");
+        let all = vec![
+            json!({"ReleaseVersion": "1.0.0", "Timestamp": Utc::now().timestamp() as f64}),
+            json!({"ReleaseVersion": "1.1.0", "Timestamp": Utc::now().timestamp() as f64}),
+        ];
+        let start = if next_marker.is_empty() {
+            0
+        } else {
+            all.iter()
+                .position(|r| r.get("ReleaseVersion").and_then(Value::as_str) == Some(next_marker))
+                .map(|p| p + 1)
+                .unwrap_or(0)
+        };
+        let page: Vec<Value> = all.iter().skip(start).take(limit).cloned().collect();
+        let next = if start + page.len() < all.len() {
+            page.last()
+                .and_then(|r| r.get("ReleaseVersion"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        } else {
+            None
+        };
+        let mut out = json!({ "ReleaseSummaries": page });
+        if let Some(n) = next {
+            out["NextMarker"] = json!(n);
+        }
+        Ok(AwsResponse::ok_json(out))
     }
 }

--- a/crates/fakecloud-wafv2/src/service/mobile_sdk.rs
+++ b/crates/fakecloud-wafv2/src/service/mobile_sdk.rs
@@ -45,7 +45,7 @@ impl Wafv2Service {
         validate_opt_next_marker(&body)?;
         let limit = body.get("Limit").and_then(Value::as_u64).unwrap_or(100) as usize;
         let next_marker = body.get("NextMarker").and_then(Value::as_str).unwrap_or("");
-        let all = vec![
+        let all = [
             json!({"ReleaseVersion": "1.0.0", "Timestamp": Utc::now().timestamp() as f64}),
             json!({"ReleaseVersion": "1.1.0", "Timestamp": Utc::now().timestamp() as f64}),
         ];

--- a/crates/fakecloud-wafv2/src/service/mobile_sdk.rs
+++ b/crates/fakecloud-wafv2/src/service/mobile_sdk.rs
@@ -49,15 +49,21 @@ impl Wafv2Service {
             json!({"ReleaseVersion": "1.0.0", "Timestamp": Utc::now().timestamp() as f64}),
             json!({"ReleaseVersion": "1.1.0", "Timestamp": Utc::now().timestamp() as f64}),
         ];
+        // Unknown NextMarker should yield an empty page, not silently
+        // restart from offset 0 — falling back duplicates results when
+        // the caller resumes from a stale token.
         let start = if next_marker.is_empty() {
-            0
+            Some(0usize)
         } else {
             all.iter()
                 .position(|r| r.get("ReleaseVersion").and_then(Value::as_str) == Some(next_marker))
                 .map(|p| p + 1)
-                .unwrap_or(0)
         };
-        let page: Vec<Value> = all.iter().skip(start).take(limit).cloned().collect();
+        let page: Vec<Value> = match start {
+            Some(s) => all.iter().skip(s).take(limit).cloned().collect(),
+            None => Vec::new(),
+        };
+        let start = start.unwrap_or(all.len());
         let next = if start + page.len() < all.len() {
             page.last()
                 .and_then(|r| r.get("ReleaseVersion"))

--- a/crates/fakecloud-wafv2/src/service/regex_pattern_sets.rs
+++ b/crates/fakecloud-wafv2/src/service/regex_pattern_sets.rs
@@ -63,7 +63,7 @@ impl Wafv2Service {
         let body = req.json_body();
         let name = require_str_len(&body, "Name", 1, 128)?;
         let scope = require_scope(&body)?;
-        let _id = require_str_len(&body, "Id", 1, 36)?;
+        let id = require_str_len(&body, "Id", 1, 36)?;
         let state = self.state.read();
         let set = state
             .accounts
@@ -71,6 +71,9 @@ impl Wafv2Service {
             .and_then(|a| a.regex_pattern_sets.get(&(scope, name)))
             .ok_or_else(|| not_found("RegexPatternSet"))?
             .clone();
+        if set.id != id {
+            return Err(not_found("RegexPatternSet"));
+        }
         Ok(AwsResponse::ok_json(json!({
             "RegexPatternSet": regex_set_detail_json(&set),
             "LockToken": set.lock_token,

--- a/crates/fakecloud-wafv2/src/service/rule_groups.rs
+++ b/crates/fakecloud-wafv2/src/service/rule_groups.rs
@@ -473,7 +473,7 @@ impl Wafv2Service {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let acl_arn = require_str(&body, "WebACLArn")?;
-        let _lock_token = require_str(&body, "WebACLLockToken")?;
+        let lock_token = require_str(&body, "WebACLLockToken")?;
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         let acl = account
@@ -481,6 +481,13 @@ impl Wafv2Service {
             .values_mut()
             .find(|a| a.arn == acl_arn)
             .ok_or_else(|| not_found("WebACL"))?;
+        if acl.lock_token != lock_token {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "WAFOptimisticLockException",
+                "Lock token stale; refetch the WebACL and retry",
+            ));
+        }
         acl.pre_process_firewall_manager_rule_groups.clear();
         acl.post_process_firewall_manager_rule_groups.clear();
         acl.lock_token = synth_uuid();

--- a/crates/fakecloud-wafv2/src/service/web_acls.rs
+++ b/crates/fakecloud-wafv2/src/service/web_acls.rs
@@ -358,10 +358,14 @@ impl Wafv2Service {
                         // returned ARNs to that family. Without this
                         // filter, listing ALB resources also returns
                         // associated APIGW/AppSync/Amplify ARNs.
-                        resource_type
+                        // AWS defaults ResourceType to
+                        // APPLICATION_LOAD_BALANCER when omitted —
+                        // returning every resource type would surface
+                        // ARNs callers didn't ask for.
+                        let rt = resource_type
                             .as_deref()
-                            .map(|rt| resource_arn_matches_type(k, rt))
-                            .unwrap_or(true)
+                            .unwrap_or("APPLICATION_LOAD_BALANCER");
+                        resource_arn_matches_type(k, rt)
                     })
                     .map(|(k, _)| k.clone())
                     .collect()

--- a/crates/fakecloud-wafv2/src/service/web_acls.rs
+++ b/crates/fakecloud-wafv2/src/service/web_acls.rs
@@ -270,8 +270,12 @@ impl Wafv2Service {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let acl_arn = require_str(&body, "WebACLArn")?;
-        let resource_arn = normalize_resource_arn(&require_str(&body, "ResourceArn")?);
+        // Enforce the documented ARN length bounds (20..2048) on both
+        // sides — otherwise bad/empty inputs land directly in the
+        // associations map and surface as stale entries.
+        let acl_arn = require_str_len(&body, "WebACLArn", 20, 2048)?;
+        let resource_arn =
+            normalize_resource_arn(&require_str_len(&body, "ResourceArn", 20, 2048)?);
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         if !account.web_acls.values().any(|a| a.arn == acl_arn) {
@@ -337,6 +341,10 @@ impl Wafv2Service {
                 "ResourceType",
             )?;
         }
+        let resource_type = body
+            .get("ResourceType")
+            .and_then(Value::as_str)
+            .map(str::to_string);
         let state = self.state.read();
         let resources: Vec<String> = state
             .accounts
@@ -345,6 +353,16 @@ impl Wafv2Service {
                 a.associations
                     .iter()
                     .filter(|(_, v)| **v == acl_arn)
+                    .filter(|(k, _)| {
+                        // When ResourceType is set, restrict the
+                        // returned ARNs to that family. Without this
+                        // filter, listing ALB resources also returns
+                        // associated APIGW/AppSync/Amplify ARNs.
+                        resource_type
+                            .as_deref()
+                            .map(|rt| resource_arn_matches_type(k, rt))
+                            .unwrap_or(true)
+                    })
                     .map(|(k, _)| k.clone())
                     .collect()
             })
@@ -352,5 +370,25 @@ impl Wafv2Service {
         Ok(AwsResponse::ok_json(json!({
             "ResourceArns": resources,
         })))
+    }
+}
+
+/// Map a `ResourceType` filter to the ARN segment that identifies that
+/// resource family. Mirrors the documented mapping in the WAFv2
+/// API reference.
+fn resource_arn_matches_type(arn: &str, ty: &str) -> bool {
+    match ty {
+        "APPLICATION_LOAD_BALANCER" => {
+            arn.contains(":elasticloadbalancing:") && arn.contains(":loadbalancer/app/")
+        }
+        "API_GATEWAY" => arn.contains(":apigateway:") && arn.contains("/restapis/"),
+        "APPSYNC" => arn.contains(":appsync:"),
+        "COGNITO_USER_POOL" => arn.contains(":cognito-idp:") && arn.contains(":userpool/"),
+        "APP_RUNNER_SERVICE" => arn.contains(":apprunner:"),
+        "VERIFIED_ACCESS_INSTANCE" => {
+            arn.contains(":ec2:") && arn.contains(":verified-access-instance/")
+        }
+        "AMPLIFY" => arn.contains(":amplify:"),
+        _ => true,
     }
 }


### PR DESCRIPTION
8 P2 fixes for the wafv2 ignored-validation cluster.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes eight P2 issues in `fakecloud-wafv2` by tightening validation, adding pagination, and enforcing lock tokens. Prevents cross-scope deletes, stale reads, and oversized listings to better match AWS WAFv2 behavior.

- Bug Fixes
  - API keys: block cross-scope deletes.
  - IP sets and regex pattern sets: Get requires matching `Id`; else NotFound.
  - Logging: `ListLoggingConfigurations` paginates via `Limit`/`NextMarker` with stable sort.
  - Mobile SDK: `ListMobileSdkReleases` paginates (`Limit`/`NextMarker`); stale `NextMarker` returns an empty page.
  - Rule groups: `DeleteFirewallManagerRuleGroups` validates `WebACLLockToken`; returns `WAFOptimisticLockException` on stale tokens.
  - Web ACLs:
    - `AssociateWebACL` enforces ARN length 20..2048 for `WebACLArn` and `ResourceArn`.
    - `ListResourcesForWebACL` applies `ResourceType` filter; defaults to `APPLICATION_LOAD_BALANCER` when omitted.

<sup>Written for commit 7ff85512beb2f575dcf6c87a9a86e2abfa348c77. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1524?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

