### PR TITLE
fix(iam): KMS authorization requires key-policy delegation to IAM (5.5)

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -1703,21 +1703,12 @@ async fn kms_identity_policy_explicit_deny_beats_key_policy() {
 
 #[tokio::test]
 async fn kms_no_identity_policy_denied() {
-    // User with no identity policy at all is denied even though the
-    // default key policy grants kms:* to the account root. In same-account
-    // mode, identity OR resource policy must allow — but the resource
-    // policy names the root, not the specific user.
-    //
-    // Wait — actually in same-account, identity OR resource policy
-    // allowing is enough. The default key policy grants root (which
-    // matches any principal in the account via AwsAccountRoot), so
-    // the user IS granted by the key policy alone.
-    //
-    // This test verifies that the key policy root grant works: a user
-    // with an identity-policy allowing kms:CreateKey (to avoid the
-    // IAM gate on CreateKey itself) can use the key even without
-    // explicit kms:Encrypt in identity policy, because the key policy
-    // grants root.
+    // The default key policy's "Enable IAM permissions" statement grants the
+    // account *root* (kms:* on the key). In AWS this does NOT directly authorize
+    // every principal in the account — it *delegates* authorization to IAM, so a
+    // principal still needs an identity policy allowing the KMS action. A user
+    // whose only identity grant is kms:DescribeKey is therefore denied
+    // kms:Encrypt (bug-audit 2026-05-28, 5.5).
     let server = start_strict().await;
     let (akid, secret) = bootstrap_user(&server, "kms_keypol_user").await;
     attach_inline_policy(
@@ -1730,23 +1721,27 @@ async fn kms_no_identity_policy_denied() {
     )
     .await;
 
-    // Create a key as root.
+    // Create a key as root (gets the default IAM-delegating key policy).
     let boot = sdk_config_with(&server, "test", "test").await;
     let kms_boot = aws_sdk_kms::Client::new(&boot);
     let key = kms_boot.create_key().send().await.unwrap();
     let key_id = key.key_metadata().unwrap().key_id().to_string();
 
-    // User encrypts -> should succeed because key policy grants root
-    // (same-account Allow-union: resource policy Allow is enough).
+    // User encrypts -> denied: the key policy only delegates to IAM, and the
+    // user's identity policy does not allow kms:Encrypt.
     let user_cfg = sdk_config_with(&server, &akid, &secret).await;
     let kms_user = aws_sdk_kms::Client::new(&user_cfg);
-    kms_user
+    let err = kms_user
         .encrypt()
         .key_id(&key_id)
         .plaintext(aws_sdk_kms::primitives::Blob::new(b"keypol-test"))
         .send()
         .await
-        .unwrap();
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied for kms:Encrypt without an identity grant, got {err:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -646,6 +646,17 @@ pub fn evaluate_with_resource_policy_and_gates_and_scps(
     }
 
     let same_account = request.principal.account_id == resource_account_id;
+    // KMS keys are governed by their key policy. Unlike the generic
+    // same-account `identity OR resource` rule, a KMS identity-policy grant
+    // only takes effect when the key policy delegates to the account's IAM
+    // (the default "Enable IAM permissions" root statement). A key policy that
+    // neither names the principal directly nor delegates to the account root
+    // makes identity grants powerless. bug-audit 2026-05-28, 5.5.
+    if same_account && request.action.starts_with("kms:") {
+        if let Some(policy) = resource_policy {
+            return evaluate_kms_same_account(policy, identity_gated, request);
+        }
+    }
     // Same-account with no resource policy: preserve the identity-only
     // path so rollouts without a bucket/topic policy behave as before.
     if resource_policy.is_none() && same_account {
@@ -672,10 +683,58 @@ pub fn evaluate_with_resource_policy_and_gates_and_scps(
     }
 }
 
+/// Same-account KMS authorization. The key policy is the root of trust:
+///
+/// 1. An explicit `Deny` in the key policy denies.
+/// 2. A *direct* grant — the key policy names this specific principal (by ARN,
+///    service, or federation, not the account-wide root entry) — allows on its
+///    own.
+/// 3. Otherwise a key-policy `Allow` can only have come from the account-root /
+///    `"AWS": "*"` delegation, which merely *enables* IAM: the request is
+///    allowed only if an identity policy (already gated by boundary/session/SCP)
+///    also allows it.
+/// 4. A key policy that neither grants directly nor delegates denies, even if
+///    identity policies allow.
+fn evaluate_kms_same_account(
+    key_policy: &PolicyDocument,
+    identity_gated: Decision,
+    request: &EvalRequest<'_>,
+) -> Decision {
+    let policies = std::slice::from_ref(key_policy);
+    let full = evaluate_inner_scoped(policies, request, true, false);
+    if matches!(full, Decision::ExplicitDeny) {
+        return Decision::ExplicitDeny;
+    }
+    // Direct grant ignores the account-wide delegation entries.
+    let direct = evaluate_inner_scoped(policies, request, true, true);
+    if matches!(direct, Decision::Allow) {
+        return Decision::Allow;
+    }
+    // A non-direct key-policy Allow is the account-root delegation to IAM:
+    // identity policies now decide. No delegation (`full` not Allow) -> deny.
+    if matches!(full, Decision::Allow) && matches!(identity_gated, Decision::Allow) {
+        return Decision::Allow;
+    }
+    Decision::ImplicitDeny
+}
+
 fn evaluate_inner(
     policies: &[PolicyDocument],
     request: &EvalRequest<'_>,
     is_resource_policy: bool,
+) -> Decision {
+    evaluate_inner_scoped(policies, request, is_resource_policy, false)
+}
+
+/// As [`evaluate_inner`], but when `ignore_account_wide` is set, account-wide
+/// resource-policy principals (`"AWS": "*"` / account root) do not match. KMS
+/// evaluation uses this to isolate a direct grant of a specific principal from
+/// the account-root delegation entry.
+fn evaluate_inner_scoped(
+    policies: &[PolicyDocument],
+    request: &EvalRequest<'_>,
+    is_resource_policy: bool,
+    ignore_account_wide: bool,
 ) -> Decision {
     let mut allowed = false;
     for policy in policies {
@@ -699,7 +758,7 @@ fn evaluate_inner(
                     }
                 }
                 PrincipalPattern::Principal(refs) => {
-                    if !principal_matches(refs, request.principal) {
+                    if !principal_matches_scoped(refs, request.principal, ignore_account_wide) {
                         continue;
                     }
                 }
@@ -752,9 +811,23 @@ fn evaluate_inner(
 /// keep unimplemented principal types (`Federated`, `CanonicalUser`)
 /// from silently granting.
 fn principal_matches(refs: &[PrincipalRef], principal: &Principal) -> bool {
+    principal_matches_scoped(refs, principal, false)
+}
+
+/// As [`principal_matches`], but when `ignore_account_wide` is set the
+/// account-wide entries (`"AWS": "*"` and `arn:aws:iam::<acct>:root`) do not
+/// match. KMS evaluation uses this to tell a *direct* grant of a specific
+/// principal apart from the default "Enable IAM" account-root delegation.
+fn principal_matches_scoped(
+    refs: &[PrincipalRef],
+    principal: &Principal,
+    ignore_account_wide: bool,
+) -> bool {
     refs.iter().any(|r| match r {
-        PrincipalRef::AnyAws => true,
-        PrincipalRef::AwsAccountRoot(account) => &principal.account_id == account,
+        PrincipalRef::AnyAws => !ignore_account_wide,
+        PrincipalRef::AwsAccountRoot(account) => {
+            !ignore_account_wide && &principal.account_id == account
+        }
         PrincipalRef::AwsArn(arn) => &principal.arn == arn,
         PrincipalRef::Service(service) => principal_is_service(principal, service),
         PrincipalRef::Federated(provider) => principal_is_federated(principal, provider),

--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -652,7 +652,14 @@ pub fn evaluate_with_resource_policy_and_gates_and_scps(
     // (the default "Enable IAM permissions" root statement). A key policy that
     // neither names the principal directly nor delegates to the account root
     // makes identity grants powerless. bug-audit 2026-05-28, 5.5.
-    if same_account && request.action.starts_with("kms:") {
+    // IAM actions are case-insensitive, so match the `kms:` service prefix
+    // case-insensitively rather than letting a mixed-case `KMS:Decrypt` slip
+    // past the key-policy delegation rule.
+    let is_kms = request
+        .action
+        .split_once(':')
+        .is_some_and(|(svc, _)| svc.eq_ignore_ascii_case("kms"));
+    if same_account && is_kms {
         if let Some(policy) = resource_policy {
             return evaluate_kms_same_account(policy, identity_gated, request);
         }

--- a/crates/fakecloud-iam/src/evaluator_tests.rs
+++ b/crates/fakecloud-iam/src/evaluator_tests.rs
@@ -2019,3 +2019,25 @@ fn kms_explicit_deny_in_key_policy_wins() {
         Decision::ExplicitDeny
     );
 }
+
+#[test]
+fn kms_delegation_rule_is_case_insensitive_on_action_prefix() {
+    // IAM actions are case-insensitive; a mixed-case service prefix must still
+    // route through the KMS key-policy delegation rule, not the generic
+    // identity-OR-resource path (bug-audit 5.5 hardening).
+    let p = principal_user("arn:aws:iam::123456789012:user/alice");
+    let key_policy = doc(json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:user/bob"},
+            "Action": "kms:*",
+            "Resource": "*"
+        }]
+    }));
+    let r = req(&p, "KMS:Decrypt", KMS_KEY_ARN);
+    assert_eq!(
+        evaluate_with_resource_policy(&[kms_identity_allow()], Some(&key_policy), &r, KMS_ACCT),
+        Decision::ImplicitDeny
+    );
+}

--- a/crates/fakecloud-iam/src/evaluator_tests.rs
+++ b/crates/fakecloud-iam/src/evaluator_tests.rs
@@ -1894,3 +1894,128 @@ fn scp_caps_identity_side_of_resource_policy() {
         Decision::ImplicitDeny
     );
 }
+
+// --- KMS key-policy delegation (bug-audit 2026-05-28, 5.5) ----------
+
+const KMS_ACCT: &str = "123456789012";
+const KMS_KEY_ARN: &str = "arn:aws:kms:us-east-1:123456789012:key/k1";
+
+fn kms_identity_allow() -> PolicyDocument {
+    doc(json!({
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "Action": "kms:Decrypt", "Resource": "*"}]
+    }))
+}
+
+#[test]
+fn kms_nondelegating_key_policy_blocks_identity_grant() {
+    // Key policy grants only some other principal; it neither names this
+    // caller nor delegates to the account root. Identity allows kms:Decrypt,
+    // but AWS denies because identity is powerless without key-policy
+    // delegation.
+    let p = principal_user("arn:aws:iam::123456789012:user/alice");
+    let key_policy = doc(json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:user/bob"},
+            "Action": "kms:*",
+            "Resource": "*"
+        }]
+    }));
+    let r = req(&p, "kms:Decrypt", KMS_KEY_ARN);
+    assert_eq!(
+        evaluate_with_resource_policy(&[kms_identity_allow()], Some(&key_policy), &r, KMS_ACCT),
+        Decision::ImplicitDeny
+    );
+}
+
+#[test]
+fn kms_default_delegating_policy_plus_identity_allows() {
+    // Default "Enable IAM permissions" key policy delegates to the account
+    // root; the identity grant then takes effect.
+    let p = principal_user("arn:aws:iam::123456789012:user/alice");
+    let key_policy = doc(json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+            "Action": "kms:*",
+            "Resource": "*"
+        }]
+    }));
+    let r = req(&p, "kms:Decrypt", KMS_KEY_ARN);
+    assert_eq!(
+        evaluate_with_resource_policy(&[kms_identity_allow()], Some(&key_policy), &r, KMS_ACCT),
+        Decision::Allow
+    );
+}
+
+#[test]
+fn kms_delegating_policy_without_identity_denies() {
+    // Delegation merely enables IAM; with no identity policy the request is
+    // denied.
+    let p = principal_user("arn:aws:iam::123456789012:user/alice");
+    let key_policy = doc(json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+            "Action": "kms:*",
+            "Resource": "*"
+        }]
+    }));
+    let r = req(&p, "kms:Decrypt", KMS_KEY_ARN);
+    assert_eq!(
+        evaluate_with_resource_policy(&[], Some(&key_policy), &r, KMS_ACCT),
+        Decision::ImplicitDeny
+    );
+}
+
+#[test]
+fn kms_direct_key_policy_grant_allows_without_identity() {
+    // Key policy names the principal directly -> allowed even with no identity
+    // policy.
+    let p = principal_user("arn:aws:iam::123456789012:user/alice");
+    let key_policy = doc(json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:user/alice"},
+            "Action": "kms:Decrypt",
+            "Resource": "*"
+        }]
+    }));
+    let r = req(&p, "kms:Decrypt", KMS_KEY_ARN);
+    assert_eq!(
+        evaluate_with_resource_policy(&[], Some(&key_policy), &r, KMS_ACCT),
+        Decision::Allow
+    );
+}
+
+#[test]
+fn kms_explicit_deny_in_key_policy_wins() {
+    let p = principal_user("arn:aws:iam::123456789012:user/alice");
+    let key_policy = doc(json!({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+                "Action": "kms:*",
+                "Resource": "*"
+            },
+            {
+                "Effect": "Deny",
+                "Principal": {"AWS": "*"},
+                "Action": "kms:Decrypt",
+                "Resource": "*"
+            }
+        ]
+    }));
+    let r = req(&p, "kms:Decrypt", KMS_KEY_ARN);
+    assert_eq!(
+        evaluate_with_resource_policy(&[kms_identity_allow()], Some(&key_policy), &r, KMS_ACCT),
+        Decision::ExplicitDeny
+    );
+}


