### PR TITLE
fix(elasticache): delete-during-create no longer resurrects cluster or orphans container

### DIFF
--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -3309,3 +3309,42 @@ async fn elasticache_modify_cache_parameter_group_applies_config_set() {
         "CONFIG SET not applied after retries. Last response: {last_response}"
     );
 }
+
+// bug-audit 2026-05-28, 4.3: deleting a cluster while it is still creating must
+// not leave an orphan or resurrect the cluster — a same-id re-create must work.
+#[tokio::test]
+async fn delete_during_create_does_not_orphan() {
+    let server = TestServer::start().await;
+    let client = ec_client(&server).await;
+    if skip_without_docker() {
+        return;
+    }
+
+    create_redis_cluster(&client, "race-redis").await;
+
+    // Delete immediately, while the background container start may still be in
+    // flight.
+    client
+        .delete_cache_cluster()
+        .cache_cluster_id("race-redis")
+        .send()
+        .await
+        .expect("delete cache cluster");
+
+    // Let the racing create-finish + delete-reap settle.
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    // The cluster must be gone (not resurrected to "available").
+    let desc = client
+        .describe_cache_clusters()
+        .cache_cluster_id("race-redis")
+        .send()
+        .await;
+    assert!(
+        desc.is_err(),
+        "deleted cluster must not be resurrected by the create-finish step"
+    );
+
+    // A same-id re-create must succeed.
+    create_redis_cluster(&client, "race-redis").await;
+}

