### PR TITLE
fix(dispatch): sanitize x-amz-error-* headers (issue #1539 Bug 2)

### DIFF
--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -936,15 +936,53 @@ fn build_error_response_with_fields(
     // carrying a body — still surface the code. AWS SDKs read this header
     // when the body is empty. Emit it on every error response so HEAD,
     // OPTIONS, and any client that strips the body still see the code.
-    Response::builder()
+    // Backend errors regularly include newlines (multi-line stderr from
+    // docker/podman/etc.); HTTP header values reject control characters,
+    // so sanitize before insertion or the builder rejects the response
+    // and the connection drops.
+    let safe_code = sanitize_header_value(code);
+    let safe_message = sanitize_header_value(message);
+    let mut builder = Response::builder()
         .status(status)
         .header("content-type", content_type)
         .header("x-amzn-requestid", request_id)
-        .header("x-amz-request-id", request_id)
-        .header("x-amz-error-code", code)
-        .header("x-amz-error-message", message)
-        .body(Body::from(body))
-        .unwrap()
+        .header("x-amz-request-id", request_id);
+    if let Ok(v) = http::HeaderValue::from_str(&safe_code) {
+        builder = builder.header("x-amz-error-code", v);
+    }
+    if let Ok(v) = http::HeaderValue::from_str(&safe_message) {
+        builder = builder.header("x-amz-error-message", v);
+    }
+    builder.body(Body::from(body)).unwrap_or_else(|_| {
+        // Builder only fails if a header is invalid; we sanitized the two
+        // we control, so the remaining ones (content-type, request id) are
+        // ASCII and safe. This fallback exists purely so we never panic.
+        Response::new(Body::empty())
+    })
+}
+
+/// Strip characters that HTTP header values reject (control bytes, CR/LF/TAB)
+/// and truncate to a length that AWS SDKs handle cleanly. Backend tools
+/// (docker, podman, kubectl, …) emit multi-line stderr, and forwarding that
+/// raw into `x-amz-error-message` previously panicked the dispatcher.
+fn sanitize_header_value(s: &str) -> String {
+    const MAX_LEN: usize = 1024;
+    let mut out = String::with_capacity(s.len().min(MAX_LEN));
+    for ch in s.chars() {
+        if out.len() >= MAX_LEN {
+            break;
+        }
+        // Header values forbid CR, LF, and other control bytes (RFC 9110).
+        // Replace with a single space so multi-line messages stay readable.
+        if ch.is_control() {
+            if !out.ends_with(' ') {
+                out.push(' ');
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out.trim().to_string()
 }
 
 /// Build the [`ConditionContext`] passed to the IAM evaluator for one
@@ -1339,6 +1377,73 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(ct.contains("xml"));
+    }
+
+    /// Regression for issue #1539: multi-line backend errors (e.g. podman
+    /// stderr) used to panic the dispatcher when stuffed into the
+    /// `x-amz-error-message` HTTP header. The response must build cleanly
+    /// and the header value must not contain control characters.
+    #[test]
+    fn build_error_response_with_multiline_message_does_not_panic() {
+        let resp = build_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "ServiceException",
+            "Lambda execution failed: container failed to start: docker start failed: \
+             Error: unable to start container \"abc\": \
+             failed to create new hosts file:\nhost-gateway is empty\n",
+            "req-multi",
+            AwsProtocol::Json,
+        );
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let msg = resp
+            .headers()
+            .get("x-amz-error-message")
+            .expect("x-amz-error-message must be set even when input contains newlines")
+            .to_str()
+            .unwrap();
+        assert!(!msg.contains('\n'));
+        assert!(!msg.contains('\r'));
+        assert!(msg.contains("Lambda execution failed"));
+        assert!(msg.contains("host-gateway is empty"));
+    }
+
+    #[test]
+    fn build_error_response_with_control_chars_strips_them() {
+        let resp = build_error_response(
+            StatusCode::BAD_REQUEST,
+            "Code\twith\ttabs",
+            "msg\x00with\x01nulls",
+            "req-ctrl",
+            AwsProtocol::Json,
+        );
+        let code = resp
+            .headers()
+            .get("x-amz-error-code")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let msg = resp
+            .headers()
+            .get("x-amz-error-message")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(!code.contains('\t'));
+        assert!(!msg.contains('\x00'));
+        assert!(!msg.contains('\x01'));
+    }
+
+    #[test]
+    fn sanitize_header_value_truncates_long_input() {
+        let huge = "x".repeat(5_000);
+        let out = sanitize_header_value(&huge);
+        assert!(out.len() <= 1024);
+    }
+
+    #[test]
+    fn sanitize_header_value_collapses_consecutive_control_runs() {
+        let out = sanitize_header_value("a\n\n\n\rb");
+        assert_eq!(out, "a b");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Backend tools (docker/podman/kubectl) emit multi-line stderr. The dispatcher used to forward the raw message into `x-amz-error-message` and `.unwrap()` the builder. HTTP rejects `\n` in header values → `InvalidHeaderValue` → request task panic → client sees `Connection was closed before we received a valid response`.

This is the actual root cause of the "connection closed" symptom reported in #1539 case 2: a podman-on-macOS `--add-host host.docker.internal:host-gateway` failure produces a multi-line error message that brought down the response.

Fix:
- `sanitize_header_value()` collapses control bytes to single spaces and truncates to 1024 chars.
- Applied to `x-amz-error-code` and `x-amz-error-message`.
- `.unwrap()` replaced with a safe fallback so a future invalid header combo can't crash the dispatcher.

This is the lowest-blast-radius slice of the four-bug fix for #1539; other bugs (podman host-gateway, cold pull, Docker image CLI) land in separate PRs.

## Test plan

- [x] New regression test `build_error_response_with_multiline_message_does_not_panic` exercises the literal podman stderr from #1539 repro.
- [x] `build_error_response_with_control_chars_strips_them` covers NUL/CTRL bytes.
- [x] `sanitize_header_value_truncates_long_input` covers the 1024-char cap.
- [x] `sanitize_header_value_collapses_consecutive_control_runs` covers run-collapsing.
- [x] `cargo test -p fakecloud-core --lib` — 199 passed.
- [x] `cargo clippy -p fakecloud-core --all-targets -- -D warnings` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes `x-amz-error-*` headers to stop connection drops from multi-line backend errors, fixing the root cause of #1539 (Bug 2). Dispatcher no longer panics; clients receive a valid error response.

- Bug Fixes
  - Added `sanitize_header_value()` to collapse control bytes to single spaces and truncate to 1024 chars.
  - Applied sanitization to `x-amz-error-code` and `x-amz-error-message`.
  - Replaced builder `.unwrap()` with a safe fallback to prevent panics on invalid headers.
  - Added regression tests for multi-line stderr, control chars, truncation, and run-collapsing.

<sup>Written for commit 3054b489bac55d54cd54dba0db3f0278293e962a. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1545?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

