### PR TITLE
fix(dynamodb): correct PartiQL number comparison for signs/decimals/exponents

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -19,9 +19,11 @@ fn compare_number_strings(x: &str, y: &str) -> std::cmp::Ordering {
         Some(v) => v,
         None => return Ordering::Equal,
     };
+    // (is_negative_x, is_negative_y): a negative value is always less than a
+    // non-negative one. Only decide by sign when the signs actually differ.
     match (xn, yn) {
-        (false, true) => return Ordering::Less,
-        (true, false) => return Ordering::Greater,
+        (true, false) => return Ordering::Less,
+        (false, true) => return Ordering::Greater,
         _ => {}
     }
     let mag = compare_magnitude(&xd, &yd);
@@ -1126,5 +1128,22 @@ mod number_compare_tests {
         assert_eq!(compare_number_strings("10", "9"), Ordering::Greater);
         assert_eq!(compare_number_strings("1e3", "1000"), Ordering::Equal);
         assert_eq!(compare_number_strings("1e-2", "0.01"), Ordering::Equal);
+    }
+
+    // A negative value must always sort below a non-negative one regardless of
+    // magnitude; the cross-sign arms must not be swapped.
+    #[test]
+    fn cross_sign_ordering_is_directional() {
+        assert_eq!(compare_number_strings("-1", "1"), Ordering::Less);
+        assert_eq!(compare_number_strings("1", "-1"), Ordering::Greater);
+        // A small negative still loses to a large positive, and vice versa.
+        assert_eq!(compare_number_strings("-100", "1"), Ordering::Less);
+        assert_eq!(compare_number_strings("100", "-1"), Ordering::Greater);
+        // Negative zero is normalized, so it ties zero rather than sorting low.
+        assert_eq!(compare_number_strings("-0", "5"), Ordering::Less);
+        assert_eq!(compare_number_strings("-0", "0"), Ordering::Equal);
+        // Both negative: larger magnitude is the smaller value.
+        assert_eq!(compare_number_strings("-100", "-1"), Ordering::Less);
+        assert_eq!(compare_number_strings("-1", "-100"), Ordering::Greater);
     }
 }


### PR DESCRIPTION
## Summary

`compare_number_strings` in the DynamoDB PartiQL helpers decided cross-sign ordering with the two match arms swapped:

```rust
match (xn, yn) {
    (false, true) => return Ordering::Less,    // x positive, y negative -> wrong
    (true, false) => return Ordering::Greater, // x negative, y positive -> wrong
    _ => {}
}
```

`(true, false)` means x is negative and y is non-negative, which must be `Less`, not `Greater`; `(false, true)` is the mirror and must be `Greater`. As written, any comparison between a negative and a non-negative number returned the opposite ordering, so e.g. `ord("-5", "3")` returned `Greater`. This failed the unit test `number_compare_tests::signs_decimals_and_exponents` (first assertion) and would sort PartiQL/DynamoDB N attributes incorrectly whenever values straddle zero.

Magnitude comparison, decimal/exponent normalization (`normalize_decimal`), and negative-zero handling were already correct and are unchanged.

## Test plan
- `cargo test -p fakecloud-dynamodb --lib` -> 279 pass, including `signs_decimals_and_exponents`.
- Added `cross_sign_ordering_is_directional` covering negative-vs-positive, small-neg vs large-pos (both directions), negative zero vs positive/zero, and both-negative magnitude ordering.
- `cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings` clean.
- `cargo build --workspace --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB PartiQL number comparison so negative values always sort before non-negative values. This corrects N attribute ordering across zero while preserving decimals and exponent normalization.

- **Bug Fixes**
  - Fixed cross-sign logic in `compare_number_strings` to return Less for (negative, non-negative) and Greater for (non-negative, negative).
  - Kept magnitude comparison and `normalize_decimal` behavior unchanged.
  - Added `cross_sign_ordering_is_directional` test; existing `signs_decimals_and_exponents` now passes in `fakecloud-dynamodb`.

<sup>Written for commit fbdc42432faf8f5bda40e0e8435176a223c650ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

