### PR TITLE
fix(scheduler): reject invalid pagination token with ValidationException (1.7)

### DIFF
--- a/crates/fakecloud-scheduler/src/service.rs
+++ b/crates/fakecloud-scheduler/src/service.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tokio::sync::Mutex as AsyncMutex;
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_persistence::SnapshotStore;
 
@@ -388,7 +388,8 @@ impl SchedulerService {
                 .then_with(|| a.name.cmp(&b.name))
         });
 
-        let (page, token) = paginate(&schedules, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&schedules, next_token.as_deref(), max_results)
+            .map_err(|_| validation("Invalid NextToken"))?;
         let summaries: Vec<Value> = page.iter().map(|s| schedule_summary_json(s)).collect();
 
         let mut out = json!({ "Schedules": summaries });
@@ -515,7 +516,8 @@ impl SchedulerService {
             .collect();
         groups.sort_by(|a, b| a.name.cmp(&b.name));
 
-        let (page, token) = paginate(&groups, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&groups, next_token.as_deref(), max_results)
+            .map_err(|_| validation("Invalid NextToken"))?;
         let summaries: Vec<Value> = page
             .iter()
             .map(|g| schedule_group_summary_json(g))
@@ -1519,6 +1521,38 @@ mod tests {
         let body = create_body("bad");
         let err = svc
             .handle(make_request(Method::POST, "/schedules/has%20space", &body))
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(err.code(), "ValidationException");
+    }
+
+    // bug-audit 2026-05-28, 1.7: a malformed NextToken must be rejected with
+    // ValidationException, not silently treated as the first page.
+    #[tokio::test]
+    async fn list_schedules_rejects_invalid_next_token() {
+        let svc = SchedulerService::new(make_state());
+        let err = svc
+            .handle(make_request(
+                Method::GET,
+                "/schedules?NextToken=not-a-valid-token",
+                "",
+            ))
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(err.code(), "ValidationException");
+    }
+
+    #[tokio::test]
+    async fn list_schedule_groups_rejects_invalid_next_token() {
+        let svc = SchedulerService::new(make_state());
+        let err = svc
+            .handle(make_request(
+                Method::GET,
+                "/schedule-groups?NextToken=not-a-valid-token",
+                "",
+            ))
             .await
             .err()
             .unwrap();


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.7** (per-service migration). `ListSchedules` / `ListScheduleGroups` silently treated a malformed `NextToken` as offset 0 (via `paginate`), risking an infinite client pagination loop. Use the new `paginate_checked` and return `ValidationException` for an unparseable token, matching AWS EventBridge Scheduler.

## Test plan
`cargo build -p fakecloud-scheduler --all-targets` + `cargo clippy -p fakecloud-scheduler --all-targets -- -D warnings` green; new unit tests `list_schedules_rejects_invalid_next_token` + `list_schedule_groups_rejects_invalid_next_token` (garbage NextToken → ValidationException).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid NextToken in Scheduler list APIs and return a ValidationException, preventing silent first-page resets and client pagination loops. Behavior now matches AWS EventBridge Scheduler.

- **Bug Fixes**
  - Switched from `paginate` to `paginate_checked` in ListSchedules and ListScheduleGroups; map parse failures to ValidationException ("Invalid NextToken").
  - Added unit tests covering invalid NextToken for both endpoints; addresses bug 1.7 from the 2026-05-28 audit.

<sup>Written for commit 4c313011bef51492e34970384b73917b4ff2919a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

