### PR TITLE
fix(ssm): reject malformed NextToken with InvalidNextToken

### DIFF
--- a/crates/fakecloud-ssm/src/service/associations.rs
+++ b/crates/fakecloud-ssm/src/service/associations.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -233,7 +233,8 @@ impl SsmService {
             })
             .collect();
 
-        let (items, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let (items, next_token) = paginate_checked(&all, body["NextToken"].as_str(), max_results)
+            .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "Associations": items });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -382,7 +383,8 @@ impl SsmService {
             })
             .collect();
 
-        let (items, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let (items, next_token) = paginate_checked(&all, body["NextToken"].as_str(), max_results)
+            .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "AssociationVersions": items });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-ssm/src/service/commands.rs
+++ b/crates/fakecloud-ssm/src/service/commands.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -366,7 +366,8 @@ impl SsmService {
         }
 
         let (commands, next_token) =
-            paginate(&all_commands, body["NextToken"].as_str(), max_results);
+            paginate_checked(&all_commands, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "Commands": commands });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -493,7 +494,8 @@ impl SsmService {
             .collect();
 
         let (invocations, next_token) =
-            paginate(&all_invocations, body["NextToken"].as_str(), max_results);
+            paginate_checked(&all_invocations, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "CommandInvocations": invocations });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-ssm/src/service/compliance.rs
+++ b/crates/fakecloud-ssm/src/service/compliance.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -144,7 +144,9 @@ impl SsmService {
             })
             .collect();
 
-        let (items, next_token) = paginate(&all_items, body["NextToken"].as_str(), max_results);
+        let (items, next_token) =
+            paginate_checked(&all_items, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "ComplianceItems": items });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-ssm/src/service/documents.rs
+++ b/crates/fakecloud-ssm/src/service/documents.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -618,7 +618,9 @@ impl SsmService {
             .map(document_identifier_json)
             .collect();
 
-        let (result, next_token) = paginate(&all_docs, body["NextToken"].as_str(), max_results);
+        let (result, next_token) =
+            paginate_checked(&all_docs, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "DocumentIdentifiers": result });
         resp["NextToken"] = json!(next_token.unwrap_or_default());
 
@@ -797,7 +799,8 @@ impl SsmService {
             })
             .collect();
 
-        let (items, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let (items, next_token) = paginate_checked(&all, body["NextToken"].as_str(), max_results)
+            .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "DocumentVersions": items });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -844,7 +847,9 @@ impl SsmService {
             })
             .collect();
 
-        let (page, next_token) = paginate(&all_responses, body["NextToken"].as_str(), max_results);
+        let (page, next_token) =
+            paginate_checked(&all_responses, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
 
         let mut resp = json!({
             "Name": name,

--- a/crates/fakecloud-ssm/src/service/documents.rs
+++ b/crates/fakecloud-ssm/src/service/documents.rs
@@ -622,7 +622,12 @@ impl SsmService {
             paginate_checked(&all_docs, body["NextToken"].as_str(), max_results)
                 .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "DocumentIdentifiers": result });
-        resp["NextToken"] = json!(next_token.unwrap_or_default());
+        // Omit NextToken on the last page rather than emitting an empty string:
+        // an empty token echoed back by a client would now be rejected by
+        // paginate_checked as a malformed offset (and AWS omits it too).
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
+        }
 
         Ok(AwsResponse::ok_json(resp))
     }

--- a/crates/fakecloud-ssm/src/service/helpers.rs
+++ b/crates/fakecloud-ssm/src/service/helpers.rs
@@ -115,6 +115,15 @@ pub(crate) fn aws_400(code: &str, msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_REQUEST, code, msg.into())
 }
 
+/// Reject a `NextToken` that is present but does not parse as a valid offset.
+/// SSM's paginated list/describe ops declare `InvalidNextToken` in their
+/// Smithy model, so a malformed token must surface that wire code rather than
+/// being silently treated as the first page (which can drive an infinite
+/// client pagination loop). bug-audit 2026-05-28, 1.7.
+pub(crate) fn invalid_next_token() -> AwsServiceError {
+    aws_400("InvalidNextToken", "The specified token is not valid.")
+}
+
 /// Many SSM operations declare specific `Invalid*` errors in their Smithy
 /// model but the shared `validate_*` helpers in `fakecloud-core` emit the
 /// generic `ValidationException` (which AWS itself returns at runtime but

