### PR TITLE
fix(docker): bundle docker CLI + sibling-container networking (issue #1539 Bug 4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,23 @@ COPY . .
 RUN cargo build --release --bin fakecloud
 
 FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
+# `docker-cli` is required for Lambda / RDS / ElastiCache / ECS container
+# orchestration when running fakecloud-in-Docker with the host socket
+# bind-mounted (the documented setup at fakecloud.dev/docs/getting-started).
+# Without it the published image silently has no way to shell out, and
+# every container-backed service returns "Docker/Podman is required"
+# (issue #1539 Bug 4). debian's `docker.io` package pulls in the daemon,
+# which we don't want — `docker-cli` ships the CLI alone.
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates docker-cli \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+# Signal to the fakecloud binary that it's running inside a container.
+# Drives the sibling-container networking path: published Lambda /
+# RDS / ElastiCache ports live on the host's loopback, not the
+# container's, so fakecloud must reach them via `host.docker.internal`.
+ENV FAKECLOUD_IN_CONTAINER=1
 COPY --from=builder /build/target/release/fakecloud /usr/local/bin/
 EXPOSE 4566
 ENTRYPOINT ["fakecloud"]

--- a/crates/fakecloud-lambda/src/runtime/docker.rs
+++ b/crates/fakecloud-lambda/src/runtime/docker.rs
@@ -36,6 +36,16 @@ pub struct DockerBackend {
     /// private-ECR URIs in `PackageType=Image` functions to fakecloud's
     /// local OCI v2 registry.
     server_port: u16,
+    /// Hostname fakecloud uses to reach sibling Lambda containers it
+    /// just spawned. `"127.0.0.1"` when fakecloud runs on the host (the
+    /// containers expose ports on the host loopback). When fakecloud is
+    /// itself running in a container with `/var/run/docker.sock`
+    /// bind-mounted, the spawned Lambda containers are *siblings* on
+    /// the host's daemon — their published ports are reachable from
+    /// inside fakecloud's container as `host.docker.internal:<port>`,
+    /// not `127.0.0.1:<port>`. Set via the `FAKECLOUD_IN_CONTAINER=1`
+    /// env var baked into the published image (issue #1539 Bug 4).
+    sibling_host: String,
     /// Isolated DOCKER_CONFIG dir with Basic auth for `127.0.0.1:<port>`.
     /// Lets `docker pull` talk to fakecloud ECR without mutating the user's
     /// `~/.docker/config.json`.
@@ -97,12 +107,14 @@ impl DockerBackend {
         };
 
         let docker_config = build_local_registry_docker_config(server_port).map(Arc::new);
+        let sibling_host = resolve_sibling_host(std::env::var("FAKECLOUD_IN_CONTAINER").ok());
         Some(Self {
             cli,
             instance_id,
             host_alias,
             add_host_arg,
             server_port,
+            sibling_host,
             docker_config,
         })
     }
@@ -232,7 +244,7 @@ impl DockerBackend {
         );
 
         Ok(WarmInstance {
-            endpoint: format!("127.0.0.1:{port}"),
+            endpoint: format!("{}:{port}", self.sibling_host),
             handle: BackendHandle::Container { id: container_id },
         })
     }
@@ -360,7 +372,7 @@ impl DockerBackend {
         );
 
         Ok(WarmInstance {
-            endpoint: format!("127.0.0.1:{port}"),
+            endpoint: format!("{}:{port}", self.sibling_host),
             handle: BackendHandle::Container { id: container_id },
         })
     }
