### PR TITLE
fix(runtime): finish #1539 podman + in-container container spawning (ECS/RDS/ElastiCache)

### DIFF
--- a/crates/fakecloud-core/src/container_net.rs
+++ b/crates/fakecloud-core/src/container_net.rs
@@ -1,0 +1,273 @@
+//! Shared container-to-host networking resolution for service runtimes
+//! that spawn sibling containers (Lambda, ECS, RDS, ElastiCache).
+//!
+//! Captures the issue #1539 fix shape in one place so the four runtimes
+//! that shell out to `docker`/`podman` can't drift apart again:
+//!
+//! - **podman** ships `host.containers.internal` as a built-in container
+//!   DNS entry on every platform and must NOT receive
+//!   `--add-host host.docker.internal:host-gateway` — rootless podman's
+//!   gvproxy leaves the magic alias empty and the `create` fails with
+//!   "host containers internal IP address is empty".
+//! - **bare docker on Linux** has no `host-gateway` magic; the bridge
+//!   gateway IP has to be resolved from the daemon and injected explicitly.
+//! - **Docker Desktop on Mac/Windows** resolves the `host-gateway` magic
+//!   value to the host's IP.
+//! - when fakecloud itself runs in a container (`FAKECLOUD_IN_CONTAINER=1`,
+//!   baked into the published image), the sibling containers it spawns
+//!   publish their ports on the *host's* daemon — reachable from inside
+//!   fakecloud's container as `host.docker.internal:<port>`, not
+//!   `127.0.0.1:<port>`.
+
+/// Auto-detect an available container CLI. Honors `FAKECLOUD_CONTAINER_CLI`
+/// as an explicit override (returns `None` if the override doesn't work),
+/// otherwise prefers `docker` then `podman`. Returns `None` when neither
+/// is usable.
+pub fn detect_container_cli() -> Option<String> {
+    if let Ok(cli) = std::env::var("FAKECLOUD_CONTAINER_CLI") {
+        return if cli_available(&cli) { Some(cli) } else { None };
+    }
+    if cli_available("docker") {
+        Some("docker".to_string())
+    } else if cli_available("podman") {
+        Some("podman".to_string())
+    } else {
+        None
+    }
+}
+
+/// True when the CLI responds to `<cli> info` with success — the same
+/// liveness probe every runtime used before this module existed.
+pub fn cli_available(cli: &str) -> bool {
+    std::process::Command::new(cli)
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// True when `cli` is podman or a podman-compatible binary. Matches on the
+/// filename component so absolute paths (`/opt/homebrew/bin/podman`) and
+/// wrappers (`podman-remote`) both register as podman. Docker Desktop's
+/// compatibility CLI is named `docker`, so this check is safe.
+pub fn is_podman_binary(cli: &str) -> bool {
+    std::path::Path::new(cli)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.contains("podman"))
+        .unwrap_or(false)
+}
+
+/// Detect the Docker bridge gateway IP on Linux. Returns `None` if
+/// detection fails (caller falls back to the conventional `172.17.0.1`).
+pub fn detect_bridge_gateway(cli: &str) -> Option<String> {
+    let output = std::process::Command::new(cli)
+        .args([
+            "network",
+            "inspect",
+            "bridge",
+            "--format",
+            "{{range .IPAM.Config}}{{.Gateway}}{{end}}",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let gateway = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if gateway.is_empty() || !gateway.contains('.') {
+        return None;
+    }
+    Some(gateway)
+}
+
+/// Resolved container-to-host networking for a given CLI. Built once at
+/// runtime construction and reused for every container spawn.
+#[derive(Debug, Clone)]
+pub struct HostNetworking {
+    /// DNS name a spawned container uses to reach fakecloud on the host.
+    /// `host.containers.internal` for podman, `host.docker.internal` for
+    /// docker.
+    pub host_alias: String,
+    /// `<alias>:<value>` argument for `--add-host`, injected into every
+    /// container `create`/`run`. `None` when the runtime provides the
+    /// alias natively (podman).
+    pub add_host_arg: Option<String>,
+    /// Address fakecloud uses to reach the *sibling* containers it just
+    /// spawned (readiness probes + advertised endpoints). `127.0.0.1`
+    /// when fakecloud runs on the host; `host.docker.internal` when
+    /// fakecloud is itself containerized (`FAKECLOUD_IN_CONTAINER=1`).
+    pub sibling_host: String,
+}
+
+impl HostNetworking {
+    /// Resolve networking for `cli`, reading `FAKECLOUD_IN_CONTAINER` from
+    /// the process environment.
+    pub fn detect(cli: &str) -> Self {
+        let (host_alias, add_host_arg) = resolve_host_alias(cli);
+        let sibling_host = resolve_sibling_host(std::env::var("FAKECLOUD_IN_CONTAINER").ok());
+        Self {
+            host_alias,
+            add_host_arg,
+            sibling_host,
+        }
+    }
+
+    /// Convenience: append the `--add-host <alias>:<value>` flag pair to a
+    /// growing argv vector when this runtime needs an explicit mapping.
+    /// No-op for podman.
+    pub fn push_add_host_args(&self, argv: &mut Vec<String>) {
+        if let Some(arg) = &self.add_host_arg {
+            argv.push("--add-host".to_string());
+            argv.push(arg.clone());
+        }
+    }
+}
+
+/// Compute the `(host_alias, add_host_arg)` pair for a CLI. Pure except
+/// for the bridge-gateway daemon probe on Linux docker, so the macOS /
+/// podman branches are unit-testable without a daemon.
+pub fn resolve_host_alias(cli: &str) -> (String, Option<String>) {
+    if is_podman_binary(cli) {
+        // Podman provides `host.containers.internal` natively on every
+        // supported platform; injecting `host-gateway` on macOS fails
+        // because rootless podman's gvproxy doesn't expose the magic alias.
+        ("host.containers.internal".to_string(), None)
+    } else if cfg!(target_os = "linux") {
+        // Bare docker on Linux: resolve the bridge gateway IP and add an
+        // explicit alias. `host.docker.internal:host-gateway` only works
+        // on Docker Desktop; native Linux docker has no such magic.
+        let ip = detect_bridge_gateway(cli).unwrap_or_else(|| "172.17.0.1".to_string());
+        (
+            "host.docker.internal".to_string(),
+            Some(format!("host.docker.internal:{ip}")),
+        )
+    } else {
+        // Docker Desktop on Mac/Windows: `host-gateway` is the magic alias
+        // that resolves to the host's IP.
+        (
+            "host.docker.internal".to_string(),
+            Some("host.docker.internal:host-gateway".to_string()),
+        )
+    }
+}
+
+/// Decide what address fakecloud uses to reach the sibling containers it
+/// just spawned. Pure helper so the env-var parsing can be tested without
+/// touching the process's real environment.
+///
+/// - `Some("1")` / `Some("true")` (case-insensitive) -> fakecloud is in a
+///   container, siblings live on `host.docker.internal:<port>`.
+/// - anything else, including `None` -> fakecloud runs on the host,
+///   siblings live on `127.0.0.1:<port>`.
+pub fn resolve_sibling_host(env_value: Option<String>) -> String {
+    let in_container = env_value
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if in_container {
+        "host.docker.internal".to_string()
+    } else {
+        "127.0.0.1".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_podman_binary_matches_bare_name() {
+        assert!(is_podman_binary("podman"));
+        assert!(is_podman_binary("podman-remote"));
+    }
+
+    #[test]
+    fn is_podman_binary_matches_absolute_path() {
+        assert!(is_podman_binary("/opt/homebrew/bin/podman"));
+        assert!(is_podman_binary("/usr/local/bin/podman-remote"));
+    }
+
+    #[test]
+    fn is_podman_binary_rejects_docker() {
+        assert!(!is_podman_binary("docker"));
+        assert!(!is_podman_binary("/usr/local/bin/docker"));
+        assert!(!is_podman_binary("docker-credential-helper"));
+    }
+
+    #[test]
+    fn resolve_host_alias_podman_has_no_add_host() {
+        let (alias, add_host) = resolve_host_alias("podman");
+        assert_eq!(alias, "host.containers.internal");
+        assert_eq!(add_host, None);
+        let (alias, add_host) = resolve_host_alias("/opt/homebrew/bin/podman");
+        assert_eq!(alias, "host.containers.internal");
+        assert_eq!(add_host, None);
+    }
+
+    #[test]
+    fn resolve_host_alias_docker_emits_add_host() {
+        let (alias, add_host) = resolve_host_alias("docker");
+        assert_eq!(alias, "host.docker.internal");
+        // On macOS this is host-gateway; on Linux it's a bridge IP. Either
+        // way docker must get an explicit --add-host.
+        assert!(add_host.is_some());
+        assert!(add_host.unwrap().starts_with("host.docker.internal:"));
+    }
+
+    #[test]
+    fn resolve_sibling_host_defaults_to_loopback() {
+        assert_eq!(resolve_sibling_host(None), "127.0.0.1");
+        assert_eq!(resolve_sibling_host(Some(String::new())), "127.0.0.1");
+        assert_eq!(resolve_sibling_host(Some("0".to_string())), "127.0.0.1");
+        assert_eq!(resolve_sibling_host(Some("false".to_string())), "127.0.0.1");
+    }
+
+    #[test]
+    fn resolve_sibling_host_uses_docker_internal_when_in_container() {
+        assert_eq!(
+            resolve_sibling_host(Some("1".to_string())),
+            "host.docker.internal"
+        );
+        assert_eq!(
+            resolve_sibling_host(Some("true".to_string())),
+            "host.docker.internal"
+        );
+        assert_eq!(
+            resolve_sibling_host(Some("TRUE".to_string())),
+            "host.docker.internal"
+        );
+    }
+
+    #[test]
+    fn push_add_host_args_noop_for_podman() {
+        let net = HostNetworking {
+            host_alias: "host.containers.internal".to_string(),
+            add_host_arg: None,
+            sibling_host: "127.0.0.1".to_string(),
+        };
+        let mut argv = vec!["create".to_string()];
+        net.push_add_host_args(&mut argv);
+        assert_eq!(argv, vec!["create".to_string()]);
+    }
+
+    #[test]
+    fn push_add_host_args_emits_for_docker() {
+        let net = HostNetworking {
+            host_alias: "host.docker.internal".to_string(),
+            add_host_arg: Some("host.docker.internal:host-gateway".to_string()),
+            sibling_host: "127.0.0.1".to_string(),
+        };
+        let mut argv = vec!["create".to_string()];
+        net.push_add_host_args(&mut argv);
+        assert_eq!(
+            argv,
+            vec![
+                "create".to_string(),
+                "--add-host".to_string(),
+                "host.docker.internal:host-gateway".to_string(),
+            ]
+        );
+    }
+}

--- a/crates/fakecloud-core/src/lib.rs
+++ b/crates/fakecloud-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod auth_message;
+pub mod container_net;
 pub mod delivery;
 pub mod dispatch;
 pub mod ecr_uri;

--- a/crates/fakecloud-ecs/src/runtime/mod.rs
+++ b/crates/fakecloud-ecs/src/runtime/mod.rs
@@ -2330,10 +2330,9 @@ mod tests {
             "containerPath": "/mnt/efs"
         });
         let resolved = resolve_mount_point(&mp, &volumes).expect("resolved");
-        assert_eq!(
-            resolved.source,
-            "/tmp/fakecloud/efs/fs-12345678/exports/app"
-        );
+        // EFS resolves to a docker named volume (container-safe), with the
+        // rootDirectory folded into the name (bug-audit 2026-05-28, 0.6).
+        assert_eq!(resolved.source, "fakecloud-efs-fs-12345678-exports-app");
         assert_eq!(resolved.container_path, "/mnt/efs");
     }
 

--- a/crates/fakecloud-ecs/src/runtime/mod.rs
+++ b/crates/fakecloud-ecs/src/runtime/mod.rs
@@ -39,7 +39,11 @@ pub enum RuntimeError {
 /// Docker/Podman executor for ECS tasks.
 pub struct EcsRuntime {
     cli: String,
-    host_ip: String,
+    /// Container-to-host networking resolution (host alias, `--add-host`
+    /// arg, sibling-container address) shared with the other runtimes via
+    /// [`fakecloud_core::container_net`]. Carries the issue #1539 podman +
+    /// in-container fixes.
+    net: fakecloud_core::container_net::HostNetworking,
     /// Port the main fakecloud server bound to. Used to translate AWS
     /// ECR URIs (`<acct>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>`) to
     /// the local OCI v2 endpoint (`127.0.0.1:<port>/<repo>:<tag>`) so
@@ -83,28 +87,12 @@ impl EcsRuntime {
     /// `server_port` is the port the main fakecloud server bound to;
     /// needed to resolve AWS ECR URIs against the local OCI v2 registry.
     pub fn new(server_port: u16) -> Option<Self> {
-        let cli = if let Ok(cli) = std::env::var("FAKECLOUD_CONTAINER_CLI") {
-            if cli_works(&cli) {
-                cli
-            } else {
-                return None;
-            }
-        } else if cli_works("docker") {
-            "docker".to_string()
-        } else if cli_works("podman") {
-            "podman".to_string()
-        } else {
-            return None;
-        };
-        let host_ip = if cfg!(target_os = "linux") {
-            "172.17.0.1".to_string()
-        } else {
-            "host-gateway".to_string()
-        };
+        let cli = fakecloud_core::container_net::detect_container_cli()?;
+        let net = fakecloud_core::container_net::HostNetworking::detect(&cli);
         let docker_config = build_local_registry_docker_config(server_port).map(Arc::new);
         Some(Self {
             cli,
-            host_ip,
+            net,
             server_port,
             docker_config,
             containers: RwLock::new(std::collections::HashMap::new()),
@@ -649,9 +637,7 @@ fn resolve_volume_source(name: &str, volume: &serde_json::Value) -> Option<Strin
             .get("rootDirectory")
             .and_then(|v| v.as_str())
             .unwrap_or("/");
-        let path = stub_dir_for("efs", fs_id, root);
-        ensure_dir_exists(&path);
-        return Some(path);
+        return Some(shared_volume_name("efs", fs_id, root));
     }
     if let Some(fsx) = volume.get("fsxWindowsFileServerVolumeConfiguration") {
         let fs_id = fsx.get("fileSystemId").and_then(|v| v.as_str())?;
@@ -659,9 +645,7 @@ fn resolve_volume_source(name: &str, volume: &serde_json::Value) -> Option<Strin
             .get("rootDirectory")
             .and_then(|v| v.as_str())
             .unwrap_or("/");
-        let path = stub_dir_for("fsx", fs_id, root);
-        ensure_dir_exists(&path);
-        return Some(path);
+        return Some(shared_volume_name("fsx", fs_id, root));
     }
     if volume.get("dockerVolumeConfiguration").is_some() {
         // Named docker volume — docker auto-creates it on first
@@ -672,17 +656,41 @@ fn resolve_volume_source(name: &str, volume: &serde_json::Value) -> Option<Strin
     Some(name.to_string())
 }
 
-/// Compose the host stub directory path for an EFS/FSx volume. Falls
-/// back to a single shared directory per filesystem id when
-/// `rootDirectory` is unset or `/`, matching the EFS convention where
-/// the root of the filesystem is the default mount target.
-fn stub_dir_for(kind: &str, fs_id: &str, root: &str) -> String {
-    let trimmed = root.trim_start_matches('/');
+/// Compose the docker **named-volume** name for an EFS/FSx volume. A
+/// single shared volume per filesystem id when `rootDirectory` is unset
+/// or `/` (the EFS default mount target); otherwise the rootDirectory is
+/// folded into the name so distinct mount targets within one filesystem
+/// stay isolated. A docker named volume lives on the daemon rather than a
+/// host path, so tasks share state correctly *and* it works when
+/// fakecloud itself runs in a container (`FAKECLOUD_IN_CONTAINER=1`),
+/// where a host-path stub created inside fakecloud's own filesystem would
+/// resolve to an empty dir against the host daemon (issue #1539, bug 0.6).
+/// The segments are sanitized to docker's volume-name charset.
+fn shared_volume_name(kind: &str, fs_id: &str, root: &str) -> String {
+    let trimmed = root.trim_start_matches('/').trim_end_matches('/');
+    let fs_id = sanitize_volume_segment(fs_id);
     if trimmed.is_empty() {
-        format!("/tmp/fakecloud/{kind}/{fs_id}")
+        format!("fakecloud-{kind}-{fs_id}")
     } else {
-        format!("/tmp/fakecloud/{kind}/{fs_id}/{trimmed}")
+        format!(
+            "fakecloud-{kind}-{fs_id}-{}",
+            sanitize_volume_segment(trimmed)
+        )
     }
+}
+
+/// Map an arbitrary string to docker's volume-name charset by replacing
+/// every character outside `[A-Za-z0-9_.-]` with `-`.
+fn sanitize_volume_segment(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
 }
 
 /// Best-effort `mkdir -p` so the EFS/FSx stub path exists before the
@@ -1164,7 +1172,8 @@ pub(crate) fn build_run_argv(
     plan: &ContainerPlan,
     env: &[(String, String)],
     task_id: &str,
-    host_ip: &str,
+    host_alias: &str,
+    add_host_arg: Option<&str>,
     run_image: &str,
     awsvpc_network_ready: bool,
 ) -> Vec<String> {
@@ -1177,8 +1186,13 @@ pub(crate) fn build_run_argv(
     argv.push(format!("fakecloud-ecs-task={}", task_id));
     argv.push("--label".into());
     argv.push(format!("fakecloud-ecs-container={}", plan.container_name));
-    argv.push("--add-host".into());
-    argv.push(format!("host.docker.internal:{}", host_ip));
+    // Inject `--add-host host.docker.internal:<ip>` only for docker;
+    // podman provides `host.containers.internal` natively and rejects
+    // the host-gateway mapping (issue #1539).
+    if let Some(arg) = add_host_arg {
+        argv.push("--add-host".into());
+        argv.push(arg.to_string());
+    }
     let use_awsvpc_network = plan.network_mode.as_deref() == Some("awsvpc") && awsvpc_network_ready;
     if use_awsvpc_network {
         argv.push("--network".into());
@@ -1204,10 +1218,10 @@ pub(crate) fn build_run_argv(
     }
     for (k, v) in env {
         let transformed = v
-            .replace("http://127.0.0.1:", "http://host.docker.internal:")
-            .replace("https://127.0.0.1:", "https://host.docker.internal:")
-            .replace("http://localhost:", "http://host.docker.internal:")
-            .replace("https://localhost:", "https://host.docker.internal:");
+            .replace("http://127.0.0.1:", &format!("http://{host_alias}:"))
+            .replace("https://127.0.0.1:", &format!("https://{host_alias}:"))
+            .replace("http://localhost:", &format!("http://{host_alias}:"))
+            .replace("https://localhost:", &format!("https://{host_alias}:"));
         argv.push("-e".into());
         argv.push(format!("{}={}", k, transformed));
     }
@@ -1429,26 +1443,20 @@ fn snapshot_task(state: &SharedEcsState, account_id: &str, task_id: &str) -> Opt
     })
 }
 
-fn cli_works(cli: &str) -> bool {
-    std::process::Command::new(cli)
-        .arg("info")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
 /// Build an isolated docker config directory with Basic auth for
-/// fakecloud ECR at `127.0.0.1:<port>`. Lets `docker pull/push/tag`
-/// work against the local OCI v2 registry without requiring the user
-/// to run `aws ecr get-login-password | docker login` first.
+/// fakecloud ECR. Lets `docker pull/push/tag` work against the local OCI
+/// v2 registry without requiring the user to run
+/// `aws ecr get-login-password | docker login` first. Authorizes both
+/// `127.0.0.1` (fakecloud on the host) and `host.docker.internal`
+/// (fakecloud in a container, pull URIs rewritten to the sibling host —
+/// issue #1539, bug 0.8).
 fn build_local_registry_docker_config(server_port: u16) -> Option<TempDir> {
     let dir = TempDir::new().ok()?;
     let auth = base64::engine::general_purpose::STANDARD.encode("AWS:fakecloud-ecs-runtime");
     let config = serde_json::json!({
         "auths": {
             format!("127.0.0.1:{server_port}"): { "auth": auth },
+            format!("host.docker.internal:{server_port}"): { "auth": auth },
         }
     });
     std::fs::write(dir.path().join("config.json"), config.to_string()).ok()?;
@@ -1711,8 +1719,10 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    fn cli_works_for_known_missing_binary_is_false() {
-        assert!(!cli_works("definitely-not-a-real-cli-binary-xyz"));
+    fn cli_available_for_known_missing_binary_is_false() {
+        assert!(!fakecloud_core::container_net::cli_available(
+            "definitely-not-a-real-cli-binary-xyz"
+        ));
     }
 
     #[test]
@@ -2163,7 +2173,15 @@ mod tests {
             interactive: false,
             readonly_rootfs: false,
         };
-        let argv = build_run_argv(&plan, &[], "task-1", "host-gateway", "alpine", true);
+        let argv = build_run_argv(
+            &plan,
+            &[],
+            "task-1",
+            "host.docker.internal",
+            None,
+            "alpine",
+            true,
+        );
         let joined = argv.join(" ");
         assert!(joined.contains("--health-cmd true"), "argv: {joined}");
         assert!(joined.contains("--health-interval=5s"), "argv: {joined}");
@@ -2200,7 +2218,15 @@ mod tests {
             interactive: false,
             readonly_rootfs: false,
         };
-        let argv = build_run_argv(&plan, &[], "task-1", "host-gateway", "alpine", true);
+        let argv = build_run_argv(
+            &plan,
+            &[],
+            "task-1",
+            "host.docker.internal",
+            None,
+            "alpine",
+            true,
+        );
         assert!(!argv.iter().any(|s| s.starts_with("--health")));
     }
 
@@ -2266,7 +2292,15 @@ mod tests {
             interactive: false,
             readonly_rootfs: false,
         };
-        let argv = build_run_argv(&plan, &[], "task-1", "host-gateway", "alpine", true);
+        let argv = build_run_argv(
+            &plan,
+            &[],
+            "task-1",
+            "host.docker.internal",
+            None,
+            "alpine",
+            true,
+        );
         let pair = argv
             .windows(2)
             .find(|w| w[0] == "-v")
@@ -2537,7 +2571,7 @@ mod tests {
             interactive: false,
             readonly_rootfs: false,
         };
-        let argv = build_run_argv(&plan, &[], "t", "host", "img", true);
+        let argv = build_run_argv(&plan, &[], "t", "host.docker.internal", None, "img", true);
         assert!(argv.contains(&"--ulimit".to_string()));
         assert!(argv.contains(&"nofile=1024:2048".to_string()));
     }
@@ -2587,7 +2621,7 @@ mod tests {
             interactive: true,
             readonly_rootfs: true,
         };
-        let argv = build_run_argv(&plan, &[], "t", "host", "img", true);
+        let argv = build_run_argv(&plan, &[], "t", "host.docker.internal", None, "img", true);
         assert!(argv.contains(&"--cap-add".to_string()));
         assert!(argv.contains(&"NET_ADMIN".to_string()));
         assert!(argv.contains(&"--cap-drop".to_string()));

--- a/crates/fakecloud-ecs/src/runtime/mod.rs
+++ b/crates/fakecloud-ecs/src/runtime/mod.rs
@@ -2395,7 +2395,8 @@ mod tests {
             "containerPath": "C:\\data"
         });
         let resolved = resolve_mount_point(&mp, &volumes).expect("resolved");
-        assert_eq!(resolved.source, "/tmp/fakecloud/fsx/fs-xyz/share");
+        // FSx resolves to a docker named volume (bug-audit 2026-05-28, 0.6).
+        assert_eq!(resolved.source, "fakecloud-fsx-fs-xyz-share");
     }
 
     /// Mount points that reference an undeclared `sourceVolume` resolve

--- a/crates/fakecloud-ecs/src/runtime/mod.rs
+++ b/crates/fakecloud-ecs/src/runtime/mod.rs
@@ -1216,12 +1216,14 @@ pub(crate) fn build_run_argv(
     if let Some(ref hc) = plan.health_check {
         argv.extend(render_health_flags(hc));
     }
+    let http_alias_prefix = format!("http://{host_alias}:");
+    let https_alias_prefix = format!("https://{host_alias}:");
     for (k, v) in env {
         let transformed = v
-            .replace("http://127.0.0.1:", &format!("http://{host_alias}:"))
-            .replace("https://127.0.0.1:", &format!("https://{host_alias}:"))
-            .replace("http://localhost:", &format!("http://{host_alias}:"))
-            .replace("https://localhost:", &format!("https://{host_alias}:"));
+            .replace("http://127.0.0.1:", http_alias_prefix.as_str())
+            .replace("https://127.0.0.1:", https_alias_prefix.as_str())
+            .replace("http://localhost:", http_alias_prefix.as_str())
+            .replace("https://localhost:", https_alias_prefix.as_str());
         argv.push("-e".into());
         argv.push(format!("{}={}", k, transformed));
     }

--- a/crates/fakecloud-ecs/src/runtime/mod.rs
+++ b/crates/fakecloud-ecs/src/runtime/mod.rs
@@ -2342,13 +2342,15 @@ mod tests {
     /// share state.
     #[test]
     fn efs_without_root_directory_uses_filesystem_root() {
+        // No rootDirectory (or "/") -> a single shared named volume per
+        // filesystem id.
         assert_eq!(
-            stub_dir_for("efs", "fs-abc", "/"),
-            "/tmp/fakecloud/efs/fs-abc"
+            shared_volume_name("efs", "fs-abc", "/"),
+            "fakecloud-efs-fs-abc"
         );
         assert_eq!(
-            stub_dir_for("efs", "fs-abc", ""),
-            "/tmp/fakecloud/efs/fs-abc"
+            shared_volume_name("efs", "fs-abc", ""),
+            "fakecloud-efs-fs-abc"
         );
     }
 

--- a/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
+++ b/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
@@ -59,11 +59,16 @@ impl EcsRuntime {
                     }
                 }
             }
+            // The agent/metadata endpoints live on fakecloud (the host);
+            // the container reaches them via the platform host alias —
+            // `host.docker.internal` for docker, `host.containers.internal`
+            // for podman (issue #1539).
+            let host_alias = &self.net.host_alias;
             if plan.has_task_role {
                 env.push((
                     "AWS_CONTAINER_CREDENTIALS_FULL_URI".into(),
                     format!(
-                        "http://host.docker.internal:{}/_fakecloud/ecs/creds/{}",
+                        "http://{host_alias}:{}/_fakecloud/ecs/creds/{}",
                         self.server_port, task_id
                     ),
                 ));
@@ -71,14 +76,14 @@ impl EcsRuntime {
             env.push((
                 "ECS_CONTAINER_METADATA_URI".into(),
                 format!(
-                    "http://host.docker.internal:{}/_fakecloud/ecs/v3/{}",
+                    "http://{host_alias}:{}/_fakecloud/ecs/v3/{}",
                     self.server_port, task_id
                 ),
             ));
             env.push((
                 "ECS_CONTAINER_METADATA_URI_V4".into(),
                 format!(
-                    "http://host.docker.internal:{}/_fakecloud/ecs/v4/{}",
+                    "http://{host_alias}:{}/_fakecloud/ecs/v4/{}",
                     self.server_port, task_id
                 ),
             ));
@@ -91,8 +96,15 @@ impl EcsRuntime {
         let mut run_images: Vec<String> = Vec::with_capacity(resolved_plans.len());
         let mut image_digests: Vec<Option<String>> = Vec::with_capacity(resolved_plans.len());
         for rp in &resolved_plans {
-            let local_pull_uri =
-                fakecloud_core::ecr_uri::translate_to_local(&rp.plan.image, self.server_port);
+            // Rewrite ECR URIs to fakecloud's local registry at the sibling
+            // host (`127.0.0.1` on the host, `host.docker.internal` when
+            // fakecloud is containerized) so the daemon/sibling can reach
+            // fakecloud's published registry port (issue #1539, bug 0.8).
+            let local_pull_uri = fakecloud_core::ecr_uri::translate_to_local_at(
+                &rp.plan.image,
+                &self.net.sibling_host,
+                self.server_port,
+            );
             let pull_uri = local_pull_uri.as_deref().unwrap_or(&rp.plan.image);
             let pull_out = self
                 .cli_command()
@@ -276,7 +288,8 @@ impl EcsRuntime {
                 &rp.plan,
                 &rp.env,
                 task_id,
-                &self.host_ip,
+                &self.net.host_alias,
+                self.net.add_host_arg.as_deref(),
                 run_image,
                 network_created,
             );

--- a/crates/fakecloud-ecs/src/service_container_instances_etc.rs
+++ b/crates/fakecloud-ecs/src/service_container_instances_etc.rs
@@ -861,12 +861,14 @@ impl EcsService {
         };
 
         let session_id = format!("ecs-execute-command-{}", uuid::Uuid::new_v4());
-        if let (Some(id), Some(_rt)) = (container_id.clone(), self.runtime.as_ref()) {
-            // Best-effort proxy: shell the command through docker exec. We
+        if let (Some(id), Some(rt)) = (container_id.clone(), self.runtime.as_ref()) {
+            // Best-effort proxy: shell the command through `<cli> exec`. We
             // don't stream back stdout/stderr in this ExecuteCommand response
             // (real AWS returns a Session token for the SSM sidecar), so log
-            // the result server-side for visibility.
-            let out = tokio::process::Command::new("docker")
+            // the result server-side for visibility. Use the runtime's
+            // detected CLI (docker or podman) rather than hardcoding docker
+            // so podman-only hosts work too (issue #1539 family, bug 0.5).
+            let out = tokio::process::Command::new(rt.cli_name())
                 .args(["exec", &id, "sh", "-c", &command])
                 .output()
                 .await

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -809,7 +809,15 @@ mod port_mapping_tests {
     }
 
     fn argv_string(plan: &ContainerPlan) -> Vec<String> {
-        build_run_argv(plan, &[], "task-1", "host-gateway", "alpine:latest", true)
+        build_run_argv(
+            plan,
+            &[],
+            "task-1",
+            "host.docker.internal",
+            None,
+            "alpine:latest",
+            true,
+        )
     }
 
     /// Helper for asserting a `--publish <spec>` pair is present in argv.

--- a/crates/fakecloud-elasticache/src/runtime.rs
+++ b/crates/fakecloud-elasticache/src/runtime.rs
@@ -33,29 +33,26 @@ pub enum RuntimeError {
 
 impl ElastiCacheRuntime {
     pub fn new() -> Option<Self> {
-        let cli = if let Ok(cli) = std::env::var("FAKECLOUD_CONTAINER_CLI") {
-            if cli_available(&cli) {
-                cli
-            } else {
-                return None;
-            }
-        } else if cli_available("docker") {
-            "docker".to_string()
-        } else if cli_available("podman") {
-            "podman".to_string()
-        } else {
-            return None;
-        };
-
+        let cli = fakecloud_core::container_net::detect_container_cli()?;
+        let net = fakecloud_core::container_net::HostNetworking::detect(&cli);
         Some(Self {
             cli,
             containers: Arc::new(RwLock::new(HashMap::new())),
             instance_id: format!("fakecloud-{}", std::process::id()),
+            net,
         })
     }
 
     pub fn cli_name(&self) -> &str {
         &self.cli
+    }
+
+    /// Address fakecloud advertises for clients to reach a spawned cache
+    /// container, and uses for readiness probes. `127.0.0.1` on the host;
+    /// `host.docker.internal` when fakecloud is containerized
+    /// (`FAKECLOUD_IN_CONTAINER=1`) (issue #1539, bug 0.4).
+    pub fn endpoint_host(&self) -> &str {
+        &self.net.sibling_host
     }
 
     pub async fn ensure_redis(

--- a/crates/fakecloud-elasticache/src/runtime.rs
+++ b/crates/fakecloud-elasticache/src/runtime.rs
@@ -97,7 +97,7 @@ impl ElastiCacheRuntime {
     ) -> Result<RunningCacheContainer, RuntimeError> {
         self.stop_container(resource_id).await;
 
-        let mut args: Vec<String> = vec![
+        let args: Vec<String> = vec![
             "create".to_string(),
             "-p".to_string(),
             format!(":{container_port}"),
@@ -105,12 +105,8 @@ impl ElastiCacheRuntime {
             format!("fakecloud-elasticache={resource_id}"),
             "--label".to_string(),
             format!("fakecloud-instance={}", self.instance_id),
+            image.to_string(),
         ];
-        if let Some(path) = rdb_path {
-            args.push("-v".to_string());
-            args.push(format!("{path}:/data/dump.rdb:ro"));
-        }
-        args.push(image.to_string());
 
         let output = tokio::process::Command::new(&self.cli)
             .args(&args)
@@ -125,6 +121,31 @@ impl ElastiCacheRuntime {
         }
 
         let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+        // Stage the snapshot RDB into the created (not yet started)
+        // container via `docker cp` rather than a `-v` bind mount. A bind
+        // mount of a host path breaks when fakecloud runs in a container
+        // (`FAKECLOUD_IN_CONTAINER=1`): the rdb is written inside
+        // fakecloud's own filesystem, but the host daemon resolves the bind
+        // source against the *host* filesystem, silently yielding an empty
+        // cache. `docker cp` copies the bytes across the daemon, so it works
+        // on host and in-container alike (issue #1539, bug 0.7). Redis loads
+        // /data/dump.rdb at startup, so the copy must precede `start`.
+        if let Some(path) = rdb_path {
+            let cp_result = tokio::process::Command::new(&self.cli)
+                .args(["cp", path, &format!("{container_id}:/data/dump.rdb")])
+                .output()
+                .await
+                .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+            if !cp_result.status.success() {
+                self.remove_container(&container_id).await;
+                return Err(RuntimeError::ContainerStartFailed(format!(
+                    "failed to stage snapshot rdb into container: {}",
+                    String::from_utf8_lossy(&cp_result.stderr).trim()
+                )));
+            }
+        }
+
         let start_result = tokio::process::Command::new(&self.cli)
             .args(["start", &container_id])
             .output()
@@ -354,14 +375,4 @@ impl ElastiCacheRuntime {
             .output()
             .await;
     }
-}
-
-fn cli_available(cli: &str) -> bool {
-    std::process::Command::new(cli)
-        .arg("info")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
 }

--- a/crates/fakecloud-elasticache/src/runtime.rs
+++ b/crates/fakecloud-elasticache/src/runtime.rs
@@ -21,6 +21,13 @@ pub struct ElastiCacheRuntime {
     cli: String,
     containers: Arc<RwLock<HashMap<String, RunningCacheContainer>>>,
     instance_id: String,
+    /// Container-to-host networking shared with the other runtimes via
+    /// [`fakecloud_core::container_net`]. ElastiCache only needs the
+    /// sibling-container address (redis/memcached don't call back into
+    /// fakecloud) — used so readiness probes reach the spawned container
+    /// instead of fakecloud's own loopback when containerized (issue
+    /// #1539, bug 0.4).
+    net: fakecloud_core::container_net::HostNetworking,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/fakecloud-lambda/src/runtime/docker.rs
+++ b/crates/fakecloud-lambda/src/runtime/docker.rs
@@ -146,7 +146,17 @@ impl DockerBackend {
             RuntimeError::ContainerStartFailed("PackageType=Image function has no ImageUri".into())
         })?;
 
-        let local_pull_uri = fakecloud_core::ecr_uri::translate_to_local(image, self.server_port);
+        // Point the registry host at `sibling_host` (not a bare
+        // `127.0.0.1`): when fakecloud runs in a container the daemon and
+        // the spawned sibling reach fakecloud's published registry port via
+        // `host.docker.internal`, since `127.0.0.1` is the host loopback
+        // from the daemon's view (issue #1539, bug 0.8). On the host,
+        // `sibling_host` is `127.0.0.1`, unchanged.
+        let local_pull_uri = fakecloud_core::ecr_uri::translate_to_local_at(
+            image,
+            &self.sibling_host,
+            self.server_port,
+        );
         let pull_uri = local_pull_uri.as_deref().unwrap_or(image);
 
         let mut pull_cmd = tokio::process::Command::new(&self.cli);
@@ -500,7 +510,11 @@ impl LambdaBackend for DockerBackend {
         // Translate AWS-flavored ECR URIs to fakecloud's local registry so
         // private-ECR `Image` package functions can be warmed too. Falls
         // back to the URI as-is for public-ECR / Docker Hub / Quay images.
-        let local_uri = fakecloud_core::ecr_uri::translate_to_local(image, self.server_port);
+        let local_uri = fakecloud_core::ecr_uri::translate_to_local_at(
+            image,
+            &self.sibling_host,
+            self.server_port,
+        );
         let pull_uri = local_uri.as_deref().unwrap_or(image);
 
         let mut cmd = tokio::process::Command::new(&self.cli);
@@ -681,9 +695,14 @@ fn is_podman_binary(cli: &str) -> bool {
 fn build_local_registry_docker_config(server_port: u16) -> Option<TempDir> {
     let dir = TempDir::new().ok()?;
     let auth = base64::engine::general_purpose::STANDARD.encode("AWS:fakecloud-lambda-runtime");
+    // Authorize both hostnames fakecloud's ECR can be addressed by:
+    // `127.0.0.1` on the host, and `host.docker.internal` when fakecloud
+    // runs in a container and the pull URI is rewritten to the sibling
+    // host (issue #1539, bug 0.8).
     let config = serde_json::json!({
         "auths": {
             format!("127.0.0.1:{server_port}"): { "auth": auth },
+            format!("host.docker.internal:{server_port}"): { "auth": auth },
         }
     });
     std::fs::write(dir.path().join("config.json"), config.to_string()).ok()?;


### PR DESCRIPTION
## Summary

The #1539 fixes (podman host-alias, `FAKECLOUD_IN_CONTAINER` sibling networking, `docker cp` instead of bind mounts) were applied to **Lambda only**. ECS, RDS, and ElastiCache spawn containers the same way and repeated both bugs. This factors the fix into a shared `fakecloud_core::container_net` module and applies it everywhere (Tier 0 of the 2026-05-28 bug audit).

### New: `fakecloud_core::container_net`
- `detect_container_cli`, `cli_available`, `is_podman_binary`, `detect_bridge_gateway`, `resolve_host_alias`, `resolve_sibling_host`
- `HostNetworking { host_alias, add_host_arg, sibling_host }` resolved once per runtime; `push_add_host_args()` injects `--add-host` only for docker.

### Tier 0 fixes
- **0.1 ECS RunTask** — `--add-host` is now docker-only (podman rejects `host-gateway`); localhost env-rewrite + agent/metadata URIs use the platform host alias.
- **0.2/0.3 RDS** — `--add-host` docker-only; `FAKECLOUD_ENDPOINT`, postgres/mysql readiness probes, and the advertised endpoint use `sibling_host`.
- **0.4 ElastiCache** — readiness probes use `sibling_host`.
- **0.5 ECS ExecuteCommand** — shells out to the detected CLI, not hardcoded `docker`.
- **0.6 ECS EFS/FSx** — host-FS stub bind mounts replaced with docker **named volumes** (container-safe, still shared per filesystem id).
- **0.7 ElastiCache snapshot restore** — stage the RDB via `docker cp` instead of a host bind mount.
- **0.8 ECS/Lambda ECR pulls** — rewrite the registry host to `sibling_host` and authorize `host.docker.internal` in the isolated docker config.

### Distribution
- `docker-compose.yml`: add `extra_hosts: host.docker.internal:host-gateway` (required on native-Linux docker); replace the broken `curl` healthcheck (curl absent from the final image, `/_fakecloud/health` never existed) with a new tooling-free `fakecloud health-check` subcommand that TCP-probes the server port.

## Test plan
- `cargo build / clippy -D warnings / fmt` clean across core, ecs, rds, elasticache, lambda, server.
- `cargo test --lib` green for all five runtime crates.
- New `container_net` unit tests cover CLI/alias/sibling resolution; ECS EFS/FSx volume tests updated for named-volume sources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized container-to-host networking and applied it across ECS, ElastiCache, and Lambda to fix podman compatibility and in-container spawning. Replaced bind mounts and unified ECR pulls/exec to the detected container CLI.

- **Refactors**
  - Added `fakecloud_core::container_net` with CLI/alias/sibling resolution and `HostNetworking`.
  - ECS EFS/FSx: switched host-path bind mounts to docker named volumes; `ExecuteCommand` uses the detected CLI.
  - ECR pulls (ECS/Lambda): translate to the local registry at `sibling_host`; isolated configs authorize `127.0.0.1` and `host.docker.internal`.
  - ElastiCache runtime adopts `container_net` and exposes `endpoint_host()`.

- **Bug Fixes**
  - ECS RunTask: inject `--add-host` only for docker; localhost env rewrites and agent/metadata URIs use the platform host alias.
  - ElastiCache: readiness/endpoints target `sibling_host`; snapshot restore stages RDB via `<cli> cp` before start.

<sup>Written for commit ae2ada9e32ec643eb84520e690ed5b0d5e07c17b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

