### PR TITLE
fix(elasticache): reject malformed Marker with InvalidParameterValue

### DIFF
--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -479,13 +479,24 @@ pub(crate) fn parse_reserved_duration_filter(
 
 /// ElastiCache wraps the core paginate helper to carry its `Option<usize>`
 /// max_records convention (default 100, hard cap 100, matching real AWS).
+///
+/// A `marker` that does not parse as a valid offset is rejected with
+/// `InvalidParameterValue` rather than being silently treated as the first
+/// page (which can drive an infinite client pagination loop). bug-audit
+/// 2026-05-28, 1.7.
 pub(crate) fn paginate<T: Clone>(
     items: &[T],
     marker: Option<&str>,
     max_records: Option<usize>,
-) -> (Vec<T>, Option<String>) {
+) -> Result<(Vec<T>, Option<String>), AwsServiceError> {
     let limit = max_records.unwrap_or(100).min(100);
-    fakecloud_core::pagination::paginate(items, marker, limit)
+    fakecloud_core::pagination::paginate_checked(items, marker, limit).map_err(|_| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterValue",
+            "Invalid value for parameter Marker.",
+        )
+    })
 }
 
 // Tag helpers

--- a/crates/fakecloud-elasticache/src/service/clusters.rs
+++ b/crates/fakecloud-elasticache/src/service/clusters.rs
@@ -339,7 +339,7 @@ impl ElastiCacheService {
             clusters
         };
 
-        let (page, next_marker) = paginate(&clusters, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&clusters, marker.as_deref(), max_records)?;
         let members_xml: String = page
             .iter()
             .map(|cluster| {

--- a/crates/fakecloud-elasticache/src/service/misc.rs
+++ b/crates/fakecloud-elasticache/src/service/misc.rs
@@ -55,7 +55,7 @@ impl ElastiCacheService {
             }
         }
 
-        let (page, next_marker) = paginate(&nodes, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&nodes, marker.as_deref(), max_records)?;
         let members_xml: String = page
             .iter()
             .map(|node| reserved_cache_node_xml(node))
@@ -123,7 +123,7 @@ impl ElastiCacheService {
             }
         }
 
-        let (page, next_marker) = paginate(&offerings, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&offerings, marker.as_deref(), max_records)?;
         let members_xml: String = page
             .iter()
             .map(|offering| reserved_cache_nodes_offering_xml(offering))
@@ -637,7 +637,7 @@ impl ElastiCacheService {
         let empty = ElastiCacheState::new(&request.account_id, &request.region);
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let events: Vec<&crate::state::CacheEvent> = state.events.iter().collect();
-        let (page, next_marker) = paginate(&events, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&events, marker.as_deref(), max_records)?;
         let members: String = page
             .iter()
             .map(|e| {

--- a/crates/fakecloud-elasticache/src/service/parameter_groups.rs
+++ b/crates/fakecloud-elasticache/src/service/parameter_groups.rs
@@ -29,7 +29,7 @@ impl ElastiCacheService {
             versions.retain(|v| seen_engines.insert(v.engine.clone()));
         }
 
-        let (page, next_marker) = paginate(&versions, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&versions, marker.as_deref(), max_records)?;
 
         let members_xml: String = page.iter().map(engine_version_xml).collect();
         let marker_xml = next_marker
@@ -79,7 +79,7 @@ impl ElastiCacheService {
             }
         }
 
-        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records)?;
 
         let members_xml: String = page.iter().map(|g| cache_parameter_group_xml(g)).collect();
         let marker_xml = next_marker
@@ -106,7 +106,7 @@ impl ElastiCacheService {
         let marker = optional_query_param(request, "Marker");
 
         let params = default_parameters_for_family(&family);
-        let (page, next_marker) = paginate(&params, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&params, marker.as_deref(), max_records)?;
 
         let params_xml: String = page.iter().map(parameter_xml).collect();
         let marker_xml = next_marker
@@ -341,7 +341,7 @@ impl ElastiCacheService {
             .get(&name)
             .map(|v| v.iter().collect())
             .unwrap_or_default();
-        let (page, next_marker) = paginate(&params, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&params, marker.as_deref(), max_records)?;
         let members: String = page.iter().map(|p| cache_parameter_xml(p)).collect();
         let marker_xml = next_marker
             .map(|m| format!("<Marker>{}</Marker>", xml_escape(&m)))

--- a/crates/fakecloud-elasticache/src/service/replication.rs
+++ b/crates/fakecloud-elasticache/src/service/replication.rs
@@ -411,7 +411,7 @@ impl ElastiCacheService {
             groups
         };
 
-        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records)?;
         let groups_xml: String = page
             .iter()
             .map(|group| {
@@ -468,7 +468,7 @@ impl ElastiCacheService {
             groups
         };
 
-        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records)?;
 
         let members_xml: String = page
             .iter()

--- a/crates/fakecloud-elasticache/src/service/security_groups.rs
+++ b/crates/fakecloud-elasticache/src/service/security_groups.rs
@@ -106,7 +106,7 @@ impl ElastiCacheService {
                 ));
             }
         }
