### PR TITLE
fix(e2e): warm sfn client pool before concurrent-ARN burst

### DIFF
--- a/crates/fakecloud-e2e/tests/sfn_sync.rs
+++ b/crates/fakecloud-e2e/tests/sfn_sync.rs
@@ -311,6 +311,26 @@ async fn sfn_sync_concurrent_executions_get_unique_arns() {
         .unwrap();
     let sm_arn = created.state_machine_arn().to_string();
 
+    // Warm the shared client's connection pool with one sequential call before
+    // the concurrent burst. Firing 16 cold `start_sync_execution` calls in the
+    // same instant otherwise makes every spawned task open its own brand-new
+    // TCP connection simultaneously, and under load the SDK connector
+    // intermittently fails one of those cold dials (surfacing as a spurious
+    // "dns error" against 127.0.0.1). One warm-up call establishes a pooled
+    // connection the concurrent tasks reuse; the invariant under test —
+    // concurrent starts mint unique ARNs — is unchanged.
+    let mut arns = std::collections::HashSet::new();
+    arns.insert(
+        sfn.start_sync_execution()
+            .state_machine_arn(&sm_arn)
+            .input("{}")
+            .send()
+            .await
+            .unwrap()
+            .execution_arn()
+            .to_string(),
+    );
+
     // Fire many sync executions concurrently; every ARN must be distinct.
     let mut handles = Vec::new();
     for _ in 0..16 {
@@ -328,9 +348,12 @@ async fn sfn_sync_concurrent_executions_get_unique_arns() {
         }));
     }
 
-    let mut arns = std::collections::HashSet::new();
     for h in handles {
         arns.insert(h.await.unwrap());
     }
-    assert_eq!(arns.len(), 16, "every sync execution must get a unique ARN");
+    assert_eq!(
+        arns.len(),
+        17,
+        "every sync execution (1 warm-up + 16 concurrent) must get a unique ARN"
+    );
 }


### PR DESCRIPTION
## Problem

`E2E general-1` stays red on main after the STS regression was fixed, because `sfn_sync_concurrent_executions_get_unique_arns` fails all 3 nextest retries with:

```
DispatchFailure { ConnectorError { Io, ConnectError("dns error", "... nodename nor servname provided, or not known") } }
```

The test fires 16 cold `start_sync_execution` calls in the same instant; each spawned task opens its own brand-new TCP connection simultaneously, and under load the SDK connector intermittently fails one of those cold dials — surfacing as a spurious "dns error" against `127.0.0.1` (which needs no DNS). The server-side ARN minting is already correct (UUID + collision loop, added by #1575), so this is purely a client connection-storm artifact. Reproduced reliably locally (failed 5/5 unpatched).

## Fix

Do one sequential warm-up `start_sync_execution` first so the shared client has a pooled connection the 16 concurrent tasks reuse, instead of all cold-dialing in unison. The invariant is unchanged and slightly strengthened: all 17 starts (1 warm-up + 16 concurrent) must still mint distinct execution ARNs.

## Verification (local, numeric exit codes)

- `cargo build -p fakecloud-e2e --tests` = 0
- `cargo clippy -p fakecloud-e2e --tests -- -D warnings` = 0
- `cargo nextest -p fakecloud-e2e -E 'test(sfn_sync_concurrent_executions_get_unique_arns)'` = 0, run 8/8 (unpatched: 0/5)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky E2E `sfn_sync_concurrent_executions_get_unique_arns` by warming the SFN client connection pool. We run one sequential `start_sync_execution` before the 16-way burst to avoid cold-connection DNS errors; the test now expects 17 unique ARNs (1 warm-up + 16 concurrent).

<sup>Written for commit d4a9ff1a81bf3af7dc5d4892dd8b282535edbc9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

