### PR TITLE
fix(e2e): use iam_client for create_role in sts assume-role tests

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -185,9 +185,9 @@ async fn sts_assume_role_unique_credentials() {
 
     // AssumeRole requires the role to exist with a trust policy admitting the
     // caller; assuming a non-existent role is denied (matches AWS).
+    let iam = server.iam_client().await;
     for role in ["role-a", "role-b"] {
-        client
-            .create_role()
+        iam.create_role()
             .role_name(role)
             .assume_role_policy_document(
                 r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}"#,
@@ -242,7 +242,10 @@ async fn sts_assume_role_temp_credentials_resolve_via_get_caller_identity() {
 
     // The role must exist with a trust policy admitting the caller before
     // AssumeRole succeeds — assuming a non-existent role is denied (matches AWS).
-    sts.create_role()
+    server
+        .iam_client()
+        .await
+        .create_role()
         .role_name("ops")
         .assume_role_policy_document(
             r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}"#,


### PR DESCRIPTION
## Problem

#1607 fixed the conformance/E2E STS regression from #1579, but its e2e `iam.rs` edits called `create_role()` on an `aws_sdk_sts::Client` (the `sts`/`client` handle), which has no such method — `CreateRole` is an IAM operation. That left `main` with the `fakecloud-e2e` `iam` test target failing to compile, so `clippy` (and the e2e build) went red.

## Fix

Route the role-creation calls through `server.iam_client()` in both affected tests (`sts_assume_role_unique_credentials`, `sts_assume_role_temp_credentials_resolve_via_get_caller_identity`). The conformance `sts.rs` and `sigv4_verification.rs` edits from #1607 already used `iam_client` / `aws_sdk_iam::Client` and are unaffected.

## Verification (local, numeric exit codes)

- `cargo build -p fakecloud-conformance -p fakecloud-e2e --tests` = 0
- `cargo build --bin fakecloud` = 0
- `cargo clippy --workspace --all-targets -- -D warnings` = 0
- `cargo nextest -p fakecloud-conformance -E 'test(/sts_assume_role/)'` = 0 (3 passed)
- `cargo nextest -p fakecloud-e2e` for the 4 affected STS tests = 0 (4 passed, incl. the 5.4 deny test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `server.iam_client()` for `create_role()` in STS assume-role e2e tests to fix a compile error and get the suite green.

- **Bug Fixes**
  - Updated `sts_assume_role_unique_credentials` and `sts_assume_role_temp_credentials_resolve_via_get_caller_identity`.
  - E2E builds cleanly; affected STS tests pass.

<sup>Written for commit a47f795c702acf8e26efea297688516d3d0de96f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

