### PR TITLE
fix(lambda): persist + echo SourceAccessConfigurations on event source mappings

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda_event_source_mappings.rs
+++ b/crates/fakecloud-e2e/tests/lambda_event_source_mappings.rs
@@ -1,18 +1,60 @@
-// bug-audit 2026-05-28, 1.17: CreateEventSourceMapping must persist the caller's
-// SourceAccessConfigurations and echo them on Get, not always return [].
+//! E2E coverage for Lambda event-source-mapping SourceAccessConfigurations
+//! (bug-audit 2026-05-28, 1.17): CreateEventSourceMapping must persist the
+//! caller's SourceAccessConfigurations and echo them on Get, not always [].
+
+mod helpers;
+
+use aws_sdk_lambda::types::{SourceAccessConfiguration, SourceAccessType};
+use helpers::TestServer;
+
+const MINIMAL_HANDLER: &str = "index.handler";
+
+async fn create_function(lambda: &aws_sdk_lambda::Client, name: &str) -> String {
+    let zip = aws_sdk_lambda::primitives::Blob::new(minimal_zip());
+    lambda
+        .create_function()
+        .function_name(name)
+        .runtime(aws_sdk_lambda::types::Runtime::Provided)
+        .role("arn:aws:iam::000000000000:role/lambda-test-role")
+        .handler(MINIMAL_HANDLER)
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(zip)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .function_arn()
+        .unwrap()
+        .to_string()
+}
+
+fn minimal_zip() -> Vec<u8> {
+    use std::io::Write;
+    let mut buf = Vec::new();
+    {
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+        zip.start_file("index.sh", opts).unwrap();
+        zip.write_all(b"#!/bin/sh\necho hi\n").unwrap();
+        zip.finish().unwrap();
+    }
+    buf
+}
+
 #[tokio::test]
 async fn source_access_configurations_round_trip() {
-    use aws_sdk_lambda::types::{SourceAccessConfiguration, SourceAccessType};
     let server = TestServer::start().await;
-    let client = lambda_client(&server).await;
-    create_fn(&client, "esm-sac-fn").await;
+    let lambda = server.lambda_client().await;
+    create_function(&lambda, "esm-sac-fn").await;
 
     let sac = SourceAccessConfiguration::builder()
         .r#type(SourceAccessType::BasicAuth)
         .uri("arn:aws:secretsmanager:us-east-1:123456789012:secret:mq-creds")
         .build();
 
-    let create = client
+    let create = lambda
         .create_event_source_mapping()
         .function_name("esm-sac-fn")
         .event_source_arn("arn:aws:mq:us-east-1:123456789012:broker:b1")
@@ -28,7 +70,7 @@ async fn source_access_configurations_round_trip() {
         Some("arn:aws:secretsmanager:us-east-1:123456789012:secret:mq-creds")
     );
 
-    let got = client
+    let got = lambda
         .get_event_source_mapping()
         .uuid(&uuid)
         .send()

--- a/crates/fakecloud-e2e/tests/lambda_event_source_mappings.rs
+++ b/crates/fakecloud-e2e/tests/lambda_event_source_mappings.rs
@@ -1,0 +1,44 @@
+// bug-audit 2026-05-28, 1.17: CreateEventSourceMapping must persist the caller's
+// SourceAccessConfigurations and echo them on Get, not always return [].
+#[tokio::test]
+async fn source_access_configurations_round_trip() {
+    use aws_sdk_lambda::types::{SourceAccessConfiguration, SourceAccessType};
+    let server = TestServer::start().await;
+    let client = lambda_client(&server).await;
+    create_fn(&client, "esm-sac-fn").await;
+
+    let sac = SourceAccessConfiguration::builder()
+        .r#type(SourceAccessType::BasicAuth)
+        .uri("arn:aws:secretsmanager:us-east-1:123456789012:secret:mq-creds")
+        .build();
+
+    let create = client
+        .create_event_source_mapping()
+        .function_name("esm-sac-fn")
+        .event_source_arn("arn:aws:mq:us-east-1:123456789012:broker:b1")
+        .source_access_configurations(sac)
+        .send()
+        .await
+        .unwrap();
+    let uuid = create.uuid().unwrap().to_string();
+    let created = create.source_access_configurations();
+    assert_eq!(created.len(), 1, "create must echo the configuration");
+    assert_eq!(
+        created[0].uri(),
+        Some("arn:aws:secretsmanager:us-east-1:123456789012:secret:mq-creds")
+    );
+
+    let got = client
+        .get_event_source_mapping()
+        .uuid(&uuid)
+        .send()
+        .await
+        .unwrap();
+    let got_sac = got.source_access_configurations();
+    assert_eq!(
+        got_sac.len(),
+        1,
+        "get must return the persisted configuration"
+    );
+    assert_eq!(got_sac[0].r#type(), Some(&SourceAccessType::BasicAuth));
+}

--- a/crates/fakecloud-lambda/src/service_event_sources.rs
+++ b/crates/fakecloud-lambda/src/service_event_sources.rs
@@ -169,6 +169,14 @@ impl LambdaService {
                     .collect()
             })
             .unwrap_or_default();
+        // SourceAccessConfigurations (VPC/auth config for Kafka/MQ/MSK sources):
+        // persist what the caller sent so Get/List/Update echo it back rather
+        // than always returning [] (bug-audit 2026-05-28, 1.17).
+        let source_access_configurations: Vec<Value> = body
+            .get("SourceAccessConfigurations")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
 
         let mapping = EventSourceMapping {
             uuid: mapping_uuid.clone(),
@@ -197,6 +205,7 @@ impl LambdaService {
             tumbling_window_in_seconds,
             topics,
             queues,
+            source_access_configurations,
         };
 
         let response = self.event_source_mapping_json(&mapping);
@@ -295,7 +304,7 @@ impl LambdaService {
             "TumblingWindowInSeconds": mapping.tumbling_window_in_seconds.unwrap_or(0),
             "Topics": mapping.topics,
             "Queues": mapping.queues,
-            "SourceAccessConfigurations": [],
+            "SourceAccessConfigurations": mapping.source_access_configurations,
             "LastProcessingResult": "No records processed",
             "StateTransitionReason": "User action",
         });


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.17**. `CreateEventSourceMapping` dropped the caller's `SourceAccessConfigurations` and the response builder always emitted `[]`, so VPC/auth config for Kafka/MQ/MSK sources silently vanished.

- add `#[serde(default)] source_access_configurations: Vec<serde_json::Value>` to `EventSourceMapping`
- parse it on create, honor it on update
- echo the stored value on Create/Get/List/Update

## Test plan
`cargo build -p fakecloud-lambda --all-targets` + `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings` green; new e2e `source_access_configurations_round_trip` (passes) creates an ESM with a `SourceAccessConfiguration` and asserts it round-trips on Create and GetEventSourceMapping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Lambda event source mappings to persist and return `SourceAccessConfigurations`, so VPC/auth settings for Kafka/MQ/MSK no longer get lost. Applies to Create/Get/List/Update responses.

- **Bug Fixes**
  - Store `SourceAccessConfigurations` on create and honor on update in `fakecloud-lambda` (added defaulted field to `EventSourceMapping`).
  - Response builder now echoes stored configs instead of always returning `[]`.
  - Added `fakecloud-e2e` test `source_access_configurations_round_trip` using the standard harness; verifies create/get round-trip.

<sup>Written for commit 55745402815821c396a289739767e539315dc192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

