### PR TITLE
test(sts): create role before AssumeRole in conformance + e2e/sigv4 tests

### DIFF
--- a/crates/fakecloud-conformance/tests/sts.rs
+++ b/crates/fakecloud-conformance/tests/sts.rs
@@ -18,6 +18,19 @@ async fn sts_get_caller_identity() {
 async fn sts_assume_role() {
     let server = TestServer::start().await;
     let client = server.sts_client().await;
+    // The role must exist with a trust policy admitting the caller before
+    // AssumeRole succeeds — assuming a non-existent role is denied (matches AWS).
+    server
+        .iam_client()
+        .await
+        .create_role()
+        .role_name("test-role")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
     let resp = client
         .assume_role()
         .role_arn("arn:aws:iam::123456789012:role/test-role")

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -183,6 +183,20 @@ async fn sts_assume_role_unique_credentials() {
     let server = TestServer::start().await;
     let client = server.sts_client().await;
 
+    // AssumeRole requires the role to exist with a trust policy admitting the
+    // caller; assuming a non-existent role is denied (matches AWS).
+    for role in ["role-a", "role-b"] {
+        client
+            .create_role()
+            .role_name(role)
+            .assume_role_policy_document(
+                r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}"#,
+            )
+            .send()
+            .await
+            .unwrap();
+    }
+
     let resp1 = client
         .assume_role()
         .role_arn("arn:aws:iam::123456789012:role/role-a")
@@ -225,6 +239,17 @@ async fn sts_assume_role_temp_credentials_resolve_via_get_caller_identity() {
 
     let server = TestServer::start().await;
     let sts = server.sts_client().await;
+
+    // The role must exist with a trust policy admitting the caller before
+    // AssumeRole succeeds — assuming a non-existent role is denied (matches AWS).
+    sts.create_role()
+        .role_name("ops")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
 
     let resp = sts
         .assume_role()

--- a/crates/fakecloud-e2e/tests/sigv4_verification.rs
+++ b/crates/fakecloud-e2e/tests/sigv4_verification.rs
@@ -179,6 +179,18 @@ async fn sts_assume_role_temp_credentials_verify_successfully() {
     let server = start_verified().await;
 
     let boot = sdk_config_with(&server, "test", "test", None).await;
+    // AssumeRole requires the role to exist with a trust policy admitting the
+    // caller; assuming a non-existent role is denied (matches AWS).
+    let iam_boot = aws_sdk_iam::Client::new(&boot);
+    iam_boot
+        .create_role()
+        .role_name("temp-role")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
     let sts_boot = StsClient::new(&boot);
     let resp = sts_boot
         .assume_role()


### PR DESCRIPTION
## Problem

PR #1579 (`fix(sts): AssumeRole on a non-existent role is denied`) correctly made `sts:AssumeRole` return `AccessDenied` when the target role does not exist, matching AWS. But several pre-existing tests still call `AssumeRole` on roles they never created, so they regressed to failing after #1579 merged:

- `conformance` -> `sts_assume_role` (assumes `role/test-role`)
- `E2E general-2` -> `iam::sts_assume_role_unique_credentials` (`role/role-a`, `role/role-b`), `iam::sts_assume_role_temp_credentials_resolve_via_get_caller_identity` (`role/ops`)
- `E2E general-1` -> `sigv4_verification::sts_assume_role_temp_credentials_verify_successfully` (`role/temp-role`)

These three CI checks were SUCCESS at the v0.16.0 release (33282a8d) and went red after #1579.

## Fix

Create each role first (with a trust policy admitting the caller) before assuming it, mirroring how AWS requires the role to exist. The #1579 deny behavior is untouched, and its dedicated test (`sts_assume_role_nonexistent_role_is_denied`, 5.4) still passes.

## Verification (local, numeric exit codes)

- `cargo build -p fakecloud-conformance -p fakecloud-e2e --tests` = 0
- `cargo clippy --workspace --all-targets -- -D warnings` = 0
- `cargo nextest -p fakecloud-conformance -E 'test(/sts_assume_role/)'` = 0 (3 passed)
- `cargo nextest -p fakecloud-e2e -E 'test(/sts_assume_role/)'` = 0 (incl. the 5.4 deny test + the previously-failing verify test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create the IAM role before calling STS AssumeRole in conformance and e2e tests. This matches AWS and fixes test failures caused by denying AssumeRole on non-existent roles.

- **Bug Fixes**
  - Updated tests: conformance `sts_assume_role`; e2e `iam::sts_assume_role_unique_credentials`, `iam::sts_assume_role_temp_credentials_resolve_via_get_caller_identity`; sigv4 `sts_assume_role_temp_credentials_verify_successfully`.
  - Each test now creates the target role with a trust policy admitting the caller, then assumes it.
  - Keeps the "non-existent role returns AccessDenied" behavior and its test unchanged.

<sup>Written for commit 610278c138f6b5f23e6cd1c6176d9d2c0ec68292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

