### PR TITLE
fix(elasticache): background Create{CacheCluster,ReplicationGroup,ServerlessCache} (3.2)

### DIFF
--- a/crates/fakecloud-conformance/tests/elasticache.rs
+++ b/crates/fakecloud-conformance/tests/elasticache.rs
@@ -194,7 +194,9 @@ async fn elasticache_create_replication_group() {
 
     let group = response.replication_group().expect("replication group");
     assert_eq!(group.replication_group_id(), Some("test-repl-group"));
-    assert_eq!(group.status(), Some("available"));
+    // CreateReplicationGroup returns "creating"; the backing container starts
+    // asynchronously (matches real AWS — bug-audit 2026-05-28, 3.2).
+    assert_eq!(group.status(), Some("creating"));
 }
 
 #[test_action("elasticache", "CreateGlobalReplicationGroup", checksum = "5a6b779c")]
@@ -245,7 +247,10 @@ async fn elasticache_create_cache_cluster() {
 
     let cluster = response.cache_cluster().expect("cache cluster");
     assert_eq!(cluster.cache_cluster_id(), Some("test-cache-cluster"));
-    assert_eq!(cluster.cache_cluster_status(), Some("available"));
+    // CreateCacheCluster returns "creating"; the backing container is started
+    // asynchronously and the cluster transitions to "available" (matches real
+    // AWS — bug-audit 2026-05-28, 3.2).
+    assert_eq!(cluster.cache_cluster_status(), Some("creating"));
     assert_eq!(cluster.engine(), Some("redis"));
 }
 
@@ -991,7 +996,13 @@ async fn elasticache_test_failover() {
 
     let group = response.replication_group().expect("replication group");
     assert_eq!(group.replication_group_id(), Some("fo-repl-group"));
-    assert_eq!(group.status(), Some("available"));
+    // The backing container starts asynchronously, so the group may still be
+    // "creating" when TestFailover runs right after create (bug-audit 3.2).
+    assert!(
+        matches!(group.status(), Some("creating") | Some("available")),
+        "unexpected status: {:?}",
+        group.status()
+    );
 }
 
 #[test_action("elasticache", "CreateServerlessCache", checksum = "f551fb86")]
