### PR TITLE
fix(s3): cap max-keys at 1000, verify Content-MD5, honor copy-source date conditions

### DIFF
--- a/crates/fakecloud-s3/src/service/objects/list.rs
+++ b/crates/fakecloud-s3/src/service/objects/list.rs
@@ -24,10 +24,14 @@ impl S3Service {
             .get("delimiter")
             .filter(|s| !s.is_empty())
             .cloned();
+        // AWS caps max-keys at 1000 regardless of the requested value, so
+        // clients that don't paginate still see truncation (bug-audit
+        // 2026-05-28, 1.4 — we used the requested value verbatim).
         let max_keys: usize = req
             .query_params
             .get("max-keys")
             .and_then(|v| v.parse().ok())
+            .map(|n: usize| n.min(1000))
             .unwrap_or(1000);
         let marker = req.query_params.get("marker").cloned().unwrap_or_default();
         let encoding_type = req.query_params.get("encoding-type").cloned();
@@ -185,10 +189,12 @@ impl S3Service {
             .get("delimiter")
             .cloned()
             .unwrap_or_default();
+        // AWS caps max-keys at 1000 (bug-audit 2026-05-28, 1.4).
         let max_keys: usize = req
             .query_params
             .get("max-keys")
             .and_then(|v| v.parse().ok())
+            .map(|n: usize| n.min(1000))
             .unwrap_or(1000);
         let start_after = req
             .query_params
@@ -406,10 +412,12 @@ impl S3Service {
             .cloned()
             .unwrap_or_default();
         let version_id_marker = req.query_params.get("version-id-marker").cloned();
+        // AWS caps max-keys at 1000 (bug-audit 2026-05-28, 1.4).
         let max_keys: usize = req
             .query_params
             .get("max-keys")
             .and_then(|s| s.parse().ok())
+            .map(|n: usize| n.min(1000))
             .unwrap_or(1000);
 
         let owner_id = &b.acl_owner_id;

--- a/crates/fakecloud-s3/src/service/objects/write.rs
+++ b/crates/fakecloud-s3/src/service/objects/write.rs
@@ -1200,7 +1200,7 @@ impl S3Service {
 /// isn't valid hex of the right length.
 fn hex_to_base64(hex: &str) -> Option<String> {
     use base64::Engine;
-    if hex.len() % 2 != 0 {
+    if !hex.len().is_multiple_of(2) {
         return None;
     }
     let mut bytes = Vec::with_capacity(hex.len() / 2);

--- a/crates/fakecloud-s3/src/service/objects/write.rs
+++ b/crates/fakecloud-s3/src/service/objects/write.rs
@@ -774,7 +774,7 @@ impl S3Service {
             .headers
             .get("x-amz-copy-source-if-unmodified-since")
             .and_then(|v| v.to_str().ok())
-            .and_then(parse_http_date)
+            .and_then(crate::service::parse_http_date)
         {
             // Fail if the source WAS modified after the given instant.
             if src_obj.last_modified > since {
@@ -789,7 +789,7 @@ impl S3Service {
             .headers
             .get("x-amz-copy-source-if-modified-since")
             .and_then(|v| v.to_str().ok())
-            .and_then(parse_http_date)
+            .and_then(crate::service::parse_http_date)
         {
             // Fail if the source was NOT modified after the given instant.
             if src_obj.last_modified <= since {

--- a/crates/fakecloud-s3/src/service/objects/write.rs
+++ b/crates/fakecloud-s3/src/service/objects/write.rs
@@ -180,6 +180,26 @@ impl S3Service {
         .await?;
         let data_size: u64 = spooled.size;
         let etag: String = spooled.md5_hex.clone();
+
+        // Content-MD5 integrity check: when the client sends the header,
+        // AWS verifies it against the body's MD5 and rejects a mismatch
+        // with `BadDigest` (bug-audit 2026-05-28, 1.9 — corrupt-digest
+        // writes used to be accepted silently). The header is the
+        // base64-encoded 128-bit MD5; the spool computed it as hex, so
+        // decode the hex to raw bytes and base64-encode to compare.
+        if let Some(content_md5) = req.headers.get("content-md5").and_then(|v| v.to_str().ok()) {
+            let supplied = content_md5.trim();
+            if !supplied.is_empty() {
+                let expected_b64 = hex_to_base64(&spooled.md5_hex);
+                if expected_b64.as_deref() != Some(supplied) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "BadDigest",
+                        "The Content-MD5 you specified did not match what we received.",
+                    ));
+                }
+            }
+        }
         let content_type = req
             .headers
             .get("content-type")
@@ -1139,5 +1159,48 @@ impl S3Service {
             body: Bytes::new().into(),
             headers: HeaderMap::new(),
         })
+    }
+}
+
+/// Convert a lowercase hex MD5 digest to its base64 form, matching the
+/// `Content-MD5` header encoding AWS expects. Returns `None` if the input
+/// isn't valid hex of the right length.
+fn hex_to_base64(hex: &str) -> Option<String> {
+    use base64::Engine;
+    if hex.len() % 2 != 0 {
+        return None;
+    }
+    let mut bytes = Vec::with_capacity(hex.len() / 2);
+    let h = hex.as_bytes();
+    let mut i = 0;
+    while i < h.len() {
+        let hi = (h[i] as char).to_digit(16)?;
+        let lo = (h[i + 1] as char).to_digit(16)?;
+        bytes.push((hi * 16 + lo) as u8);
+        i += 2;
+    }
+    Some(base64::engine::general_purpose::STANDARD.encode(bytes))
+}
+
+#[cfg(test)]
+mod content_md5_tests {
+    use super::hex_to_base64;
+
+    // bug-audit 2026-05-28, 1.9: the spool yields a hex MD5; the
+    // Content-MD5 header is base64 of the raw digest. Verify the
+    // conversion matches the canonical base64 form.
+    #[test]
+    fn hex_md5_converts_to_base64() {
+        // MD5("") = d41d8cd98f00b204e9800998ecf8427e
+        assert_eq!(
+            hex_to_base64("d41d8cd98f00b204e9800998ecf8427e").as_deref(),
+            Some("1B2M2Y8AsgTpgAmY7PhCfg==")
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_hex() {
+        assert_eq!(hex_to_base64("xyz"), None); // odd length
+        assert_eq!(hex_to_base64("zz"), None); // non-hex digits
     }
 }

--- a/crates/fakecloud-s3/src/service/objects/write.rs
+++ b/crates/fakecloud-s3/src/service/objects/write.rs
@@ -767,6 +767,39 @@ impl S3Service {
                 ));
             }
         }
+        // Date-based copy-source preconditions (bug-audit 2026-05-28,
+        // 1.10 — these were ignored, so a copy always succeeded). A
+        // malformed date header is ignored, matching AWS.
+        if let Some(since) = req
+            .headers
+            .get("x-amz-copy-source-if-unmodified-since")
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_http_date)
+        {
+            // Fail if the source WAS modified after the given instant.
+            if src_obj.last_modified > since {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::PRECONDITION_FAILED,
+                    "PreconditionFailed",
+                    "At least one of the pre-conditions you specified did not hold",
+                ));
+            }
+        }
+        if let Some(since) = req
+            .headers
+            .get("x-amz-copy-source-if-modified-since")
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_http_date)
+        {
+            // Fail if the source was NOT modified after the given instant.
+            if src_obj.last_modified <= since {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::PRECONDITION_FAILED,
+                    "PreconditionFailed",
+                    "At least one of the pre-conditions you specified did not hold",
+                ));
+            }
+        }
 
         // Check copy-in-place validity
         let has_version_id = src_version_id.is_some();


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1 S3 correctness fixes (silent wrong-behavior class).

