### PR TITLE
fix(misc): athena/bedrock-agent/dynamodb P2 cleanup

### DIFF
--- a/crates/fakecloud-athena/src/service/notebooks.rs
+++ b/crates/fakecloud-athena/src/service/notebooks.rs
@@ -503,12 +503,22 @@ impl AthenaService {
             .get("NextToken")
             .and_then(Value::as_str)
             .map(str::to_owned);
+        let state_filter = body
+            .get("StateFilter")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         let mut all: Vec<Calculation> = account
             .calculations
             .values()
             .filter(|c| c.session_id == session_id)
+            .filter(|c| {
+                state_filter
+                    .as_deref()
+                    .map(|sf| c.state == sf)
+                    .unwrap_or(true)
+            })
             .cloned()
             .collect();
         all.sort_by(|a, b| a.calculation_execution_id.cmp(&b.calculation_execution_id));

--- a/crates/fakecloud-bedrock-agent/src/service/knowledge_bases.rs
+++ b/crates/fakecloud-bedrock-agent/src/service/knowledge_bases.rs
@@ -143,6 +143,20 @@ impl BedrockAgentService {
         if !state.knowledge_bases.contains_key(&kb_id) {
             return Err(not_found(format!("KnowledgeBase {kb_id} not found")));
         }
+        // Validate the data source exists and belongs to this KB —
+        // otherwise jobs land tagged with a foreign dataSourceId and
+        // downstream queries return empty results with no failure.
+        match state.data_sources.get(&ds_id) {
+            Some(ds) if ds.knowledge_base_id == kb_id => {}
+            Some(_) => {
+                return Err(not_found(format!(
+                    "DataSource {ds_id} does not belong to KnowledgeBase {kb_id}"
+                )));
+            }
+            None => {
+                return Err(not_found(format!("DataSource {ds_id} not found")));
+            }
+        }
         let job = IngestionJob {
             ingestion_job_id: job_id.clone(),
             knowledge_base_id: kb_id.clone(),
@@ -237,17 +251,44 @@ impl BedrockAgentService {
         ))
     }
 
+    /// Validate `knowledgeBaseId` exists and `dataSourceId` (when
+    /// supplied) belongs to it. Used by every documents endpoint so
+    /// the API doesn't silently accept foreign dataSourceIds.
+    fn validate_kb_ds(
+        &self,
+        state: &crate::state::BedrockAgentState,
+        kb_id: &str,
+        ds_id: Option<&str>,
+    ) -> Result<(), AwsServiceError> {
+        if !state.knowledge_bases.contains_key(kb_id) {
+            return Err(not_found(format!("KnowledgeBase {kb_id} not found")));
+        }
+        if let Some(ds) = ds_id {
+            match state.data_sources.get(ds) {
+                Some(d) if d.knowledge_base_id == kb_id => {}
+                Some(_) => {
+                    return Err(not_found(format!(
+                        "DataSource {ds} does not belong to KnowledgeBase {kb_id}"
+                    )));
+                }
+                None => {
+                    return Err(not_found(format!("DataSource {ds} not found")));
+                }
+            }
+        }
+        Ok(())
+    }
+
     pub(super) fn ingest_knowledge_base_documents(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let kb_id = req_str(&body, "knowledgeBaseId")?;
+        let ds_id = req_str(&body, "dataSourceId")?;
         let mut accts = self.state.write();
         let state = accts.get_or_create(&req.account_id, &req.region);
-        if !state.knowledge_bases.contains_key(&kb_id) {
-            return Err(not_found(format!("KnowledgeBase {kb_id} not found")));
-        }
+        self.validate_kb_ds(state, &kb_id, Some(&ds_id))?;
         Ok(AwsResponse::ok_json(json!({})))
     }
 
@@ -257,11 +298,10 @@ impl BedrockAgentService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let kb_id = req_str(&body, "knowledgeBaseId")?;
+        let ds_id = req_str(&body, "dataSourceId")?;
         let mut accts = self.state.write();
         let state = accts.get_or_create(&req.account_id, &req.region);
-        if !state.knowledge_bases.contains_key(&kb_id) {
-            return Err(not_found(format!("KnowledgeBase {kb_id} not found")));
-        }
+        self.validate_kb_ds(state, &kb_id, Some(&ds_id))?;
         Ok(AwsResponse::ok_json(json!({})))
     }
 
