### PR TITLE
fix(iam,s3): cross-account S3 requires bucket policy to grant access (5.3)

### DIFF
--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -469,6 +469,18 @@ pub trait ResourcePolicyProvider: Send + Sync {
     /// match the service prefix they own and return `None` for
     /// anything else so providers can be composed safely.
     fn resource_policy(&self, service: &str, resource_arn: &str) -> Option<String>;
+
+    /// Resolve the 12-digit account that owns `resource_arn` on `service`,
+    /// when the ARN itself does not carry it. S3 ARNs have an empty account
+    /// field (`arn:aws:s3:::bucket`), so without this the dispatcher would
+    /// fall back to the caller's account and treat every S3 request as
+    /// same-account — letting account A reach account B's bucket without B's
+    /// bucket policy granting it (bug-audit 2026-05-28, 5.3). Providers whose
+    /// ARNs already carry the account (SQS/SNS/Lambda/…) return `None` and let
+    /// the dispatcher parse it from the ARN. Default `None`.
+    fn resource_owner_account(&self, _service: &str, _resource_arn: &str) -> Option<String> {
+        None
+    }
 }
 
 /// Failure mode for IAM PassRole trust-policy validation.
@@ -576,6 +588,12 @@ impl ResourcePolicyProvider for MultiResourcePolicyProvider {
         self.providers
             .iter()
             .find_map(|p| p.resource_policy(service, resource_arn))
+    }
+
+    fn resource_owner_account(&self, service: &str, resource_arn: &str) -> Option<String> {
+        self.providers
+            .iter()
+            .find_map(|p| p.resource_owner_account(service, resource_arn))
     }
 }
 

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -524,12 +524,22 @@ pub async fn dispatch(
                             config.resource_policy_provider.as_ref().and_then(|p| {
                                 p.resource_policy(&detected.service, &iam_action.resource)
                             });
-                        // Derive the resource-owning account from the
-                        // resource ARN. Wildcard (`*`) means the action
-                        // isn't scoped to a specific resource (e.g.
-                        // ListQueues, GetCallerIdentity) — treat it as
-                        // same-account by using the caller's account.
-                        let resource_account_id = parse_account_from_arn(&iam_action.resource)
+                        // Derive the resource-owning account. Prefer a provider
+                        // lookup (S3 ARNs carry no account, so the bucket's
+                        // owner is resolved from state — without this, account
+                        // A reaching account B's bucket would be mis-read as
+                        // same-account and skip B's bucket-policy requirement,
+                        // bug-audit 2026-05-28, 5.3), then fall back to the
+                        // account embedded in the ARN (SQS/SNS/Lambda/…), then
+                        // to the caller's account for wildcard / unscoped
+                        // actions (ListQueues, GetCallerIdentity).
+                        let resource_account_id = config
+                            .resource_policy_provider
+                            .as_ref()
+                            .and_then(|p| {
+                                p.resource_owner_account(&detected.service, &iam_action.resource)
+                            })
+                            .or_else(|| parse_account_from_arn(&iam_action.resource))
                             .unwrap_or_else(|| principal.account_id.clone());
                         // SCP ceiling: resolve the inherited SCP chain
                         // for this principal (management accounts and

--- a/crates/fakecloud-s3/src/resource_policy.rs
+++ b/crates/fakecloud-s3/src/resource_policy.rs
@@ -56,6 +56,21 @@ impl ResourcePolicyProvider for S3ResourcePolicyProvider {
             .get(bucket_name)
             .and_then(|b| b.policy.clone())
     }
+
+    fn resource_owner_account(&self, service: &str, resource_arn: &str) -> Option<String> {
+        if !service.eq_ignore_ascii_case("s3") {
+            return None;
+        }
+        // S3 ARNs carry no account, so resolve the bucket's owner from state.
+        // This lets the dispatcher detect cross-account access (account A
+        // reaching account B's bucket) and require B's bucket policy to grant
+        // it, instead of falling back to the caller's account and treating it
+        // as same-account (bug-audit 2026-05-28, 5.3).
+        let bucket_name = parse_bucket_name(resource_arn)?;
+        let mas = self.state.read();
+        mas.find_account(|s| s.buckets.contains_key(bucket_name))
+            .map(|a| a.to_string())
+    }
 }
 
 /// Extract the bucket name from an S3 ARN.
