### PR TITLE
fix(apigateway): TestInvokeAuthorizer honors identity source instead of canned Allow

### DIFF
--- a/crates/fakecloud-apigateway/src/service_integrations.rs
+++ b/crates/fakecloud-apigateway/src/service_integrations.rs
@@ -335,12 +335,64 @@ impl ApiGatewayService {
 
     pub(super) fn test_invoke_authorizer(
         &self,
-        _req: &AwsRequest,
-        _params: &BTreeMap<String, String>,
+        req: &AwsRequest,
+        params: &BTreeMap<String, String>,
     ) -> Result<AwsResponse, AwsServiceError> {
-        // Authorizer execution would need a Lambda/Cognito hook;
-        // fakecloud emits an Allow stub so callers can prove the
-        // surface is wired without modeling the real policy.
+        // Authorizer execution would need a real Lambda/Cognito hook, so the
+        // returned policy is still a canned Allow. But we DO evaluate the
+        // authorizer's identity source against the supplied request headers:
+        // AWS returns clientStatus 401 (no policy) when a required
+        // identity-source header is absent, rather than always allowing
+        // (bug-audit 2026-05-28, 1.18 — this op was a blanket Allow stub).
+        let rest_api_id = params.get("restApiId").cloned().unwrap_or_default();
+        let authorizer_id = params.get("authorizerId").cloned().unwrap_or_default();
+        let body = req.json_body();
+
+        let identity_source = {
+            let accounts = self.state.read();
+            let state = accounts
+                .get(&request_account(req))
+                .ok_or_else(|| not_found("Authorizer not found"))?;
+            let authorizer = state
+                .authorizers
+                .get(&rest_api_id)
+                .and_then(|m| m.get(&authorizer_id))
+                .ok_or_else(|| not_found("Authorizer not found"))?;
+            authorizer.identity_source.clone()
+        };
+
+        let req_headers = body.get("headers").and_then(Value::as_object);
+        let identity_present = match identity_source.as_deref() {
+            // No identity source configured: nothing to require -> allow.
+            None | Some("") => true,
+            Some(src) => src
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                // Each entry looks like `method.request.header.Authorization`;
+                // the header name is the final dotted segment.
+                .all(|entry| {
+                    let header = entry.rsplit('.').next().unwrap_or(entry);
+                    req_headers
+                        .and_then(|h| h.iter().find(|(k, _)| k.eq_ignore_ascii_case(header)))
+                        .and_then(|(_, v)| v.as_str())
+                        .map(|v| !v.is_empty())
+                        .unwrap_or(false)
+                }),
+        };
+
+        if !identity_present {
+            // Missing identity source -> Unauthorized, no policy.
+            return ok(json!({
+                "clientStatus": 401,
+                "log": "TestInvokeAuthorizer: identity source not found",
+                "latency": 0,
+                "principalId": "",
+                "authorization": {},
+                "claims": {},
+            }));
+        }
+
         ok(json!({
             "clientStatus": 200,
             "log": "TestInvokeAuthorizer ok",

--- a/crates/fakecloud-e2e/tests/apigateway.rs
+++ b/crates/fakecloud-e2e/tests/apigateway.rs
@@ -833,3 +833,61 @@ async fn data_plane_request_validator_rejects_missing_body_field() {
         .expect("send");
     assert_eq!(good.status(), 200);
 }
+
+// bug-audit 2026-05-28, 1.18: TestInvokeAuthorizer must deny (clientStatus
+// 401) when the authorizer's identity-source header is absent, not always
+// return a canned Allow.
+#[tokio::test]
+async fn test_invoke_authorizer_honors_identity_source() {
+    let server = TestServer::start().await;
+    let client = server.apigateway_client().await;
+
+    let api = client
+        .create_rest_api()
+        .name("testinvoke-authz")
+        .send()
+        .await
+        .expect("create_rest_api");
+    let api_id = api.id().unwrap().to_string();
+
+    let authorizer = client
+        .create_authorizer()
+        .rest_api_id(&api_id)
+        .name("tok-authz")
+        .r#type(aws_sdk_apigateway::types::AuthorizerType::Token)
+        .identity_source("method.request.header.Authorization")
+        .send()
+        .await
+        .expect("create_authorizer");
+    let authorizer_id = authorizer.id().unwrap().to_string();
+
+    // Identity source configured but no matching request header -> 401.
+    let denied = client
+        .test_invoke_authorizer()
+        .rest_api_id(&api_id)
+        .authorizer_id(&authorizer_id)
+        .send()
+        .await
+        .expect("test_invoke_authorizer denied");
+    assert_eq!(denied.client_status(), 401);
+
+    // An authorizer with no identity source requires nothing -> 200.
+    let open_authorizer = client
+        .create_authorizer()
+        .rest_api_id(&api_id)
+        .name("open-authz")
+        .r#type(aws_sdk_apigateway::types::AuthorizerType::Token)
+        .send()
+        .await
+        .expect("create open authorizer");
+    let open_id = open_authorizer.id().unwrap().to_string();
+
+    let allowed = client
+        .test_invoke_authorizer()
+        .rest_api_id(&api_id)
+        .authorizer_id(&open_id)
+        .send()
+        .await
+        .expect("test_invoke_authorizer allowed");
+    assert_eq!(allowed.client_status(), 200);
+}


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.18**. `TestInvokeAuthorizer` ignored the request and always returned an Allow stub with `clientStatus` 200.

Now it looks up the authorizer and evaluates its identity source against the supplied request headers: a missing/empty required identity-source header yields `clientStatus` 401 with no policy, matching AWS; a present header (or an authorizer with no identity source) yields the Allow policy.

## Test plan
`cargo clippy -p fakecloud-apigateway --all-targets -- -D warnings` green; new e2e `test_invoke_authorizer_honors_identity_source` (401 with identity source + no header, 200 for an open authorizer) passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API Gateway `TestInvokeAuthorizer` to honor the authorizer’s identity source. Missing required header now returns clientStatus 401 with no policy; valid header or no identity source returns the canned Allow.

- **Bug Fixes**
  - Looks up the authorizer and evaluates its identity source against request headers.
  - Supports comma-separated sources and case-insensitive header names; empty values count as missing.
  - Adds an e2e test in `fakecloud-e2e` covering 401 (missing header) and 200 (open authorizer) paths.

<sup>Written for commit 574c4f54cc8428f3beb0e43d5387ebbfcaa0b824. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

