### PR TITLE
fix(athena): reject invalid pagination token (1.7)

### DIFF
--- a/crates/fakecloud-athena/src/service/capacity.rs
+++ b/crates/fakecloud-athena/src/service/capacity.rs
@@ -73,7 +73,8 @@ impl AthenaService {
         let mut all: Vec<CapacityReservation> =
             account.capacity_reservations.values().cloned().collect();
         all.sort_by(|a, b| a.name.cmp(&b.name));
-        let (page, next) = paginate(&all, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&all, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_request("Invalid NextToken"))?;
         let crs: Vec<Value> = page.iter().map(capacity_reservation_json).collect();
         let mut response = json!({ "CapacityReservations": crs });
         if let Some(t) = next {

--- a/crates/fakecloud-athena/src/service/data_catalogs.rs
+++ b/crates/fakecloud-athena/src/service/data_catalogs.rs
@@ -87,7 +87,8 @@ impl AthenaService {
         let account = account_mut(&mut state, &req.account_id);
         let mut all: Vec<DataCatalog> = account.data_catalogs.values().cloned().collect();
         all.sort_by(|a, b| a.name.cmp(&b.name));
-        let (page, next) = paginate(&all, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&all, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_request("Invalid NextToken"))?;
         let summaries: Vec<Value> = page
             .iter()
             .map(|c| {

--- a/crates/fakecloud-athena/src/service/mod.rs
+++ b/crates/fakecloud-athena/src/service/mod.rs
@@ -10,7 +10,7 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use fakecloud_aws::arn::Arn;
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_glue::SharedGlueState;
 use fakecloud_s3::SharedS3State;
@@ -1367,5 +1367,16 @@ mod tests {
         // Exact expression must match the name, not every name.
         assert!(match_table_expression("orders", "orders"));
         assert!(!match_table_expression("orders", "sales"));
+    }
+}
+
+#[cfg(test)]
+mod pagination_reject_test {
+    #[test]
+    fn paginate_checked_rejects_invalid_token() {
+        use fakecloud_core::pagination::paginate_checked;
+        let items: Vec<i32> = (0..5).collect();
+        assert!(paginate_checked(&items, Some("bad"), 3).is_err());
+        assert!(paginate_checked(&items, Some("2"), 3).is_ok());
     }
 }

--- a/crates/fakecloud-athena/src/service/named_queries.rs
+++ b/crates/fakecloud-athena/src/service/named_queries.rs
@@ -87,7 +87,8 @@ impl AthenaService {
             .map(|q| q.named_query_id.clone())
             .collect();
         ids.sort();
-        let (page, next) = paginate(&ids, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&ids, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_request("Invalid NextToken"))?;
         let mut response = json!({ "NamedQueryIds": page });
         if let Some(t) = next {
             response

--- a/crates/fakecloud-athena/src/service/notebooks.rs
+++ b/crates/fakecloud-athena/src/service/notebooks.rs
@@ -117,7 +117,8 @@ impl AthenaService {
             .cloned()
             .collect();
         all.sort_by(|a, b| a.notebook_id.cmp(&b.notebook_id));
-        let (page, next) = paginate(&all, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&all, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_request("Invalid NextToken"))?;
         let metadatas: Vec<Value> = page.iter().map(notebook_metadata_json).collect();
         let mut response = json!({ "NotebookMetadataList": metadatas });
         if let Some(t) = next {
@@ -324,7 +325,8 @@ impl AthenaService {
             .cloned()
             .collect();
         all.sort_by(|a, b| a.session_id.cmp(&b.session_id));
-        let (page, next) = paginate(&all, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&all, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_request("Invalid NextToken"))?;
         let summaries: Vec<Value> = page.iter().map(session_summary_json).collect();
         let mut response = json!({ "Sessions": summaries });
         if let Some(t) = next {
@@ -532,7 +534,8 @@ impl AthenaService {
             .cloned()
             .collect();
         all.sort_by(|a, b| a.calculation_execution_id.cmp(&b.calculation_execution_id));
-        let (page, next) = paginate(&all, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&all, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_request("Invalid NextToken"))?;
         let summaries: Vec<Value> = page.iter().map(calculation_summary_json).collect();
         let mut response = json!({ "Calculations": summaries });
         if let Some(t) = next {

--- a/crates/fakecloud-athena/src/service/prepared_statements.rs
+++ b/crates/fakecloud-athena/src/service/prepared_statements.rs
@@ -83,7 +83,8 @@ impl AthenaService {
             .map(|(_, p)| p.clone())
             .collect();
         ps.sort_by(|a, b| a.statement_name.cmp(&b.statement_name));
-        let (page, next) = paginate(&ps, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&ps, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_request("Invalid NextToken"))?;
         let summaries: Vec<Value> = page
             .iter()
             .map(|p| {

--- a/crates/fakecloud-athena/src/service/queries.rs
+++ b/crates/fakecloud-athena/src/service/queries.rs
@@ -218,7 +218,8 @@ impl AthenaService {
             .collect();
         all.sort_by_key(|q| std::cmp::Reverse(q.submission_time));
         let ids: Vec<String> = all.iter().map(|q| q.query_execution_id.clone()).collect();
-        let (page, next) = paginate(&ids, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&ids, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_request("Invalid NextToken"))?;
         let mut response = json!({ "QueryExecutionIds": page });
         if let Some(t) = next {
             response

--- a/crates/fakecloud-athena/src/service/work_groups.rs
+++ b/crates/fakecloud-athena/src/service/work_groups.rs
@@ -66,7 +66,8 @@ impl AthenaService {
         let account = account_mut(&mut state, &req.account_id);
         let mut all: Vec<WorkGroup> = account.work_groups.values().cloned().collect();
         all.sort_by(|a, b| a.name.cmp(&b.name));
-        let (page, next) = paginate(&all, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&all, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_request("Invalid NextToken"))?;
         let summaries: Vec<Value> = page.iter().map(workgroup_summary_json).collect();
         let mut response = json!({ "WorkGroups": summaries });
         if let Some(t) = next {


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.7** (per-service migration). The Athena `List*` operations (work groups, query executions, named queries, data catalogs, prepared statements, notebooks/sessions, capacity reservations) silently treated a malformed `NextToken` as offset 0 (via `paginate`), risking an infinite client pagination loop. Use `paginate_checked` and return `InvalidRequestException` for an unparseable token (9 sites across 8 files).

## Test plan
`cargo build -p fakecloud-athena --all-targets` + `cargo clippy -p fakecloud-athena --all-targets -- -D warnings` clean; new unit test `paginate_checked_rejects_invalid_token`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid Athena pagination tokens and return `InvalidRequestException` instead of falling back to page 1, preventing infinite loops in List* APIs. Fixes bug 1.7.

- **Bug Fixes**
  - Switched List* handlers in `fakecloud-athena` to `paginate_checked` from `fakecloud_core`; malformed `NextToken` now returns `InvalidRequestException` ("Invalid NextToken").
  - Affects: work groups, query executions, named queries, data catalogs, prepared statements, notebooks, sessions, capacity reservations.
  - Added unit test to verify invalid tokens are rejected; valid tokens behave unchanged.

<sup>Written for commit 67e28f45c9f583b6cebf179928aef12bfb87c95a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

