### PR TITLE
fix(e2e): repair elasticache delete-during-create test to use real harness helpers

### DIFF
--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -3314,13 +3314,21 @@ async fn elasticache_modify_cache_parameter_group_applies_config_set() {
 // not leave an orphan or resurrect the cluster — a same-id re-create must work.
 #[tokio::test]
 async fn delete_during_create_does_not_orphan() {
-    let server = TestServer::start().await;
-    let client = ec_client(&server).await;
-    if skip_without_docker() {
+    if !require_docker_or_skip("elasticache_delete_during_create_does_not_orphan") {
         return;
     }
 
-    create_redis_cluster(&client, "race-redis").await;
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_cluster()
+        .cache_cluster_id("race-redis")
+        .cache_node_type("cache.t3.micro")
+        .preferred_availability_zone("us-east-1a")
+        .send()
+        .await
+        .unwrap();
 
     // Delete immediately, while the background container start may still be in
     // flight.
@@ -3346,5 +3354,12 @@ async fn delete_during_create_does_not_orphan() {
     );
 
     // A same-id re-create must succeed.
-    create_redis_cluster(&client, "race-redis").await;
+    client
+        .create_cache_cluster()
+        .cache_cluster_id("race-redis")
+        .cache_node_type("cache.t3.micro")
+        .preferred_availability_zone("us-east-1a")
+        .send()
+        .await
+        .expect("re-create with same id must succeed after delete-during-create");
 }


### PR DESCRIPTION
## Summary
PR #1586 (bug-audit 4.3) merged with the new `delete_during_create_does_not_orphan` e2e test referencing helpers that don't exist in `crates/fakecloud-e2e/tests/elasticache.rs` — `ec_client`, `skip_without_docker`, `create_redis_cluster` — so the `fakecloud-e2e` elasticache test binary fails to compile on main (the gating `test` check). The 4.3 **source** fix is correct and unaffected.

Rewrite the test against the file's real harness: `require_docker_or_skip(..)`, `server.elasticache_client()`, and inline `create_cache_cluster()` calls matching the existing tests.

## Test plan
`cargo test -p fakecloud-e2e --test elasticache --no-run` Finished (compiles); no remaining references to the undefined helpers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repair the ElastiCache e2e test to use the real harness, replacing undefined helpers. Restores compilation of the `fakecloud-e2e` ElastiCache test on main.

- **Bug Fixes**
  - Replaced `ec_client`, `skip_without_docker`, `create_redis_cluster` with `server.elasticache_client()`, `require_docker_or_skip(...)`, and inline `create_cache_cluster()` calls.
  - Keeps the delete-during-create flow and same-id re-create assertions intact while compiling.

<sup>Written for commit 037fdcbb95bcb0a8a76bbf88180ec050d057ad0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

