### PR TITLE
fix(ssm): State Manager associations record + return execution history

### DIFF
--- a/crates/fakecloud-ssm/src/service/associations.rs
+++ b/crates/fakecloud-ssm/src/service/associations.rs
@@ -77,6 +77,7 @@ impl SsmService {
             last_execution_date: None,
             instance_id: input.instance_id,
             versions: vec![version],
+            executions: Vec::new(),
         };
 
         let resp = association_to_json(&assoc);

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -241,6 +241,25 @@ pub struct SsmAssociation {
     pub last_execution_date: Option<DateTime<Utc>>,
     pub instance_id: Option<String>,
     pub versions: Vec<SsmAssociationVersion>,
+    /// Recorded executions (StartAssociationsOnce / scheduled applies). Empty
+    /// until the association runs; surfaced by DescribeAssociationExecutions
+    /// and DescribeAssociationExecutionTargets (bug-audit 2026-05-28, 1.15).
+    #[serde(default)]
+    pub executions: Vec<AssociationExecution>,
+}
+
+/// One recorded run of an SSM State Manager association. fakecloud applies
+/// associations synchronously and always succeeds, so every execution is a
+/// `Success` over the association's resolved targets.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AssociationExecution {
+    pub execution_id: String,
+    pub status: String,
+    pub detailed_status: String,
+    pub created_time: DateTime<Utc>,
+    pub resource_count: usize,
+    /// Resolved target resource ids covered by this execution.
+    pub resource_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.15**. `StartAssociationsOnce` only flipped association status and recorded nothing, so `DescribeAssociationExecutions` and `DescribeAssociationExecutionTargets` always returned empty lists.

Now each association stores its executions: `StartAssociationsOnce` appends a `Success` execution over the association's resolved target resource ids, and the two execution-history ops return them in AWS shape (AssociationExecution + AssociationExecutionTarget rows).

## Test plan
`cargo clippy -p fakecloud-ssm --all-targets -- -D warnings` + `cargo test -p fakecloud-ssm --lib` green; new unit test `start_associations_once_records_execution_history` (empty before run; one Success execution + one covered target after).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSM State Manager execution history: associations now record runs and the history APIs return real data instead of empty lists. Addresses bug-audit 1.15 where StartAssociationsOnce didn't persist executions.

- **Bug Fixes**
  - Added `executions: Vec<AssociationExecution>` to each association (serde default).
  - `StartAssociationsOnce` now appends a Success execution over resolved target resource IDs.
  - `DescribeAssociationExecutions` and `DescribeAssociationExecutionTargets` return the stored history in AWS shape.

<sup>Written for commit b27cff1e5e8792c873b4dae8803579f043d7f506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

