### PR TITLE
chore(release): bump workspace to v0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4096,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4118,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4167,7 +4167,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -101,167 +101,167 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.15.0"
+version = "0.15.1"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.15.0")
+    testImplementation("dev.fakecloud:fakecloud:0.15.1")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.15.0</version>
+    <version>0.15.1</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.15.0"
+version = "0.15.1"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.15.0"
+version = "0.15.1"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Patch release v0.15.1. Headline: native Kubernetes backend for Lambda execution (issue #1234).

What's in 0.15.1 since 0.15.0:
- #1534 — extract \`LambdaBackend\` trait from \`ContainerRuntime\`
- #1535 — \`FAKECLOUD_LAMBDA_BACKEND=k8s\` Kubernetes Pod backend + docs
- #1536 — opt-in \`kind\` integration tests + GHA workflow
- #1537 — website operations \`_index.md\` template fix that unblocked all docs deploys

## Bumps

- Cargo.toml workspace.package + 41 workspace dep version refs
- \`sdks/typescript/package.json\`
- \`sdks/python/pyproject.toml\`
- \`sdks/java/build.gradle.kts\` + README.md install examples
- \`Cargo.lock\` auto-regenerated

## Topo audit (per feedback_release_topo_order)

No new crates added since v0.15.0. The K8s backend module added kube + k8s-openapi as direct deps in fakecloud-lambda but no internal fakecloud-* deps shifted. server's admin_lambda_artifacts added tar (also external). \`publish-crates\` ordering in release.yml needs no changes.

## After merge

Tag \`v0.15.1\` against the merge commit triggers \`release.yml\`: GitHub Release + binaries (linux/macOS x86_64+arm64) + crates.io publish (every workspace crate) + npm + PyPI + Maven Central + Packagist + Go module tag + docker.yml + docker-rds-images.yml.

## Test plan

- [x] \`cargo build --workspace\` succeeds with bumped versions
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] Cargo.lock regenerated (48 \`0.15.1\` refs, 0 \`0.15.0\` refs)
- [ ] Full CI green on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.15.1 to ship the native Kubernetes Pod backend for Lambda (`FAKECLOUD_LAMBDA_BACKEND=k8s`) and fix the website operations template. This bumps the workspace and SDK versions to 0.15.1.

- **Dependencies**
  - Bumped `Cargo.toml` workspace package and 41 crate versions to 0.15.1; regenerated `Cargo.lock`.
  - Updated SDK versions: `sdks/typescript/package.json`, `sdks/python/pyproject.toml`, `sdks/java/build.gradle.kts`; aligned README install examples.

<sup>Written for commit 07aaf9ab68e963971eca50dfb946906a873e8929. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1538?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

