### PR TITLE
fix: add source_access_configurations to all EventSourceMapping constructors (unbreak build)

### DIFF
--- a/crates/fakecloud-e2e/tests/sts.rs
+++ b/crates/fakecloud-e2e/tests/sts.rs
@@ -1,23 +1,15 @@
 // bug-audit 2026-05-28, 5.4: AssumeRole targeting a role that does not exist
 // must be denied, not silently minted credentials.
+mod helpers;
+
+use aws_sdk_sts::error::SdkError;
+use helpers::TestServer;
+
 #[tokio::test]
 async fn sts_assume_role_nonexistent_role_is_denied() {
     let server = TestServer::start().await;
-    let endpoint = server.endpoint();
+    let sts = server.sts_client().await;
 
-    let config = aws_sdk_sts::Config::builder()
-        .behavior_version(BehaviorVersion::latest())
-        .region(Region::new("us-east-1"))
-        .credentials_provider(Credentials::new(
-            "AKIAIOSFODNN7EXAMPLE",
-            "secret",
-            None,
-            None,
-            "test",
-        ))
-        .endpoint_url(endpoint)
-        .build();
-    let sts = aws_sdk_sts::Client::from_conf(config);
     let err = sts
         .assume_role()
         .role_arn("arn:aws:iam::123456789012:role/this-role-does-not-exist-5p4")

--- a/crates/fakecloud-server/src/sqs_lambda_poller.rs
+++ b/crates/fakecloud-server/src/sqs_lambda_poller.rs
@@ -587,6 +587,7 @@ mod tests {
                 tumbling_window_in_seconds: None,
                 topics: Vec::new(),
                 queues: Vec::new(),
+                source_access_configurations: Vec::new(),
             };
             l.event_source_mappings
                 .insert(mapping.uuid.clone(), mapping);


### PR DESCRIPTION
## Summary

PR #1590 added a new field to `fakecloud_lambda::EventSourceMapping`:

```rust
#[serde(default)]
pub source_access_configurations: Vec<serde_json::Value>,
```

Several direct struct-literal constructors of `EventSourceMapping` were not updated, causing `error[E0063]: missing field source_access_configurations` and breaking the workspace build/CI. Four sites were fixed in #1601-#1604; this PR sweeps the workspace and fixes the last remaining constructor: the SQS->Lambda poller test fixture in `crates/fakecloud-server/src/sqs_lambda_poller.rs`. Verified via the compiler that no other `E0063` remains anywhere.

While verifying `--all-targets`, the build was still red on a **separate** pre-existing breakage: the 5.4 bug-audit test `crates/fakecloud-e2e/tests/sts.rs` (added in 707d085f) referenced `TestServer`, `SdkError`, `Region`, `Credentials` and `BehaviorVersion` without importing them (`error[E0433]`). This PR repairs it to follow the established e2e pattern (`mod helpers; use helpers::TestServer;` + `server.sts_client()`) so the test compiles and exercises the intended AccessDenied assertion.

## Test plan

- `cargo build --workspace --all-targets` -> exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` -> exit 0
- `cargo test --workspace --no-run` -> exit 0