### PR TITLE
fix(server,compose): real container healthcheck + native-Linux extra_hosts

### DIFF
--- a/crates/fakecloud-server/src/cli.rs
+++ b/crates/fakecloud-server/src/cli.rs
@@ -108,6 +108,19 @@ pub(crate) struct Cli {
         env = "FAKECLOUD_IAM",
     )]
     pub iam_mode: IamModeArg,
+
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+/// Optional subcommands. Absent (the default) starts the server.
+#[derive(clap::Subcommand)]
+pub(crate) enum Command {
+    /// Probe a running server's `/_fakecloud/health` endpoint and exit 0 if
+    /// healthy, non-zero otherwise. Used by the container HEALTHCHECK so the
+    /// published image needs no extra tooling (curl/wget are not installed).
+    /// Targets `127.0.0.1:<port>`, where the port is taken from `--addr`.
+    Healthcheck,
 }
 
 impl Cli {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -7328,55 +7328,86 @@ fn fatal_exit(args: std::fmt::Arguments<'_>) -> ! {
     std::process::exit(1);
 }
 
-/// Probe `127.0.0.1:<port>/_fakecloud/health` over a raw TCP request (the
+/// Probe `<loopback>:<port>/_fakecloud/health` over a raw TCP request (the
 /// published image ships no curl/wget) and return a process exit code: 0 when
 /// the server answers `200 OK`, 1 otherwise. The port is taken from the same
 /// `--addr`/`FAKECLOUD_ADDR` the server binds, so the container HEALTHCHECK and
 /// the server agree without extra configuration.
+///
+/// The bind host decides which loopback to probe: a specific IP is used as-is,
+/// while a wildcard / unspecified bind (`0.0.0.0`, `::`, empty) is probed on
+/// both IPv4 and IPv6 loopback so a server listening only on `::` is still
+/// reported healthy.
 fn run_healthcheck(addr: &str) -> i32 {
-    use std::io::{Read, Write};
-    let port = match addr.rsplit(':').next().and_then(|p| p.parse::<u16>().ok()) {
-        Some(p) => p,
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    let (host, port) = match split_host_port(addr) {
+        Some(hp) => hp,
         None => {
-            eprintln!("healthcheck: could not parse port from addr {addr:?}");
+            eprintln!("healthcheck: could not parse host:port from addr {addr:?}");
             return 1;
         }
     };
-    let target = (std::net::Ipv4Addr::LOCALHOST, port);
-    let timeout = std::time::Duration::from_secs(2);
-    let socket = match std::net::TcpStream::connect(target) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("healthcheck: connect 127.0.0.1:{port} failed: {e}");
-            return 1;
+    let candidates: Vec<IpAddr> = match host.parse::<IpAddr>() {
+        // Wildcard / unspecified bind: try both loopback families.
+        Ok(ip) if ip.is_unspecified() => {
+            vec![
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
+            ]
         }
+        Ok(ip) => vec![ip],
+        // Non-IP host (e.g. "localhost" or empty): try both loopbacks.
+        Err(_) => vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ],
+    };
+    for ip in &candidates {
+        if healthcheck_probe(*ip, port) {
+            return 0;
+        }
+    }
+    eprintln!("healthcheck: no healthy response on port {port} (tried {candidates:?})");
+    1
+}
+
+/// Split a bind address into its host and port. Handles bracketed IPv6
+/// (`[::1]:4566`), plain `host:port`, and `0.0.0.0:4566`.
+fn split_host_port(addr: &str) -> Option<(String, u16)> {
+    if let Some(rest) = addr.strip_prefix('[') {
+        // [ipv6]:port
+        let (host, tail) = rest.split_once(']')?;
+        let port = tail.strip_prefix(':')?.parse().ok()?;
+        return Some((host.to_string(), port));
+    }
+    let (host, port) = addr.rsplit_once(':')?;
+    Some((host.to_string(), port.parse().ok()?))
+}
+
+/// Open one probe to `ip:port`, send the health request, and return whether the
+/// server answered with a 2xx status line.
+fn healthcheck_probe(ip: std::net::IpAddr, port: u16) -> bool {
+    use std::io::{Read, Write};
+    let timeout = std::time::Duration::from_secs(2);
+    let Ok(mut socket) = std::net::TcpStream::connect((ip, port)) else {
+        return false;
     };
     let _ = socket.set_read_timeout(Some(timeout));
     let _ = socket.set_write_timeout(Some(timeout));
-    let mut socket = socket;
-    let request = "GET /_fakecloud/health HTTP/1.0\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
-    if let Err(e) = socket.write_all(request.as_bytes()) {
-        eprintln!("healthcheck: write failed: {e}");
-        return 1;
+    let request = "GET /_fakecloud/health HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    if socket.write_all(request.as_bytes()).is_err() {
+        return false;
     }
     let mut response = String::new();
-    if let Err(e) = socket.read_to_string(&mut response) {
-        eprintln!("healthcheck: read failed: {e}");
-        return 1;
+    if socket.read_to_string(&mut response).is_err() {
+        return false;
     }
     // Status line looks like `HTTP/1.0 200 OK`. Accept any 2xx.
-    let healthy = response
+    response
         .lines()
         .next()
         .and_then(|line| line.split_whitespace().nth(1))
-        .is_some_and(|code| code.starts_with('2'));
-    if healthy {
-        0
-    } else {
-        let first = response.lines().next().unwrap_or("<no response>");
-        eprintln!("healthcheck: unhealthy response: {first}");
-        1
-    }
+        .is_some_and(|code| code.starts_with('2'))
 }
 /// Route panics through `tracing::error!` so they show up in CI logs with
 /// the same formatting as regular errors. Runs the default hook afterwards
@@ -7717,6 +7748,43 @@ mod startup_tests {
     #[test]
     fn healthcheck_one_on_unparseable_addr() {
         assert_eq!(run_healthcheck("not-an-addr"), 1);
+    }
+
+    #[test]
+    fn split_host_port_handles_ipv4_ipv6_and_wildcard() {
+        assert_eq!(
+            split_host_port("0.0.0.0:4566"),
+            Some(("0.0.0.0".to_string(), 4566))
+        );
+        assert_eq!(
+            split_host_port("[::1]:4566"),
+            Some(("::1".to_string(), 4566))
+        );
+        assert_eq!(split_host_port("[::]:80"), Some(("::".to_string(), 80)));
+        assert_eq!(split_host_port("no-colon"), None);
+    }
+
+    #[test]
+    fn healthcheck_probes_ipv6_loopback_when_bound_on_ipv6() {
+        // Cubic: a server bound on IPv6 must still be reported healthy. Bind an
+        // IPv6 loopback listener and probe it via a bracketed IPv6 addr.
+        use std::io::{Read, Write};
+        let listener = match std::net::TcpListener::bind(("::1", 0)) {
+            Ok(l) => l,
+            // Some CI sandboxes lack IPv6 loopback; skip rather than fail.
+            Err(_) => return,
+        };
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut sock, _)) = listener.accept() {
+                let mut buf = [0u8; 256];
+                let _ = sock.read(&mut buf);
+                let _ = sock.write_all(b"HTTP/1.0 200 OK\r\nConnection: close\r\n\r\nok");
+            }
+        });
+        let code = run_healthcheck(&format!("[::1]:{port}"));
+        handle.join().unwrap();
+        assert_eq!(code, 0);
     }
 
     #[test]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -77,6 +77,11 @@ use hooks::*;
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    // `fakecloud healthcheck` probes a running server and exits — used by the
+    // container HEALTHCHECK so the slim published image needs no curl/wget.
+    if let Some(cli::Command::Healthcheck) = cli.command {
+        std::process::exit(run_healthcheck(&cli.addr));
+    }
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_new(&cli.log_level)
@@ -7322,6 +7327,57 @@ fn fatal_exit(args: std::fmt::Arguments<'_>) -> ! {
     let _ = std::io::stderr().flush();
     std::process::exit(1);
 }
