### PR TITLE
fix(route53): 7 Cubic P2 fixes on cidr/dnssec/routing/pagination

### DIFF
--- a/crates/fakecloud-route53/src/service/cidr.rs
+++ b/crates/fakecloud-route53/src/service/cidr.rs
@@ -331,7 +331,7 @@ impl Route53Service {
         fn decode_token(t: &str) -> Option<(&str, &str)> {
             let (len_str, rest) = t.split_once(':')?;
             let loc_len: usize = len_str.parse().ok()?;
-            if rest.len() < loc_len + 1 {
+            if rest.len() < loc_len + 1 || !rest.is_char_boundary(loc_len) {
                 return None;
             }
             let (loc, after) = rest.split_at(loc_len);

--- a/crates/fakecloud-route53/src/service/cidr.rs
+++ b/crates/fakecloud-route53/src/service/cidr.rs
@@ -322,9 +322,20 @@ impl Route53Service {
             .get("nexttoken")
             .cloned()
             .unwrap_or_default();
+        // Token encodes `<LocationName>|<CidrBlock>` so the same CIDR
+        // text in two locations resumes at the correct position. Bare
+        // CIDR-only tokens collide and could skip or duplicate entries.
         let start = if nexttoken.is_empty() {
             0
+        } else if let Some((loc, cidr)) = nexttoken.split_once('|') {
+            blocks
+                .iter()
+                .position(|(n, b)| n == loc && b == cidr)
+                .map(|p| p + 1)
+                .unwrap_or(0)
         } else {
+            // Backward-compat: treat legacy CIDR-only tokens as a best-
+            // effort lookup (first match).
             blocks
                 .iter()
                 .position(|(_, b)| b == &nexttoken)
@@ -333,7 +344,7 @@ impl Route53Service {
         };
         let slice: Vec<&(String, String)> = blocks.iter().skip(start).take(max_items).collect();
         let next = if start + slice.len() < blocks.len() {
-            slice.last().map(|(_, b)| b.clone())
+            slice.last().map(|(loc, cidr)| format!("{loc}|{cidr}"))
         } else {
             None
         };

--- a/crates/fakecloud-route53/src/service/cidr.rs
+++ b/crates/fakecloud-route53/src/service/cidr.rs
@@ -193,9 +193,23 @@ impl Route53Service {
             .unwrap_or_default();
         drop(state);
         colls.sort_by(|a, b| a.id.cmp(&b.id));
-        let slice: Vec<&StoredCidrCollection> = colls.iter().take(max_items).collect();
-        let next = if slice.len() < colls.len() {
-            Some(colls[slice.len()].id.clone())
+        let nexttoken = req
+            .query_params
+            .get("nexttoken")
+            .cloned()
+            .unwrap_or_default();
+        let start = if nexttoken.is_empty() {
+            0
+        } else {
+            colls
+                .iter()
+                .position(|c| c.id == nexttoken)
+                .map(|p| p + 1)
+                .unwrap_or(0)
+        };
+        let slice: Vec<&StoredCidrCollection> = colls.iter().skip(start).take(max_items).collect();
+        let next = if start + slice.len() < colls.len() {
+            slice.last().map(|c| c.id.clone())
         } else {
             None
         };
@@ -241,9 +255,23 @@ impl Route53Service {
         drop(state);
         let mut names: Vec<String> = coll.locations.keys().cloned().collect();
         names.sort();
-        let slice: Vec<&String> = names.iter().take(max_items).collect();
-        let next = if slice.len() < names.len() {
-            Some(names[slice.len()].clone())
+        let nexttoken = req
+            .query_params
+            .get("nexttoken")
+            .cloned()
+            .unwrap_or_default();
+        let start = if nexttoken.is_empty() {
+            0
+        } else {
+            names
+                .iter()
+                .position(|n| n == &nexttoken)
+                .map(|p| p + 1)
+                .unwrap_or(0)
+        };
+        let slice: Vec<&String> = names.iter().skip(start).take(max_items).collect();
+        let next = if start + slice.len() < names.len() {
+            slice.last().map(|n| (*n).clone())
         } else {
             None
         };
@@ -289,9 +317,23 @@ impl Route53Service {
             .filter(|(n, _)| location_name.as_ref().is_none_or(|name| name == *n))
             .flat_map(|(n, blocks)| blocks.iter().map(move |b| (n.clone(), b.clone())))
             .collect();
-        let slice: Vec<&(String, String)> = blocks.iter().take(max_items).collect();
-        let next = if slice.len() < blocks.len() {
-            Some(blocks[slice.len()].1.clone())
+        let nexttoken = req
+            .query_params
+            .get("nexttoken")
+            .cloned()
+            .unwrap_or_default();
+        let start = if nexttoken.is_empty() {
+            0
+        } else {
+            blocks
+                .iter()
+                .position(|(_, b)| b == &nexttoken)
+                .map(|p| p + 1)
+                .unwrap_or(0)
+        };
+        let slice: Vec<&(String, String)> = blocks.iter().skip(start).take(max_items).collect();
+        let next = if start + slice.len() < blocks.len() {
+            slice.last().map(|(_, b)| b.clone())
         } else {
             None
         };

--- a/crates/fakecloud-route53/src/service/cidr.rs
+++ b/crates/fakecloud-route53/src/service/cidr.rs
@@ -322,20 +322,31 @@ impl Route53Service {
             .get("nexttoken")
             .cloned()
             .unwrap_or_default();
-        // Token encodes `<LocationName>|<CidrBlock>` so the same CIDR
-        // text in two locations resumes at the correct position. Bare
-        // CIDR-only tokens collide and could skip or duplicate entries.
+        // Token format: `<loc_len>:<location>:<cidr>`. Length-prefixing
+        // the location name keeps the boundary unambiguous when the
+        // location itself contains separators (`|`, `:`, etc).
+        fn encode_token(loc: &str, cidr: &str) -> String {
+            format!("{}:{loc}:{cidr}", loc.len())
+        }
+        fn decode_token(t: &str) -> Option<(&str, &str)> {
+            let (len_str, rest) = t.split_once(':')?;
+            let loc_len: usize = len_str.parse().ok()?;
+            if rest.len() < loc_len + 1 {
+                return None;
+            }
+            let (loc, after) = rest.split_at(loc_len);
+            let cidr = after.strip_prefix(':')?;
+            Some((loc, cidr))
+        }
         let start = if nexttoken.is_empty() {
             0
-        } else if let Some((loc, cidr)) = nexttoken.split_once('|') {
+        } else if let Some((loc, cidr)) = decode_token(&nexttoken) {
             blocks
                 .iter()
                 .position(|(n, b)| n == loc && b == cidr)
                 .map(|p| p + 1)
                 .unwrap_or(0)
         } else {
-            // Backward-compat: treat legacy CIDR-only tokens as a best-
-            // effort lookup (first match).
             blocks
                 .iter()
                 .position(|(_, b)| b == &nexttoken)
@@ -344,7 +355,7 @@ impl Route53Service {
         };
         let slice: Vec<&(String, String)> = blocks.iter().skip(start).take(max_items).collect();
         let next = if start + slice.len() < blocks.len() {
-            slice.last().map(|(loc, cidr)| format!("{loc}|{cidr}"))
+            slice.last().map(|(loc, cidr)| encode_token(loc, cidr))
         } else {
             None
         };

--- a/crates/fakecloud-route53/src/service/dnssec.rs
+++ b/crates/fakecloud-route53/src/service/dnssec.rs
@@ -371,13 +371,15 @@ impl Route53Service {
             .get(&(zone_id.clone(), name.clone()))
             .ok_or_else(|| no_such_key_signing_key(&zone_id, &name))?;
         // Real Route 53 requires Status == INACTIVE before delete.
-        if ksk.status.eq_ignore_ascii_case("ACTIVE") {
+        // ACTION_NEEDED / DELETING / other transient states are also
+        // rejected — only INACTIVE is OK.
+        if !ksk.status.eq_ignore_ascii_case("INACTIVE") {
             return Err(aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidKeySigningKeyStatus",
                 format!(
-                    "KeySigningKey {}/{} must be deactivated before deletion",
-                    zone_id, name
+                    "KeySigningKey {}/{} must be INACTIVE before deletion (status={})",
+                    zone_id, name, ksk.status
                 ),
             ));
         }

--- a/crates/fakecloud-route53/src/service/mod.rs
+++ b/crates/fakecloud-route53/src/service/mod.rs
@@ -445,7 +445,13 @@ fn resolve_routing_policy(
             }
         }
         if let Some(s) = secondary {
-            return rr_values(s);
+            // Only fall through to secondary when it's actually healthy;
+            // returning an unhealthy secondary while the primary is also
+            // unhealthy hands clients a known-broken endpoint instead
+            // of the documented "return primary as last resort".
+            if is_healthy(s, health_checks) {
+                return rr_values(s);
+            }
         }
         return primary.map(|p| rr_values(p)).unwrap_or_default();
     }
@@ -467,9 +473,16 @@ fn resolve_routing_policy(
             .iter()
             .filter(|r| is_healthy(r, health_checks) && r.weight.is_some())
             .collect();
-        let total: i64 = healthy.iter().map(|r| r.weight.unwrap_or(0)).sum();
-        if total == 0 || healthy.is_empty() {
+        if healthy.is_empty() {
             return candidates.first().map(|r| rr_values(r)).unwrap_or_default();
+        }
+        let total: i64 = healthy.iter().map(|r| r.weight.unwrap_or(0)).sum();
+        if total == 0 {
+            // All healthy candidates have weight 0 — uniform random
+            // pick among them rather than always returning the first
+            // candidate (which may be unhealthy).
+            let idx = (subnet_hash(edns0_subnet) as usize) % healthy.len();
+            return rr_values(healthy[idx]);
         }
         let mut pick = (subnet_hash(edns0_subnet) % total as u64) as i64;
         for r in &healthy {

--- a/crates/fakecloud-route53/src/service/traffic_policies.rs
+++ b/crates/fakecloud-route53/src/service/traffic_policies.rs
@@ -614,8 +614,18 @@ impl Route53Service {
         };
         let slice: Vec<&StoredTrafficPolicyInstance> =
             instances.iter().skip(start).take(max_items).collect();
-        let next_marker = if start + slice.len() < instances.len() {
-            slice.last().map(|i| i.name.clone())
+        // Emit all three markers consumed at start: subsequent pages
+        // must echo them so the position lookup matches the same
+        // (hosted-zone, name, type) tuple — otherwise emitting only
+        // the name marker drops the request back to page 1.
+        let next: Option<(String, String, String)> = if start + slice.len() < instances.len() {
+            slice.last().map(|i| {
+                (
+                    i.hosted_zone_id.clone(),
+                    i.name.clone(),
+                    i.traffic_policy_type.clone(),
+                )
+            })
         } else {
             None
         };
@@ -629,15 +639,20 @@ impl Route53Service {
             push_traffic_policy_instance(&mut body, i);
         }
         body.push_str("</TrafficPolicyInstances>");
-        body.push_str(&format!(
-            "<IsTruncated>{}</IsTruncated>",
-            next_marker.is_some()
-        ));
+        body.push_str(&format!("<IsTruncated>{}</IsTruncated>", next.is_some()));
         body.push_str(&format!("<MaxItems>{}</MaxItems>", max_items));
-        if let Some(nm) = &next_marker {
+        if let Some((hz, nm, ty)) = &next {
+            body.push_str(&format!(
+                "<HostedZoneIdMarker>{}</HostedZoneIdMarker>",
+                esc(hz)
+            ));
             body.push_str(&format!(
                 "<TrafficPolicyInstanceNameMarker>{}</TrafficPolicyInstanceNameMarker>",
                 esc(nm)
+            ));
+            body.push_str(&format!(
+                "<TrafficPolicyInstanceTypeMarker>{}</TrafficPolicyInstanceTypeMarker>",
+                esc(ty)
             ));
         }
         body.push_str("</ListTrafficPolicyInstancesResponse>");

--- a/crates/fakecloud-route53/src/service/traffic_policies.rs
+++ b/crates/fakecloud-route53/src/service/traffic_policies.rs
@@ -580,9 +580,42 @@ impl Route53Service {
             .unwrap_or_default();
         drop(state);
         instances.sort_by(|a, b| a.id.cmp(&b.id));
-        let slice: Vec<&StoredTrafficPolicyInstance> = instances.iter().take(max_items).collect();
-        let next_marker = if slice.len() < instances.len() {
-            Some(instances[slice.len()].name.clone())
+        // Honor incoming pagination markers. Without consuming
+        // `hostedzoneidmarker` / `trafficpolicyinstancenamemarker` /
+        // `trafficpolicyinstancetypemarker`, follow-up pages
+        // repeatedly returned the first page.
+        let hz_marker = req
+            .query_params
+            .get("hostedzoneidmarker")
+            .cloned()
+            .unwrap_or_default();
+        let name_marker = req
+            .query_params
+            .get("trafficpolicyinstancenamemarker")
+            .cloned()
+            .unwrap_or_default();
+        let type_marker = req
+            .query_params
+            .get("trafficpolicyinstancetypemarker")
+            .cloned()
+            .unwrap_or_default();
+        let start = if hz_marker.is_empty() && name_marker.is_empty() && type_marker.is_empty() {
+            0
+        } else {
+            instances
+                .iter()
+                .position(|i| {
+                    i.hosted_zone_id == hz_marker
+                        && i.name == name_marker
+                        && i.traffic_policy_type == type_marker
+                })
+                .map(|p| p + 1)
+                .unwrap_or(0)
+        };
+        let slice: Vec<&StoredTrafficPolicyInstance> =
+            instances.iter().skip(start).take(max_items).collect();
+        let next_marker = if start + slice.len() < instances.len() {
+            slice.last().map(|i| i.name.clone())
         } else {
             None
         };


### PR DESCRIPTION
7 P2 fixes for route53.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pagination (including length‑prefixed CIDR tokens with safe decoding and traffic‑policy markers), DNSSEC deletion safety, and routing behavior in the Route 53 service to match AWS behavior and resolve 7 P2 issues. Improves correctness for listing APIs and traffic selection.

- **Bug Fixes**
  - Pagination: CIDR list endpoints now consume `nexttoken`; `ListCidrBlocks` uses length‑prefixed `<len>:<location>:<cidr>` tokens with fallback to legacy CIDR‑only tokens, and validates UTF‑8 boundaries when decoding. Traffic policy instances consume `hostedzoneidmarker`, `trafficpolicyinstancenamemarker`, and `trafficpolicyinstancetypemarker`, and emit all three markers to avoid resets to page 1.
  - DNSSEC: `DeleteKeySigningKey` only allows deletion when status is `INACTIVE`; all other states are rejected with a clear error.
  - Routing: Failover returns secondary only if it’s healthy; if both are unhealthy, return primary as last resort. Weighted routing with total weight 0 now picks uniformly among healthy records using subnet hash.

<sup>Written for commit c9f74d776ee83a9ac738e50e4f3fe8b1f81a8943. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1525?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

