### PR TITLE
revert(eventbridge): undo 1.7 migration — broke the build

### DIFF
--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::delivery::DeliveryBus;
-use fakecloud_core::pagination::paginate_checked;
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 use fakecloud_persistence::SnapshotStore;
@@ -372,14 +372,7 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (page, next_token) = paginate_checked(&filtered, body["NextToken"].as_str(), limit)
-            .map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    "Invalid NextToken".to_string(),
-                )
-            })?;
+        let (page, next_token) = paginate(&filtered, body["NextToken"].as_str(), limit);
         let buses: Vec<Value> = page
             .iter()
             .map(|b| json!({ "Name": b.name, "Arn": b.arn }))

--- a/crates/fakecloud-eventbridge/src/service_archives_replays.rs
+++ b/crates/fakecloud-eventbridge/src/service_archives_replays.rs
@@ -7,7 +7,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 
-use fakecloud_core::pagination::paginate_checked;
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::*;
@@ -257,14 +257,7 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (archives, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
-            .map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    "Invalid NextToken".to_string(),
-                )
-            })?;
+        let (archives, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "Archives": archives });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -683,14 +676,7 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (replays, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
-            .map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    "Invalid NextToken".to_string(),
-                )
-            })?;
+        let (replays, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "Replays": replays });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-eventbridge/src/service_connections_apidests.rs
+++ b/crates/fakecloud-eventbridge/src/service_connections_apidests.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate_checked;
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::*;
@@ -216,14 +216,7 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (conns, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
-            .map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    "Invalid NextToken".to_string(),
-                )
-            })?;
+        let (conns, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "Connections": conns });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -469,14 +462,7 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (dests, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
-            .map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    "Invalid NextToken".to_string(),
-                )
-            })?;
+        let (dests, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "ApiDestinations": dests });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-eventbridge/src/service_endpoints.rs
+++ b/crates/fakecloud-eventbridge/src/service_endpoints.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate_checked;
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::*;
@@ -183,14 +183,7 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (endpoints, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
-            .map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    "Invalid NextToken".to_string(),
-                )
-            })?;
+        let (endpoints, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "Endpoints": endpoints });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-eventbridge/src/service_partner_sources.rs
+++ b/crates/fakecloud-eventbridge/src/service_partner_sources.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate_checked;
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::*;
@@ -148,14 +148,7 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (sources, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
-            .map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    "Invalid NextToken".to_string(),
-                )
-            })?;
+        let (sources, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "PartnerEventSources": sources });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -305,14 +298,7 @@ impl EventBridgeService {
             })
             .collect();
 
-        let (sources, next_token) = paginate_checked(&all, body["NextToken"].as_str(), limit)
-            .map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    "Invalid NextToken".to_string(),
-                )
-            })?;
+        let (sources, next_token) = paginate(&all, body["NextToken"].as_str(), limit);
         let mut resp = json!({ "EventSources": sources });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);


### PR DESCRIPTION
## Summary
#1599 broke main: the EventBridge crate already has a 2-arg `paginate_checked` reachable via `use super::*`, so the core 3-arg `paginate_checked` calls introduced by #1599 failed to compile (`error[E0061]`). main does not build.

This restores `crates/fakecloud-eventbridge` to its pre-#1599 (compiling) state to un-break CI. The 1.7 NextToken hardening for EventBridge will be redone using a fully-qualified `fakecloud_core::pagination::paginate_checked` call path to avoid the name collision.

## Test plan
`cargo build --workspace --all-targets` = clean (verified locally; main currently fails to compile without this revert).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the EventBridge 1.7 pagination change to fix a compile error and restore the build. `fakecloud-eventbridge` now uses `paginate` again instead of the 3-arg `paginate_checked`.

- **Bug Fixes**
  - Replaced `fakecloud_core::pagination::paginate_checked` calls with `paginate` across EventBridge services.
  - Resolves Rust E0061 from a local 2-arg `paginate_checked` exposed via `super::*`; build succeeds again.

<sup>Written for commit 251ffb80bcad489e727b47f48205b50c0befe600. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

