### PR TITLE
fix(sts): AssumeRole on a non-existent role is denied

### DIFF
--- a/crates/fakecloud-e2e/tests/sts.rs
+++ b/crates/fakecloud-e2e/tests/sts.rs
@@ -1,0 +1,33 @@
+// bug-audit 2026-05-28, 5.4: AssumeRole targeting a role that does not exist
+// must be denied, not silently minted credentials.
+#[tokio::test]
+async fn sts_assume_role_nonexistent_role_is_denied() {
+    let server = TestServer::start().await;
+    let endpoint = server.endpoint();
+
+    let config = aws_sdk_sts::Config::builder()
+        .behavior_version(BehaviorVersion::latest())
+        .region(Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(
+            "AKIAIOSFODNN7EXAMPLE",
+            "secret",
+            None,
+            None,
+            "test",
+        ))
+        .endpoint_url(endpoint)
+        .build();
+    let sts = aws_sdk_sts::Client::from_conf(config);
+    let err = sts
+        .assume_role()
+        .role_arn("arn:aws:iam::123456789012:role/this-role-does-not-exist-5p4")
+        .role_session_name("session")
+        .send()
+        .await
+        .expect_err("assuming a non-existent role must be denied");
+    let code = match &err {
+        SdkError::ServiceError(e) => e.err().meta().code().map(str::to_string),
+        _ => None,
+    };
+    assert_eq!(code.as_deref(), Some("AccessDenied"), "err: {err:?}");
+}

--- a/crates/fakecloud-iam/src/sts_service/assume.rs
+++ b/crates/fakecloud-iam/src/sts_service/assume.rs
@@ -208,6 +208,23 @@ impl StsService {
                     ));
                 }
             }
+        } else {
+            // AssumeRole against a role that does not exist must be denied
+            // rather than fall through to credential minting with no trust
+            // check (bug-audit 2026-05-28, 5.4). AWS returns AccessDenied for
+            // sts:AssumeRole on a role it cannot resolve.
+            let caller_arn = req
+                .principal
+                .as_ref()
+                .map(|p| p.arn.clone())
+                .unwrap_or_else(|| Arn::global("iam", &req.account_id, "root").to_string());
+            return Err(AwsServiceError::aws_error(
+                StatusCode::FORBIDDEN,
+                "AccessDenied",
+                format!(
+                    "User: {caller_arn} is not authorized to perform: sts:AssumeRole on resource: {role_arn}"
+                ),
+            ));
         }
 
         let role_id = target_state


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 5, bug **5.4**. The trust-policy gate only ran inside `if let Some(role)`, so an `AssumeRole` call naming a role that does not exist fell through to unconditional credential minting with no trust check. Added an `else` branch returning `AccessDenied`, matching AWS.

(Only observable with `--iam` enabled; off by default by design.)

## Test plan
`cargo build -p fakecloud-iam` green; new e2e `assume_role_nonexistent_role_is_denied` (tests/sts.rs) passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix STS AssumeRole to deny non-existent roles with AccessDenied and avoid minting credentials without a trust-policy check, matching AWS. Added e2e test `sts_assume_role_nonexistent_role_is_denied` to cover this case.

<sup>Written for commit 707d085f58c3e66b4e4883000c8e9e33c676498e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

