### PR TITLE
fix(sqs): FIFO dedup'd send replays original MessageId + SequenceNumber

### DIFF
--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -1668,3 +1668,51 @@ async fn sqs_encryption_defaults_and_mode_switch() {
         "300"
     );
 }
+
+// bug-audit 2026-05-28, 1.13: a deduplicated FIFO send replays the ORIGINAL
+// MessageId + SequenceNumber instead of minting new ones / advancing the seq.
+#[tokio::test]
+async fn fifo_dedup_replays_original_id_and_sequence() {
+    let client = sqs_client().await;
+    let queue_url = create_fifo_queue(&client, "dedup-replay.fifo").await;
+
+    let first = client
+        .send_message()
+        .queue_url(&queue_url)
+        .message_body("hello")
+        .message_group_id("g1")
+        .message_deduplication_id("d1")
+        .send()
+        .await
+        .expect("first send");
+    let second = client
+        .send_message()
+        .queue_url(&queue_url)
+        .message_body("hello")
+        .message_group_id("g1")
+        .message_deduplication_id("d1")
+        .send()
+        .await
+        .expect("second send");
+
+    assert_eq!(
+        first.message_id(),
+        second.message_id(),
+        "dedup'd send must replay the original MessageId"
+    );
+    assert_eq!(
+        first.sequence_number(),
+        second.sequence_number(),
+        "dedup'd send must replay the original SequenceNumber"
+    );
+
+    // Only one message actually enqueued.
+    let recv = client
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .expect("receive");
+    assert_eq!(recv.messages().len(), 1, "duplicate must not enqueue twice");
+}

--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -193,16 +193,18 @@ impl SqsService {
             if queue.is_fifo {
                 if let Some(ref dedup_id) = effective_dedup_id {
                     let now = Utc::now();
-                    queue.dedup_cache.retain(|_, expiry| *expiry > now);
-                    if queue.dedup_cache.contains_key(dedup_id) {
-                        let msg_id = uuid::Uuid::new_v4().to_string();
-                        let seq = queue.next_sequence_number;
-                        queue.next_sequence_number += 1;
+                    queue.dedup_cache.retain(|_, e| e.expiry > now);
+                    if let Some(entry) = queue.dedup_cache.get(dedup_id) {
+                        // Duplicate within the dedup window: AWS replays the
+                        // ORIGINAL MessageId + SequenceNumber, does not enqueue
+                        // again, and does not advance the counter (1.13).
                         let mut resp = json!({
-                            "MessageId": msg_id,
+                            "MessageId": entry.message_id,
                             "MD5OfMessageBody": &md5_of_body,
-                            "SequenceNumber": seq.to_string(),
                         });
+                        if let Some(ref seq) = entry.sequence_number {
+                            resp["SequenceNumber"] = json!(seq);
+                        }
                         if let Some(ref md5) = md5_of_attrs {
                             resp["MD5OfMessageAttributes"] = json!(md5);
                         }
@@ -295,9 +297,14 @@ impl SqsService {
             // the dedup_id un-cached so the caller's retry can succeed.
             if queue.is_fifo {
                 if let Some(ref dedup_id) = effective_dedup_id {
-                    queue
-                        .dedup_cache
-                        .insert(dedup_id.clone(), now + chrono::Duration::minutes(5));
+                    queue.dedup_cache.insert(
+                        dedup_id.clone(),
+                        crate::state::DedupEntry {
+                            message_id: message_id.clone(),
+                            sequence_number: sequence_number.clone(),
+                            expiry: Utc::now() + chrono::Duration::minutes(5),
+                        },
+                    );
                 }
             }
 

--- a/crates/fakecloud-sqs/src/state.rs
+++ b/crates/fakecloud-sqs/src/state.rs
@@ -12,6 +12,16 @@ pub struct MessageAttribute {
     pub binary_value: Option<Vec<u8>>,
 }
 
+/// One FIFO dedup-cache entry: the original (non-duplicate) send result,
+/// kept until `expiry`; a duplicate within the window replays it verbatim
+/// (bug-audit 2026-05-28, 1.13).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DedupEntry {
+    pub message_id: String,
+    pub sequence_number: Option<String>,
+    pub expiry: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SqsMessage {
     pub message_id: String,
@@ -50,8 +60,11 @@ pub struct SqsQueue {
     pub inflight: Vec<SqsMessage>,
     pub attributes: BTreeMap<String, String>,
     pub is_fifo: bool,
-    /// For FIFO dedup: dedup_id -> expiry
-    pub dedup_cache: BTreeMap<String, DateTime<Utc>>,
+    /// For FIFO dedup: dedup_id -> the original send's result + expiry,
+    /// so a duplicate within the window replays the ORIGINAL MessageId +
+    /// SequenceNumber without re-enqueuing or advancing the counter
+    /// (bug-audit 2026-05-28, 1.13).
+    pub dedup_cache: BTreeMap<String, DedupEntry>,
     /// DLQ redrive policy
     pub redrive_policy: Option<RedrivePolicy>,
     /// Queue tags (key -> value)


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.13**. A duplicate FIFO send within the dedup window minted a fresh `MessageId` and advanced the sequence counter. AWS returns the ORIGINAL send's `MessageId` + `SequenceNumber`, does not enqueue again, and does not advance the counter.

- `dedup_cache` value `DateTime<Utc>` -> `DedupEntry { message_id, sequence_number, expiry }`.
- Dedup hit returns the stored id+seq (no new uuid, no counter bump); commit stores the full entry.

## Test plan
`cargo clippy -p fakecloud-sqs --all-targets -- -D warnings` + `cargo test -p fakecloud-sqs --lib` green. (Regression test in crates/fakecloud-e2e/tests/sqs_fifo.rs to follow on this branch.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FIFO dedup behavior to replay the original MessageId and SequenceNumber for duplicate sends within the dedup window, matching AWS. Prevents re-enqueue and sequence counter increments on duplicates.

- **Bug Fixes**
  - Replace dedup cache with a full entry {message_id, optional sequence_number, expiry}; store on commit and prune expired entries before checks.
  - On dedup hit, return the stored id/seq; skip enqueue and do not bump the counter.
  - Add e2e test asserting duplicates replay the original id/sequence and only one message is enqueued.

<sup>Written for commit b6f0eac5b184554aba9a69662835199ccaf22394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

