### PR TITLE
chore(release): bump workspace to v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4123,7 +4123,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -101,167 +101,167 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.15.4"
+version = "0.16.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.15.4")
+    testImplementation("dev.fakecloud:fakecloud:0.16.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.15.4</version>
+    <version>0.16.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.15.4"
+version = "0.16.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.15.4"
+version = "0.16.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.15.4",
+  "version": "0.16.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Minor release **v0.15.4 → v0.16.0**.

### What's in it
- **4 services to true 100% Smithy conformance** in the harness (PRs #1554-#1558): CloudWatch (Metrics & Alarms, 46 ops), Firehose (12), Glue (265), Organizations (63). The baseline is now **40 services / 99,678 of 99,678 variants** at `passed == total`.
- **IAM-bypass introspection endpoints + SDK methods** (PRs #1560, #1561) in all 6 first-party SDKs: CloudWatch alarms/metrics, Glue crawlers, Organizations responsibility-transfers, Firehose delivery-streams.
- Per-service docs + service tables synced (#1559).

### Bump
Workspace package version + internal `fakecloud-*` dependency pins, `Cargo.lock`, and the TypeScript / Python / Java SDK manifests + Java README. No new crates → publish-crates topo order unchanged.

After merge, push the `v0.16.0` tag to trigger the publish workflow (binary + GitHub Release + crates.io + PyPI + npm + Maven + Packagist + Go).

## Test plan
- Full CI (build/test/clippy/conformance/e2e + all SDK builds) green on the bumped tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the v0.16.0 release. It includes 100% Smithy conformance for CloudWatch (Metrics & Alarms), Firehose, Glue, and Organizations, plus IAM-bypass introspection endpoints and SDK methods across all first-party SDKs.

- **Dependencies**
  - Bump `fakecloud` workspace and all `fakecloud-*` crates to 0.16.0 (incl. `Cargo.lock`).
  - Update `fakecloud` SDK manifests and README refs for TypeScript, Python, and Java to 0.16.0.

- **Migration**
  - After merge, tag `v0.16.0` to trigger publishing.

<sup>Written for commit f5a3bd2a423be947704c40ec71efd0d3e5b1e991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