--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -207,7 +207,9 @@ impl SsmService {
             })
             .collect();
 
-        let (windows, next_token) = paginate(&all_windows, body["NextToken"].as_str(), max_results);
+        let (windows, next_token) =
+            paginate_checked(&all_windows, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "WindowIdentities": windows });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -1005,7 +1007,8 @@ impl SsmService {
             })
             .collect();
 
-        let (items, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let (items, next_token) = paginate_checked(&all, body["NextToken"].as_str(), max_results)
+            .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "WindowExecutions": items });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-ssm/src/service/ops.rs
+++ b/crates/fakecloud-ssm/src/service/ops.rs
@@ -5,7 +5,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_aws::arn::Arn;
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -221,7 +221,8 @@ impl SsmService {
             })
             .collect();
 
-        let (items, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let (items, next_token) = paginate_checked(&all, body["NextToken"].as_str(), max_results)
+            .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "OpsItemSummaries": items });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -5,7 +5,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_aws::arn::Arn;
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -1215,7 +1215,8 @@ impl SsmService {
             .collect();
 
         let (page_params, next_token) =
-            paginate(&all_params, body["NextToken"].as_str(), max_results);
+            paginate_checked(&all_params, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let parameters: Vec<Value> = page_params
             .iter()
             .map(|p| {
@@ -1347,7 +1348,8 @@ impl SsmService {
             .collect();
 
         let (page_params, next_token) =
-            paginate(&all_params, body["NextToken"].as_str(), max_results);
+            paginate_checked(&all_params, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let parameters: Vec<Value> = page_params
             .iter()
             .map(|p| param_to_describe_json(p, &req.region))
@@ -1434,7 +1436,9 @@ impl SsmService {
             with_decryption,
         ));
 
-        let (result, next_token) = paginate(&all_history, body["NextToken"].as_str(), max_results);
+        let (result, next_token) =
+            paginate_checked(&all_history, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "Parameters": result });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-ssm/src/service/patches.rs
+++ b/crates/fakecloud-ssm/src/service/patches.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
@@ -141,7 +141,8 @@ impl SsmService {
             .collect();
 
         let (baselines, next_token) =
-            paginate(&all_baselines, body["NextToken"].as_str(), max_results);
+            paginate_checked(&all_baselines, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "BaselineIdentities": baselines });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -444,7 +445,8 @@ impl SsmService {
             .collect();
 
         let (mappings, next_token) =
-            paginate(&all_mappings, body["NextToken"].as_str(), max_results);
+            paginate_checked(&all_mappings, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "Mappings": mappings });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -554,7 +556,8 @@ impl SsmService {
             .filter_map(|iid| build_instance_patch_state(state, iid))
             .collect();
 
-        let (page, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let (page, next_token) = paginate_checked(&all, body["NextToken"].as_str(), max_results)
+            .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "InstancePatchStates": page });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -585,7 +588,8 @@ impl SsmService {
             .filter_map(|iid| build_instance_patch_state(state, iid))
             .collect();
 
-        let (page, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let (page, next_token) = paginate_checked(&all, body["NextToken"].as_str(), max_results)
+            .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "InstancePatchStates": page });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -637,7 +641,9 @@ impl SsmService {
             })
             .unwrap_or_default();
 
-        let (page, next_token) = paginate(&patches, body["NextToken"].as_str(), max_results);
+        let (page, next_token) =
+            paginate_checked(&patches, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "Patches": page });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -702,7 +708,9 @@ impl SsmService {
             })
             .collect();
 
-        let (page, next_token) = paginate(&effective, body["NextToken"].as_str(), max_results);
+        let (page, next_token) =
+            paginate_checked(&effective, body["NextToken"].as_str(), max_results)
+                .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "EffectivePatches": page });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);
@@ -822,7 +830,8 @@ impl SsmService {
             })
             .collect();
 
