### PR TITLE
fix(rds): 11 Cubic P2 fixes

### DIFF
--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -537,7 +537,29 @@ impl RdsService {
                     if new != name {
                         if let Some(m) = state.extras.get_mut("proxies") {
                             if let Some(val) = m.remove(&name) {
-                                m.insert(new, val);
+                                m.insert(new.clone(), val);
+                            }
+                        }
+                        // proxy_target_groups is keyed `<proxy>/<group>` —
+                        // rekey every entry that belongs to this proxy so
+                        // filtered describes by the new name keep matching.
+                        if let Some(m) = state.extras.get_mut("proxy_target_groups") {
+                            let old_prefix = format!("{name}/");
+                            let migrations: Vec<(String, String)> = m
+                                .keys()
+                                .filter(|k| k.starts_with(&old_prefix))
+                                .map(|k| {
+                                    let suffix = &k[old_prefix.len()..];
+                                    (k.clone(), format!("{new}/{suffix}"))
+                                })
+                                .collect();
+                            for (old_k, new_k) in migrations {
+                                if let Some(mut val) = m.remove(&old_k) {
+                                    if let Some(obj) = val.as_object_mut() {
+                                        obj.insert("DBProxyName".to_string(), json!(new));
+                                    }
+                                    m.insert(new_k, val);
+                                }
                             }
                         }
                     }

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -297,11 +297,23 @@ impl RdsService {
             "DeleteDBClusterSnapshot" => {
                 let id = get_param(req, "DBClusterSnapshotIdentifier").ok_or_else(|| missing("DBClusterSnapshotIdentifier"))?;
                 let arn = Arn::new("rds", region, &aid, &format!("cluster-snapshot:{id}")).to_string();
-                {
+                // Recover the source cluster id from stored state before
+                // remove — emitting a hardcoded "default" would corrupt
+                // downstream consumers that key off DBClusterIdentifier.
+                let cluster = {
                     let mut accounts = write_state!();
                     let state = accounts.get_or_create(&aid);
+                    let prior = state
+                        .extras
+                        .get("cluster_snapshots")
+                        .and_then(|m| m.get(&id))
+                        .and_then(|v| v.get("DBClusterIdentifier"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
                     if let Some(m) = state.extras.get_mut("cluster_snapshots") { m.remove(&id); }
-                }
+                    prior
+                };
                 self.emit_event(
                     RdsSourceType::DbClusterSnapshot,
                     &id,
@@ -310,7 +322,7 @@ impl RdsService {
                     &["deletion"],
                     "DB cluster snapshot deleted",
                 );
-                Ok(xml_response("DeleteDBClusterSnapshot", cluster_snapshot_xml(&id, &arn, "default"), &rid))
+                Ok(xml_response("DeleteDBClusterSnapshot", cluster_snapshot_xml(&id, &arn, &cluster), &rid))
             }
             "DescribeDBClusterSnapshots" => list_extras_xml(self, &aid, "cluster_snapshots", "DBClusterSnapshots", "DescribeDBClusterSnapshots", cluster_snapshot_member_xml, &rid),
             "DescribeDBClusterSnapshotAttributes" | "ModifyDBClusterSnapshotAttribute" => {
@@ -485,6 +497,7 @@ impl RdsService {
             "ModifyDBProxy" => {
                 let name = get_param(req, "DBProxyName").ok_or_else(|| missing("DBProxyName"))?;
                 let auth = parse_proxy_auth(req);
+                let new_name = get_param(req, "NewDBProxyName");
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
                 let entry = state
@@ -511,11 +524,24 @@ impl RdsService {
                     if let Some(v) = get_param(req, "DebugLogging") {
                         obj.insert("DebugLogging".to_string(), json!(v.eq_ignore_ascii_case("true")));
                     }
-                    if let Some(v) = get_param(req, "NewDBProxyName") {
+                    if let Some(v) = new_name.as_ref() {
                         obj.insert("DBProxyName".to_string(), json!(v));
                     }
                 }
                 let updated = entry.clone();
+                // Rekey the map so subsequent Describe/Delete/Modify
+                // against NewDBProxyName actually find the entry —
+                // otherwise the rename only mutates the payload field
+                // and Describe still keys by the old name.
+                if let Some(new) = new_name {
+                    if new != name {
+                        if let Some(m) = state.extras.get_mut("proxies") {
+                            if let Some(val) = m.remove(&name) {
+                                m.insert(new, val);
+                            }
+                        }
+                    }
+                }
                 Ok(xml_response("ModifyDBProxy", format!("    <DBProxy>\n{}\n    </DBProxy>", proxy_xml(&updated)), &rid))
             }
             "DeleteDBProxy" => {
@@ -537,6 +563,7 @@ impl RdsService {
             "ModifyDBProxyEndpoint" => {
                 let name = get_param(req, "DBProxyEndpointName").ok_or_else(|| missing("DBProxyEndpointName"))?;
                 let vpc_sgs = parse_member_list(req, "VpcSecurityGroupIds");
+                let new_name = get_param(req, "NewDBProxyEndpointName");
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
                 let entry = state
@@ -554,11 +581,23 @@ impl RdsService {
                     if !vpc_sgs.is_empty() {
                         obj.insert("VpcSecurityGroupIds".to_string(), json!(vpc_sgs));
                     }
-                    if let Some(v) = get_param(req, "NewDBProxyEndpointName") {
+                    if let Some(v) = new_name.as_ref() {
                         obj.insert("DBProxyEndpointName".to_string(), json!(v));
                     }
                 }
-                Ok(xml_response("ModifyDBProxyEndpoint", format!("    <DBProxyEndpoint>\n      <DBProxyEndpointName>{}</DBProxyEndpointName>\n    </DBProxyEndpoint>", xml_escape(&name)), &rid))
+                let final_name = new_name.clone().unwrap_or_else(|| name.clone());
+                // Rekey so the rename is visible to subsequent lookups,
+                // not just to the payload field.
+                if let Some(new) = new_name {
+                    if new != name {
+                        if let Some(m) = state.extras.get_mut("proxy_endpoints") {
+                            if let Some(val) = m.remove(&name) {
+                                m.insert(new, val);
+                            }
+                        }
+                    }
+                }
+                Ok(xml_response("ModifyDBProxyEndpoint", format!("    <DBProxyEndpoint>\n      <DBProxyEndpointName>{}</DBProxyEndpointName>\n    </DBProxyEndpoint>", xml_escape(&final_name)), &rid))
             }
             "DeleteDBProxyEndpoint" => {
                 let name = get_param(req, "DBProxyEndpointName").ok_or_else(|| missing("DBProxyEndpointName"))?;
@@ -567,8 +606,60 @@ impl RdsService {
                 if let Some(m) = state.extras.get_mut("proxy_endpoints") { m.remove(&name); }
                 Ok(xml_response("DeleteDBProxyEndpoint", "    <DBProxyEndpoint/>".to_string(), &rid))
             }
-            "DescribeDBProxyEndpoints" => Ok(xml_response("DescribeDBProxyEndpoints", "    <DBProxyEndpoints/>".to_string(), &rid)),
-            "DescribeDBProxyTargetGroups" => Ok(xml_response("DescribeDBProxyTargetGroups", "    <TargetGroups/>".to_string(), &rid)),
+            "DescribeDBProxyEndpoints" => {
+                let accounts = self.state.read();
+                let state_opt = accounts.get(&aid);
+                let mut members = String::new();
+                if let Some(state) = state_opt {
+                    if let Some(m) = state.extras.get("proxy_endpoints") {
+                        for v in m.values() {
+                            // Render with the same field shape as
+                            // CreateDBProxyEndpoint above so consumers
+                            // see the persisted endpoint name and any
+                            // VpcSecurityGroupIds we recorded.
+                            let n = v
+                                .get("DBProxyEndpointName")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or_default();
+                            members.push_str(&format!(
+                                "      <member>\n        <DBProxyEndpointName>{}</DBProxyEndpointName>\n      </member>\n",
+                                xml_escape(n)
+                            ));
+                        }
+                    }
+                }
+                Ok(xml_response("DescribeDBProxyEndpoints", format!("    <DBProxyEndpoints>\n{members}    </DBProxyEndpoints>"), &rid))
+            }
+            "DescribeDBProxyTargetGroups" => {
+                let accounts = self.state.read();
+                let state_opt = accounts.get(&aid);
+                let filter_proxy = get_param(req, "DBProxyName");
+                let mut members = String::new();
+                if let Some(state) = state_opt {
+                    if let Some(m) = state.extras.get("proxy_target_groups") {
+                        for v in m.values() {
+                            let proxy = v
+                                .get("DBProxyName")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or_default();
+                            if let Some(want) = filter_proxy.as_deref() {
+                                if proxy != want {
+                                    continue;
+                                }
+                            }
+                            let tgn = v
+                                .get("TargetGroupName")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or_default();
+                            members.push_str(&format!(
+                                "      <member>\n        <DBProxyName>{}</DBProxyName>\n        <TargetGroupName>{}</TargetGroupName>\n      </member>\n",
+                                xml_escape(proxy), xml_escape(tgn)
+                            ));
+                        }
+                    }
+                }
+                Ok(xml_response("DescribeDBProxyTargetGroups", format!("    <TargetGroups>\n{members}    </TargetGroups>"), &rid))
+            }
             "DescribeDBProxyTargets" => Ok(xml_response("DescribeDBProxyTargets", "    <Targets/>".to_string(), &rid)),
             "ModifyDBProxyTargetGroup" => {
                 let proxy = get_param(req, "DBProxyName").ok_or_else(|| missing("DBProxyName"))?;

--- a/crates/fakecloud-rds/src/extras/parse.rs
+++ b/crates/fakecloud-rds/src/extras/parse.rs
@@ -77,6 +77,40 @@ pub(super) fn parse_options_to_include(req: &AwsRequest) -> Vec<Value> {
         if let Some(v) = version {
             entry.insert("OptionVersion".to_string(), json!(v));
         }
+        // Capture nested security-group memberships — the doc-comment
+        // promised them but the loop above never read them, so
+        // ModifyOptionGroup was dropping that part of the request.
+        let mut dbsg = Vec::new();
+        for j in 1.. {
+            let id = get_param(
+                req,
+                &format!("OptionsToInclude.member.{i}.DBSecurityGroupMemberships.member.{j}"),
+            );
+            match id {
+                Some(v) => dbsg.push(json!(v)),
+                None => break,
+            }
+        }
+        if !dbsg.is_empty() {
+            entry.insert("DBSecurityGroupMemberships".to_string(), Value::Array(dbsg));
+        }
+        let mut vpcsg = Vec::new();
+        for j in 1.. {
+            let id = get_param(
+                req,
+                &format!("OptionsToInclude.member.{i}.VpcSecurityGroupMemberships.member.{j}"),
+            );
+            match id {
+                Some(v) => vpcsg.push(json!(v)),
+                None => break,
+            }
+        }
+        if !vpcsg.is_empty() {
+            entry.insert(
+                "VpcSecurityGroupMemberships".to_string(),
+                Value::Array(vpcsg),
+            );
+        }
         out.push(Value::Object(entry));
     }
     out

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -569,26 +569,52 @@ impl RdsService {
         }
 
         let running = if let Some(runtime) = self.runtime.as_ref() {
-            Some(
-                runtime
-                    .ensure_postgres(
-                        &db_instance_identifier,
-                        &instance.engine,
-                        &instance.engine_version,
-                        &instance.master_username,
-                        &instance.master_user_password,
-                        instance
-                            .db_name
-                            .as_deref()
-                            .unwrap_or(default_db_name(&instance.engine)),
-                        &request.account_id,
-                        &request.region,
-                    )
-                    .await
-                    .map_err(runtime_error_to_service_error)?,
-            )
+            match runtime
+                .ensure_postgres(
+                    &db_instance_identifier,
+                    &instance.engine,
+                    &instance.engine_version,
+                    &instance.master_username,
+                    &instance.master_user_password,
+                    instance
+                        .db_name
+                        .as_deref()
+                        .unwrap_or(default_db_name(&instance.engine)),
+                    &request.account_id,
+                    &request.region,
+                )
+                .await
+            {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    // Roll the row back to `stopped` so the next
+                    // Describe doesn't report a permanently-`starting`
+                    // instance with no container behind it.
+                    let mut accounts = self.state.write();
+                    let state = accounts.get_or_create(&request.account_id);
+                    if let Some(inst) = state.instances.get_mut(&db_instance_identifier) {
+                        inst.db_instance_status = "stopped".to_string();
+                    }
+                    return Err(runtime_error_to_service_error(e));
+                }
+            }
         } else {
-            None
+            // No container runtime configured: StartDBInstance should
+            // fail rather than report success against a backend that
+            // does not exist. Roll the row back so subsequent calls
+            // don't see a stuck `starting` state.
+            {
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(&request.account_id);
+                if let Some(inst) = state.instances.get_mut(&db_instance_identifier) {
+                    inst.db_instance_status = "stopped".to_string();
+                }
+            }
+            return Err(AwsServiceError::aws_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "InternalFailure",
+                "Container runtime is not configured; cannot start DB instance",
+            ));
         };
 
         let instance = {

--- a/crates/fakecloud-rds/src/service/parameter_groups.rs
+++ b/crates/fakecloud-rds/src/service/parameter_groups.rs
@@ -11,6 +11,18 @@ impl RdsService {
         let db_parameter_group_family = required_query_param(request, "DBParameterGroupFamily")?;
         let description = required_query_param(request, "Description")?;
 
+        // `default.*` is the reserved prefix for AWS-managed engine
+        // default groups. DeleteDBParameterGroup unconditionally
+        // refuses that prefix, so accepting it on create would mint
+        // groups the caller can never delete.
+        if db_parameter_group_name.starts_with("default.") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                "DBParameterGroupName cannot start with the reserved 'default.' prefix",
+            ));
+        }
+
         // Family is stored verbatim. Real AWS rejects unknown families
         // with `InvalidParameterValue`, but that code isn't declared on
         // `CreateDBParameterGroup` so the strict probe drops responses

--- a/crates/fakecloud-rds/src/service/restore.rs
+++ b/crates/fakecloud-rds/src/service/restore.rs
@@ -62,28 +62,29 @@ impl RdsService {
                 })
                 .or_else(|| {
                     // Real shape: `arn:aws:rds:<region>:<acct>:auto-backup:ab-<id>`.
-                    // Match permissively against several candidate ids
-                    // since we don't store a separate auto_backup_id:
-                    // dbi_resource_id, the bare `ab-<id>` form, the raw
-                    // last ARN segment, and (last resort) substring of
-                    // dbi_resource_id — covers the common AWS shapes
-                    // without forcing callers to know our internal id.
+                    // Only resolve when the ARN names a recognized
+                    // resource type and the trailing id matches a stored
+                    // dbi_resource_id exactly — substring/suffix matches
+                    // would let partial ARNs restore from unrelated
+                    // instances.
                     source_backup_arn.as_deref().and_then(|arn| {
-                        let last = arn.rsplit(':').next().unwrap_or("");
-                        if last.is_empty() {
+                        let parts: Vec<&str> = arn.split(':').collect();
+                        if parts.len() < 7
+                            || parts[0] != "arn"
+                            || parts[2] != "rds"
+                            || parts[5] != "auto-backup"
+                        {
                             return None;
                         }
+                        let last = parts[6];
                         let bare = last.strip_prefix("ab-").unwrap_or(last);
+                        if bare.is_empty() {
+                            return None;
+                        }
                         state
                             .instances
                             .iter()
-                            .find(|(_, inst)| {
-                                let rid = inst.dbi_resource_id.as_str();
-                                rid == last
-                                    || rid == bare
-                                    || rid.ends_with(bare)
-                                    || bare.contains(rid)
-                            })
+                            .find(|(_, inst)| inst.dbi_resource_id == bare)
                             .map(|(k, v)| (k.clone(), v.clone()))
                     })
                 });

--- a/crates/fakecloud-rds/src/service/restore.rs
+++ b/crates/fakecloud-rds/src/service/restore.rs
@@ -61,17 +61,22 @@ impl RdsService {
                     })
                 })
                 .or_else(|| {
+                    // Real shape: `arn:aws:rds:<region>:<acct>:auto-backup:ab-<id>`.
+                    // The trailing segment is `ab-<id>`, not a DB instance
+                    // identifier — match by stored `auto_backup_id` (and
+                    // fall back to dbi_resource_id) rather than assuming
+                    // the segment is the user-supplied DBInstanceId.
                     source_backup_arn.as_deref().and_then(|arn| {
-                        let id = arn.rsplit(':').next().unwrap_or("");
-                        if id.is_empty() {
-                            None
-                        } else {
-                            state
-                                .instances
-                                .get(id)
-                                .cloned()
-                                .map(|i| (id.to_string(), i))
+                        let last = arn.rsplit(':').next().unwrap_or("");
+                        let ab = last.strip_prefix("ab-").unwrap_or(last);
+                        if ab.is_empty() {
+                            return None;
                         }
+                        state
+                            .instances
+                            .iter()
+                            .find(|(_, inst)| inst.dbi_resource_id == ab)
+                            .map(|(k, v)| (k.clone(), v.clone()))
                     })
                 });
 

--- a/crates/fakecloud-rds/src/service/restore.rs
+++ b/crates/fakecloud-rds/src/service/restore.rs
@@ -62,20 +62,28 @@ impl RdsService {
                 })
                 .or_else(|| {
                     // Real shape: `arn:aws:rds:<region>:<acct>:auto-backup:ab-<id>`.
-                    // The trailing segment is `ab-<id>`, not a DB instance
-                    // identifier — match by stored `auto_backup_id` (and
-                    // fall back to dbi_resource_id) rather than assuming
-                    // the segment is the user-supplied DBInstanceId.
+                    // Match permissively against several candidate ids
+                    // since we don't store a separate auto_backup_id:
+                    // dbi_resource_id, the bare `ab-<id>` form, the raw
+                    // last ARN segment, and (last resort) substring of
+                    // dbi_resource_id — covers the common AWS shapes
+                    // without forcing callers to know our internal id.
                     source_backup_arn.as_deref().and_then(|arn| {
                         let last = arn.rsplit(':').next().unwrap_or("");
-                        let ab = last.strip_prefix("ab-").unwrap_or(last);
-                        if ab.is_empty() {
+                        if last.is_empty() {
                             return None;
                         }
+                        let bare = last.strip_prefix("ab-").unwrap_or(last);
                         state
                             .instances
                             .iter()
-                            .find(|(_, inst)| inst.dbi_resource_id == ab)
+                            .find(|(_, inst)| {
+                                let rid = inst.dbi_resource_id.as_str();
+                                rid == last
+                                    || rid == bare
+                                    || rid.ends_with(bare)
+                                    || bare.contains(rid)
+                            })
                             .map(|(k, v)| (k.clone(), v.clone()))
                     })
                 });

--- a/crates/fakecloud-rds/src/service/restore.rs
+++ b/crates/fakecloud-rds/src/service/restore.rs
@@ -13,14 +13,20 @@ impl RdsService {
         // Smithy model doesn't mark any of them required at the input
         // shape, so don't reject for omission — map the missing case
         // onto the declared `DBInstanceNotFoundFault` instead.
-        let source_id = optional_query_param(request, "SourceDBInstanceIdentifier")
-            .or_else(|| optional_query_param(request, "SourceDbiResourceId"))
-            .or_else(|| optional_query_param(request, "SourceDBInstanceAutomatedBackupsArn"))
-            .ok_or_else(|| db_instance_not_found("(none)"))?;
+        let source_identifier = optional_query_param(request, "SourceDBInstanceIdentifier");
+        let source_dbi_resource_id = optional_query_param(request, "SourceDbiResourceId");
+        let source_backup_arn =
+            optional_query_param(request, "SourceDBInstanceAutomatedBackupsArn");
+        if source_identifier.is_none()
+            && source_dbi_resource_id.is_none()
+            && source_backup_arn.is_none()
+        {
+            return Err(db_instance_not_found("(none)"));
+        }
         let vpc_security_group_ids = parse_vpc_security_group_ids(request);
         let tags = parse_tags(request)?;
 
-        let (source_instance, db_name) = {
+        let (source_id, source_instance, db_name) = {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
 
@@ -32,11 +38,52 @@ impl RdsService {
                 ));
             }
 
-            let source_instance = match state.instances.get(&source_id).cloned() {
-                Some(inst) => inst,
+            // Resolve any one of the three accepted source forms to the
+            // stored DBInstance. SourceDbiResourceId matches the
+            // per-instance immutable resource id; the backups ARN
+            // ends in `:db:<identifier>` per AWS shape.
+            let resolved: Option<(String, crate::state::DbInstance)> = source_identifier
+                .as_deref()
+                .and_then(|id| {
+                    state
+                        .instances
+                        .get(id)
+                        .cloned()
+                        .map(|i| (id.to_string(), i))
+                })
+                .or_else(|| {
+                    source_dbi_resource_id.as_deref().and_then(|rid| {
+                        state
+                            .instances
+                            .iter()
+                            .find(|(_, inst)| inst.dbi_resource_id == rid)
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                    })
+                })
+                .or_else(|| {
+                    source_backup_arn.as_deref().and_then(|arn| {
+                        let id = arn.rsplit(':').next().unwrap_or("");
+                        if id.is_empty() {
+                            None
+                        } else {
+                            state
+                                .instances
+                                .get(id)
+                                .cloned()
+                                .map(|i| (id.to_string(), i))
+                        }
+                    })
+                });
+
+            let (source_id, source_instance) = match resolved {
+                Some(pair) => pair,
                 None => {
                     state.cancel_instance_creation(&target_id);
-                    return Err(db_instance_not_found(&source_id));
+                    let probe = source_identifier
+                        .or(source_dbi_resource_id)
+                        .or(source_backup_arn)
+                        .unwrap_or_default();
+                    return Err(db_instance_not_found(&probe));
                 }
             };
 
@@ -47,7 +94,7 @@ impl RdsService {
                 .unwrap_or(default_db)
                 .to_string();
 
-            (source_instance, db_name)
+            (source_id, source_instance, db_name)
         };
 
         let runtime = match self.require_runtime() {

--- a/crates/fakecloud-rds/src/service/subnet_groups.rs
+++ b/crates/fakecloud-rds/src/service/subnet_groups.rs
@@ -32,11 +32,19 @@ impl RdsService {
         }
 
         let vpc_id = format!("vpc-{}", uuid::Uuid::new_v4().simple());
-        let subnet_availability_zones: Vec<String> = (0..subnet_ids.len())
-            .map(|i| format!("{}{}", &state.region, char::from(b'a' + (i % 6) as u8)))
+        // We don't track real VPC subnet -> AZ mappings, so synthesize
+        // one AZ per subnet by hashing the subnet id. Two distinct
+        // subnet ids land in the same AZ only on hash collision, which
+        // makes the uniqueness check meaningful (the previous version
+        // derived AZ from index and was always unique by construction).
+        let subnet_availability_zones: Vec<String> = subnet_ids
+            .iter()
+            .map(|sid| {
+                let bucket = sid.bytes().fold(0u32, |a, b| a.wrapping_add(b as u32)) % 6;
+                format!("{}{}", &state.region, char::from(b'a' + bucket as u8))
+            })
             .collect();
 
-        // Validate that subnets span at least 2 unique Availability Zones
         let unique_azs: std::collections::HashSet<_> = subnet_availability_zones.iter().collect();
         if unique_azs.len() < 2 {
             return Err(AwsServiceError::aws_error(
@@ -200,11 +208,14 @@ impl RdsService {
                 )
             })?;
 
-        let subnet_availability_zones: Vec<String> = (0..subnet_ids.len())
-            .map(|i| format!("{}{}", &region, char::from(b'a' + (i % 6) as u8)))
+        let subnet_availability_zones: Vec<String> = subnet_ids
+            .iter()
+            .map(|sid| {
+                let bucket = sid.bytes().fold(0u32, |a, b| a.wrapping_add(b as u32)) % 6;
+                format!("{}{}", &region, char::from(b'a' + bucket as u8))
+            })
             .collect();
 
-        // Validate that subnets span at least 2 unique Availability Zones
         let unique_azs: std::collections::HashSet<_> = subnet_availability_zones.iter().collect();
         if unique_azs.len() < 2 {
             return Err(AwsServiceError::aws_error(

--- a/crates/fakecloud-rds/src/service/subnet_groups.rs
+++ b/crates/fakecloud-rds/src/service/subnet_groups.rs
@@ -37,13 +37,21 @@ impl RdsService {
         // subnet ids land in the same AZ only on hash collision, which
         // makes the uniqueness check meaningful (the previous version
         // derived AZ from index and was always unique by construction).
-        let subnet_availability_zones: Vec<String> = subnet_ids
-            .iter()
-            .map(|sid| {
-                let bucket = sid.bytes().fold(0u32, |a, b| a.wrapping_add(b as u32)) % 6;
-                format!("{}{}", &state.region, char::from(b'a' + bucket as u8))
-            })
-            .collect();
+        // Distinct subnet ids land in distinct AZs (each one gets its
+        // own letter) so the uniqueness check rejects only the case
+        // where the caller actually repeated a subnet id. We don't
+        // simulate real VPC subnet -> AZ mappings, so the previous
+        // hash-to-6-buckets approach produced spurious collisions for
+        // unrelated subnets.
+        let mut subnet_availability_zones: Vec<String> = Vec::with_capacity(subnet_ids.len());
+        let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        let region = &state.region;
+        for sid in &subnet_ids {
+            let next = seen.len();
+            let idx = *seen.entry(sid.as_str()).or_insert(next);
+            let bucket = (idx % 26) as u8;
+            subnet_availability_zones.push(format!("{}{}", region, char::from(b'a' + bucket)));
+        }
 
         let unique_azs: std::collections::HashSet<_> = subnet_availability_zones.iter().collect();
         if unique_azs.len() < 2 {
@@ -208,13 +216,14 @@ impl RdsService {
                 )
             })?;
 
-        let subnet_availability_zones: Vec<String> = subnet_ids
-            .iter()
-            .map(|sid| {
-                let bucket = sid.bytes().fold(0u32, |a, b| a.wrapping_add(b as u32)) % 6;
-                format!("{}{}", &region, char::from(b'a' + bucket as u8))
-            })
-            .collect();
+        let mut subnet_availability_zones: Vec<String> = Vec::with_capacity(subnet_ids.len());
+        let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        for sid in &subnet_ids {
+            let next = seen.len();
+            let idx = *seen.entry(sid.as_str()).or_insert(next);
+            let bucket = (idx % 26) as u8;
+            subnet_availability_zones.push(format!("{}{}", region, char::from(b'a' + bucket)));
+        }
 
         let unique_azs: std::collections::HashSet<_> = subnet_availability_zones.iter().collect();
         if unique_azs.len() < 2 {


### PR DESCRIPTION
## Summary

RDS P2 Cubic findings from quality audit 2026-05-19.

- DeleteDBClusterSnapshot returns the stored DBClusterIdentifier instead of a hardcoded \"default\".
- ModifyDBProxy / ModifyDBProxyEndpoint now rekey the underlying map when New*Name is provided.
- DescribeDBProxyEndpoints / DescribeDBProxyTargetGroups render the persisted state (with DBProxyName filter for target groups).
- parse_options_to_include actually parses the nested DB/Vpc SecurityGroupMemberships members the doc-comment promised.
- StartDBInstance: fails with InternalFailure when no container runtime is configured, and rolls back to \"stopped\" on container-start failure instead of leaving \"starting\".
- CreateDBParameterGroup: rejects the reserved \"default.\" prefix (delete unconditionally refuses it).
- RestoreDBInstanceToPointInTime: resolves source via SourceDBInstanceIdentifier / SourceDbiResourceId / SourceDBInstanceAutomatedBackupsArn.
- Create/ModifyDBSubnetGroup: AZ bucket derived from subnet id hash so the uniqueness check actually validates input.

## Test plan

- [x] cargo build -p fakecloud-rds
- [x] cargo clippy -p fakecloud-rds --all-targets -- -D warnings
- [x] cargo test -p fakecloud-rds --lib (205 pass)
- [ ] CI workspace + e2e + conformance
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 11 P2 RDS issues in `fakecloud-rds` from the Cubic audit, aligning behavior with AWS and preventing stuck states and empty responses. Extends rename consistency for proxies/target groups, tightens automated-backup ARN matching to exact IDs, and makes subnet AZ validation reliable.

- **Bug Fixes**
  - DeleteDBClusterSnapshot: return stored DBClusterIdentifier, not "default".
  - ModifyDBProxy/ModifyDBProxyEndpoint: rekey maps on rename; also rekey proxy target groups so Describe/Delete/Modify work with new names.
  - DescribeDBProxyEndpoints/DescribeDBProxyTargetGroups: return persisted entries; TargetGroups supports DBProxyName filter.
  - parse_options_to_include: parse nested DBSecurityGroupMemberships and VpcSecurityGroupMemberships as documented.
  - StartDBInstance: fail with InternalFailure when no container runtime; on container start failure, set status back to "stopped".
  - CreateDBParameterGroup: reject names with reserved "default." prefix.
  - RestoreDBInstanceToPointInTime: resolve source via Identifier, DbiResourceId, or AutomatedBackups ARN; for ARN, require exact `auto-backup:ab-<dbi_resource_id>` match; on missing source, cancel target creation and return not found.
  - Create/ModifyDBSubnetGroup: map each unique subnet id to its own AZ bucket (duplicates map to the same AZ) so the AZ uniqueness check is meaningful without spurious collisions.

<sup>Written for commit 14510cd0d4da2cf52f9ebc40f809f31b6b508971. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1530?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

