### PR TITLE
fix(lambda): add missing source_access_configurations field (unbreak main)

### DIFF
--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -200,6 +200,11 @@ pub struct EventSourceMapping {
     /// `Queues` — Amazon MQ broker queue list.
     #[serde(default)]
     pub queues: Vec<String>,
+    /// `SourceAccessConfigurations` — VPC/auth config (security groups,
+    /// subnets, SASL/SCRAM secrets) for Kafka/MQ/MSK sources. Round-tripped
+    /// so Get/List/Update echo back what the caller supplied (1.17).
+    #[serde(default)]
+    pub source_access_configurations: Vec<serde_json::Value>,
 }
 
 /// A recorded Lambda invocation from cross-service delivery.


### PR DESCRIPTION
## Summary
Main currently fails to compile. Bug-audit 1.17 (#1585) added `source_access_configurations` parse/build/echo logic in `service_event_sources.rs` (lines 175/208/307) but the backing field on the `EventSourceMapping` struct was never committed, producing `error[E0560]` and `error[E0609]` across the workspace (clippy/msrv/test/build-and-test all red on every PR).

Adds the `source_access_configurations: Vec<serde_json::Value>` field with `#[serde(default)]` so CreateEventSourceMapping / Update / Get / List round-trip it.

## Test plan
`cargo build -p fakecloud-lambda --all-targets` + `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings` clean; `cargo test -p fakecloud-lambda --lib` = 185 passed (incl `create_event_source_mapping_round_trips_advanced_fields`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compile failure by adding the missing `source_access_configurations` field to `EventSourceMapping` in `fakecloud-lambda`. Restores builds and round-trips the field for Create/Update/Get/List.

- **Bug Fixes**
  - Added `source_access_configurations: Vec<serde_json::Value>` with `#[serde(default)]` to `EventSourceMapping`.
  - Matches existing logic in `service_event_sources.rs` and resolves E0560/E0609 errors.

<sup>Written for commit ba15e4edbe2d78adda7cfbdc0498a146bb403340. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