+
+/// Probe `127.0.0.1:<port>/_fakecloud/health` over a raw TCP request (the
+/// published image ships no curl/wget) and return a process exit code: 0 when
+/// the server answers `200 OK`, 1 otherwise. The port is taken from the same
+/// `--addr`/`FAKECLOUD_ADDR` the server binds, so the container HEALTHCHECK and
+/// the server agree without extra configuration.
+fn run_healthcheck(addr: &str) -> i32 {
+    use std::io::{Read, Write};
+    let port = match addr.rsplit(':').next().and_then(|p| p.parse::<u16>().ok()) {
+        Some(p) => p,
+        None => {
+            eprintln!("healthcheck: could not parse port from addr {addr:?}");
+            return 1;
+        }
+    };
+    let target = (std::net::Ipv4Addr::LOCALHOST, port);
+    let timeout = std::time::Duration::from_secs(2);
+    let socket = match std::net::TcpStream::connect(target) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("healthcheck: connect 127.0.0.1:{port} failed: {e}");
+            return 1;
+        }
+    };
+    let _ = socket.set_read_timeout(Some(timeout));
+    let _ = socket.set_write_timeout(Some(timeout));
+    let mut socket = socket;
+    let request = "GET /_fakecloud/health HTTP/1.0\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+    if let Err(e) = socket.write_all(request.as_bytes()) {
+        eprintln!("healthcheck: write failed: {e}");
+        return 1;
+    }
+    let mut response = String::new();
+    if let Err(e) = socket.read_to_string(&mut response) {
+        eprintln!("healthcheck: read failed: {e}");
+        return 1;
+    }
+    // Status line looks like `HTTP/1.0 200 OK`. Accept any 2xx.
+    let healthy = response
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .is_some_and(|code| code.starts_with('2'));
+    if healthy {
+        0
+    } else {
+        let first = response.lines().next().unwrap_or("<no response>");
+        eprintln!("healthcheck: unhealthy response: {first}");
+        1
+    }
+}
 /// Route panics through `tracing::error!` so they show up in CI logs with
 /// the same formatting as regular errors. Runs the default hook afterwards
 /// so the process keeps its usual backtrace behaviour for developers
