### PR TITLE
fix: unbreak main (CFN SnsTopic fifo_sequence + e2e fifo_dedup harness)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
@@ -44,6 +44,7 @@ impl ResourceProvisioner {
             is_fifo: topic_name.ends_with(".fifo"),
             created_at: Utc::now(),
             subscriptions_deleted: 0,
+            fifo_sequence: 0,
         };
 
         state.topics.insert(topic_arn.clone(), topic);

--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -1673,8 +1673,19 @@ async fn sqs_encryption_defaults_and_mode_switch() {
 // MessageId + SequenceNumber instead of minting new ones / advancing the seq.
 #[tokio::test]
 async fn fifo_dedup_replays_original_id_and_sequence() {
-    let client = sqs_client().await;
-    let queue_url = create_fifo_queue(&client, "dedup-replay.fifo").await;
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let queue_url = client
+        .create_queue()
+        .queue_name("dedup-replay.fifo")
+        .attributes(QueueAttributeName::FifoQueue, "true")
+        .attributes(QueueAttributeName::ContentBasedDeduplication, "false")
+        .send()
+        .await
+        .expect("create fifo queue")
+        .queue_url()
+        .unwrap()
+        .to_string();
 
     let first = client
         .send_message()


### PR DESCRIPTION
## Summary
**main is currently build-broken in two places**; this restores it.

1. The SNS FIFO `SequenceNumber` work added a required `fifo_sequence: u64` field to `SnsTopic`, but the CloudFormation resource provisioner's `SnsTopic` initializer (`resource_provisioner/sns.rs:39`) was not updated, so `fakecloud-cloudformation` (and the `fakecloud` binary) fail to compile with E0063.
2. The merged 1.13 SQS test (`fifo_dedup_replays_original_id_and_sequence`) referenced nonexistent `sqs_client()`/`create_fifo_queue()` helpers and left placeholder bindings, so `fakecloud-e2e` failed to compile (`test`/`clippy` red).

Fix 1: initialize `fifo_sequence: 0` for CFN-created topics. Fix 2: rewrite the test to use the real `TestServer` + `server.sqs_client()` harness and create the FIFO queue inline.

## Test plan
`cargo build -p fakecloud` + `cargo clippy --workspace --all-targets -- -D warnings` green (RC=0); `fifo_dedup_replays_original_id_and_sequence` passes.