### PR DESCRIPTION
## Summary
KMS reused the generic same-account `identity OR resource` rule, so an identity-policy grant authorized a key op even when the key policy did not delegate to IAM. AWS treats the key policy as the root of trust: identity policies only take effect when the key policy delegates to the account root (the default "Enable IAM permissions" statement).

New same-account KMS path: explicit Deny denies; a direct grant naming the principal allows alone; otherwise a key-policy Allow is account-root delegation that only *enables* IAM, so the request also needs an identity grant; a key policy that neither grants directly nor delegates denies even if identity allows. Cross-account unchanged. bug-audit 2026-05-28, 5.5.

## Test plan
- 5 new tests: non-delegating+identity→deny, default-delegating+identity→allow, delegating-no-identity→deny, direct-grant-no-identity→allow, explicit-deny→deny
- `cargo test -p fakecloud-iam --lib` — 454 pass (449 prior intact), clippy + fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes same-account KMS authorization to require key policy delegation to IAM, matching AWS. Also routes mixed-case KMS actions through this logic; identity policies only grant when the key policy delegates or directly names the principal.

- **Bug Fixes**
  - KMS-specific same-account path: explicit Deny wins; a direct key-policy grant allows; otherwise a key-policy Allow is delegation that only enables IAM, so an identity Allow is also required; no delegation → deny.
  - KMS action prefix match is case-insensitive (e.g., KMS:Decrypt).
  - Cross-account KMS evaluation is unchanged.
  - Added 6 tests in `crates/fakecloud-iam` (non-delegating+identity deny, default-delegating+identity allow, delegating-without-identity deny, direct-grant allow, explicit-deny, mixed-case routing) and updated e2e `kms_no_identity_policy_denied` to assert AccessDenied.

<sup>Written for commit 3f66e7848e339dd7c95e132fee3f5a4fcc2ba606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

