### PR TITLE
ci(release): manual npm publish workflow for tag backfill

### DIFF
--- a/.github/workflows/npm-publish-tag.yml
+++ b/.github/workflows/npm-publish-tag.yml
@@ -1,0 +1,72 @@
+name: Publish npm (manual)
+
+# Manual escape hatch for publishing a tagged release to npm when the
+# normal release.yml publish-npm job failed at tag time. Originally
+# added to backfill v0.15.1 to npm after the NPM_TOKEN secret expired
+# during that release; left in place because the same recovery path
+# can surface again (registry hiccup, OIDC misconfiguration, etc.).
+#
+# Trusted Publishing on npmjs is configured against `release.yml`
+# AND `npm-publish-tag.yml` — register this filename in the package's
+# trusted publisher list (https://www.npmjs.com/package/fakecloud/access)
+# before running.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v0.15.1). Must already exist.'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish-npm:
+    name: Publish npm for ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install npm 11.5+ (Trusted Publishing support)
+        run: npm install -g npm@latest
+
+      - name: Verify tag matches package.json version
+        working-directory: sdks/typescript
+        run: |
+          TAG="${{ inputs.tag }}"
+          TAG="${TAG#v}"
+          VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "::error::Tag v${TAG} does not match package.json version ${VERSION}"
+            exit 1
+          fi
+          echo "Tag v${TAG} matches package.json version ${VERSION}"
+
+      - name: Build
+        working-directory: sdks/typescript
+        run: |
+          npm ci
+          npm run build
+
+      - name: Publish
+        working-directory: sdks/typescript
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          npm publish --provenance --access public || {
+            echo "Publish attempt failed; checking whether it was already published..."
+            if npm view fakecloud@"$VERSION" version >/dev/null 2>&1; then
+              echo "fakecloud@$VERSION already on registry; treating as success."
+              exit 0
+            fi
+            exit 1
+          }


### PR DESCRIPTION
Workflow_dispatch escape hatch that publishes a tagged release to npm via OIDC. Immediate use: backfill v0.15.1 (original release run failed at publish-npm due to expired NPM_TOKEN; tag's snapshot of release.yml pre-dates OIDC fix #1541). After merge, you'll need to add 'npm-publish-tag.yml' as a second trusted publisher on npmjs (alongside release.yml) before triggering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a manual npm publish workflow (`npm-publish-tag.yml`) as an escape hatch when the normal release pipeline's publish step fails. Designed to backfill `v0.15.1` to npm after the original release failed due to an expired `NPM_TOKEN`.

- **Migration**
  - Before triggering the workflow, add `npm-publish-tag.yml` as a second trusted publisher on npmjs alongside `release.yml`.

<sup>Written for commit d3dca839ba5078ba2b85db94d9181564406d94e8. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1542?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