@@ -144,6 +159,45 @@ mod tests {
         let provider = S3ResourcePolicyProvider::new(state);
         assert_eq!(
             provider.resource_policy("s3", "arn:aws:s3:::mybucket"),
+            None
+        );
+    }
+
+    #[test]
+    fn resource_owner_account_resolves_bucket_owner() {
+        // bug-audit 5.3: a bucket owned by account B must report B as its
+        // owner so the dispatcher detects cross-account access from account A
+        // and requires B's bucket policy to grant it.
+        let mut mas: fakecloud_core::multi_account::MultiAccountState<S3State> =
+            fakecloud_core::multi_account::MultiAccountState::new("111111111111", "us-east-1", "");
+        let s = mas.get_or_create("222222222222");
+        s.buckets.insert(
+            "acct-b-bucket".to_string(),
+            S3Bucket::new("acct-b-bucket", "us-east-1", "owner"),
+        );
+        let provider = S3ResourcePolicyProvider::new(Arc::new(RwLock::new(mas)));
+        assert_eq!(
+            provider.resource_owner_account("s3", "arn:aws:s3:::acct-b-bucket"),
+            Some("222222222222".to_string())
+        );
+    }
+
+    #[test]
+    fn resource_owner_account_none_for_unknown_bucket() {
+        let state = state_with_bucket("mybucket", None);
+        let provider = S3ResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_owner_account("s3", "arn:aws:s3:::ghost"),
+            None
+        );
+    }
+
+    #[test]
+    fn resource_owner_account_none_for_non_s3_service() {
+        let state = state_with_bucket("mybucket", None);
+        let provider = S3ResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_owner_account("sqs", "arn:aws:s3:::mybucket"),
             None
         );
     }


### PR DESCRIPTION
## Summary
S3 ARNs carry no account field, so dispatch fell back to the caller's account as the resource owner → every S3 request evaluated as same-account (`identity OR resource`). Account A with `s3:*` on `*` could reach account B's bucket without B's bucket policy granting it. AWS requires identity AND resource cross-account.

Add a `resource_owner_account` hook to `ResourcePolicyProvider` (default `None`; S3 provider resolves the bucket's owning account from state) and have dispatch prefer it over the ARN-parsed account. SQS/SNS/Lambda ARNs already carry the account and fall through unchanged. bug-audit 2026-05-28, 5.3.

Scope: the S3 bypass (clearly exploitable). The SQS/SNS `sqs_resource_for` owner-ARN refinement is a distinct code path, tracked as a follow-up.

## Test plan
- 3 new S3 provider tests: owner resolves to the bucket's account; None for unknown bucket; None for non-s3 service
- `cargo test -p fakecloud-core -p fakecloud-s3 --lib` — 212 + 332 pass; clippy + fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cross-account S3 auth bug where S3 ARNs lacked an account ID, causing requests to be treated as same-account and bypassing required bucket policies. The dispatcher now resolves the bucket owner via the S3 provider and enforces the bucket policy for cross-account access, matching AWS behavior.

- **Bug Fixes**
  - Added `resource_owner_account` to `ResourcePolicyProvider` (default `None`).
  - Implemented in `fakecloud-s3` to resolve the bucket’s owning account from state; non-S3 services unchanged.
  - Dispatcher prefers provider-resolved owner, then ARN account, then caller for unscoped actions.
  - Added tests for bucket owner resolution and edge cases.

<sup>Written for commit 7a0d9ac5e46f1421cb6b54e45d3c5c2961ca12ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

