### PR TITLE
fix(dynamodb): persist un-consumed stream change records across restart

### DIFF
--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -9,6 +9,28 @@ fn empty_stream_records() -> Arc<RwLock<Vec<StreamRecord>>> {
     Arc::new(RwLock::new(Vec::new()))
 }
 
+/// Serde for `Arc<RwLock<Vec<StreamRecord>>>`: persist the inner change records
+/// so a stream consumer's un-read records survive a snapshot restart
+/// (bug-audit 2026-05-28, 4.5). The field was `#[serde(skip)]`, so table data
+/// was preserved across restart but pending stream records silently vanished.
+mod stream_records_serde {
+    use super::{Arc, RwLock, StreamRecord};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        v: &Arc<RwLock<Vec<StreamRecord>>>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        v.read().serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Arc<RwLock<Vec<StreamRecord>>>, D::Error> {
+        Ok(Arc::new(RwLock::new(Vec::<StreamRecord>::deserialize(d)?)))
+    }
+}
+
 /// A single DynamoDB attribute value (tagged union matching the AWS wire format).
 /// AWS sends attribute values as `{"S": "hello"}`, `{"N": "42"}`, etc.
 pub type AttributeValue = Value;
@@ -108,7 +130,7 @@ pub struct DynamoTable {
     pub stream_arn: Option<String>,
     /// Stream records (retained for 24 hours). Not persisted: stream
     /// records are ephemeral and would be garbage anyway across restarts.
-    #[serde(skip, default = "empty_stream_records")]
+    #[serde(with = "stream_records_serde", default = "empty_stream_records")]
     pub stream_records: Arc<RwLock<Vec<StreamRecord>>>,
     /// Server-side encryption type: AES256 (owned) or KMS
     pub sse_type: Option<String>,

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -155,20 +155,25 @@ mod tests {
     #[test]
     fn stream_records_persist_across_serde() {
         let table = make_stream_table();
-        table.stream_records.write().push(StreamRecord {
-            event_id: "e1".to_string(),
-            event_name: "INSERT".to_string(),
-            sequence_number: "100".to_string(),
-            keys: std::collections::BTreeMap::new(),
-            old_image: None,
-            new_image: None,
-            stream_view_type: "NEW_AND_OLD_IMAGES".to_string(),
-            event_source_region: "eu-west-1".to_string(),
-        });
+        let mut keys = HashMap::new();
+        keys.insert("pk".to_string(), json!({"S": "user1"}));
+        let record = generate_stream_record(
+            &table,
+            "INSERT",
+            keys,
+            None,
+            Some(HashMap::from([("pk".to_string(), json!({"S": "user1"}))])),
+            "eu-west-1",
+        )
+        .expect("stream record should be generated");
+        let want_event_id = record.event_id.clone();
+        table.stream_records.write().push(record);
+
         let json = serde_json::to_string(&table).unwrap();
         let restored: DynamoTable = serde_json::from_str(&json).unwrap();
         let recs = restored.stream_records.read();
         assert_eq!(recs.len(), 1, "pending stream record must survive restart");
-        assert_eq!(recs[0].event_id, "e1");
+        assert_eq!(recs[0].event_id, want_event_id);
+        assert_eq!(recs[0].event_name, "INSERT");
     }
 }

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -148,4 +148,27 @@ mod tests {
             "stream record must use the configured region, not a hardcoded value"
         );
     }
+
+    // bug-audit 2026-05-28, 4.5: un-consumed stream change records must survive a
+    // serialize/deserialize (snapshot restart) cycle; they used to be
+    // #[serde(skip)] and silently vanished.
+    #[test]
+    fn stream_records_persist_across_serde() {
+        let table = make_stream_table();
+        table.stream_records.write().push(StreamRecord {
+            event_id: "e1".to_string(),
+            event_name: "INSERT".to_string(),
+            sequence_number: "100".to_string(),
+            keys: std::collections::BTreeMap::new(),
+            old_image: None,
+            new_image: None,
+            stream_view_type: "NEW_AND_OLD_IMAGES".to_string(),
+            event_source_region: "eu-west-1".to_string(),
+        });
+        let json = serde_json::to_string(&table).unwrap();
+        let restored: DynamoTable = serde_json::from_str(&json).unwrap();
+        let recs = restored.stream_records.read();
+        assert_eq!(recs.len(), 1, "pending stream record must survive restart");
+        assert_eq!(recs[0].event_id, "e1");
+    }
 }


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 4, bug **4.5**. `DynamoTable.stream_records` (`Arc<RwLock<Vec<StreamRecord>>>`) was `#[serde(skip)]`, so table data survived a snapshot restart but any change records a stream consumer had not yet read silently vanished.

Add a serde helper module that persists the inner `Vec<StreamRecord>` through the `Arc<RwLock<..>>` so pending stream records survive reload.

## Test plan
`cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings` + `cargo test -p fakecloud-dynamodb --lib` green; new `stream_records_persist_across_serde` round-trips a table with a pending record and asserts it survives.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist unconsumed DynamoDB stream change records across snapshot restarts in `fakecloud-dynamodb` (bug-audit 2026-05-28, 4.5). Introduces serde for `Arc<RwLock<Vec<StreamRecord>>>` so pending records survive reload.

- **Bug Fixes**
  - Persist `DynamoTable.stream_records` via a serde helper (replaces `#[serde(skip)]`).
  - Added `stream_records_persist_across_serde` test using `generate_stream_record` to verify round-trip persistence.

<sup>Written for commit 3acf609d847300d189e1ca6a4a95e9bc6758e313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

