### PR TITLE
fix(eventbridge): reject invalid pagination token (1.7)

### DIFF
--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::delivery::DeliveryBus;
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 use fakecloud_persistence::SnapshotStore;
@@ -372,7 +372,14 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (page, next_token) = paginate(&filtered, body["NextToken"].as_str(), limit);
+        let (page, next_token) = paginate_checked(&filtered, body["NextToken"].as_str(), limit)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Invalid NextToken".to_string(),
+                )
+            })?;
         let buses: Vec<Value> = page
             .iter()
             .map(|b| json!({ "Name": b.name, "Arn": b.arn }))

--- a/crates/fakecloud-eventbridge/src/service_archives_replays.rs
+++ b/crates/fakecloud-eventbridge/src/service_archives_replays.rs
@@ -7,7 +7,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::*;
@@ -257,7 +257,14 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (archives, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
+        let (archives, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Invalid NextToken".to_string(),
+                )
+            })?;
         let mut resp = json!({ "Archives": archives });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -676,7 +683,14 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (replays, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
+        let (replays, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Invalid NextToken".to_string(),
+                )
+            })?;
         let mut resp = json!({ "Replays": replays });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-eventbridge/src/service_connections_apidests.rs
+++ b/crates/fakecloud-eventbridge/src/service_connections_apidests.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::*;
@@ -216,7 +216,14 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (conns, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
+        let (conns, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Invalid NextToken".to_string(),
+                )
+            })?;
         let mut resp = json!({ "Connections": conns });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -462,7 +469,14 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (dests, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
+        let (dests, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Invalid NextToken".to_string(),
+                )
+            })?;
         let mut resp = json!({ "ApiDestinations": dests });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-eventbridge/src/service_endpoints.rs
+++ b/crates/fakecloud-eventbridge/src/service_endpoints.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::*;
@@ -183,7 +183,14 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (endpoints, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
+        let (endpoints, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Invalid NextToken".to_string(),
+                )
+            })?;
         let mut resp = json!({ "Endpoints": endpoints });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-eventbridge/src/service_partner_sources.rs
+++ b/crates/fakecloud-eventbridge/src/service_partner_sources.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::*;
@@ -148,7 +148,14 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (sources, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
+        let (sources, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Invalid NextToken".to_string(),
+                )
+            })?;
         let mut resp = json!({ "PartnerEventSources": sources });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -298,7 +305,14 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (sources, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
+        let (sources, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Invalid NextToken".to_string(),
+                )
+            })?;
         let mut resp = json!({ "EventSources": sources });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);


### PR DESCRIPTION
## Summary
Bug-audit 2026-05-28 Tier 1, bug **1.7** (per-service migration). The EventBridge `List*` operations (rules/event buses, endpoints, partner event sources, connections, API destinations, archives, replays) silently treated a malformed `NextToken` as offset 0 (via `paginate`), risking an infinite client pagination loop. Use `paginate_checked` and return `ValidationException` for an unparseable token (8 sites across 5 files).

## Test plan
`cargo build -p fakecloud-eventbridge --all-targets` + `cargo clippy -p fakecloud-eventbridge --all-targets -- -D warnings` clean; new unit test `paginate_checked_rejects_invalid_token`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed pagination tokens in EventBridge List operations to prevent infinite client loops. Invalid `NextToken` now triggers a `ValidationException` instead of resetting to the first page.

- **Bug Fixes**
  - Switched to `fakecloud_core::pagination::paginate_checked` across List APIs (event buses, endpoints, partner event sources, connections, API destinations, archives, replays).
  - On parse failure, return 400 `ValidationException` with message "Invalid NextToken".
  - Added unit test `paginate_checked_rejects_invalid_token` in `fakecloud-eventbridge`.

<sup>Written for commit 21789c10b4c0c8082345fb9ad356e38330b24003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

