### PR TITLE
fix(stepfunctions): reject invalid pagination token (1.7)

### DIFF
--- a/crates/fakecloud-stepfunctions/src/service/executions.rs
+++ b/crates/fakecloud-stepfunctions/src/service/executions.rs
@@ -216,7 +216,8 @@ impl StepFunctionsService {
             })
             .collect();
 
-        let (page, token) = paginate(&items, next_token, max_results);
+        let (page, token) =
+            paginate_checked(&items, next_token, max_results).map_err(|_| invalid_token())?;
 
         let mut resp = json!({ "executions": page });
         if let Some(t) = token {
@@ -272,7 +273,8 @@ impl StepFunctionsService {
             events.reverse();
         }
 
-        let (page, token) = paginate(&events, next_token, max_results);
+        let (page, token) =
+            paginate_checked(&events, next_token, max_results).map_err(|_| invalid_token())?;
 
         let mut resp = json!({ "events": page });
         if let Some(t) = token {

--- a/crates/fakecloud-stepfunctions/src/service/map_runs.rs
+++ b/crates/fakecloud-stepfunctions/src/service/map_runs.rs
@@ -66,7 +66,8 @@ impl StepFunctionsService {
                 })
             })
             .collect();
-        let (page, token) = paginate(&items, next_token, max_results);
+        let (page, token) =
+            paginate_checked(&items, next_token, max_results).map_err(|_| invalid_token())?;
         let mut resp = json!({ "mapRuns": page });
         if let Some(t) = token {
             resp["nextToken"] = json!(t);

--- a/crates/fakecloud-stepfunctions/src/service/mod.rs
+++ b/crates/fakecloud-stepfunctions/src/service/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::delivery::DeliveryBus;
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::registry::ServiceRegistry;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
@@ -268,7 +268,8 @@ impl StepFunctionsService {
                 })
             })
             .collect();
-        let (page, token) = paginate(&items, next_token, max_results);
+        let (page, token) =
+            paginate_checked(&items, next_token, max_results).map_err(|_| invalid_token())?;
         let mut resp = json!({ "activities": page });
         if let Some(t) = token {
             resp["nextToken"] = json!(t);
@@ -584,6 +585,13 @@ fn validate_arn_length(field: &str, value: &str, max: usize) -> Result<(), AwsSe
         ));
     }
     Ok(())
+}
+
+/// Shared error for a malformed (unparseable) `nextToken` reaching the
+/// pagination helper — `InvalidToken` is the only pagination error code
+/// declared on every list op.
+pub(super) fn invalid_token() -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "InvalidToken", "Invalid nextToken")
 }
 
 /// `nextToken` is declared as `PageToken` (length 1..=1024). The only
@@ -1484,5 +1492,16 @@ mod tests {
         let req = make_request("StartSyncExecution", &body.to_string());
         let err = expect_err(svc.start_sync_execution(&req).await);
         assert!(err.to_string().contains("InvalidExecutionInput"));
+    }
+}
+
+#[cfg(test)]
+mod pagination_reject_test {
+    #[test]
+    fn paginate_checked_rejects_invalid_token() {
+        use fakecloud_core::pagination::paginate_checked;
+        let items: Vec<i32> = (0..5).collect();
+        assert!(paginate_checked(&items, Some("bad"), 3).is_err());
+        assert!(paginate_checked(&items, Some("2"), 3).is_ok());
     }
 }

--- a/crates/fakecloud-stepfunctions/src/service/state_machines.rs
+++ b/crates/fakecloud-stepfunctions/src/service/state_machines.rs
@@ -153,7 +153,8 @@ impl StepFunctionsService {
             })
             .collect();
 
-        let (page, token) = paginate(&items, next_token, max_results);
+        let (page, token) =
+            paginate_checked(&items, next_token, max_results).map_err(|_| invalid_token())?;
 
         let mut resp = json!({ "stateMachines": page });
         if let Some(t) = token {
@@ -359,7 +360,8 @@ impl StepFunctionsService {
                 })
             })
             .collect();
-        let (page, token) = paginate(&items, next_token, max_results);
+        let (page, token) =
+            paginate_checked(&items, next_token, max_results).map_err(|_| invalid_token())?;
         let mut resp = json!({ "stateMachineVersions": page });
         if let Some(t) = token {
             resp["nextToken"] = json!(t);
@@ -500,7 +502,8 @@ impl StepFunctionsService {
                 })
             })
             .collect();
-        let (page, token) = paginate(&items, next_token, max_results);
+        let (page, token) =
+            paginate_checked(&items, next_token, max_results).map_err(|_| invalid_token())?;
         let mut resp = json!({ "stateMachineAliases": page });
         if let Some(t) = token {
             resp["nextToken"] = json!(t);


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.7** (per-service migration). The Step Functions `List*` operations (state machines, executions, execution history, map runs, versions, aliases) silently treated a malformed `nextToken` as offset 0 (via `paginate`), risking an infinite client pagination loop. Use `paginate_checked` and return `InvalidToken` for an unparseable token (7 sites across state_machines/executions/map_runs).

## Test plan
`cargo build -p fakecloud-stepfunctions --all-targets` + `cargo clippy -p fakecloud-stepfunctions --all-targets -- -D warnings` clean; new unit test `paginate_checked_rejects_invalid_token`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed pagination tokens in Step Functions List* APIs to prevent silent resets to page 0 and infinite client pagination loops. Switches to `paginate_checked` and returns `InvalidToken` when `nextToken` cannot be parsed.

- **Bug Fixes**
  - Applies to listing state machines, executions (and history), map runs, versions, aliases, and activities.
  - Adds shared `invalid_token()` to standardize `InvalidToken` (400) responses.
  - Adds a unit test to confirm bad tokens are rejected.

<sup>Written for commit d7922b06fad8d8c9bd8d009b1593e88a85d3fd86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

