### PR TITLE
fix(organizations): reject invalid pagination token (1.7)

### DIFF
--- a/crates/fakecloud-organizations/src/service/accounts.rs
+++ b/crates/fakecloud-organizations/src/service/accounts.rs
@@ -228,7 +228,8 @@ impl OrganizationsService {
             .filter(|s| states.is_empty() || states.iter().any(|st| st == &s.state))
             .map(create_account_status_payload)
             .collect();
-        let (page, token) = paginate(&filtered, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&filtered, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_input("Invalid NextToken"))?;
         let mut body = json!({ "CreateAccountStatuses": page });
         if let Some(t) = token {
             body["NextToken"] = json!(t);
@@ -363,7 +364,8 @@ impl OrganizationsService {
                 .collect(),
             None => Vec::new(),
         };
-        let (page, token) = paginate(&filtered, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&filtered, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_input("Invalid NextToken"))?;
         let mut body = json!({ "Handshakes": page });
         if let Some(t) = token {
             body["NextToken"] = json!(t);
@@ -391,7 +393,8 @@ impl OrganizationsService {
                 })
             })
             .collect();
-        let (page, token) = paginate(&entries, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&entries, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_input("Invalid NextToken"))?;
         let mut body = json!({ "DelegatedServices": page });
         if let Some(t) = token {
             body["NextToken"] = json!(t);

--- a/crates/fakecloud-organizations/src/service/delegated.rs
+++ b/crates/fakecloud-organizations/src/service/delegated.rs
@@ -63,7 +63,8 @@ impl OrganizationsService {
                 }))
             })
             .collect();
-        let (page, token) = paginate(&entries, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&entries, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_input("Invalid NextToken"))?;
         let mut body = json!({ "DelegatedAdministrators": page });
         if let Some(t) = token {
             body["NextToken"] = json!(t);

--- a/crates/fakecloud-organizations/src/service/handshakes.rs
+++ b/crates/fakecloud-organizations/src/service/handshakes.rs
@@ -115,7 +115,8 @@ impl OrganizationsService {
             .filter(|h| handshake_matches_filter(h, &filter))
             .map(|h| handshake_payload(&h))
             .collect();
-        let (page, token) = paginate(&filtered, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&filtered, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_input("Invalid NextToken"))?;
         let mut body = json!({ "Handshakes": page });
         if let Some(t) = token {
             body["NextToken"] = json!(t);

--- a/crates/fakecloud-organizations/src/service/mod.rs
+++ b/crates/fakecloud-organizations/src/service/mod.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use http::StatusCode;
 use rand::Rng;
 use serde_json::{json, Value};
@@ -398,6 +398,10 @@ fn invalid_policy_filter(filter: &str) -> AwsServiceError {
     )
 }
 
+pub(super) fn invalid_input(msg: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "InvalidInputException", msg)
+}
+
 fn org_error_to_aws(err: OrgError) -> AwsServiceError {
     match err {
         OrgError::ParentNotFound(id) => AwsServiceError::aws_error(
@@ -730,3 +734,14 @@ fn organization_payload(org: &OrganizationState) -> Value {
 #[cfg(test)]
 #[path = "tests.rs"]
 mod tests;
+
+#[cfg(test)]
+mod pagination_reject_test {
+    #[test]
+    fn paginate_checked_rejects_invalid_token() {
+        use fakecloud_core::pagination::paginate_checked;
+        let items: Vec<i32> = (0..5).collect();
+        assert!(paginate_checked(&items, Some("bad"), 3).is_err());
+        assert!(paginate_checked(&items, Some("2"), 3).is_ok());
+    }
+}

--- a/crates/fakecloud-organizations/src/service/responsibility.rs
+++ b/crates/fakecloud-organizations/src/service/responsibility.rs
@@ -272,7 +272,8 @@ impl OrganizationsService {
             .filter(|t| t.direction == direction && t.transfer_type == transfer_type)
             .map(transfer_payload)
             .collect();
-        let (page, token) = paginate(&filtered, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&filtered, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_input("Invalid NextToken"))?;
         let mut out = json!({ "ResponsibilityTransfers": page });
         if let Some(t) = token {
             out["NextToken"] = json!(t);

--- a/crates/fakecloud-organizations/src/service/service_access.rs
+++ b/crates/fakecloud-organizations/src/service/service_access.rs
@@ -49,7 +49,8 @@ impl OrganizationsService {
                 })
             })
             .collect();
-        let (page, token) = paginate(&entries, next_token.as_deref(), max_results);
+        let (page, token) = paginate_checked(&entries, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_input("Invalid NextToken"))?;
         let mut body = json!({ "EnabledServicePrincipals": page });
         if let Some(t) = token {
             body["NextToken"] = json!(t);


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.7** (per-service migration). The Organizations `List*` operations (accounts, create-account status, handshakes, enabled service principals, delegated administrators, responsibility transfers) silently treated a malformed `NextToken` as offset 0 (via `paginate`), risking an infinite client pagination loop. Use `paginate_checked` and return `InvalidInputException` for an unparseable token.

## Test plan
`cargo build -p fakecloud-organizations --all-targets` + `cargo clippy -p fakecloud-organizations --all-targets -- -D warnings` clean; new unit test `paginate_checked_rejects_invalid_token`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid pagination tokens in Organizations List* APIs to prevent infinite pagination loops. Malformed NextToken now returns InvalidInputException instead of defaulting to the first page.

- **Bug Fixes**
  - Replaced `paginate` with `paginate_checked` in accounts, create-account status, handshakes, enabled service principals, delegated administrators, and responsibility transfers.
  - Return InvalidInputException (400) on bad NextToken via a new `invalid_input` helper.
  - Added unit test to ensure invalid tokens are rejected and valid tokens pass.

<sup>Written for commit 271dc50b1995f78f71ddac563aeb61c4f757e277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

