### PR TITLE
ci(release): publish npm via OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,12 +219,24 @@ jobs:
     name: Publish npm
     needs: check
     runs-on: ubuntu-latest
+    # OIDC auth via npm Trusted Publishing (configured at
+    # https://www.npmjs.com/package/fakecloud/access). No NPM_TOKEN —
+    # the GitHub OIDC token is exchanged for a short-lived publish
+    # credential. id-token write is the only extra permission needed.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org
+
+      # setup-node@v4 with node 22 ships npm 10.x. Trusted Publishing
+      # OIDC support landed in npm 11.5.1; upgrade explicitly.
+      - name: Install npm 11.5+ (Trusted Publishing support)
+        run: npm install -g npm@latest
 
       - name: Verify tag matches package.json version
         working-directory: sdks/typescript
@@ -245,9 +257,10 @@ jobs:
 
       - name: Publish
         working-directory: sdks/typescript
-        run: npm publish --access public || { echo "Package may already be published"; npm view fakecloud@"$(node -p "require('./package.json').version")" version && echo "Already published, skipping" || exit 1; }
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # --provenance ships the sigstore-signed link between this
+        # workflow run and the tarball, visible on npmjs as the
+        # "Provenance" badge. Free with OIDC, no extra setup.
+        run: npm publish --provenance --access public || { echo "Package may already be published"; npm view fakecloud@"$(node -p "require('./package.json').version")" version && echo "Already published, skipping" || exit 1; }
 
   publish-pypi:
     name: Publish PyPI


### PR DESCRIPTION
Drop NPM_TOKEN. Trusted Publisher configured at npmjs (release.yml -> faiscadev/fakecloud -> fakecloud pkg). Changes: id-token:write permission, npm 11.5+ install (OIDC support), --provenance flag (sigstore attestation), NODE_AUTH_TOKEN removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch npm publishing to OIDC Trusted Publishing to remove long-lived secrets and add supply-chain provenance. Drops `NPM_TOKEN`, adds minimal OIDC permissions, upgrades to `npm` 11.5+, and publishes with `--provenance`.

- **Refactors**
  - Use GitHub OIDC with `id-token: write`; no `NODE_AUTH_TOKEN`.
  - Explicitly install `npm` 11.5+ (OIDC support); keep `setup-node@v4`.
  - Add `--provenance` to `npm publish` for sigstore attestation.

- **Migration**
  - Delete the repo `NPM_TOKEN` secret; it is no longer used.

<sup>Written for commit 9e45853d747bb004865c95bbb349558d2c2b3944. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1541?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

