### PR TITLE
fix(stepfunctions): StartSyncExecution mints unique execution ARNs

### DIFF
--- a/crates/fakecloud-e2e/tests/sfn_sync.rs
+++ b/crates/fakecloud-e2e/tests/sfn_sync.rs
@@ -286,3 +286,51 @@ async fn sfn_sync_ecs_run_task_waits_for_stopped() {
         desc.cause(),
     );
 }
+
+// bug-audit 2026-05-28, 4.2: StartSyncExecution must mint a unique execution
+// ARN per call. It used a millisecond timestamp, so concurrent Express starts
+// in the same millisecond produced identical ARNs and overwrote each other.
+#[tokio::test]
+async fn sfn_sync_concurrent_executions_get_unique_arns() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+
+    let definition = json!({
+        "StartAt": "Done",
+        "States": { "Done": { "Type": "Pass", "End": true } }
+    });
+
+    let created = sfn
+        .create_state_machine()
+        .name("express-unique-arns")
+        .definition(definition.to_string())
+        .role_arn("arn:aws:iam::123456789012:role/sfn-role")
+        .r#type(aws_sdk_sfn::types::StateMachineType::Express)
+        .send()
+        .await
+        .unwrap();
+    let sm_arn = created.state_machine_arn().to_string();
+
+    // Fire many sync executions concurrently; every ARN must be distinct.
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let sfn = sfn.clone();
+        let sm_arn = sm_arn.clone();
+        handles.push(tokio::spawn(async move {
+            sfn.start_sync_execution()
+                .state_machine_arn(sm_arn)
+                .input("{}")
+                .send()
+                .await
+                .unwrap()
+                .execution_arn()
+                .to_string()
+        }));
+    }
+
+    let mut arns = std::collections::HashSet::new();
+    for h in handles {
+        arns.insert(h.await.unwrap());
+    }
+    assert_eq!(arns.len(), 16, "every sync execution must get a unique ARN");
+}

--- a/crates/fakecloud-stepfunctions/src/service/executions.rs
+++ b/crates/fakecloud-stepfunctions/src/service/executions.rs
@@ -340,11 +340,21 @@ impl StepFunctionsService {
                 ));
             }
             let now = chrono::Utc::now();
-            let exec_name = format!("sync-{}", now.timestamp_millis());
-            let exec_arn = format!(
-                "arn:aws:states:{}:{}:express:{}:{}",
-                state.region, state.account_id, sm.name, exec_name
-            );
+            // Mint a unique execution name with a UUID rather than a
+            // millisecond timestamp: Express workflows start concurrently, so a
+            // ms-resolution name collides and same-ms starts overwrote each
+            // other (bug-audit 2026-05-28, 4.2). Loop on the (vanishingly
+            // unlikely) UUID collision, mirroring the async StartExecution path.
+            let (exec_name, exec_arn) = loop {
+                let candidate = format!("sync-{}", uuid::Uuid::new_v4());
+                let arn = format!(
+                    "arn:aws:states:{}:{}:express:{}:{}",
+                    state.region, state.account_id, sm.name, candidate
+                );
+                if !state.executions.contains_key(&arn) {
+                    break (candidate, arn);
+                }
+            };
             let execution = Execution {
                 execution_arn: exec_arn.clone(),
                 state_machine_arn: sm_arn.clone(),


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 4, bug **4.2**. `StartSyncExecution` built the execution name from a millisecond timestamp (`format!("sync-{}", now.timestamp_millis())`) with no dedup, so concurrent Express-workflow starts within the same millisecond produced identical ARNs and overwrote each other.

Now the name is minted from a UUID with a collision check against existing executions, mirroring the async `StartExecution` path.

## Test plan
`cargo clippy -p fakecloud-stepfunctions --all-targets -- -D warnings` green; new e2e `sfn_sync_concurrent_executions_get_unique_arns` (16 concurrent sync starts yield 16 distinct ARNs).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
StartSyncExecution now mints unique execution ARNs to prevent collisions during concurrent Express workflow starts. Switched from millisecond timestamp names to UUIDs with a collision check (mirrors async StartExecution) in `fakecloud-stepfunctions`, and added an e2e test in `fakecloud-e2e` verifying 16 concurrent sync starts produce 16 distinct ARNs.

<sup>Written for commit 408bfc49bbeffcb4eb0d3dce1a5209f11345a907. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

