### PR TITLE
fix(apigatewayv2): 2 Cubic P2 fixes (ipAddressType, custom-domain path normalize)

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/service/apis.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/apis.rs
@@ -39,16 +39,20 @@ impl ApiGatewayV2Service {
         }
         let protocol_type = protocol_type.to_string();
 
-        // IpAddressType is an optional enum: ipv4 | dualstack.
-        if let Some(ip) = body.get("ipAddressType").and_then(|v| v.as_str()) {
-            if ip != "ipv4" && ip != "dualstack" {
+        // IpAddressType is an optional enum: ipv4 | dualstack. Capture
+        // it now so the persisted HttpApi reflects the request — the
+        // prior code validated and dropped it on the floor.
+        let requested_ip_type = match body.get("ipAddressType").and_then(|v| v.as_str()) {
+            Some(ip) if ip != "ipv4" && ip != "dualstack" => {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "BadRequestException",
                     format!("Invalid ipAddressType: {}", ip),
                 ));
             }
-        }
+            Some(ip) => Some(ip.to_string()),
+            None => None,
+        };
 
         let description = body["description"].as_str().map(|s| s.to_string());
         let tags = body["tags"].as_object().map(|m| {
@@ -76,6 +80,9 @@ impl ApiGatewayV2Service {
         let mut api = HttpApi::new(api_id, name, description, tags, region);
         api.cors_configuration = cors_configuration;
         api.protocol_type = protocol_type.clone();
+        if let Some(ip) = requested_ip_type {
+            api.ip_address_type = ip;
+        }
         if protocol_type == "WEBSOCKET" {
             // WebSocket APIs use a body-based selection expression by default
             // and have no implicit api-key header selector.

--- a/crates/fakecloud-apigatewayv2/src/service/mod.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/mod.rs
@@ -554,6 +554,15 @@ fn resolve_custom_domain(
     }
 
     best.map(|(api_id, stage, segs, resource_path)| {
+        // Custom-domain strip can leave an empty resource_path when the
+        // request exactly matches the base path. Normalize to "/" so
+        // downstream route matching sees a valid path instead of an
+        // empty string.
+        let resource_path = if resource_path.is_empty() {
+            "/".to_string()
+        } else {
+            resource_path
+        };
         (api_id.to_string(), stage.to_string(), segs, resource_path)
     })
 }


### PR DESCRIPTION
2 P2 fixes. Stage P2s already covered by PR #1483.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two P2 issues in `fakecloud-apigatewayv2`: we now persist a validated `ipAddressType` on HTTP APIs and normalize custom-domain base path matches to "/" to avoid empty paths breaking routing.

- **Bug Fixes**
  - Persist `ipAddressType` ("ipv4" or "dualstack") on `HttpApi` after validation; previously it was ignored.
  - When a custom-domain base path exactly matches, normalize the stripped path to "/" so downstream route matching works.

<sup>Written for commit d12e45e42b92e1222885e2e02f21eb560c15cda6. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1527?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

