### PR TITLE
fix: 19 Cubic P2 fixes across apigateway/athena/bedrock/cfn/conformance/ddb/ecr/ecs/iam/s3/sqs

### DIFF
--- a/crates/fakecloud-apigateway/src/data_plane/routing.rs
+++ b/crates/fakecloud-apigateway/src/data_plane/routing.rs
@@ -94,7 +94,10 @@ pub(super) fn extract_lambda_arn(uri: &str) -> Option<String> {
         return None;
     }
     let prefix = uri.split("/functions/").nth(1)?;
-    let arn = prefix.trim_end_matches("/invocations");
+    // Require the `/invocations` suffix explicitly. Without this check,
+    // a malformed URI like `.../functions/<arn>` resolved to the bare
+    // ARN and AWS-shaped 4xx wasn't surfaced.
+    let arn = prefix.strip_suffix("/invocations")?;
     Some(arn.to_string())
 }
 

--- a/crates/fakecloud-athena/src/service/named_queries.rs
+++ b/crates/fakecloud-athena/src/service/named_queries.rs
@@ -130,8 +130,12 @@ impl AthenaService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let id = require_str(&body, "NamedQueryId")?;
-        let name = require_str(&body, "Name")?;
-        let query_string = require_str(&body, "QueryString")?;
+        // Match the same length bounds enforced on CreateNamedQuery so
+        // oversized inputs can't bypass API constraints via the update
+        // path.
+        let name = validate_required_string_len(&body, "Name", 1, 128)?;
+        let query_string = validate_required_string_len(&body, "QueryString", 1, 262144)?;
+        validate_opt_string_len(&body, "Description", 1, 1024)?;
         let description = body
             .get("Description")
             .and_then(Value::as_str)

