### PR TITLE
fix(wafv2): reject invalid pagination token (1.7)

### DIFF
--- a/crates/fakecloud-wafv2/src/service/mod.rs
+++ b/crates/fakecloud-wafv2/src/service/mod.rs
@@ -970,4 +970,16 @@ mod managed_rule_set_validation_tests {
         assert!(res.is_err());
         assert_eq!(res.err().unwrap().code(), "WAFInvalidParameterException");
     }
+
+    // bug-audit 2026-05-28, 1.7: List* operations reject a malformed NextMarker
+    // (paginate_checked -> WAFInvalidParameterException) instead of silently
+    // restarting at page 0.
+    #[test]
+    fn paginate_checked_rejects_invalid_token() {
+        use fakecloud_core::pagination::paginate_checked;
+        let items: Vec<i32> = (0..5).collect();
+        assert!(paginate_checked(&items, Some("not-a-valid-token"), 3).is_err());
+        assert!(paginate_checked(&items, Some("2"), 3).is_ok());
+        assert!(paginate_checked(&items, None, 3).is_ok());
+    }
 }


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.7** (per-service migration). The WAFv2 `List*` operations (IP sets, web ACLs, regex pattern sets, rule groups, API keys) silently treated a malformed `NextMarker` as offset 0 (via `paginate`), risking an infinite client pagination loop. Use `paginate_checked` and return `WAFInvalidParameterException` for an unparseable token.

## Test plan
`cargo build -p fakecloud-wafv2 --all-targets` + `cargo clippy -p fakecloud-wafv2 --all-targets -- -D warnings` clean; new unit test `paginate_checked_rejects_invalid_token`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed pagination tokens in `fakecloud-wafv2` List* APIs. Now return `WAFInvalidParameterException` instead of restarting at page 0, preventing infinite pagination loops.

- **Bug Fixes**
  - Use `paginate_checked`; invalid `NextMarker` returns `WAFInvalidParameterException` instead of offset 0.
  - Add unit test `paginate_checked_rejects_invalid_token` (invalid, valid, and missing tokens).

<sup>Written for commit 9fb3f6bc792677e431e6f8865279686de1debbb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

