### PR TITLE
fix(sqs): unbreak build — complete driver_pid for restart-orphaned move tasks (#1583 follow-up)

### DIFF
--- a/crates/fakecloud-sqs/src/service/moves.rs
+++ b/crates/fakecloud-sqs/src/service/moves.rs
@@ -163,6 +163,7 @@ impl SqsService {
                 messages_to_move: total,
                 started_timestamp: Utc::now().timestamp_millis(),
                 failure_reason: None,
+                driver_pid: std::process::id(),
                 cancel_flag: Arc::new(AtomicBool::new(false)),
             });
             return Ok(sqs_response(
@@ -187,6 +188,7 @@ impl SqsService {
             messages_to_move: total,
             started_timestamp: Utc::now().timestamp_millis(),
             failure_reason: None,
+            driver_pid: std::process::id(),
             cancel_flag: cancel_flag.clone(),
         });
         drop(accounts);
@@ -359,13 +361,17 @@ impl SqsService {
 /// re-spawned on load) and must not block new moves forever
 /// (bug-audit 2026-05-28, 4.6).
 fn task_blocks_new_move(task: &MessageMoveTask, source_arn: &str, pid: u32) -> bool {
-    task.source_arn == source_arn && task.status == "RUNNING" && task.driver_pid == pid
+    task.source_arn == source_arn
+        && task.status == MessageMoveTaskStatus::Running
+        && task.driver_pid == pid
 }
 
 #[cfg(test)]
 mod move_zombie_tests {
     use super::task_blocks_new_move;
-    use crate::state::MessageMoveTask;
+    use crate::state::{MessageMoveTask, MessageMoveTaskStatus};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
 
     const ARN: &str = "arn:aws:sqs:us-east-1:000000000000:dlq";
 
@@ -374,13 +380,14 @@ mod move_zombie_tests {
             task_handle: "h".to_string(),
             source_arn: ARN.to_string(),
             destination_arn: None,
-            max_number_of_messages_per_second: None,
-            approximate_number_of_messages_moved: 0,
-            approximate_number_of_messages_to_move: 0,
-            status: "RUNNING".to_string(),
-            started_at: 0,
+            max_messages_per_second: None,
+            status: MessageMoveTaskStatus::Running,
+            messages_moved: 0,
+            messages_to_move: 0,
+            started_timestamp: 0,
             failure_reason: None,
             driver_pid: pid,
+            cancel_flag: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -402,7 +409,7 @@ mod move_zombie_tests {
     #[test]
     fn completed_task_does_not_block() {
         let mut t = running_task(std::process::id());
-        t.status = "COMPLETED".to_string();
+        t.status = MessageMoveTaskStatus::Completed;
         assert!(!task_blocks_new_move(&t, ARN, std::process::id()));
     }
 }

--- a/crates/fakecloud-sqs/src/service/moves.rs
+++ b/crates/fakecloud-sqs/src/service/moves.rs
@@ -80,17 +80,18 @@ impl SqsService {
             }
         }
 
-        // Reject if there's already an active task for this source —
-        // RUNNING or CANCELLING. CANCELLING is still actively moving
-        // (or finishing the in-flight batch), so a second task starting
-        // alongside it would double-drain the source queue.
-        if state.message_move_tasks.iter().any(|t| {
-            t.source_arn == source_arn
-                && matches!(
-                    t.status,
-                    MessageMoveTaskStatus::Running | MessageMoveTaskStatus::Cancelling
-                )
-        }) {
+        // Reject if there's already an active task for this source — RUNNING or
+        // CANCELLING, driven by the current process. CANCELLING is still
+        // actively moving (or finishing the in-flight batch), so a second task
+        // starting alongside it would double-drain the source queue. A task left
+        // by a previous process (driver_pid mismatch) was orphaned by a restart
+        // and must not block forever (bug-audit 2026-05-28, 4.6).
+        let pid = std::process::id();
+        if state
+            .message_move_tasks
+            .iter()
+            .any(|t| task_blocks_new_move(t, &source_arn, pid))
+        {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "AWS.SimpleQueueService.UnsupportedOperation",
@@ -356,13 +357,16 @@ impl SqsService {
 }
 
 /// A persisted move task blocks a new StartMessageMoveTask for its source queue
-/// only if it is RUNNING AND driven by the current process. A RUNNING task with
-/// a different `driver_pid` was orphaned by a restart (its driver task is never
-/// re-spawned on load) and must not block new moves forever
-/// (bug-audit 2026-05-28, 4.6).
+/// only if it is actively draining (RUNNING or CANCELLING) AND driven by the
+/// current process. A task with a different `driver_pid` was orphaned by a
+/// restart (its driver task is never re-spawned on load) and must not block new
+/// moves forever (bug-audit 2026-05-28, 4.6).
 fn task_blocks_new_move(task: &MessageMoveTask, source_arn: &str, pid: u32) -> bool {
     task.source_arn == source_arn
-        && task.status == MessageMoveTaskStatus::Running
+        && matches!(
+            task.status,
+            MessageMoveTaskStatus::Running | MessageMoveTaskStatus::Cancelling
+        )
         && task.driver_pid == pid
 }
 
@@ -410,6 +414,22 @@ mod move_zombie_tests {
     fn completed_task_does_not_block() {
         let mut t = running_task(std::process::id());
         t.status = MessageMoveTaskStatus::Completed;
+        assert!(!task_blocks_new_move(&t, ARN, std::process::id()));
+    }
+
+    #[test]
+    fn current_pid_cancelling_task_blocks() {
+        // A Cancelling task is still draining the source, so a second move
+        // would double-drain — it must block (bug-audit 2026-05-28, 4.6).
+        let mut t = running_task(std::process::id());
+        t.status = MessageMoveTaskStatus::Cancelling;
+        assert!(task_blocks_new_move(&t, ARN, std::process::id()));
+    }
+
+    #[test]
+    fn stale_pid_cancelling_task_does_not_block() {
+        let mut t = running_task(0);
+        t.status = MessageMoveTaskStatus::Cancelling;
         assert!(!task_blocks_new_move(&t, ARN, std::process::id()));
     }
 }

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -2254,6 +2254,7 @@ fn start_message_move_task_blocks_concurrent_running() {
             messages_to_move: 0,
             started_timestamp: 0,
             failure_reason: None,
+            driver_pid: std::process::id(),
             cancel_flag: Arc::new(AtomicBool::new(false)),
         });
     }
@@ -2280,6 +2281,7 @@ fn cancel_message_move_task_cancels_running() {
             messages_to_move: 10,
             started_timestamp: 0,
             failure_reason: None,
+            driver_pid: std::process::id(),
             cancel_flag: Arc::new(AtomicBool::new(false)),
         });
     }
@@ -2315,6 +2317,7 @@ fn list_message_move_tasks_caps_at_max_and_excludes_running_handle() {
                 messages_to_move: 0,
                 started_timestamp: i,
                 failure_reason: None,
+                driver_pid: std::process::id(),
                 cancel_flag: Arc::new(AtomicBool::new(false)),
             });
         }

