### PR TITLE
test(lambda): K8s integration tests + kind-based CI workflow

### DIFF
--- a/.github/workflows/lambda-k8s.yml
+++ b/.github/workflows/lambda-k8s.yml
@@ -1,0 +1,54 @@
+name: Lambda K8s Backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/fakecloud-lambda/**'
+      - '.github/workflows/lambda-k8s.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/fakecloud-lambda/**'
+      - '.github/workflows/lambda-k8s.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  k8s-integration:
+    name: K8s backend (kind)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Create kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1
+        with:
+          cluster_name: fakecloud-k8s-test
+          # Single node is enough — these tests only exercise the
+          # control-plane interactions (create/list/delete pods,
+          # reap orphans by label). Multi-node would just slow boot.
+          wait: 120s
+
+      - name: Pre-pull pause image into the cluster
+        run: |
+          docker pull registry.k8s.io/pause:3.10
+          kind load docker-image registry.k8s.io/pause:3.10 --name fakecloud-k8s-test
+
+      - name: Run K8s integration tests
+        env:
+          FAKECLOUD_K8S_TEST: '1'
+        run: |
+          cargo test -p fakecloud-lambda \
+            --features k8s-integration \
+            --test k8s_integration \
+            -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,6 +3813,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "reqwest",
+ "rustls 0.23.38",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/fakecloud-lambda/Cargo.toml
+++ b/crates/fakecloud-lambda/Cargo.toml
@@ -32,6 +32,12 @@ bytes = { workspace = true }
 kube = { workspace = true }
 k8s-openapi = { workspace = true }
 futures-util = "0.3"
+# rustls 0.23 dropped the implicit default CryptoProvider; kube's
+# rustls-tls feature builds a Client but every request panics unless
+# one is installed up front. We install `ring` once at K8sBackend
+# construction so neither the server's runtime path nor opt-in
+# integration tests have to wire this in themselves.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/fakecloud-lambda/Cargo.toml
+++ b/crates/fakecloud-lambda/Cargo.toml
@@ -35,3 +35,14 @@ futures-util = "0.3"
 
 [dev-dependencies]
 bytes = { workspace = true }
+
+[features]
+# Opt-in integration tests that need a real Kubernetes cluster
+# (typically a local `kind` cluster). Run with:
+#   FAKECLOUD_K8S_TEST=1 cargo test -p fakecloud-lambda \
+#       --features k8s-integration --test k8s_integration
+# Without the feature flag the test binary is not built; with the
+# feature flag, the first test hard-fails if FAKECLOUD_K8S_TEST is
+# unset rather than silently skipping
+# (see feedback_tests_never_silently_skip).
+k8s-integration = []

--- a/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
@@ -67,6 +67,7 @@ impl K8sBackend {
         default_ecr_port: u16,
         internal_token: String,
     ) -> Result<Self, K8sBackendError> {
+        ensure_crypto_provider();
         let self_url =
             std::env::var("FAKECLOUD_K8S_SELF_URL").map_err(|_| K8sBackendError::MissingSelfUrl)?;
         let parsed = reqwest::Url::parse(&self_url)
@@ -182,6 +183,21 @@ impl K8sBackend {
             "RIE on {pod_ip}:8080 did not accept connections within 10s"
         )))
     }
+}
+
+/// Install rustls' `ring` CryptoProvider once per process. Rustls
+/// 0.23 dropped the implicit default and every TLS connection now
+/// panics until something installs one. Kube's `rustls-tls` feature
+/// doesn't pull in a provider on our behalf, so we do it here. Safe
+/// to call concurrently; the `.ok()` swallows the "already installed"
+/// error in case another component (a different test, a future
+/// service) beat us to it.
+fn ensure_crypto_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
 }
 
 /// Extract the account ID from a function ARN

--- a/crates/fakecloud-lambda/tests/k8s_integration.rs
+++ b/crates/fakecloud-lambda/tests/k8s_integration.rs
@@ -44,7 +44,21 @@ fn require_test_env() {
     }
 }
 
+/// rustls 0.23 dropped the implicit default CryptoProvider, so every
+/// kube TLS connection panics until something installs one. Each test
+/// that builds a `Client` directly (without going through
+/// `K8sBackend::from_env`) needs to install the provider explicitly;
+/// the call is process-wide and idempotent.
+fn install_crypto_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 async fn client() -> Client {
+    install_crypto_provider();
     Client::try_default()
         .await
         .expect("kube::Client::try_default failed — set KUBECONFIG or run inside a cluster")

--- a/crates/fakecloud-lambda/tests/k8s_integration.rs
+++ b/crates/fakecloud-lambda/tests/k8s_integration.rs
@@ -1,0 +1,246 @@
+//! Opt-in K8s integration tests for the Lambda Kubernetes backend.
+//!
+//! These tests need a real cluster (a local `kind` cluster works) and
+//! a valid kubeconfig. They are gated behind the `k8s-integration`
+//! feature so a casual `cargo test` doesn't try to talk to a cluster
+//! that isn't there.
+//!
+//! Per `feedback_tests_never_silently_skip`: when the feature is on,
+//! missing toolchain (no `FAKECLOUD_K8S_TEST=1`, no reachable cluster)
+//! must **panic with a clear message**, not silently pass. Skipping a
+//! test that the operator opted into is a worse failure mode than a
+//! red bar — they at least see the red bar.
+//!
+//! Run with:
+//! ```sh
+//! kind create cluster --name fakecloud-test
+//! FAKECLOUD_K8S_TEST=1 cargo test -p fakecloud-lambda \
+//!     --features k8s-integration --test k8s_integration
+//! ```
+
+#![cfg(feature = "k8s-integration")]
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use k8s_openapi::api::core::v1::{Container, Pod, PodSpec};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::api::{Api, DeleteParams, ListParams, PostParams};
+use kube::Client;
+
+use fakecloud_lambda::runtime::{K8sBackend, LambdaBackend};
+
+const TEST_NS: &str = "fakecloud-k8s-test";
+
+fn require_test_env() {
+    if std::env::var("FAKECLOUD_K8S_TEST").is_err() {
+        panic!(
+            "FAKECLOUD_K8S_TEST not set — refusing to silently skip K8s integration tests.\n\
+             Set FAKECLOUD_K8S_TEST=1 and point KUBECONFIG at a cluster, e.g.:\n  \
+             kind create cluster --name fakecloud-test\n  \
+             FAKECLOUD_K8S_TEST=1 cargo test -p fakecloud-lambda \\\n      \
+                 --features k8s-integration --test k8s_integration"
+        );
+    }
+}
+
+async fn client() -> Client {
+    Client::try_default()
+        .await
+        .expect("kube::Client::try_default failed — set KUBECONFIG or run inside a cluster")
+}
+
+async fn ensure_namespace(c: &Client) {
+    use k8s_openapi::api::core::v1::Namespace;
+    let api: Api<Namespace> = Api::all(c.clone());
+    let ns = Namespace {
+        metadata: ObjectMeta {
+            name: Some(TEST_NS.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    match api.create(&PostParams::default(), &ns).await {
+        Ok(_) => {}
+        Err(kube::Error::Api(e)) if e.code == 409 => {}
+        Err(e) => panic!("failed to create test namespace: {e}"),
+    }
+}
+
+fn dummy_pod(name: &str, instance_label: &str) -> Pod {
+    let mut labels = BTreeMap::new();
+    labels.insert("fakecloud-managed-by".into(), "fakecloud".into());
+    labels.insert("fakecloud-instance".into(), instance_label.into());
+    labels.insert("fakecloud-lambda".into(), "test-fn".into());
+    Pod {
+        metadata: ObjectMeta {
+            name: Some(name.into()),
+            namespace: Some(TEST_NS.into()),
+            labels: Some(labels),
+            ..Default::default()
+        },
+        spec: Some(PodSpec {
+            restart_policy: Some("Never".into()),
+            containers: vec![Container {
+                name: "pause".into(),
+                // gcr.io/google_containers/pause is the canonical do-nothing
+                // sleep-forever image; tiny and always reachable.
+                image: Some("registry.k8s.io/pause:3.10".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+async fn wait_for_pod_gone(api: &Api<Pod>, name: &str, max_secs: u64) {
+    for _ in 0..(max_secs * 2) {
+        match api.get_opt(name).await {
+            Ok(None) => return,
+            Ok(Some(_)) => tokio::time::sleep(Duration::from_millis(500)).await,
+            Err(e) => panic!("error polling pod {name}: {e}"),
+        }
+    }
+    panic!("pod {name} still exists after {max_secs}s");
+}
+
+#[tokio::test]
+async fn precondition_env_must_be_set() {
+    require_test_env();
+}
+
+#[tokio::test]
+async fn k8s_client_connects() {
+    require_test_env();
+    let c = client().await;
+    use k8s_openapi::api::core::v1::Node;
+    let api: Api<Node> = Api::all(c);
+    let nodes = api
+        .list(&ListParams::default())
+        .await
+        .expect("list nodes failed");
+    assert!(!nodes.items.is_empty(), "cluster has no nodes");
+}
+
+#[tokio::test]
+async fn from_env_initializes_backend() {
+    require_test_env();
+    let _saved = std::env::var("FAKECLOUD_K8S_SELF_URL").ok();
+    // SAFETY: tests in this file are mutually serializable via the
+    // shared cluster; we set required env then construct.
+    std::env::set_var(
+        "FAKECLOUD_K8S_SELF_URL",
+        "http://fakecloud.fakecloud-k8s-test.svc.cluster.local:4566",
+    );
+    std::env::set_var("FAKECLOUD_K8S_NAMESPACE", TEST_NS);
+    let backend = K8sBackend::from_env(4566, "test-token".to_string())
+        .await
+        .expect("K8sBackend::from_env failed");
+    assert_eq!(backend.name(), "kubernetes");
+}
+
+#[tokio::test]
+async fn reap_stale_deletes_foreign_instance_pods() {
+    require_test_env();
+    let c = client().await;
+    ensure_namespace(&c).await;
+    let api: Api<Pod> = Api::namespaced(c.clone(), TEST_NS);
+
+    let foreign = "fakecloud-reap-foreign";
+    // Clean up from any prior failed run.
+    let _ = api.delete(foreign, &DeleteParams::default()).await;
+    wait_for_pod_gone(&api, foreign, 30).await;
+
+    api.create(
+        &PostParams::default(),
+        &dummy_pod(foreign, "fakecloud-99999"),
+    )
+    .await
+    .expect("create foreign pod");
+
+    std::env::set_var(
+        "FAKECLOUD_K8S_SELF_URL",
+        "http://fakecloud.fakecloud-k8s-test.svc.cluster.local:4566",
+    );
+    std::env::set_var("FAKECLOUD_K8S_NAMESPACE", TEST_NS);
+    let backend = K8sBackend::from_env(4566, "tok".to_string())
+        .await
+        .expect("K8sBackend::from_env");
+
+    backend.reap_stale().await;
+
+    wait_for_pod_gone(&api, foreign, 30).await;
+}
+
+#[tokio::test]
+async fn reap_stale_preserves_own_instance_pods() {
+    require_test_env();
+    let c = client().await;
+    ensure_namespace(&c).await;
+    let api: Api<Pod> = Api::namespaced(c.clone(), TEST_NS);
+
+    let own_instance = format!("fakecloud-{}", std::process::id());
+    let mine = "fakecloud-reap-mine";
+
+    let _ = api.delete(mine, &DeleteParams::default()).await;
+    wait_for_pod_gone(&api, mine, 30).await;
+
+    api.create(&PostParams::default(), &dummy_pod(mine, &own_instance))
+        .await
+        .expect("create own pod");
+
+    std::env::set_var(
+        "FAKECLOUD_K8S_SELF_URL",
+        "http://fakecloud.fakecloud-k8s-test.svc.cluster.local:4566",
+    );
+    std::env::set_var("FAKECLOUD_K8S_NAMESPACE", TEST_NS);
+    let backend = K8sBackend::from_env(4566, "tok".to_string())
+        .await
+        .expect("K8sBackend::from_env");
+
+    backend.reap_stale().await;
+
+    let still_there = api
+        .get_opt(mine)
+        .await
+        .expect("get own pod after reap")
+        .is_some();
+    // Clean up regardless of assertion outcome.
+    let _ = api.delete(mine, &DeleteParams::default()).await;
+    wait_for_pod_gone(&api, mine, 30).await;
+
+    assert!(
+        still_there,
+        "reap_stale must preserve pods labeled with current fakecloud-instance"
+    );
+}
+
+#[tokio::test]
+async fn terminate_pod_handle_is_idempotent() {
+    require_test_env();
+    let c = client().await;
+    ensure_namespace(&c).await;
+    let api: Api<Pod> = Api::namespaced(c.clone(), TEST_NS);
+
+    let name = "fakecloud-terminate-idem";
+    let _ = api.delete(name, &DeleteParams::default()).await;
+    wait_for_pod_gone(&api, name, 30).await;
+
+    std::env::set_var(
+        "FAKECLOUD_K8S_SELF_URL",
+        "http://fakecloud.fakecloud-k8s-test.svc.cluster.local:4566",
+    );
+    std::env::set_var("FAKECLOUD_K8S_NAMESPACE", TEST_NS);
+    let backend = K8sBackend::from_env(4566, "tok".to_string())
+        .await
+        .expect("K8sBackend::from_env");
+
+    let handle = fakecloud_lambda::runtime::BackendHandle::Pod {
+        namespace: TEST_NS.into(),
+        name: name.into(),
+    };
+    // Delete-not-found must not panic.
+    backend.terminate(&handle).await;
+    backend.terminate(&handle).await;
+}

--- a/website/content/docs/guides/kubernetes-backend.md
+++ b/website/content/docs/guides/kubernetes-backend.md
@@ -152,6 +152,20 @@ spec:
 - **`fakecloud-lambda` Pods are leaking after fakecloud crashes** — confirm fakecloud has `delete` permission on `pods` in the configured namespace. The startup reaper deletes any Pod labeled `fakecloud-managed-by=fakecloud` whose `fakecloud-instance` differs from the current process.
 - **`kubectl get pods -l fakecloud-managed-by=fakecloud`** — quick health check showing every Lambda Pod fakecloud has spawned.
 
+## Running the test suite
+
+The K8s backend has unit tests (Pod-spec generation, helpers) that run on every workspace `cargo test`. Real-cluster integration tests are opt-in and gated behind the `k8s-integration` feature so a casual `cargo test` doesn't try to talk to a cluster that isn't there.
+
+To run them:
+
+```sh
+kind create cluster --name fakecloud-k8s-test
+FAKECLOUD_K8S_TEST=1 cargo test -p fakecloud-lambda \
+    --features k8s-integration --test k8s_integration -- --test-threads=1
+```
+
+The first test hard-fails (not skips) when `FAKECLOUD_K8S_TEST` is unset, so you can't silently miss a regression. CI runs the same suite against a kind cluster on every push that touches `crates/fakecloud-lambda/**` via [`.github/workflows/lambda-k8s.yml`](https://github.com/faiscadev/fakecloud/blob/main/.github/workflows/lambda-k8s.yml).
+
 ## Status
 
 Shipped in fakecloud 0.14.x. Beta — please open an issue or comment on [#1234](https://github.com/faiscadev/fakecloud/issues/1234) if you hit edge cases.


### PR DESCRIPTION
## Summary

Closes the integration-test gap from issue [#1234](https://github.com/faiscadev/fakecloud/issues/1234). Adds opt-in real-cluster tests for the K8s Lambda backend shipped in #1535, plus a GitHub Actions workflow that runs them against a \`kind\` cluster.

Tests are gated behind the \`k8s-integration\` Cargo feature. First test hard-fails (not silently skips) when \`FAKECLOUD_K8S_TEST\` is unset — opted-in test runs that lose toolchain produce a red bar, not green silence.

## Coverage

- \`precondition_env_must_be_set\` — env-var sanity check.
- \`k8s_client_connects\` — \`kube::Client::try_default()\` + list nodes.
- \`from_env_initializes_backend\` — \`K8sBackend::from_env\` parses env vars.
- \`reap_stale_deletes_foreign_instance_pods\` — orphan sweep removes Pods labeled with a foreign \`fakecloud-instance\`.
- \`reap_stale_preserves_own_instance_pods\` — sweep does **not** touch the current process's Pods.
- \`terminate_pod_handle_is_idempotent\` — delete-not-found is a clean no-op.

## CI

- \`.github/workflows/lambda-k8s.yml\` spins a single-node \`kind\` cluster via \`helm/kind-action\`, pre-pulls \`registry.k8s.io/pause:3.10\` (test fixture) to avoid Docker Hub rate-limit flakes, runs the suite with \`--test-threads=1\` so cluster-shared state doesn't race.
- Triggers only on PRs touching \`crates/fakecloud-lambda/**\` or the workflow yaml itself (saves ~90s of kind boot on unrelated PRs), plus \`workflow_dispatch\` for manual runs.

## Test plan

- [x] \`cargo clippy --workspace --all-targets --features fakecloud-lambda/k8s-integration -- -D warnings\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo check -p fakecloud-lambda --features k8s-integration --tests\` compiles
- [ ] First green run of \`lambda-k8s.yml\` against this PR

## Out of scope

- Full RIE-invocation integration tests (would require running fakecloud as a Pod inside kind + port-forwarding for the test driver). The shipped tests cover the control-plane interactions (create / list / delete / label) that the K8s backend is built on; the RIE invocation path is the same HTTP POST used by the Docker backend's existing E2E suite (\`crates/fakecloud-e2e/tests/lambda_*.rs\`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in Kubernetes integration tests for the Lambda backend and a CI workflow that runs them on a `kind` cluster. Also fixes a TLS handshake panic by installing the rustls `ring` CryptoProvider at `K8sBackend` construction time.

- **Features**
  - Opt-in tests gated behind `k8s-integration`; first test hard-fails if `FAKECLOUD_K8S_TEST` is unset.
  - Coverage: `kube::Client::try_default` connects; `K8sBackend::from_env` initializes; `reap_stale` deletes foreign pods and preserves own; `terminate` is idempotent on missing pods.
  - CI: `.github/workflows/lambda-k8s.yml` creates a single-node `kind` cluster, pre-pulls `registry.k8s.io/pause:3.10`, runs with `--test-threads=1`, and triggers only on `crates/fakecloud-lambda/**`, the workflow file, or `workflow_dispatch`.
  - Docs: added a "Running the test suite" section to the Kubernetes backend guide.

- **Bug Fixes**
  - Installs rustls `ring` provider via `std::sync::Once` in `K8sBackend::from_env` to prevent TLS handshake panics in production and tests.

<sup>Written for commit 84e32066e6b7eb893651f6f58994a0ff6a4f9e81. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1536?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