-        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records)?;
         let members: String = page
             .iter()
             .map(|g| {

--- a/crates/fakecloud-elasticache/src/service/serverless.rs
+++ b/crates/fakecloud-elasticache/src/service/serverless.rs
@@ -166,7 +166,7 @@ impl ElastiCacheService {
             caches
         };
 
-        let (page, next_token) = paginate(&caches, next_token.as_deref(), max_results);
+        let (page, next_token) = paginate(&caches, next_token.as_deref(), max_results)?;
         let members_xml: String = page
             .iter()
             .map(|cache| format!("<member>{}</member>", serverless_cache_xml(cache)))

--- a/crates/fakecloud-elasticache/src/service/snapshots.rs
+++ b/crates/fakecloud-elasticache/src/service/snapshots.rs
@@ -134,7 +134,7 @@ impl ElastiCacheService {
                 snapshots
             };
 
-        let (page, next_token) = paginate(&snapshots, next_token.as_deref(), max_results);
+        let (page, next_token) = paginate(&snapshots, next_token.as_deref(), max_results)?;
         let members_xml: String = page
             .iter()
             .map(|snapshot| {
@@ -383,7 +383,7 @@ impl ElastiCacheService {
             snaps
         };
 
-        let (page, next_marker) = paginate(&snapshots, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&snapshots, marker.as_deref(), max_records)?;
 
         let members_xml: String = page
             .iter()

--- a/crates/fakecloud-elasticache/src/service/subnet_groups.rs
+++ b/crates/fakecloud-elasticache/src/service/subnet_groups.rs
@@ -104,7 +104,7 @@ impl ElastiCacheService {
             groups
         };
 
-        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records)?;
 
         let members_xml: String = page
             .iter()

--- a/crates/fakecloud-elasticache/src/service/users.rs
+++ b/crates/fakecloud-elasticache/src/service/users.rs
@@ -160,7 +160,7 @@ impl ElastiCacheService {
             users
         };
 
-        let (page, next_marker) = paginate(&users, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&users, marker.as_deref(), max_records)?;
 
         let members_xml: String = page
             .iter()
@@ -334,7 +334,7 @@ impl ElastiCacheService {
             groups
         };
 
-        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records);
+        let (page, next_marker) = paginate(&groups, marker.as_deref(), max_records)?;
 
         let members_xml: String = page
             .iter()

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -221,7 +221,7 @@ fn filter_engine_versions_unknown_engine() {
 #[test]
 fn paginate_returns_all_when_within_limit() {
     let items = vec![1, 2, 3];
-    let (page, marker) = paginate(&items, None, None);
+    let (page, marker) = paginate(&items, None, None).unwrap();
     assert_eq!(page, vec![1, 2, 3]);
     assert!(marker.is_none());
 }
@@ -229,17 +229,28 @@ fn paginate_returns_all_when_within_limit() {
 #[test]
 fn paginate_respects_max_records() {
     let items = vec![1, 2, 3, 4, 5];
-    let (page, marker) = paginate(&items, None, Some(2));
+    let (page, marker) = paginate(&items, None, Some(2)).unwrap();
     assert_eq!(page, vec![1, 2]);
     assert_eq!(marker, Some("2".to_string()));
 
-    let (page2, marker2) = paginate(&items, Some("2"), Some(2));
+    let (page2, marker2) = paginate(&items, Some("2"), Some(2)).unwrap();
     assert_eq!(page2, vec![3, 4]);
     assert_eq!(marker2, Some("4".to_string()));
 
-    let (page3, marker3) = paginate(&items, Some("4"), Some(2));
+    let (page3, marker3) = paginate(&items, Some("4"), Some(2)).unwrap();
     assert_eq!(page3, vec![5]);
     assert!(marker3.is_none());
+}
+
+#[test]
+fn paginate_rejects_invalid_marker() {
+    // bug-audit 2026-05-28, 1.7: a Marker that does not parse as a valid offset
+    // must surface InvalidParameterValue rather than being silently treated as
+    // the first page (which can drive an infinite client pagination loop).
+    let items = vec![1, 2, 3, 4, 5];
+    let err =
+        paginate(&items, Some("not-a-number"), Some(2)).expect_err("malformed Marker must error");
+    assert_eq!(err.code(), "InvalidParameterValue");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
The ElastiCache `paginate` wrapper passed the raw `Marker` to the lenient offset helper, so a corrupted Marker was silently treated as the first page across all 17 `Describe*` list ops — a client echoing back a bad token would loop forever.

Make the wrapper return a `Result` that rejects an unparseable marker with `InvalidParameterValue` (the wire code AWS returns for a bad Marker, already used elsewhere in this crate) and propagate it at every call site. bug-audit 2026-05-28, 1.7.

## Test plan
- New `paginate_rejects_invalid_marker` asserts a malformed Marker yields `InvalidParameterValue`
- `cargo test -p fakecloud-elasticache --lib` — 217 pass
- `cargo clippy -p fakecloud-elasticache --all-targets -- -D warnings` clean, `cargo fmt` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed ElastiCache pagination markers and return `InvalidParameterValue` (HTTP 400) instead of treating them as the first page. This prevents client loops and matches AWS behavior across all list APIs.

- **Bug Fixes**
  - Validate `Marker` in `paginate` and return `Result<(Vec<T>, Option<String>), AwsServiceError>`.
  - Use `fakecloud_core::pagination::paginate_checked` and propagate errors at all call sites.
  - Add `paginate_rejects_invalid_marker` test.

<sup>Written for commit e21e9219b48f2022ecd15766bb3fe279d1250acc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

