### PR TITLE
fix(cloudformation): pre-pull CFN-provisioned Lambda images in background (3.3)

### DIFF
--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -1908,6 +1908,7 @@ mod tests {
             )),
             glue: Arc::new(parking_lot::RwLock::new(fakecloud_glue::GlueAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
+            lambda_runtime: None,
         }
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
@@ -105,6 +105,7 @@ impl ResourceProvisioner {
             glue_state: self.glue_state.clone(),
             cloudformation_state: self.cloudformation_state.clone(),
             delivery: self.delivery.clone(),
+            lambda_runtime: self.lambda_runtime.clone(),
             account_id: self.account_id.clone(),
             region: self.region.clone(),
             stack_id: child_stack_id.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/lambda.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/lambda.rs
@@ -141,6 +141,36 @@ impl ResourceProvisioner {
             last_update_status_reason_code: None,
         };
 
+        // Pre-pull the runtime image in the background so the first Invoke of
+        // this CFN-provisioned function doesn't pay the cold-pull cost (the
+        // #1539 timeout, through the CloudFormation door — mirrors the
+        // CreateFunction path in the lambda service). Best-effort: Invoke still
+        // re-pulls as a fallback, so a pre-pull error is not fatal, and we only
+        // spawn when a Tokio runtime is active (provisioning runs inside the
+        // async request handler; unit tests that call the provisioner directly
+        // have no runtime and simply skip the warm-up).
+        if let Some(runtime) = self.lambda_runtime.clone() {
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                let func_for_prepull = func.clone();
+                let name = function_name.clone();
+                handle.spawn(async move {
+                    match runtime.prepull_for_function(&func_for_prepull).await {
+                        Some(Ok(())) => {
+                            tracing::info!(function = %name, "pre-pulled CFN Lambda runtime image");
+                        }
+                        Some(Err(e)) => {
+                            tracing::warn!(
+                                function = %name,
+                                error = %e,
+                                "CFN Lambda runtime image pre-pull failed; Invoke will retry on cold path"
+                            );
+                        }
+                        None => {} // no resolvable image (e.g. unsupported runtime)
+                    }
+                });
+            }
+        }
+
         let mut accounts = self.lambda_state.write();
         let state = accounts.get_or_create(&self.account_id);
         state.functions.insert(function_name.clone(), func);

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -860,6 +860,10 @@ pub struct ResourceProvisioner {
     pub glue_state: fakecloud_glue::SharedGlueState,
     pub cloudformation_state: SharedCloudFormationState,
     pub delivery: Arc<DeliveryBus>,
+    /// Lambda container runtime for pre-pulling CFN-provisioned function
+    /// images (see `CloudFormationDeps::lambda_runtime`). `None` outside a
+    /// configured runtime (e.g. unit tests).
+    pub lambda_runtime: Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
     pub account_id: String,
     pub region: String,
     pub stack_id: String,
@@ -5932,6 +5936,7 @@ mod tests {
                 fakecloud_glue::GlueAccounts::new(),
             )),
             delivery: Arc::new(DeliveryBus::new()),
+            lambda_runtime: None,
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),
             stack_id: "arn:aws:cloudformation:us-east-1:123456789012:stack/test/00000000-0000-0000-0000-000000000000".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -191,6 +191,13 @@ pub struct CloudFormationDeps {
     pub firehose: fakecloud_firehose::SharedFirehoseState,
     pub glue: fakecloud_glue::SharedGlueState,
     pub delivery: Arc<DeliveryBus>,
+    /// Lambda container runtime, when Docker/Podman is available. Used to
+    /// pre-pull the runtime image of a CFN-provisioned `AWS::Lambda::Function`
+    /// in the background so its first Invoke doesn't pay the cold-pull cost
+    /// (the #1539 timeout, through the CloudFormation door). `None` when no
+    /// runtime is configured — provisioning still works, the first Invoke just
+    /// falls back to a cold pull.
+    pub lambda_runtime: Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
 }
 
 pub struct CloudFormationService {
@@ -279,6 +286,7 @@ impl CloudFormationService {
             glue_state: self.deps.glue.clone(),
             cloudformation_state: self.state.clone(),
             delivery: self.deps.delivery.clone(),
+            lambda_runtime: self.deps.lambda_runtime.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
             stack_id: stack_id.to_string(),
@@ -1907,6 +1915,7 @@ mod tests {
             )),
             glue: Arc::new(parking_lot::RwLock::new(fakecloud_glue::GlueAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
+            lambda_runtime: None,
         };
         CloudFormationService::new(cf_state, deps)
     }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -789,6 +789,7 @@ async fn main() {
             firehose: firehose_state.clone(),
             glue: glue_state.clone(),
             delivery: delivery_for_cf,
+            lambda_runtime: container_runtime.clone(),
         },
     );
     if let Some(store) = cloudformation_snapshot_store {


### PR DESCRIPTION
## Summary
A Lambda deployed via `AWS::Lambda::Function` bypassed the #1539 pre-pull warm-up that the direct CreateFunction path runs, so the **first Invoke** of a CFN-deployed function paid the full cold image pull and could hit the AWS CLI 60s read timeout (the #1539 failure, through the CloudFormation door).

Plumb the Lambda container runtime into the CloudFormation provisioner and, on `AWS::Lambda::Function` creation, spawn a best-effort background pre-pull of the runtime image (mirroring the lambda service's CreateFunction warm-up). Invoke still re-pulls as a fallback so a pre-pull failure is non-fatal, and the spawn is skipped when no Tokio runtime is active (unit tests). bug-audit 2026-05-28, 3.3.

## Test plan
- `cargo build -p fakecloud-cloudformation --all-targets` + `cargo build --bin fakecloud` clean
- `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` + server clippy clean
- `cargo test -p fakecloud-cloudformation --lib` — 201 pass (None-runtime plumbing path)
- The Some(runtime) path is exercised by the existing Docker-gated e2e `cloudformation_custom_resource_invokes_lambda` (deploy + invoke a CFN Lambda)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-pull runtime images for CloudFormation-provisioned Lambdas so the first Invoke doesn’t pay the cold image pull and risk the 60s CLI timeout. `AWS::Lambda::Function` creation now triggers a best‑effort background image pre-pull via the `fakecloud-lambda` container runtime.

- **Bug Fixes**
  - Plumb optional `lambda_runtime` through `fakecloud-cloudformation` (`CloudFormationService` → `ResourceProvisioner`) and `fakecloud-server`.
  - On `AWS::Lambda::Function` create, spawn a background pre-pull via `tokio` when a runtime is present; log success/failure and skip for unsupported runtimes.
  - Keep Invoke re-pull as a fallback; unit tests run with `None` runtime and are unchanged.

<sup>Written for commit ce461f432f2476e25a58c3cbc811974ba915e161. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