--- a/crates/fakecloud-elasticache/src/service/clusters.rs
+++ b/crates/fakecloud-elasticache/src/service/clusters.rs
@@ -249,6 +249,27 @@ impl ElastiCacheService {
         {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
+            // If a DeleteCacheCluster arrived while we were starting the
+            // container (the lock-drop window above), do NOT resurrect the
+            // cluster. Drop the in-progress marker and reap the container we
+            // started (bug-audit 2026-05-28, 4.3). We still return the
+            // CreateCacheCluster response — the cluster existed momentarily and
+            // a follow-up Describe correctly shows it gone.
+            if state.take_cache_cluster_delete_request(&cache_cluster_id) {
+                state.cancel_cache_cluster_creation(&cache_cluster_id);
+                drop(accounts);
+                if let Some(ref runtime) = self.runtime {
+                    runtime.stop_container(&cache_cluster_id).await;
+                }
+                return Ok(AwsResponse::xml(
+                    StatusCode::OK,
+                    query_response_xml(
+                        "CreateCacheCluster",
+                        ELASTICACHE_NS,
+                        &format!("<CacheCluster>{xml}</CacheCluster>"),
+                    ),
+                ));
+            }
             let cluster_arn = cluster.arn.clone();
             state.finish_cache_cluster_creation(cluster.clone());
             // Initialise the tag bucket for this resource ARN, then merge any
@@ -340,33 +361,50 @@ impl ElastiCacheService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let cache_cluster_id = required_query_param(request, "CacheClusterId")?;
 
-        let cluster = {
+        // A delete that arrives while the cluster is still being created (in the
+        // lock-drop window of CreateCacheCluster, before the cluster is inserted)
+        // must not 404 and must not be silently undone by the create's finish
+        // step. Record the delete request so finish reaps the container instead
+        // of resurrecting the cluster (bug-audit 2026-05-28, 4.3).
+        let removed = {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
-            let cluster = state
-                .cache_clusters
-                .remove(&cache_cluster_id)
-                .ok_or_else(|| {
-                    AwsServiceError::aws_error(
-                        StatusCode::NOT_FOUND,
-                        "CacheClusterNotFound",
-                        format!("CacheCluster {cache_cluster_id} not found."),
-                    )
-                })?;
-            if let Some(ref group_id) = cluster.replication_group_id {
-                remove_cluster_from_replication_group(state, group_id, &cluster.cache_cluster_id);
+            if let Some(cluster) = state.cache_clusters.remove(&cache_cluster_id) {
+                if let Some(ref group_id) = cluster.replication_group_id {
+                    remove_cluster_from_replication_group(
+                        state,
+                        group_id,
+                        &cluster.cache_cluster_id,
+                    );
+                }
+                state.tags.remove(&cluster.arn);
+                Some(cluster)
+            } else if state.cache_cluster_creation_in_progress(&cache_cluster_id) {
+                state.request_cache_cluster_delete_during_creation(&cache_cluster_id);
+                None
+            } else {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "CacheClusterNotFound",
+                    format!("CacheCluster {cache_cluster_id} not found."),
+                ));
             }
-            state.tags.remove(&cluster.arn);
-            cluster
         };
 
         if let Some(ref runtime) = self.runtime {
             runtime.stop_container(&cache_cluster_id).await;
         }
 
-        let mut deleted_cluster = cluster;
-        deleted_cluster.cache_cluster_status = "deleting".to_string();
-        let xml = cache_cluster_xml(&deleted_cluster, true);
+        let xml = match removed {
+            Some(mut deleted_cluster) => {
+                deleted_cluster.cache_cluster_status = "deleting".to_string();
+                cache_cluster_xml(&deleted_cluster, true)
+            }
+            None => format!(
+                "<CacheClusterId>{cache_cluster_id}</CacheClusterId>\
+                 <CacheClusterStatus>deleting</CacheClusterStatus>"
+            ),
+        };
 
         Ok(AwsResponse::xml(
             StatusCode::OK,

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -570,6 +570,13 @@ pub struct ElastiCacheState {
     pub serverless_cache_snapshots: BTreeMap<String, ServerlessCacheSnapshot>,
     pub tags: BTreeMap<String, Vec<(String, String)>>,
     in_progress_cache_cluster_ids: HashSet<String>,
+    /// Cache cluster ids whose DeleteCacheCluster arrived while the cluster was
+    /// still being created (its container started during the lock-drop window of
+    /// CreateCacheCluster). The create's finish step consults this so it reaps
+    /// the container and does NOT resurrect the deleted cluster
+    /// (bug-audit 2026-05-28, 4.3).
+    #[serde(default)]
+    delete_requested_cache_clusters: HashSet<String>,
     in_progress_replication_group_ids: HashSet<String>,
     in_progress_serverless_cache_names: HashSet<String>,
     #[serde(default)]
@@ -612,6 +619,7 @@ impl ElastiCacheState {
             serverless_cache_snapshots: BTreeMap::new(),
             tags,
             in_progress_cache_cluster_ids: HashSet::new(),
+            delete_requested_cache_clusters: HashSet::new(),
             in_progress_replication_group_ids: HashSet::new(),
             in_progress_serverless_cache_names: HashSet::new(),
             security_groups: BTreeMap::new(),
@@ -673,6 +681,32 @@ impl ElastiCacheState {
 
     pub fn cancel_cache_cluster_creation(&mut self, cache_cluster_id: &str) {
         self.in_progress_cache_cluster_ids.remove(cache_cluster_id);
+    }
+
+    /// True if `id` is currently being created (in the lock-drop window of
+    /// CreateCacheCluster, before it is inserted into `cache_clusters`).
+    pub fn cache_cluster_creation_in_progress(&self, cache_cluster_id: &str) -> bool {
+        self.in_progress_cache_cluster_ids
+            .contains(cache_cluster_id)
+    }
+
+    /// Record that a DeleteCacheCluster arrived for `id` while it was still
+    /// being created. The create's finish step calls
+    /// [`take_cache_cluster_delete_request`] to detect this and reap the
+    /// container instead of resurrecting the deleted cluster
+    /// (bug-audit 2026-05-28, 4.3).
+    pub fn request_cache_cluster_delete_during_creation(&mut self, cache_cluster_id: &str) {
+        self.delete_requested_cache_clusters
+            .insert(cache_cluster_id.to_string());
+    }
+
+    /// Consume a pending delete request for `id` (set while it was creating).
+    /// Returns true if one was present, in which case the caller must drop the
+    /// in-progress marker and reap any started container without inserting the
+    /// cluster.
+    pub fn take_cache_cluster_delete_request(&mut self, cache_cluster_id: &str) -> bool {
+        self.delete_requested_cache_clusters
+            .remove(cache_cluster_id)
     }
 
     pub fn begin_replication_group_creation(&mut self, replication_group_id: &str) -> bool {


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 4, bug **4.3**. `CreateCacheCluster` sets an in-progress marker, drops the state lock to start the backing container (`ensure_redis`/`ensure_memcached` `.await`), then re-acquires the lock to insert the cluster. A `DeleteCacheCluster` arriving in that window found nothing in `cache_clusters` → returned a spurious 404, its `stop_container` matched no started container, and the create's finish step then inserted the cluster as `available` — **resurrecting the deleted cluster and orphaning its container**.

Fix: track delete-during-create requests.
- `DeleteCacheCluster`, when the id is still in-progress, records the request and returns a `deleting` response (not 404), and always calls `stop_container`.
- the create finish step consumes the request, drops the in-progress marker, reaps the container, and skips the insert — the cluster stays deleted.

## Test plan
`cargo build -p fakecloud-elasticache --all-targets` + `cargo clippy -p fakecloud-elasticache --all-targets -- -D warnings` green; `cargo test -p fakecloud-elasticache --lib` (2 new state unit tests pass); `cargo test -p fakecloud-e2e --test elasticache --no-run` compiles. New Docker-gated e2e `delete_during_create_does_not_orphan`: create → immediate delete → assert the cluster is gone and a same-id re-create succeeds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where deleting a cache cluster during creation could resurrect the cluster and leave its container running. We now record delete-during-create, stop the container, and skip inserting the cluster so it stays deleted.

- Bug Fixes
  - `DeleteCacheCluster`: when the id is still creating, record the delete, return a `deleting` response (not 404), and always call `stop_container`.
  - Create finish step: if a delete was recorded, drop the in-progress marker, reap the container, and do not insert the cluster (tracked via `delete_requested_cache_clusters` in `fakecloud-elasticache` state).
  - Tests: added state unit tests and a Docker e2e `delete_during_create_does_not_orphan` in `fakecloud-e2e`.

<sup>Written for commit e4b0e79eb3f65bb5d0bf4847651cf3fb9260b382. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

