### PR TITLE
fix(ecs): reject invalid pagination token (1.7)

### DIFF
--- a/crates/fakecloud-ecs/src/service_daemons.rs
+++ b/crates/fakecloud-ecs/src/service_daemons.rs
@@ -11,7 +11,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::*;
@@ -181,7 +181,14 @@ impl EcsService {
         }
         summaries.sort_by(|a, b| a.task_definition_arn.cmp(&b.task_definition_arn));
 
-        let (page, token) = paginate(&summaries, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&summaries, next_token.as_deref(), max_results)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "Invalid nextToken".to_string(),
+                )
+            })?;
         let json_page: Vec<Value> = page
             .iter()
             .map(daemon_task_definition_summary_json)
@@ -673,7 +680,14 @@ impl EcsService {
                     + daemon.updated_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
             }));
         }
-        let (page, token) = paginate(&summaries, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&summaries, next_token.as_deref(), max_results)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "Invalid nextToken".to_string(),
+                )
+            })?;
         Ok(AwsResponse::ok_json(json!({
             "daemonSummariesList": page,
             "nextToken": token,
@@ -751,7 +765,14 @@ impl EcsService {
             }
             summaries.push(daemon_deployment_summary_json(d));
         }
-        let (page, token) = paginate(&summaries, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&summaries, next_token.as_deref(), max_results)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "Invalid nextToken".to_string(),
+                )
+            })?;
         Ok(AwsResponse::ok_json(json!({
             "daemonDeployments": page,
             "nextToken": token,

--- a/crates/fakecloud-ecs/src/service_tests.rs
+++ b/crates/fakecloud-ecs/src/service_tests.rs
@@ -229,3 +229,41 @@ fn matches_filter_respects_none() {
     assert!(matches_filter(Some("x"), "x"));
     assert!(!matches_filter(Some("x"), "y"));
 }
+
+// bug-audit 2026-05-28, 1.7: a malformed nextToken must be rejected with
+// InvalidParameterException rather than silently restarting from page 0.
+#[tokio::test]
+async fn list_daemon_task_definitions_rejects_invalid_next_token() {
+    let svc = svc();
+    let err = call_expect_err(
+        &svc,
+        "AmazonEC2ContainerServiceV20141113.ListDaemonTaskDefinitions",
+        json!({ "nextToken": "not-a-valid-token" }),
+    )
+    .await;
+    assert_eq!(err.code(), "InvalidParameterException");
+}
+
+#[tokio::test]
+async fn list_daemons_rejects_invalid_next_token() {
+    let svc = svc();
+    let err = call_expect_err(
+        &svc,
+        "AmazonEC2ContainerServiceV20141113.ListDaemons",
+        json!({ "nextToken": "not-a-valid-token" }),
+    )
+    .await;
+    assert_eq!(err.code(), "InvalidParameterException");
+}
+
+#[tokio::test]
+async fn list_daemon_deployments_rejects_invalid_next_token() {
+    let svc = svc();
+    let err = call_expect_err(
+        &svc,
+        "AmazonEC2ContainerServiceV20141113.ListDaemonDeployments",
+        json!({ "nextToken": "not-a-valid-token" }),
+    )
+    .await;
+    assert_eq!(err.code(), "InvalidParameterException");
+}


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.7** (per-service migration). `ListDaemonTaskDefinitions`, `ListDaemons`, and `ListDaemonDeployments` silently treated a malformed `nextToken` as offset 0 (via `paginate`), risking an infinite client pagination loop. Use `paginate_checked` and return `InvalidParameterException` for an unparseable token, matching ECS.

## Test plan
`cargo build -p fakecloud-ecs --all-targets` + `cargo clippy -p fakecloud-ecs --all-targets -- -D warnings` clean; new unit tests `list_daemon_task_definitions_rejects_invalid_next_token`, `list_daemons_rejects_invalid_next_token`, `list_daemon_deployments_rejects_invalid_next_token` (garbage nextToken -> InvalidParameterException).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid pagination tokens in `fakecloud-ecs` list APIs to match AWS behavior and prevent infinite client pagination loops. We now return `InvalidParameterException` instead of restarting at page 0.

- **Bug Fixes**
  - Switched from `paginate` to `paginate_checked` in `ListDaemonTaskDefinitions`, `ListDaemons`, and `ListDaemonDeployments` to emit `InvalidParameterException` on bad `nextToken`.
  - Added unit tests covering each endpoint’s rejection of malformed tokens.

<sup>Written for commit d76129035d98c4594de2ec3426cf80b5595fcb3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

