### PR TITLE
fix(lambda): 11 Cubic P2 fixes

### DIFF
--- a/crates/fakecloud-lambda/src/extras/aliases.rs
+++ b/crates/fakecloud-lambda/src/extras/aliases.rs
@@ -19,6 +19,16 @@ impl LambdaService {
             .as_str()
             .ok_or_else(|| missing("Name"))?
             .to_string();
+        // Smithy Alias.name @length(1, 128). Reject early so we don't
+        // mint aliases that GetAlias / UpdateAlias / DeleteAlias would
+        // refuse later.
+        if name.is_empty() || name.chars().count() > 128 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValueException",
+                "Alias name must be 1..128 chars",
+            ));
+        }
         let version = body["FunctionVersion"]
             .as_str()
             .unwrap_or("$LATEST")

--- a/crates/fakecloud-lambda/src/extras/code_signing.rs
+++ b/crates/fakecloud-lambda/src/extras/code_signing.rs
@@ -177,10 +177,13 @@ impl LambdaService {
         let id = extract_csc_id(csc_id);
         let region = self.region_for(account_id);
         self.with_state_read(account_id, &region, |state| {
+            // Exact id match — substring matching would surface
+            // functions bound to a different csc that happens to share
+            // a prefix/suffix.
             let funcs: Vec<&String> = state
                 .function_code_signing
                 .iter()
-                .filter(|(_, v)| v.contains(&id))
+                .filter(|(_, v)| extract_csc_id(v) == id)
                 .map(|(k, _)| k)
                 .collect();
             ok(json!({"FunctionArns": funcs}))

--- a/crates/fakecloud-lambda/src/extras/function_url.rs
+++ b/crates/fakecloud-lambda/src/extras/function_url.rs
@@ -126,12 +126,26 @@ impl LambdaService {
             .get_mut(function_name)
             .ok_or_else(|| not_found("FunctionUrlConfig", function_name))?;
         if let Some(a) = body["AuthType"].as_str() {
+            if a != "NONE" && a != "AWS_IAM" {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    format!("AuthType must be NONE or AWS_IAM, got '{a}'"),
+                ));
+            }
             cfg.auth_type = a.to_string();
         }
         if let Some(c) = body.get("Cors") {
             cfg.cors = Some(c.clone());
         }
         if let Some(m) = body["InvokeMode"].as_str() {
+            if m != "BUFFERED" && m != "RESPONSE_STREAM" {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    format!("InvokeMode must be BUFFERED or RESPONSE_STREAM, got '{m}'"),
+                ));
+            }
             cfg.invoke_mode = m.to_string();
         }
         cfg.last_modified_time = Utc::now();

--- a/crates/fakecloud-lambda/src/extras/runtime.rs
+++ b/crates/fakecloud-lambda/src/extras/runtime.rs
@@ -35,15 +35,21 @@ impl LambdaService {
         // Reject non-string RuntimeVersionArn values instead of silently
         // coercing to "". The Smithy shape is @length(26, 2048) on a
         // string; passing a number / array / null is a 400 input error.
-        let runtime_version_arn = match &body["RuntimeVersionArn"] {
-            serde_json::Value::Null => String::new(),
-            serde_json::Value::String(s) => s.clone(),
-            _ => {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidParameterValueException",
-                    "RuntimeVersionArn must be a string",
-                ));
+        // Absent key (no entry in the JSON body) is allowed and means
+        // "leave unset"; explicit `null` is not the same — AWS treats
+        // it as a malformed enum value.
+        let runtime_version_arn = if body.get("RuntimeVersionArn").is_none() {
+            String::new()
+        } else {
+            match &body["RuntimeVersionArn"] {
+                serde_json::Value::String(s) => s.clone(),
+                _ => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValueException",
+                        "RuntimeVersionArn must be a string",
+                    ));
+                }
             }
         };
         // `RuntimeVersionArn` Smithy shape: length 26..2048. Empty

--- a/crates/fakecloud-lambda/src/extras/runtime.rs
+++ b/crates/fakecloud-lambda/src/extras/runtime.rs
@@ -32,7 +32,20 @@ impl LambdaService {
                 ),
             ));
         }
-        let runtime_version_arn = body["RuntimeVersionArn"].as_str().unwrap_or("").to_string();
+        // Reject non-string RuntimeVersionArn values instead of silently
+        // coercing to "". The Smithy shape is @length(26, 2048) on a
+        // string; passing a number / array / null is a 400 input error.
+        let runtime_version_arn = match &body["RuntimeVersionArn"] {
+            serde_json::Value::Null => String::new(),
+            serde_json::Value::String(s) => s.clone(),
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    "RuntimeVersionArn must be a string",
+                ));
+            }
+        };
         // `RuntimeVersionArn` Smithy shape: length 26..2048. Empty
         // means "unset" (valid); any non-empty value must satisfy the
         // minimum.