@@ -1016,7 +1027,9 @@ async fn elasticache_create_serverless_cache() {
     let cache = response.serverless_cache().expect("serverless cache");
     assert_eq!(cache.serverless_cache_name(), Some("test-serverless"));
     assert_eq!(cache.engine(), Some("redis"));
-    assert_eq!(cache.status(), Some("available"));
+    // CreateServerlessCache returns "creating"; the backing container starts
+    // asynchronously (matches real AWS — bug-audit 2026-05-28, 3.2).
+    assert_eq!(cache.status(), Some("creating"));
 }
 
 #[test_action("elasticache", "DescribeServerlessCaches", checksum = "130bb42b")]

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -45,9 +45,14 @@ async fn elasticache_create_cache_cluster_and_describe() {
 
     let cluster = create_resp.cache_cluster().expect("cache cluster");
     assert_eq!(cluster.cache_cluster_id(), Some("classic-cluster"));
-    assert_eq!(cluster.cache_cluster_status(), Some("available"));
+    assert_eq!(cluster.cache_cluster_status(), Some("creating"));
     assert_eq!(cluster.engine(), Some("redis"));
-    let arn = cluster.arn().expect("cluster arn");
+    let arn = cluster.arn().expect("cluster arn").to_string();
+
+    // The backing container starts in the background, so the cluster comes up
+    // as "creating"; wait for "available" before reading its endpoint
+    // (bug-audit 2026-05-28, 3.2).
+    helpers::wait_for_cache_cluster_available(&client, "classic-cluster", 120).await;
 
     let describe_resp = client
         .describe_cache_clusters()
@@ -683,7 +688,11 @@ async fn elasticache_create_replication_group_and_describe() {
     let group = create_resp.replication_group().expect("replication group");
     assert_eq!(group.replication_group_id(), Some("my-repl-group"));
     assert_eq!(group.description(), Some("My test replication group"));
-    assert_eq!(group.status(), Some("available"));
+    assert_eq!(group.status(), Some("creating"));
+
+    // Backing container starts in the background; wait for "available", then
+    // read the endpoint from the ready group (bug-audit 2026-05-28, 3.2).
+    let group = helpers::wait_for_replication_group_available(&client, "my-repl-group", 120).await;
 
     // Verify endpoint is populated and reachable
     let node_groups = group.node_groups();
@@ -1970,6 +1979,7 @@ async fn elasticache_test_failover() {
         .send()
         .await
         .unwrap();
+    helpers::wait_for_replication_group_available(&client, "fo-rg", 120).await;
 
     let response = client
         .test_failover()
@@ -2213,7 +2223,10 @@ async fn elasticache_create_serverless_cache_and_describe() {
 
     let cache = create_resp.serverless_cache().expect("serverless cache");
     assert_eq!(cache.serverless_cache_name(), Some("serverless-main"));
-    assert_eq!(cache.status(), Some("available"));
+    assert_eq!(cache.status(), Some("creating"));
+    // Backing container starts in the background; wait for "available" then read
+    // the endpoint from the ready cache (bug-audit 2026-05-28, 3.2).
+    let cache = helpers::wait_for_serverless_cache_available(&client, "serverless-main", 120).await;
     let endpoint = cache.endpoint().expect("endpoint");
     let addr = endpoint.address().expect("endpoint address");
     let port = endpoint.port().expect("endpoint port");
@@ -2559,7 +2572,10 @@ async fn elasticache_create_memcached_cluster_and_connect() {
     let cluster = create_resp.cache_cluster().expect("cache cluster");
     assert_eq!(cluster.engine(), Some("memcached"));
     assert_eq!(cluster.engine_version(), Some("1.6.22"));
-    assert_eq!(cluster.cache_cluster_status(), Some("available"));
+    assert_eq!(cluster.cache_cluster_status(), Some("creating"));
+
+    // Backing container starts in the background; wait before reading endpoint.
+    helpers::wait_for_cache_cluster_available(&client, "mc-cluster", 120).await;
 
     let describe = client
         .describe_cache_clusters()
@@ -3045,8 +3061,13 @@ async fn elasticache_memcached_cluster_emits_configuration_endpoint() {
         .await
         .unwrap();
 
-    let cluster = create_resp.cache_cluster().expect("cache cluster");
-    assert_eq!(cluster.engine(), Some("memcached"));
+    assert_eq!(
+        create_resp.cache_cluster().and_then(|c| c.engine()),
+        Some("memcached")
+    );
+    // Backing container starts in the background; the configuration endpoint
+    // port is filled in once it is ready (bug-audit 2026-05-28, 3.2).
+    let cluster = helpers::wait_for_cache_cluster_available(&client, "memc-config", 120).await;
     let ep = cluster
         .configuration_endpoint()
         .expect("memcached cluster must emit ConfigurationEndpoint");
@@ -3171,18 +3192,17 @@ async fn elasticache_modify_user_applies_acl_to_running_redis() {
         .await
         .unwrap();
 
-    let rg = client
+    client
         .create_replication_group()
         .replication_group_id("acl-rg")
         .replication_group_description("acl test")
         .user_group_ids("aclgroup")
         .send()
         .await
-        .unwrap()
-        .replication_group()
-        .expect("replication group")
-        .clone();
+        .unwrap();
 
+    // Backing container starts in the background; wait for the endpoint port.
+    let rg = helpers::wait_for_replication_group_available(&client, "acl-rg", 120).await;
     let port = rg
         .node_groups()
         .first()
@@ -3247,18 +3267,17 @@ async fn elasticache_modify_cache_parameter_group_applies_config_set() {
         .await
         .unwrap();
 
-    let cluster = client
+    client
         .create_cache_cluster()
         .cache_cluster_id("param-cluster")
         .cache_parameter_group_name("param-test")
         .cache_node_type("cache.t3.micro")
         .send()
         .await
-        .unwrap()
-        .cache_cluster()
-        .expect("cache cluster")
-        .clone();
+        .unwrap();
 
+    // Backing container starts in the background; wait for the endpoint port.
+    let cluster = helpers::wait_for_cache_cluster_available(&client, "param-cluster", 120).await;
     let port = cluster.cache_nodes()[0]
         .endpoint()
         .expect("cache node endpoint")

--- a/crates/fakecloud-e2e/tests/elasticache_persistence.rs
+++ b/crates/fakecloud-e2e/tests/elasticache_persistence.rs
@@ -47,6 +47,11 @@ async fn persistence_cache_cluster_endpoint_works_after_restart() {
         .await
         .unwrap();
 
+    // The backing container starts in the background; let the cluster reach
+    // "available" before snapshotting so the restart recovers a complete row
+    // (bug-audit 2026-05-28, 3.2).
+    helpers::wait_for_cache_cluster_available(&client, "restart-cache", 120).await;
+
     drop(client);
     server.restart().await;
     let client = server.elasticache_client().await;

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -105,3 +105,82 @@ pub async fn wait_for_db_available(
         db_instance_identifier, max_secs
     );
 }
+
+/// Poll DescribeCacheClusters until the cluster reaches "available" and return
+/// it. CreateCacheCluster now returns "creating" and starts the backing
+/// container in the background (bug-audit 3.2), so tests that read the endpoint
+/// or assert availability must wait first.
+pub async fn wait_for_cache_cluster_available(
+    client: &aws_sdk_elasticache::Client,
+    cache_cluster_id: &str,
+    max_secs: u64,
+) -> aws_sdk_elasticache::types::CacheCluster {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(max_secs);
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = client
+            .describe_cache_clusters()
+            .cache_cluster_id(cache_cluster_id)
+            .show_cache_node_info(true)
+            .send()
+            .await
+        {
+            for c in resp.cache_clusters() {
+                if c.cache_cluster_status() == Some("available") {
+                    return c.clone();
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    panic!("cache cluster {cache_cluster_id} did not reach 'available' within {max_secs}s");
+}
+
+/// Poll DescribeReplicationGroups until the group reaches "available".
+pub async fn wait_for_replication_group_available(
+    client: &aws_sdk_elasticache::Client,
+    replication_group_id: &str,
+    max_secs: u64,
+) -> aws_sdk_elasticache::types::ReplicationGroup {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(max_secs);
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = client
+            .describe_replication_groups()
+            .replication_group_id(replication_group_id)
+            .send()
+            .await
+        {
+            for g in resp.replication_groups() {
+                if g.status() == Some("available") {
+                    return g.clone();
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    panic!("replication group {replication_group_id} did not reach 'available' within {max_secs}s");
+}
+
+/// Poll DescribeServerlessCaches until the cache reaches "available".
+pub async fn wait_for_serverless_cache_available(
+    client: &aws_sdk_elasticache::Client,
+    serverless_cache_name: &str,
+    max_secs: u64,
+) -> aws_sdk_elasticache::types::ServerlessCache {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(max_secs);
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = client
+            .describe_serverless_caches()
+            .serverless_cache_name(serverless_cache_name)
+            .send()
+            .await
+        {
+            for c in resp.serverless_caches() {
+                if c.status() == Some("available") {
+                    return c.clone();
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    panic!("serverless cache {serverless_cache_name} did not reach 'available' within {max_secs}s");
+}

--- a/crates/fakecloud-e2e/tests/sdk.rs
+++ b/crates/fakecloud-e2e/tests/sdk.rs
@@ -235,7 +235,14 @@ async fn sdk_elasticache_get_serverless_caches() {
         .find(|c| c.serverless_cache_name == "sdk-ec-serverless")
         .expect("sdk-ec-serverless");
     assert_eq!(cache.engine, "redis");
-    assert_eq!(cache.status, "available");
+    // The backing container starts asynchronously, so right after create the
+    // cache is "creating" and transitions to "available" (bug-audit 3.2). This
+    // test only verifies introspection lists the cache, so accept either.
+    assert!(
+        cache.status == "creating" || cache.status == "available",
+        "unexpected serverless cache status: {}",
+        cache.status
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -1432,22 +1432,6 @@ pub(crate) fn user_group_xml(g: &ElastiCacheUserGroup) -> String {
     )
 }
 
-pub(crate) fn runtime_error_to_service_error(error: RuntimeError) -> AwsServiceError {
-    match error {
-        RuntimeError::Unavailable => AwsServiceError::aws_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "InvalidParameterValue",
-            "Docker/Podman is required for ElastiCache replication groups but is not available"
-                .to_string(),
-        ),
-        RuntimeError::ContainerStartFailed(msg) => AwsServiceError::aws_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "InvalidParameterValue",
-            format!("Failed to start Redis container: {msg}"),
-        ),
-    }
-}
-
 pub(crate) fn add_cluster_to_replication_group(
     state: &mut ElastiCacheState,
     replication_group_id: &str,

--- a/crates/fakecloud-elasticache/src/service/clusters.rs
+++ b/crates/fakecloud-elasticache/src/service/clusters.rs
@@ -166,46 +166,25 @@ impl ElastiCacheService {
             (preferred_availability_zone, arn, rdb_path)
         };
 
-        // When a container runtime is available, start the backing redis /
-        // memcached container so clients connecting to the returned endpoint
-        // talk to a real engine. When no runtime is available, fall back to
-        // metadata-only creation (no container, host_port=0): the cluster is
-        // visible to control-plane APIs and survives describe/modify/delete
-        // round-trips, just without a live data-plane. This mirrors how
-        // LocalStack-class fakes degrade and matches the Smithy contract —
-        // no declared error covers "Docker missing" so refusing the call
-        // would emit an undeclared wire code.
-        let running = if let Some(runtime) = self.runtime.as_ref() {
-            let runtime_result = if engine == ENGINE_MEMCACHED {
-                runtime.ensure_memcached(&cache_cluster_id).await
-            } else {
-                runtime
-                    .ensure_redis(&cache_cluster_id, rdb_path.as_deref())
-                    .await
-            };
-            match runtime_result {
-                Ok(r) => r,
-                Err(e) => {
-                    self.state
-                        .write()
-                        .get_or_create(&request.account_id)
-                        .cancel_cache_cluster_creation(&cache_cluster_id);
-                    return Err(runtime_error_to_service_error(e));
-                }
-            }
-        } else {
-            crate::runtime::RunningCacheContainer {
-                container_id: String::new(),
-                host_port: 0,
-            }
-        };
-
+        // Insert the cluster in the "creating" state and return immediately.
+        // Starting the backing container can cold-pull a multi-hundred-MB image
+        // and wait ~20s for readiness; blocking the CreateCacheCluster response
+        // on that made the AWS CLI hit its 60s read timeout. Instead we register
+        // the cluster as "creating" (endpoint port 0) and start the container in
+        // a background task that flips it to "available" once ready — matching
+        // real AWS and how RDS/ECS/Lambda already behave. When no runtime is
+        // available we degrade to a metadata-only cluster that is immediately
+        // "available" (no data plane), as before. bug-audit 2026-05-28, 3.2.
         let cluster = CacheCluster {
             cache_cluster_id: cache_cluster_id.clone(),
             cache_node_type,
-            engine,
+            engine: engine.clone(),
             engine_version,
-            cache_cluster_status: "available".to_string(),
+            cache_cluster_status: if self.runtime.is_some() {
+                "creating".to_string()
+            } else {
+                "available".to_string()
+            },
             num_cache_nodes,
             preferred_availability_zone,
             cache_subnet_group_name,
@@ -213,10 +192,10 @@ impl ElastiCacheService {
             arn,
             created_at: chrono::Utc::now().to_rfc3339(),
             endpoint_address: "127.0.0.1".to_string(),
-            endpoint_port: running.host_port,
-            container_id: running.container_id,
-            host_port: running.host_port,
-            replication_group_id,
+            endpoint_port: 0,
+            container_id: String::new(),
+            host_port: 0,
+            replication_group_id: replication_group_id.clone(),
             cache_parameter_group_name: cache_parameter_group_name.clone(),
             security_group_ids,
             log_delivery_configurations,
@@ -246,51 +225,92 @@ impl ElastiCacheService {
         };
 
         let xml = cache_cluster_xml(&cluster, true);
-        // All write-guard work is confined to this block so the (non-Send) lock
-        // guard is fully released before any `.await` below — otherwise the
-        // returned `handle` future is not `Send`.
-        let deleted_during_create = {
+        {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
-            // If a DeleteCacheCluster arrived while we were starting the
-            // container (the lock-drop window above), do NOT resurrect the
-            // cluster. Drop the in-progress marker; the container is reaped
-            // after the lock is released (bug-audit 2026-05-28, 4.3). We still
-            // return the CreateCacheCluster response — the cluster existed
-            // momentarily and a follow-up Describe correctly shows it gone.
+            // A DeleteCacheCluster may have raced in during param validation;
+            // honor it and do not resurrect the cluster (bug-audit 4.3).
             if state.take_cache_cluster_delete_request(&cache_cluster_id) {
                 state.cancel_cache_cluster_creation(&cache_cluster_id);
-                true
-            } else {
-                let cluster_arn = cluster.arn.clone();
-                state.finish_cache_cluster_creation(cluster.clone());
-                // Initialise the tag bucket for this resource ARN, then merge
-                // any `Tags.Tag.N` entries supplied at create time. Mirrors the
-                // pattern used by CreateReplicationGroup / CreateUser etc.
-                state.tags.entry(cluster_arn.clone()).or_default();
-                if !tags.is_empty() {
-                    merge_tags(state.tags.entry(cluster_arn).or_default(), &tags);
-                }
-                if let Some(ref group_id) = cluster.replication_group_id {
-                    add_cluster_to_replication_group(state, group_id, &cluster.cache_cluster_id);
-                }
-                false
+                return Ok(AwsResponse::xml(
+                    StatusCode::OK,
+                    query_response_xml(
+                        "CreateCacheCluster",
+                        ELASTICACHE_NS,
+                        &format!("<CacheCluster>{xml}</CacheCluster>"),
+                        &request.request_id,
+                    ),
+                ));
             }
-        };
+            let cluster_arn = cluster.arn.clone();
+            state.finish_cache_cluster_creation(cluster);
+            // Initialise the tag bucket for this resource ARN, then merge any
+            // `Tags.Tag.N` entries supplied at create time.
+            state.tags.entry(cluster_arn.clone()).or_default();
+            if !tags.is_empty() {
+                merge_tags(state.tags.entry(cluster_arn).or_default(), &tags);
+            }
+            if let Some(ref group_id) = replication_group_id {
+                add_cluster_to_replication_group(state, group_id, &cache_cluster_id);
+            }
+        }
 
-        if deleted_during_create {
-            if let Some(ref runtime) = self.runtime {
-                runtime.stop_container(&cache_cluster_id).await;
-            }
-            return Ok(AwsResponse::xml(
-                StatusCode::OK,
-                query_response_xml(
-                    "CreateCacheCluster",
-                    ELASTICACHE_NS,
-                    &format!("<CacheCluster>{xml}</CacheCluster>"),
-                    &request.request_id,
-                ),
-            ));
+        // Start the backing container off the request path. The task flips the
+        // cluster to "available" (and fills in the endpoint port) when ready, or
+        // tears it down if a DeleteCacheCluster arrived while it was starting.
+        if let Some(runtime) = self.runtime.clone() {
+            let state = self.state.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            let account_id = request.account_id.clone();
+            let id = cache_cluster_id.clone();
+            let is_memcached = engine == ENGINE_MEMCACHED;
+            tokio::spawn(async move {
+                let result = if is_memcached {
+                    runtime.ensure_memcached(&id).await
+                } else {
+                    runtime.ensure_redis(&id, rdb_path.as_deref()).await
+                };
+                let mut stop_container = false;
+                {
+                    let mut accounts = state.write();
+                    if let Some(s) = accounts.get_mut(&account_id) {
+                        let deleted = s.take_cache_cluster_delete_request(&id);
+                        match &result {
+                            Ok(running) if !deleted => {
+                                if let Some(c) = s.cache_clusters.get_mut(&id) {
+                                    c.cache_cluster_status = "available".to_string();
+                                    c.endpoint_address = "127.0.0.1".to_string();
+                                    c.endpoint_port = running.host_port;
+                                    c.host_port = running.host_port;
+                                    c.container_id = running.container_id.clone();
+                                }
+                            }
+                            Ok(_) => {
+                                // Deleted while creating: drop it, reap the
+                                // container after the lock is released.
+                                s.cancel_cache_cluster_creation(&id);
+                                s.cache_clusters.remove(&id);
+                                stop_container = true;
+                            }
+                            Err(error) => {
+                                tracing::error!(
+                                    %error,
+                                    cache_cluster_id = %id,
+                                    "failed to start elasticache cache cluster container",
+                                );
+                                if let Some(c) = s.cache_clusters.get_mut(&id) {
+                                    c.cache_cluster_status = "incompatible-network".to_string();
+                                }
+                            }
+                        }
+                    }
+                }
+                if stop_container {
+                    runtime.stop_container(&id).await;
+                }
+                save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+            });
         }
         if let Some(ref param_group) = cache_parameter_group_name {
             self.apply_parameters_for_group(&request.account_id, param_group)

--- a/crates/fakecloud-elasticache/src/service/mod.rs
+++ b/crates/fakecloud-elasticache/src/service/mod.rs
@@ -10,7 +10,7 @@ use fakecloud_core::query::{optional_query_param, query_response_xml, required_q
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_persistence::SnapshotStore;
 
-use crate::runtime::{ElastiCacheRuntime, RuntimeError};
+use crate::runtime::ElastiCacheRuntime;
 use crate::state::{
     default_engine_versions, default_parameters_for_family, CacheCluster, CacheEngineVersion,
     CacheParameterGroup, CacheSnapshot, CacheSubnetGroup, ElastiCacheSnapshot, ElastiCacheState,

--- a/crates/fakecloud-elasticache/src/service/replication.rs
+++ b/crates/fakecloud-elasticache/src/service/replication.rs
@@ -264,6 +264,7 @@ impl ElastiCacheService {
             let cluster_enabled_flag = cluster_enabled;
             tokio::spawn(async move {
                 let result = runtime.ensure_redis(&id, rdb_path.as_deref()).await;
+                let mut stop_container = false;
                 {
                     let mut accounts = state.write();
                     if let Some(s) = accounts.get_mut(&account_id) {
@@ -280,6 +281,11 @@ impl ElastiCacheService {
                                             Some("127.0.0.1".to_string());
                                         g.configuration_endpoint_port = Some(running.host_port);
                                     }
+                                } else {
+                                    // Deleted during startup: the container came
+                                    // up but the group is gone — reap it after
+                                    // the lock is released so it isn't orphaned.
+                                    stop_container = true;
                                 }
                             }
                             Err(error) => {
@@ -293,7 +299,13 @@ impl ElastiCacheService {
                                 }
                             }
                         }
+                    } else {
+                        // Whole account gone; reap a started container.
+                        stop_container = result.is_ok();
                     }
+                }
+                if stop_container {
+                    runtime.stop_container(&id).await;
                 }
                 save_snapshot_static(state, snapshot_store, snapshot_lock).await;
             });

--- a/crates/fakecloud-elasticache/src/service/replication.rs
+++ b/crates/fakecloud-elasticache/src/service/replication.rs
@@ -156,29 +156,13 @@ impl ElastiCacheService {
                 .and_then(|snap| snap.rdb_path.clone())
         };
 
-        let running = if let Some(runtime) = self.runtime.as_ref() {
-            match runtime
-                .ensure_redis(&replication_group_id, rdb_path.as_deref())
-                .await
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    self.state
-                        .write()
-                        .get_or_create(&request.account_id)
-                        .cancel_replication_group_creation(&replication_group_id);
-                    return Err(runtime_error_to_service_error(e));
-                }
-            }
-        } else {
-            // No container runtime: degrade to metadata-only replication
-            // group. The control-plane response shape is unaffected and
-            // describe/modify/delete still work; only the data plane
-            // (connecting to the endpoint) is unavailable.
-            crate::runtime::RunningCacheContainer {
-                container_id: String::new(),
-                host_port: 0,
-            }
+        // The backing container is started off the request path (below), so the
+        // group begins life with no endpoint port and is filled in once ready.
+        // Blocking the response on the cold image pull + readiness made the AWS
+        // CLI hit its 60s read timeout (bug-audit 2026-05-28, 3.2).
+        let running = crate::runtime::RunningCacheContainer {
+            container_id: String::new(),
+            host_port: 0,
         };
 
         let member_clusters: Vec<String> = (1..=num_cache_clusters)
@@ -201,7 +185,11 @@ impl ElastiCacheService {
             description,
             global_replication_group_id: None,
             global_replication_group_role: None,
-            status: "available".to_string(),
+            status: if self.runtime.is_some() {
+                "creating".to_string()
+            } else {
+                "available".to_string()
+            },
             cache_node_type,
             engine,
             engine_version,
@@ -263,6 +251,52 @@ impl ElastiCacheService {
             if !tags.is_empty() {
                 merge_tags(state.tags.entry(arn).or_default(), &tags);
             }
+        }
+
+        // Start the backing container off the request path and flip the group
+        // to "available" (filling in the endpoint port) once it is ready.
+        if let Some(runtime) = self.runtime.clone() {
+            let state = self.state.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            let account_id = request.account_id.clone();
+            let id = replication_group_id.clone();
+            let cluster_enabled_flag = cluster_enabled;
+            tokio::spawn(async move {
+                let result = runtime.ensure_redis(&id, rdb_path.as_deref()).await;
+                {
+                    let mut accounts = state.write();
+                    if let Some(s) = accounts.get_mut(&account_id) {
+                        match &result {
+                            Ok(running) => {
+                                if let Some(g) = s.replication_groups.get_mut(&id) {
+                                    g.status = "available".to_string();
+                                    g.endpoint_address = "127.0.0.1".to_string();
+                                    g.endpoint_port = running.host_port;
+                                    g.host_port = running.host_port;
+                                    g.container_id = running.container_id.clone();
+                                    if cluster_enabled_flag {
+                                        g.configuration_endpoint_address =
+                                            Some("127.0.0.1".to_string());
+                                        g.configuration_endpoint_port = Some(running.host_port);
+                                    }
+                                }
+                            }
+                            Err(error) => {
+                                tracing::error!(
+                                    %error,
+                                    replication_group_id = %id,
+                                    "failed to start elasticache replication group container",
+                                );
+                                if let Some(g) = s.replication_groups.get_mut(&id) {
+                                    g.status = "incompatible-network".to_string();
+                                }
+                            }
+                        }
+                    }
+                }
+                save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+            });
         }
         if !user_group_ids.is_empty() {
             self.apply_acls_for_replication_group(&request.account_id, &replication_group_id)

--- a/crates/fakecloud-elasticache/src/service/serverless.rs
+++ b/crates/fakecloud-elasticache/src/service/serverless.rs
@@ -125,6 +125,7 @@ impl ElastiCacheService {
             let name = serverless_cache_name.clone();
             tokio::spawn(async move {
                 let result = runtime.ensure_redis(&name, None).await;
+                let mut stop_container = false;
                 {
                     let mut accounts = state.write();
                     if let Some(s) = accounts.get_mut(&account_id) {
@@ -136,6 +137,11 @@ impl ElastiCacheService {
                                     c.reader_endpoint.port = running.host_port;
                                     c.host_port = running.host_port;
                                     c.container_id = running.container_id.clone();
+                                } else {
+                                    // Deleted during startup: the container came
+                                    // up but the cache is gone — reap it after
+                                    // the lock is released so it isn't orphaned.
+                                    stop_container = true;
                                 }
                             }
                             Err(error) => {
@@ -149,7 +155,12 @@ impl ElastiCacheService {
                                 }
                             }
                         }
+                    } else {
+                        stop_container = result.is_ok();
                     }
+                }
+                if stop_container {
+                    runtime.stop_container(&name).await;
                 }
                 save_snapshot_static(state, snapshot_store, snapshot_lock).await;
             });

--- a/crates/fakecloud-elasticache/src/service/serverless.rs
+++ b/crates/fakecloud-elasticache/src/service/serverless.rs
@@ -67,33 +67,17 @@ impl ElastiCacheService {
             (arn, "127.0.0.1".to_string())
         };
 
-        let running = if let Some(runtime) = self.runtime.as_ref() {
-            match runtime.ensure_redis(&serverless_cache_name, None).await {
-                Ok(r) => r,
-                Err(e) => {
-                    self.state
-                        .write()
-                        .get_or_create(&request.account_id)
-                        .cancel_serverless_cache_creation(&serverless_cache_name);
-                    return Err(runtime_error_to_service_error(e));
-                }
-            }
-        } else {
-            // No container runtime: metadata-only serverless cache. Matches
-            // the CreateCacheCluster / CreateReplicationGroup degradation.
-            crate::runtime::RunningCacheContainer {
-                container_id: String::new(),
-                host_port: 0,
-            }
-        };
-
+        // The backing container is started off the request path (below); the
+        // cache begins with no endpoint port and is filled in once ready, so the
+        // response doesn't block on the cold image pull + readiness (which made
+        // the AWS CLI hit its 60s read timeout). bug-audit 2026-05-28, 3.2.
         let endpoint = ServerlessCacheEndpoint {
             address: endpoint_address.clone(),
-            port: running.host_port,
+            port: 0,
         };
         let reader_endpoint = ServerlessCacheEndpoint {
             address: endpoint_address,
-            port: running.host_port,
+            port: 0,
         };
         let cache = ServerlessCache {
             serverless_cache_name: serverless_cache_name.clone(),
@@ -101,7 +85,11 @@ impl ElastiCacheService {
             engine,
             major_engine_version,
             full_engine_version,
-            status: "available".to_string(),
+            status: if self.runtime.is_some() {
+                "creating".to_string()
+            } else {
+                "available".to_string()
+            },
             endpoint,
             reader_endpoint,
             arn: arn.clone(),
@@ -113,8 +101,8 @@ impl ElastiCacheService {
             user_group_id,
             snapshot_retention_limit,
             daily_snapshot_time,
-            container_id: running.container_id,
-            host_port: running.host_port,
+            container_id: String::new(),
+            host_port: 0,
         };
 
         let xml = serverless_cache_xml(&cache);
@@ -125,6 +113,46 @@ impl ElastiCacheService {
             if !tags.is_empty() {
                 merge_tags(state.tags.entry(arn).or_default(), &tags);
             }
+        }
+
+        // Start the backing container off the request path and flip the cache
+        // to "available" (filling in the endpoint ports) once it is ready.
+        if let Some(runtime) = self.runtime.clone() {
+            let state = self.state.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            let account_id = request.account_id.clone();
+            let name = serverless_cache_name.clone();
+            tokio::spawn(async move {
+                let result = runtime.ensure_redis(&name, None).await;
+                {
+                    let mut accounts = state.write();
+                    if let Some(s) = accounts.get_mut(&account_id) {
+                        match &result {
+                            Ok(running) => {
+                                if let Some(c) = s.serverless_caches.get_mut(&name) {
+                                    c.status = "available".to_string();
+                                    c.endpoint.port = running.host_port;
+                                    c.reader_endpoint.port = running.host_port;
+                                    c.host_port = running.host_port;
+                                    c.container_id = running.container_id.clone();
+                                }
+                            }
+                            Err(error) => {
+                                tracing::error!(
+                                    %error,
+                                    serverless_cache_name = %name,
+                                    "failed to start elasticache serverless cache container",
+                                );
+                                if let Some(c) = s.serverless_caches.get_mut(&name) {
+                                    c.status = "create-failed".to_string();
+                                }
+                            }
+                        }
+                    }
+                }
+                save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+            });
         }
 
         Ok(AwsResponse::xml(

--- a/sdks/go/e2e/e2e_test.go
+++ b/sdks/go/e2e/e2e_test.go
@@ -239,28 +239,43 @@ func TestE2EElastiCacheClusters(t *testing.T) {
 	}
 
 	fc := fakecloud.New(fakecloudURL)
-	resp, err := fc.ElastiCache().GetClusters(ctx)
-	if err != nil {
-		t.Fatalf("ElastiCache().GetClusters() failed: %v", err)
-	}
 
-	found := false
-	for _, cluster := range resp.Clusters {
-		if cluster.CacheClusterID == "sdk-go-ec-cluster" {
-			found = true
-			if cluster.Engine != "redis" {
-				t.Fatalf("expected redis engine, got %s", cluster.Engine)
-			}
-			if cluster.NumCacheNodes != 1 {
-				t.Fatalf("expected 1 cache node, got %d", cluster.NumCacheNodes)
-			}
-			if cluster.ContainerID == nil || *cluster.ContainerID == "" {
-				t.Fatal("expected container id")
+	// The backing container starts asynchronously (bug-audit 3.2), so poll the
+	// introspection endpoint until the cluster reaches "available".
+	var found *fakecloud.ElastiCacheCluster
+	for i := 0; i < 120; i++ {
+		resp, err := fc.ElastiCache().GetClusters(ctx)
+		if err != nil {
+			t.Fatalf("ElastiCache().GetClusters() failed: %v", err)
+		}
+		found = nil
+		for idx := range resp.Clusters {
+			if resp.Clusters[idx].CacheClusterID == "sdk-go-ec-cluster" {
+				found = &resp.Clusters[idx]
+				break
 			}
 		}
+		if found != nil && found.CacheClusterStatus == "available" {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
 	}
-	if !found {
-		t.Fatal("expected to find sdk-go-ec-cluster via introspection")
+	if found == nil || found.CacheClusterStatus != "available" {
+		t.Fatal("expected to find sdk-go-ec-cluster 'available' via introspection")
+	}
+	if found.Engine != "redis" {
+		t.Fatalf("expected redis engine, got %s", found.Engine)
+	}
+	if found.NumCacheNodes != 1 {
+		t.Fatalf("expected 1 cache node, got %d", found.NumCacheNodes)
+	}
+	// A real backing container exposes a host port + container id; without a
+	// container runtime the cluster is metadata-only (host port 0), so only
+	// assert the container id when a container actually started.
+	if found.HostPort != nil && *found.HostPort != 0 {
+		if found.ContainerID == nil || *found.ContainerID == "" {
+			t.Fatal("expected container id for a running cluster")
+		}
 	}
 }
 

--- a/sdks/go/e2e/e2e_test.go
+++ b/sdks/go/e2e/e2e_test.go
@@ -339,8 +339,10 @@ func TestE2EElastiCacheServerlessCaches(t *testing.T) {
 			if cache.Engine != "redis" {
 				t.Fatalf("expected redis engine, got %s", cache.Engine)
 			}
-			if cache.Status != "available" {
-				t.Fatalf("expected available status, got %s", cache.Status)
+			// Backing container starts asynchronously; status is "creating"
+			// right after create and transitions to "available" (bug-audit 3.2).
+			if cache.Status != "available" && cache.Status != "creating" {
+				t.Fatalf("expected available or creating status, got %s", cache.Status)
 			}
 		}
 	}

--- a/sdks/java/src/test/java/dev/fakecloud/E2ETest.java
+++ b/sdks/java/src/test/java/dev/fakecloud/E2ETest.java
@@ -425,7 +425,11 @@ class E2ETest {
                 .findFirst()
                 .orElseThrow();
         assertEquals("redis", cache.engine());
-        assertEquals("available", cache.status());
+        // Backing container starts asynchronously; status is "creating" right
+        // after create and transitions to "available" (bug-audit 3.2).
+        assertTrue(
+                "creating".equals(cache.status()) || "available".equals(cache.status()),
+                "unexpected status: " + cache.status());
     }
 
     // ── Bedrock introspection ──────────────────────────────────────

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -212,7 +212,9 @@ def test_elasticache_get_serverless_caches(
         if c.serverless_cache_name == "py-sdk-ec-serverless"
     )
     assert cache.engine == "redis"
-    assert cache.status == "available"
+    # Backing container starts asynchronously; status is "creating" right after
+    # create and transitions to "available" (bug-audit 3.2).
+    assert cache.status in ("creating", "available")
 
 
 # ── Reset ─────────────────────────────────────────────────────────────

--- a/sdks/typescript/tests/e2e.test.ts
+++ b/sdks/typescript/tests/e2e.test.ts
@@ -214,7 +214,9 @@ describe("elasticache", () => {
     );
     expect(cache).toBeDefined();
     expect(cache!.engine).toBe("redis");
-    expect(cache!.status).toBe("available");
+    // The backing container starts asynchronously, so the cache is "creating"
+    // right after create and transitions to "available" (bug-audit 3.2).
+    expect(["creating", "available"]).toContain(cache!.status);
   });
 });
 


### PR DESCRIPTION
## Summary
ElastiCache `Create*` blocked the response on a cold image pull + ~20s readiness → AWS CLI hit its 60s read timeout. It was the odd one out (RDS/ECS/Lambda already background their creates).

Now: insert the resource as `creating` (no endpoint port), return immediately, and start the backing container in a background task that flips it to `available` and fills in the endpoint once ready (mirrors the existing recovery-spawn). Delete-during-create is honored inside the task (drop + reap the container, no resurrection). With no container runtime, creates remain synchronously `available` (metadata-only), as before.

## Test plan
- `cargo test -p fakecloud-elasticache --lib` — 217 pass; clippy + fmt clean
- **Full EC e2e suite run locally with Docker: `elasticache` 69 passed / 0 failed**, plus `elasticache_persistence` + `cloudformation_elasticache`(_cluster) green
- New e2e wait helpers; create-then-assert/endpoint tests wait for `available` (the AWS-accurate flow)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backgrounded ElastiCache creates for cache clusters, replication groups, and serverless caches to avoid blocking on image pulls and readiness. Create now returns resources in "creating" with no endpoint; a background task flips them to "available" and fills the endpoint when ready.

- **Bug Fixes**
  - Start the container in the background; set status to "available" and populate endpoints on readiness.
  - Delete during create: clusters, replication groups, and serverless caches drop the resource and reap the container (no resurrection, no orphaned containers).
  - No container runtime: keep synchronous, metadata-only creates marked "available".
  - On container failures, set "incompatible-network" (cluster/group) or "create-failed" (serverless) and log the error.
  - SDKs/tests: accept "creating" right after create; Go SDK e2e now polls introspection until a cluster is "available" and only asserts a container ID when a real container started.

- **Migration**
  - Poll Describe* until status is "available" before reading endpoints.
  - New e2e helpers: `wait_for_cache_cluster_available`, `wait_for_replication_group_available`, `wait_for_serverless_cache_available`.

<sup>Written for commit b732417a5154f31c85f7e5f64840172055d36896. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