@@ -271,13 +311,12 @@ impl BedrockAgentService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let kb_id = req_str(&body, "knowledgeBaseId")?;
+        let ds_id = req_str(&body, "dataSourceId")?;
         let accts = self.state.read();
         let state = accts
             .get(&req.account_id)
             .ok_or_else(|| not_found(format!("KnowledgeBase {kb_id} not found")))?;
-        if !state.knowledge_bases.contains_key(&kb_id) {
-            return Err(not_found(format!("KnowledgeBase {kb_id} not found")));
-        }
+        self.validate_kb_ds(state, &kb_id, Some(&ds_id))?;
         Ok(AwsResponse::ok_json(json!({
             "documentDetails": [],
         })))
@@ -289,13 +328,12 @@ impl BedrockAgentService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let kb_id = req_str(&body, "knowledgeBaseId")?;
+        let ds_id = req_str(&body, "dataSourceId")?;
         let accts = self.state.read();
         let state = accts
             .get(&req.account_id)
             .ok_or_else(|| not_found(format!("KnowledgeBase {kb_id} not found")))?;
-        if !state.knowledge_bases.contains_key(&kb_id) {
-            return Err(not_found(format!("KnowledgeBase {kb_id} not found")));
-        }
+        self.validate_kb_ds(state, &kb_id, Some(&ds_id))?;
         Ok(AwsResponse::ok_json(json!({
             "documentDetails": [],
         })))

--- a/crates/fakecloud-dynamodb/src/service/helpers/paths.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/paths.rs
@@ -30,8 +30,8 @@ pub(crate) fn resolve_path(
     if !path.contains('.') && !path.contains('[') {
         return item.get(&resolve_attr_name(path, expr_attr_names)).cloned();
     }
-    let resolved = resolve_projection_path(path, expr_attr_names);
-    resolve_nested_path(item, &resolved)
+    let segs = resolve_projection_path_segments(path, expr_attr_names);
+    resolve_nested_path_segments(item, &segs)
 }
 
 pub(crate) fn project_item(
@@ -54,9 +54,9 @@ pub(crate) fn project_item(
                         result.insert(key, v.clone());
                     }
                 } else {
-                    let resolved = resolve_projection_path(raw, &expr_attr_names);
-                    if let Some(v) = resolve_nested_path(item, &resolved) {
-                        insert_nested_value(&mut result, &resolved, v);
+                    let segs = resolve_projection_path_segments(raw, &expr_attr_names);
+                    if let Some(v) = resolve_nested_path_segments(item, &segs) {
+                        insert_nested_value_segments(&mut result, &segs, v);
                     }
                 }
             }
@@ -66,63 +66,89 @@ pub(crate) fn project_item(
     }
 }
 
