### PR TITLE
fix(e2e): stagger + retry sfn_sync concurrent-ARN starts to avoid connect storm

### DIFF
--- a/crates/fakecloud-e2e/tests/sfn_sync.rs
+++ b/crates/fakecloud-e2e/tests/sfn_sync.rs
@@ -311,20 +311,37 @@ async fn sfn_sync_concurrent_executions_get_unique_arns() {
         .unwrap();
     let sm_arn = created.state_machine_arn().to_string();
 
-    // Fire many sync executions concurrently; every ARN must be distinct.
+    // Fire many sync executions with overlapping in-flight requests; every ARN
+    // must be distinct. We stagger each task's launch by a few ms and retry on
+    // transient dispatch failures rather than opening all 16 cold TCP
+    // connections in the exact same instant — that unbounded burst made the SDK
+    // connector intermittently fail a dial under load and surface a spurious
+    // "dns error" against 127.0.0.1 (which needs no DNS). The invariant under
+    // test is server-side: overlapping Express starts must each mint a unique
+    // execution ARN.
     let mut handles = Vec::new();
-    for _ in 0..16 {
+    for i in 0..16 {
         let sfn = sfn.clone();
         let sm_arn = sm_arn.clone();
         handles.push(tokio::spawn(async move {
-            sfn.start_sync_execution()
-                .state_machine_arn(sm_arn)
-                .input("{}")
-                .send()
-                .await
-                .unwrap()
-                .execution_arn()
-                .to_string()
+            tokio::time::sleep(Duration::from_millis(5 * i)).await;
+            for attempt in 0..8 {
+                match sfn
+                    .start_sync_execution()
+                    .state_machine_arn(sm_arn.clone())
+                    .input("{}")
+                    .send()
+                    .await
+                {
+                    Ok(resp) => return resp.execution_arn().to_string(),
+                    Err(aws_sdk_sfn::error::SdkError::DispatchFailure(e)) if attempt < 7 => {
+                        eprintln!("transient dispatch failure (attempt {attempt}): {e:?}");
+                        tokio::time::sleep(Duration::from_millis(100 * (attempt + 1))).await;
+                    }
+                    Err(e) => panic!("start_sync_execution failed: {e:?}"),
+                }
+            }
+            unreachable!("retry loop returns or panics")
         }));
     }
 


### PR DESCRIPTION
## Problem

`E2E general-1` stays red on main after the STS regression was fixed (#1607/#1608), because `sfn_sync_concurrent_executions_get_unique_arns` fails — across multiple CI attempts and all 3 nextest retries — with:

```
DispatchFailure { ConnectorError { Io, ConnectError("dns error", "... nodename nor servname provided, or not known") } }
```

The test fires 16 cold `start_sync_execution` calls in the exact same instant; each spawned task opens its own brand-new TCP connection at once, and under load the SDK connector intermittently fails one of those simultaneous cold dials — surfacing as a spurious "dns error" against `127.0.0.1` (which needs no DNS). Reproduces on CI and locally (100% under load). The server-side ARN minting is already correct (UUID + collision loop, #1575), so this is a client connection-storm artifact.

## Fix

Stagger each spawned task's launch by a few ms and retry on transient `DispatchFailure` so the 16 connections don't dial in unison. The invariant under test is unchanged and is a server property: overlapping Express starts must each mint a distinct execution ARN.

## Verification (local, numeric exit codes)

- `cargo build -p fakecloud-e2e --tests` = 0
- `cargo clippy -p fakecloud-e2e --tests -- -D warnings` = 0
- `cargo nextest -p fakecloud-e2e -E 'test(sfn_sync_concurrent_executions_get_unique_arns)'` = 0, **18/18 runs** (10 normal + 8 under heavy CPU load); the unpatched test fails reliably under the same load.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky E2E by staggering and retrying concurrent `start_sync_execution` calls to avoid a client connection storm that caused intermittent "dns error" failures. Stabilizes `E2E general-1` without changing the server invariant that overlapping starts mint unique execution ARNs.

- **Bug Fixes**
  - Stagger each spawned task by `5ms * i` so 16 cold TCP dials don’t hit at once.
  - Retry up to 8 times with incremental `100ms` backoff on `DispatchFailure`; fail fast on other errors.
  - Keeps the test’s goal the same (unique ARNs); only the client-side request pattern changed.

<sup>Written for commit 015fb4a2bafe10364c4996ad0b7d96faeae567b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

