### PR TITLE
fix(docker): bump bundled docker CLI to 29.5.2 to clear Trivy CVE gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,11 @@ RUN cargo build --release --bin fakecloud
 # platform in the build matrix (issue #1539 Bug 4).
 FROM debian:bookworm-slim AS docker-cli
 ARG TARGETARCH
-ARG DOCKER_CLI_VERSION=27.5.1
+# Pin a docker CLI built with a current Go toolchain — the static build
+# bakes the Go stdlib into the binary, so a stale toolchain trips the
+# image's Trivy CRITICAL/HIGH gate (27.5.1 shipped go1.22.11, flagged by
+# CVE-2025-68121). 29.5.2 ships go1.26.3, which clears the gate.
+ARG DOCKER_CLI_VERSION=29.5.2
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates \
     && case "$TARGETARCH" in \


### PR DESCRIPTION
## Summary

The docker static binary added in #1550 pinned **27.5.1**, which bakes in the Go 1.22.11 stdlib. Trivy flagged 29 stdlib vulnerabilities (1 CRITICAL `CVE-2025-68121` crypto/tls cert validation, 28 HIGH), failing the image `scan` job on main.

Bump to docker **29.5.2** (built with `go1.26.3`, past the fixed-in version for every flagged CVE).

## Test plan

- [x] `docker build --target docker-cli` reports `Docker version 29.5.2`
- [x] Local Trivy with the exact CI config (`aquasec/trivy:0.70.0 image --severity CRITICAL,HIGH --ignore-unfixed --vuln-type os,library --exit-code 1`): **0 findings** in both the debian layer and the docker gobinary, exit 0
- [ ] Docker workflow `scan` job green after merge to main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the bundled Docker CLI from 27.5.1 to 29.5.2 to clear Trivy CRITICAL/HIGH Go stdlib CVEs and unblock the image scan. 29.5.2 is built with go1.26.3, which resolves the flagged issues.

- **Dependencies**
  - Pin `DOCKER_CLI_VERSION=29.5.2` in the `docker-cli` build stage.

<sup>Written for commit 4941148ac528b845b3446e618f85b717b51e79f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1551?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

