### PR TITLE
fix(elasticache): add missing request_id arg (unbreak build)

### DIFF
--- a/crates/fakecloud-elasticache/src/service/clusters.rs
+++ b/crates/fakecloud-elasticache/src/service/clusters.rs
@@ -267,6 +267,7 @@ impl ElastiCacheService {
                         "CreateCacheCluster",
                         ELASTICACHE_NS,
                         &format!("<CacheCluster>{xml}</CacheCluster>"),
+                        &request.request_id,
                     ),
                 ));
             }


### PR DESCRIPTION
## Summary
main fails to compile: `crates/fakecloud-elasticache/src/service/clusters.rs:266` calls `query_response_xml` with 3 args, but the helper requires a 4th `request_id: &str` (`error[E0061]`). The delete-during-create early-return branch of `create_cache_cluster` was missed when the request_id param was added; every other call site already passes `&request.request_id`.

Adds `&request.request_id` to that one call.

## Test plan
`cargo build --workspace --all-targets` exits 0 (was 101 on main). One-line change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workspace build by passing the missing request_id to query_response_xml in the ElastiCache CreateCacheCluster early-return path. This restores successful cargo builds by matching other call sites that pass &request.request_id.

<sup>Written for commit fff12b4222a30d08ca5e709019d07896eb4e96e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

