### PR TITLE
fix(acm): SearchCertificates honors CertificateStatuses filter + SortBy/SortOrder

### DIFF
--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -1058,14 +1058,30 @@ impl AcmService {
                 return Err(validation_error("Invalid SortOrder"));
             }
         }
-        let key_types: Vec<String> = body
-            .get("FilterStatement")
-            .and_then(|f| f.get("Filter"))
-            .and_then(|f| f.get("KeyTypes"))
+        // Filter values live under FilterStatement.Filter.<Key>; AWS ANDs the
+        // leaf filters and, within each leaf, keeps certs that match ANY listed
+        // value. Only KeyTypes was applied before (bug-audit 2026-05-28, 1.5).
+        let filter_values = |key: &str| -> Vec<String> {
+            body.get("FilterStatement")
+                .and_then(|f| f.get("Filter"))
+                .and_then(|f| f.get(key))
+                .and_then(Value::as_array)
+                .map(|v| {
+                    v.iter()
+                        .filter_map(|s| s.as_str().map(|s| s.to_ascii_uppercase()))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        let key_types = filter_values("KeyTypes");
+
+        // CertificateStatuses is a top-level filter on the certificate status.
+        let statuses: Vec<String> = body
+            .get("CertificateStatuses")
             .and_then(Value::as_array)
             .map(|v| {
                 v.iter()
-                    .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                    .filter_map(|s| s.as_str().map(|s| s.to_ascii_uppercase()))
                     .collect()
             })
             .unwrap_or_default();
@@ -1077,10 +1093,46 @@ impl AcmService {
             .map(|a| a.certificates.values().cloned().collect())
             .unwrap_or_default();
         drop(state);
-        all.sort_by(|a, b| a.arn.cmp(&b.arn));
+
         if !key_types.is_empty() {
-            all.retain(|c| key_types.contains(&c.key_algorithm));
+            all.retain(|c| key_types.contains(&c.key_algorithm.to_ascii_uppercase()));
         }
+        if !statuses.is_empty() {
+            all.retain(|c| statuses.contains(&c.status.to_ascii_uppercase()));
+        }
+
+        // Apply SortBy/SortOrder (validated above but previously never applied,
+        // 1.5). Default order is descending; the default key is CREATED_AT.
+        let sort_by = body
+            .get("SortBy")
+            .and_then(Value::as_str)
+            .unwrap_or("CREATED_AT")
+            .to_string();
+        let descending = body
+            .get("SortOrder")
+            .and_then(Value::as_str)
+            .map(|o| !o.eq_ignore_ascii_case("ASCENDING"))
+            .unwrap_or(true);
+        all.sort_by(|a, b| {
+            let ord = match sort_by.as_str() {
+                "NOT_AFTER" => a.not_after.cmp(&b.not_after),
+                "NOT_BEFORE" => a.not_before.cmp(&b.not_before),
+                "ISSUED_AT" => a.issued_at.cmp(&b.issued_at),
+                "STATUS" => a.status.cmp(&b.status),
+                "KEY_ALGORITHM" => a.key_algorithm.cmp(&b.key_algorithm),
+                "TYPE" => a.cert_type.cmp(&b.cert_type),
+                "CERTIFICATE_ARN" => a.arn.cmp(&b.arn),
+                // CREATED_AT and any other validated-but-unmodeled key.
+                _ => a.created_at.cmp(&b.created_at),
+            };
+            // Stable tiebreak by ARN keeps paging deterministic.
+            let ord = ord.then_with(|| a.arn.cmp(&b.arn));
+            if descending {
+                ord.reverse()
+            } else {
+                ord
+            }
+        });
         let start = next_token
             .and_then(|t| t.parse::<usize>().ok())
             .unwrap_or(0);
@@ -2249,5 +2301,105 @@ mod tests {
                     .ends_with("-----END RSA PRIVATE KEY-----")
         );
         assert!(key_pem.len() > 200);
+    }
+
+    // bug-audit 2026-05-28, 1.5: SearchCertificates must honor the
+    // CertificateStatuses filter and apply SortBy/SortOrder (previously only
+    // KeyTypes was applied and the order was hardcoded).
+    #[tokio::test]
+    async fn search_certificates_filters_by_status_and_sorts() {
+        let svc = AcmService::default();
+        let mut arn: std::collections::HashMap<&str, String> = std::collections::HashMap::new();
+        for d in ["a.example.com", "b.example.com", "c.example.com"] {
+            let resp = svc
+                .handle(make_req("RequestCertificate", json!({ "DomainName": d })))
+                .await
+                .unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            arn.insert(d, body["CertificateArn"].as_str().unwrap().to_string());
+        }
+
+        // Stamp deterministic statuses + creation times: a oldest, c newest.
+        {
+            let mut state = svc.state.write();
+            let certs = &mut state.accounts.get_mut("123456789012").unwrap().certificates;
+            let now = chrono::Utc::now();
+            for c in certs.values_mut() {
+                match c.domain_name.as_str() {
+                    "a.example.com" => {
+                        c.status = "ISSUED".to_string();
+                        c.created_at = now - chrono::Duration::hours(2);
+                    }
+                    "b.example.com" => {
+                        c.status = "PENDING_VALIDATION".to_string();
+                        c.created_at = now - chrono::Duration::hours(1);
+                    }
+                    _ => {
+                        c.status = "ISSUED".to_string();
+                        c.created_at = now;
+                    }
+                }
+            }
+        }
+
+        let domains = |body: &Value| -> Vec<String> {
+            body["Results"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|r| r["CertificateArn"].as_str().unwrap().to_string())
+                .collect()
+        };
+
+        // CertificateStatuses filter keeps only ISSUED (a + c).
+        let resp = svc
+            .handle(make_req(
+                "SearchCertificates",
+                json!({ "CertificateStatuses": ["ISSUED"] }),
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let mut issued = domains(&body);
+        issued.sort();
+        let mut want = vec![arn["a.example.com"].clone(), arn["c.example.com"].clone()];
+        want.sort();
+        assert_eq!(issued, want);
+
+        // SortBy CREATED_AT ASCENDING -> oldest first.
+        let resp = svc
+            .handle(make_req(
+                "SearchCertificates",
+                json!({ "SortBy": "CREATED_AT", "SortOrder": "ASCENDING" }),
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            domains(&body),
+            vec![
+                arn["a.example.com"].clone(),
+                arn["b.example.com"].clone(),
+                arn["c.example.com"].clone(),
+            ]
+        );
+
+        // DESCENDING -> newest first (reverse).
+        let resp = svc
+            .handle(make_req(
+                "SearchCertificates",
+                json!({ "SortBy": "CREATED_AT", "SortOrder": "DESCENDING" }),
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            domains(&body),
+            vec![
+                arn["c.example.com"].clone(),
+                arn["b.example.com"].clone(),
+                arn["a.example.com"].clone(),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.5**. `SearchCertificates` only applied the `KeyTypes` filter and sorted with a hardcoded order, ignoring `CertificateStatuses` and the (already-validated) `SortBy`/`SortOrder`.

Now it filters by `CertificateStatuses` (certificate status) and sorts by the requested `SortBy` field (CREATED_AT default) honoring `SortOrder` (DESCENDING default), with a stable ARN tiebreak for deterministic paging.

## Test plan
`cargo clippy -p fakecloud-acm --all-targets -- -D warnings` + `cargo test -p fakecloud-acm --lib` green; new unit test `search_certificates_filters_by_status_and_sorts` (status filter keeps only ISSUED; ASCENDING vs DESCENDING give opposite ordering).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the ACM SearchCertificates endpoint to honor CertificateStatuses and SortBy/SortOrder. Results are now correctly filtered and stably sorted (ARN tiebreak) for consistent pagination.

- **Bug Fixes**
  - Applies CertificateStatuses alongside KeyTypes; matching is case-insensitive.
  - Honors SortBy/SortOrder across supported fields (default CREATED_AT, DESCENDING).

<sup>Written for commit e7628da66593344c8f8bbbbe929c157e65c76fc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

