### PR TITLE
fix(cloudformation): add source_access_configurations to EventSourceMapping initializer (unbreak build)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/lambda.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/lambda.rs
@@ -378,6 +378,7 @@ impl ResourceProvisioner {
             tumbling_window_in_seconds: cfg.tumbling_window_in_seconds,
             topics: cfg.topics,
             queues: cfg.queues,
+            source_access_configurations: Vec::new(),
         };
         state.event_source_mappings.insert(uuid.clone(), esm);
         Ok(ProvisionResult::new(uuid.clone()).with("Id", uuid))


### PR DESCRIPTION
## Summary
main fails to compile (build-and-test/clippy/test all red): #1590 added `source_access_configurations` to `fakecloud_lambda::EventSourceMapping`, but the CloudFormation lambda resource provisioner constructs that struct directly (`resource_provisioner/lambda.rs:354`) and was not updated → `error[E0063]`.

Initialize the field to an empty `Vec` (CFN does not model SourceAccessConfigurations).

## Test plan
`cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-run` all exit 0 on a fresh checkout (were 101).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the build by initializing the new `source_access_configurations` field to an empty Vec when constructing EventSourceMapping in the CloudFormation Lambda resource provisioner.
This unblocks compilation after `fakecloud_lambda::EventSourceMapping` added the field; CFN does not model SourceAccessConfigurations.

<sup>Written for commit 2b5d4f9c01f73c33ced3a96e4ce23fc2747aba7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

