### PR TITLE
test(cognito,sqs): current-thread runtime in block_on to stop CI hangs

### DIFF
--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -6,8 +6,20 @@ use crate::state::{
 use crate::triggers;
 
 /// Helper to run an async fn in sync test context.
+///
+/// Uses a current-thread runtime, not the default multi-threaded one.
+/// libtest runs these ~320 unit tests in parallel; a multi-threaded
+/// `Runtime::new()` per call spawns a worker-thread pool each time, and
+/// hundreds of those at once exhaust the runner's thread/fd limits,
+/// which intermittently hangs a random test until the 6h CI ceiling
+/// kills the job. A current-thread runtime drives the future on the
+/// calling thread with no extra workers.
 fn block_on<F: std::future::Future>(f: F) -> F::Output {
-    tokio::runtime::Runtime::new().unwrap().block_on(f)
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(f)
 }
 
 #[test]

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -1112,7 +1112,10 @@ fn delete_message_batch_removes_listed_messages() {
     send_msg_simple(&svc, &url, "a");
     send_msg_simple(&svc, &url, "b");
 
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
     let recv = rt
         .block_on(svc.receive_message(&make_request(
             "ReceiveMessage",
@@ -1152,7 +1155,10 @@ fn change_message_visibility_batch_updates_multiple() {
     send_msg_simple(&svc, &url, "a");
     send_msg_simple(&svc, &url, "b");
 
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
     let recv = rt
         .block_on(svc.receive_message(&make_request(
             "ReceiveMessage",
@@ -2200,7 +2206,10 @@ fn start_message_move_task_drains_to_explicit_destination() {
         .unwrap();
     assert!(body_json(resp)["TaskHandle"].as_str().is_some());
     // Verify destination queue received both messages.
-    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
     let recv = runtime
         .block_on(svc.receive_message(&make_request(
             "ReceiveMessage",


### PR DESCRIPTION
## Summary

The v0.15.4 `release.yml` run hung ~6h and hit GitHub's job ceiling, skipping all publish jobs. Root cause: the cognito unit-test `block_on` helper built a default **multi-threaded** tokio runtime (`Runtime::new()`) per call. libtest runs the crate's ~320 unit tests in parallel, so hundreds of worker-thread pools spin up at once, exhausting the runner's thread/fd limits and intermittently wedging a random test. `admin_create_user_duplicate_fails` was the victim that run (identified by diffing the 319 printed results against the 320 in the binary), but the hang is nondeterministic.

Fix: current-thread runtime (`Builder::new_current_thread().enable_all()`) — drives the future on the calling thread, no extra workers. Same fix applied to the 3 ad-hoc `Runtime::new()` call sites in the SQS service tests (identical latent flake). `main.rs`'s production runtime is intentionally left multi-threaded.

## Test plan

- [x] `cargo test -p fakecloud-cognito --lib` — 320 passed
- [x] `cargo test -p fakecloud-sqs --lib` — 148 passed
- [x] `cargo clippy -p fakecloud-cognito -p fakecloud-sqs --tests -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop CI hangs by switching test runtimes to a current-thread `tokio` runtime in `fakecloud-cognito` and `fakecloud-sqs` tests. This prevents spawning per-test thread pools that exhausted runner limits and wedged tests.

- **Bug Fixes**
  - In `fakecloud-cognito` tests, changed `block_on` to use `tokio::runtime::Builder::new_current_thread().enable_all().build()`.
  - Replaced three `Runtime::new()` call sites in `fakecloud-sqs` service tests with the same current-thread runtime.
  - Avoids thread/fd exhaustion under parallel test runs; production `main.rs` remains multi-threaded.

<sup>Written for commit b60863492c7d0b1cd2febe93ef8841f95c6caa26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1553?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

