### PR TITLE
feat(server): wire Lambda invoke metrics to CloudWatch

### DIFF
--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1140,7 +1140,8 @@ async fn main() {
     // EventBridge / Lambda by ARN scheme.
     let mut lambda_destinations_inner = DeliveryBus::new()
         .with_sqs(sqs_delivery.clone())
-        .with_sns(sns_delivery.clone());
+        .with_sns(sns_delivery.clone())
+        .with_cloudwatch_metrics(cloudwatch_delivery_for_logs.clone());
     if let Some(ref ld) = lambda_delivery {
         lambda_destinations_inner = lambda_destinations_inner.with_lambda(ld.clone());
     }


### PR DESCRIPTION
## Summary

Parity audit 2026-05-10 #38: Lambda's invoke path already calls `bus.put_cloudwatch_metric` for Invocations / Duration / Errors (service/invoke.rs:285-316), but the production DeliveryBus wired into LambdaService had no `cloudwatch_metrics` sender — so every publish silently no-op'd.

Attach `cloudwatch_delivery_for_logs` (same adapter that backs Logs metric filters) to the Lambda destinations bus.

## Test plan
- [x] cargo build -p fakecloud
- [x] cargo clippy --all-targets -- -D warnings
- [ ] CI workspace
- [ ] Cubic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wire Lambda’s `DeliveryBus` to CloudWatch metrics so Invocations, Duration, and Errors are published instead of no-op. Reuses the existing `cloudwatch_delivery_for_logs` adapter, addressing parity audit 2026-05-10 #38.

<sup>Written for commit 894c22b25251db00273c8efec235fecfa84b4826. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1533?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

