### PR TITLE
fix(eventbridge,scheduler): real cron field parsing + anything-but prefix

### DIFF
--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -445,6 +445,26 @@ pub(crate) fn matches_single(pattern_elem: &Value, event_value: &Value) -> bool 
                     Value::String(s) => event_value.as_str() != Some(s.as_str()),
                     Value::Array(arr) => !arr.iter().any(|v| values_equal(v, event_value)),
                     Value::Number(_) => event_value != anything_but_val,
+                    // Nested-matcher negation, e.g.
+                    // {"anything-but": {"prefix": "x"}} matches when the
+                    // field does NOT start with "x". Previously the object
+                    // form always matched, so excluded events were still
+                    // delivered (bug-audit 2026-05-28, 1.14).
+                    Value::Object(nested) => {
+                        let fv = event_value.as_str();
+                        if let Some(p) = nested.get("prefix").and_then(|v| v.as_str()) {
+                            !fv.is_some_and(|s| s.starts_with(p))
+                        } else if let Some(suf) = nested.get("suffix").and_then(|v| v.as_str()) {
+                            !fv.is_some_and(|s| s.ends_with(suf))
+                        } else if let Some(eic) =
+                            nested.get("equals-ignore-case").and_then(|v| v.as_str())
+                        {
+                            !fv.is_some_and(|s| s.eq_ignore_ascii_case(eic))
+                        } else {
+                            // Unknown nested matcher: default to matching.
+                            true
+                        }
+                    }
                     _ => true,
                 };
             }

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -259,7 +259,7 @@ fn term_matches(term: &CronTerm, value: u32) -> bool {
         CronTerm::Single(v) => *v == value,
         CronTerm::Range(a, b) => value >= *a && value <= *b,
         CronTerm::Step { start, end, step } => {
-            value >= *start && value <= *end && (value - start) % step == 0
+            value >= *start && value <= *end && (value - start).is_multiple_of(*step)
         }
     }
 }

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -253,6 +253,7 @@ fn parse_cron_term(part: &str, spec: &FieldSpec, is_dow: bool) -> Option<CronTer
     Some(CronTerm::Single(v))
 }
 
