### PR TITLE
fix(s3,core): guard header/XML parsing against panics on malformed input

### DIFF
--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2445,7 +2445,10 @@ pub(crate) fn extract_xml_value(xml: &str, tag: &str) -> Option<String> {
     let open = format!("<{tag}>");
     let close = format!("</{tag}>");
     let start = xml.find(&open)? + open.len();
-    let end = xml.find(&close)?;
+    // Search for the closing tag AFTER the opening one so a malformed body
+    // (closing tag before opening) can't make end < start and panic the
+    // slice (bug-audit 2026-05-28, 2.2).
+    let end = xml[start..].find(&close)? + start;
     Some(xml[start..end].to_string())
 }
 
@@ -2712,3 +2715,33 @@ pub(crate) fn check_object_lock_for_overwrite(
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod extract_xml_value_tests {
+    use super::extract_xml_value;
+
+    #[test]
+    fn returns_inner_value() {
+        assert_eq!(
+            extract_xml_value("<Root><Key>value</Key></Root>", "Key"),
+            Some("value".to_string())
+        );
+    }
+
+    #[test]
+    fn missing_tag_is_none() {
+        assert_eq!(extract_xml_value("<Root></Root>", "Key"), None);
+    }
+
+    // bug-audit 2026-05-28, 2.2: a closing tag before the opening one used to
+    // slice with end < start and panic; must return None instead.
+    #[test]
+    fn close_before_open_does_not_panic() {
+        assert_eq!(extract_xml_value("</Key>oops<Key>value", "Key"), None);
+    }
+
+    #[test]
+    fn open_without_close_is_none() {
+        assert_eq!(extract_xml_value("<Key>value", "Key"), None);
+    }
+}


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 2 panics (2.1, 2.2, 2.3):

- **2.1** — S3 GetObject echoed a client-supplied SSE-KMS key id via `HeaderValue::parse().unwrap()`; an invalid value panicked the worker. Now skips the header when it isn't a valid `HeaderValue` (3 sites in `objects/read.rs`).
- **2.2** — `extract_xml_value` sliced `xml[start..end]` where `end` could precede `start` when a closing tag appeared before the opening one. Now searches the closing tag *after* the opening offset so `end >= start`, else returns `None`.
- **2.3** — the dispatch success-path response-header loop used `HeaderName`/`HeaderValue` `.expect()`; a metadata value echoing arbitrary client input panicked. Now skips invalid headers.

## Test plan
`cargo clippy -p fakecloud-s3 -p fakecloud-core --all-targets -- -D warnings` + `cargo test -p fakecloud-s3 -p fakecloud-core --lib` green; new `extract_xml_value` tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents panics from malformed client input by skipping invalid headers and making XML parsing robust in `fakecloud-s3` (and related `fakecloud-core` paths). This hardens S3 GetObject and response header handling to avoid worker crashes.

- Bug Fixes
  - S3 GetObject: ignore invalid SSE-KMS key ID headers instead of `.unwrap()`.
  - Response path: skip headers that fail to parse; remove `.expect()` panics.
  - XML: `extract_xml_value` now searches the closing tag after the opening; returns None on malformed order. Added targeted tests.

<sup>Written for commit 3a626d4e4b2e8e9d07ceda06b7acb35bd4088ce1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

