### PR TITLE
fix(persistence): unique temp file name for atomic writes

### DIFF
--- a/crates/fakecloud-persistence/src/atomic.rs
+++ b/crates/fakecloud-persistence/src/atomic.rs
@@ -139,6 +139,40 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), b"hello world");
     }
 
+    // bug-audit 2026-05-28, 4.1: many concurrent writers to one path must never
+    // produce a corrupt (interleaved) file. With a fixed `.tmp` suffix they
+    // raced on the same temp file; unique temp names + the atomic rename
+    // guarantee the final file equals exactly one writer's payload.
+    #[test]
+    fn concurrent_writes_never_corrupt() {
+        use std::sync::Arc;
+        let dir = tempdir().unwrap();
+        let path = Arc::new(dir.path().join("snap.bin"));
+        let payloads: Vec<Vec<u8>> = (0..16).map(|i| vec![b'A' + i as u8; 8192]).collect();
+        let handles: Vec<_> = payloads
+            .iter()
+            .cloned()
+            .map(|p| {
+                let path = Arc::clone(&path);
+                std::thread::spawn(move || write_atomic_bytes(&path, &p).unwrap())
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        let got = std::fs::read(&*path).unwrap();
+        assert!(
+            payloads.contains(&got),
+            "persisted file is not any single writer's payload (corrupt interleave)"
+        );
+        let leftover: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(leftover.is_empty(), "leftover temp files: {leftover:?}");
+    }
+
     #[test]
     fn write_atomic_bytes_overwrites() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/fakecloud-persistence/src/atomic.rs
+++ b/crates/fakecloud-persistence/src/atomic.rs
@@ -5,8 +5,18 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 
 fn tmp_path(path: &Path) -> PathBuf {
+    // Unique temp name per write. A fixed `<path>.tmp` let two concurrent
+    // writers to the same path (e.g. the KMS snapshot_lock-guarded save and the
+    // lock-free auto-provision snapshot hook firing from another worker)
+    // truncate+write the SAME temp file and interleave their bytes, producing a
+    // corrupt blob that fails to parse on restart -> KMS keys + all ciphertext
+    // permanently lost (bug-audit 2026-05-28, 4.1). A process id + monotonic
+    // counter make every in-flight temp distinct; the rename stays atomic.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
     let mut os = path.as_os_str().to_owned();
-    os.push(".tmp");
+    os.push(format!(".{}.{}.tmp", std::process::id(), seq));
     PathBuf::from(os)
 }
 


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 4, bug **4.1** (CRITICAL). `tmp_path` returned a fixed `<path>.tmp`, so two concurrent writers to the same path — e.g. the KMS `snapshot_lock`-guarded save and the lock-free auto-provision snapshot hook firing from another worker — truncate+write the **same** temp file and interleave their bytes, producing a corrupt blob that fails to parse on restart. On reload KMS then starts empty, making every key and all ciphertext written before the restart permanently undecryptable (SSE-KMS for SQS/SNS/S3/Secrets).

Make `tmp_path` unique per write (process id + monotonic counter) before the atomic rename. Fixes every `write_atomic_*` caller at once, no shared lock required.

## Test plan
`cargo clippy -p fakecloud-persistence --all-targets -- -D warnings` + `cargo test -p fakecloud-persistence --lib` green; new `concurrent_writes_never_corrupt`: 16 concurrent writers to one path yield a file equal to exactly one writer's payload with no leftover temp files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make atomic writes in `fakecloud-persistence` use a unique temp filename per write, then atomically rename. Prevents concurrent writers from clobbering the same temp file and corrupting KMS snapshots, avoiding data loss on restart.

- **Bug Fixes**
  - `tmp_path` now returns a per-write temp path (`<path>.<pid>.<seq>.tmp`), covering all `write_atomic_*` callers.
  - Added `concurrent_writes_never_corrupt` test (16 concurrent writers) to ensure the final file matches exactly one payload with no leftover `.tmp` files.

<sup>Written for commit 604610fd9fa0e5740f2ad407bb923ca10934c03f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