--- a/crates/fakecloud-sqs/src/state.rs
+++ b/crates/fakecloud-sqs/src/state.rs
@@ -109,6 +109,13 @@ pub struct MessageMoveTask {
     pub messages_to_move: u64,
     pub started_timestamp: i64,
     pub failure_reason: Option<String>,
+    /// Process id of the worker driving this task. A Running task whose pid is
+    /// not the current process was orphaned by a restart (the background mover
+    /// is never re-spawned on load), so it is treated as stale rather than
+    /// blocking new move tasks for the queue forever (bug-audit 2026-05-28,
+    /// 4.6). Defaults to 0 for tasks persisted before this field existed.
+    #[serde(default)]
+    pub driver_pid: u32,
     /// Set to `true` by `CancelMessageMoveTask` to request that the
     /// background mover stop after its current iteration. Not persisted
     /// — restored snapshots resume with a fresh flag in its default


### PR DESCRIPTION
## Summary
**main does not compile.** PR #1583 (bug-audit 2026-05-28, 4.6) merged with the move-zombie guard + tests appended to `service/moves.rs`, but the supporting `driver_pid` struct field was never added and the helper compared the `MessageMoveTaskStatus` enum against a `&str`. `cargo build -p fakecloud-sqs` fails with E0609 (`no field driver_pid`) and E0308 (enum vs `&str`).

This completes 4.6:
- add `#[serde(default)] driver_pid: u32` to `MessageMoveTask` (state.rs)
- set `driver_pid: std::process::id()` in both task literals
- derive `PartialEq/Eq/Copy` on `MessageMoveTaskStatus`; compare the enum (not a string) in `task_blocks_new_move`
- route the active-task guard through `task_blocks_new_move` so a `Running` task left by a previous process (orphaned by restart — the background mover is never re-spawned on load) no longer blocks new `StartMessageMoveTask` forever
- fix the unit-test builder to use the real field names + enum status

## Test plan
`cargo build -p fakecloud-sqs` Finished; `cargo test -p fakecloud-sqs --lib move_zombie_tests` 3 passed; `cargo clippy -p fakecloud-sqs --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes build errors in `fakecloud-sqs` and completes the restart-orphaned move task guard. Tracks driver PIDs and only blocks new moves for Running or Cancelling tasks from the current process.

- **Bug Fixes**
  - Added `#[serde(default)] driver_pid: u32` to `MessageMoveTask`; set to `std::process::id()` when creating tasks.
  - Derived `PartialEq/Eq/Copy` on `MessageMoveTaskStatus` and compare the enum in `task_blocks_new_move`.
  - Routed `StartMessageMoveTask` through `task_blocks_new_move` to block only for `Running`/`Cancelling` tasks with matching `driver_pid`; stale PIDs don’t block.
  - Added tests for `Cancelling` cases and updated all test literals (including `service_tests.rs`) to include `driver_pid`.

<sup>Written for commit 906e3f1e15abd61906bdca5fceeb1f3f05535528. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