--- a/crates/fakecloud-athena/src/service/notebooks.rs
+++ b/crates/fakecloud-athena/src/service/notebooks.rs
@@ -305,12 +305,22 @@ impl AthenaService {
             .get("NextToken")
             .and_then(Value::as_str)
             .map(str::to_owned);
+        let state_filter = body
+            .get("StateFilter")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         let mut all: Vec<Session> = account
             .sessions
             .values()
             .filter(|s| s.work_group == work_group)
+            .filter(|s| {
+                state_filter
+                    .as_deref()
+                    .map(|sf| s.state == sf)
+                    .unwrap_or(true)
+            })
             .cloned()
             .collect();
         all.sort_by(|a, b| a.session_id.cmp(&b.session_id));
@@ -503,12 +513,22 @@ impl AthenaService {
             .get("NextToken")
             .and_then(Value::as_str)
             .map(str::to_owned);
+        let state_filter = body
+            .get("StateFilter")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         let mut all: Vec<Calculation> = account
             .calculations
             .values()
             .filter(|c| c.session_id == session_id)
+            .filter(|c| {
+                state_filter
+                    .as_deref()
+                    .map(|sf| c.state == sf)
+                    .unwrap_or(true)
+            })
             .cloned()
             .collect();
         all.sort_by(|a, b| a.calculation_execution_id.cmp(&b.calculation_execution_id));

--- a/crates/fakecloud-bedrock-agent/src/service/knowledge_bases.rs
+++ b/crates/fakecloud-bedrock-agent/src/service/knowledge_bases.rs
@@ -143,6 +143,18 @@ impl BedrockAgentService {
         if !state.knowledge_bases.contains_key(&kb_id) {
             return Err(not_found(format!("KnowledgeBase {kb_id} not found")));
         }
+        // Validate the data source exists AND belongs to this KB before
+        // starting the job. Without the ownership check, ingestion jobs
+        // could be started under one KB referencing another KB's data
+        // source.
+        match state.data_sources.get(&ds_id) {
+            Some(ds) if ds.knowledge_base_id == kb_id => {}
+            _ => {
+                return Err(not_found(format!(
+                    "DataSource {ds_id} not found in KnowledgeBase {kb_id}"
+                )));
+            }
+        }
         let job = IngestionJob {
             ingestion_job_id: job_id.clone(),
             knowledge_base_id: kb_id.clone(),

--- a/crates/fakecloud-cloudformation/src/template/conditions.rs
+++ b/crates/fakecloud-cloudformation/src/template/conditions.rs
@@ -75,8 +75,8 @@ pub(super) fn eval_condition_expr(
         return Ok(a == b);
     }
     if let Some(args) = map.get("Fn::And").and_then(|v| v.as_array()) {
-        if !(1..=10).contains(&args.len()) {
-            return Err("Fn::And requires between 1 and 10 conditions".to_string());
+        if !(2..=10).contains(&args.len()) {
+            return Err("Fn::And requires between 2 and 10 conditions".to_string());
         }
         for a in args {
             if !eval_condition_expr(a, conds, parameters, memo, in_progress)? {
@@ -86,8 +86,8 @@ pub(super) fn eval_condition_expr(
         return Ok(true);
     }
     if let Some(args) = map.get("Fn::Or").and_then(|v| v.as_array()) {
-        if !(1..=10).contains(&args.len()) {
-            return Err("Fn::Or requires between 1 and 10 conditions".to_string());
+        if !(2..=10).contains(&args.len()) {
+            return Err("Fn::Or requires between 2 and 10 conditions".to_string());
         }
         for a in args {
             if eval_condition_expr(a, conds, parameters, memo, in_progress)? {

--- a/crates/fakecloud-cloudformation/src/template/intrinsics.rs
+++ b/crates/fakecloud-cloudformation/src/template/intrinsics.rs
@@ -578,6 +578,12 @@ pub(super) fn compute_cidr_subnets(
     count: u32,
     cidr_bits: u32,
 ) -> Option<Vec<String>> {
+    // CloudFormation Fn::Cidr documents `count` in 1..=256. Reject
+    // out-of-range values before allocating to avoid oversized Vec
+    // construction on bad input.
+    if !(1..=256).contains(&count) {
+        return None;
+    }
     let (ip_str, prefix_str) = ip_block.split_once('/')?;
     let prefix: u32 = prefix_str.parse().ok()?;
     let ip: std::net::Ipv4Addr = ip_str.parse().ok()?;

--- a/crates/fakecloud-conformance/src/probe/rest_request.rs
+++ b/crates/fakecloud-conformance/src/probe/rest_request.rs
@@ -449,7 +449,8 @@ pub(super) fn rest_request_config(
             "CreateBucket" => (reqwest::Method::PUT, format!("/{}", BUCKET), None),
             "DeleteBucket" => (reqwest::Method::DELETE, format!("/{}", BUCKET), None),
             "HeadBucket" => (reqwest::Method::HEAD, format!("/{}", BUCKET), None),
-            "ListObjects" | "ListObjectsV2" => (
+            "ListObjects" => (reqwest::Method::GET, format!("/{}", BUCKET), None),
+            "ListObjectsV2" => (
                 reqwest::Method::GET,
                 format!("/{}", BUCKET),
                 Some("list-type=2".to_string()),

--- a/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
@@ -173,8 +173,19 @@ pub(crate) fn evaluate_single_key_condition(
         return key_cond_begins_with(rest, item, expr_attr_names, expr_attr_values);
     }
 
-    if let Some(between_pos) = part.to_ascii_uppercase().find("BETWEEN") {
-        return key_cond_between(part, between_pos, item, expr_attr_names, expr_attr_values);
+    // Require BETWEEN to sit on a word boundary so identifiers like
+    // `my_between_attr` or placeholders containing `between` aren't
+    // misparsed as range conditions.
+    let upper = part.to_ascii_uppercase();
+    if let Some(between_pos) = upper.find(" BETWEEN ") {
+        // Adjust for the leading space so callers see the keyword start.
+        return key_cond_between(
+            part,
+            between_pos + 1,
+            item,
+            expr_attr_names,
+            expr_attr_values,
+        );
     }
 
     key_cond_simple_comparison(part, item, expr_attr_names, expr_attr_values)

--- a/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
@@ -176,16 +176,24 @@ pub(crate) fn evaluate_single_key_condition(
     // Require BETWEEN to sit on a word boundary so identifiers like
     // `my_between_attr` or placeholders containing `between` aren't
     // misparsed as range conditions.
+    // Match `BETWEEN` only when bracketed by ASCII whitespace on both
+    // sides so tabs / newlines / multiple spaces in user-supplied
+    // expressions are accepted, while identifiers like `my_between` are
+    // not. Literal-space matching here would falsely reject valid
+    // multi-line expressions.
     let upper = part.to_ascii_uppercase();
-    if let Some(between_pos) = upper.find(" BETWEEN ") {
-        // Adjust for the leading space so callers see the keyword start.
-        return key_cond_between(
-            part,
-            between_pos + 1,
-            item,
-            expr_attr_names,
-            expr_attr_values,
-        );
+    let bytes = upper.as_bytes();
+    let between_pos = (0..bytes.len().saturating_sub(7)).find(|&i| {
+        bytes[i..].starts_with(b"BETWEEN")
+            && i > 0
+            && (bytes[i - 1] as char).is_ascii_whitespace()
+            && bytes
+                .get(i + 7)
+                .map(|c| (*c as char).is_ascii_whitespace())
+                .unwrap_or(false)
+    });
+    if let Some(between_pos) = between_pos {
+        return key_cond_between(part, between_pos, item, expr_attr_names, expr_attr_values);
     }
 
     key_cond_simple_comparison(part, item, expr_attr_names, expr_attr_values)

--- a/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
@@ -360,14 +360,20 @@ pub(crate) fn parse_update_clauses(expr: &str) -> Vec<(UpdateAction, Vec<String>
     let upper = expr.to_ascii_uppercase();
     let mut positions: Vec<(usize, UpdateAction)> = Vec::new();
 
+    // Identifiers in DynamoDB expressions can contain underscores
+    // (`my_set_field`) and `#`/`:` placeholder prefixes; treating any
+    // non-alphanumeric as a keyword boundary mis-parses those as
+    // genuine SET/ADD/REMOVE/DELETE clauses. Require an ASCII whitespace
+    // boundary on each side so `set foo = ...` is a keyword, but
+    // `:set_arg`, `my_set_field`, `#set` are not.
+    let is_boundary = |b: u8| b == b' ' || b == b'\t' || b == b'\n' || b == b'\r';
     for &(kw, action) in UpdateAction::KEYWORDS {
         let mut search_from = 0;
         while let Some(pos) = upper[search_from..].find(kw) {
             let abs_pos = search_from + pos;
-            let before_ok = abs_pos == 0 || !expr.as_bytes()[abs_pos - 1].is_ascii_alphanumeric();
+            let before_ok = abs_pos == 0 || is_boundary(expr.as_bytes()[abs_pos - 1]);
             let after_pos = abs_pos + kw.len();
-            let after_ok =
-                after_pos >= expr.len() || !expr.as_bytes()[after_pos].is_ascii_alphanumeric();
+            let after_ok = after_pos >= expr.len() || is_boundary(expr.as_bytes()[after_pos]);
             if before_ok && after_ok {
                 positions.push((abs_pos, action));
             }

--- a/crates/fakecloud-ecr/src/service/lifecycle.rs
+++ b/crates/fakecloud-ecr/src/service/lifecycle.rs
@@ -110,7 +110,20 @@ impl EcrService {
         let name = req_str(&body, "repositoryName")?.to_string();
         let account = target_account_id(request, &body);
         let policy = match opt_str(&body, "lifecyclePolicyText") {
-            Some(s) => s.to_string(),
+            Some(s) => {
+                // Validate the supplied policy is JSON before pretending the
+                // preview succeeded; otherwise malformed input lands on
+                // `lifecycle_policy_preview` and downstream GetLifecyclePolicyPreview
+                // returns a bogus "successful" result.
+                if serde_json::from_str::<serde_json::Value>(s).is_err() {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterException",
+                        "lifecyclePolicyText is not valid JSON",
+                    ));
+                }
+                s.to_string()
+            }
             None => {
                 let accounts = self.state.read();
                 let state = accounts

--- a/crates/fakecloud-ecr/src/service/scanning.rs
+++ b/crates/fakecloud-ecr/src/service/scanning.rs
@@ -204,7 +204,15 @@ impl EcrService {
                     "repositoryArn": repo.repository_arn,
                     "repositoryName": n,
                     "scanOnPush": repo.image_scanning_configuration.scan_on_push,
-                    "scanFrequency": "SCAN_ON_PUSH",
+                    // Real ECR derives scanFrequency from the
+                    // repository's scanOnPush flag: SCAN_ON_PUSH when
+                    // set, MANUAL otherwise. Hardcoding SCAN_ON_PUSH
+                    // surfaced inconsistent responses.
+                    "scanFrequency": if repo.image_scanning_configuration.scan_on_push {
+                        "SCAN_ON_PUSH"
+                    } else {
+                        "MANUAL"
+                    },
                     "appliedScanFilters": [],
                 })),
                 None => failures.push(json!({

--- a/crates/fakecloud-ecs/src/runtime/secrets.rs
+++ b/crates/fakecloud-ecs/src/runtime/secrets.rs
@@ -13,9 +13,22 @@ impl EcsRuntime {
             let accounts = state.read();
             let sm = accounts.get(account_id)?;
             // ARN shape: arn:aws:secretsmanager:<region>:<acct>:secret:<name>-<6char>
+            // ECS also allows trailing `:json-key:version-stage:version-id`
+            // (https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_ecs.html).
+            // Strip those trailing segments before parsing the secret name.
+            let mut arn_tail = value_from.rsplit(":secret:").next()?;
+            // Drop any of the up-to-3 trailing colon-separated optional
+            // selectors (json-key, version-stage, version-id) that ECS
+            // tacks on after the secret name.
+            for _ in 0..3 {
+                if let Some((head, _)) = arn_tail.rsplit_once(':') {
+                    arn_tail = head;
+                } else {
+                    break;
+                }
+            }
             // Stored key is the secret name (no suffix). Strip the
             // AWS-generated 6-char suffix when comparing.
-            let arn_tail = value_from.rsplit(":secret:").next()?;
             let name = arn_tail
                 .rsplit_once('-')
                 .map(|(n, _)| n)

--- a/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
+++ b/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
@@ -268,7 +268,7 @@ impl EcsRuntime {
                     .wait_for_depends_on(upstream, dep.condition, upstream_has_health_check)
                     .await
                 {
-                    self.cleanup_partial_start(&started);
+                    self.cleanup_partial_start(&started, task_id);
                     return Err(err);
                 }
             }
@@ -284,12 +284,12 @@ impl EcsRuntime {
             cmd.args(&argv);
             let run_out = cmd.output().await.map_err(|e| {
                 // Cleanup already-started containers on launch failure.
-                self.cleanup_partial_start(&started);
+                self.cleanup_partial_start(&started, task_id);
                 RuntimeError::ContainerStart(e.to_string())
             })?;
             if !run_out.status.success() {
                 let err = String::from_utf8_lossy(&run_out.stderr).to_string();
-                self.cleanup_partial_start(&started);
+                self.cleanup_partial_start(&started, task_id);
                 return Err(RuntimeError::ContainerStart(err));
             }
             let container_id = String::from_utf8_lossy(&run_out.stdout).trim().to_string();
@@ -587,37 +587,22 @@ impl EcsRuntime {
 
     /// Best-effort cleanup of containers we already started when a later
     /// container in the task failed to launch. Without this, half-launched
-    /// tasks leak docker containers.
-    pub(super) fn cleanup_partial_start(&self, started: &[RunningContainer]) {
+    /// tasks leak docker containers. `task_id` mirrors the value used at
+    /// network creation so `network rm` targets the right name —
+    /// deriving it from a container_id prefix was wrong (container ids
+    /// are docker-assigned, not task-shaped).
+    pub(super) fn cleanup_partial_start(&self, started: &[RunningContainer], task_id: &str) {
         let cli = self.cli.clone();
         let ids: Vec<String> = started.iter().map(|c| c.container_id.clone()).collect();
-        // Also tear down any per-task awsvpc network we created; without
-        // this, failed launches leak `fakecloud-ecs-<task>` networks
-        // until process exit. We only know the task name through the
-        // running containers' names — they all share the same prefix.
-        let network = started
-            .first()
-            .and_then(|c| {
-                c.container_id
-                    .split('-')
-                    .next()
-                    .map(|s| format!("fakecloud-ecs-{s}"))
-            })
-            .or_else(|| {
-                started
-                    .first()
-                    .map(|c| format!("fakecloud-ecs-{}", c.container_id))
-            });
+        let network = format!("fakecloud-ecs-{task_id}");
         tokio::spawn(async move {
             for id in ids {
                 let _ = Command::new(&cli).args(["rm", "-f", &id]).output().await;
             }
-            if let Some(net) = network {
-                let _ = Command::new(&cli)
-                    .args(["network", "rm", &net])
-                    .output()
-                    .await;
-            }
+            let _ = Command::new(&cli)
+                .args(["network", "rm", &network])
+                .output()
+                .await;
         });
     }
 

--- a/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
+++ b/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
@@ -591,9 +591,32 @@ impl EcsRuntime {
     pub(super) fn cleanup_partial_start(&self, started: &[RunningContainer]) {
         let cli = self.cli.clone();
         let ids: Vec<String> = started.iter().map(|c| c.container_id.clone()).collect();
+        // Also tear down any per-task awsvpc network we created; without
+        // this, failed launches leak `fakecloud-ecs-<task>` networks
+        // until process exit. We only know the task name through the
+        // running containers' names — they all share the same prefix.
+        let network = started
+            .first()
+            .and_then(|c| {
+                c.container_id
+                    .split('-')
+                    .next()
+                    .map(|s| format!("fakecloud-ecs-{s}"))
+            })
+            .or_else(|| {
+                started
+                    .first()
+                    .map(|c| format!("fakecloud-ecs-{}", c.container_id))
+            });
         tokio::spawn(async move {
             for id in ids {
                 let _ = Command::new(&cli).args(["rm", "-f", &id]).output().await;
+            }
+            if let Some(net) = network {
+                let _ = Command::new(&cli)
+                    .args(["network", "rm", &net])
+                    .output()
+                    .await;
             }
         });
     }

--- a/crates/fakecloud-iam/src/sts_service/caller.rs
+++ b/crates/fakecloud-iam/src/sts_service/caller.rs
@@ -29,8 +29,11 @@ impl StsService {
         // (the `test` root bypass and similar smoke probes) by falling
         // back to root only when an Authorization header was present
         // but didn't resolve to a stored principal.
-        let has_auth_header = req.headers.contains_key("authorization")
-            || req.headers.contains_key("x-amz-security-token");
+        // Accepting `x-amz-security-token` alone lets an unauthenticated
+        // request pass this guard — that header is metadata that
+        // accompanies sigv4 auth, not a substitute for it. Require an
+        // actual Authorization header.
+        let has_auth_header = req.headers.contains_key("authorization");
         if !has_auth_header {
             return Err(AwsServiceError::aws_error(
                 StatusCode::FORBIDDEN,

--- a/crates/fakecloud-iam/src/sts_service/federation.rs
+++ b/crates/fakecloud-iam/src/sts_service/federation.rs
@@ -168,7 +168,11 @@ impl StsService {
             "kid": "fakecloud-sts-stub",
         });
         let mut payload = serde_json::json!({
-            "iss": format!("https://sts.{}.amazonaws.com", req.region),
+            // Partition-aware iss: AWS GovCloud and China regions use
+            // different STS hostnames; hardcoding `.amazonaws.com`
+            // produces issuer values that OIDC providers in those
+            // partitions won't trust.
+            "iss": sts_issuer_url(&req.region),
             "sub": principal_arn,
             "aud": audiences,
             "iat": issued_at.timestamp(),

--- a/crates/fakecloud-iam/src/sts_service/mod.rs
+++ b/crates/fakecloud-iam/src/sts_service/mod.rs
@@ -206,6 +206,19 @@ impl AwsService for StsService {
     }
 }
 
+/// Partition-aware STS issuer URL for JWT `iss` claims. Mirrors the
+/// `*.amazonaws.com.cn` quirk in China and the regional STS
+/// endpoints AWS publishes in the GovCloud and ISO partitions.
+pub(super) fn sts_issuer_url(region: &str) -> String {
+    let suffix = match partition_for_region(region) {
+        "aws-cn" => "amazonaws.com.cn",
+        // GovCloud + ISO partitions still use `.amazonaws.com` for
+        // their public STS endpoints today.
+        _ => "amazonaws.com",
+    };
+    format!("https://sts.{region}.{suffix}")
+}
+
 /// Get the AWS partition from a region string.
 fn partition_for_region(region: &str) -> &str {
     if region.starts_with("cn-") {

--- a/crates/fakecloud-s3/src/service/config/cors.rs
+++ b/crates/fakecloud-s3/src/service/config/cors.rs
@@ -41,7 +41,13 @@ impl S3Service {
                 }
                 remaining = &after[end + 16..];
             } else {
-                break;
+                // Opening tag without a matching closer is malformed
+                // XML; reject instead of saving a half-parsed config.
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "MalformedXML",
+                    "The XML you provided was not well-formed or did not validate against our published schema",
+                ));
             }
         }
 

--- a/crates/fakecloud-s3/src/service/config/encryption.rs
+++ b/crates/fakecloud-s3/src/service/config/encryption.rs
@@ -31,15 +31,35 @@ impl S3Service {
             .buckets
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        // Normalize: add BucketKeyEnabled=false to each Rule if missing
-        let normalized = if body_str.contains("<Rule>") && !body_str.contains("<BucketKeyEnabled>")
-        {
-            body_str.replace(
-                "</Rule>",
-                "<BucketKeyEnabled>false</BucketKeyEnabled></Rule>",
-            )
-        } else {
-            body_str
+        // Normalize: add BucketKeyEnabled=false to each <Rule> that
+        // is missing one. The prior whole-body check skipped this when
+        // a different rule already had BucketKeyEnabled, so mixed
+        // configs would drop the default on rules that needed it.
+        let normalized = {
+            let mut out = String::with_capacity(body_str.len() + 64);
+            let mut cursor = 0usize;
+            while let Some(start) = body_str[cursor..].find("<Rule>") {
+                let abs_start = cursor + start;
+                out.push_str(&body_str[cursor..abs_start]);
+                let rule_open = abs_start;
+                let rest = &body_str[rule_open..];
+                if let Some(end_rel) = rest.find("</Rule>") {
+                    let rule_block = &rest[..end_rel];
+                    let mut rule_out = rule_block.to_string();
+                    if !rule_block.contains("<BucketKeyEnabled>") {
+                        rule_out.push_str("<BucketKeyEnabled>false</BucketKeyEnabled>");
+                    }
+                    rule_out.push_str("</Rule>");
+                    out.push_str(&rule_out);
+                    cursor = rule_open + end_rel + "</Rule>".len();
+                } else {
+                    out.push_str(rest);
+                    cursor = body_str.len();
+                    break;
+                }
+            }
+            out.push_str(&body_str[cursor..]);
+            out
         };
         b.encryption_config = Some(normalized.clone());
         self.store

--- a/crates/fakecloud-s3/src/service/config/ownership.rs
+++ b/crates/fakecloud-s3/src/service/config/ownership.rs
@@ -9,7 +9,17 @@ impl S3Service {
         req: &AwsRequest,
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        // Reject non-UTF-8 bodies instead of silently coercing to ""
+        // and erasing the stored ownership config.
+        let body_str = std::str::from_utf8(&req.body)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "MalformedXML",
+                    "PutBucketOwnershipControls body is not valid UTF-8",
+                )
+            })?
+            .to_string();
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);
         let b = state

--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -721,6 +721,17 @@ impl SqsService {
             .ok_or_else(|| missing_param("ReceiptHandle"))?;
         let visibility_timeout = val_as_i64(&body["VisibilityTimeout"])
             .ok_or_else(|| missing_param("VisibilityTimeout"))?;
+        // AWS limits VisibilityTimeout to 0..=43200 seconds (12 h).
+        // Anything outside that range is InvalidParameterValue.
+        if !(0..=43200).contains(&visibility_timeout) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!(
+                    "VisibilityTimeout {visibility_timeout} is invalid. Reason: Must be between 0 and 43200 seconds."
+                ),
+            ));
+        }
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);

--- a/crates/fakecloud-sqs/src/service/mod.rs
+++ b/crates/fakecloud-sqs/src/service/mod.rs
@@ -322,13 +322,35 @@ impl AwsService for SqsService {
             "CreateQueue" | "TagQueue" => {
                 let body = parse_body(request);
                 let mut tags = std::collections::HashMap::new();
-                // Both CreateQueue and TagQueue send tags as JSON objects
+                // JSON-protocol clients send tags as objects.
                 for field in &["tags", "Tags"] {
                     if let Some(obj) = body[field].as_object() {
                         for (k, v) in obj {
                             if let Some(val) = v.as_str() {
                                 tags.insert(k.clone(), val.to_string());
                             }
+                        }
+                    }
+                }
+                // Query-protocol clients flatten tags into `Tag.N.Key` /
+                // `Tag.N.Value` query params (CreateQueue) or
+                // `Tags.member.N.Key` / `.Value` (TagQueue). Without
+                // walking those, IAM tag conditions evaluate against
+                // an empty tag set.
+                for prefix in &["Tag.", "Tags.member.", "tags.member.", "tag."] {
+                    let mut idx = 1usize;
+                    loop {
+                        let key_param = format!("{prefix}{idx}.Key");
+                        let val_param = format!("{prefix}{idx}.Value");
+                        match (
+                            request.query_params.get(&key_param),
+                            request.query_params.get(&val_param),
+                        ) {
+                            (Some(k), Some(v)) => {
+                                tags.insert(k.clone(), v.clone());
+                                idx += 1;
+                            }
+                            _ => break,
                         }
                     }
                 }


### PR DESCRIPTION
Bulk P2 fixes across small services. dynamodb paths alias-dot + PartiQL is_mutating deferred.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 19 P2 issues across API Gateway, Athena, Bedrock, CloudFormation, DynamoDB, ECR, ECS, IAM, S3, and SQS to better match AWS behavior, tighten validation, and prevent resource leaks.

- **Bug Fixes**
  - API Gateway: require “/invocations” suffix when extracting Lambda ARNs.
  - Athena: enforce UpdateNamedQuery string lengths; add StateFilter to ListSessions and ListCalculationExecutions.
  - Bedrock Agent: verify data source belongs to the knowledge base before starting ingestion.
  - CloudFormation: require 2–10 operands for Fn::And/Or; Fn::Cidr validates count in 1–256.
  - Conformance: route ListObjects (v1) without list-type; ListObjectsV2 requires list-type=2.
  - DynamoDB: detect BETWEEN only on ASCII‑whitespace boundaries; parse SET/ADD/REMOVE/DELETE only on whitespace boundaries.
  - ECR: validate lifecyclePolicyText as JSON for previews; derive scanFrequency from scanOnPush.
  - ECS: support Secrets Manager ARN selectors in valueFrom; clean up per-task awsvpc networks on failed starts using task_id.
  - IAM STS: GetCallerIdentity requires Authorization header; federation JWT iss uses partition‑aware STS URL.
  - S3: CORS parser rejects unmatched tags (MalformedXML); encryption adds BucketKeyEnabled=false per <Rule>; ownership rejects non‑UTF‑8 bodies.
  - SQS: ChangeMessageVisibility validates 0–43200 seconds; CreateQueue/TagQueue parse query-style Tag.N/Tags.member.N parameters.

<sup>Written for commit bf9c41c56d8af5251c8a758c8b9e951c1e51b1e7. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1528?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