@@ -388,7 +400,7 @@ impl DockerBackend {
     async fn wait_for_ready(&self, container_id: &str, port: u16) -> Result<(), RuntimeError> {
         for _ in 0..20 {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            if tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            if tokio::net::TcpStream::connect(format!("{}:{port}", self.sibling_host))
                 .await
                 .is_ok()
             {
@@ -624,6 +636,26 @@ fn detect_bridge_gateway(cli: &str) -> Option<String> {
     None
 }
 
+/// Decide what loopback address fakecloud uses to reach the *sibling*
+/// Lambda containers it just spawned. Pure helper so the env-var
+/// parsing can be tested without touching the process's real
+/// environment (which would race with parallel tests).
+///
+/// - `Some("1")` or `Some("true")` -> fakecloud is in a container,
+///   sibling published ports live on `host.docker.internal:<port>`.
+/// - Anything else, including `None` -> fakecloud runs on the host,
+///   sibling ports live on `127.0.0.1:<port>`.
+fn resolve_sibling_host(env_value: Option<String>) -> String {
+    let in_container = env_value
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if in_container {
+        "host.docker.internal".to_string()
+    } else {
+        "127.0.0.1".to_string()
+    }
+}
+
 fn is_cli_available(name: &str) -> bool {
     std::process::Command::new(name)
         .arg("info")
@@ -751,6 +783,30 @@ mod tests {
         assert!(!is_podman_binary("/usr/local/bin/docker"));
         // Docker Desktop's compatibility CLI is `docker`, not `podman`.
         assert!(!is_podman_binary("docker-credential-helper"));
+    }
+
+    #[test]
+    fn resolve_sibling_host_defaults_to_loopback() {
+        assert_eq!(resolve_sibling_host(None), "127.0.0.1");
+        assert_eq!(resolve_sibling_host(Some("".to_string())), "127.0.0.1");
+        assert_eq!(resolve_sibling_host(Some("0".to_string())), "127.0.0.1");
+        assert_eq!(resolve_sibling_host(Some("false".to_string())), "127.0.0.1");
+    }
+
+    #[test]
+    fn resolve_sibling_host_uses_docker_internal_when_in_container() {
+        assert_eq!(
+            resolve_sibling_host(Some("1".to_string())),
+            "host.docker.internal"
+        );
+        assert_eq!(
+            resolve_sibling_host(Some("true".to_string())),
+            "host.docker.internal"
+        );
+        assert_eq!(
+            resolve_sibling_host(Some("TRUE".to_string())),
+            "host.docker.internal"
+        );
     }
 
     #[test]

--- a/website/content/docs/getting-started/install.md
+++ b/website/content/docs/getting-started/install.md
@@ -36,11 +36,16 @@ cargo run --release --bin fakecloud
 docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud
 ```
 
-To enable Lambda function execution (real code in containers), mount the Docker socket:
+To enable Lambda / RDS / ElastiCache / ECS function execution (real code in containers), mount the Docker socket **and** add the host-gateway alias so fakecloud can reach the sibling containers it spawns on the host's daemon:
 
 ```sh
-docker run --rm -p 4566:4566 -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/faiscadev/fakecloud
+docker run --rm -p 4566:4566 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --add-host host.docker.internal:host-gateway \
+  ghcr.io/faiscadev/fakecloud
 ```
+
+The image ships with the `docker` CLI installed and `FAKECLOUD_IN_CONTAINER=1` set, so fakecloud automatically reaches spawned Lambda containers via `host.docker.internal:<port>` instead of `127.0.0.1:<port>` (which would resolve to fakecloud's own loopback inside its container).
 
 ## Docker Compose
 
@@ -53,6 +58,8 @@ services:
       - "4566:4566"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # required for Lambda Invoke
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # required for Lambda Invoke
     environment:
       FAKECLOUD_LOG: info
 ```

--- a/website/content/test-lambda-locally.md
+++ b/website/content/test-lambda-locally.md
@@ -67,7 +67,7 @@ Step-by-step guide with S3, SQS, EventBridge triggers and test-assertion example
 ## Install
 
 - Binary: `curl -fsSL https://fakecloud.dev/install.sh | bash`
-- Docker: `docker run --rm -p 4566:4566 -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/faiscadev/fakecloud`
+- Docker: `docker run --rm -p 4566:4566 -v /var/run/docker.sock:/var/run/docker.sock --add-host host.docker.internal:host-gateway ghcr.io/faiscadev/fakecloud`
 - Cargo: `cargo install fakecloud`
 
 ## Links


### PR DESCRIPTION
## Summary

Published \`ghcr.io/faiscadev/fakecloud\` image was \`debian:bookworm-slim\` + the fakecloud binary, **with no \`docker\` or \`podman\` CLI inside.** Our own docs told users to bind-mount \`/var/run/docker.sock\` for Lambda — but without a client in the image the mount was useless, and every container-backed service returned \"Docker/Podman is required\". Even fixing the CLI absence isn't enough: spawning sibling containers via the host's socket exposes their ports on the host's loopback, which fakecloud (from inside its own container) can't reach at \`127.0.0.1\`.

## What changes

- **Dockerfile**: install \`docker-cli\` (Debian's CLI-only package, no daemon) and bake \`FAKECLOUD_IN_CONTAINER=1\` into the image as the runtime signal.
- **DockerBackend**: pure helper \`resolve_sibling_host\` reads the env var and returns \`host.docker.internal\` (containerized) or \`127.0.0.1\` (bare host). Wired into \`WarmInstance.endpoint\` and the \`wait_for_ready\` TCP probe.
- **Docs**: \`install.md\` and \`test-lambda-locally.md\` updated to include \`--add-host host.docker.internal:host-gateway\` in the recommended \`docker run\` and \`extra_hosts\` in the Compose recipe. Without those, \`host.docker.internal\` isn't resolvable from inside fakecloud's container on Linux Docker.

Per project rule \`feedback_no_blogpost_updates\` the existing blog posts that show older \`docker run\` recipes are NOT retroactively updated.

## Test plan

- [x] \`resolve_sibling_host_defaults_to_loopback\` (new) — None / empty / \`0\` / \`false\` -> \`127.0.0.1\`.
- [x] \`resolve_sibling_host_uses_docker_internal_when_in_container\` (new) — \`1\` / \`true\` / \`TRUE\` -> \`host.docker.internal\`.
- [x] \`cargo test -p fakecloud-lambda --lib\` — 180 passed.
- [x] \`cargo clippy -p fakecloud-lambda --all-targets -- -D warnings\` clean.
- [ ] Full DinD smoke test (build the new image, \`docker run\` with socket mount + --add-host, CreateFunction + Invoke) is a manual verification documented in the install page — adding it to CI is its own follow-up since it requires a self-mounted-socket job pattern we don't have yet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundles the `docker` CLI in the `ghcr.io/faiscadev/fakecloud` image and uses `host.docker.internal` for sibling-container networking when running in Docker. Restores Lambda/RDS/ElastiCache/ECS execution via a socket mount (fixes issue #1539).

- **Bug Fixes**
  - Install `docker-cli` (CLI-only) and set `FAKECLOUD_IN_CONTAINER=1` in the image.
  - Add `resolve_sibling_host` to use `host.docker.internal` in-container and `127.0.0.1` on host.
  - Use the resolved host for `WarmInstance.endpoint` and the TCP readiness probe; add unit tests.

- **Migration**
  - Docker run: add `--add-host host.docker.internal:host-gateway`.
  - Docker Compose: add `extra_hosts: ["host.docker.internal:host-gateway"]`.

<sup>Written for commit 0701fdcb63b0db95de5d059106c70f2297aabcf0. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1548?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

