### PR TITLE
fix(persistence): qualify tempfile::tempdir() in atomic test (unbreak build)

### DIFF
--- a/crates/fakecloud-persistence/src/atomic.rs
+++ b/crates/fakecloud-persistence/src/atomic.rs
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn concurrent_writes_never_corrupt() {
         use std::sync::Arc;
-        let dir = tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let path = Arc::new(dir.path().join("snap.bin"));
         let payloads: Vec<Vec<u8>> = (0..16).map(|i| vec![b'A' + i as u8; 8192]).collect();
         let handles: Vec<_> = payloads


### PR DESCRIPTION
## Summary
main's test/all-targets build fails: `fakecloud-persistence/src/atomic.rs:149` calls bare `tempdir()` but only `tempfile::TempDir` is in scope (`error[E0425]`). Every sibling call uses `tempfile::tempdir()`; make this one match.

## Test plan
`cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-run` all exit 0 on a fresh checkout (were 101).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workspace test build by qualifying `tempfile::tempdir()` in `crates/fakecloud-persistence/src/atomic.rs`, resolving error[E0425] from a bare `tempdir()` call.

<sup>Written for commit 694ae69a292fe662621545167446b93abdf5e701. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