-/// Resolve expression attribute names within each segment of a projection path.
-/// For example, "people[0].#n" with {"#n": "name"} => "people[0].name".
-pub(crate) fn resolve_projection_path(
+/// Resolve a projection path to logical `PathSegment`s, substituting
+/// `#alias` references without re-splitting the resolved name. Use
+/// this when the result will feed back into
+/// [`resolve_nested_path_segments`] / [`insert_nested_value_segments`]
+/// — otherwise an alias whose value contains `.` (e.g. `#sw` ->
+/// `Safety.Warning`) produces extra spurious segments.
+pub(crate) fn resolve_projection_path_segments(
     path: &str,
     expr_attr_names: &HashMap<String, String>,
-) -> String {
-    // Split on dots, resolve each part, rejoin
-    let mut result = String::new();
-    for (i, segment) in path.split('.').enumerate() {
-        if i > 0 {
-            result.push('.');
-        }
-        // A segment might be like "#n" or "people[0]" or "#attr[0]"
-        if let Some(bracket_pos) = segment.find('[') {
-            let key_part = &segment[..bracket_pos];
-            let index_part = &segment[bracket_pos..];
-            result.push_str(&resolve_attr_name(key_part, expr_attr_names));
-            result.push_str(index_part);
-        } else {
-            result.push_str(&resolve_attr_name(segment, expr_attr_names));
-        }
-    }
-    result
+) -> Vec<PathSegment> {
+    let raw = parse_path_segments(path);
+    raw.into_iter()
+        .map(|seg| match seg {
+            PathSegment::Key(k) => PathSegment::Key(resolve_attr_name(&k, expr_attr_names)),
+            other => other,
+        })
+        .collect()
 }
 
-/// Resolve a potentially nested path like "a.b.c" or "a[0].b" from an item.
-pub(crate) fn resolve_nested_path(
+/// Like [`resolve_nested_path`] but operating on pre-resolved segments.
+pub(crate) fn resolve_nested_path_segments(
     item: &HashMap<String, AttributeValue>,
-    path: &str,
+    segments: &[PathSegment],
 ) -> Option<Value> {
-    let segments = parse_path_segments(path);
     if segments.is_empty() {
         return None;
     }
-
-    let first = &segments[0];
-    let top_key = match first {
+    let top_key = match &segments[0] {
         PathSegment::Key(k) => k.as_str(),
         _ => return None,
     };
-
     let mut current = item.get(top_key)?.clone();
-
     for segment in &segments[1..] {
         match segment {
             PathSegment::Key(k) => {
-                // Navigate into a Map: {"M": {"key": ...}}
                 current = current.get("M")?.get(k)?.clone();
             }
             PathSegment::Index(idx) => {
-                // Navigate into a List: {"L": [...]}
                 current = current.get("L")?.get(*idx)?.clone();
             }
         }
     }
-
     Some(current)
+}
+
+/// Insert a value into `result` at the given pre-resolved segment path.
+pub(crate) fn insert_nested_value_segments(
+    result: &mut HashMap<String, AttributeValue>,
+    segments: &[PathSegment],
+    value: Value,
+) {
+    if segments.is_empty() {
+        return;
+    }
+    let top_key = match &segments[0] {
+        PathSegment::Key(k) => k.clone(),
+        _ => return,
+    };
+    if segments.len() == 1 {
+        result.insert(top_key, value);
+        return;
+    }
+    let wrapped = wrap_value_in_path(&segments[1..], value);
+    let existing = result.remove(&top_key);
+    let merged = match existing {
+        Some(existing) => merge_attribute_values(existing, wrapped),
+        None => wrapped,
+    };
+    result.insert(top_key, merged);
+}
+
+/// Resolve a potentially nested path like "a.b.c" or "a[0].b" from an item.
+///
+/// Kept for tests that exercise raw path parsing; production callers
+/// should resolve aliases first via
+/// [`resolve_projection_path_segments`] and then call
+/// [`resolve_nested_path_segments`] directly.
+#[cfg(test)]
+pub(crate) fn resolve_nested_path(
+    item: &HashMap<String, AttributeValue>,
+    path: &str,
+) -> Option<Value> {
+    resolve_nested_path_segments(item, &parse_path_segments(path))
 }
 
 /// Parse a path like "a.b[0].c" into segments: [Key("a"), Key("b"), Index(0), Key("c")]
@@ -166,45 +192,6 @@ pub(crate) fn parse_path_segments(path: &str) -> Vec<PathSegment> {
         segments.push(PathSegment::Key(current));
     }
     segments
-}
-
-/// Insert a value at a nested path in the result HashMap.
-/// For a path like "a.b", we set result["a"] = {"M": {"b": value}}.
-pub(crate) fn insert_nested_value(
-    result: &mut HashMap<String, AttributeValue>,
-    path: &str,
-    value: Value,
-) {
-    // Simple case: no nesting
-    if !path.contains('.') && !path.contains('[') {
-        result.insert(path.to_string(), value);
-        return;
-    }
-
-    let segments = parse_path_segments(path);
-    if segments.is_empty() {
-        return;
-    }
-
-    let top_key = match &segments[0] {
-        PathSegment::Key(k) => k.clone(),
-        _ => return,
-    };
-
-    if segments.len() == 1 {
-        result.insert(top_key, value);
-        return;
-    }
-
-    // For nested paths, wrap the value back into the nested structure
-    let wrapped = wrap_value_in_path(&segments[1..], value);
-    // Merge into existing value if present
-    let existing = result.remove(&top_key);
-    let merged = match existing {
-        Some(existing) => merge_attribute_values(existing, wrapped),
-        None => wrapped,
-    };
-    result.insert(top_key, merged);
 }
 
 /// Wrap a value in the nested path structure.

--- a/crates/fakecloud-dynamodb/src/service/helpers/request.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/request.rs
@@ -4,6 +4,11 @@ use super::*;
 
 /// Actions that mutate DynamoDB state and therefore require a snapshot
 /// write after success. Kept in sync with the dispatch table above.
+///
+/// For PartiQL ops (`ExecuteStatement`, `BatchExecuteStatement`,
+/// `ExecuteTransaction`) call [`is_mutating_request`] instead — those
+/// can carry read-only SELECTs and forcing a snapshot per call wastes
+/// I/O.
 pub(crate) fn is_mutating_action(action: &str) -> bool {
     matches!(
         action,
@@ -17,9 +22,6 @@ pub(crate) fn is_mutating_action(action: &str) -> bool {
             | "TagResource"
             | "UntagResource"
             | "TransactWriteItems"
-            | "ExecuteStatement"
-            | "BatchExecuteStatement"
-            | "ExecuteTransaction"
             | "UpdateTimeToLive"
             | "PutResourcePolicy"
             | "DeleteResourcePolicy"
@@ -39,6 +41,82 @@ pub(crate) fn is_mutating_action(action: &str) -> bool {
             | "ExportTableToPointInTime"
             | "ImportTable"
     )
+}
+
+/// True when a PartiQL statement is a write (INSERT / UPDATE / DELETE
+/// / UPSERT / MERGE). DynamoDB rejects `CREATE` / `DROP` PartiQL, so
+/// only the data-modification verbs are interesting.
+fn partiql_is_write(stmt: &str) -> bool {
+    let trimmed = stmt.trim_start();
+    // Strip any leading SQL comments (`-- ...` or `/* ... */`).
+    let trimmed = strip_sql_comments(trimmed);
+    let kw = trimmed
+        .split(|c: char| c.is_whitespace())
+        .next()
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    matches!(
+        kw.as_str(),
+        "INSERT" | "UPDATE" | "DELETE" | "UPSERT" | "MERGE"
+    )
+}
+
+fn strip_sql_comments(s: &str) -> &str {
+    let s = s.trim_start();
+    if let Some(rest) = s.strip_prefix("--") {
+        if let Some(nl) = rest.find('\n') {
+            return strip_sql_comments(&rest[nl + 1..]);
+        }
+        return "";
+    }
+    if let Some(rest) = s.strip_prefix("/*") {
+        if let Some(end) = rest.find("*/") {
+            return strip_sql_comments(&rest[end + 2..]);
+        }
+        return "";
+    }
+    s
+}
+
+/// Whether a specific request mutates state — extends
+/// [`is_mutating_action`] with body inspection for PartiQL ops so
+/// read-only SELECTs don't trigger snapshot writes.
+pub(crate) fn is_mutating_request(action: &str, body: &Value) -> bool {
+    if is_mutating_action(action) {
+        return true;
+    }
+    match action {
+        "ExecuteStatement" => body
+            .get("Statement")
+            .and_then(Value::as_str)
+            .map(partiql_is_write)
+            .unwrap_or(true),
+        "ExecuteTransaction" => body
+            .get("TransactStatements")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter().any(|s| {
+                    s.get("Statement")
+                        .and_then(Value::as_str)
+                        .map(partiql_is_write)
+                        .unwrap_or(true)
+                })
+            })
+            .unwrap_or(true),
+        "BatchExecuteStatement" => body
+            .get("Statements")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter().any(|s| {
+                    s.get("Statement")
+                        .and_then(Value::as_str)
+                        .map(partiql_is_write)
+                        .unwrap_or(true)
+                })
+            })
+            .unwrap_or(true),
+        _ => false,
+    }
 }
 
 // ── Helper functions ────────────────────────────────────────────────────

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -275,7 +275,7 @@ impl AwsService for DynamoDbService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let mutates = is_mutating_action(req.action.as_str());
+        let mutates = is_mutating_request(req.action.as_str(), &req.json_body());
         let result = match req.action.as_str() {
             "CreateTable" => self.create_table(&req),
             "DeleteTable" => self.delete_table(&req),

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -275,7 +275,19 @@ impl AwsService for DynamoDbService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let mutates = is_mutating_request(req.action.as_str(), &req.json_body());
+        // Avoid parsing the body for ops where the action alone tells us
+        // they mutate (or don't). Only PartiQL ops need statement
+        // inspection.
+        let mutates = if is_mutating_action(req.action.as_str()) {
+            true
+        } else if matches!(
+            req.action.as_str(),
+            "ExecuteStatement" | "BatchExecuteStatement" | "ExecuteTransaction"
+        ) {
+            is_mutating_request(req.action.as_str(), &req.json_body())
+        } else {
+            false
+        };
         let result = match req.action.as_str() {
             "CreateTable" => self.create_table(&req),
             "DeleteTable" => self.delete_table(&req),


### PR DESCRIPTION
## Summary

Final batch of P2 Cubic findings from audit 2026-05-19 that weren't bundled into the per-service PRs.

- athena: list_calculation_executions honors the validated StateFilter (was ignored).
- bedrock-agent: every documents endpoint + StartIngestionJob now validates that the supplied dataSourceId exists and belongs to the requested KB.
- dynamodb projection paths: resolve #alias references per parsed segment so aliases whose value contains '.' don't gain extra spurious segments.
- dynamodb PartiQL: ExecuteStatement/BatchExecuteStatement/ExecuteTransaction parse the statement keyword to decide mutate vs read-only.

## Test plan

- [x] cargo clippy --all-targets -- -D warnings on affected crates
- [x] cargo test -p fakecloud-dynamodb --lib (272 pass)
- [x] cargo test -p fakecloud-athena --lib (22 pass)
- [ ] CI workspace
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Final P2 cleanup across Athena, Bedrock Agent, and DynamoDB to fix request validation and projection paths, and avoid unnecessary snapshot writes for read-only PartiQL. Also reduces overhead by parsing request bodies only for PartiQL operations.

- **Bug Fixes**
  - `fakecloud-athena`: list_calculation_executions now respects StateFilter.
  - `fakecloud-bedrock-agent`: All documents endpoints and StartIngestionJob validate that dataSourceId exists and belongs to the given knowledgeBase.
  - `fakecloud-dynamodb`: Resolve projection path aliases per segment so alias values with '.' don’t create extra segments.

- **Performance**
  - `fakecloud-dynamodb`: Parse PartiQL to detect writes; SELECTs in ExecuteStatement/BatchExecuteStatement/ExecuteTransaction no longer trigger snapshot writes, and bodies are only parsed for those PartiQL actions.

<sup>Written for commit 3656e3288ef98aee2ab3e929548e97cbf4f1932a. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1531?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

