### PR TITLE
fix(core): handle new SigV4Error presigned variants in dispatch match (unbreak build)

### DIFF
--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -334,6 +334,24 @@ pub async fn dispatch(
                     detected.protocol,
                 );
             }
+            Err(fakecloud_aws::sigv4::SigV4Error::PresignedUrlExpired { .. }) => {
+                return build_error_response(
+                    StatusCode::FORBIDDEN,
+                    "AccessDenied",
+                    "Request has expired",
+                    &request_id,
+                    detected.protocol,
+                );
+            }
+            Err(fakecloud_aws::sigv4::SigV4Error::InvalidPresignExpires(_)) => {
+                return build_error_response(
+                    StatusCode::BAD_REQUEST,
+                    "AuthorizationQueryParametersError",
+                    "X-Amz-Expires must be a number between 1 and 604800 seconds",
+                    &request_id,
+                    detected.protocol,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
**Build fix — main currently fails to compile.** PR #1577 (sigv4 5.2) added `SigV4Error::PresignedUrlExpired` and `SigV4Error::InvalidPresignExpires`, but the SigV4 verification `match` in `crates/fakecloud-core/src/dispatch.rs` is exhaustive (no catch-all) and was not updated, so `fakecloud-core` fails with `E0004` non-exhaustive patterns.

Adds the two missing arms:
- `PresignedUrlExpired` -> 403 `AccessDenied` "Request has expired"
- `InvalidPresignExpires` -> 400 `AuthorizationQueryParametersError`

## Test plan
`cargo build --workspace` + `cargo clippy -p fakecloud-core --all-targets -- -D warnings` green (both fail on main without this).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compile error in `fakecloud-core` by handling new `SigV4Error` presigned variants in the dispatch verification match. Adds explicit arms to return correct AWS-style responses for expired or invalid presigned requests.

- **Bug Fixes**
  - Map `SigV4Error::PresignedUrlExpired` to 403 `AccessDenied` with "Request has expired".
  - Map `SigV4Error::InvalidPresignExpires` to 400 `AuthorizationQueryParametersError` with "X-Amz-Expires must be a number between 1 and 604800 seconds".

<sup>Written for commit 31d81bc6dba5d32eadcdd84b1e486a556882e94a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