+#[allow(clippy::manual_is_multiple_of)] // keep `% step == 0` for MSRV
 fn term_matches(term: &CronTerm, value: u32) -> bool {
     match term {
         CronTerm::Single(v) => *v == value,

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -20,20 +20,84 @@ enum Schedule {
     Cron(CronExpr),
 }
 
-/// A simplified cron expression with 6 fields: min hour dom month dow year.
-/// Each field is either `Any` (wildcard) or a specific numeric value.
+/// A cron expression with 6 fields: min hour dom month dow year.
 struct CronExpr {
     minute: CronField,
     hour: CronField,
     day_of_month: CronField,
     month: CronField,
     day_of_week: CronField,
-    // year is parsed but not checked (always matches)
+    year: CronField,
 }
 
+#[derive(Debug, Clone, PartialEq)]
 enum CronField {
+    /// `*` or `?` — matches any value.
     Any,
-    Value(u32),
+    /// Comma-separated list of terms; matches when ANY term matches.
+    Terms(Vec<CronTerm>),
+}
+
+/// One comma-separated element of a cron field.
+#[derive(Debug, Clone, PartialEq)]
+enum CronTerm {
+    Single(u32),
+    Range(u32, u32),
+    Step { start: u32, end: u32, step: u32 },
+}
+
+/// Field bounds + name aliases used to parse and validate one cron field.
+struct FieldSpec {
+    min: u32,
+    max: u32,
+    names: &'static [(&'static str, u32)],
+}
+
+const MONTH_NAMES: &[(&str, u32)] = &[
+    ("JAN", 1),
+    ("FEB", 2),
+    ("MAR", 3),
+    ("APR", 4),
+    ("MAY", 5),
+    ("JUN", 6),
+    ("JUL", 7),
+    ("AUG", 8),
+    ("SEP", 9),
+    ("OCT", 10),
+    ("NOV", 11),
+    ("DEC", 12),
+];
+
+// Day-of-week names normalized to 0=Sunday..6=Saturday (chrono's
+// num_days_from_sunday space).
+const DOW_NAMES: &[(&str, u32)] = &[
+    ("SUN", 0),
+    ("MON", 1),
+    ("TUE", 2),
+    ("WED", 3),
+    ("THU", 4),
+    ("FRI", 5),
+    ("SAT", 6),
+];
+
+fn resolve_token(tok: &str, spec: &FieldSpec, is_dow: bool) -> Option<u32> {
+    let tok = tok.trim();
+    if let Ok(n) = tok.parse::<u32>() {
+        if is_dow {
+            // AWS EventBridge day-of-week: 1=SUN..7=SAT -> 0=SUN..6=SAT.
+            return match n {
+                0 => Some(0),
+                1..=7 => Some(n - 1),
+                _ => None,
+            };
+        }
+        return Some(n);
+    }
+    let upper = tok.to_ascii_uppercase();
+    spec.names
+        .iter()
+        .find(|(name, _)| upper.starts_with(name))
+        .map(|&(_, v)| v)
 }
 
 fn parse_schedule(expr: &str) -> Option<Schedule> {
@@ -69,39 +133,154 @@ fn parse_cron(inner: &str) -> Option<Schedule> {
     if parts.len() != 6 {
         return None;
     }
+    // AWS EventBridge field bounds. Any field failing to parse rejects the
+    // whole expression so PutRule surfaces a validation error rather than
+    // silently accepting a rule that fires at the wrong times (bug-audit
+    // 2026-05-28, 1.2).
     Some(Schedule::Cron(CronExpr {
-        minute: parse_cron_field(parts[0]),
-        hour: parse_cron_field(parts[1]),
-        day_of_month: parse_cron_field(parts[2]),
-        month: parse_cron_field(parts[3]),
-        day_of_week: parse_cron_field(parts[4]),
-        // year field parsed but not stored (always matches)
+        minute: parse_cron_field(
+            parts[0],
+            &FieldSpec {
+                min: 0,
+                max: 59,
+                names: &[],
+            },
+            false,
+        )?,
+        hour: parse_cron_field(
+            parts[1],
+            &FieldSpec {
+                min: 0,
+                max: 23,
+                names: &[],
+            },
+            false,
+        )?,
+        day_of_month: parse_cron_field(
+            parts[2],
+            &FieldSpec {
+                min: 1,
+                max: 31,
+                names: &[],
+            },
+            false,
+        )?,
+        month: parse_cron_field(
+            parts[3],
+            &FieldSpec {
+                min: 1,
+                max: 12,
+                names: MONTH_NAMES,
+            },
+            false,
+        )?,
+        // Day-of-week normalized to 0=SUN..6=SAT during parsing.
+        day_of_week: parse_cron_field(
+            parts[4],
+            &FieldSpec {
+                min: 0,
+                max: 6,
+                names: DOW_NAMES,
+            },
+            true,
+        )?,
+        year: parse_cron_field(
+            parts[5],
+            &FieldSpec {
+                min: 1970,
+                max: 2199,
+                names: &[],
+            },
+            false,
+        )?,
     }))
 }
 
-fn parse_cron_field(s: &str) -> CronField {
+/// Parse one cron field: `*`/`?`, single values, ranges (`9-17`), lists
+/// (`0,30`), steps (`*/5`, `9-17/2`), and name aliases. Returns `None`
+/// (rejecting the whole expression) for any malformed or out-of-range
+/// field — previously ranges/lists/steps/names were coerced to wildcard,
+/// so a rule would fire at the wrong times (bug-audit 2026-05-28, 1.2).
+fn parse_cron_field(s: &str, spec: &FieldSpec, is_dow: bool) -> Option<CronField> {
+    let s = s.trim();
     if s == "*" || s == "?" {
-        return CronField::Any;
+        return Some(CronField::Any);
     }
-    match s.parse::<u32>() {
-        Ok(v) => CronField::Value(v),
-        Err(_) => CronField::Any,
+    let mut terms = Vec::new();
+    for part in s.split(',') {
+        terms.push(parse_cron_term(part.trim(), spec, is_dow)?);
+    }
+    if terms.is_empty() {
+        return None;
+    }
+    Some(CronField::Terms(terms))
+}
+
+fn parse_cron_term(part: &str, spec: &FieldSpec, is_dow: bool) -> Option<CronTerm> {
+    let in_bounds = |v: u32| v >= spec.min && v <= spec.max;
+    if let Some((base, step_s)) = part.split_once('/') {
+        let step: u32 = step_s.trim().parse().ok()?;
+        if step == 0 {
+            return None;
+        }
+        let (start, end) = if base == "*" {
+            (spec.min, spec.max)
+        } else if let Some((a, b)) = base.split_once('-') {
+            (
+                resolve_token(a, spec, is_dow)?,
+                resolve_token(b, spec, is_dow)?,
+            )
+        } else {
+            (resolve_token(base, spec, is_dow)?, spec.max)
+        };
+        if !in_bounds(start) || !in_bounds(end) || start > end {
+            return None;
+        }
+        return Some(CronTerm::Step { start, end, step });
+    }
+    if let Some((a, b)) = part.split_once('-') {
+        let start = resolve_token(a, spec, is_dow)?;
+        let end = resolve_token(b, spec, is_dow)?;
+        if !in_bounds(start) || !in_bounds(end) || start > end {
+            return None;
+        }
+        return Some(CronTerm::Range(start, end));
+    }
+    let v = resolve_token(part, spec, is_dow)?;
+    if !in_bounds(v) {
+        return None;
+    }
+    Some(CronTerm::Single(v))
+}
+
+fn term_matches(term: &CronTerm, value: u32) -> bool {
+    match term {
+        CronTerm::Single(v) => *v == value,
+        CronTerm::Range(a, b) => value >= *a && value <= *b,
+        CronTerm::Step { start, end, step } => {
+            value >= *start && value <= *end && (value - start) % step == 0
+        }
+    }
+}
+
+fn matches_field(field: &CronField, value: u32) -> bool {
+    match field {
+        CronField::Any => true,
+        CronField::Terms(terms) => terms.iter().any(|t| term_matches(t, value)),
     }
 }
 
 fn cron_matches_now(cron: &CronExpr) -> bool {
-    let now = Utc::now();
-    let matches_field = |field: &CronField, actual: u32| -> bool {
-        match field {
-            CronField::Any => true,
-            CronField::Value(v) => *v == actual,
-        }
-    };
+    cron_matches_at(cron, Utc::now())
+}
+
+fn cron_matches_at(cron: &CronExpr, now: chrono::DateTime<Utc>) -> bool {
     matches_field(&cron.minute, now.minute())
         && matches_field(&cron.hour, now.hour())
         && matches_field(&cron.day_of_month, now.day())
         && matches_field(&cron.month, now.month())
         && matches_field(&cron.day_of_week, now.weekday().num_days_from_sunday())
+        && matches_field(&cron.year, now.year() as u32)
 }
 
 /// Background scheduler that fires scheduled EventBridge rules.
@@ -381,11 +560,11 @@ mod tests {
         let s = parse_schedule("cron(0 12 * * ? *)");
         match s {
             Some(Schedule::Cron(c)) => {
-                assert!(matches!(c.minute, CronField::Value(0)));
-                assert!(matches!(c.hour, CronField::Value(12)));
-                assert!(matches!(c.day_of_month, CronField::Any));
-                assert!(matches!(c.month, CronField::Any));
-                assert!(matches!(c.day_of_week, CronField::Any));
+                assert_eq!(c.minute, CronField::Terms(vec![CronTerm::Single(0)]));
+                assert_eq!(c.hour, CronField::Terms(vec![CronTerm::Single(12)]));
+                assert_eq!(c.day_of_month, CronField::Any);
+                assert_eq!(c.month, CronField::Any);
+                assert_eq!(c.day_of_week, CronField::Any);
             }
             _ => panic!("expected cron"),
         }
@@ -417,12 +596,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_cron_non_numeric_field_is_any() {
-        let s = parse_schedule("cron(xyz 12 * * ? *)");
-        match s {
-            Some(Schedule::Cron(c)) => assert!(matches!(c.minute, CronField::Any)),
-            _ => panic!("expected cron"),
-        }
+    fn parse_cron_non_numeric_field_is_rejected() {
+        // bug-audit 2026-05-28, 1.2: unknown tokens must reject the whole
+        // expression, not coerce to wildcard (which fired every minute).
+        assert!(parse_schedule("cron(xyz 12 * * ? *)").is_none());
     }
 
     #[test]
@@ -433,6 +610,7 @@ mod tests {
             day_of_month: CronField::Any,
             month: CronField::Any,
             day_of_week: CronField::Any,
+            year: CronField::Any,
         };
         assert!(cron_matches_now(&cron));
     }
@@ -440,13 +618,73 @@ mod tests {
     #[test]
     fn cron_impossible_minute_never_matches() {
         let cron = CronExpr {
-            minute: CronField::Value(99),
+            minute: CronField::Terms(vec![CronTerm::Single(99)]),
             hour: CronField::Any,
             day_of_month: CronField::Any,
             month: CronField::Any,
             day_of_week: CronField::Any,
+            year: CronField::Any,
         };
         assert!(!cron_matches_now(&cron));
+    }
+
+    // bug-audit 2026-05-28, 1.2: ranges/lists/steps/names fire only at the
+    // right times; numeric DOW is AWS one-based-Sunday; year is enforced.
+    fn at(min: u32, hour: u32, dom: u32, month: u32, year: i32) -> chrono::DateTime<Utc> {
+        use chrono::TimeZone;
+        Utc.with_ymd_and_hms(year, month, dom, hour, min, 0)
+            .unwrap()
+    }
+
+    #[test]
+    fn cron_step_minute_fires_only_on_multiples() {
+        let Some(Schedule::Cron(c)) = parse_schedule("cron(*/5 * * * ? *)") else {
+            panic!("expected cron");
+        };
+        assert!(cron_matches_at(&c, at(0, 9, 1, 6, 2026)));
+        assert!(cron_matches_at(&c, at(5, 9, 1, 6, 2026)));
+        assert!(!cron_matches_at(&c, at(3, 9, 1, 6, 2026)));
+    }
+
+    #[test]
+    fn cron_hour_range_and_dow_names() {
+        // 2026-06-01 = Monday, 2026-06-06 = Saturday.
+        let Some(Schedule::Cron(c)) = parse_schedule("cron(0 9-17 ? * MON-FRI *)") else {
+            panic!("expected cron");
+        };
+        assert!(cron_matches_at(&c, at(0, 9, 1, 6, 2026)));
+        assert!(cron_matches_at(&c, at(0, 17, 1, 6, 2026)));
+        assert!(!cron_matches_at(&c, at(0, 8, 1, 6, 2026)));
+        assert!(!cron_matches_at(&c, at(0, 9, 6, 6, 2026)));
+    }
+
+    #[test]
+    fn cron_list_and_month_name_and_year() {
+        let Some(Schedule::Cron(c)) = parse_schedule("cron(0,30 0 1 JAN ? 2027)") else {
+            panic!("expected cron");
+        };
+        assert!(cron_matches_at(&c, at(0, 0, 1, 1, 2027)));
+        assert!(cron_matches_at(&c, at(30, 0, 1, 1, 2027)));
+        assert!(!cron_matches_at(&c, at(15, 0, 1, 1, 2027))); // not in list
+        assert!(!cron_matches_at(&c, at(0, 0, 1, 1, 2026))); // wrong year
+    }
+
+    #[test]
+    fn cron_numeric_dow_is_one_based_sunday() {
+        // AWS: 2 = Monday. 2026-06-01 is a Monday.
+        let Some(Schedule::Cron(c)) = parse_schedule("cron(0 0 ? * 2 *)") else {
+            panic!("expected cron");
+        };
+        assert!(cron_matches_at(&c, at(0, 0, 1, 6, 2026)));
+        assert!(!cron_matches_at(&c, at(0, 0, 2, 6, 2026)));
+    }
+
+    #[test]
+    fn cron_invalid_fields_rejected() {
+        assert!(parse_schedule("cron(99 * * * ? *)").is_none());
+        assert!(parse_schedule("cron(0 25 * * ? *)").is_none());
+        assert!(parse_schedule("cron(0 0 1 13 ? *)").is_none());
+        assert!(parse_schedule("cron(0 0 ? * BADDAY *)").is_none());
     }
 
     mod tick_tests {

--- a/crates/fakecloud-scheduler/src/expr.rs
+++ b/crates/fakecloud-scheduler/src/expr.rs
@@ -436,16 +436,15 @@ mod tests {
         let Some(Expr::Cron(c)) = parse("cron(*/15 9-17 ? * MON-FRI *)") else {
             panic!("expected cron");
         };
-        let at = |min, hour, dom, dow_ok: bool| {
-            // pick a Monday (1st) or Saturday (6th) of June 2026
-            let day = if dow_ok { 1 } else { 6 };
+        // 2026-06-01 is a Monday, 2026-06-06 is a Saturday.
+        let at = |min: u32, hour: u32, day: u32| {
             Utc.with_ymd_and_hms(2026, 6, day, hour, min, 0).unwrap()
         };
-        assert!(matches_cron(&c, at(0, 9, 1, true)));
-        assert!(matches_cron(&c, at(15, 17, 1, true)));
-        assert!(!matches_cron(&c, at(10, 9, 1, true))); // not /15
-        assert!(!matches_cron(&c, at(0, 8, 1, true))); // before hour range
-        assert!(!matches_cron(&c, at(0, 9, 6, false))); // Saturday
+        assert!(matches_cron(&c, at(0, 9, 1))); // Mon 09:00, /15 ok
+        assert!(matches_cron(&c, at(15, 17, 1))); // Mon 17:15
+        assert!(!matches_cron(&c, at(10, 9, 1))); // minute not a /15 multiple
+        assert!(!matches_cron(&c, at(0, 8, 1))); // before hour range
+        assert!(!matches_cron(&c, at(0, 9, 6))); // Saturday, outside MON-FRI
     }
 
     #[test]

--- a/crates/fakecloud-scheduler/src/expr.rs
+++ b/crates/fakecloud-scheduler/src/expr.rs
@@ -277,7 +277,7 @@ fn term_matches(term: &CronTerm, value: u32) -> bool {
         CronTerm::Single(v) => *v == value,
         CronTerm::Range(a, b) => value >= *a && value <= *b,
         CronTerm::Step { start, end, step } => {
-            value >= *start && value <= *end && (value - start) % step == 0
+            value >= *start && value <= *end && (value - start).is_multiple_of(*step)
         }
     }
 }

--- a/crates/fakecloud-scheduler/src/expr.rs
+++ b/crates/fakecloud-scheduler/src/expr.rs
@@ -154,56 +154,66 @@ fn parse_cron(inner: &str) -> Option<Expr> {
     // valid AWS schedules were silently disabled (bug-audit 2026-05-28,
     // 1.3). `year` (parts[5]) is parsed/validated but not enforced at
     // fire time — matches the eventbridge ticker contract.
-    Some(
-        Expr::Cron(CronExpr {
-            minute: parse_cron_field(
-                parts[0],
-                &FieldSpec {
-                    min: 0,
-                    max: 59,
-                    names: &[],
-                },
-                false,
-            )?,
-            hour: parse_cron_field(
-                parts[1],
-                &FieldSpec {
-                    min: 0,
-                    max: 23,
-                    names: &[],
-                },
-                false,
-            )?,
-            day_of_month: parse_cron_field(
-                parts[2],
-                &FieldSpec {
-                    min: 1,
-                    max: 31,
-                    names: &[],
-                },
-                false,
-            )?,
-            month: parse_cron_field(
-                parts[3],
-                &FieldSpec {
-                    min: 1,
-                    max: 12,
-                    names: MONTH_NAMES,
-                },
-                false,
-            )?,
-            day_of_week: parse_cron_field(
-                parts[4],
-                &FieldSpec {
-                    min: 0,
-                    max: 6,
-                    names: DOW_NAMES,
-                },
-                true,
-            )?,
-        })
-        .validated(parts[5])?,
-    )
+    let cron = CronExpr {
+        minute: parse_cron_field(
+            parts[0],
+            &FieldSpec {
+                min: 0,
+                max: 59,
+                names: &[],
+            },
+            false,
+        )?,
+        hour: parse_cron_field(
+            parts[1],
+            &FieldSpec {
+                min: 0,
+                max: 23,
+                names: &[],
+            },
+            false,
+        )?,
+        day_of_month: parse_cron_field(
+            parts[2],
+            &FieldSpec {
+                min: 1,
+                max: 31,
+                names: &[],
+            },
+            false,
+        )?,
+        month: parse_cron_field(
+            parts[3],
+            &FieldSpec {
+                min: 1,
+                max: 12,
+                names: MONTH_NAMES,
+            },
+            false,
+        )?,
+        day_of_week: parse_cron_field(
+            parts[4],
+            &FieldSpec {
+                min: 0,
+                max: 6,
+                names: DOW_NAMES,
+            },
+            true,
+        )?,
+    };
+    // Validate the year field (parsed for correctness, not stored — the
+    // ticker contract doesn't enforce year at fire time). A malformed year
+    // still rejects the expression so CreateSchedule surfaces an error.
+    parse_cron_field(
+        parts[5],
+        &FieldSpec {
+            min: 1970,
+            max: 2199,
+            names: &[],
+        },
+        false,
+    )?;
+    Some(Expr::Cron(cron))
 }
 
 /// Parse one cron field, supporting `*`/`?`, single values, ranges,
@@ -261,6 +271,7 @@ fn parse_cron_term(part: &str, spec: &FieldSpec, is_dow: bool) -> Option<CronTer
     Some(CronTerm::Single(v))
 }
 
+#[allow(clippy::manual_is_multiple_of)] // keep `% step == 0` for MSRV
 fn term_matches(term: &CronTerm, value: u32) -> bool {
     match term {
         CronTerm::Single(v) => *v == value,
@@ -268,25 +279,6 @@ fn term_matches(term: &CronTerm, value: u32) -> bool {
         CronTerm::Step { start, end, step } => {
             value >= *start && value <= *end && (value - start) % step == 0
         }
-    }
-}
-
-impl CronExpr {
-    /// Validate the year field (parsed for correctness but not stored,
-    /// since the ticker contract doesn't enforce year at fire time) and
-    /// return self. Rejects a malformed year so CreateSchedule surfaces a
-    /// validation error.
-    fn validated(self, year_field: &str) -> Option<Self> {
-        parse_cron_field(
-            year_field,
-            &FieldSpec {
-                min: 1970,
-                max: 2199,
-                names: &[],
-            },
-            false,
-        )?;
-        Some(self)
     }
 }
 

--- a/crates/fakecloud-scheduler/src/expr.rs
+++ b/crates/fakecloud-scheduler/src/expr.rs
@@ -37,8 +37,71 @@ pub struct CronExpr {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CronField {
+    /// `*` or `?` — matches any value.
     Any,
-    Value(u32),
+    /// Comma-separated list of terms; matches when ANY term matches.
+    Terms(Vec<CronTerm>),
+}
+
+/// One comma-separated element of a cron field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CronTerm {
+    Single(u32),
+    Range(u32, u32),
+    Step { start: u32, end: u32, step: u32 },
+}
+
+/// Field bounds + name aliases used to parse and validate one cron field.
+struct FieldSpec {
+    min: u32,
+    max: u32,
+    names: &'static [(&'static str, u32)],
+}
+
+const MONTH_NAMES: &[(&str, u32)] = &[
+    ("JAN", 1),
+    ("FEB", 2),
+    ("MAR", 3),
+    ("APR", 4),
+    ("MAY", 5),
+    ("JUN", 6),
+    ("JUL", 7),
+    ("AUG", 8),
+    ("SEP", 9),
+    ("OCT", 10),
+    ("NOV", 11),
+    ("DEC", 12),
+];
+
+// Day-of-week names normalized to 0=Sunday..6=Saturday.
+const DOW_NAMES: &[(&str, u32)] = &[
+    ("SUN", 0),
+    ("MON", 1),
+    ("TUE", 2),
+    ("WED", 3),
+    ("THU", 4),
+    ("FRI", 5),
+    ("SAT", 6),
+];
+
+fn resolve_token(tok: &str, spec: &FieldSpec, is_dow: bool) -> Option<u32> {
+    let tok = tok.trim();
+    if let Ok(n) = tok.parse::<u32>() {
+        if is_dow {
+            // AWS Scheduler day-of-week: 1=SUN..7=SAT -> 0=SUN..6=SAT.
+            return match n {
+                0 => Some(0),
+                1..=7 => Some(n - 1),
+                _ => None,
+            };
+        }
+        return Some(n);
+    }
+    let upper = tok.to_ascii_uppercase();
+    spec.names
+        .iter()
+        .find(|(name, _)| upper.starts_with(name))
+        .map(|&(_, v)| v)
 }
 
 /// Parse a schedule expression. Returns `None` on any shape we don't
@@ -85,25 +148,146 @@ fn parse_cron(inner: &str) -> Option<Expr> {
     if parts.len() != 6 {
         return None;
     }
-    // Reject tokens we don't understand (ranges, lists, step values,
-    // month/weekday name shorthands). Falling back to wildcard would
-    // cause unsupported schedules to fire every minute instead of
-    // being silently disabled. `year` (parts[5]) is accepted but not
-    // enforced at fire time — matches existing eventbridge behavior.
-    Some(Expr::Cron(CronExpr {
-        minute: parse_cron_field(parts[0])?,
-        hour: parse_cron_field(parts[1])?,
-        day_of_month: parse_cron_field(parts[2])?,
-        month: parse_cron_field(parts[3])?,
-        day_of_week: parse_cron_field(parts[4])?,
-    }))
+    // Support single values, ranges (9-17), lists (0,30), steps (*/5,
+    // 9-17/2), and JAN/MON-style names; reject malformed/out-of-range
+    // fields. Previously ranges/lists/steps were rejected entirely, so
+    // valid AWS schedules were silently disabled (bug-audit 2026-05-28,
+    // 1.3). `year` (parts[5]) is parsed/validated but not enforced at
+    // fire time — matches the eventbridge ticker contract.
+    Some(
+        Expr::Cron(CronExpr {
+            minute: parse_cron_field(
+                parts[0],
+                &FieldSpec {
+                    min: 0,
+                    max: 59,
+                    names: &[],
+                },
+                false,
+            )?,
+            hour: parse_cron_field(
+                parts[1],
+                &FieldSpec {
+                    min: 0,
+                    max: 23,
+                    names: &[],
+                },
+                false,
+            )?,
+            day_of_month: parse_cron_field(
+                parts[2],
+                &FieldSpec {
+                    min: 1,
+                    max: 31,
+                    names: &[],
+                },
+                false,
+            )?,
+            month: parse_cron_field(
+                parts[3],
+                &FieldSpec {
+                    min: 1,
+                    max: 12,
+                    names: MONTH_NAMES,
+                },
+                false,
+            )?,
+            day_of_week: parse_cron_field(
+                parts[4],
+                &FieldSpec {
+                    min: 0,
+                    max: 6,
+                    names: DOW_NAMES,
+                },
+                true,
+            )?,
+        })
+        .validated(parts[5])?,
+    )
 }
 
-fn parse_cron_field(s: &str) -> Option<CronField> {
+/// Parse one cron field, supporting `*`/`?`, single values, ranges,
+/// steps, comma lists, and name aliases. `None` rejects the whole
+/// expression for any malformed/out-of-range field.
+fn parse_cron_field(s: &str, spec: &FieldSpec, is_dow: bool) -> Option<CronField> {
+    let s = s.trim();
     if s == "*" || s == "?" {
         return Some(CronField::Any);
     }
-    s.parse::<u32>().ok().map(CronField::Value)
+    let mut terms = Vec::new();
+    for part in s.split(',') {
+        terms.push(parse_cron_term(part.trim(), spec, is_dow)?);
+    }
+    if terms.is_empty() {
+        return None;
+    }
+    Some(CronField::Terms(terms))
+}
+
+fn parse_cron_term(part: &str, spec: &FieldSpec, is_dow: bool) -> Option<CronTerm> {
+    let in_bounds = |v: u32| v >= spec.min && v <= spec.max;
+    if let Some((base, step_s)) = part.split_once('/') {
+        let step: u32 = step_s.trim().parse().ok()?;
+        if step == 0 {
+            return None;
+        }
+        let (start, end) = if base == "*" {
+            (spec.min, spec.max)
+        } else if let Some((a, b)) = base.split_once('-') {
+            (
+                resolve_token(a, spec, is_dow)?,
+                resolve_token(b, spec, is_dow)?,
+            )
+        } else {
+            (resolve_token(base, spec, is_dow)?, spec.max)
+        };
+        if !in_bounds(start) || !in_bounds(end) || start > end {
+            return None;
+        }
+        return Some(CronTerm::Step { start, end, step });
+    }
+    if let Some((a, b)) = part.split_once('-') {
+        let start = resolve_token(a, spec, is_dow)?;
+        let end = resolve_token(b, spec, is_dow)?;
+        if !in_bounds(start) || !in_bounds(end) || start > end {
+            return None;
+        }
+        return Some(CronTerm::Range(start, end));
+    }
+    let v = resolve_token(part, spec, is_dow)?;
+    if !in_bounds(v) {
+        return None;
+    }
+    Some(CronTerm::Single(v))
+}
+
+fn term_matches(term: &CronTerm, value: u32) -> bool {
+    match term {
+        CronTerm::Single(v) => *v == value,
+        CronTerm::Range(a, b) => value >= *a && value <= *b,
+        CronTerm::Step { start, end, step } => {
+            value >= *start && value <= *end && (value - start) % step == 0
+        }
+    }
+}
+
+impl CronExpr {
+    /// Validate the year field (parsed for correctness but not stored,
+    /// since the ticker contract doesn't enforce year at fire time) and
+    /// return self. Rejects a malformed year so CreateSchedule surfaces a
+    /// validation error.
+    fn validated(self, year_field: &str) -> Option<Self> {
+        parse_cron_field(
+            year_field,
+            &FieldSpec {
+                min: 1970,
+                max: 2199,
+                names: &[],
+            },
+            false,
+        )?;
+        Some(self)
+    }
 }
 
 /// Decide whether `expr` is due to fire, given its `last_fired` time
@@ -178,7 +362,10 @@ fn matches_cron_fields(
     day_of_week: u32,
 ) -> bool {
     let match_field = |f: &CronField, actual: u32| -> bool {
-        matches!(f, CronField::Any) || matches!(f, CronField::Value(v) if *v == actual)
+        match f {
+            CronField::Any => true,
+            CronField::Terms(terms) => terms.iter().any(|t| term_matches(t, actual)),
+        }
     };
     match_field(&c.minute, minute)
         && match_field(&c.hour, hour)
@@ -231,14 +418,42 @@ mod tests {
     }
 
     #[test]
-    fn parse_cron_rejects_unsupported_tokens() {
-        // Non-numeric, non-wildcard tokens are now rejected instead
-        // of being silently converted to wildcards (which would make
-        // every unsupported schedule fire every minute).
-        assert!(parse("cron(*/5 * * * ? *)").is_none());
-        assert!(parse("cron(1,3,5 * * * ? *)").is_none());
-        assert!(parse("cron(1-3 * * * ? *)").is_none());
+    fn parse_cron_supports_ranges_lists_steps() {
+        // bug-audit 2026-05-28, 1.3: ranges/lists/steps are now real cron
+        // syntax that parses and fires, instead of being rejected (so the
+        // schedule silently never fired).
+        assert!(matches!(parse("cron(*/5 * * * ? *)"), Some(Expr::Cron(_))));
+        assert!(matches!(
+            parse("cron(1,3,5 * * * ? *)"),
+            Some(Expr::Cron(_))
+        ));
+        assert!(matches!(parse("cron(1-3 * * * ? *)"), Some(Expr::Cron(_))));
+        assert!(matches!(
+            parse("cron(0 9-17 ? * MON-FRI *)"),
+            Some(Expr::Cron(_))
+        ));
+        // Malformed / out-of-range still rejected.
         assert!(parse("cron(xyz 12 * * ? *)").is_none());
+        assert!(parse("cron(99 * * * ? *)").is_none());
+        assert!(parse("cron(0 0 1 13 ? *)").is_none());
+    }
+
+    #[test]
+    fn cron_ranges_and_steps_fire_correctly() {
+        // 2026-06-01 = Monday.
+        let Some(Expr::Cron(c)) = parse("cron(*/15 9-17 ? * MON-FRI *)") else {
+            panic!("expected cron");
+        };
+        let at = |min, hour, dom, dow_ok: bool| {
+            // pick a Monday (1st) or Saturday (6th) of June 2026
+            let day = if dow_ok { 1 } else { 6 };
+            Utc.with_ymd_and_hms(2026, 6, day, hour, min, 0).unwrap()
+        };
+        assert!(matches_cron(&c, at(0, 9, 1, true)));
+        assert!(matches_cron(&c, at(15, 17, 1, true)));
+        assert!(!matches_cron(&c, at(10, 9, 1, true))); // not /15
+        assert!(!matches_cron(&c, at(0, 8, 1, true))); // before hour range
+        assert!(!matches_cron(&c, at(0, 9, 6, false))); // Saturday
     }
 
     #[test]
@@ -322,7 +537,7 @@ mod tests {
     #[test]
     fn is_due_cron_specific_minute_mismatch() {
         let c = CronExpr {
-            minute: CronField::Value(45),
+            minute: CronField::Terms(vec![CronTerm::Single(45)]),
             hour: CronField::Any,
             day_of_month: CronField::Any,
             month: CronField::Any,


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1 cron/filter fixes (silent wrong-behavior class).

- **1.2** — EventBridge cron parser understood only `*`, `?`, and bare ints; any range/list/step/name was silently coerced to wildcard, so `cron(*/5 * * * ? *)` fired *every minute* and `cron(0 9-17 ? * MON-FRI *)` fired every minute of every day. Numeric day-of-week was off by one (0=Sun vs AWS 1=Sun) and the year field was parsed but never enforced. Now supports single values, ranges (`9-17`), lists (`0,30`), steps (`*/5`, `9-17/2`), and `JAN`/`MON` names; enforces all six fields incl. year; rejects malformed expressions so `PutRule` surfaces a validation error.
- **1.3** — The `fakecloud-scheduler` crate had the same impoverished parser and rejected ranges/lists/steps outright, so valid AWS schedules were silently disabled. Applied the same rich parser and updated the simulation enumerator for the new term kinds. `CreateSchedule`/`UpdateSchedule` reject when parse returns `None`.
- **1.14** — `{"anything-but": {"prefix": ...}}` always matched, so excluded events were still delivered. The object form now negates `prefix`/`suffix`/`equals-ignore-case` nested matchers.

## Test plan
- `cargo clippy -D warnings` + `cargo test --lib` green for both crates (eventbridge 218, scheduler 83).
- New tests: step/range/list/name firing, numeric-DOW one-based-Sunday, year enforcement, invalid-expression rejection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full cron support to `fakecloud-eventbridge` and `fakecloud-scheduler` (ranges, lists, steps, and JAN/MON names), fixes AWS day-of-week mapping, and corrects `anything-but` object negation. EventBridge now enforces the year field; Scheduler validates the year but does not enforce it at runtime.

- **Bug Fixes**
  - Cron parsing: both crates support ranges/lists/steps and names, use AWS DOW (1=SUN), and reject malformed expressions. EventBridge enforces all six fields (including year); Scheduler validates year syntax only; `PutRule`/`CreateSchedule`/`UpdateSchedule` fail fast on invalid input. Step matching uses is_multiple_of.
  - Event pattern matching: `{"anything-but": {"prefix"|"suffix"|"equals-ignore-case"}}` now properly negates the nested matcher.

- **Migration**
  - APIs may now return validation errors for malformed cron; update schedules to valid AWS EventBridge syntax.

<sup>Written for commit ddd1fe68b793422b4c75a3ad6980f6264c5ffa7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

