### PR TITLE
fix(docker): install docker CLI from static binary (fixes red main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,19 +12,41 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --bin fakecloud
 
+# Fetch the standalone docker CLI binary. Debian's repos have no
+# CLI-only package — `docker.io` bundles the daemon (~bloat we don't
+# want) and the lean `docker-ce-cli` lives only in Docker's own apt
+# repo. The upstream static tarball ships exactly the client binary,
+# so we extract just that. `TARGETARCH` is provided by buildx for each
+# platform in the build matrix (issue #1539 Bug 4).
+FROM debian:bookworm-slim AS docker-cli
+ARG TARGETARCH
+ARG DOCKER_CLI_VERSION=27.5.1
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && case "$TARGETARCH" in \
+         amd64) ARCH=x86_64 ;; \
+         arm64) ARCH=aarch64 ;; \
+         *) echo "unsupported TARGETARCH: $TARGETARCH" && exit 1 ;; \
+       esac \
+    && curl -fsSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_CLI_VERSION}.tgz" -o /tmp/docker.tgz \
+    && tar -xzf /tmp/docker.tgz -C /tmp \
+    && install -m 0755 /tmp/docker/docker /usr/local/bin/docker \
+    && rm -rf /tmp/docker /tmp/docker.tgz \
+    && /usr/local/bin/docker --version
+
 FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
-# `docker-cli` is required for Lambda / RDS / ElastiCache / ECS container
-# orchestration when running fakecloud-in-Docker with the host socket
-# bind-mounted (the documented setup at fakecloud.dev/docs/getting-started).
-# Without it the published image silently has no way to shell out, and
-# every container-backed service returns "Docker/Podman is required"
-# (issue #1539 Bug 4). debian's `docker.io` package pulls in the daemon,
-# which we don't want — `docker-cli` ships the CLI alone.
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends ca-certificates docker-cli \
+    && apt-get install -y --no-install-recommends ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+# The docker CLI is required for Lambda / RDS / ElastiCache / ECS
+# container orchestration when running fakecloud-in-Docker with the host
+# socket bind-mounted (the documented setup at
+# fakecloud.dev/docs/getting-started). Without it the published image has
+# no way to shell out, and every container-backed service returns
+# "Docker/Podman is required" (issue #1539 Bug 4).
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
 # Signal to the fakecloud binary that it's running inside a container.
 # Drives the sibling-container networking path: published Lambda /
 # RDS / ElastiCache ports live on the host's loopback, not the


### PR DESCRIPTION
## Summary

The v0.15.3 Dockerfile change (#1548) used `apt-get install docker-cli`, which doesn't exist as a Debian package. The Docker image build went red on main:

```
E: Unable to locate package docker-cli
ERROR: failed to solve: process "/bin/sh -c apt-get update ..." did not complete successfully: exit code: 100
```

Debian's repos have no CLI-only docker package — `docker.io` bundles the daemon, and `docker-ce-cli` lives only in Docker's own apt repo. The build failed on both `linux/amd64` and `linux/arm64`, so the 0.15.3 image never published to ghcr.

Fix: a `docker-cli` build stage fetches Docker's upstream **static** tarball (just the client) and copies `docker/docker` into the final image. `TARGETARCH` selects x86_64 / aarch64 so both matrix platforms work.

## Test plan

- [x] `docker build --target docker-cli` builds locally on arm64
- [x] `docker run --entrypoint /usr/local/bin/docker <image> --version` -> `Docker version 27.5.1, build 9f9e405`
- [ ] Docker workflow (amd64 + arm64) green on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken Docker image builds by installing the Docker CLI from Docker’s static binary instead of the nonexistent Debian `docker-cli` package. Restores multi-arch (amd64/arm64) builds and unblocks publishing.

- **Bug Fixes**
  - Add a `docker-cli` build stage that downloads Docker CLI `27.5.1` static tarball and copies `docker` into the final image.
  - Use `TARGETARCH` to select `x86_64` or `aarch64`.
  - Remove `apt-get install docker-cli`; keep `ca-certificates`.
  - Verify CLI availability with `/usr/local/bin/docker --version`.

<sup>Written for commit bbf04ed3005361fc51800b4a9be2425cfdcdb12e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1550?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