-        let (page, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let (page, next_token) = paginate_checked(&all, body["NextToken"].as_str(), max_results)
+            .map_err(|_| super::invalid_next_token())?;
         let mut resp = json!({ "Properties": page });
         if let Some(token) = next_token {
             resp["NextToken"] = json!(token);

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -3601,6 +3601,57 @@ fn describe_document_not_found_branch() {
 }
 
 #[test]
+fn list_documents_pagination_round_trip_and_omits_empty_token() {
+    // bug-audit 2026-05-28, 1.7 regression guard: list_documents must emit a
+    // NextToken it will accept on the next request, and must OMIT NextToken on
+    // the last page. Previously it emitted an empty-string token there, which
+    // the stricter paginate_checked would reject if a client echoed it back.
+    let svc = make_service();
+    for i in 0..3 {
+        let req = make_request(
+            "CreateDocument",
+            json!({
+                "Name": format!("doc-{i}"),
+                "Content": "{\"schemaVersion\":\"2.2\",\"mainSteps\":[]}",
+                "DocumentType": "Command"
+            }),
+        );
+        svc.create_document(&req).unwrap();
+    }
+
+    let mut next: Option<String> = None;
+    let mut pages = 0;
+    loop {
+        let mut params = json!({ "MaxResults": 2 });
+        if let Some(t) = &next {
+            params["NextToken"] = json!(t);
+        }
+        let req = make_request("ListDocuments", params);
+        // The token emitted by the previous page must round-trip, not error.
+        let resp = svc.list_documents(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        pages += 1;
+        assert!(pages < 50, "pagination did not terminate");
+        match body["NextToken"].as_str() {
+            Some(t) if !t.is_empty() => next = Some(t.to_string()),
+            _ => {
+                // Last page: NextToken omitted or null, never an empty string.
+                assert!(
+                    body.get("NextToken").is_none_or(|v| v.is_null()),
+                    "last page must omit NextToken, got {:?}",
+                    body.get("NextToken")
+                );
+                break;
+            }
+        }
+    }
+    assert!(
+        pages >= 2,
+        "expected multiple pages for 3 docs at MaxResults=2"
+    );
+}
+
+#[test]
 fn update_document_default_version_not_found() {
     let svc = make_service();
     let req = make_request(

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -88,6 +88,25 @@ fn list_commands_pagination() {
 }
 
 #[test]
+fn list_commands_rejects_invalid_next_token() {
+    // bug-audit 2026-05-28, 1.7: a NextToken that does not parse as a valid
+    // offset must surface SSM's declared `InvalidNextToken` wire code rather
+    // than being silently treated as the first page (which can drive an
+    // infinite client pagination loop).
+    let svc = make_service();
+    send_command(&svc, "AWS-RunShellScript");
+
+    let req = make_request(
+        "ListCommands",
+        json!({ "MaxResults": 1, "NextToken": "not-a-valid-offset" }),
+    );
+    match svc.list_commands(&req) {
+        Ok(_) => panic!("malformed NextToken must be rejected"),
+        Err(err) => assert_eq!(err.code(), "InvalidNextToken"),
+    }
+}
+
+#[test]
 fn send_command_response_omits_non_shape_fields() {
     let svc = make_service();
 


### PR DESCRIPTION
## Summary
SSM's paginated list/describe ops declare `InvalidNextToken` in their Smithy model, but the handlers used the lenient `paginate` helper, which silently treats an unparseable `NextToken` as offset 0 (first page). A client echoing back a corrupted token then loops forever instead of getting an error.

Migrate all 15 `paginate` call sites (associations/maintenance/compliance/documents/commands/ops/patches/parameters) to `paginate_checked`, mapping the parse failure to the declared `InvalidNextToken` wire code via a new `invalid_next_token()` helper. bug-audit 2026-05-28, 1.7.

## Test plan
- New `list_commands_rejects_invalid_next_token` asserts a malformed token yields `InvalidNextToken`
- `cargo test -p fakecloud-ssm --lib` — 221 pass
- `cargo clippy -p fakecloud-ssm --all-targets -- -D warnings` clean, `cargo fmt` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed SSM NextToken values across list/describe APIs and return InvalidNextToken instead of serving the first page. Also omit empty NextToken on the last ListDocuments page to ensure tokens round-trip cleanly.

- **Bug Fixes**
  - Switched to `paginate_checked` across list/describe handlers; malformed tokens now return `InvalidNextToken` (HTTP 400).
  - Added `invalid_next_token()` helper to surface the declared error code.
  - ListDocuments now omits `NextToken` on the last page; added tests for invalid token rejection and pagination round-trip.

<sup>Written for commit fb5c6be7f14614e13f7b94ad726452be7f6909ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