@@ -7617,6 +7673,52 @@ mod endpoint_url_tests {
 #[cfg(test)]
 mod startup_tests {
     use super::*;
+
+    // Spawn a one-shot TCP server that replies with `status_line`, then probe
+    // it via run_healthcheck. Returns the exit code.
+    fn probe_with_status(status_line: &'static str) -> i32 {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut sock, _)) = listener.accept() {
+                let mut buf = [0u8; 256];
+                let _ = sock.read(&mut buf);
+                let _ = sock.write_all(
+                    format!("{status_line}\r\nConnection: close\r\n\r\nbody").as_bytes(),
+                );
+            }
+        });
+        let code = run_healthcheck(&format!("0.0.0.0:{port}"));
+        handle.join().unwrap();
+        code
+    }
+
+    #[test]
+    fn healthcheck_zero_on_2xx() {
+        assert_eq!(probe_with_status("HTTP/1.0 200 OK"), 0);
+    }
+
+    #[test]
+    fn healthcheck_one_on_5xx() {
+        assert_eq!(probe_with_status("HTTP/1.0 500 Internal Server Error"), 1);
+    }
+
+    #[test]
+    fn healthcheck_one_when_unreachable() {
+        // Grab a port then drop the listener so nothing is accepting on it.
+        let port = {
+            let l = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+            l.local_addr().unwrap().port()
+        };
+        assert_eq!(run_healthcheck(&format!("0.0.0.0:{port}")), 1);
+    }
+
+    #[test]
+    fn healthcheck_one_on_unparseable_addr() {
+        assert_eq!(run_healthcheck("not-an-addr"), 1);
+    }
+
     #[test]
     fn announce_bound_port_uses_tagged_prefix() {
         let mut buf: Vec<u8> = Vec::new();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,21 @@ services:
       - "4566:4566"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    # Lambda / RDS / ElastiCache / ECS publish their backing-container ports on
+    # the host loopback; the fakecloud container reaches them via
+    # host.docker.internal. Docker Desktop maps this automatically, but on
+    # native-Linux Docker it must be wired explicitly (matches install.md).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       FAKECLOUD_ADDR: "0.0.0.0:4566"
       FAKECLOUD_REGION: "us-east-1"
       FAKECLOUD_ACCOUNT_ID: "123456789012"
       FAKECLOUD_LOG: "info"
+    # The slim image ships no curl/wget — use the binary's own healthcheck
+    # subcommand, which probes 127.0.0.1:<port>/_fakecloud/health.
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4566/_fakecloud/health"]
+      test: ["CMD", "fakecloud", "healthcheck"]
       interval: 5s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
## Summary
The compose healthcheck shelled out to `curl`, absent from the published image (ca-certificates + docker CLI only) → container permanently `(unhealthy)`, any `depends_on: { condition: service_healthy }` hangs forever (audit Tier 0 distribution, **CRITICAL**).

- New `fakecloud healthcheck` subcommand: probes `127.0.0.1:<port>/_fakecloud/health` over a raw TCP request (no curl/wget), exits 0 on 2xx else 1. Port taken from `--addr`/`FAKECLOUD_ADDR`.
- Compose healthcheck now `["CMD","fakecloud","healthcheck"]`.
- Added `host.docker.internal:host-gateway` `extra_hosts` required for native-Linux Docker (audit Tier 0, HIGH).

## Test plan
- 4 unit tests: 2xx→0, 5xx→1, unreachable→1, unparseable addr→1
- `cargo build --bin fakecloud`, clippy, fmt all clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Compose healthcheck with a built-in `fakecloud healthcheck` so containers report healthy across IPv4 and IPv6. Also added `host.docker.internal` for native-Linux Docker so `depends_on: { condition: service_healthy }` works reliably.

- **Bug Fixes**
  - Added `healthcheck` subcommand that probes `/_fakecloud/health` over raw TCP; exits 0 on 2xx, else 1. Uses `--addr`/`FAKECLOUD_ADDR` and supports IPv4, IPv6, and wildcard binds.
  - Updated compose HEALTHCHECK to `["CMD","fakecloud","healthcheck"]` to remove the curl dependency.
  - Added `extra_hosts: ["host.docker.internal:host-gateway"]` for native-Linux Docker networking.

<sup>Written for commit 31462e400d6bcec5677fe33a9826c584712f80f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