- **1.4** — `ListObjects`/`ListObjectsV2`/`ListObjectVersions` used the requested `max-keys` verbatim; AWS caps it at 1000 regardless, so a client that doesn't paginate never saw truncation. Cap all three parse sites at 1000.
- **1.9** — `PutObject` ignored `Content-MD5`, so corrupt-digest writes were accepted silently. Now decode the body's spooled hex MD5 to base64 and reject a mismatching `Content-MD5` with `BadDigest` (400). Added `hex_to_base64` helper + unit tests.
- **1.10** — `CopyObject` honored `x-amz-copy-source-if-[none-]match` but ignored the date conditions. `x-amz-copy-source-if-unmodified-since` / `-if-modified-since` are now enforced against the source's `last_modified`, returning 412 `PreconditionFailed`.

## Test plan
- `cargo build / clippy -D warnings / fmt` clean.
- `cargo test -p fakecloud-s3 --lib` green incl. new hex_to_base64 cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns S3 behavior with AWS: cap list results at 1000, verify `Content-MD5`, and enforce copy-source date preconditions. Fixes silent wrong behavior and improves integrity.

- **Bug Fixes**
  - `ListObjects`/`ListObjectsV2`/`ListObjectVersions`: cap `max-keys` at 1000.
  - `PutObject`: verify `Content-MD5` against the body; mismatches return 400 `BadDigest`. Added `hex_to_base64` + tests; uses `is_multiple_of` to satisfy clippy `-D warnings`.
  - `CopyObject`: enforce `x-amz-copy-source-if-unmodified-since` and `-if-modified-since`; failures return 412 `PreconditionFailed`. Malformed dates ignored. Qualified `crate::service::parse_http_date` to fix build.

<sup>Written for commit 3148f4718e89ebc926db3e47b05af32d3248d2dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

