### PR TITLE
fix(e2e): retry transient dispatch errors in sfn_sync concurrent ARN test

### DIFF
--- a/crates/fakecloud-e2e/tests/sfn_sync.rs
+++ b/crates/fakecloud-e2e/tests/sfn_sync.rs
@@ -312,19 +312,33 @@ async fn sfn_sync_concurrent_executions_get_unique_arns() {
     let sm_arn = created.state_machine_arn().to_string();
 
     // Fire many sync executions concurrently; every ARN must be distinct.
+    // Each task retries on transient dispatch (connection) errors: 16 brand-new
+    // cold TCP connections opened in the same instant occasionally trip the
+    // SDK connector under the heavily-parallel CI nextest partition (surfacing
+    // as a spurious "dns error" against 127.0.0.1). The retry keeps the test
+    // focused on its real invariant — concurrent starts mint unique ARNs — and
+    // every call must still ultimately succeed with a distinct ARN.
     let mut handles = Vec::new();
     for _ in 0..16 {
         let sfn = sfn.clone();
         let sm_arn = sm_arn.clone();
         handles.push(tokio::spawn(async move {
-            sfn.start_sync_execution()
-                .state_machine_arn(sm_arn)
-                .input("{}")
-                .send()
-                .await
-                .unwrap()
-                .execution_arn()
-                .to_string()
+            for attempt in 0..5 {
+                match sfn
+                    .start_sync_execution()
+                    .state_machine_arn(sm_arn.clone())
+                    .input("{}")
+                    .send()
+                    .await
+                {
+                    Ok(resp) => return resp.execution_arn().to_string(),
+                    Err(e) if attempt < 4 && matches!(e, aws_sdk_sfn::error::SdkError::DispatchFailure(_)) => {
+                        tokio::time::sleep(Duration::from_millis(50 * (attempt + 1))).await;
+                    }
+                    Err(e) => panic!("start_sync_execution failed: {e:?}"),
+                }
+            }
+            unreachable!("retry loop returns or panics")
         }));
     }
 


### PR DESCRIPTION
## Problem

`E2E general-1` is red on `main` because `sfn_sync_concurrent_executions_get_unique_arns` fails all 3 nextest retries with:

```
DispatchFailure { ConnectorError { Io, ... ConnectError("dns error", "failed to lookup address information: Name or service not known") } }
```

The test fires 16 brand-new cold TCP connections in the same instant. Under the heavily-parallel CI nextest partition, the SDK connector intermittently trips on one of them and surfaces a spurious "dns error" — against `127.0.0.1`, which needs no DNS. The test passes reliably locally (verified 35/35 + 5/5 after the fix); it is a CI connection-storm artifact, not a logic bug. (This test was added 2026-05-29 by #1575 for bug-audit 4.2 and is what turned general-1 red alongside the now-fixed STS regression.)

## Fix

Retry each spawned `start_sync_execution` on transient `DispatchFailure` (up to 5 attempts, short backoff). The test's real invariant is unchanged: all 16 concurrent starts must still succeed and yield distinct execution ARNs.

## Verification (local, numeric exit codes)

- `cargo build -p fakecloud-e2e --tests` = 0
- `cargo clippy -p fakecloud-e2e --tests -- -D warnings` = 0
- `cargo nextest -p fakecloud-e2e -E 'test(sfn_sync_concurrent_executions_get_unique_arns)'` = 0 (5/5 runs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes the SFN sync concurrent ARN test by retrying transient connector dispatch errors. Stabilizes `E2E general-1` in CI without changing the test’s invariant.

- **Bug Fixes**
  - Retries each concurrent `start_sync_execution` up to 5 times with a short incremental backoff.
  - Retries only on `aws_sdk_sfn::error::SdkError::DispatchFailure`; other errors still fail fast.
  - Test still requires all 16 executions to succeed and produce unique ARNs.

<sup>Written for commit fb1f6a55efbb753261781086bcdc7e428ca128c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

