### PR TITLE
feat(cloudwatch): persist alarms + dashboards + metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,6 +3216,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "quick-xml",

--- a/crates/fakecloud-cloudwatch/Cargo.toml
+++ b/crates/fakecloud-cloudwatch/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
@@ -17,6 +18,7 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros", "sync"] }
 tracing = { workspace = true }
 uuid = { workspace = true }
 quick-xml = { workspace = true }

--- a/crates/fakecloud-cloudwatch/src/lib.rs
+++ b/crates/fakecloud-cloudwatch/src/lib.rs
@@ -5,6 +5,6 @@ pub(crate) mod state;
 pub use delivery::CloudwatchDeliveryImpl;
 pub use service::CloudWatchService;
 pub use state::{
-    AlarmState, CloudWatchAccounts, CloudWatchState, Dashboard, MetricAlarm, MetricDatum,
-    SharedCloudWatchState,
+    AlarmState, CloudWatchAccounts, CloudWatchSnapshot, CloudWatchState, Dashboard, MetricAlarm,
+    MetricDatum, SharedCloudWatchState, CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -9,8 +9,14 @@ use fakecloud_core::query::{
 };
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
+use std::sync::Arc;
+
+use fakecloud_persistence::SnapshotStore;
+use tokio::sync::Mutex;
+
 use crate::state::{
-    AlarmState, Dashboard, MetricAlarm, MetricDatum, SharedCloudWatchState, StatisticSet,
+    AlarmState, CloudWatchSnapshot, Dashboard, MetricAlarm, MetricDatum, SharedCloudWatchState,
+    StatisticSet, CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const NS: &str = "http://monitoring.amazonaws.com/doc/2010-08-01/";
@@ -32,11 +38,50 @@ const SUPPORTED_ACTIONS: &[&str] = &[
 
 pub struct CloudWatchService {
     state: SharedCloudWatchState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<Mutex<()>>,
 }
 
 impl CloudWatchService {
     pub fn new(state: SharedCloudWatchState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    /// Attach a `SnapshotStore` so alarms / dashboards / metrics survive
+    /// restarts. Without this, all CloudWatch state is in-memory only —
+    /// alarms wired to actions fire on a freshly-started process.
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Cloned + serialized under
+    /// the snapshot lock so concurrent mutators can't race a stale-last
+    /// write.
+    pub(crate) async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let snapshot = CloudWatchSnapshot {
+            schema_version: CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
+            accounts: self.state.read().clone_for_snapshot(),
+        };
+        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let bytes = serde_json::to_vec(&snapshot)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            store.save(&bytes)
+        })
+        .await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::error!(%err, "failed to write cloudwatch snapshot"),
+            Err(err) => tracing::error!(%err, "cloudwatch snapshot task panicked"),
+        }
     }
 }
 
@@ -51,7 +96,18 @@ impl AwsService for CloudWatchService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = matches!(
+            req.action.as_str(),
+            "PutMetricData"
+                | "PutMetricAlarm"
+                | "DeleteAlarms"
+                | "EnableAlarmActions"
+                | "DisableAlarmActions"
+                | "SetAlarmState"
+                | "PutDashboard"
+                | "DeleteDashboards"
+        );
+        let result = match req.action.as_str() {
             "PutMetricData" => self.put_metric_data(&req),
             "GetMetricStatistics" => self.get_metric_statistics(&req),
             "GetMetricData" => self.get_metric_data(&req),
@@ -72,7 +128,11 @@ impl AwsService for CloudWatchService {
                 "monitoring",
                 &req.action,
             )),
+        };
+        if mutates && result.is_ok() {
+            self.save_snapshot().await;
         }
+        result
     }
 }
 

--- a/crates/fakecloud-cloudwatch/src/state.rs
+++ b/crates/fakecloud-cloudwatch/src/state.rs
@@ -7,7 +7,16 @@ use serde::{Deserialize, Serialize};
 
 pub type SharedCloudWatchState = Arc<RwLock<CloudWatchAccounts>>;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+/// On-disk snapshot envelope for CloudWatch state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudWatchSnapshot {
+    pub schema_version: u32,
+    pub accounts: CloudWatchAccounts,
+}
+
+pub const CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct CloudWatchAccounts {
     pub accounts: BTreeMap<String, CloudWatchState>,
 }
