### PR TITLE
fix(iam): reject malformed Marker in List*Tags instead of silent first-page

### DIFF
--- a/crates/fakecloud-iam/src/iam_service/helpers.rs
+++ b/crates/fakecloud-iam/src/iam_service/helpers.rs
@@ -631,7 +631,16 @@ pub(crate) fn paginated_tags_response(
     let max_items: usize = max_items_i64.unwrap_or(100) as usize;
 
     let next_token = req.query_params.get("Marker").map(|s| s.as_str());
-    let (page, next_marker) = paginate(tags, next_token, max_items);
+    // A Marker that does not parse as a valid offset is rejected with the same
+    // "Invalid Marker." ValidationError the other IAM list ops emit, rather than
+    // being silently treated as the first page (bug-audit 2026-05-28, 1.7).
+    let (page, next_marker) = paginate_checked(tags, next_token, max_items).map_err(|_| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationError",
+            "Invalid Marker.",
+        )
+    })?;
 
     let is_truncated = next_marker.is_some();
     let members = tags_xml(&page);

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use http::StatusCode;
 
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 // NOTE: The shared validation helpers use ValidationException error codes, but real IAM
 // typically returns InvalidInput or ValidationError for input validation failures. This is

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -1235,6 +1235,36 @@ fn tag_untag_role() {
     assert!(!body.contains("<Key>env</Key>"));
 }
 
+#[test]
+fn list_role_tags_rejects_invalid_marker() {
+    // bug-audit 2026-05-28, 1.7: a Marker that does not parse as a valid offset
+    // must be rejected with "Invalid Marker." (the same ValidationError the
+    // other IAM list ops return) rather than silently falling back to the first
+    // page.
+    let svc = make_service();
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    svc.create_role(&make_request(
+        "CreateRole",
+        vec![
+            ("RoleName", "marker-role"),
+            ("AssumeRolePolicyDocument", trust),
+        ],
+    ))
+    .unwrap();
+
+    let req = make_request(
+        "ListRoleTags",
+        vec![("RoleName", "marker-role"), ("Marker", "not-a-number")],
+    );
+    match svc.list_role_tags(&req) {
+        Ok(_) => panic!("malformed Marker must be rejected"),
+        Err(err) => {
+            assert_eq!(err.code(), "ValidationError");
+            assert!(err.message().contains("Invalid Marker"));
+        }
+    }
+}
+
 // ---- Tag Policy Tests ----
 
 #[test]


### PR DESCRIPTION
## Summary
`paginated_tags_response` (ListRoleTags / ListPolicyTags / ListOpenIDConnectProviderTags, etc.) passed the raw `Marker` query param to the lenient offset `paginate` helper, so a corrupted Marker was silently treated as the first page — a client echoing back a bad token would loop forever.

Every other IAM list op already validates the Marker and returns `Invalid Marker.` (`ValidationError`). Use `paginate_checked` and map the parse failure to that same error for consistency. bug-audit 2026-05-28, 1.7.

## Test plan
- New `list_role_tags_rejects_invalid_marker` asserts a malformed Marker yields `ValidationError` / "Invalid Marker."
- `cargo test -p fakecloud-iam --lib` — 449 pass
- `cargo clippy -p fakecloud-iam --all-targets -- -D warnings` clean, `cargo fmt` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed `Marker` in List*Tags and return `ValidationError` ("Invalid Marker.") instead of serving the first page. This prevents client loops and matches other IAM list endpoints.

- **Bug Fixes**
  - Use `fakecloud-core` `paginate_checked` in `paginated_tags_response`; parse failures map to `ValidationError` ("Invalid Marker.").
  - Added test `list_role_tags_rejects_invalid_marker`.

<sup>Written for commit ea02f7abfc7fe403d1bb07702f23d4c5380ada73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