--- a/crates/fakecloud-lambda/src/service/init.rs
+++ b/crates/fakecloud-lambda/src/service/init.rs
@@ -70,7 +70,12 @@ impl LambdaService {
             && segs.get(3).map(|s| s.as_str()) == Some("provisioned-concurrency")
         {
             let res = segs.get(2).map(|s| s.to_string());
-            if req.method == Method::GET && req.query_params.contains_key("List") {
+            // AWS keys this overload on `List=ALL` specifically — any
+            // other value (or a bare key) is a malformed request, not
+            // an alias for the list op.
+            if req.method == Method::GET
+                && req.query_params.get("List").map(|v| v.as_str()) == Some("ALL")
+            {
                 return Some(("ListProvisionedConcurrencyConfigs", res));
             }
             return match req.method {
@@ -197,7 +202,10 @@ impl LambdaService {
                 _ => None,
             };
         }
-        if segs.get(1).map(|s| s.as_str()) == Some("function-urls") && req.method == Method::GET {
+        if segs.get(1).map(|s| s.as_str()) == Some("function-urls")
+            && segs.len() == 2
+            && req.method == Method::GET
+        {
             return Some(("ListFunctionUrlConfigs", None));
         }
         if segs.get(1).map(|s| s.as_str()) == Some("functions")

--- a/crates/fakecloud-lambda/src/service/invoke.rs
+++ b/crates/fakecloud-lambda/src/service/invoke.rs
@@ -27,7 +27,10 @@ impl LambdaService {
             let state = accounts.get(account_id).unwrap_or(&empty);
             resolve_qualifier_to_version(state, function_name, qualifier)
         };
-        let executed_version = resolved_version
+        // Tracks the version actually executed — diverges from the
+        // requested version when the version snapshot is missing and
+        // we fall back to $LATEST code below.
+        let mut executed_version = resolved_version
             .clone()
             .unwrap_or_else(|| "$LATEST".to_string());
         let (func, layer_zips) = {
@@ -40,12 +43,21 @@ impl LambdaService {
             // the snapshot is missing (legacy state) so we never 404 a
             // routable invoke.
             let func = match resolved_version.as_deref() {
-                Some(v) => state
-                    .function_version_snapshots
-                    .get(function_name)
-                    .and_then(|m| m.get(v))
-                    .cloned()
-                    .or_else(|| state.functions.get(function_name).cloned()),
+                Some(v) => {
+                    let snap = state
+                        .function_version_snapshots
+                        .get(function_name)
+                        .and_then(|m| m.get(v))
+                        .cloned();
+                    if snap.is_none() {
+                        // Snapshot missing: code is whatever is in
+                        // `functions` ($LATEST). Reflect that in the
+                        // response header so callers can't be misled
+                        // into thinking they ran v=`v`.
+                        executed_version = "$LATEST".to_string();
+                    }
+                    snap.or_else(|| state.functions.get(function_name).cloned())
+                }
                 None => state.functions.get(function_name).cloned(),
             }
             .ok_or_else(|| {
@@ -163,7 +175,8 @@ impl LambdaService {
                     let func_clone = func.clone();
                     let payload_vec = payload.to_vec();
                     let bus = self.delivery_bus.clone();
-                    let destination_config = self.lookup_destination_config(&func, account_id);
+                    let destination_config =
+                        self.lookup_destination_config(&func, account_id, qualifier);
                     let function_arn = func.function_arn.clone();
                     let layer_zips_async = layer_zips.clone();
                     let async_guard = _concurrency_guard;
@@ -314,14 +327,25 @@ impl LambdaService {
         &self,
         func: &crate::state::LambdaFunction,
         account_id: &str,
+        qualifier: Option<&str>,
     ) -> Option<serde_json::Value> {
         let accounts = self.state.read();
         let state = accounts.get(account_id)?;
-        let key = format!("{}:$LATEST", func.function_name);
-        state
-            .event_invoke_configs
-            .get(&key)
-            .and_then(|cfg| cfg.destination_config.clone())
-            .filter(|v| !v.is_null() && !v.as_object().map(|o| o.is_empty()).unwrap_or(false))
+        // EventInvokeConfig is keyed per-qualifier on AWS — alias/version
+        // can carry its own DestinationConfig. Walk qualifier-specific
+        // first, then fall back to $LATEST so unqualified invokes still
+        // see function-level config.
+        let candidates = [qualifier.unwrap_or("$LATEST"), "$LATEST"];
+        for q in candidates {
+            let key = format!("{}:{}", func.function_name, q);
+            if let Some(cfg) = state.event_invoke_configs.get(&key) {
+                if let Some(dc) = cfg.destination_config.clone() {
+                    if !dc.is_null() && !dc.as_object().map(|o| o.is_empty()).unwrap_or(false) {
+                        return Some(dc);
+                    }
+                }
+            }
+        }
+        None
     }
 }

--- a/crates/fakecloud-lambda/src/service/mod.rs
+++ b/crates/fakecloud-lambda/src/service/mod.rs
@@ -952,23 +952,31 @@ impl AwsService for LambdaService {
         // listings cap at 50). Pick the right ceiling for the routed
         // action so above-max variants trip the validation reliably.
         if let Some(raw) = req.query_params.get("MaxItems") {
-            if let Ok(n) = raw.parse::<i64>() {
-                let max = match action {
-                    "ListLayers"
-                    | "ListLayerVersions"
-                    | "ListFunctionUrlConfigs"
-                    | "ListProvisionedConcurrencyConfigs"
-                    | "ListFunctionEventInvokeConfigs"
-                    | "ListAliases" => 50,
-                    _ => 10000,
-                };
-                if !(1..=max).contains(&n) {
-                    return Err(AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "InvalidParameterValueException",
-                        format!("MaxItems must be between 1 and {} (got {})", max, n),
-                    ));
-                }
+            // Non-numeric MaxItems is a malformed request, not "use the
+            // default". AWS responds 400 — reject before falling through
+            // to range-check on the parsed value.
+            let n = raw.parse::<i64>().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    format!("MaxItems must be a number (got '{raw}')"),
+                )
+            })?;
+            let max = match action {
+                "ListLayers"
+                | "ListLayerVersions"
+                | "ListFunctionUrlConfigs"
+                | "ListProvisionedConcurrencyConfigs"
+                | "ListFunctionEventInvokeConfigs"
+                | "ListAliases" => 50,
+                _ => 10000,
+            };
+            if !(1..=max).contains(&n) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    format!("MaxItems must be between 1 and {} (got {})", max, n),
+                ));
             }
         }
 
@@ -1370,10 +1378,16 @@ impl AwsService for LambdaService {
             | "AddPermission"
             | "RemovePermission"
             | "GetPolicy" => {
-                let name = resource_name.unwrap_or_default();
-                if name.is_empty() {
+                let raw = resource_name.unwrap_or_default();
+                if raw.is_empty() {
                     "*".to_string()
                 } else {
+                    // Normalize ARN / `function:Name` / partial-ARN
+                    // inputs to bare names — IAM resource derivation
+                    // must produce the same ARN regardless of how the
+                    // caller spelled FunctionName, or policy evaluation
+                    // mismatches the actual function.
+                    let name = normalize_function_name(&raw);
                     format!(
                         "arn:aws:lambda:{}:{}:function:{}",
                         state.region, state.account_id, name


### PR DESCRIPTION
## Summary

Lambda P2 Cubic findings from quality audit 2026-05-19. Fixes 11 distinct issues across aliases / code_signing / function_url / runtime / init routing / invoke / service mod.

Highlights:
- CreateAlias rejects empty / >128-char names (Smithy length 1..128) instead of minting unfetchable aliases.
- ListCodeSigningConfigs uses exact CSC id match (substring matching could surface unrelated functions).
- UpdateFunctionUrlConfig enforces AuthType (NONE|AWS_IAM) and InvokeMode (BUFFERED|RESPONSE_STREAM) enums (parity with create).
- PutRuntimeManagement rejects non-string RuntimeVersionArn with 400 instead of silently empty.
- Route resolution: `List=ALL` literal required for ListProvisionedConcurrencyConfigs; `/function-urls` only matches at exact len 2.
- Invoke: `x-amz-executed-version` reports `$LATEST` when version snapshot fallback occurs; async DestinationConfig now resolves per-qualifier.
- IAM resource derivation normalizes FunctionName so ARN/`function:Name`/partial-ARN inputs all map to the same policy ARN.
- MaxItems non-numeric → 400 instead of silently ignored.

## Test plan

- [x] `cargo build -p fakecloud-lambda`
- [x] `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings`
- [x] `cargo test -p fakecloud-lambda --lib` — 151 pass
- [ ] CI: full workspace + e2e + conformance
- [ ] Cubic review on these specific fixes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 11 P2 Cubic findings in the Lambda emulator to better match AWS behavior and avoid invalid state. Tightens input validation, routing, and invoke behavior.

- **Bug Fixes**
  - CreateAlias: reject empty or >128-char names.
  - ListCodeSigningConfigs by function: exact CSC id match only.
  - UpdateFunctionUrlConfig: enforce AuthType (NONE | AWS_IAM) and InvokeMode (BUFFERED | RESPONSE_STREAM).
  - PutRuntimeManagement: reject non-string `RuntimeVersionArn` (including null) with 400.
  - Routing: `ListProvisionedConcurrencyConfigs` requires `List=ALL`; `/function-urls` list only when path has exactly 2 segments.
  - Invoke: set `x-amz-executed-version` to `$LATEST` when falling back from missing version snapshot.
  - Async invoke: resolve `DestinationConfig` per qualifier; fallback to `$LATEST` if unset.
  - IAM: normalize `FunctionName` (ARN/partial-ARN/`function:Name`) before building policy ARN.
  - Query params: non-numeric `MaxItems` returns 400; numeric values now range-checked per action.

<sup>Written for commit 9f6b33ce922855fb31ba9ce63e8634e7f0dca712. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1529?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

