### PR TITLE
fix(cloudformation): provision stacks via block_in_place to avoid worker starvation (3.1)

### DIFF
--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -685,8 +685,30 @@ impl CloudFormationService {
         )?;
 
         let provisioner = self.provisioner(&stack_id, &req.account_id, &req.region);
-        let resources =
-            provision_stack_resources(&provisioner, &parsed.resources, template_body, &parameters)?;
+        // Provisioning is synchronous and can run for a long time — cold image
+        // pulls, and custom-resource Lambda invokes that block on their own
+        // runtime (`invoke_lambda_sync`). On the multi-threaded server runtime,
+        // run it via `block_in_place` so the current worker is handed off and a
+        // replacement keeps serving other requests; otherwise enough concurrent
+        // CreateStack calls would starve the worker pool and stall unrelated
+        // requests server-wide (bug-audit 2026-05-28, 3.1). Outside a
+        // multi-thread runtime (unit tests / current-thread), provision inline.
+        let resources = {
+            let provision = || {
+                provision_stack_resources(
+                    &provisioner,
+                    &parsed.resources,
+                    template_body,
+                    &parameters,
+                )
+            };
+            match tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()) {
+                Ok(tokio::runtime::RuntimeFlavor::MultiThread) => {
+                    tokio::task::block_in_place(provision)
+                }
+                _ => provision(),
+            }
+        }?;
 
         let outputs =
             Self::resolve_template_outputs(template_body, &parameters, &resources, &self.state);


### PR DESCRIPTION
## Summary
CreateStack provisioned resources synchronously on the async worker, and custom-resource Lambda invokes block on their own runtime (`invoke_lambda_sync` = `thread::scope` + `block_on`). Enough concurrent CreateStack calls could starve the worker pool and stall unrelated requests server-wide (the CRITICAL harm in audit 3.1).

Run provisioning under `tokio::task::block_in_place` on the multi-threaded server runtime so the worker is handed off and a replacement keeps serving other requests; provision inline outside a multi-thread runtime (unit tests). CreateStack still returns CREATE_COMPLETE — the full async `CREATE_IN_PROGRESS` flow (which would require polling across the whole CFN e2e suite) is a separate, larger change.

## Test plan
- `cargo test -p fakecloud-cloudformation --lib` — 201 pass; clippy + fmt clean
- `cargo test -p fakecloud-e2e --test cloudformation` — 15 passed / 0 failed (locally, with Docker)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented async worker starvation during CloudFormation stack provisioning by running blocking resource creation under `tokio::task::block_in_place` on multi-thread runtimes. This keeps other requests responsive and addresses audit item 3.1.

- **Bug Fixes**
  - Use `block_in_place` when the runtime flavor is MultiThread to offload long-running provisioning and free the worker.
  - Fall back to inline provisioning when not on a multi-thread runtime (e.g., unit tests).
  - No API change: `CreateStack` still returns `CREATE_COMPLETE`; async `CREATE_IN_PROGRESS` flow is out of scope.

<sup>Written for commit 8447fee755a9b1b3f0378e8eb849e66a09b3e596. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

