### PR TITLE
fix(dynamodb): monotonic unique stream sequence numbers (4.4)

### DIFF
--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -27,7 +27,14 @@ mod stream_records_serde {
     pub fn deserialize<'de, D: Deserializer<'de>>(
         d: D,
     ) -> Result<Arc<RwLock<Vec<StreamRecord>>>, D::Error> {
-        Ok(Arc::new(RwLock::new(Vec::<StreamRecord>::deserialize(d)?)))
+        let records = Vec::<StreamRecord>::deserialize(d)?;
+        // Raise the in-memory sequence-number floor above every persisted
+        // record so newly-minted numbers cannot collide with them after a
+        // restart, even if the wall-clock seed went backwards (4.4 / Cubic).
+        for r in &records {
+            crate::streams::observe_stream_sequence(&r.dynamodb.sequence_number);
+        }
+        Ok(Arc::new(RwLock::new(records)))
     }
 }
 

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -17,23 +17,43 @@ use uuid::Uuid;
 ///
 /// The counter is *seeded once* from the current wall-clock nanoseconds rather
 /// than from 1. Stream records persist across restart (4.5), so a counter that
-/// reset to 1 on restart would re-mint sequence numbers that collide with
-/// already-persisted records. Seeding from the clock — which only moves forward
-/// between restarts — keeps every post-restart number above any minted before,
-/// while the atomic increment preserves uniqueness + monotonicity within a run.
-/// Zero-padded to a fixed width so the decimal strings sort lexicographically.
-/// bug-audit 2026-05-28, 4.4.
-fn next_stream_sequence() -> String {
-    static STREAM_SEQUENCE: OnceLock<AtomicU64> = OnceLock::new();
-    let counter = STREAM_SEQUENCE.get_or_init(|| {
+/// reset to 1 would re-mint sequence numbers that collide with already-persisted
+/// records. The clock seed handles the common forward-moving case; because a
+/// clock can also step *backwards* (NTP), `observe_stream_sequence` additionally
+/// raises the floor above every persisted record loaded on restart, so the next
+/// minted number is guaranteed greater. The atomic increment preserves
+/// uniqueness + monotonicity within a run; zero-padding to a fixed width keeps
+/// the decimal strings lexicographically ordered. bug-audit 2026-05-28, 4.4.
+static STREAM_SEQUENCE: OnceLock<AtomicU64> = OnceLock::new();
+
+fn stream_sequence_counter() -> &'static AtomicU64 {
+    STREAM_SEQUENCE.get_or_init(|| {
         let seed = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos() as u64)
             .unwrap_or(1)
             .max(1);
         AtomicU64::new(seed)
-    });
-    format!("{:021}", counter.fetch_add(1, Ordering::Relaxed))
+    })
+}
+
+fn next_stream_sequence() -> String {
+    format!(
+        "{:021}",
+        stream_sequence_counter().fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+/// Raise the sequence-number floor so the next minted number exceeds an
+/// already-existing one. Called for every persisted stream record loaded on
+/// restart: the wall-clock seed alone is not restart-safe (the clock can step
+/// backwards via NTP and reissue a persisted number), so we also bump the
+/// counter above the maximum sequence number we have ever seen. bug-audit
+/// 2026-05-28, 4.4.
+pub fn observe_stream_sequence(sequence_number: &str) {
+    if let Ok(seq) = sequence_number.parse::<u64>() {
+        stream_sequence_counter().fetch_max(seq.saturating_add(1), Ordering::Relaxed);
+    }
 }
 
 /// Generate a stream record for a table mutation.
@@ -144,6 +164,22 @@ mod tests {
         assert!(
             n > 1_000_000_000_000_000_000,
             "sequence not clock-seeded: {seq}"
+        );
+    }
+
+    #[test]
+    fn observe_stream_sequence_raises_floor_above_persisted() {
+        // bug-audit 4.4 (Cubic): after observing a persisted sequence number,
+        // the next minted number must exceed it — even if it is far above the
+        // wall-clock seed (simulating a clock that went backwards on restart).
+        // A high-but-u64-valid value (real sequence numbers are u64), well
+        // above the ~1.7e18 nanosecond seed, zero-padded to the 21-char width.
+        let high = format!("{:021}", 9_000_000_000_000_000_000u64);
+        observe_stream_sequence(&high);
+        let next: u64 = next_stream_sequence().parse().unwrap();
+        assert!(
+            next >= 9_000_000_000_000_000_000,
+            "floor not raised: {next}"
         );
     }
 

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -2,6 +2,7 @@ use crate::state::{AttributeValue, DynamoDbStreamRecord, DynamoTable, StreamReco
 use chrono::Utc;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
 use uuid::Uuid;
 
 /// Mint a strictly-monotonic, unique DynamoDB stream sequence number.
@@ -10,13 +11,29 @@ use uuid::Uuid;
 /// collides under batch writes in the same nanosecond and can go backwards on
 /// a coarse clock or NTP step. Since `AT_SEQUENCE_NUMBER`/`AFTER_SEQUENCE_NUMBER`
 /// iterators locate a record by exact match, a duplicate seq makes them replay
-/// or skip records. A process-global atomic counter guarantees every record
-/// gets a unique, monotonically increasing number (per-stream ordering is a
-/// monotonic subset of the global one). Zero-padded to a fixed width so the
-/// decimal strings also sort lexicographically. bug-audit 2026-05-28, 4.4.
+/// or skip records. An atomic counter guarantees every record gets a unique,
+/// monotonically increasing number (per-stream ordering is a monotonic subset
+/// of the global one).
+///
+/// The counter is *seeded once* from the current wall-clock nanoseconds rather
+/// than from 1. Stream records persist across restart (4.5), so a counter that
+/// reset to 1 on restart would re-mint sequence numbers that collide with
+/// already-persisted records. Seeding from the clock — which only moves forward
+/// between restarts — keeps every post-restart number above any minted before,
+/// while the atomic increment preserves uniqueness + monotonicity within a run.
+/// Zero-padded to a fixed width so the decimal strings sort lexicographically.
+/// bug-audit 2026-05-28, 4.4.
 fn next_stream_sequence() -> String {
-    static STREAM_SEQUENCE: AtomicU64 = AtomicU64::new(1);
-    format!("{:021}", STREAM_SEQUENCE.fetch_add(1, Ordering::Relaxed))
+    static STREAM_SEQUENCE: OnceLock<AtomicU64> = OnceLock::new();
+    let counter = STREAM_SEQUENCE.get_or_init(|| {
+        let seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(1)
+            .max(1);
+        AtomicU64::new(seed)
+    });
+    format!("{:021}", counter.fetch_add(1, Ordering::Relaxed))
 }
 
 /// Generate a stream record for a table mutation.
@@ -113,6 +130,21 @@ mod tests {
             assert!(w[0] < w[1], "sequence numbers must strictly increase");
             assert_eq!(w[0].len(), w[1].len(), "fixed-width padding");
         }
+    }
+
+    #[test]
+    fn stream_sequence_numbers_seeded_above_low_persisted_values() {
+        // bug-audit 4.4 (Cubic): the counter is wall-clock seeded, not reset to
+        // 1, so post-restart numbers never collide with low sequence numbers
+        // already persisted from a prior run.
+        let seq = next_stream_sequence();
+        let n: u128 = seq.parse().unwrap();
+        // Nanoseconds since the 2017 epoch are well above 1e18; certainly above
+        // any handful of records a prior run would have minted from a low seed.
+        assert!(
+            n > 1_000_000_000_000_000_000,
+            "sequence not clock-seeded: {seq}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -178,8 +178,8 @@ mod tests {
         observe_stream_sequence(&high);
         let next: u64 = next_stream_sequence().parse().unwrap();
         assert!(
-            next >= 9_000_000_000_000_000_000,
-            "floor not raised: {next}"
+            next > 9_000_000_000_000_000_000,
+            "floor not strictly above observed: {next}"
         );
     }
 

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -1,7 +1,23 @@
 use crate::state::{AttributeValue, DynamoDbStreamRecord, DynamoTable, StreamRecord};
 use chrono::Utc;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use uuid::Uuid;
+
+/// Mint a strictly-monotonic, unique DynamoDB stream sequence number.
+///
+/// Sequence numbers were previously the wall-clock nanosecond timestamp, which
+/// collides under batch writes in the same nanosecond and can go backwards on
+/// a coarse clock or NTP step. Since `AT_SEQUENCE_NUMBER`/`AFTER_SEQUENCE_NUMBER`
+/// iterators locate a record by exact match, a duplicate seq makes them replay
+/// or skip records. A process-global atomic counter guarantees every record
+/// gets a unique, monotonically increasing number (per-stream ordering is a
+/// monotonic subset of the global one). Zero-padded to a fixed width so the
+/// decimal strings also sort lexicographically. bug-audit 2026-05-28, 4.4.
+fn next_stream_sequence() -> String {
+    static STREAM_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+    format!("{:021}", STREAM_SEQUENCE.fetch_add(1, Ordering::Relaxed))
+}
 
 /// Generate a stream record for a table mutation.
 /// This should be called after the mutation is applied.
@@ -42,7 +58,7 @@ pub fn generate_stream_record(
             .unwrap_or(0);
 
     let event_id = Uuid::new_v4().to_string();
-    let sequence_number = Utc::now().timestamp_nanos_opt()?.to_string();
+    let sequence_number = next_stream_sequence();
 
     Some(StreamRecord {
         event_id,
@@ -82,6 +98,45 @@ mod tests {
     use serde_json::json;
     use std::collections::BTreeMap;
     use std::sync::Arc;
+
+    #[test]
+    fn stream_sequence_numbers_are_unique_and_monotonic() {
+        // bug-audit 4.4: even when minted in a tight loop (formerly all the
+        // same nanosecond timestamp), every sequence number must be distinct
+        // and strictly increasing — otherwise AT/AFTER_SEQUENCE_NUMBER
+        // iterators replay or skip records.
+        let seqs: Vec<String> = (0..10_000).map(|_| next_stream_sequence()).collect();
+        let unique: std::collections::HashSet<&String> = seqs.iter().collect();
+        assert_eq!(unique.len(), seqs.len(), "sequence numbers must be unique");
+        for w in seqs.windows(2) {
+            // Fixed-width zero-padding makes lexicographic order == numeric.
+            assert!(w[0] < w[1], "sequence numbers must strictly increase");
+            assert_eq!(w[0].len(), w[1].len(), "fixed-width padding");
+        }
+    }
+
+    #[test]
+    fn stream_sequence_numbers_unique_under_concurrency() {
+        // Mint from many threads at once: the atomic counter must still hand
+        // out distinct numbers (no same-instant collision).
+        use std::thread;
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                thread::spawn(|| {
+                    (0..1000)
+                        .map(|_| next_stream_sequence())
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        let mut all = std::collections::HashSet::new();
+        for h in handles {
+            for s in h.join().unwrap() {
+                assert!(all.insert(s), "duplicate sequence number across threads");
+            }
+        }
+        assert_eq!(all.len(), 8 * 1000);
+    }
 
     fn make_stream_table() -> DynamoTable {
         DynamoTable {


### PR DESCRIPTION
## Summary
Stream sequence numbers used the wall-clock nanosecond timestamp → collisions under same-nanosecond batch writes + non-monotonic on clock skew/NTP step. Since AT/AFTER_SEQUENCE_NUMBER iterators match by exact sequence string, a duplicate makes them replay or skip records.

Mint from a process-global atomic counter, zero-padded to fixed width (unique + strictly increasing + lexicographically ordered). bug-audit 2026-05-28, 4.4.

## Test plan
- New tests: 10k tight-loop seqs all unique + strictly increasing; 8-thread concurrent mint all unique
- `cargo test -p fakecloud-dynamodb --lib`, clippy, fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB stream sequence numbers in `fakecloud-dynamodb` by minting them from a process‑global atomic counter seeded from the wall clock and raising the counter floor above persisted records on restore. Guarantees unique, strictly increasing, lexicographically ordered numbers so `AT_SEQUENCE_NUMBER`/`AFTER_SEQUENCE_NUMBER` iterators don’t replay or skip records across restarts.

- **Bug Fixes**
  - Replace wall‑clock nanosecond strings with a zero‑padded 21‑digit atomic `u64` counter seeded once; on startup, observe persisted sequence numbers and bump the counter strictly above the max seen to avoid collisions even if the clock moved backward.
  - Add tests for 10k monotonic uniqueness, 8‑thread concurrency, and restart safety with a strict “greater than” floor (tightened from >=).

<sup>Written for commit 11cdd65d0fed4f2f22983605b565f425cb8c0afa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

