### PR TITLE
feat(lambda): native Kubernetes backend behind FAKECLOUD_LAMBDA_BACKEND=k8s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,7 +136,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -134,7 +147,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -166,6 +179,40 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "async-trait"
@@ -1540,11 +1587,11 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.38",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -1718,7 +1765,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1741,6 +1788,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.17",
+ "instant",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1802,7 +1860,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1813,6 +1871,12 @@ dependencies = [
  "shlex",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1865,7 +1929,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -1882,7 +1946,7 @@ checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
 dependencies = [
  "aligned-vec",
  "arrayvec",
- "bitflags",
+ "bitflags 2.11.1",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -1974,7 +2038,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -2322,6 +2386,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2676,6 +2749,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,7 +2946,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2923,8 +3028,10 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sha2 0.10.9",
+ "tar",
  "tokio",
- "tower-http",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3699,7 +3806,10 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-persistence",
+ "futures-util",
  "http 1.4.0",
+ "k8s-openapi",
+ "kube",
  "parking_lot",
  "percent-encoding",
  "reqwest",
@@ -4226,6 +4336,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4336,6 +4455,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4412,6 +4545,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -4567,7 +4701,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -4575,6 +4709,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -4617,6 +4755,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.4.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.4.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4653,6 +4815,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.2",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4778,6 +4949,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.4.0",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4801,10 +4992,24 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
+ "log",
  "rustls 0.23.38",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -5002,6 +5207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "intrusive-collections"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5123,6 +5337,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+dependencies = [
+ "lazy_static",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+dependencies = [
+ "fluent-uri",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5137,12 +5389,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-openapi"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
 name = "keyed_priority_queue"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
  "indexmap",
+]
+
+[[package]]
+name = "kube"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa21063c854820a77c5d7f8deeb7ffa55246d8304e4bcd8cce2956752c6604f8"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+ "kube-runtime",
+]
+
+[[package]]
+name = "kube-client"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c2355f5c9d8a11900e71a6fe1e47abd5ec45bf971eb4b162ffe97b46db9bb7"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-http-proxy",
+ "hyper-rustls 0.27.9",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls 0.23.38",
+ "rustls-pemfile",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3030bd91c9db544a50247e7d48d7db9cf633c172732dce13351854526b1e666"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http 1.4.0",
+ "json-patch",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "kube-runtime"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5895cb8aa641ac922408f128b935652b34c2995f16ad7db0984f6caa50217914"
+dependencies = [
+ "ahash 0.8.12",
+ "async-broadcast",
+ "async-stream",
+ "async-trait",
+ "backoff",
+ "derivative",
+ "futures",
+ "hashbrown 0.14.5",
+ "json-patch",
+ "jsonptr",
+ "k8s-openapi",
+ "kube-client",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -5188,7 +5548,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -5425,7 +5785,7 @@ dependencies = [
  "base64 0.21.7",
  "bigdecimal",
  "bindgen",
- "bitflags",
+ "bitflags 2.11.1",
  "bitvec",
  "btoi",
  "byteorder",
@@ -5464,10 +5824,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -5488,7 +5848,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5591,7 +5951,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5636,7 +5996,7 @@ version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5658,6 +6018,12 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -5672,6 +6038,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -5798,6 +6173,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "phf"
@@ -6320,7 +6738,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6329,7 +6747,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6419,8 +6837,8 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
- "tower",
- "tower-http",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6560,11 +6978,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6586,7 +7004,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -6595,14 +7015,36 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6627,13 +7069,13 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.23.38",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6777,12 +7219,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6828,6 +7293,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -7042,7 +7517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7097,7 +7572,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7187,7 +7662,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -7235,7 +7710,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7487,6 +7962,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -7563,6 +8039,23 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -7579,18 +8072,37 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.11.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7708,6 +8220,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-bidi"
@@ -7980,7 +8498,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver 1.0.28",
@@ -8050,7 +8568,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8427,7 +8945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,3 +262,12 @@ version = "0.15.0"
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
 version = "0.15.0"
+
+[workspace.dependencies.kube]
+version = "0.95"
+default-features = false
+features = ["client", "rustls-tls", "runtime"]
+
+[workspace.dependencies.k8s-openapi]
+version = "0.23"
+features = ["latest"]

--- a/crates/fakecloud-core/src/ecr_uri.rs
+++ b/crates/fakecloud-core/src/ecr_uri.rs
@@ -29,6 +29,14 @@ pub fn is_aws_ecr_uri(image: &str) -> bool {
 /// Docker's localhost-registry behaviour means the daemon on both Linux
 /// and macOS Docker Desktop accepts `127.0.0.1:<port>` over plain HTTP.
 pub fn translate_to_local(image: &str, server_port: u16) -> Option<String> {
+    translate_to_local_at(image, "127.0.0.1", server_port)
+}
+
+/// Like [`translate_to_local`] but lets the caller pick the host the
+/// rewritten URI should point at. Lambda's Kubernetes backend needs
+/// this — inside a cluster, the in-cluster fakecloud Service hostname
+/// (not `127.0.0.1`) is the only address Lambda Pods can reach.
+pub fn translate_to_local_at(image: &str, host: &str, server_port: u16) -> Option<String> {
     if !is_aws_ecr_uri(image) {
         return None;
     }
@@ -36,7 +44,7 @@ pub fn translate_to_local(image: &str, server_port: u16) -> Option<String> {
     if path.is_empty() {
         return None;
     }
-    Some(format!("127.0.0.1:{server_port}/{path}"))
+    Some(format!("{host}:{server_port}/{path}"))
 }
 
 /// Is `image` a digest-pinned reference (`repo@sha256:...`)? Docker's
@@ -113,5 +121,22 @@ mod tests {
             translate_to_local("123456789012.dkr.ecr.us-east-1.amazonaws.com/", 4566),
             None
         );
+    }
+
+    #[test]
+    fn translate_to_local_at_overrides_host() {
+        assert_eq!(
+            translate_to_local_at(
+                "123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:tag",
+                "fakecloud.fakecloud.svc.cluster.local",
+                4566
+            ),
+            Some("fakecloud.fakecloud.svc.cluster.local:4566/repo:tag".to_string())
+        );
+    }
+
+    #[test]
+    fn translate_to_local_at_returns_none_for_non_ecr() {
+        assert_eq!(translate_to_local_at("alpine:3.20", "anything", 4566), None);
     }
 }

--- a/crates/fakecloud-lambda/Cargo.toml
+++ b/crates/fakecloud-lambda/Cargo.toml
@@ -29,6 +29,9 @@ tempfile = { workspace = true }
 percent-encoding = { workspace = true }
 crc32fast = { workspace = true }
 bytes = { workspace = true }
+kube = { workspace = true }
+k8s-openapi = { workspace = true }
+futures-util = "0.3"
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/fakecloud-lambda/src/runtime/backend.rs
+++ b/crates/fakecloud-lambda/src/runtime/backend.rs
@@ -32,6 +32,7 @@ pub enum RuntimeError {
 #[derive(Debug, Clone)]
 pub enum BackendHandle {
     Container { id: String },
+    Pod { namespace: String, name: String },
 }
 
 /// What [`LambdaBackend::launch`] returns. `endpoint` is the `host:port`

--- a/crates/fakecloud-lambda/src/runtime/docker.rs
+++ b/crates/fakecloud-lambda/src/runtime/docker.rs
@@ -442,6 +442,9 @@ impl LambdaBackend for DockerBackend {
     async fn terminate(&self, handle: &BackendHandle) {
         match handle {
             BackendHandle::Container { id } => self.remove_container(id).await,
+            // Pod handles belong to the K8s backend — defensive no-op
+            // so a mis-wired multi-backend setup doesn't panic.
+            BackendHandle::Pod { .. } => {}
         }
     }
 }

--- a/crates/fakecloud-lambda/src/runtime/facade.rs
+++ b/crates/fakecloud-lambda/src/runtime/facade.rs
@@ -76,6 +76,26 @@ impl LambdaRuntime {
         Self::auto_detect_docker(server_port)
     }
 
+    /// Construct a runtime backed by the Kubernetes backend. Reads
+    /// configuration from env vars (`FAKECLOUD_K8S_SELF_URL`,
+    /// `FAKECLOUD_K8S_NAMESPACE`, etc.) and connects to the cluster
+    /// via in-cluster service account or kubeconfig. Hard-fails on
+    /// any configuration or connectivity issue — we don't silently
+    /// fall back to Docker because the operator explicitly opted in
+    /// to K8s.
+    ///
+    /// `internal_token` is the bearer token the artifact endpoints on
+    /// the fakecloud server expect from Pod init containers — caller
+    /// must register the same token on those endpoints.
+    pub async fn new_k8s(
+        server_port: u16,
+        internal_token: String,
+    ) -> Result<Self, super::k8s::K8sBackendError> {
+        let backend = super::k8s::K8sBackend::from_env(server_port, internal_token).await?;
+        backend.reap_stale().await;
+        Ok(Self::from_backend(Arc::new(backend)))
+    }
+
     pub fn cli_name(&self) -> &str {
         self.backend.name()
     }
@@ -255,15 +275,26 @@ impl LambdaRuntime {
                     .unwrap_or_default();
                 let last_used = entry.last_used.read();
                 let idle_secs = last_used.elapsed().as_secs();
-                let container_id = match &entry.instance.handle {
-                    BackendHandle::Container { id } => id.clone(),
-                };
-                serde_json::json!({
+                let mut row = serde_json::json!({
                     "functionName": name,
                     "runtime": runtime,
-                    "containerId": container_id,
+                    "backend": self.backend.name(),
                     "lastUsedSecsAgo": idle_secs,
-                })
+                });
+                let obj = row.as_object_mut().expect("json object");
+                match &entry.instance.handle {
+                    BackendHandle::Container { id } => {
+                        obj.insert("containerId".into(), serde_json::Value::String(id.clone()));
+                    }
+                    BackendHandle::Pod { namespace, name } => {
+                        obj.insert("podName".into(), serde_json::Value::String(name.clone()));
+                        obj.insert(
+                            "namespace".into(),
+                            serde_json::Value::String(namespace.clone()),
+                        );
+                    }
+                }
+                row
             })
             .collect()
     }

--- a/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
@@ -1,0 +1,360 @@
+//! Kubernetes [`LambdaBackend`] implementation.
+//!
+//! Spawns Lambda function runtimes as native Pods in a Kubernetes
+//! cluster instead of as Docker containers. Gated by
+//! `FAKECLOUD_LAMBDA_BACKEND=k8s` on the fakecloud server.
+//!
+//! See `website/content/docs/guides/kubernetes-backend.md` for the
+//! operator-facing setup (ServiceAccount, RBAC, Deployment yaml).
+
+pub mod spec;
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, DeleteParams, ListParams, PostParams};
+use kube::Client;
+
+use super::backend::{BackendHandle, LambdaBackend, RuntimeError, WarmInstance};
+use crate::state::LambdaFunction;
+use spec::{build_pod_spec, pod_name_for, PodSpecContext};
+
+/// Errors that can prevent the K8s backend from initializing. Surfaced
+/// to the operator at fakecloud startup; never silently swallowed.
+#[derive(Debug, thiserror::Error)]
+pub enum K8sBackendError {
+    #[error("FAKECLOUD_K8S_SELF_URL must be set when FAKECLOUD_LAMBDA_BACKEND=k8s")]
+    MissingSelfUrl,
+    #[error("FAKECLOUD_K8S_SELF_URL is not a valid URL: {0}")]
+    InvalidSelfUrl(String),
+    #[error("failed to construct Kubernetes client: {0}")]
+    Client(#[from] kube::Error),
+    #[error("failed to read kubeconfig / in-cluster config: {0}")]
+    Config(String),
+}
+
+/// Native Kubernetes Lambda execution backend.
+pub struct K8sBackend {
+    client: Client,
+    namespace: String,
+    instance_id: String,
+    /// In-cluster URL of the fakecloud server (e.g.
+    /// `http://fakecloud.fakecloud.svc.cluster.local:4566`). Init
+    /// containers fetch code + layers from this host.
+    self_url: String,
+    /// Just the host part of `self_url` — used to rewrite localhost env
+    /// values so user code can talk to fakecloud from inside the Pod.
+    self_host: String,
+    /// Host:port for the fakecloud ECR endpoint (defaults to the host
+    /// of `self_url` when `FAKECLOUD_K8S_ECR_URL` is unset).
+    ecr_host: String,
+    ecr_port: u16,
+    /// Bearer token the init container presents when fetching code +
+    /// layers. Generated at server startup, kept in process memory only.
+    internal_token: String,
+    /// Optional `imagePullSecrets` reference for image-package functions
+    /// that pull from a registry needing credentials.
+    pull_secret: Option<String>,
+}
+
+impl K8sBackend {
+    /// Read configuration from env vars and connect to the cluster.
+    /// Fails fast on missing required config — never silently degrades.
+    /// `default_ecr_port` is fakecloud's bound port; used as the ECR
+    /// port when `FAKECLOUD_K8S_ECR_URL` is unset.
+    pub async fn from_env(
+        default_ecr_port: u16,
+        internal_token: String,
+    ) -> Result<Self, K8sBackendError> {
+        let self_url =
+            std::env::var("FAKECLOUD_K8S_SELF_URL").map_err(|_| K8sBackendError::MissingSelfUrl)?;
+        let parsed = reqwest::Url::parse(&self_url)
+            .map_err(|e| K8sBackendError::InvalidSelfUrl(e.to_string()))?;
+        let self_host = parsed
+            .host_str()
+            .ok_or_else(|| K8sBackendError::InvalidSelfUrl("missing host".into()))?
+            .to_string();
+        let self_port = parsed.port_or_known_default().unwrap_or(default_ecr_port);
+
+        let (ecr_host, ecr_port) = match std::env::var("FAKECLOUD_K8S_ECR_URL").ok() {
+            Some(raw) => {
+                let u = reqwest::Url::parse(&raw)
+                    .map_err(|e| K8sBackendError::InvalidSelfUrl(e.to_string()))?;
+                let h = u
+                    .host_str()
+                    .ok_or_else(|| K8sBackendError::InvalidSelfUrl("ECR url missing host".into()))?
+                    .to_string();
+                let p = u.port_or_known_default().unwrap_or(default_ecr_port);
+                (h, p)
+            }
+            None => (self_host.clone(), self_port),
+        };
+
+        let namespace =
+            std::env::var("FAKECLOUD_K8S_NAMESPACE").unwrap_or_else(|_| "default".to_string());
+        let pull_secret = std::env::var("FAKECLOUD_K8S_PULL_SECRET").ok();
+
+        let client = Client::try_default()
+            .await
+            .map_err(|e| K8sBackendError::Config(e.to_string()))?;
+
+        let instance_id = format!("fakecloud-{}", std::process::id());
+
+        tracing::info!(
+            namespace = %namespace,
+            self_url = %self_url,
+            ecr = %format!("{ecr_host}:{ecr_port}"),
+            "K8s Lambda backend initialized"
+        );
+
+        Ok(Self {
+            client,
+            namespace,
+            instance_id,
+            self_url,
+            self_host,
+            ecr_host,
+            ecr_port,
+            internal_token,
+            pull_secret,
+        })
+    }
+
+    fn pods_api(&self) -> Api<Pod> {
+        Api::namespaced(self.client.clone(), &self.namespace)
+    }
+
+    /// Watch the pod until it has a non-empty `status.podIP`. Polled
+    /// rather than streamed — simpler, and the polling cadence (1s) is
+    /// well below the typical 5-30s pod boot time for an RIE image.
+    async fn wait_for_pod_ip(&self, pod_name: &str) -> Result<String, RuntimeError> {
+        let api = self.pods_api();
+        let deadline = std::time::Instant::now() + Duration::from_secs(60);
+        loop {
+            let pod = api.get(pod_name).await.map_err(|e| {
+                RuntimeError::ContainerStartFailed(format!("k8s get pod {pod_name}: {e}"))
+            })?;
+            if let Some(ip) = pod
+                .status
+                .as_ref()
+                .and_then(|s| s.pod_ip.as_ref())
+                .filter(|s| !s.is_empty())
+            {
+                // Pod might have IP but not yet be Running — check phase
+                let phase = pod
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.phase.as_deref())
+                    .unwrap_or("Unknown");
+                if phase == "Running" {
+                    return Ok(ip.clone());
+                }
+                if phase == "Failed" || phase == "Succeeded" {
+                    return Err(RuntimeError::ContainerStartFailed(format!(
+                        "pod {pod_name} reached terminal phase {phase} during startup"
+                    )));
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(RuntimeError::ContainerStartFailed(format!(
+                    "pod {pod_name} did not become Running with podIP within 60s"
+                )));
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    /// TCP-handshake the RIE port. Pod-Running doesn't guarantee the
+    /// RIE inside the main container is listening yet — same logic as
+    /// Docker's `wait_for_ready`.
+    async fn wait_for_rie_ready(&self, pod_ip: &str) -> Result<(), RuntimeError> {
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            if tokio::net::TcpStream::connect(format!("{pod_ip}:8080"))
+                .await
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+        Err(RuntimeError::ContainerStartFailed(format!(
+            "RIE on {pod_ip}:8080 did not accept connections within 10s"
+        )))
+    }
+}
+
+/// Extract the account ID from a function ARN
+/// (`arn:aws:lambda:<region>:<account>:function:<name>[:<qual>]`).
+fn account_id_from_arn(arn: &str) -> &str {
+    arn.split(':').nth(4).unwrap_or("000000000000")
+}
+
+#[async_trait]
+impl LambdaBackend for K8sBackend {
+    fn name(&self) -> &str {
+        "kubernetes"
+    }
+
+    async fn launch(
+        &self,
+        func: &LambdaFunction,
+        _code_zip: Option<&[u8]>,
+        _layers: &[Vec<u8>],
+        deploy_id: &str,
+    ) -> Result<WarmInstance, RuntimeError> {
+        let account_id = account_id_from_arn(&func.function_arn);
+        let ctx = PodSpecContext {
+            instance_id: &self.instance_id,
+            namespace: &self.namespace,
+            self_url: &self.self_url,
+            self_host: &self.self_host,
+            ecr_host: &self.ecr_host,
+            ecr_port: self.ecr_port,
+            internal_token: &self.internal_token,
+            account_id,
+            pull_secret: self.pull_secret.as_deref(),
+        };
+        let pod =
+            build_pod_spec(func, deploy_id, &ctx).map_err(RuntimeError::ContainerStartFailed)?;
+        let pod_name = pod
+            .metadata
+            .name
+            .clone()
+            .unwrap_or_else(|| pod_name_for(&func.function_name, deploy_id));
+
+        let api = self.pods_api();
+
+        // Best-effort delete of any stale pod with the same name (e.g.
+        // a previous fakecloud process left it behind). `Created` from
+        // a stale pod would otherwise come back as `Conflict (409)`.
+        let _ = api.delete(&pod_name, &DeleteParams::default()).await;
+        // Give the API server a moment to actually delete; otherwise
+        // create can race and 409. Polling for absence would be more
+        // correct — keep simple for now and retry create on 409.
+        for attempt in 0..6 {
+            match api.create(&PostParams::default(), &pod).await {
+                Ok(_) => break,
+                Err(kube::Error::Api(e)) if e.code == 409 && attempt < 5 => {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    let _ = api.delete(&pod_name, &DeleteParams::default()).await;
+                    continue;
+                }
+                Err(e) => {
+                    return Err(RuntimeError::ContainerStartFailed(format!(
+                        "k8s create pod {pod_name}: {e}"
+                    )));
+                }
+            }
+        }
+
+        let pod_ip = self.wait_for_pod_ip(&pod_name).await.inspect_err(|_| {
+            let api = self.pods_api();
+            let name = pod_name.clone();
+            tokio::spawn(async move {
+                let _ = api.delete(&name, &DeleteParams::default()).await;
+            });
+        })?;
+        self.wait_for_rie_ready(&pod_ip).await.inspect_err(|_| {
+            let api = self.pods_api();
+            let name = pod_name.clone();
+            tokio::spawn(async move {
+                let _ = api.delete(&name, &DeleteParams::default()).await;
+            });
+        })?;
+
+        tracing::info!(
+            function = %func.function_name,
+            pod = %pod_name,
+            namespace = %self.namespace,
+            pod_ip = %pod_ip,
+            "Lambda Pod started"
+        );
+
+        Ok(WarmInstance {
+            endpoint: format!("{pod_ip}:8080"),
+            handle: BackendHandle::Pod {
+                namespace: self.namespace.clone(),
+                name: pod_name,
+            },
+        })
+    }
+
+    async fn terminate(&self, handle: &BackendHandle) {
+        let (ns, name) = match handle {
+            BackendHandle::Pod { namespace, name } => (namespace.clone(), name.clone()),
+            // Docker handles aren't ours to manage — defensive no-op.
+            BackendHandle::Container { .. } => return,
+        };
+        let api: Api<Pod> = Api::namespaced(self.client.clone(), &ns);
+        if let Err(e) = api.delete(&name, &DeleteParams::default()).await {
+            // 404 is normal on idempotent re-delete; surface anything else.
+            if let kube::Error::Api(api_err) = &e {
+                if api_err.code == 404 {
+                    return;
+                }
+            }
+            tracing::warn!(pod = %name, namespace = %ns, error = %e, "k8s delete pod failed");
+        }
+    }
+
+    /// Sweep Lambda Pods that belong to a previous fakecloud process.
+    /// Without this, a fakecloud restart leaks the previous run's Pods
+    /// and `Create` collides on function names. Mirrors the docker
+    /// `reaper` semantics.
+    async fn reap_stale(&self) {
+        let api = self.pods_api();
+        let lp = ListParams::default().labels("fakecloud-managed-by=fakecloud");
+        let list = match api.list(&lp).await {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!(error = %e, "k8s reap_stale: list pods failed");
+                return;
+            }
+        };
+        let mut reaped = 0usize;
+        for pod in list.items {
+            let labels = pod.metadata.labels.as_ref();
+            let inst = labels.and_then(|l| l.get("fakecloud-instance")).cloned();
+            if inst.as_deref() == Some(self.instance_id.as_str()) {
+                continue;
+            }
+            if let Some(name) = pod.metadata.name {
+                if let Err(e) = api.delete(&name, &DeleteParams::default()).await {
+                    tracing::warn!(pod = %name, error = %e, "k8s reap_stale: delete failed");
+                } else {
+                    reaped += 1;
+                }
+            }
+        }
+        if reaped > 0 {
+            tracing::info!(reaped, "k8s reap_stale: removed orphan Lambda Pods");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::account_id_from_arn;
+
+    #[test]
+    fn account_id_from_simple_arn() {
+        assert_eq!(
+            account_id_from_arn("arn:aws:lambda:us-east-1:123456789012:function:my-fn"),
+            "123456789012"
+        );
+    }
+
+    #[test]
+    fn account_id_from_qualified_arn() {
+        assert_eq!(
+            account_id_from_arn("arn:aws:lambda:us-east-1:000000000000:function:my-fn:PROD"),
+            "000000000000"
+        );
+    }
+
+    #[test]
+    fn account_id_falls_back_for_malformed_arn() {
+        assert_eq!(account_id_from_arn("not-an-arn"), "000000000000");
+    }
+}

--- a/crates/fakecloud-lambda/src/runtime/k8s/spec.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/spec.rs
@@ -1,0 +1,613 @@
+//! Pod spec construction for the Kubernetes [`super::K8sBackend`].
+//!
+//! Pure functions over `k8s_openapi::api::core::v1::Pod` — no cluster
+//! interaction, fully unit-testable.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::{
+    Container, EmptyDirVolumeSource, EnvVar, LocalObjectReference, Pod, PodSpec,
+    ResourceRequirements, Volume, VolumeMount,
+};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+use super::super::docker::runtime_to_image;
+use super::super::env_rewrite::rewrite_localhost_envs;
+use crate::state::LambdaFunction;
+
+/// Inputs that don't come from the function itself — instance identity,
+/// the in-cluster fakecloud URL, the bearer token the init container
+/// uses to fetch code/layers, etc.
+pub struct PodSpecContext<'a> {
+    pub instance_id: &'a str,
+    pub namespace: &'a str,
+    /// In-cluster URL of the fakecloud server (e.g.
+    /// `http://fakecloud.fakecloud.svc.cluster.local:4566`). Init
+    /// containers fetch code + layers from this host.
+    pub self_url: &'a str,
+    /// Host part of `self_url` — used to rewrite `localhost`/`127.0.0.1`
+    /// env values so user code can reach fakecloud from inside the Pod.
+    pub self_host: &'a str,
+    /// Host:port for the fakecloud ECR endpoint (for `PackageType=Image`
+    /// functions that reference AWS private-ECR URIs).
+    pub ecr_host: &'a str,
+    pub ecr_port: u16,
+    /// Bearer token the init container presents when fetching code +
+    /// layers from `self_url`. Never logged.
+    pub internal_token: &'a str,
+    /// Account ID owning the function. Embedded in init-container URLs
+    /// so the artifact endpoint can find the right LambdaState.
+    pub account_id: &'a str,
+    /// Optional name of a Kubernetes `Secret` of type
+    /// `kubernetes.io/dockerconfigjson` used as `imagePullSecrets` for
+    /// container-image functions.
+    pub pull_secret: Option<&'a str>,
+}
+
+/// Resource cap for the `/tmp` `emptyDir` (`medium: Memory`) — sized
+/// from the function's `ephemeral_storage_size`. AWS defaults to 512
+/// MiB; clamp at 64 MiB so wildly stale snapshots still produce a spec
+/// the kubelet accepts.
+fn ephemeral_storage_mib(size: Option<i64>) -> i64 {
+    size.unwrap_or(512).max(64)
+}
+
+/// Build the Pod spec for a single Lambda function invocation runtime.
+/// The Pod has one init container (busybox) that downloads code + layers
+/// from fakecloud over HTTP, and one main container running the AWS RIE
+/// image (zip functions) or the user-supplied image (image functions).
+pub fn build_pod_spec(
+    func: &LambdaFunction,
+    deploy_id: &str,
+    ctx: &PodSpecContext<'_>,
+) -> Result<Pod, String> {
+    let is_image = func.package_type == "Image";
+
+    let main_image = if is_image {
+        let raw = func
+            .image_uri
+            .as_deref()
+            .ok_or_else(|| "PackageType=Image function has no ImageUri".to_string())?;
+        fakecloud_core::ecr_uri::translate_to_local_at(raw, ctx.ecr_host, ctx.ecr_port)
+            .unwrap_or_else(|| raw.to_string())
+    } else {
+        runtime_to_image(&func.runtime)
+            .ok_or_else(|| format!("unsupported runtime: {}", func.runtime))?
+    };
+
+    let pod_name = pod_name_for(&func.function_name, deploy_id);
+
+    let mut labels = BTreeMap::new();
+    labels.insert("fakecloud-managed-by".into(), "fakecloud".into());
+    labels.insert("fakecloud-instance".into(), ctx.instance_id.into());
+    labels.insert("fakecloud-lambda".into(), label_safe(&func.function_name));
+    labels.insert(
+        "fakecloud-deploy-id".into(),
+        label_safe(&deploy_id[..deploy_id.len().min(40)]),
+    );
+
+    // Env vars — user-supplied (with localhost rewritten to in-cluster
+    // fakecloud host) + the AWS_LAMBDA_FUNCTION_TIMEOUT the RIE honors.
+    let mut env: Vec<EnvVar> = rewrite_localhost_envs(&func.environment, ctx.self_host)
+        .into_iter()
+        .map(|(k, v)| EnvVar {
+            name: k,
+            value: Some(v),
+            value_from: None,
+        })
+        .collect();
+    env.push(EnvVar {
+        name: "AWS_LAMBDA_FUNCTION_TIMEOUT".into(),
+        value: Some(func.timeout.to_string()),
+        value_from: None,
+    });
+
+    // Shared volumes — init container writes /var/task, /opt, layers;
+    // main container reads them. `/tmp` is sized from ephemeral_storage.
+    let tmp_mib = ephemeral_storage_mib(func.ephemeral_storage_size);
+    let volumes = vec![
+        Volume {
+            name: "fakecloud-task".into(),
+            empty_dir: Some(EmptyDirVolumeSource::default()),
+            ..Volume::default()
+        },
+        Volume {
+            name: "fakecloud-opt".into(),
+            empty_dir: Some(EmptyDirVolumeSource::default()),
+            ..Volume::default()
+        },
+        Volume {
+            name: "fakecloud-tmp".into(),
+            empty_dir: Some(EmptyDirVolumeSource {
+                medium: Some("Memory".into()),
+                size_limit: Some(Quantity(format!("{tmp_mib}Mi"))),
+            }),
+            ..Volume::default()
+        },
+    ];
+
+    let common_mounts = vec![
+        VolumeMount {
+            name: "fakecloud-task".into(),
+            mount_path: "/var/task".into(),
+            ..VolumeMount::default()
+        },
+        VolumeMount {
+            name: "fakecloud-opt".into(),
+            mount_path: "/opt".into(),
+            ..VolumeMount::default()
+        },
+        VolumeMount {
+            name: "fakecloud-tmp".into(),
+            mount_path: "/tmp".into(),
+            ..VolumeMount::default()
+        },
+    ];
+
+    // Init container: busybox + wget. Downloads code zip + layers tar
+    // and unpacks them into the shared emptyDir volumes. For
+    // image-package functions the code+layers endpoint short-circuits
+    // (image already contains code) so we only fetch the layers tar.
+    let init_script = if is_image {
+        "set -eu; \
+         wget -q --header=\"authorization: Bearer $FAKECLOUD_INTERNAL_TOKEN\" \
+              -O /tmp/layers.tar \
+              \"$FAKECLOUD_SELF_URL/_fakecloud/lambda/_internal/layers/$ACCT/$FN/$DEPLOY_ID.tar\"; \
+         if [ -s /tmp/layers.tar ]; then tar -xf /tmp/layers.tar -C /opt; fi"
+            .to_string()
+    } else {
+        "set -eu; \
+         wget -q --header=\"authorization: Bearer $FAKECLOUD_INTERNAL_TOKEN\" \
+              -O /tmp/code.zip \
+              \"$FAKECLOUD_SELF_URL/_fakecloud/lambda/_internal/code/$ACCT/$FN/$DEPLOY_ID.zip\"; \
+         unzip -q /tmp/code.zip -d /var/task; \
+         wget -q --header=\"authorization: Bearer $FAKECLOUD_INTERNAL_TOKEN\" \
+              -O /tmp/layers.tar \
+              \"$FAKECLOUD_SELF_URL/_fakecloud/lambda/_internal/layers/$ACCT/$FN/$DEPLOY_ID.tar\"; \
+         if [ -s /tmp/layers.tar ]; then tar -xf /tmp/layers.tar -C /opt; fi"
+            .to_string()
+    };
+
+    let init_env = vec![
+        EnvVar {
+            name: "FAKECLOUD_SELF_URL".into(),
+            value: Some(ctx.self_url.into()),
+            value_from: None,
+        },
+        EnvVar {
+            name: "FAKECLOUD_INTERNAL_TOKEN".into(),
+            value: Some(ctx.internal_token.into()),
+            value_from: None,
+        },
+        EnvVar {
+            name: "ACCT".into(),
+            value: Some(ctx.account_id.into()),
+            value_from: None,
+        },
+        EnvVar {
+            name: "FN".into(),
+            value: Some(func.function_name.clone()),
+            value_from: None,
+        },
+        EnvVar {
+            name: "DEPLOY_ID".into(),
+            value: Some(deploy_id.into()),
+            value_from: None,
+        },
+    ];
+
+    let init_container = Container {
+        name: "fakecloud-init".into(),
+        // busybox ships `wget`, `unzip`, `tar` — covers everything the
+        // bootstrap script needs without depending on what's in the
+        // runtime image.
+        image: Some("busybox:1.36".into()),
+        command: Some(vec!["sh".into(), "-c".into(), init_script]),
+        env: Some(init_env),
+        volume_mounts: Some(common_mounts.clone()),
+        ..Container::default()
+    };
+
+    // Main container — runs the RIE image (zip) or the user's image.
+    // For zip functions the handler is passed as the cmd argument, same
+    // as Docker (`docker create <image> <handler>`).
+    let mut main_container = Container {
+        name: "fakecloud-lambda".into(),
+        image: Some(main_image.clone()),
+        env: Some(env),
+        volume_mounts: Some(common_mounts),
+        resources: Some(memory_resources(func.memory_size)),
+        ..Container::default()
+    };
+    if !is_image {
+        main_container.command = None;
+        main_container.args = Some(vec![func.handler.clone()]);
+    }
+
+    let pull_secrets = ctx.pull_secret.map(|name| {
+        vec![LocalObjectReference {
+            name: name.to_string(),
+        }]
+    });
+
+    Ok(Pod {
+        metadata: ObjectMeta {
+            name: Some(pod_name),
+            namespace: Some(ctx.namespace.to_string()),
+            labels: Some(labels),
+            ..ObjectMeta::default()
+        },
+        spec: Some(PodSpec {
+            restart_policy: Some("Never".into()),
+            init_containers: Some(vec![init_container]),
+            containers: vec![main_container],
+            volumes: Some(volumes),
+            image_pull_secrets: pull_secrets,
+            ..PodSpec::default()
+        }),
+        ..Pod::default()
+    })
+}
+
+/// Build a deterministic, DNS-1123-safe Pod name for the given
+/// function + deploy_id. Truncated/lowercased so it fits the 63-char
+/// label limit.
+pub fn pod_name_for(function_name: &str, deploy_id: &str) -> String {
+    // function_name may contain underscores or uppercase; convert.
+    let fn_part = label_safe(function_name);
+    // deploy_id is base64 — pick the first 12 chars of a hex projection
+    // so the suffix is stable across restarts and DNS-safe.
+    let digest = simple_hex12(deploy_id);
+    // Keep total length under 63. fn_part already <=40, digest is 12,
+    // prefix "fakecloud-lambda-" is 17. Trim function part to 30.
+    let fn_short: String = fn_part.chars().take(30).collect();
+    format!("fakecloud-lambda-{fn_short}-{digest}")
+}
+
+/// Map the function's `memory_size` (MiB) onto both `requests` and
+/// `limits`. Mirrors real Lambda: CPU is implicitly proportional to
+/// memory, but k8s requires explicit values, so we set memory only and
+/// leave CPU unlimited (clusters with LimitRange policies can layer
+/// their own defaults).
+fn memory_resources(memory_size: i64) -> ResourceRequirements {
+    let mut req = BTreeMap::new();
+    req.insert(
+        "memory".to_string(),
+        Quantity(format!("{}Mi", memory_size.max(128))),
+    );
+    let mut lim = BTreeMap::new();
+    lim.insert(
+        "memory".to_string(),
+        Quantity(format!("{}Mi", memory_size.max(128))),
+    );
+    ResourceRequirements {
+        requests: Some(req),
+        limits: Some(lim),
+        claims: None,
+    }
+}
+
+/// Lowercase + replace anything outside `[a-z0-9-]` with `-`. DNS-1123
+/// label rules: 63 chars max, ends with alphanumeric.
+fn label_safe(s: &str) -> String {
+    let mut out: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    // Trim trailing dashes so the label ends in an alphanumeric.
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+/// 12-char hex projection of an arbitrary string, used to suffix Pod
+/// names so deploy_id changes produce a new Pod without colliding with
+/// the old one. Deterministic so the watcher and the launch step agree
+/// on the name. Not a cryptographic hash — collision space (2^48) is
+/// plenty for per-function uniqueness.
+fn simple_hex12(s: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    let bytes = h.finalize();
+    let hex: String = bytes.iter().take(6).map(|b| format!("{b:02x}")).collect();
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::LambdaFunction;
+    use chrono::Utc;
+
+    fn ctx<'a>() -> PodSpecContext<'a> {
+        PodSpecContext {
+            instance_id: "fakecloud-1234",
+            namespace: "fakecloud",
+            self_url: "http://fakecloud.fakecloud.svc.cluster.local:4566",
+            self_host: "fakecloud.fakecloud.svc.cluster.local",
+            ecr_host: "fakecloud.fakecloud.svc.cluster.local",
+            ecr_port: 4566,
+            internal_token: "secret-token-xyz",
+            account_id: "000000000000",
+            pull_secret: None,
+        }
+    }
+
+    fn zip_function(name: &str) -> LambdaFunction {
+        let mut f = LambdaFunction {
+            function_name: name.into(),
+            function_arn: format!("arn:aws:lambda:us-east-1:000000000000:function:{name}"),
+            runtime: "python3.12".into(),
+            role: "arn:aws:iam::000000000000:role/test".into(),
+            handler: "lambda_function.lambda_handler".into(),
+            description: String::new(),
+            timeout: 30,
+            memory_size: 256,
+            code_sha256: "abc".into(),
+            code_size: 0,
+            version: "$LATEST".into(),
+            last_modified: Utc::now(),
+            tags: BTreeMap::new(),
+            environment: BTreeMap::new(),
+            architectures: vec!["x86_64".into()],
+            package_type: "Zip".into(),
+            code_zip: None,
+            image_uri: None,
+            policy: None,
+            layers: Vec::new(),
+            revision_id: "rev-1".into(),
+            tracing_mode: None,
+            kms_key_arn: None,
+            ephemeral_storage_size: Some(1024),
+            vpc_config: None,
+            snap_start: None,
+            dead_letter_config_arn: None,
+            file_system_configs: Vec::new(),
+            logging_config: None,
+            image_config: None,
+            durable_config: None,
+            signing_profile_version_arn: None,
+            signing_job_arn: None,
+            runtime_version_config: None,
+            master_arn: None,
+            state_reason: None,
+            state_reason_code: None,
+            last_update_status_reason: None,
+            last_update_status_reason_code: None,
+        };
+        f.environment
+            .insert("FAKECLOUD_URL".into(), "http://localhost:4566".into());
+        f
+    }
+
+    #[test]
+    fn zip_pod_has_init_container_with_code_download() {
+        let f = zip_function("my-fn");
+        let pod = build_pod_spec(&f, "deploy-xyz", &ctx()).unwrap();
+        let spec = pod.spec.unwrap();
+        let init = &spec.init_containers.unwrap()[0];
+        let script = init.command.as_ref().unwrap().last().unwrap();
+        assert!(
+            script.contains("code/$ACCT/$FN/$DEPLOY_ID.zip"),
+            "init script must include code download for zip functions: {script}"
+        );
+        assert!(
+            script.contains("layers/$ACCT/$FN/$DEPLOY_ID.tar"),
+            "init script must include layers download: {script}"
+        );
+        // Bearer header references env, not the literal token, so we
+        // don't leak the secret into describe output / logs.
+        assert!(script.contains("$FAKECLOUD_INTERNAL_TOKEN"));
+        assert!(!script.contains("secret-token-xyz"));
+    }
+
+    #[test]
+    fn image_pod_skips_code_download() {
+        let mut f = zip_function("img-fn");
+        f.package_type = "Image".into();
+        f.image_uri = Some("public.ecr.aws/test/img:1".into());
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        let init = &pod.spec.unwrap().init_containers.unwrap()[0];
+        let script = init.command.as_ref().unwrap().last().unwrap();
+        assert!(!script.contains("code/"));
+        assert!(script.contains("layers/"));
+    }
+
+    #[test]
+    fn image_pod_translates_aws_ecr_uri() {
+        let mut f = zip_function("img-fn");
+        f.package_type = "Image".into();
+        f.image_uri = Some("123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:tag".into());
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        let image = pod.spec.unwrap().containers[0].image.clone().unwrap();
+        assert_eq!(image, "fakecloud.fakecloud.svc.cluster.local:4566/repo:tag");
+    }
+
+    #[test]
+    fn image_pod_leaves_non_ecr_uri_alone() {
+        let mut f = zip_function("img-fn");
+        f.package_type = "Image".into();
+        f.image_uri = Some("public.ecr.aws/test/img:1".into());
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        let image = pod.spec.unwrap().containers[0].image.clone().unwrap();
+        assert_eq!(image, "public.ecr.aws/test/img:1");
+    }
+
+    #[test]
+    fn zip_pod_uses_runtime_to_image_for_main_container() {
+        let f = zip_function("my-fn");
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        let image = pod.spec.unwrap().containers[0].image.clone().unwrap();
+        assert_eq!(image, "public.ecr.aws/lambda/python:3.12");
+    }
+
+    #[test]
+    fn handler_passed_as_args_for_zip_pod() {
+        let f = zip_function("my-fn");
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        let args = pod.spec.unwrap().containers[0].args.clone().unwrap();
+        assert_eq!(args, vec!["lambda_function.lambda_handler"]);
+    }
+
+    #[test]
+    fn env_vars_rewrite_localhost_to_self_host() {
+        let f = zip_function("my-fn");
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        let env = pod.spec.unwrap().containers[0].env.clone().unwrap();
+        let url = env
+            .iter()
+            .find(|e| e.name == "FAKECLOUD_URL")
+            .unwrap()
+            .value
+            .clone()
+            .unwrap();
+        assert_eq!(url, "http://fakecloud.fakecloud.svc.cluster.local:4566");
+    }
+
+    #[test]
+    fn function_timeout_env_set() {
+        let f = zip_function("my-fn");
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        let env = pod.spec.unwrap().containers[0].env.clone().unwrap();
+        let t = env
+            .iter()
+            .find(|e| e.name == "AWS_LAMBDA_FUNCTION_TIMEOUT")
+            .unwrap()
+            .value
+            .clone()
+            .unwrap();
+        assert_eq!(t, "30");
+    }
+
+    #[test]
+    fn ephemeral_storage_maps_to_emptydir_memory_with_size_limit() {
+        let f = zip_function("my-fn");
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        let vol = pod
+            .spec
+            .unwrap()
+            .volumes
+            .unwrap()
+            .into_iter()
+            .find(|v| v.name == "fakecloud-tmp")
+            .unwrap();
+        let ed = vol.empty_dir.unwrap();
+        assert_eq!(ed.medium.as_deref(), Some("Memory"));
+        assert_eq!(ed.size_limit.unwrap().0, "1024Mi");
+    }
+
+    #[test]
+    fn ephemeral_storage_defaults_to_512mib() {
+        let mut f = zip_function("my-fn");
+        f.ephemeral_storage_size = None;
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        let vol = pod
+            .spec
+            .unwrap()
+            .volumes
+            .unwrap()
+            .into_iter()
+            .find(|v| v.name == "fakecloud-tmp")
+            .unwrap();
+        assert_eq!(vol.empty_dir.unwrap().size_limit.unwrap().0, "512Mi");
+    }
+
+    #[test]
+    fn memory_size_maps_to_resources_requests_and_limits() {
+        let f = zip_function("my-fn");
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        let res = pod.spec.unwrap().containers[0].resources.clone().unwrap();
+        assert_eq!(res.requests.unwrap().get("memory").unwrap().0, "256Mi");
+        assert_eq!(res.limits.unwrap().get("memory").unwrap().0, "256Mi");
+    }
+
+    #[test]
+    fn labels_identify_fakecloud_ownership() {
+        let f = zip_function("my-fn");
+        let pod = build_pod_spec(&f, "deploy-xyz", &ctx()).unwrap();
+        let labels = pod.metadata.labels.unwrap();
+        assert_eq!(
+            labels.get("fakecloud-managed-by"),
+            Some(&"fakecloud".into())
+        );
+        assert_eq!(
+            labels.get("fakecloud-instance"),
+            Some(&"fakecloud-1234".into())
+        );
+        assert_eq!(labels.get("fakecloud-lambda"), Some(&"my-fn".into()));
+        assert!(labels.contains_key("fakecloud-deploy-id"));
+    }
+
+    #[test]
+    fn pull_secret_attached_when_configured() {
+        let f = zip_function("my-fn");
+        let mut c = ctx();
+        c.pull_secret = Some("fakecloud-ecr-secret");
+        let pod = build_pod_spec(&f, "d", &c).unwrap();
+        let secrets = pod.spec.unwrap().image_pull_secrets.unwrap();
+        assert_eq!(secrets.len(), 1);
+        assert_eq!(secrets[0].name, "fakecloud-ecr-secret");
+    }
+
+    #[test]
+    fn no_pull_secret_when_unset() {
+        let f = zip_function("my-fn");
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        assert!(pod.spec.unwrap().image_pull_secrets.is_none());
+    }
+
+    #[test]
+    fn pod_name_is_dns1123_safe() {
+        let name = pod_name_for("My_Awesome_Function", "abc/123+def==");
+        assert!(name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
+        assert!(!name.ends_with('-'));
+        assert!(name.len() <= 63);
+    }
+
+    #[test]
+    fn pod_name_is_stable_for_same_inputs() {
+        let a = pod_name_for("fn", "deploy");
+        let b = pod_name_for("fn", "deploy");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn pod_name_differs_when_deploy_id_changes() {
+        let a = pod_name_for("fn", "deploy-1");
+        let b = pod_name_for("fn", "deploy-2");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn restart_policy_never() {
+        let f = zip_function("my-fn");
+        let pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        assert_eq!(pod.spec.unwrap().restart_policy.as_deref(), Some("Never"));
+    }
+
+    #[test]
+    fn unsupported_runtime_errors() {
+        let mut f = zip_function("my-fn");
+        f.runtime = "cobol1.0".into();
+        let err = build_pod_spec(&f, "d", &ctx()).unwrap_err();
+        assert!(err.contains("unsupported runtime"));
+    }
+
+    #[test]
+    fn image_function_without_uri_errors() {
+        let mut f = zip_function("my-fn");
+        f.package_type = "Image".into();
+        f.image_uri = None;
+        let err = build_pod_spec(&f, "d", &ctx()).unwrap_err();
+        assert!(err.contains("ImageUri"));
+    }
+}

--- a/crates/fakecloud-lambda/src/runtime/mod.rs
+++ b/crates/fakecloud-lambda/src/runtime/mod.rs
@@ -10,10 +10,12 @@ pub(crate) mod backend;
 pub(crate) mod docker;
 pub(crate) mod env_rewrite;
 pub(crate) mod facade;
+pub mod k8s;
 
 pub use backend::{BackendHandle, LambdaBackend, RuntimeError, StreamingInvocation, WarmInstance};
 pub use docker::{extract_zip, runtime_to_image, DockerBackend};
 pub use facade::LambdaRuntime;
+pub use k8s::{K8sBackend, K8sBackendError};
 
 /// Backwards-compatible alias used by callers across the workspace
 /// (eventbridge bridge, scheduler, lambda_delivery, reset state, server

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -68,6 +68,7 @@ clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = "0.7"
+tar = "0.4"
 tokio = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
@@ -75,3 +76,6 @@ tracing-subscriber = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+tower = "0.5"

--- a/crates/fakecloud-server/src/admin_lambda_artifacts.rs
+++ b/crates/fakecloud-server/src/admin_lambda_artifacts.rs
@@ -1,0 +1,340 @@
+//! Internal HTTP endpoints that serve Lambda function code + layer
+//! archives to in-cluster Pod init containers for the Kubernetes
+//! backend.
+//!
+//! Guarded by a process-wide bearer token (generated at fakecloud
+//! startup, kept in memory only) so requests from outside the
+//! init-container side channel are rejected. The token is templated
+//! into the Pod spec at launch time and never logged or persisted.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use fakecloud_lambda::extras::parse_layer_version_arn;
+use fakecloud_lambda::SharedLambdaState;
+
+/// Routes mounted under `/_fakecloud/lambda/_internal/*`.
+#[derive(Clone)]
+pub struct ArtifactRoutesContext {
+    pub lambda_state: SharedLambdaState,
+    pub bearer_token: Arc<String>,
+}
+
+pub fn router(ctx: ArtifactRoutesContext) -> Router {
+    Router::new()
+        .route(
+            "/_fakecloud/lambda/_internal/code/{account_id}/{function_name}/{deploy}",
+            get(serve_code),
+        )
+        .route(
+            "/_fakecloud/lambda/_internal/layers/{account_id}/{function_name}/{deploy}",
+            get(serve_layers),
+        )
+        .with_state(ctx)
+}
+
+fn check_bearer(headers: &HeaderMap, expected: &str) -> Result<(), StatusCode> {
+    let header = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let supplied = header.strip_prefix("Bearer ").unwrap_or("");
+    if supplied.is_empty() {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    if !constant_time_eq(supplied.as_bytes(), expected.as_bytes()) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    Ok(())
+}
+
+/// Constant-time bytes-equal so the token check doesn't leak via
+/// timing differences. Both args must be the same length for the
+/// `==` comparison to be valid.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+async fn serve_code(
+    Path((account_id, function_name, _deploy)): Path<(String, String, String)>,
+    headers: HeaderMap,
+    State(ctx): State<ArtifactRoutesContext>,
+) -> impl IntoResponse {
+    if let Err(s) = check_bearer(&headers, &ctx.bearer_token) {
+        return s.into_response();
+    }
+    let bytes = {
+        let accounts = ctx.lambda_state.read();
+        accounts
+            .get(&account_id)
+            .and_then(|s| s.functions.get(&function_name))
+            .and_then(|f| f.code_zip.clone())
+    };
+    match bytes {
+        Some(b) => (
+            StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, "application/zip")],
+            b,
+        )
+            .into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            "function not found or no code zip available",
+        )
+            .into_response(),
+    }
+}
+
+async fn serve_layers(
+    Path((account_id, function_name, deploy)): Path<(String, String, String)>,
+    headers: HeaderMap,
+    State(ctx): State<ArtifactRoutesContext>,
+) -> impl IntoResponse {
+    if let Err(s) = check_bearer(&headers, &ctx.bearer_token) {
+        return s.into_response();
+    }
+    // The deploy id is encoded into the path so we can later add
+    // staleness rejection without changing the contract; today we
+    // serve the function's current attached layer set unconditionally
+    // and rely on the facade to spawn a fresh Pod when the deploy
+    // fingerprint drifts.
+    let _ = deploy;
+
+    let layer_zips: Vec<Vec<u8>> = {
+        let accounts = ctx.lambda_state.read();
+        let func = match accounts
+            .get(&account_id)
+            .and_then(|s| s.functions.get(&function_name))
+        {
+            Some(f) => f.clone(),
+            None => {
+                return (StatusCode::NOT_FOUND, "function not found").into_response();
+            }
+        };
+        let mut out: Vec<Vec<u8>> = Vec::with_capacity(func.layers.len());
+        for attached in &func.layers {
+            if let Some((acct, name, ver)) = parse_layer_version_arn(&attached.arn) {
+                if let Some(bytes) = accounts
+                    .get(&acct)
+                    .and_then(|s| s.layers.get(&name))
+                    .and_then(|l| l.versions.iter().find(|v| v.version == ver))
+                    .and_then(|v| v.code_zip.clone())
+                {
+                    out.push(bytes);
+                }
+            }
+        }
+        out
+    };
+
+    match build_layers_tar(&layer_zips) {
+        Ok(tar_bytes) => (
+            StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, "application/x-tar")],
+            tar_bytes,
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to build layers tar: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+/// Pack the supplied layer ZIPs into a single tar archive whose
+/// entries the init container unzips into `/opt`. The tar holds the
+/// raw ZIP bytes as files named `layer-0.zip`, `layer-1.zip`, …; the
+/// init container loops + unzips each.
+///
+/// Returning a tar means one HTTP round-trip per Pod boot regardless
+/// of layer count, which matters for cold-start latency in CI.
+fn build_layers_tar(layer_zips: &[Vec<u8>]) -> Result<Vec<u8>, std::io::Error> {
+    let mut builder = tar::Builder::new(Vec::new());
+    for (i, bytes) in layer_zips.iter().enumerate() {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(format!("layer-{i}.zip"))?;
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, &bytes[..])?;
+    }
+    builder.into_inner()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use fakecloud_lambda::{LambdaFunction, LambdaState};
+    use tower::ServiceExt; // for `.oneshot`
+
+    fn mk_state(code: Option<Vec<u8>>) -> SharedLambdaState {
+        let mut mas: MultiAccountState<LambdaState> =
+            MultiAccountState::new("000000000000", "us-east-1", "");
+        let acct = mas.get_or_create("000000000000");
+        let mut f = LambdaFunction {
+            function_name: "my-fn".into(),
+            function_arn: "arn:aws:lambda:us-east-1:000000000000:function:my-fn".into(),
+            runtime: "python3.12".into(),
+            role: "arn:aws:iam::000000000000:role/r".into(),
+            handler: "h".into(),
+            description: String::new(),
+            timeout: 3,
+            memory_size: 128,
+            code_sha256: String::new(),
+            code_size: 0,
+            version: "$LATEST".into(),
+            last_modified: chrono::Utc::now(),
+            tags: Default::default(),
+            environment: Default::default(),
+            architectures: Vec::new(),
+            package_type: "Zip".into(),
+            code_zip: code,
+            image_uri: None,
+            policy: None,
+            layers: Vec::new(),
+            revision_id: "r".into(),
+            tracing_mode: None,
+            kms_key_arn: None,
+            ephemeral_storage_size: None,
+            vpc_config: None,
+            snap_start: None,
+            dead_letter_config_arn: None,
+            file_system_configs: Vec::new(),
+            logging_config: None,
+            image_config: None,
+            durable_config: None,
+            signing_profile_version_arn: None,
+            signing_job_arn: None,
+            runtime_version_config: None,
+            master_arn: None,
+            state_reason: None,
+            state_reason_code: None,
+            last_update_status_reason: None,
+            last_update_status_reason_code: None,
+        };
+        f.environment = Default::default();
+        acct.functions.insert("my-fn".into(), f);
+        Arc::new(parking_lot::RwLock::new(mas))
+    }
+
+    fn app(state: SharedLambdaState, token: &str) -> Router {
+        router(ArtifactRoutesContext {
+            lambda_state: state,
+            bearer_token: Arc::new(token.to_string()),
+        })
+    }
+
+    async fn get_with_auth(app: &Router, path: &str, token: Option<&str>) -> (StatusCode, Vec<u8>) {
+        let mut req = Request::builder().uri(path).method("GET");
+        if let Some(t) = token {
+            req = req.header("authorization", format!("Bearer {t}"));
+        }
+        let resp = app
+            .clone()
+            .oneshot(req.body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec();
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn code_endpoint_requires_bearer() {
+        let state = mk_state(Some(b"zipbytes".to_vec()));
+        let app = app(state, "tok");
+        let (status, _) = get_with_auth(
+            &app,
+            "/_fakecloud/lambda/_internal/code/000000000000/my-fn/d.zip",
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn code_endpoint_rejects_wrong_bearer() {
+        let state = mk_state(Some(b"zipbytes".to_vec()));
+        let app = app(state, "tok");
+        let (status, _) = get_with_auth(
+            &app,
+            "/_fakecloud/lambda/_internal/code/000000000000/my-fn/d.zip",
+            Some("nope"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn code_endpoint_returns_zip_bytes() {
+        let state = mk_state(Some(b"zipbytes".to_vec()));
+        let app = app(state, "tok");
+        let (status, body) = get_with_auth(
+            &app,
+            "/_fakecloud/lambda/_internal/code/000000000000/my-fn/d.zip",
+            Some("tok"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, b"zipbytes".to_vec());
+    }
+
+    #[tokio::test]
+    async fn code_endpoint_404_when_no_zip() {
+        let state = mk_state(None);
+        let app = app(state, "tok");
+        let (status, _) = get_with_auth(
+            &app,
+            "/_fakecloud/lambda/_internal/code/000000000000/my-fn/d.zip",
+            Some("tok"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn code_endpoint_404_unknown_function() {
+        let state = mk_state(Some(b"x".to_vec()));
+        let app = app(state, "tok");
+        let (status, _) = get_with_auth(
+            &app,
+            "/_fakecloud/lambda/_internal/code/000000000000/missing/d.zip",
+            Some("tok"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn layers_endpoint_empty_for_no_layers_returns_empty_tar() {
+        let state = mk_state(Some(b"x".to_vec()));
+        let app = app(state, "tok");
+        let (status, body) = get_with_auth(
+            &app,
+            "/_fakecloud/lambda/_internal/layers/000000000000/my-fn/d.tar",
+            Some("tok"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        // Empty tar = two 512-byte all-zero blocks (the EOF marker).
+        assert_eq!(body, vec![0u8; 1024]);
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -13,6 +13,7 @@ use fakecloud_core::dispatch::{self, DispatchConfig};
 use fakecloud_core::registry::ServiceRegistry;
 use fakecloud_sdk::types;
 
+mod admin_lambda_artifacts;
 mod appas_hooks;
 mod cli;
 mod dynamodb_streams_lambda_poller;
@@ -182,17 +183,37 @@ async fn main() {
     // Reap any backing containers left behind by a previous fakecloud process
     // that was killed before it could run its own cleanup (SIGKILL, crash, OOM).
     reaper::reap_stale_containers();
-    // Auto-detect Docker/Podman for Lambda execution
-    let container_runtime =
-        fakecloud_lambda::runtime::ContainerRuntime::new(bound_addr.port()).map(Arc::new);
+    // Lambda execution backend. FAKECLOUD_LAMBDA_BACKEND=k8s opts into
+    // the native Kubernetes Pod backend (issue #1234); anything else
+    // (or unset) auto-detects Docker/Podman.
+    let lambda_backend_choice = std::env::var("FAKECLOUD_LAMBDA_BACKEND")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let k8s_internal_token: Arc<String> = Arc::new(generate_k8s_internal_token());
+    let container_runtime = if lambda_backend_choice == "k8s" {
+        match fakecloud_lambda::runtime::LambdaRuntime::new_k8s(
+            bound_addr.port(),
+            (*k8s_internal_token).clone(),
+        )
+        .await
+        {
+            Ok(rt) => Some(Arc::new(rt)),
+            Err(e) => {
+                eprintln!(
+                    "FAKECLOUD_LAMBDA_BACKEND=k8s but Kubernetes backend failed to initialize: {e}"
+                );
+                std::process::exit(1);
+            }
+        }
+    } else {
+        fakecloud_lambda::runtime::ContainerRuntime::new(bound_addr.port()).map(Arc::new)
+    };
     if let Some(ref rt) = container_runtime {
-        tracing::info!(
-            cli = rt.cli_name(),
-            "Lambda execution enabled via container runtime"
-        );
+        tracing::info!(backend = rt.cli_name(), "Lambda execution enabled");
     } else {
         tracing::info!("Docker/Podman not available — Lambda Invoke will return errors for functions with code");
     }
+    let lambda_backend_is_k8s = lambda_backend_choice == "k8s";
     let secretsmanager_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new(
             &cli.account_id,
@@ -7035,6 +7056,23 @@ async fn main() {
                 }
             }),
         )
+        .merge({
+            // K8s Lambda backend needs in-cluster Pod init containers to
+            // pull function code + layers over HTTP. The routes are
+            // mounted unconditionally (gated by bearer-token check, never
+            // exposed without auth) so the K8s backend can boot at any
+            // time after server start.
+            if lambda_backend_is_k8s {
+                admin_lambda_artifacts::router(
+                    admin_lambda_artifacts::ArtifactRoutesContext {
+                        lambda_state: lambda_state.clone(),
+                        bearer_token: k8s_internal_token.clone(),
+                    },
+                )
+            } else {
+                axum::Router::new()
+            }
+        })
         .fallback(dispatch::dispatch)
         .layer({
             let registry_arc = Arc::new(registry);
@@ -7344,6 +7382,17 @@ async fn bind_listener(addr: &str) -> std::io::Result<(TcpListener, std::net::So
 /// writer keeps this testable without capturing process stdout.
 fn announce_bound_port<W: std::io::Write>(port: u16, writer: &mut W) -> std::io::Result<()> {
     writeln!(writer, "{PORT_HANDSHAKE_PREFIX}{port}")
+}
+/// Generate the per-process bearer token used by the K8s backend's
+/// internal artifact endpoints. 32 random bytes, hex-encoded, never
+/// persisted. Pod specs embed this value at launch; teardown
+/// invalidates it by virtue of the next fakecloud process minting a
+/// fresh one.
+fn generate_k8s_internal_token() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 /// Build a public-facing endpoint URL from the address the server actually
 /// bound to. Wildcard hosts (``0.0.0.0`` / ``[::]``) are rewritten to

--- a/website/content/docs/guides/kubernetes-backend.md
+++ b/website/content/docs/guides/kubernetes-backend.md
@@ -1,0 +1,157 @@
++++
+title = "Kubernetes backend for Lambda"
+description = "Run fakecloud Lambda functions as native Kubernetes Pods instead of Docker containers. Avoid docker-in-docker, get real resource limits, debug with kubectl."
+weight = 30
++++
+
+By default, fakecloud executes Lambda functions in Docker containers via `docker run`. When fakecloud itself runs inside Kubernetes (CI pipelines, multi-tenant test clusters), that means docker-in-docker: privileged pods, opaque resource accounting, and harder debugging.
+
+The Kubernetes backend (issue [#1234](https://github.com/faiscadev/fakecloud/issues/1234)) replaces the Docker path with native Pods. Each Lambda function gets a Pod sized from the function's `MemorySize`, executes the AWS Runtime Interface Emulator image, and is reused across invocations exactly like a warm Docker container.
+
+## When to use it
+
+- fakecloud runs as a Pod in your CI / dev cluster
+- You'd rather not grant fakecloud's Pod the `privileged` security context that docker-in-docker requires
+- You want real Kubernetes `requests` / `limits` on Lambda Pods so the scheduler can pack them
+- You want `kubectl logs` / `kubectl describe pod` on misbehaving functions
+
+If fakecloud runs on your laptop with Docker Desktop, stick with the default Docker backend — it's faster (no init-container HTTP fetch) and needs no cluster.
+
+## Enabling it
+
+Set on the fakecloud Pod:
+
+```
+FAKECLOUD_LAMBDA_BACKEND=k8s
+FAKECLOUD_K8S_SELF_URL=http://fakecloud.fakecloud.svc.cluster.local:4566
+```
+
+`FAKECLOUD_K8S_SELF_URL` must resolve from inside Lambda Pods — that's how init containers pull function code and layers from the fakecloud process. Use the in-cluster service DNS name, never `localhost` or `127.0.0.1`.
+
+Optional env vars:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `FAKECLOUD_K8S_NAMESPACE` | `default` | Namespace Lambda Pods are created in. |
+| `FAKECLOUD_K8S_ECR_URL` | host of `FAKECLOUD_K8S_SELF_URL` | Override the host:port the backend rewrites AWS private-ECR URIs to. |
+| `FAKECLOUD_K8S_PULL_SECRET` | unset | Name of a `kubernetes.io/dockerconfigjson` Secret attached as `imagePullSecrets`. Only needed for `PackageType=Image` Lambda functions whose image registry requires auth. |
+
+## RBAC
+
+The fakecloud Pod's ServiceAccount needs permission to create / list / watch / delete Pods in the configured namespace.
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fakecloud
+  namespace: fakecloud
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fakecloud-lambda-pods
+  namespace: fakecloud
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fakecloud-lambda-pods
+  namespace: fakecloud
+subjects:
+  - kind: ServiceAccount
+    name: fakecloud
+    namespace: fakecloud
+roleRef:
+  kind: Role
+  name: fakecloud-lambda-pods
+  apiGroup: rbac.authorization.k8s.io
+```
+
+If you set `FAKECLOUD_K8S_NAMESPACE` to a different namespace from where fakecloud itself runs, create the Role + RoleBinding in that target namespace.
+
+## Deployment + Service
+
+A minimal in-cluster install:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fakecloud
+  namespace: fakecloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: fakecloud }
+  template:
+    metadata:
+      labels: { app: fakecloud }
+    spec:
+      serviceAccountName: fakecloud
+      containers:
+        - name: fakecloud
+          image: ghcr.io/faiscadev/fakecloud:latest
+          ports:
+            - containerPort: 4566
+          env:
+            - name: FAKECLOUD_LAMBDA_BACKEND
+              value: "k8s"
+            - name: FAKECLOUD_K8S_SELF_URL
+              value: "http://fakecloud.fakecloud.svc.cluster.local:4566"
+            - name: FAKECLOUD_K8S_NAMESPACE
+              value: "fakecloud"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fakecloud
+  namespace: fakecloud
+spec:
+  selector: { app: fakecloud }
+  ports:
+    - name: http
+      port: 4566
+      targetPort: 4566
+```
+
+## How it works
+
+1. Your test client calls `lambda:Invoke` against the fakecloud Service.
+2. The Lambda service in fakecloud computes a deploy fingerprint (function code SHA + attached layer hashes) and looks for a matching warm Pod. If one exists, it POSTs the invocation payload to that Pod's `:8080`.
+3. On a cache miss, fakecloud creates a new Pod via the Kubernetes API. The Pod has:
+   - A `busybox` init container that downloads the function's code zip and a tar of its layers from fakecloud's internal `/_fakecloud/lambda/_internal/*` endpoints (bearer-token-protected, per-process token), unpacks them into shared `emptyDir` volumes mounted at `/var/task` and `/opt`.
+   - A main container running the AWS RIE image for the function's runtime (`public.ecr.aws/lambda/python:3.12`, `public.ecr.aws/lambda/nodejs:20`, etc.). For `PackageType=Image` functions, the user's image is used directly; AWS private-ECR URIs are rewritten to the in-cluster fakecloud OCI registry.
+   - Resource requests / limits sized from `MemorySize`, ephemeral `/tmp` as `emptyDir { medium: Memory, sizeLimit: EphemeralStorage.Size }`, `restartPolicy: Never`.
+4. fakecloud watches the Pod until `status.podIP` is populated, then TCP-handshakes the RIE port and forwards the invocation.
+5. Idle Pods are torn down by the same TTL loop the Docker backend uses.
+6. On fakecloud startup, any Pod labeled `fakecloud-managed-by=fakecloud` whose `fakecloud-instance` label doesn't match the current process is deleted — covers crashes that left orphans behind.
+
+## Security model
+
+- Init containers pull code over the cluster network via a process-local bearer token. The token is generated at fakecloud startup, embedded into Pod specs at launch time, and never persisted or logged. Each fakecloud restart mints a fresh token, invalidating any in-flight artifact downloads.
+- Pods carry labels `fakecloud-managed-by=fakecloud`, `fakecloud-instance=<pid>`, `fakecloud-lambda=<function>`, `fakecloud-deploy-id=<hash>` so you can `kubectl get pods -l fakecloud-managed-by=fakecloud`.
+- Pods run with whatever default security context your cluster's `PodSecurityPolicy` / `PodSecurityAdmission` enforces — no `privileged`, no special capabilities. The fakecloud Pod itself also doesn't need privileged.
+
+## Limitations
+
+- The Kubernetes backend only covers Lambda execution. ECS task execution, the RDS Postgres / MySQL container runtimes, and ElastiCache still shell out to Docker — they're follow-up work tracked off issue #1234.
+- Container-image Lambda functions whose image registry requires auth need a manually-created `kubernetes.io/dockerconfigjson` Secret referenced via `FAKECLOUD_K8S_PULL_SECRET`. Auto-creating that secret requires `secrets` permissions that not every cluster admin wants to grant fakecloud.
+- Cold-start latency adds the init container HTTP round-trip to download code + layers (typically <500ms intra-cluster), on top of image pull + RIE start. Warm-Pod reuse keeps subsequent invocations as fast as the Docker backend.
+- The K8s backend requires fakecloud's process to remain reachable at `FAKECLOUD_K8S_SELF_URL` for the lifetime of each Pod's init container. If fakecloud restarts mid-init, that Pod's bootstrap fails and the facade will spawn a fresh one on the next invocation.
+
+## Troubleshooting
+
+- **`FAKECLOUD_LAMBDA_BACKEND=k8s but Kubernetes backend failed to initialize`** — kube client construction failed. fakecloud uses `kube::Client::try_default()`: in-cluster service account first, then `KUBECONFIG`. Make sure the Pod has a ServiceAccount mounted at `/var/run/secrets/kubernetes.io/serviceaccount`, or set `KUBECONFIG` for out-of-cluster testing.
+- **Lambda Pods stuck in `Init:0/1` with `ImagePullBackOff` on busybox** — the cluster's default image registry can't reach `docker.io`. Mirror `busybox:1.36` to your internal registry, or configure a default-pull-secret that has Docker Hub credentials.
+- **Init container exits non-zero with `wget: server returned error: HTTP/1.1 401`** — fakecloud restarted between Pod create and init-container start, invalidating the bearer token. The facade will retry on the next invocation.
+- **`fakecloud-lambda` Pods are leaking after fakecloud crashes** — confirm fakecloud has `delete` permission on `pods` in the configured namespace. The startup reaper deletes any Pod labeled `fakecloud-managed-by=fakecloud` whose `fakecloud-instance` differs from the current process.
+- **`kubectl get pods -l fakecloud-managed-by=fakecloud`** — quick health check showing every Lambda Pod fakecloud has spawned.
+
+## Status
+
+Shipped in fakecloud 0.14.x. Beta — please open an issue or comment on [#1234](https://github.com/faiscadev/fakecloud/issues/1234) if you hit edge cases.

--- a/website/content/docs/reference/configuration.md
+++ b/website/content/docs/reference/configuration.md
@@ -16,6 +16,11 @@ fakecloud is configured via CLI flags or environment variables. Flags take prece
 | `--data-path`        | `FAKECLOUD_DATA_PATH`       | —                  | Directory to persist state to. Required when `--storage-mode=persistent`.                |
 | `--s3-cache-size`    | `FAKECLOUD_S3_CACHE_SIZE`   | `268435456`        | In-memory LRU cache for S3 object bodies in persistent mode. Default 256 MiB.            |
 |                      | `FAKECLOUD_CONTAINER_CLI`   | auto-detect        | Container CLI to use (`docker` or `podman`)                                              |
+|                      | `FAKECLOUD_LAMBDA_BACKEND`  | unset (docker)     | `k8s` to run Lambda functions as native Kubernetes Pods instead of Docker containers. See [Kubernetes backend](/docs/guides/kubernetes-backend/). |
+|                      | `FAKECLOUD_K8S_NAMESPACE`   | `default`          | Namespace fakecloud creates Lambda Pods in. Only honored with `FAKECLOUD_LAMBDA_BACKEND=k8s`. |
+|                      | `FAKECLOUD_K8S_SELF_URL`    | —                  | In-cluster URL of the fakecloud Service (e.g. `http://fakecloud.fakecloud.svc.cluster.local:4566`). Required for the K8s backend so init containers can fetch function code + layers. |
+|                      | `FAKECLOUD_K8S_ECR_URL`     | host of `_SELF_URL`| Override the host:port the K8s backend rewrites AWS private-ECR URIs to. Defaults to the host of `FAKECLOUD_K8S_SELF_URL`. |
+|                      | `FAKECLOUD_K8S_PULL_SECRET` | unset              | Name of a `kubernetes.io/dockerconfigjson` Secret used as `imagePullSecrets` for image-package Lambda Pods. |
 |                      | `FAKECLOUD_MAX_REQUEST_BODY_BYTES` | `1073741824` | Max bytes a buffered request body can absorb before fakecloud returns 413. Default 1 GiB. Streaming routes (S3 `PutObject` / `UploadPart`, ECR OCI blob upload `PATCH` / `PUT`) bypass this cap entirely — they spool the raw HTTP body to disk instead of buffering it all in RAM. Raise this only when stress-testing buffered requests past 1 GiB. |
 
 ## Examples


### PR DESCRIPTION
## Summary

Closes [issue #1234](https://github.com/faiscadev/fakecloud/issues/1234) (WarpRat) — Lambda functions can now run as native Kubernetes Pods instead of Docker containers, gated by \`FAKECLOUD_LAMBDA_BACKEND=k8s\`. Docker remains the default; zero regression for existing users.

Why: fakecloud in k8s CI today needs docker-in-docker (privileged pod, opaque resource limits, hard-to-debug). Native Pods solve all three.

How:
- New \`K8sBackend\` impl of the \`LambdaBackend\` trait (extracted in #1534).
- Each Lambda invocation gets a Pod with:
  - busybox init container that downloads code zip + a tar of attached layers from bearer-token-protected \`/_fakecloud/lambda/_internal/*\` endpoints, unpacks into shared \`emptyDir\` volumes at \`/var/task\` + \`/opt\`.
  - Main container = AWS RIE image (\`public.ecr.aws/lambda/<runtime>:<ver>\`) for zip functions, or the user's image (with AWS private-ECR URIs rewritten to the in-cluster fakecloud OCI service) for image functions.
  - Memory \`requests\`/\`limits\` from \`MemorySize\`; \`/tmp\` = \`emptyDir { medium: Memory, sizeLimit: EphemeralStorage.Size }\`.
  - \`restartPolicy: Never\` to match Docker semantics.
- Per-process bearer token, regenerated each fakecloud start, never persisted/logged.
- Startup reaper deletes orphan Pods labeled with a foreign \`fakecloud-instance\`.
- Hard-fails when \`FAKECLOUD_LAMBDA_BACKEND=k8s\` but the kube client can't initialize (no silent Docker fallback — matches \`feedback_no_stub_responses.md\`).

Out of scope for this PR (separate follow-up):
- Integration tests against a real \`kind\` cluster + the GHA workflow (PR3).
- ECS / RDS / ElastiCache Pod backends — Lambda only per issue thread.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` zero warnings
- [x] \`cargo fmt --check\` clean
- [x] 23 new spec/backend unit tests + 6 admin-artifact endpoint tests
- [x] Full workspace tests green (155 lambda + 50 server + rest)
- [ ] Lambda E2E suite against Docker (CI — refactor regression net)
- [ ] Real kind cluster smoke (deferred to PR3)

## Docs

- \`website/content/docs/guides/kubernetes-backend.md\` — overview, RBAC yaml, Deployment+Service example, security model, limitations, troubleshooting.
- \`website/content/docs/reference/configuration.md\` — 5 new env var rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Kubernetes backend for Lambda behind `FAKECLOUD_LAMBDA_BACKEND=k8s`, so functions run as Pods instead of Docker. This removes docker-in-docker in k8s environments and improves resource control and debugging.

- **New Features**
  - New `K8sBackend` (`LambdaBackend`) runs each function in a Pod: a `busybox` init container fetches code/layers from `/_fakecloud/lambda/_internal/*`, then the main container runs the AWS RIE image (zip) or the user’s image (image functions). Memory is mapped to `requests/limits`; `/tmp` is an in‑memory `emptyDir` sized from EphemeralStorage; `restartPolicy: Never`.
  - Internal artifact endpoints added on the server, protected by a per‑process bearer token (generated at startup; never persisted). `BackendHandle` gains a `Pod` variant; startup reaper deletes orphan Pods.
  - AWS private‑ECR image URIs are rewritten to the in‑cluster OCI host via `translate_to_local_at`, enabling image functions without docker‑in‑docker.
  - Hard‑fail if `FAKECLOUD_LAMBDA_BACKEND=k8s` is set but the kube client cannot initialize. Docs added under guides and configuration. New deps: `kube`, `k8s-openapi`.

- **Migration**
  - Set `FAKECLOUD_LAMBDA_BACKEND=k8s` and `FAKECLOUD_K8S_SELF_URL` to the in‑cluster Service URL (e.g., `http://fakecloud.fakecloud.svc.cluster.local:4566`). Optional: `FAKECLOUD_K8S_NAMESPACE`, `FAKECLOUD_K8S_ECR_URL`, `FAKECLOUD_K8S_PULL_SECRET`.
  - Grant the fakecloud ServiceAccount Pod RBAC (`create/get/list/watch/delete`) in the target namespace. Add `imagePullSecrets` when image registries require auth.
  - No changes needed for Docker users; it remains the default path.

<sup>Written for commit 7ba4803f49a9454519337b49c1dd01ec1c230d06. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1535?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

