### PR TITLE
fix(lambda): make Lambda Invoke work on podman macOS (issue #1539 Bug 1)

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda_podman_regression.rs
+++ b/crates/fakecloud-e2e/tests/lambda_podman_regression.rs
@@ -72,11 +72,7 @@ def handler(event, context):
         .runtime(Runtime::Python312)
         .role("arn:aws:iam::123456789012:role/test-role")
         .handler("index.handler")
-        .code(
-            FunctionCode::builder()
-                .zip_file(Blob::new(zip))
-                .build(),
-        )
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
         .send()
         .await
         .expect("create_function should succeed under podman backend");

--- a/crates/fakecloud-e2e/tests/lambda_podman_regression.rs
+++ b/crates/fakecloud-e2e/tests/lambda_podman_regression.rs
@@ -1,0 +1,115 @@
+//! Regression test for issue #1539 Bug 1: Lambda Invoke on podman macOS
+//! used to fail at container start because fakecloud passed
+//! `--add-host host.docker.internal:host-gateway`, which Docker Desktop
+//! understands but podman does not.
+//!
+//! The main test suite picks `docker` over `podman` whenever both are
+//! installed (see `fakecloud_testkit::detect_container_cli`), so the
+//! podman code path was never exercised in CI and the bug shipped. This
+//! file pins the runtime to podman explicitly. It is `#[ignore]`-gated
+//! so it doesn't run by default — opt in with `cargo test
+//! --test lambda_podman_regression -- --ignored` (or wire a dedicated
+//! CI job that does).
+//!
+//! Per the project's no-silent-skip rule: when this test does run, it
+//! hard-fails if podman is unavailable. It must not pretend to pass on a
+//! machine without the toolchain.
+
+mod helpers;
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use aws_sdk_lambda::primitives::Blob;
+use aws_sdk_lambda::types::{FunctionCode, Runtime};
+use helpers::TestServer;
+
+fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    for (name, content) in entries {
+        let options = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+        writer.start_file(*name, options).unwrap();
+        writer.write_all(content).unwrap();
+    }
+    let cursor = writer.finish().unwrap();
+    cursor.into_inner()
+}
+
+fn require_podman() {
+    let ok = Command::new("podman")
+        .arg("info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    assert!(
+        ok,
+        "podman is required for this regression test but `podman info` failed. \
+         Install podman + start a machine (`podman machine start`) before running with --ignored."
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires podman + machine running; opt in with --ignored. Pins the runtime to podman to exercise the macOS host-alias path that broke in issue #1539."]
+async fn lambda_invoke_works_with_podman_backend() {
+    require_podman();
+
+    let server = TestServer::start_with_env(&[("FAKECLOUD_CONTAINER_CLI", "podman")]).await;
+    let client = server.lambda_client().await;
+
+    let handler = r#"
+def handler(event, context):
+    return {"ok": True, "echo": event}
+"#;
+    let zip = make_zip(&[("index.py", handler.as_bytes())]);
+
+    client
+        .create_function()
+        .function_name("podman-regression-1539")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            FunctionCode::builder()
+                .zip_file(Blob::new(zip))
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create_function should succeed under podman backend");
+
+    let resp = client
+        .invoke()
+        .function_name("podman-regression-1539")
+        .payload(Blob::new(br#"{"hi":"podman"}"#.to_vec()))
+        .send()
+        .await
+        .expect(
+            "Lambda Invoke under podman backend should succeed. \
+             Pre-fix: container start failed because `--add-host host.docker.internal:host-gateway` \
+             is rejected by podman with 'host containers internal IP address is empty'.",
+        );
+
+    assert_eq!(
+        resp.status_code(),
+        200,
+        "Invoke returned non-200 — backend container probably failed to start. \
+         Check the fakecloud test log for `host-gateway` or `Lambda invocation failed` lines."
+    );
+
+    let body = resp
+        .payload()
+        .map(|p| String::from_utf8(p.as_ref().to_vec()).unwrap())
+        .unwrap_or_default();
+    assert!(
+        body.contains("\"ok\": true") || body.contains("\"ok\":true"),
+        "unexpected invoke payload: {body}"
+    );
+    assert!(
+        body.contains("podman"),
+        "invoke payload should echo back the input event: {body}"
+    );
+}

--- a/crates/fakecloud-lambda/src/runtime/docker.rs
+++ b/crates/fakecloud-lambda/src/runtime/docker.rs
@@ -19,8 +19,19 @@ use crate::state::LambdaFunction;
 pub struct DockerBackend {
     cli: String,
     instance_id: String,
-    /// IP address that containers should use to reach the host.
-    host_ip: String,
+    /// DNS name the container uses to reach fakecloud on the host. For
+    /// docker we use the cross-platform `host.docker.internal` alias (and
+    /// inject it via `--add-host host.docker.internal:host-gateway` on
+    /// Mac/Windows; bridge gateway IP on Linux). For podman we use its
+    /// built-in `host.containers.internal` alias, which podman injects
+    /// automatically without an `--add-host` flag — passing `host-gateway`
+    /// to podman on macOS fails with "host containers internal IP address
+    /// is empty" because podman's gvproxy network doesn't populate the
+    /// magic alias. See issue #1539.
+    host_alias: String,
+    /// `--add-host <alias>:<value>` argument injected into every container
+    /// `create`, or `None` when the runtime provides the alias natively.
+    add_host_arg: Option<String>,
     /// Port the main fakecloud server bound to. Used to translate AWS
     /// private-ECR URIs in `PackageType=Image` functions to fakecloud's
     /// local OCI v2 registry.
@@ -60,22 +71,49 @@ impl DockerBackend {
 
         let instance_id = format!("fakecloud-{}", std::process::id());
 
-        // On Linux use the bridge gateway IP directly; on Mac/Windows use
-        // Docker Desktop's `host-gateway` magic alias.
-        let host_ip = if cfg!(target_os = "linux") {
-            detect_bridge_gateway(&cli).unwrap_or_else(|| "172.17.0.1".to_string())
+        let (host_alias, add_host_arg) = if is_podman_binary(&cli) {
+            // Podman ships `host.containers.internal` as a built-in container
+            // DNS entry on every supported platform; injecting `host-gateway`
+            // on macOS fails because rootless podman's gvproxy doesn't
+            // expose the magic alias (issue #1539).
+            ("host.containers.internal".to_string(), None)
+        } else if cfg!(target_os = "linux") {
+            // Bare docker on Linux: resolve the bridge gateway IP and add
+            // an explicit alias. `host.docker.internal:host-gateway` only
+            // works on Docker Desktop; native Linux docker has no such
+            // magic.
+            let ip = detect_bridge_gateway(&cli).unwrap_or_else(|| "172.17.0.1".to_string());
+            (
+                "host.docker.internal".to_string(),
+                Some(format!("host.docker.internal:{ip}")),
+            )
         } else {
-            "host-gateway".to_string()
+            // Docker Desktop on Mac/Windows: `host-gateway` is a Docker
+            // Desktop-only alias that resolves to the host's IP.
+            (
+                "host.docker.internal".to_string(),
+                Some("host.docker.internal:host-gateway".to_string()),
+            )
         };
 
         let docker_config = build_local_registry_docker_config(server_port).map(Arc::new);
         Some(Self {
             cli,
             instance_id,
-            host_ip,
+            host_alias,
+            add_host_arg,
             server_port,
             docker_config,
         })
+    }
+
+    /// Append `--add-host` arguments to `cmd` when the runtime needs an
+    /// explicit host alias mapping (docker on Linux/Mac/Windows). No-op
+    /// for podman, which provides `host.containers.internal` natively.
+    fn apply_host_alias(&self, cmd: &mut tokio::process::Command) {
+        if let Some(arg) = &self.add_host_arg {
+            cmd.arg("--add-host").arg(arg);
+        }
     }
 
     fn docker_config_path(&self) -> Option<PathBuf> {
@@ -139,11 +177,10 @@ impl DockerBackend {
             .arg("--label")
             .arg(format!("fakecloud-lambda={}", func.function_name))
             .arg("--label")
-            .arg(format!("fakecloud-instance={}", self.instance_id))
-            .arg("--add-host")
-            .arg(format!("host.docker.internal:{}", self.host_ip));
+            .arg(format!("fakecloud-instance={}", self.instance_id));
+        self.apply_host_alias(&mut cmd);
 
-        for (key, value) in rewrite_localhost_envs(&func.environment, "host.docker.internal") {
+        for (key, value) in rewrite_localhost_envs(&func.environment, &self.host_alias) {
             cmd.arg("-e").arg(format!("{key}={value}"));
         }
         cmd.arg("-e")
@@ -227,11 +264,10 @@ impl DockerBackend {
             .arg("--label")
             .arg(format!("fakecloud-lambda={}", func.function_name))
             .arg("--label")
-            .arg(format!("fakecloud-instance={}", self.instance_id))
-            .arg("--add-host")
-            .arg(format!("host.docker.internal:{}", self.host_ip));
+            .arg(format!("fakecloud-instance={}", self.instance_id));
+        self.apply_host_alias(&mut cmd);
 
-        for (key, value) in rewrite_localhost_envs(&func.environment, "host.docker.internal") {
+        for (key, value) in rewrite_localhost_envs(&func.environment, &self.host_alias) {
             cmd.arg("-e").arg(format!("{key}={value}"));
         }
 
@@ -573,6 +609,18 @@ fn is_cli_available(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// True when `cli` is podman or a podman-compatible binary. Matches on the
+/// filename component so absolute paths (`/opt/homebrew/bin/podman`) and
+/// wrappers (`podman-remote`) both register as podman. Docker Desktop's
+/// compatibility CLI is named `docker`, so this check is safe.
+fn is_podman_binary(cli: &str) -> bool {
+    std::path::Path::new(cli)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.contains("podman"))
+        .unwrap_or(false)
+}
+
 fn build_local_registry_docker_config(server_port: u16) -> Option<TempDir> {
     let dir = TempDir::new().ok()?;
     let auth = base64::engine::general_purpose::STANDARD.encode("AWS:fakecloud-lambda-runtime");
@@ -658,6 +706,26 @@ mod tests {
             Some("public.ecr.aws/lambda/dotnet:10".to_string())
         );
         assert_eq!(runtime_to_image("unknown"), None);
+    }
+
+    #[test]
+    fn is_podman_binary_matches_bare_name() {
+        assert!(is_podman_binary("podman"));
+        assert!(is_podman_binary("podman-remote"));
+    }
+
+    #[test]
+    fn is_podman_binary_matches_absolute_path() {
+        assert!(is_podman_binary("/opt/homebrew/bin/podman"));
+        assert!(is_podman_binary("/usr/local/bin/podman-remote"));
+    }
+
+    #[test]
+    fn is_podman_binary_rejects_docker() {
+        assert!(!is_podman_binary("docker"));
+        assert!(!is_podman_binary("/usr/local/bin/docker"));
+        // Docker Desktop's compatibility CLI is `docker`, not `podman`.
+        assert!(!is_podman_binary("docker-credential-helper"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

fakecloud unconditionally passed `--add-host host.docker.internal:host-gateway` to the container runtime. The `host-gateway` magic alias is a Docker Desktop feature; podman on macOS rejects it with `host containers internal IP address is empty`, which made Lambda completely unusable on podman macOS (issue #1539 Bug 1).

The fix detects the runtime CLI shape and picks the right host-alias strategy:

| Runtime + platform | Strategy |
|---|---|
| docker on Linux | `--add-host host.docker.internal:<bridge IP>` |
| docker on Mac/Windows | `--add-host host.docker.internal:host-gateway` |
| podman (any platform) | no `--add-host` — use podman's built-in `host.containers.internal` and rewrite env vars to that name |

Verified end-to-end on Apple Silicon macOS 26.3.1 + podman 5.0.2: CreateFunction + Invoke for `python3.12` round-trips in ~1.9s on a warm image, where it previously failed at container start. Docker Desktop behavior is unchanged.

## Test plan

- [x] Unit tests for `is_podman_binary` (bare name, absolute path, docker rejection).
- [x] Manual end-to-end with podman: `FAKECLOUD_CONTAINER_CLI=podman fakecloud` -> CreateFunction -> Invoke -> got `{"ok": true, "echo": {"hi": "podman"}}`.
- [x] `cargo test -p fakecloud-lambda --lib` clean.
- [x] `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings` clean.
- [ ] E2E regression test for podman backend will land in the dedicated #1539 follow-up that wires podman into CI (tracked below).

Note: regression e2e for podman invoke would have caught this. CI doesn't currently run a podman-backed Lambda invoke — adding one would have flagged this bug before it shipped. Will fold into the follow-up batch on Dockerfile/CLI bundling that opens up containerized fakecloud testing anyway.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Lambda Invoke on podman macOS by removing the Docker-only host-gateway flag and using podman’s built-in host alias. Adds an opt-in e2e regression test for the podman path; Docker Desktop and Linux docker behavior is unchanged.

- **Bug Fixes**
  - Detect runtime and choose host alias:
    - docker Linux: `--add-host host.docker.internal:<bridge IP>`
    - docker Mac/Windows: `--add-host host.docker.internal:host-gateway`
    - podman: no `--add-host`; use `host.containers.internal` and rewrite env vars
  - Replace `host_ip` with `(host_alias, add_host_arg)` and apply via `apply_host_alias`.
  - Add `is_podman_binary` with unit tests; verified end-to-end on macOS + podman.
  - Add ignored e2e regression test `lambda_podman_regression` that pins `FAKECLOUD_CONTAINER_CLI=podman`, hard-fails if podman is unavailable, and validates CreateFunction + Invoke. Run with: `cargo test --test lambda_podman_regression -- --ignored`.

<sup>Written for commit e01f7d726ddb11e09aae0024c5d3520769b8d3e8. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1546?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

