### PR TITLE
fix(kinesis): stream-unique sequence numbers via shard discriminator

### DIFF
--- a/crates/fakecloud-kinesis/src/service_helpers.rs
+++ b/crates/fakecloud-kinesis/src/service_helpers.rs
@@ -215,7 +215,12 @@ pub(crate) fn append_record(
     partition_key: &str,
     data: Vec<u8>,
 ) -> String {
-    let sequence_number = format!("{:056}", shard.next_sequence_number);
+    // Stream-unique sequence number: pack a per-shard discriminator into
+    // the low 5 digits so two shards can never mint the same value, while
+    // the high digits keep per-shard monotonic ordering (bug-audit
+    // 2026-05-28, 1.12 — values were only per-shard unique).
+    let disc = shard_discriminator(&shard.shard_id);
+    let sequence_number = format!("{:05}{:051}", disc, shard.next_sequence_number);
     shard.next_sequence_number += 1;
     shard.records.push(KinesisRecord {
         sequence_number: sequence_number.clone(),
@@ -331,4 +336,44 @@ pub(crate) fn expired_iterator() -> AwsServiceError {
         "ExpiredIteratorException",
         "Shard iterator is expired or invalid.",
     )
+}
+
+/// Numeric discriminator from a shard id like `shardId-000000000003` -> 3,
+/// clamped to 5 digits; 0 when there is no numeric suffix. Packed into the
+/// low digits of each sequence number so they are unique stream-wide.
+pub(crate) fn shard_discriminator(shard_id: &str) -> u32 {
+    let digits: String = shard_id
+        .rsplit('-')
+        .next()
+        .unwrap_or("")
+        .chars()
+        .filter(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse::<u64>().unwrap_or(0).min(99_999) as u32
+}
+
+#[cfg(test)]
+mod sequence_discriminator_tests {
+    use super::shard_discriminator;
+
+    #[test]
+    fn parses_numeric_suffix() {
+        assert_eq!(shard_discriminator("shardId-000000000000"), 0);
+        assert_eq!(shard_discriminator("shardId-000000000003"), 3);
+        assert_eq!(shard_discriminator("shardId-000000000042"), 42);
+    }
+
+    #[test]
+    fn distinct_shards_differ() {
+        assert_ne!(
+            shard_discriminator("shardId-000000000001"),
+            shard_discriminator("shardId-000000000002")
+        );
+    }
+
+    #[test]
+    fn handles_missing_suffix() {
+        assert_eq!(shard_discriminator("weird"), 0);
+        assert_eq!(shard_discriminator(""), 0);
+    }
 }


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.12**. Sequence numbers were a 56-digit per-shard counter, so two shards minting at the same counter value produced identical numbers — cross-shard collisions. Kinesis sequence numbers must be unique stream-wide.

Pack a 5-digit shard discriminator (numeric suffix of the shard id) into the HIGH digits: `format!("{:05}{:051}", disc, counter)`. Single shard (disc 0) keeps identical values; distinct shards can never collide; within-shard ordering is preserved. Iterator lookup is exact-string match, so the format change is safe.

## Test plan
`cargo clippy -p fakecloud-kinesis --all-targets -- -D warnings` + `cargo test -p fakecloud-kinesis --lib` green; +3 discriminator tests; existing put-record sequence assertions still pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Kinesis sequence numbers unique across the whole stream by prefixing a 5-digit per-shard discriminator to the 51-digit counter. This prevents cross-shard collisions while preserving within-shard order; existing iterator lookups still work.

- Bug Fixes
  - Prefixed a 5-digit shard discriminator (from the shard ID) to sequence numbers: format "{:05}{:051}".
  - Added `shard_discriminator` helper with clamping and tests.
  - No migration needed; iterators use exact-string matches.

<sup>Written for commit 1b1190ddc13f4dec4b35538e2832be7e5f5cf464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

