### PR TITLE
fix(elasticache): 4 Cubic P2 fixes on migration + replication-group teardown

### DIFF
--- a/crates/fakecloud-elasticache/src/service/mod.rs
+++ b/crates/fakecloud-elasticache/src/service/mod.rs
@@ -470,7 +470,6 @@ fn is_mutating_action(action: &str) -> bool {
             | "DescribeServiceUpdates"
             | "DescribeUpdateActions"
             | "ListAllowedNodeTypeModifications"
-            | "TestMigration"
     )
 }
 
@@ -605,21 +604,27 @@ impl ElastiCacheService {
         let id = required_query_param(request, "ReplicationGroupId")?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
-        let migration = state.migrations.get_mut(&id).ok_or_else(|| {
-            AwsServiceError::aws_error(
+        // Validate all prerequisites BEFORE mutating migration.status —
+        // the prior order flipped status to "complete" and only then
+        // surfaced ReplicationGroupNotFoundFault on the lookup, leaving
+        // a stale "complete" status on the migration.
+        if !state.migrations.contains_key(&id) {
+            return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "ReplicationGroupNotUnderMigrationFault",
                 format!("ReplicationGroup {id} is not currently being migrated."),
-            )
-        })?;
-        migration.status = "complete".to_string();
-        let group = state.replication_groups.get(&id).ok_or_else(|| {
-            AwsServiceError::aws_error(
+            ));
+        }
+        if !state.replication_groups.contains_key(&id) {
+            return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "ReplicationGroupNotFoundFault",
                 format!("ReplicationGroup {id} not found."),
-            )
-        })?;
+            ));
+        }
+        let migration = state.migrations.get_mut(&id).expect("checked above");
+        migration.status = "complete".to_string();
+        let group = state.replication_groups.get(&id).expect("checked above");
         let region = state.region.clone();
         let xml = replication_group_xml(group, &region);
         Ok(AwsResponse::xml(

--- a/crates/fakecloud-elasticache/src/service/replication.rs
+++ b/crates/fakecloud-elasticache/src/service/replication.rs
@@ -515,14 +515,20 @@ impl ElastiCacheService {
                 )
             })?;
 
+        // Stop runtime containers for any primary we're about to drop —
+        // otherwise the Docker containers + their port bindings leak
+        // until process exit and a later CreateReplicationGroup hits
+        // port conflicts. Collect first because container teardown
+        // releases the state lock asynchronously.
+        let mut to_drop: Vec<String> = Vec::new();
         for member in &group.members {
             if !retain_primary && member.role == "primary" {
-                // Delete the primary replication group when RetainPrimaryReplicationGroup=false
                 if let Some(rg) = state
                     .replication_groups
                     .remove(&member.replication_group_id)
                 {
                     state.tags.remove(&rg.arn);
+                    to_drop.push(member.replication_group_id.clone());
                 }
             } else if let Some(replication_group) = state
                 .replication_groups
@@ -530,6 +536,16 @@ impl ElastiCacheService {
             {
                 replication_group.global_replication_group_id = None;
                 replication_group.global_replication_group_role = None;
+            }
+        }
+        if !to_drop.is_empty() {
+            if let Some(runtime) = self.runtime.clone() {
+                let to_drop = to_drop.clone();
+                tokio::spawn(async move {
+                    for id in to_drop {
+                        runtime.stop_container(&id).await;
+                    }
+                });
             }
         }
 
@@ -787,7 +803,15 @@ impl ElastiCacheService {
                 group.log_delivery_configurations = new_log_delivery_configurations;
             }
             if remove_user_groups == Some(true) {
-                group.user_group_ids.clear();
+                let cleared = std::mem::take(&mut group.user_group_ids);
+                // Drop the reverse pointer too — otherwise
+                // DescribeUserGroups keeps reporting this replication
+                // group as a member after it was detached.
+                for ug_id in &cleared {
+                    if let Some(ug) = state.user_groups.get_mut(ug_id) {
+                        ug.replication_groups.retain(|r| r != &replication_group_id);
+                    }
+                }
             }
             // Add / remove user-group ids on the replication group itself.
             // Skipped when RemoveUserGroups already cleared the list above only


### PR DESCRIPTION
4 P2 fixes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four P2 issues in ElastiCache migration and replication-group teardown. Prevents stale migration state, leaked containers, and stale user-group memberships; also treats TestMigration as a mutating action.

- **Bug Fixes**
  - Treat TestMigration as mutating so state snapshots run.
  - Validate migration and replication group exist before setting status=complete to avoid stale "complete" on errors.
  - When RetainPrimaryReplicationGroup=false, stop runtime containers for dropped primaries to prevent Docker port leaks and future port conflicts.
  - With RemoveUserGroups=true, also remove reverse links in user groups so DescribeUserGroups no longer reports detached memberships.

<sup>Written for commit 11299cada44b2b3f2efb331546ba31f5c7ebdfd9. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1526?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

