### PR TITLE
fix(sqs): restart-orphaned message-move tasks no longer block new moves

### DIFF
--- a/crates/fakecloud-sqs/src/service/moves.rs
+++ b/crates/fakecloud-sqs/src/service/moves.rs
@@ -352,3 +352,12 @@ impl SqsService {
         ))
     }
 }
+
+/// A persisted move task blocks a new StartMessageMoveTask for its source queue
+/// only if it is RUNNING AND driven by the current process. A RUNNING task with
+/// a different `driver_pid` was orphaned by a restart (its driver task is never
+/// re-spawned on load) and must not block new moves forever
+/// (bug-audit 2026-05-28, 4.6).
+fn task_blocks_new_move(task: &MessageMoveTask, source_arn: &str, pid: u32) -> bool {
+    task.source_arn == source_arn && task.status == "RUNNING" && task.driver_pid == pid
+}

--- a/crates/fakecloud-sqs/src/service/moves.rs
+++ b/crates/fakecloud-sqs/src/service/moves.rs
@@ -361,3 +361,48 @@ impl SqsService {
 fn task_blocks_new_move(task: &MessageMoveTask, source_arn: &str, pid: u32) -> bool {
     task.source_arn == source_arn && task.status == "RUNNING" && task.driver_pid == pid
 }
+
+#[cfg(test)]
+mod move_zombie_tests {
+    use super::task_blocks_new_move;
+    use crate::state::MessageMoveTask;
+
+    const ARN: &str = "arn:aws:sqs:us-east-1:000000000000:dlq";
+
+    fn running_task(pid: u32) -> MessageMoveTask {
+        MessageMoveTask {
+            task_handle: "h".to_string(),
+            source_arn: ARN.to_string(),
+            destination_arn: None,
+            max_number_of_messages_per_second: None,
+            approximate_number_of_messages_moved: 0,
+            approximate_number_of_messages_to_move: 0,
+            status: "RUNNING".to_string(),
+            started_at: 0,
+            failure_reason: None,
+            driver_pid: pid,
+        }
+    }
+
+    #[test]
+    fn stale_pid_running_task_does_not_block() {
+        assert!(!task_blocks_new_move(
+            &running_task(0),
+            ARN,
+            std::process::id()
+        ));
+    }
+
+    #[test]
+    fn current_pid_running_task_blocks() {
+        let pid = std::process::id();
+        assert!(task_blocks_new_move(&running_task(pid), ARN, pid));
+    }
+
+    #[test]
+    fn completed_task_does_not_block() {
+        let mut t = running_task(std::process::id());
+        t.status = "COMPLETED".to_string();
+        assert!(!task_blocks_new_move(&t, ARN, std::process::id()));
+    }
+}


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 4, bug **4.6**. `MessageMoveTask` is persisted with status `RUNNING` but `run_message_move_task` is never re-spawned on load, so after a restart the in-memory driver is gone yet `active_move_task_exists` still sees a `RUNNING` task and rejects every new `StartMessageMoveTask` for that queue forever.

Stamp each task with the driving worker's process id (`driver_pid`). A `RUNNING` task whose `driver_pid` is not the current process was orphaned by a restart and no longer counts as active (predicate extracted to `task_blocks_new_move`). Tasks persisted before this field default `driver_pid` to 0 and are treated as stale.

## Test plan
`cargo clippy -p fakecloud-sqs --all-targets -- -D warnings` + `cargo test -p fakecloud-sqs --lib` green; new unit tests: stale-pid RUNNING does not block, current-pid RUNNING blocks, COMPLETED does not block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent restart-orphaned SQS message-move tasks from blocking new moves by tracking the worker PID and ignoring stale RUNNING tasks. Ensures new moves can start after a process restarts.

- **Bug Fixes**
  - Persist `driver_pid` on `MessageMoveTask` and only block when PID matches the current process.
  - Extracted predicate `task_blocks_new_move` for clear, testable logic.
  - Pre-existing tasks default `driver_pid` to 0 and are treated as stale (do not block).
  - Added unit tests for stale PID, current PID, and completed-task cases.

<sup>Written for commit b7643d9db0672c745c9ac96fa272651ec648dd71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

