### PR TITLE
feat(lambda): pre-pull runtime images on CreateFunction (issue #1539 Bug 3)

### DIFF
--- a/crates/fakecloud-lambda/src/runtime/backend.rs
+++ b/crates/fakecloud-lambda/src/runtime/backend.rs
@@ -93,4 +93,18 @@ pub trait LambdaBackend: Send + Sync + 'static {
     /// their function names don't leak across restarts. Default no-op;
     /// backends with out-of-process state should override.
     async fn reap_stale(&self) {}
+
+    /// Optional hook: pre-warm the runtime image so the first `launch()`
+    /// for a function doesn't pay the cold-pull cost. Called in the
+    /// background after `CreateFunction` persists; backends that don't
+    /// benefit from pre-pulling (e.g. Kubernetes, which pulls images on
+    /// the scheduling node anyway) leave this as a no-op.
+    ///
+    /// `image` is the registry URI fetched from `runtime_to_image` for
+    /// Zip-package functions, or the user-supplied `ImageUri` (already
+    /// translated to the local registry if applicable) for Image-package
+    /// functions.
+    async fn prepull_image(&self, _image: &str) -> Result<(), RuntimeError> {
+        Ok(())
+    }
 }

--- a/crates/fakecloud-lambda/src/runtime/docker.rs
+++ b/crates/fakecloud-lambda/src/runtime/docker.rs
@@ -447,6 +447,31 @@ impl LambdaBackend for DockerBackend {
             BackendHandle::Pod { .. } => {}
         }
     }