@@ -15,6 +24,16 @@ pub struct CloudWatchAccounts {
 impl CloudWatchAccounts {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Deep-clone for snapshot serialization. `Clone` isn't derived
+    /// because the live state is held behind a `RwLock` and the rest of
+    /// the crate references it by reference — this helper makes the
+    /// intent explicit at the persistence boundary.
+    pub fn clone_for_snapshot(&self) -> CloudWatchAccounts {
+        CloudWatchAccounts {
+            accounts: self.accounts.clone(),
+        }
     }
 
     pub fn get_or_create(&mut self, account_id: &str) -> &mut CloudWatchState {
@@ -28,7 +47,7 @@ impl CloudWatchAccounts {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct CloudWatchState {
     pub account_id: String,
     /// region -> namespace -> Vec<MetricDatum>

--- a/crates/fakecloud-e2e/tests/cloudwatch_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cloudwatch_persistence.rs
@@ -1,0 +1,65 @@
+mod helpers;
+
+use aws_sdk_cloudwatch::types::{ComparisonOperator, StandardUnit, Statistic};
+use helpers::TestServer;
+
+/// Alarm + dashboard survive a restart. Audit 2026-05-10 flagged CW
+/// state as in-memory only; this guards against regression.
+#[tokio::test]
+async fn persistence_round_trip_alarm_and_dashboard() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let cw = aws_sdk_cloudwatch::Client::new(&server.aws_config().await);
+
+    cw.put_metric_alarm()
+        .alarm_name("persist-alarm")
+        .metric_name("CPUUtilization")
+        .namespace("AWS/EC2")
+        .statistic(Statistic::Average)
+        .period(60)
+        .evaluation_periods(1)
+        .threshold(80.0)
+        .comparison_operator(ComparisonOperator::GreaterThanThreshold)
+        .unit(StandardUnit::Percent)
+        .send()
+        .await
+        .unwrap();
+
+    cw.put_dashboard()
+        .dashboard_name("persist-dashboard")
+        .dashboard_body(r#"{"widgets": []}"#)
+        .send()
+        .await
+        .unwrap();
+
+    drop(cw);
+    server.restart().await;
+    let cw = aws_sdk_cloudwatch::Client::new(&server.aws_config().await);
+
+    let alarms = cw
+        .describe_alarms()
+        .alarm_names("persist-alarm")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        alarms.metric_alarms().len(),
+        1,
+        "alarm should survive restart"
+    );
+    assert_eq!(
+        alarms.metric_alarms()[0].alarm_name(),
+        Some("persist-alarm")
+    );
+
+    let dashboards = cw.list_dashboards().send().await.unwrap();
+    let names: Vec<_> = dashboards
+        .dashboard_entries()
+        .iter()
+        .filter_map(|d| d.dashboard_name())
+        .collect();
+    assert!(
+        names.contains(&"persist-dashboard"),
+        "dashboard should survive restart; got {names:?}"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2144,7 +2144,57 @@ async fn main() {
     registry.register(Arc::new(firehose_service));
     let glue_service = fakecloud_glue::GlueService::new(glue_state.clone());
     registry.register(Arc::new(glue_service));
-    let cloudwatch_service = fakecloud_cloudwatch::CloudWatchService::new(cloudwatch_state.clone());
+    let cloudwatch_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("cloudwatch").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_cloudwatch::CloudWatchSnapshot>(&bytes)
+                    {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_cloudwatch::CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "cloudwatch persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_cloudwatch::CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let account_count = snapshot.accounts.accounts.len();
+                            *cloudwatch_state.write() = snapshot.accounts;
+                            tracing::info!(
+                                accounts = account_count,
+                                "loaded cloudwatch persistence snapshot"
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse cloudwatch persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no cloudwatch persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read cloudwatch persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut cloudwatch_service =
+        fakecloud_cloudwatch::CloudWatchService::new(cloudwatch_state.clone());
+    if let Some(store) = cloudwatch_snapshot_store {
+        cloudwatch_service = cloudwatch_service.with_snapshot_store(store);
+    }
     registry.register(Arc::new(cloudwatch_service));
     let app_autoscaling_service =
         fakecloud_application_autoscaling::ApplicationAutoScalingService::new(


### PR DESCRIPTION
## Summary

Parity audit 2026-05-10 #31: CloudWatch state was in-memory only — alarms wired to actions fired anew on every restart. Add SnapshotStore wiring symmetric to SNS/SQS/IAM.

- new \`CloudWatchSnapshot\` + schema_version
- \`CloudWatchService::with_snapshot_store\` + \`save_snapshot\` after each mutating op
- server bootstrap loads on startup, fatal-exits on schema-too-new
- e2e \`cloudwatch_persistence.rs\`: alarm + dashboard survive \`restart()\`

## Test plan
- [x] cargo build -p fakecloud
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test -p fakecloud-e2e --test cloudwatch_persistence (1 pass)
- [ ] CI workspace
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist CloudWatch alarms, dashboards, and metrics across restarts by adding snapshot storage and wiring load/save in the server. Fixes the parity gap where CloudWatch state was in-memory only.

- **New Features**
  - Added `CloudWatchSnapshot` and `CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION`.
  - `CloudWatchService` now supports `with_snapshot_store` and saves after mutating actions.
  - `fakecloud-server` loads a snapshot on startup and fatal-exits if the schema is too new.
  - New e2e test ensures an alarm and dashboard survive `restart()`.

- **Migration**
  - To persist data, run the server in persistent mode with a `data_path`; snapshot is stored at `cloudwatch/snapshot.json`.
  - No changes needed for ephemeral mode.

<sup>Written for commit 584adb92febc73106ff0b28178ad88a4be7932a7. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1532?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

