### PR TITLE
fix(e2e): bound concurrency in sfn_sync unique-ARN test to avoid connect storm

### DIFF
--- a/crates/fakecloud-e2e/tests/sfn_sync.rs
+++ b/crates/fakecloud-e2e/tests/sfn_sync.rs
@@ -312,19 +312,39 @@ async fn sfn_sync_concurrent_executions_get_unique_arns() {
     let sm_arn = created.state_machine_arn().to_string();
 
     // Fire many sync executions concurrently; every ARN must be distinct.
+    // A semaphore caps in-flight calls so we still exercise real parallelism
+    // (multiple simultaneous starts, which is what the unique-ARN invariant is
+    // about) without opening all 16 cold TCP connections in the exact same
+    // instant. The unbounded burst made the SDK connector intermittently fail a
+    // dial under load and surface a spurious "dns error" against 127.0.0.1.
+    // Each call also retries on transient DispatchFailure so a momentarily
+    // saturated connector can't fail the run; every start must still ultimately
+    // succeed with a distinct ARN.
+    let limit = std::sync::Arc::new(tokio::sync::Semaphore::new(4));
     let mut handles = Vec::new();
     for _ in 0..16 {
         let sfn = sfn.clone();
         let sm_arn = sm_arn.clone();
+        let limit = limit.clone();
         handles.push(tokio::spawn(async move {
-            sfn.start_sync_execution()
-                .state_machine_arn(sm_arn)
-                .input("{}")
-                .send()
-                .await
-                .unwrap()
-                .execution_arn()
-                .to_string()
+            let _permit = limit.acquire().await.unwrap();
+            for attempt in 0..5 {
+                match sfn
+                    .start_sync_execution()
+                    .state_machine_arn(sm_arn.clone())
+                    .input("{}")
+                    .send()
+                    .await
+                {
+                    Ok(resp) => return resp.execution_arn().to_string(),
+                    Err(aws_sdk_sfn::error::SdkError::DispatchFailure(e)) if attempt < 4 => {
+                        eprintln!("transient dispatch failure (attempt {attempt}): {e:?}");
+                        tokio::time::sleep(Duration::from_millis(50 * (attempt + 1))).await;
+                    }
+                    Err(e) => panic!("start_sync_execution failed: {e:?}"),
+                }
+            }
+            unreachable!("retry loop returns or panics")
         }));
     }
 


### PR DESCRIPTION
## Problem

`E2E general-1` stays red on main after the STS regression was fixed (#1607/#1608), because `sfn_sync_concurrent_executions_get_unique_arns` fails all 3 nextest retries with:

```
DispatchFailure { ConnectorError { Io, ConnectError("dns error", "... nodename nor servname provided, or not known") } }
```

The test fires 16 cold `start_sync_execution` calls in the same instant; each spawned task opens its own brand-new TCP connection simultaneously, and under load the SDK connector intermittently fails one of those cold dials — surfacing as a spurious "dns error" against `127.0.0.1` (which needs no DNS). The server-side ARN minting is already correct (UUID + collision loop, added by #1575), so this is a client connection-storm artifact. Reproduced reliably locally (failed 8/8 under load).

## Fix

Cap in-flight calls with a `Semaphore(4)` so the test still exercises real parallelism (the unique-ARN invariant is about simultaneous starts) without the 16-way cold-dial thundering herd, plus retry each call on transient `DispatchFailure` as a safety net. The invariant is unchanged: all 16 concurrent starts must mint distinct execution ARNs.

## Verification (local, numeric exit codes)

- `cargo build -p fakecloud-e2e --tests` = 0
- `cargo clippy -p fakecloud-e2e --tests -- -D warnings` = 0
- `cargo nextest -p fakecloud-e2e -E 'test(sfn_sync_concurrent_executions_get_unique_arns)'` = 0, 18/18 runs incl. 6/6 under heavy CPU load (unpatched: 0/8 under the same load)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound concurrency and added transient-retry to the `sfn_sync_concurrent_executions_get_unique_arns` e2e test to prevent connection storms causing spurious DNS errors. Preserves the unique-ARN invariant and stabilizes `E2E general-1` on `main`.

- Bug Fixes
  - Limit in-flight `start_sync_execution` calls with `tokio::sync::Semaphore(4)` to avoid 16-way cold dials.
  - Retry up to 5 times with small backoff on `aws_sdk_sfn::error::SdkError::DispatchFailure`.
  - Test behavior unchanged: 16 concurrent starts must yield distinct execution ARNs.

<sup>Written for commit a05e2a9e7f51e4167c12408dc0beb645889eda2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