+
+    async fn prepull_image(&self, image: &str) -> Result<(), RuntimeError> {
+        // Translate AWS-flavored ECR URIs to fakecloud's local registry so
+        // private-ECR `Image` package functions can be warmed too. Falls
+        // back to the URI as-is for public-ECR / Docker Hub / Quay images.
+        let local_uri = fakecloud_core::ecr_uri::translate_to_local(image, self.server_port);
+        let pull_uri = local_uri.as_deref().unwrap_or(image);
+
+        let mut cmd = tokio::process::Command::new(&self.cli);
+        if let Some(p) = self.docker_config_path() {
+            cmd.env("DOCKER_CONFIG", p);
+        }
+        let out = cmd
+            .args(["pull", pull_uri])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(format!("docker pull: {e}")))?;
+        if !out.status.success() {
+            return Err(RuntimeError::ContainerStartFailed(format!(
+                "docker pull failed for {pull_uri}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            )));
+        }
+        Ok(())
+    }
 }
 
 /// Map AWS runtime identifier to a Docker image tag.

--- a/crates/fakecloud-lambda/src/runtime/facade.rs
+++ b/crates/fakecloud-lambda/src/runtime/facade.rs
@@ -100,6 +100,31 @@ impl LambdaRuntime {
         self.backend.name()
     }
 
+    /// Background pre-warm hook: pull the image a Zip-package function
+    /// will need at invoke time, or the `ImageUri` of an Image-package
+    /// function. The first cold pull of an AWS base image (~700 MB)
+    /// frequently exceeds the AWS CLI default 60s read timeout, surfacing
+    /// to users as `Connection was closed` (issue #1539). Call after
+    /// `CreateFunction` persists so the warm path is ready before the
+    /// caller turns around and calls `Invoke`.
+    ///
+    /// Returns `None` if the function has no resolvable image (e.g. an
+    /// unsupported runtime string we can't map to a base image).
+    /// Otherwise returns the result of the backend's `prepull_image` —
+    /// callers log failures and move on, since invoke time still
+    /// re-attempts the pull as a fallback.
+    pub async fn prepull_for_function(
+        &self,
+        func: &LambdaFunction,
+    ) -> Option<Result<(), super::backend::RuntimeError>> {
+        let image = if func.package_type == "Image" {
+            func.image_uri.clone()?
+        } else {
+            super::docker::runtime_to_image(&func.runtime)?
+        };
+        Some(self.backend.prepull_image(&image).await)
+    }
+
     /// Invoke a Lambda function, starting an instance if needed. Layer
     /// ZIPs are extracted into `/opt` of the runtime sandbox; AWS base
     /// images already include `/opt/python`, `/opt/nodejs/node_modules`,

--- a/crates/fakecloud-lambda/src/service/functions.rs
+++ b/crates/fakecloud-lambda/src/service/functions.rs
@@ -116,6 +116,32 @@ impl LambdaService {
 
         let response = self.function_config_json(&func);
 
+        // Pre-pull the runtime image in the background so the first
+        // Invoke doesn't pay the cold-pull cost. Cold pulls of AWS base
+        // images (~700 MB) routinely exceed the AWS CLI default 60s read
+        // timeout, surfacing to users as `Connection was closed`
+        // (issue #1539). Invoke still re-pulls as a fallback if this
+        // task lost the race or failed, so a pre-pull error is not fatal.
+        if let Some(runtime) = self.runtime.clone() {
+            let func_for_prepull = func.clone();
+            let name = func.function_name.clone();
+            tokio::spawn(async move {
+                match runtime.prepull_for_function(&func_for_prepull).await {
+                    Some(Ok(())) => {
+                        tracing::info!(function = %name, "pre-pulled Lambda runtime image");
+                    }
+                    Some(Err(e)) => {
+                        tracing::warn!(
+                            function = %name,
+                            error = %e,
+                            "Lambda runtime image pre-pull failed; Invoke will retry on cold path"
+                        );
+                    }
+                    None => {} // no resolvable image (e.g. unsupported runtime)
+                }
+            });
+        }
+
         state.functions.insert(input.function_name, func);
 
         Ok(AwsResponse::json(StatusCode::CREATED, response.to_string()))

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -2834,3 +2834,93 @@ async fn put_function_event_invoke_destination_config_echo_variants() {
         "missing OnSuccess half should be backfilled as empty object"
     );
 }
+
+/// In-memory `LambdaBackend` used by the pre-pull regression test below.
+/// Records every `prepull_image` call so the test can assert that
+/// CreateFunction kicked one off, without spinning up a real container.
+#[derive(Default, Clone)]
+struct PrepullSpy {
+    pulled: Arc<parking_lot::Mutex<Vec<String>>>,
+}
+
+#[async_trait::async_trait]
+impl crate::runtime::LambdaBackend for PrepullSpy {
+    fn name(&self) -> &str {
+        "prepull-spy"
+    }
+    async fn launch(
+        &self,
+        _func: &crate::state::LambdaFunction,
+        _code_zip: Option<&[u8]>,
+        _layers: &[Vec<u8>],
+        _deploy_id: &str,
+    ) -> Result<crate::runtime::WarmInstance, crate::runtime::RuntimeError> {
+        unreachable!("prepull regression test never invokes launch")
+    }
+    async fn terminate(&self, _handle: &crate::runtime::BackendHandle) {}
+    async fn prepull_image(&self, image: &str) -> Result<(), crate::runtime::RuntimeError> {
+        self.pulled.lock().push(image.to_string());
+        Ok(())
+    }
+}
+
+/// Regression for issue #1539 Bug 3: CreateFunction used to leave the
+/// runtime image cold, so the first Invoke paid a ~700 MB pull cost
+/// that routinely exceeded the AWS CLI default 60s read timeout. After
+/// the fix CreateFunction spawns a background pre-pull keyed off
+/// `runtime_to_image`.
+#[tokio::test]
+async fn create_function_kicks_off_background_prepull() {
+    let spy = PrepullSpy::default();
+    let pulled = spy.pulled.clone();
+    let backend: Arc<dyn crate::runtime::LambdaBackend> = Arc::new(spy);
+    let runtime = Arc::new(crate::runtime::LambdaRuntime::from_backend(backend));
+    let svc = LambdaService::new(make_state()).with_runtime(runtime);
+
+    let create_body = json!({
+        "FunctionName": "prepull-fn",
+        "Runtime": "python3.12",
+        "Role": "arn:aws:iam::123456789012:role/lambda-role",
+        "Handler": "index.handler",
+        "Code": {"ZipFile": ""},
+    })
+    .to_string();
+    let req = make_request(Method::POST, "/2015-03-31/functions", &create_body);
+    svc.handle(req).await.expect("create function");
+
+    // The pre-pull is `tokio::spawn`-ed; give it a brief chance to land
+    // on the runtime queue and run to completion. PrepullSpy returns
+    // immediately so this poll is bounded by scheduler latency, not I/O.
+    for _ in 0..50 {
+        if !pulled.lock().is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    let calls = pulled.lock().clone();
+    assert_eq!(
+        calls,
+        vec!["public.ecr.aws/lambda/python:3.12".to_string()],
+        "CreateFunction must dispatch exactly one background pre-pull for the runtime image"
+    );
+}
+
+/// CreateFunction must not fail when no container runtime is wired up
+/// (e.g. fakecloud started without docker/podman available). The
+/// pre-pull is best-effort; absence of a runtime means there's nothing
+/// to pre-pull and the function still has to persist.
+#[tokio::test]
+async fn create_function_succeeds_without_runtime_prepull_hook() {
+    let svc = LambdaService::new(make_state()); // no `.with_runtime(...)`
+    let create_body = json!({
+        "FunctionName": "no-runtime-fn",
+        "Runtime": "python3.12",
+        "Role": "arn:aws:iam::123456789012:role/lambda-role",
+        "Handler": "index.handler",
+        "Code": {"ZipFile": ""},
+    })
+    .to_string();
+    let req = make_request(Method::POST, "/2015-03-31/functions", &create_body);
+    let resp = svc.handle(req).await.expect("create function");
+    assert_eq!(resp.status, StatusCode::CREATED);
+}


### PR DESCRIPTION
## Summary

First Invoke of a Zip-package function used to trigger a cold pull of the AWS base image (~700 MB), often blowing past the AWS CLI default 60s read timeout. Users saw `Read timeout on endpoint URL` or `Connection was closed`. Issue #1539 case 2 (post-#1545 unwrap of the multi-line-error panic) reduces to this once #1545/#1546 are in.

Pre-pull the image in the background as soon as CreateFunction lands so the first Invoke hits a warm cache. Invoke still re-pulls synchronously as a fallback if the pre-pull lost a race or failed, so the new path is strictly best-effort.

## What changes

- `LambdaBackend::prepull_image` trait method (default no-op).
- `DockerBackend::prepull_image` runs `docker pull` with the cached `DOCKER_CONFIG` so private-ECR `ImageUri` functions warm fakecloud's local registry too.
- `K8sBackend` keeps the default no-op (kubelet pulls per-node anyway).
- `LambdaRuntime::prepull_for_function` resolves Zip runtimes via `runtime_to_image` and dispatches to the backend.
- `create_function` `tokio::spawn`s the pre-pull after persisting; logs success/failure but doesn't block the response.

## Test plan

- [x] `create_function_kicks_off_background_prepull` (new) — exercises the full CreateFunction path against an in-memory `PrepullSpy` backend, asserts exactly one prepull is dispatched and the right URI lands.
- [x] `create_function_succeeds_without_runtime_prepull_hook` (new) — fakecloud-without-runtime case still returns 201.
- [x] `cargo test -p fakecloud-lambda --lib` — 180 passed.
- [x] `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-pulls Lambda runtime images on `CreateFunction` so the first `Invoke` hits a warm cache and avoids CLI read timeouts. The pull runs in the background and is best-effort; `Invoke` still pulls if needed.

- Bug Fixes
  - Added `LambdaBackend::prepull_image` (default no-op); implemented for Docker to run `docker pull` using cached `DOCKER_CONFIG` and local-registry translation for private ECR.
  - Left `K8sBackend` as no-op (kubelet handles pulls per node).
  - Added `LambdaRuntime::prepull_for_function` to resolve Zip runtimes via `runtime_to_image` or use `ImageUri` directly; `create_function` spawns this without blocking the response.
  - Added tests for background pre-pull dispatch and for success when no runtime is configured.

<sup>Written for commit da36c21fdb1a1ee80fafc6357a46451e322d6eae. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1547?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

