### PR TITLE
feat(k8s): shared fakecloud-k8s crate + global backend selection (batch 1/5)

### DIFF
--- a/.github/workflows/lambda-k8s.yml
+++ b/.github/workflows/lambda-k8s.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'crates/fakecloud-lambda/**'
+      - 'crates/fakecloud-k8s/**'
       - '.github/workflows/lambda-k8s.yml'
   pull_request:
     branches: [main]
     paths:
       - 'crates/fakecloud-lambda/**'
+      - 'crates/fakecloud-k8s/**'
       - '.github/workflows/lambda-k8s.yml'
   workflow_dispatch:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,7 +1764,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -3002,6 +3002,7 @@ dependencies = [
  "fakecloud-firehose",
  "fakecloud-glue",
  "fakecloud-iam",
+ "fakecloud-k8s",
  "fakecloud-kinesis",
  "fakecloud-kms",
  "fakecloud-lambda",
@@ -3110,7 +3111,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tracing",
  "uuid",
 ]
@@ -3554,7 +3555,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-postgres",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "x509-cert",
  "zip",
 ]
@@ -3749,6 +3750,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fakecloud-k8s"
+version = "0.16.0"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "k8s-openapi",
+ "kube",
+ "reqwest",
+ "rustls 0.23.38",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "fakecloud-kinesis"
 version = "0.16.0"
 dependencies = [
@@ -3810,8 +3828,8 @@ dependencies = [
  "crc32fast",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-k8s",
  "fakecloud-persistence",
- "futures-util",
  "http 1.4.0",
  "k8s-openapi",
  "kube",
@@ -5453,6 +5471,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
+ "rand 0.8.5",
  "rustls 0.23.38",
  "rustls-pemfile",
  "secrecy",
@@ -5461,6 +5480,7 @@ dependencies = [
  "serde_yaml",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tokio-util",
  "tower 0.4.13",
  "tower-http 0.5.2",
@@ -7949,6 +7969,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -7956,7 +7988,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -8197,6 +8229,24 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -8306,6 +8356,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "crates/fakecloud-acm", "crates/fakecloud-apigateway", "crates/fakecloud-apigatewayv2", "crates/fakecloud-application-autoscaling", "crates/fakecloud-athena", "crates/fakecloud-aws", "crates/fakecloud-bedrock", "crates/fakecloud-bedrock-agent", "crates/fakecloud-bedrock-agent-runtime", "crates/fakecloud-cloudformation", "crates/fakecloud-cloudfront", "crates/fakecloud-cloudwatch", "crates/fakecloud-cognito", "crates/fakecloud-conformance", "crates/fakecloud-conformance-macros", "crates/fakecloud-core", "crates/fakecloud-dynamodb", "crates/fakecloud-e2e", "crates/fakecloud-ecr", "crates/fakecloud-ecs", "crates/fakecloud-elasticache", "crates/fakecloud-elbv2", "crates/fakecloud-eventbridge", "crates/fakecloud-firehose", "crates/fakecloud-glue", "crates/fakecloud-iam", "crates/fakecloud-kinesis", "crates/fakecloud-kms", "crates/fakecloud-lambda", "crates/fakecloud-logs", "crates/fakecloud-organizations", "crates/fakecloud-parity", "crates/fakecloud-persistence", "crates/fakecloud-rds", "crates/fakecloud-route53", "crates/fakecloud-s3", "crates/fakecloud-scheduler", "crates/fakecloud-sdk", "crates/fakecloud-secretsmanager", "crates/fakecloud-server", "crates/fakecloud-ses", "crates/fakecloud-sns", "crates/fakecloud-sqs", "crates/fakecloud-ssm", "crates/fakecloud-stepfunctions", "crates/fakecloud-testkit", "crates/fakecloud-tfacc", "crates/fakecloud-wafv2",]
+members = [ "crates/fakecloud-acm", "crates/fakecloud-apigateway", "crates/fakecloud-apigatewayv2", "crates/fakecloud-application-autoscaling", "crates/fakecloud-athena", "crates/fakecloud-aws", "crates/fakecloud-bedrock", "crates/fakecloud-bedrock-agent", "crates/fakecloud-bedrock-agent-runtime", "crates/fakecloud-cloudformation", "crates/fakecloud-cloudfront", "crates/fakecloud-cloudwatch", "crates/fakecloud-cognito", "crates/fakecloud-conformance", "crates/fakecloud-conformance-macros", "crates/fakecloud-core", "crates/fakecloud-dynamodb", "crates/fakecloud-e2e", "crates/fakecloud-ecr", "crates/fakecloud-ecs", "crates/fakecloud-elasticache", "crates/fakecloud-elbv2", "crates/fakecloud-eventbridge", "crates/fakecloud-firehose", "crates/fakecloud-glue", "crates/fakecloud-iam", "crates/fakecloud-kinesis", "crates/fakecloud-kms", "crates/fakecloud-k8s", "crates/fakecloud-lambda", "crates/fakecloud-logs", "crates/fakecloud-organizations", "crates/fakecloud-parity", "crates/fakecloud-persistence", "crates/fakecloud-rds", "crates/fakecloud-route53", "crates/fakecloud-s3", "crates/fakecloud-scheduler", "crates/fakecloud-sdk", "crates/fakecloud-secretsmanager", "crates/fakecloud-server", "crates/fakecloud-ses", "crates/fakecloud-sns", "crates/fakecloud-sqs", "crates/fakecloud-ssm", "crates/fakecloud-stepfunctions", "crates/fakecloud-testkit", "crates/fakecloud-tfacc", "crates/fakecloud-wafv2",]
 resolver = "2"
 
 [workspace.package]
@@ -143,6 +143,10 @@ version = "0.16.0"
 path = "crates/fakecloud-lambda"
 version = "0.16.0"
 
+[workspace.dependencies.fakecloud-k8s]
+path = "crates/fakecloud-k8s"
+version = "0.16.0"
+
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
 version = "0.16.0"
@@ -266,7 +270,7 @@ version = "0.16.0"
 [workspace.dependencies.kube]
 version = "0.95"
 default-features = false
-features = ["client", "rustls-tls", "runtime"]
+features = ["client", "rustls-tls", "runtime", "ws"]
 
 [workspace.dependencies.k8s-openapi]
 version = "0.23"

--- a/crates/fakecloud-k8s/Cargo.toml
+++ b/crates/fakecloud-k8s/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "fakecloud-k8s"
+description = "Shared Kubernetes backend primitives for FakeCloud (client bootstrap, Pod lifecycle, exec, reaping, naming, backend selection)"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+version.workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+reqwest = { workspace = true }
+sha2 = { workspace = true }
+serde_json = { workspace = true }
+kube = { workspace = true }
+k8s-openapi = { workspace = true }
+futures-util = "0.3"
+# rustls 0.23 dropped the implicit default CryptoProvider; kube's
+# rustls-tls feature builds a Client but every request panics unless
+# one is installed up front. Installed once at client construction so
+# neither the server runtime nor opt-in integration tests have to wire
+# it in themselves.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/crates/fakecloud-k8s/src/backend.rs
+++ b/crates/fakecloud-k8s/src/backend.rs
@@ -1,0 +1,152 @@
+//! Backend selection: Docker (default) vs native Kubernetes Pods.
+//!
+//! A FakeCloud server can run every container-backed service on Docker
+//! (the default) or on Kubernetes. The choice is per-service with a
+//! global fallback:
+//!
+//! - `FAKECLOUD_<SERVICE>_BACKEND=k8s|docker` — explicit per-service
+//!   override (e.g. `FAKECLOUD_ELASTICACHE_BACKEND`,
+//!   `FAKECLOUD_LAMBDA_BACKEND`). An explicit value always wins.
+//! - `FAKECLOUD_CONTAINER_BACKEND=k8s|docker` — global default applied
+//!   to any service whose own variable is unset.
+//! - Unset everywhere -> [`Backend::Docker`].
+//!
+//! This lets an operator flip the whole stack to Kubernetes with one
+//! variable while still pinning an individual service back to Docker.
+
+/// Which execution backend a service should use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backend {
+    /// Shell out to a local Docker/Podman daemon (the default).
+    Docker,
+    /// Spawn native Pods in a Kubernetes cluster.
+    K8s,
+}
+
+/// The global default backend variable, consulted when a service's own
+/// variable is unset.
+pub const GLOBAL_BACKEND_ENV: &str = "FAKECLOUD_CONTAINER_BACKEND";
+
+/// Resolve the backend for a service given the name of its per-service
+/// override variable (e.g. `"FAKECLOUD_ELASTICACHE_BACKEND"`).
+///
+/// An explicit per-service value wins over the global default; only
+/// `k8s` and `docker` are recognized (case-insensitive), and any other
+/// value is ignored (treated as unset) so a typo can't silently leave a
+/// service on an unexpected backend without falling through to the
+/// documented precedence.
+pub fn backend_choice(per_service_env: &str) -> Backend {
+    match read_choice(per_service_env) {
+        Some(b) => b,
+        None => read_choice(GLOBAL_BACKEND_ENV).unwrap_or(Backend::Docker),
+    }
+}
+
+/// Parse a single backend variable. Returns `None` when unset or set to
+/// an unrecognized value so the caller can fall through to the next
+/// level of precedence.
+fn read_choice(var: &str) -> Option<Backend> {
+    match std::env::var(var)
+        .ok()?
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "k8s" | "kubernetes" => Some(Backend::K8s),
+        "docker" | "podman" => Some(Backend::Docker),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Env vars are process-global; serialize the tests that mutate them.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
+        let _g = ENV_LOCK.lock().unwrap();
+        let saved: Vec<(String, Option<String>)> = vars
+            .iter()
+            .map(|(k, _)| (k.to_string(), std::env::var(k).ok()))
+            .collect();
+        for (k, v) in vars {
+            match v {
+                Some(v) => std::env::set_var(k, v),
+                None => std::env::remove_var(k),
+            }
+        }
+        f();
+        for (k, v) in saved {
+            match v {
+                Some(v) => std::env::set_var(&k, v),
+                None => std::env::remove_var(&k),
+            }
+        }
+    }
+
+    const SVC: &str = "FAKECLOUD_ELASTICACHE_BACKEND";
+
+    #[test]
+    fn defaults_to_docker_when_unset() {
+        with_env(&[(SVC, None), (GLOBAL_BACKEND_ENV, None)], || {
+            assert_eq!(backend_choice(SVC), Backend::Docker);
+        });
+    }
+
+    #[test]
+    fn per_service_k8s_wins() {
+        with_env(&[(SVC, Some("k8s")), (GLOBAL_BACKEND_ENV, None)], || {
+            assert_eq!(backend_choice(SVC), Backend::K8s);
+        });
+    }
+
+    #[test]
+    fn global_k8s_applies_when_service_unset() {
+        with_env(&[(SVC, None), (GLOBAL_BACKEND_ENV, Some("k8s"))], || {
+            assert_eq!(backend_choice(SVC), Backend::K8s);
+        });
+    }
+
+    #[test]
+    fn per_service_docker_overrides_global_k8s() {
+        with_env(
+            &[(SVC, Some("docker")), (GLOBAL_BACKEND_ENV, Some("k8s"))],
+            || {
+                assert_eq!(backend_choice(SVC), Backend::Docker);
+            },
+        );
+    }
+
+    #[test]
+    fn case_insensitive_and_trimmed() {
+        with_env(
+            &[(SVC, Some("  K8s  ")), (GLOBAL_BACKEND_ENV, None)],
+            || {
+                assert_eq!(backend_choice(SVC), Backend::K8s);
+            },
+        );
+    }
+
+    #[test]
+    fn unrecognized_service_value_falls_through_to_global() {
+        with_env(
+            &[(SVC, Some("banana")), (GLOBAL_BACKEND_ENV, Some("k8s"))],
+            || {
+                assert_eq!(backend_choice(SVC), Backend::K8s);
+            },
+        );
+    }
+
+    #[test]
+    fn unrecognized_everywhere_is_docker() {
+        with_env(
+            &[(SVC, Some("banana")), (GLOBAL_BACKEND_ENV, Some("nope"))],
+            || {
+                assert_eq!(backend_choice(SVC), Backend::Docker);
+            },
+        );
+    }
+}

--- a/crates/fakecloud-k8s/src/backend.rs
+++ b/crates/fakecloud-k8s/src/backend.rs
@@ -66,12 +66,29 @@ mod tests {
     // Env vars are process-global; serialize the tests that mutate them.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Restores saved env vars on drop, so a panicking test closure can't
+    /// leak its mutated environment into the next test.
+    struct EnvGuard(Vec<(String, Option<String>)>);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.0 {
+                match v {
+                    Some(v) => std::env::set_var(k, v),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
     fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
-        let _g = ENV_LOCK.lock().unwrap();
-        let saved: Vec<(String, Option<String>)> = vars
-            .iter()
-            .map(|(k, _)| (k.to_string(), std::env::var(k).ok()))
-            .collect();
+        // Tolerate a poisoned lock from an earlier panicking test — the
+        // EnvGuard already restored the environment, so the data is sound.
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _restore = EnvGuard(
+            vars.iter()
+                .map(|(k, _)| (k.to_string(), std::env::var(k).ok()))
+                .collect(),
+        );
         for (k, v) in vars {
             match v {
                 Some(v) => std::env::set_var(k, v),
@@ -79,12 +96,6 @@ mod tests {
             }
         }
         f();
-        for (k, v) in saved {
-            match v {
-                Some(v) => std::env::set_var(&k, v),
-                None => std::env::remove_var(&k),
-            }
-        }
     }
 
     const SVC: &str = "FAKECLOUD_ELASTICACHE_BACKEND";

--- a/crates/fakecloud-k8s/src/client.rs
+++ b/crates/fakecloud-k8s/src/client.rs
@@ -144,18 +144,21 @@ impl K8sClient {
         loop {
             let pod = api.get(name).await?;
             let status = pod.status.as_ref();
+            let phase = status.and_then(|s| s.phase.as_deref()).unwrap_or("Unknown");
+            // Fail fast on a terminal phase regardless of whether an IP was
+            // ever assigned — a Pod that crashes before getting an IP should
+            // error immediately, not wait out the full timeout.
+            if let "Failed" | "Succeeded" = phase {
+                return Err(K8sError::Other(format!(
+                    "pod {name} reached terminal phase {phase} during startup"
+                )));
+            }
             let ip = status
                 .and_then(|s| s.pod_ip.as_ref())
                 .filter(|s| !s.is_empty());
             if let Some(ip) = ip {
-                match status.and_then(|s| s.phase.as_deref()).unwrap_or("Unknown") {
-                    "Running" => return Ok(ip.clone()),
-                    phase @ ("Failed" | "Succeeded") => {
-                        return Err(K8sError::Other(format!(
-                            "pod {name} reached terminal phase {phase} during startup"
-                        )));
-                    }
-                    _ => {}
+                if phase == "Running" {
+                    return Ok(ip.clone());
                 }
             }
             if Instant::now() >= deadline {

--- a/crates/fakecloud-k8s/src/client.rs
+++ b/crates/fakecloud-k8s/src/client.rs
@@ -174,11 +174,22 @@ impl K8sClient {
     ///
     /// [`wait_for_pod_ip`]: Self::wait_for_pod_ip
     pub async fn wait_for_tcp(ip: &str, port: u16, timeout: Duration) -> Result<(), K8sError> {
+        // Bound each connect so a single hung handshake (SYN dropped, no
+        // RST) can't run past the overall deadline. The kernel's default
+        // connect timeout is tens of seconds, well beyond `timeout`.
+        const PER_ATTEMPT: Duration = Duration::from_secs(2);
         let deadline = Instant::now() + timeout;
         let addr = format!("{ip}:{port}");
         loop {
-            if tokio::net::TcpStream::connect(&addr).await.is_ok() {
-                return Ok(());
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let attempt_budget = remaining.min(PER_ATTEMPT);
+            if !attempt_budget.is_zero() {
+                if let Ok(Ok(_)) =
+                    tokio::time::timeout(attempt_budget, tokio::net::TcpStream::connect(&addr))
+                        .await
+                {
+                    return Ok(());
+                }
             }
             if Instant::now() >= deadline {
                 return Err(K8sError::Timeout(format!(

--- a/crates/fakecloud-k8s/src/client.rs
+++ b/crates/fakecloud-k8s/src/client.rs
@@ -1,0 +1,398 @@
+//! Kube client wrapper + generic Pod lifecycle shared by every backend.
+//!
+//! Wraps a [`kube::Client`] scoped to one namespace and provides the
+//! handful of operations every FakeCloud k8s backend performs: create a
+//! Pod (idempotently, replacing any stale same-named Pod), wait for it
+//! to get an IP and become reachable, `exec` a command inside it, delete
+//! it, and reap Pods orphaned by a previous process. Service-specific
+//! Pod *construction* stays in each service; this is only the plumbing.
+
+use std::time::{Duration, Instant};
+
+use k8s_openapi::api::core::v1::Pod;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
+use kube::api::{Api, AttachParams, DeleteParams, ListParams, PostParams};
+use kube::Client;
+use tokio::io::AsyncReadExt;
+
+use crate::labels;
+
+/// Errors from Pod lifecycle operations.
+#[derive(Debug, thiserror::Error)]
+pub enum K8sError {
+    #[error("kubernetes API error: {0}")]
+    Kube(#[from] kube::Error),
+    #[error("failed to construct Kubernetes client: {0}")]
+    Connect(String),
+    #[error("timed out: {0}")]
+    Timeout(String),
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Output of an [`K8sClient::exec`] call.
+#[derive(Debug, Clone)]
+pub struct ExecOutput {
+    /// Bytes written to the command's stdout.
+    pub stdout: Vec<u8>,
+    /// The command's stderr, decoded lossily as UTF-8.
+    pub stderr: String,
+    /// The command's exit code, if Kubernetes reported one. `Some(0)` on
+    /// success, `Some(n)` on a non-zero exit, `None` if the status was
+    /// unparseable.
+    pub exit_code: Option<i32>,
+}
+
+impl ExecOutput {
+    /// Whether the command exited successfully (exit code 0).
+    pub fn success(&self) -> bool {
+        self.exit_code == Some(0)
+    }
+
+    /// Stdout decoded lossily as UTF-8.
+    pub fn stdout_str(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(&self.stdout)
+    }
+}
+
+/// A namespaced kube client plus this process's instance identity.
+#[derive(Clone)]
+pub struct K8sClient {
+    client: Client,
+    namespace: String,
+    instance_id: String,
+}
+
+impl K8sClient {
+    /// Install the rustls CryptoProvider, connect a client from the
+    /// ambient config (in-cluster ServiceAccount or kubeconfig), and
+    /// scope it to `namespace`.
+    pub async fn connect(namespace: impl Into<String>) -> Result<Self, K8sError> {
+        ensure_crypto_provider();
+        let client = Client::try_default()
+            .await
+            .map_err(|e| K8sError::Connect(e.to_string()))?;
+        Ok(Self::from_client(client, namespace.into()))
+    }
+
+    /// Wrap an already-constructed client (used by tests and callers that
+    /// share a client across backends).
+    pub fn from_client(client: Client, namespace: String) -> Self {
+        Self {
+            client,
+            namespace,
+            instance_id: labels::instance_id(),
+        }
+    }
+
+    /// The namespace Pods are created in.
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// This process's instance identity (`fakecloud-<pid>`), used for the
+    /// [`labels::INSTANCE`] label.
+    pub fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+
+    /// The underlying client, for callers that need raw API access.
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
+    /// Namespaced Pod API handle.
+    pub fn pods(&self) -> Api<Pod> {
+        Api::namespaced(self.client.clone(), &self.namespace)
+    }
+
+    /// Create `pod`, first deleting any stale Pod with the same name left
+    /// behind by a previous process (which would otherwise make `create`
+    /// return `409 Conflict`). Retries the create a few times while the
+    /// API server finishes deleting the old Pod.
+    pub async fn create_pod(&self, pod: &Pod) -> Result<(), K8sError> {
+        let name = pod
+            .metadata
+            .name
+            .clone()
+            .ok_or_else(|| K8sError::Other("pod spec has no metadata.name".into()))?;
+        let api = self.pods();
+        let _ = api.delete(&name, &DeleteParams::default()).await;
+        for attempt in 0..6 {
+            match api.create(&PostParams::default(), pod).await {
+                Ok(_) => return Ok(()),
+                Err(kube::Error::Api(e)) if e.code == 409 && attempt < 5 => {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    let _ = api.delete(&name, &DeleteParams::default()).await;
+                    continue;
+                }
+                Err(e) => return Err(K8sError::Kube(e)),
+            }
+        }
+        Err(K8sError::Timeout(format!(
+            "pod {name} could not be created after repeated 409 conflicts"
+        )))
+    }
+
+    /// Poll until the Pod has a non-empty `status.podIP` and phase
+    /// `Running`, returning the IP. Errors if the Pod reaches a terminal
+    /// phase (`Failed`/`Succeeded`) during startup or if `timeout`
+    /// elapses first.
+    pub async fn wait_for_pod_ip(&self, name: &str, timeout: Duration) -> Result<String, K8sError> {
+        let api = self.pods();
+        let deadline = Instant::now() + timeout;
+        loop {
+            let pod = api.get(name).await?;
+            let status = pod.status.as_ref();
+            let ip = status
+                .and_then(|s| s.pod_ip.as_ref())
+                .filter(|s| !s.is_empty());
+            if let Some(ip) = ip {
+                match status.and_then(|s| s.phase.as_deref()).unwrap_or("Unknown") {
+                    "Running" => return Ok(ip.clone()),
+                    phase @ ("Failed" | "Succeeded") => {
+                        return Err(K8sError::Other(format!(
+                            "pod {name} reached terminal phase {phase} during startup"
+                        )));
+                    }
+                    _ => {}
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(K8sError::Timeout(format!(
+                    "pod {name} did not become Running with a podIP within {timeout:?}"
+                )));
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    /// TCP-handshake `ip:port` until it accepts a connection or `timeout`
+    /// elapses. A Pod being `Running` doesn't guarantee the process
+    /// inside it is listening yet, so backends follow [`wait_for_pod_ip`]
+    /// with this.
+    ///
+    /// [`wait_for_pod_ip`]: Self::wait_for_pod_ip
+    pub async fn wait_for_tcp(ip: &str, port: u16, timeout: Duration) -> Result<(), K8sError> {
+        let deadline = Instant::now() + timeout;
+        let addr = format!("{ip}:{port}");
+        loop {
+            if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(K8sError::Timeout(format!(
+                    "{addr} did not accept connections within {timeout:?}"
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    /// Run `cmd` inside `pod` (in `container`, or the default container
+    /// when `None`) and collect stdout/stderr/exit-code. This is the k8s
+    /// equivalent of `docker exec` — used for operations like issuing
+    /// `redis-cli` commands or copying a file out of a Pod.
+    pub async fn exec(
+        &self,
+        pod: &str,
+        container: Option<&str>,
+        cmd: &[&str],
+    ) -> Result<ExecOutput, K8sError> {
+        let api = self.pods();
+        let mut ap = AttachParams::default()
+            .stdin(false)
+            .stdout(true)
+            .stderr(true);
+        if let Some(c) = container {
+            ap = ap.container(c.to_string());
+        }
+        let mut proc = api.exec(pod, cmd.iter().copied(), &ap).await?;
+
+        let mut stdout = Vec::new();
+        if let Some(mut s) = proc.stdout() {
+            s.read_to_end(&mut stdout)
+                .await
+                .map_err(|e| K8sError::Other(format!("reading exec stdout: {e}")))?;
+        }
+        let mut stderr_buf = Vec::new();
+        if let Some(mut s) = proc.stderr() {
+            // stderr being unreadable shouldn't mask a successful command.
+            let _ = s.read_to_end(&mut stderr_buf).await;
+        }
+        let status = match proc.take_status() {
+            Some(fut) => fut.await,
+            None => None,
+        };
+        // Drain the connection so the websocket closes cleanly.
+        let _ = proc.join().await;
+
+        Ok(ExecOutput {
+            stdout,
+            stderr: String::from_utf8_lossy(&stderr_buf).into_owned(),
+            exit_code: exit_code_from_status(status.as_ref()),
+        })
+    }
+
+    /// Delete a Pod by name. Idempotent — a `404` (already gone) is
+    /// treated as success; other errors are logged but not returned,
+    /// since teardown is best-effort.
+    pub async fn delete_pod(&self, name: &str) {
+        let api = self.pods();
+        if let Err(e) = api.delete(name, &DeleteParams::default()).await {
+            if let kube::Error::Api(api_err) = &e {
+                if api_err.code == 404 {
+                    return;
+                }
+            }
+            tracing::warn!(pod = %name, namespace = %self.namespace, error = %e, "k8s delete pod failed");
+        }
+    }
+
+    /// Delete Pods of the given `service` left behind by a *different*
+    /// process. Lists Pods labelled with both [`labels::MANAGED_BY`] and
+    /// the `service` value, and deletes those whose [`labels::INSTANCE`]
+    /// differs from this process's. Mirrors the Docker reaper so a
+    /// restart doesn't leak the previous run's Pods. Returns the count
+    /// reaped.
+    pub async fn reap_stale(&self, service: &str) -> usize {
+        let api = self.pods();
+        let selector = format!(
+            "{}={},{}={}",
+            labels::MANAGED_BY,
+            labels::MANAGED_BY_VALUE,
+            labels::SERVICE,
+            service
+        );
+        let lp = ListParams::default().labels(&selector);
+        let list = match api.list(&lp).await {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!(service, error = %e, "k8s reap_stale: list pods failed");
+                return 0;
+            }
+        };
+        let mut reaped = 0usize;
+        for pod in list.items {
+            let inst = pod
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|l| l.get(labels::INSTANCE))
+                .map(String::as_str);
+            if inst == Some(self.instance_id.as_str()) {
+                continue;
+            }
+            if let Some(name) = pod.metadata.name {
+                if let Err(e) = api.delete(&name, &DeleteParams::default()).await {
+                    tracing::warn!(pod = %name, error = %e, "k8s reap_stale: delete failed");
+                } else {
+                    reaped += 1;
+                }
+            }
+        }
+        if reaped > 0 {
+            tracing::info!(service, reaped, "k8s reap_stale: removed orphan Pods");
+        }
+        reaped
+    }
+}
+
+/// Install rustls' `ring` CryptoProvider once per process. Rustls 0.23
+/// dropped the implicit default and every TLS connection panics until
+/// one is installed; kube's `rustls-tls` feature doesn't pull one in on
+/// our behalf. Safe to call concurrently and repeatedly — the `.ok()`
+/// swallows the "already installed" error.
+pub fn ensure_crypto_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+/// Derive an exit code from the terminal `Status` Kubernetes returns for
+/// an `exec`. `Success` -> 0; a `Failure` carries the real code in
+/// `details.causes[reason=ExitCode].message`, falling back to 1 when the
+/// cause is absent.
+fn exit_code_from_status(status: Option<&Status>) -> Option<i32> {
+    let status = status?;
+    match status.status.as_deref() {
+        Some("Success") => Some(0),
+        Some("Failure") => status
+            .details
+            .as_ref()
+            .and_then(|d| d.causes.as_ref())
+            .and_then(|causes| {
+                causes
+                    .iter()
+                    .find(|c| c.reason.as_deref() == Some("ExitCode"))
+            })
+            .and_then(|c| c.message.as_ref())
+            .and_then(|m| m.parse::<i32>().ok())
+            .or(Some(1)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{StatusCause, StatusDetails};
+
+    fn status(state: &str, causes: Option<Vec<StatusCause>>) -> Status {
+        Status {
+            status: Some(state.to_string()),
+            details: causes.map(|c| StatusDetails {
+                causes: Some(c),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn success_status_is_exit_zero() {
+        assert_eq!(
+            exit_code_from_status(Some(&status("Success", None))),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn failure_with_exit_code_cause_parses_code() {
+        let causes = vec![StatusCause {
+            reason: Some("ExitCode".into()),
+            message: Some("137".into()),
+            ..Default::default()
+        }];
+        assert_eq!(
+            exit_code_from_status(Some(&status("Failure", Some(causes)))),
+            Some(137)
+        );
+    }
+
+    #[test]
+    fn failure_without_cause_defaults_to_one() {
+        assert_eq!(
+            exit_code_from_status(Some(&status("Failure", None))),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn missing_status_is_none() {
+        assert_eq!(exit_code_from_status(None), None);
+    }
+
+    #[test]
+    fn exec_output_helpers() {
+        let out = ExecOutput {
+            stdout: b"hello".to_vec(),
+            stderr: String::new(),
+            exit_code: Some(0),
+        };
+        assert!(out.success());
+        assert_eq!(out.stdout_str(), "hello");
+    }
+}

--- a/crates/fakecloud-k8s/src/env.rs
+++ b/crates/fakecloud-k8s/src/env.rs
@@ -58,7 +58,10 @@ impl K8sEnv {
             .host_str()
             .ok_or_else(|| K8sEnvError::InvalidSelfUrl("missing host".into()))?
             .to_string();
-        let self_port = parsed.port_or_known_default().unwrap_or(default_port);
+        // When the URL omits a port, fall back to fakecloud's actual bound
+        // port — not the scheme default (80/443), which fakecloud doesn't
+        // serve on in-cluster.
+        let self_port = parsed.port().unwrap_or(default_port);
 
         let (ecr_host, ecr_port) = match std::env::var("FAKECLOUD_K8S_ECR_URL").ok() {
             Some(raw) => {
@@ -68,7 +71,7 @@ impl K8sEnv {
                     .host_str()
                     .ok_or_else(|| K8sEnvError::InvalidEcrUrl("missing host".into()))?
                     .to_string();
-                let p = u.port_or_known_default().unwrap_or(default_port);
+                let p = u.port().unwrap_or(default_port);
                 (h, p)
             }
             None => (self_host.clone(), self_port),
@@ -87,5 +90,108 @@ impl K8sEnv {
             ecr_port,
             pull_secret,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // from_env reads process-global vars; serialize the tests touching them.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    const VARS: &[&str] = &[
+        "FAKECLOUD_K8S_SELF_URL",
+        "FAKECLOUD_K8S_ECR_URL",
+        "FAKECLOUD_K8S_NAMESPACE",
+        "FAKECLOUD_K8S_PULL_SECRET",
+    ];
+
+    fn with_env(set: &[(&str, &str)], f: impl FnOnce()) {
+        let _g = ENV_LOCK.lock().unwrap();
+        let saved: Vec<(String, Option<String>)> = VARS
+            .iter()
+            .map(|k| (k.to_string(), std::env::var(k).ok()))
+            .collect();
+        for k in VARS {
+            std::env::remove_var(k);
+        }
+        for (k, v) in set {
+            std::env::set_var(k, v);
+        }
+        f();
+        for (k, v) in saved {
+            match v {
+                Some(v) => std::env::set_var(&k, v),
+                None => std::env::remove_var(&k),
+            }
+        }
+    }
+
+    #[test]
+    fn missing_self_url_errors() {
+        with_env(&[], || {
+            assert!(matches!(
+                K8sEnv::from_env(4566),
+                Err(K8sEnvError::MissingSelfUrl)
+            ));
+        });
+    }
+
+    #[test]
+    fn portless_url_falls_back_to_default_port_not_scheme_default() {
+        with_env(
+            &[("FAKECLOUD_K8S_SELF_URL", "http://fakecloud.svc")],
+            || {
+                let env = K8sEnv::from_env(4566).unwrap();
+                // Not 80 (the http scheme default) — fakecloud's bound port.
+                assert_eq!(env.self_port, 4566);
+                assert_eq!(env.self_host, "fakecloud.svc");
+                // ECR defaults to the self host:port when its URL is unset.
+                assert_eq!(env.ecr_host, "fakecloud.svc");
+                assert_eq!(env.ecr_port, 4566);
+            },
+        );
+    }
+
+    #[test]
+    fn explicit_port_is_respected() {
+        with_env(
+            &[("FAKECLOUD_K8S_SELF_URL", "http://fakecloud.svc:4566")],
+            || {
+                let env = K8sEnv::from_env(9999).unwrap();
+                assert_eq!(env.self_port, 4566);
+            },
+        );
+    }
+
+    #[test]
+    fn ecr_url_overrides_and_defaults_namespace_pull_secret() {
+        with_env(
+            &[
+                ("FAKECLOUD_K8S_SELF_URL", "http://fakecloud.svc:4566"),
+                ("FAKECLOUD_K8S_ECR_URL", "http://registry.svc:5000"),
+                ("FAKECLOUD_K8S_NAMESPACE", "fc"),
+                ("FAKECLOUD_K8S_PULL_SECRET", "ecr-secret"),
+            ],
+            || {
+                let env = K8sEnv::from_env(4566).unwrap();
+                assert_eq!(env.ecr_host, "registry.svc");
+                assert_eq!(env.ecr_port, 5000);
+                assert_eq!(env.namespace, "fc");
+                assert_eq!(env.pull_secret.as_deref(), Some("ecr-secret"));
+            },
+        );
+    }
+
+    #[test]
+    fn namespace_defaults_to_default() {
+        with_env(
+            &[("FAKECLOUD_K8S_SELF_URL", "http://fakecloud.svc:4566")],
+            || {
+                assert_eq!(K8sEnv::from_env(4566).unwrap().namespace, "default");
+            },
+        );
     }
 }

--- a/crates/fakecloud-k8s/src/env.rs
+++ b/crates/fakecloud-k8s/src/env.rs
@@ -77,9 +77,16 @@ impl K8sEnv {
             None => (self_host.clone(), self_port),
         };
 
-        let namespace =
-            std::env::var("FAKECLOUD_K8S_NAMESPACE").unwrap_or_else(|_| "default".to_string());
-        let pull_secret = std::env::var("FAKECLOUD_K8S_PULL_SECRET").ok();
+        // An explicitly-empty value is treated as unset: an empty namespace
+        // is invalid, and an empty pull-secret name would attach a bogus
+        // imagePullSecrets reference.
+        let namespace = std::env::var("FAKECLOUD_K8S_NAMESPACE")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "default".to_string());
+        let pull_secret = std::env::var("FAKECLOUD_K8S_PULL_SECRET")
+            .ok()
+            .filter(|s| !s.trim().is_empty());
 
         Ok(Self {
             namespace,
@@ -108,12 +115,27 @@ mod tests {
         "FAKECLOUD_K8S_PULL_SECRET",
     ];
 
+    /// Restores saved env vars on drop, so a panicking test closure can't
+    /// leak its mutated environment into the next test.
+    struct EnvGuard(Vec<(String, Option<String>)>);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.0 {
+                match v {
+                    Some(v) => std::env::set_var(k, v),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
     fn with_env(set: &[(&str, &str)], f: impl FnOnce()) {
-        let _g = ENV_LOCK.lock().unwrap();
-        let saved: Vec<(String, Option<String>)> = VARS
-            .iter()
-            .map(|k| (k.to_string(), std::env::var(k).ok()))
-            .collect();
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _restore = EnvGuard(
+            VARS.iter()
+                .map(|k| (k.to_string(), std::env::var(k).ok()))
+                .collect(),
+        );
         for k in VARS {
             std::env::remove_var(k);
         }
@@ -121,12 +143,6 @@ mod tests {
             std::env::set_var(k, v);
         }
         f();
-        for (k, v) in saved {
-            match v {
-                Some(v) => std::env::set_var(&k, v),
-                None => std::env::remove_var(&k),
-            }
-        }
     }
 
     #[test]
@@ -181,6 +197,22 @@ mod tests {
                 assert_eq!(env.ecr_port, 5000);
                 assert_eq!(env.namespace, "fc");
                 assert_eq!(env.pull_secret.as_deref(), Some("ecr-secret"));
+            },
+        );
+    }
+
+    #[test]
+    fn empty_namespace_and_pull_secret_treated_as_unset() {
+        with_env(
+            &[
+                ("FAKECLOUD_K8S_SELF_URL", "http://fakecloud.svc:4566"),
+                ("FAKECLOUD_K8S_NAMESPACE", "  "),
+                ("FAKECLOUD_K8S_PULL_SECRET", ""),
+            ],
+            || {
+                let env = K8sEnv::from_env(4566).unwrap();
+                assert_eq!(env.namespace, "default");
+                assert_eq!(env.pull_secret, None);
             },
         );
     }

--- a/crates/fakecloud-k8s/src/env.rs
+++ b/crates/fakecloud-k8s/src/env.rs
@@ -1,0 +1,91 @@
+//! Parsing of the `FAKECLOUD_K8S_*` operator configuration.
+//!
+//! When FakeCloud runs on Kubernetes it needs to know how Pods reach it
+//! back (`FAKECLOUD_K8S_SELF_URL`), which namespace to create Pods in
+//! (`FAKECLOUD_K8S_NAMESPACE`), where its in-cluster ECR endpoint lives
+//! (`FAKECLOUD_K8S_ECR_URL`), and optionally an `imagePullSecrets` name
+//! for private images (`FAKECLOUD_K8S_PULL_SECRET`). Every k8s backend
+//! shares this configuration, so it's parsed once here.
+
+/// Parsed `FAKECLOUD_K8S_*` configuration.
+#[derive(Debug, Clone)]
+pub struct K8sEnv {
+    /// Namespace Pods are created in. Defaults to `default`.
+    pub namespace: String,
+    /// In-cluster URL of the FakeCloud server, e.g.
+    /// `http://fakecloud.fakecloud.svc.cluster.local:4566`. Pods fetch
+    /// artifacts from and call back to this URL.
+    pub self_url: String,
+    /// Host part of [`self_url`](Self::self_url) — used to rewrite
+    /// `localhost`/`127.0.0.1` env values so workloads inside a Pod can
+    /// reach FakeCloud.
+    pub self_host: String,
+    /// Port part of [`self_url`](Self::self_url).
+    pub self_port: u16,
+    /// Host of the in-cluster ECR endpoint (for image URI translation).
+    /// Defaults to [`self_host`](Self::self_host).
+    pub ecr_host: String,
+    /// Port of the in-cluster ECR endpoint. Defaults to
+    /// [`self_port`](Self::self_port).
+    pub ecr_port: u16,
+    /// Optional name of a `kubernetes.io/dockerconfigjson` Secret used as
+    /// `imagePullSecrets` for Pods pulling private images.
+    pub pull_secret: Option<String>,
+}
+
+/// Errors parsing the `FAKECLOUD_K8S_*` configuration.
+#[derive(Debug, thiserror::Error)]
+pub enum K8sEnvError {
+    #[error("FAKECLOUD_K8S_SELF_URL must be set when using the Kubernetes backend")]
+    MissingSelfUrl,
+    #[error("FAKECLOUD_K8S_SELF_URL is not a valid URL: {0}")]
+    InvalidSelfUrl(String),
+    #[error("FAKECLOUD_K8S_ECR_URL is not a valid URL: {0}")]
+    InvalidEcrUrl(String),
+}
+
+impl K8sEnv {
+    /// Read configuration from the environment. `default_port` is
+    /// FakeCloud's bound port, used as the self/ECR port when the URL
+    /// omits one. Fails fast on missing/invalid required config — never
+    /// silently degrades.
+    pub fn from_env(default_port: u16) -> Result<Self, K8sEnvError> {
+        let self_url =
+            std::env::var("FAKECLOUD_K8S_SELF_URL").map_err(|_| K8sEnvError::MissingSelfUrl)?;
+        let parsed = reqwest::Url::parse(&self_url)
+            .map_err(|e| K8sEnvError::InvalidSelfUrl(e.to_string()))?;
+        let self_host = parsed
+            .host_str()
+            .ok_or_else(|| K8sEnvError::InvalidSelfUrl("missing host".into()))?
+            .to_string();
+        let self_port = parsed.port_or_known_default().unwrap_or(default_port);
+
+        let (ecr_host, ecr_port) = match std::env::var("FAKECLOUD_K8S_ECR_URL").ok() {
+            Some(raw) => {
+                let u = reqwest::Url::parse(&raw)
+                    .map_err(|e| K8sEnvError::InvalidEcrUrl(e.to_string()))?;
+                let h = u
+                    .host_str()
+                    .ok_or_else(|| K8sEnvError::InvalidEcrUrl("missing host".into()))?
+                    .to_string();
+                let p = u.port_or_known_default().unwrap_or(default_port);
+                (h, p)
+            }
+            None => (self_host.clone(), self_port),
+        };
+
+        let namespace =
+            std::env::var("FAKECLOUD_K8S_NAMESPACE").unwrap_or_else(|_| "default".to_string());
+        let pull_secret = std::env::var("FAKECLOUD_K8S_PULL_SECRET").ok();
+
+        Ok(Self {
+            namespace,
+            self_url,
+            self_host,
+            self_port,
+            ecr_host,
+            ecr_port,
+            pull_secret,
+        })
+    }
+}

--- a/crates/fakecloud-k8s/src/labels.rs
+++ b/crates/fakecloud-k8s/src/labels.rs
@@ -1,0 +1,25 @@
+//! Pod label conventions shared by every FakeCloud k8s backend.
+//!
+//! Every Pod FakeCloud creates carries three labels so it can be found
+//! and cleaned up later:
+//! - [`MANAGED_BY`] = [`MANAGED_BY_VALUE`] marks the Pod as FakeCloud's.
+//! - [`INSTANCE`] holds the owning process identity (`fakecloud-<pid>`),
+//!   so a restarted server can tell its own Pods from a dead run's.
+//! - [`SERVICE`] holds which service owns it (`lambda`, `elasticache`,
+//!   `rds`, `ecs`) so each service reaps only its own kind of Pod.
+
+/// Label key marking a Pod as managed by FakeCloud.
+pub const MANAGED_BY: &str = "fakecloud-managed-by";
+/// Value for [`MANAGED_BY`].
+pub const MANAGED_BY_VALUE: &str = "fakecloud";
+/// Label key holding the owning process identity (`fakecloud-<pid>`).
+pub const INSTANCE: &str = "fakecloud-instance";
+/// Label key holding the owning service name.
+pub const SERVICE: &str = "fakecloud-service";
+
+/// The per-process instance identity used for the [`INSTANCE`] label.
+/// Stable for the lifetime of the process; changes across restarts so
+/// reaping can distinguish a new run's Pods from a dead run's.
+pub fn instance_id() -> String {
+    format!("fakecloud-{}", std::process::id())
+}

--- a/crates/fakecloud-k8s/src/lib.rs
+++ b/crates/fakecloud-k8s/src/lib.rs
@@ -1,0 +1,30 @@
+//! Shared Kubernetes-backend primitives for FakeCloud.
+//!
+//! FakeCloud can run its container-backed services (Lambda, ElastiCache,
+//! RDS, ECS) either by shelling out to a local Docker/Podman daemon (the
+//! default) or by spawning native Pods in a Kubernetes cluster. The k8s
+//! path is the same for every service — connect a client, build a Pod,
+//! wait for it to come up, optionally `exec` into it, tear it down, and
+//! reap orphans left by a previous process. This crate holds that common
+//! machinery so each service only has to describe *its* Pod, not
+//! re-implement the client bootstrap, readiness polling, exec plumbing,
+//! reaping, and DNS-safe naming.
+//!
+//! Backend selection (`FAKECLOUD_CONTAINER_BACKEND` /
+//! `FAKECLOUD_<SERVICE>_BACKEND`) lives in [`backend`]. The kube client
+//! wrapper and Pod lifecycle live in [`client`]. Env parsing
+//! (`FAKECLOUD_K8S_*`) lives in [`env`]. Naming + label conventions live
+//! in [`names`] and [`labels`].
+//!
+//! See `website/content/docs/guides/kubernetes-backend.md` for the
+//! operator-facing setup (ServiceAccount, RBAC, Deployment yaml).
+
+pub mod backend;
+pub mod client;
+pub mod env;
+pub mod labels;
+pub mod names;
+
+pub use backend::{backend_choice, Backend};
+pub use client::{ExecOutput, K8sClient, K8sError};
+pub use env::{K8sEnv, K8sEnvError};

--- a/crates/fakecloud-k8s/src/names.rs
+++ b/crates/fakecloud-k8s/src/names.rs
@@ -10,11 +10,12 @@
 pub const DNS1123_MAX: usize = 63;
 
 /// Lowercase + replace anything outside `[a-z0-9-]` with `-`, then trim
-/// trailing dashes so the result ends in an alphanumeric (a DNS-1123
-/// label requirement). Does not enforce the length cap — callers that
-/// need a bounded label should truncate the result.
+/// leading and trailing dashes so the result both starts and ends in an
+/// alphanumeric (DNS-1123 label requirements — a leading dash is just as
+/// invalid as a trailing one). Does not enforce the length cap — callers
+/// that need a bounded label should truncate the result.
 pub fn label_safe(s: &str) -> String {
-    let mut out: String = s
+    let out: String = s
         .chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() {
@@ -24,10 +25,7 @@ pub fn label_safe(s: &str) -> String {
             }
         })
         .collect();
-    while out.ends_with('-') {
-        out.pop();
-    }
-    out
+    out.trim_matches('-').to_string()
 }
 
 /// 12-char hex projection of an arbitrary string. Used to suffix Pod
@@ -78,6 +76,14 @@ mod tests {
     #[test]
     fn label_safe_trims_trailing_dashes() {
         assert_eq!(label_safe("foo___"), "foo");
+    }
+
+    #[test]
+    fn label_safe_trims_leading_dashes() {
+        // A leading non-alphanumeric must not produce a leading dash —
+        // that's an invalid DNS-1123 label value.
+        assert_eq!(label_safe("_foo"), "foo");
+        assert_eq!(label_safe(".9lives-"), "9lives");
     }
 
     #[test]

--- a/crates/fakecloud-k8s/src/names.rs
+++ b/crates/fakecloud-k8s/src/names.rs
@@ -1,0 +1,124 @@
+//! DNS-1123-safe naming helpers shared by every FakeCloud k8s backend.
+//!
+//! Kubernetes object names must be DNS-1123 labels: lowercase
+//! alphanumerics and dashes, 63 chars max, ending in an alphanumeric.
+//! Resource identifiers FakeCloud works with (function names, cluster
+//! IDs, task ARNs) routinely violate that, so every backend funnels its
+//! identifiers through [`pod_name`] / [`label_safe`].
+
+/// Maximum length of a DNS-1123 label (and therefore a Pod name).
+pub const DNS1123_MAX: usize = 63;
+
+/// Lowercase + replace anything outside `[a-z0-9-]` with `-`, then trim
+/// trailing dashes so the result ends in an alphanumeric (a DNS-1123
+/// label requirement). Does not enforce the length cap — callers that
+/// need a bounded label should truncate the result.
+pub fn label_safe(s: &str) -> String {
+    let mut out: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+/// 12-char hex projection of an arbitrary string. Used to suffix Pod
+/// names so that a changed identifier (a new deploy, a recreated
+/// resource) produces a fresh, non-colliding Pod name while staying
+/// deterministic — the launcher and any later lookup agree on the name.
+/// Not cryptographic; the 2^48 space is ample for per-resource
+/// uniqueness within a namespace.
+pub fn simple_hex12(s: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    let bytes = h.finalize();
+    bytes.iter().take(6).map(|b| format!("{b:02x}")).collect()
+}
+
+/// Build a deterministic, DNS-1123-safe Pod name of the form
+/// `<prefix>-<id-part>-<hex12>`.
+///
+/// `prefix` is the service marker (e.g. `fakecloud-lambda`,
+/// `fakecloud-ec`); `id` is the resource identifier whose hash forms the
+/// stable suffix; `id_part` is a human-readable slug derived from
+/// `id` (or a separate display name) and truncated so the whole name
+/// fits in [`DNS1123_MAX`].
+pub fn pod_name(prefix: &str, id_part: &str, id: &str) -> String {
+    let digest = simple_hex12(id);
+    // Reserve room for: prefix + '-' + slug + '-' + 12-char digest.
+    let fixed = prefix.len() + 1 + 1 + digest.len();
+    let slug_budget = DNS1123_MAX.saturating_sub(fixed);
+    let slug: String = label_safe(id_part).chars().take(slug_budget).collect();
+    let slug = slug.trim_end_matches('-');
+    if slug.is_empty() {
+        format!("{prefix}-{digest}")
+    } else {
+        format!("{prefix}-{slug}-{digest}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_safe_lowercases_and_dashes() {
+        assert_eq!(label_safe("My_Awesome.Fn"), "my-awesome-fn");
+    }
+
+    #[test]
+    fn label_safe_trims_trailing_dashes() {
+        assert_eq!(label_safe("foo___"), "foo");
+    }
+
+    #[test]
+    fn pod_name_is_dns1123_safe() {
+        let name = pod_name("fakecloud-lambda", "My_Awesome_Function", "abc/123+def==");
+        assert!(name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
+        assert!(!name.ends_with('-'));
+        assert!(name.len() <= DNS1123_MAX, "{} too long", name);
+    }
+
+    #[test]
+    fn pod_name_stable_for_same_inputs() {
+        assert_eq!(
+            pod_name("fakecloud-ec", "redis-1", "deploy"),
+            pod_name("fakecloud-ec", "redis-1", "deploy")
+        );
+    }
+
+    #[test]
+    fn pod_name_differs_when_id_changes() {
+        assert_ne!(
+            pod_name("fakecloud-ec", "c", "id-1"),
+            pod_name("fakecloud-ec", "c", "id-2")
+        );
+    }
+
+    #[test]
+    fn pod_name_handles_very_long_slug() {
+        let long = "a".repeat(200);
+        let name = pod_name("fakecloud-elasticache", &long, "x");
+        assert!(name.len() <= DNS1123_MAX);
+        assert!(name.starts_with("fakecloud-elasticache-"));
+    }
+
+    #[test]
+    fn pod_name_handles_empty_slug() {
+        // An id_part of only special chars collapses to empty -> name is
+        // prefix + digest, still valid.
+        let name = pod_name("fakecloud-rds", "___", "id");
+        assert!(name.starts_with("fakecloud-rds-"));
+        assert!(!name.ends_with('-'));
+        assert!(name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
+    }
+}

--- a/crates/fakecloud-lambda/Cargo.toml
+++ b/crates/fakecloud-lambda/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-k8s = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
@@ -29,18 +30,15 @@ tempfile = { workspace = true }
 percent-encoding = { workspace = true }
 crc32fast = { workspace = true }
 bytes = { workspace = true }
-kube = { workspace = true }
+# spec.rs builds k8s Pod objects; the client bootstrap, lifecycle, and
+# reaping all live in fakecloud-k8s now.
 k8s-openapi = { workspace = true }
-futures-util = "0.3"
-# rustls 0.23 dropped the implicit default CryptoProvider; kube's
-# rustls-tls feature builds a Client but every request panics unless
-# one is installed up front. We install `ring` once at K8sBackend
-# construction so neither the server's runtime path nor opt-in
-# integration tests have to wire this in themselves.
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [dev-dependencies]
 bytes = { workspace = true }
+# The opt-in k8s-integration test drives a real cluster directly.
+kube = { workspace = true }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [features]
 # Opt-in integration tests that need a real Kubernetes cluster

--- a/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
@@ -2,7 +2,13 @@
 //!
 //! Spawns Lambda function runtimes as native Pods in a Kubernetes
 //! cluster instead of as Docker containers. Gated by
-//! `FAKECLOUD_LAMBDA_BACKEND=k8s` on the fakecloud server.
+//! `FAKECLOUD_LAMBDA_BACKEND=k8s` (or the global
+//! `FAKECLOUD_CONTAINER_BACKEND=k8s`) on the fakecloud server.
+//!
+//! The shared client bootstrap, Pod lifecycle (create/wait/delete),
+//! reaping, and naming live in the `fakecloud-k8s` crate; this module
+//! only builds the Lambda-specific Pod spec and wires the lifecycle into
+//! the [`LambdaBackend`] trait.
 //!
 //! See `website/content/docs/guides/kubernetes-backend.md` for the
 //! operator-facing setup (ServiceAccount, RBAC, Deployment yaml).
@@ -12,33 +18,29 @@ pub mod spec;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use k8s_openapi::api::core::v1::Pod;
-use kube::api::{Api, DeleteParams, ListParams, PostParams};
-use kube::Client;
+use fakecloud_k8s::{K8sClient, K8sEnv, K8sEnvError};
 
 use super::backend::{BackendHandle, LambdaBackend, RuntimeError, WarmInstance};
 use crate::state::LambdaFunction;
 use spec::{build_pod_spec, pod_name_for, PodSpecContext};
 
+/// Which `fakecloud-service` label Lambda Pods carry, so reaping only
+/// touches Lambda Pods.
+const SERVICE: &str = "lambda";
+
 /// Errors that can prevent the K8s backend from initializing. Surfaced
 /// to the operator at fakecloud startup; never silently swallowed.
 #[derive(Debug, thiserror::Error)]
 pub enum K8sBackendError {
-    #[error("FAKECLOUD_K8S_SELF_URL must be set when FAKECLOUD_LAMBDA_BACKEND=k8s")]
-    MissingSelfUrl,
-    #[error("FAKECLOUD_K8S_SELF_URL is not a valid URL: {0}")]
-    InvalidSelfUrl(String),
-    #[error("failed to construct Kubernetes client: {0}")]
-    Client(#[from] kube::Error),
-    #[error("failed to read kubeconfig / in-cluster config: {0}")]
-    Config(String),
+    #[error(transparent)]
+    Env(#[from] K8sEnvError),
+    #[error("failed to connect to the Kubernetes cluster: {0}")]
+    Connect(String),
 }
 
 /// Native Kubernetes Lambda execution backend.
 pub struct K8sBackend {
-    client: Client,
-    namespace: String,
-    instance_id: String,
+    client: K8sClient,
     /// In-cluster URL of the fakecloud server (e.g.
     /// `http://fakecloud.fakecloud.svc.cluster.local:4566`). Init
     /// containers fetch code + layers from this host.
@@ -67,137 +69,28 @@ impl K8sBackend {
         default_ecr_port: u16,
         internal_token: String,
     ) -> Result<Self, K8sBackendError> {
-        ensure_crypto_provider();
-        let self_url =
-            std::env::var("FAKECLOUD_K8S_SELF_URL").map_err(|_| K8sBackendError::MissingSelfUrl)?;
-        let parsed = reqwest::Url::parse(&self_url)
-            .map_err(|e| K8sBackendError::InvalidSelfUrl(e.to_string()))?;
-        let self_host = parsed
-            .host_str()
-            .ok_or_else(|| K8sBackendError::InvalidSelfUrl("missing host".into()))?
-            .to_string();
-        let self_port = parsed.port_or_known_default().unwrap_or(default_ecr_port);
-
-        let (ecr_host, ecr_port) = match std::env::var("FAKECLOUD_K8S_ECR_URL").ok() {
-            Some(raw) => {
-                let u = reqwest::Url::parse(&raw)
-                    .map_err(|e| K8sBackendError::InvalidSelfUrl(e.to_string()))?;
-                let h = u
-                    .host_str()
-                    .ok_or_else(|| K8sBackendError::InvalidSelfUrl("ECR url missing host".into()))?
-                    .to_string();
-                let p = u.port_or_known_default().unwrap_or(default_ecr_port);
-                (h, p)
-            }
-            None => (self_host.clone(), self_port),
-        };
-
-        let namespace =
-            std::env::var("FAKECLOUD_K8S_NAMESPACE").unwrap_or_else(|_| "default".to_string());
-        let pull_secret = std::env::var("FAKECLOUD_K8S_PULL_SECRET").ok();
-
-        let client = Client::try_default()
+        let env = K8sEnv::from_env(default_ecr_port)?;
+        let client = K8sClient::connect(env.namespace.clone())
             .await
-            .map_err(|e| K8sBackendError::Config(e.to_string()))?;
-
-        let instance_id = format!("fakecloud-{}", std::process::id());
+            .map_err(|e| K8sBackendError::Connect(e.to_string()))?;
 
         tracing::info!(
-            namespace = %namespace,
-            self_url = %self_url,
-            ecr = %format!("{ecr_host}:{ecr_port}"),
+            namespace = %env.namespace,
+            self_url = %env.self_url,
+            ecr = %format!("{}:{}", env.ecr_host, env.ecr_port),
             "K8s Lambda backend initialized"
         );
 
         Ok(Self {
             client,
-            namespace,
-            instance_id,
-            self_url,
-            self_host,
-            ecr_host,
-            ecr_port,
+            self_url: env.self_url,
+            self_host: env.self_host,
+            ecr_host: env.ecr_host,
+            ecr_port: env.ecr_port,
             internal_token,
-            pull_secret,
+            pull_secret: env.pull_secret,
         })
     }
-
-    fn pods_api(&self) -> Api<Pod> {
-        Api::namespaced(self.client.clone(), &self.namespace)
-    }
-
-    /// Watch the pod until it has a non-empty `status.podIP`. Polled
-    /// rather than streamed — simpler, and the polling cadence (1s) is
-    /// well below the typical 5-30s pod boot time for an RIE image.
-    async fn wait_for_pod_ip(&self, pod_name: &str) -> Result<String, RuntimeError> {
-        let api = self.pods_api();
-        let deadline = std::time::Instant::now() + Duration::from_secs(60);
-        loop {
-            let pod = api.get(pod_name).await.map_err(|e| {
-                RuntimeError::ContainerStartFailed(format!("k8s get pod {pod_name}: {e}"))
-            })?;
-            if let Some(ip) = pod
-                .status
-                .as_ref()
-                .and_then(|s| s.pod_ip.as_ref())
-                .filter(|s| !s.is_empty())
-            {
-                // Pod might have IP but not yet be Running — check phase
-                let phase = pod
-                    .status
-                    .as_ref()
-                    .and_then(|s| s.phase.as_deref())
-                    .unwrap_or("Unknown");
-                if phase == "Running" {
-                    return Ok(ip.clone());
-                }
-                if phase == "Failed" || phase == "Succeeded" {
-                    return Err(RuntimeError::ContainerStartFailed(format!(
-                        "pod {pod_name} reached terminal phase {phase} during startup"
-                    )));
-                }
-            }
-            if std::time::Instant::now() >= deadline {
-                return Err(RuntimeError::ContainerStartFailed(format!(
-                    "pod {pod_name} did not become Running with podIP within 60s"
-                )));
-            }
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-    }
-
-    /// TCP-handshake the RIE port. Pod-Running doesn't guarantee the
-    /// RIE inside the main container is listening yet — same logic as
-    /// Docker's `wait_for_ready`.
-    async fn wait_for_rie_ready(&self, pod_ip: &str) -> Result<(), RuntimeError> {
-        for _ in 0..20 {
-            tokio::time::sleep(Duration::from_millis(500)).await;
-            if tokio::net::TcpStream::connect(format!("{pod_ip}:8080"))
-                .await
-                .is_ok()
-            {
-                return Ok(());
-            }
-        }
-        Err(RuntimeError::ContainerStartFailed(format!(
-            "RIE on {pod_ip}:8080 did not accept connections within 10s"
-        )))
-    }
-}
-
-/// Install rustls' `ring` CryptoProvider once per process. Rustls
-/// 0.23 dropped the implicit default and every TLS connection now
-/// panics until something installs one. Kube's `rustls-tls` feature
-/// doesn't pull in a provider on our behalf, so we do it here. Safe
-/// to call concurrently; the `.ok()` swallows the "already installed"
-/// error in case another component (a different test, a future
-/// service) beat us to it.
-fn ensure_crypto_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    });
 }
 
 /// Extract the account ID from a function ARN
@@ -221,8 +114,8 @@ impl LambdaBackend for K8sBackend {
     ) -> Result<WarmInstance, RuntimeError> {
         let account_id = account_id_from_arn(&func.function_arn);
         let ctx = PodSpecContext {
-            instance_id: &self.instance_id,
-            namespace: &self.namespace,
+            instance_id: self.client.instance_id(),
+            namespace: self.client.namespace(),
             self_url: &self.self_url,
             self_host: &self.self_host,
             ecr_host: &self.ecr_host,
@@ -239,50 +132,37 @@ impl LambdaBackend for K8sBackend {
             .clone()
             .unwrap_or_else(|| pod_name_for(&func.function_name, deploy_id));
 
-        let api = self.pods_api();
+        self.client
+            .create_pod(&pod)
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(format!("k8s create pod: {e}")))?;
 
-        // Best-effort delete of any stale pod with the same name (e.g.
-        // a previous fakecloud process left it behind). `Created` from
-        // a stale pod would otherwise come back as `Conflict (409)`.
-        let _ = api.delete(&pod_name, &DeleteParams::default()).await;
-        // Give the API server a moment to actually delete; otherwise
-        // create can race and 409. Polling for absence would be more
-        // correct — keep simple for now and retry create on 409.
-        for attempt in 0..6 {
-            match api.create(&PostParams::default(), &pod).await {
-                Ok(_) => break,
-                Err(kube::Error::Api(e)) if e.code == 409 && attempt < 5 => {
-                    tokio::time::sleep(Duration::from_millis(500)).await;
-                    let _ = api.delete(&pod_name, &DeleteParams::default()).await;
-                    continue;
-                }
-                Err(e) => {
-                    return Err(RuntimeError::ContainerStartFailed(format!(
-                        "k8s create pod {pod_name}: {e}"
-                    )));
-                }
+        // Tear the Pod down again if it never becomes ready, so a failed
+        // launch doesn't leak a Pod.
+        let pod_ip = match self
+            .client
+            .wait_for_pod_ip(&pod_name, Duration::from_secs(60))
+            .await
+        {
+            Ok(ip) => ip,
+            Err(e) => {
+                self.client.delete_pod(&pod_name).await;
+                return Err(RuntimeError::ContainerStartFailed(e.to_string()));
             }
+        };
+        // Pod-Running doesn't guarantee the RIE inside the main container
+        // is listening yet — TCP-handshake the invoke port like Docker.
+        if let Err(e) = K8sClient::wait_for_tcp(&pod_ip, 8080, Duration::from_secs(10)).await {
+            self.client.delete_pod(&pod_name).await;
+            return Err(RuntimeError::ContainerStartFailed(format!(
+                "RIE on {pod_ip}:8080 not ready: {e}"
+            )));
         }
-
-        let pod_ip = self.wait_for_pod_ip(&pod_name).await.inspect_err(|_| {
-            let api = self.pods_api();
-            let name = pod_name.clone();
-            tokio::spawn(async move {
-                let _ = api.delete(&name, &DeleteParams::default()).await;
-            });
-        })?;
-        self.wait_for_rie_ready(&pod_ip).await.inspect_err(|_| {
-            let api = self.pods_api();
-            let name = pod_name.clone();
-            tokio::spawn(async move {
-                let _ = api.delete(&name, &DeleteParams::default()).await;
-            });
-        })?;
 
         tracing::info!(
             function = %func.function_name,
             pod = %pod_name,
-            namespace = %self.namespace,
+            namespace = %self.client.namespace(),
             pod_ip = %pod_ip,
             "Lambda Pod started"
         );
@@ -290,27 +170,17 @@ impl LambdaBackend for K8sBackend {
         Ok(WarmInstance {
             endpoint: format!("{pod_ip}:8080"),
             handle: BackendHandle::Pod {
-                namespace: self.namespace.clone(),
+                namespace: self.client.namespace().to_string(),
                 name: pod_name,
             },
         })
     }
 
     async fn terminate(&self, handle: &BackendHandle) {
-        let (ns, name) = match handle {
-            BackendHandle::Pod { namespace, name } => (namespace.clone(), name.clone()),
+        match handle {
+            BackendHandle::Pod { name, .. } => self.client.delete_pod(name).await,
             // Docker handles aren't ours to manage — defensive no-op.
-            BackendHandle::Container { .. } => return,
-        };
-        let api: Api<Pod> = Api::namespaced(self.client.clone(), &ns);
-        if let Err(e) = api.delete(&name, &DeleteParams::default()).await {
-            // 404 is normal on idempotent re-delete; surface anything else.
-            if let kube::Error::Api(api_err) = &e {
-                if api_err.code == 404 {
-                    return;
-                }
-            }
-            tracing::warn!(pod = %name, namespace = %ns, error = %e, "k8s delete pod failed");
+            BackendHandle::Container { .. } => {}
         }
     }
 
@@ -319,33 +189,7 @@ impl LambdaBackend for K8sBackend {
     /// and `Create` collides on function names. Mirrors the docker
     /// `reaper` semantics.
     async fn reap_stale(&self) {
-        let api = self.pods_api();
-        let lp = ListParams::default().labels("fakecloud-managed-by=fakecloud");
-        let list = match api.list(&lp).await {
-            Ok(l) => l,
-            Err(e) => {
-                tracing::warn!(error = %e, "k8s reap_stale: list pods failed");
-                return;
-            }
-        };
-        let mut reaped = 0usize;
-        for pod in list.items {
-            let labels = pod.metadata.labels.as_ref();
-            let inst = labels.and_then(|l| l.get("fakecloud-instance")).cloned();
-            if inst.as_deref() == Some(self.instance_id.as_str()) {
-                continue;
-            }
-            if let Some(name) = pod.metadata.name {
-                if let Err(e) = api.delete(&name, &DeleteParams::default()).await {
-                    tracing::warn!(pod = %name, error = %e, "k8s reap_stale: delete failed");
-                } else {
-                    reaped += 1;
-                }
-            }
-        }
-        if reaped > 0 {
-            tracing::info!(reaped, "k8s reap_stale: removed orphan Lambda Pods");
-        }
+        self.client.reap_stale(SERVICE).await;
     }
 }
 

--- a/crates/fakecloud-lambda/src/runtime/k8s/spec.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/spec.rs
@@ -12,6 +12,8 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
+use fakecloud_k8s::names::label_safe;
+
 use super::super::docker::runtime_to_image;
 use super::super::env_rewrite::rewrite_localhost_envs;
 use crate::state::LambdaFunction;
@@ -79,8 +81,15 @@ pub fn build_pod_spec(
     let pod_name = pod_name_for(&func.function_name, deploy_id);
 
     let mut labels = BTreeMap::new();
-    labels.insert("fakecloud-managed-by".into(), "fakecloud".into());
-    labels.insert("fakecloud-instance".into(), ctx.instance_id.into());
+    labels.insert(
+        fakecloud_k8s::labels::MANAGED_BY.into(),
+        fakecloud_k8s::labels::MANAGED_BY_VALUE.into(),
+    );
+    labels.insert(
+        fakecloud_k8s::labels::INSTANCE.into(),
+        ctx.instance_id.into(),
+    );
+    labels.insert(fakecloud_k8s::labels::SERVICE.into(), super::SERVICE.into());
     labels.insert("fakecloud-lambda".into(), label_safe(&func.function_name));
     labels.insert(
         "fakecloud-deploy-id".into(),
@@ -252,17 +261,10 @@ pub fn build_pod_spec(
 
 /// Build a deterministic, DNS-1123-safe Pod name for the given
 /// function + deploy_id. Truncated/lowercased so it fits the 63-char
-/// label limit.
+/// label limit. The suffix is a stable hash of `deploy_id` so a new
+/// deploy gets a fresh, non-colliding Pod name.
 pub fn pod_name_for(function_name: &str, deploy_id: &str) -> String {
-    // function_name may contain underscores or uppercase; convert.
-    let fn_part = label_safe(function_name);
-    // deploy_id is base64 — pick the first 12 chars of a hex projection
-    // so the suffix is stable across restarts and DNS-safe.
-    let digest = simple_hex12(deploy_id);
-    // Keep total length under 63. fn_part already <=40, digest is 12,
-    // prefix "fakecloud-lambda-" is 17. Trim function part to 30.
-    let fn_short: String = fn_part.chars().take(30).collect();
-    format!("fakecloud-lambda-{fn_short}-{digest}")
+    fakecloud_k8s::names::pod_name("fakecloud-lambda", function_name, deploy_id)
 }
 
 /// Map the function's `memory_size` (MiB) onto both `requests` and
@@ -286,40 +288,6 @@ fn memory_resources(memory_size: i64) -> ResourceRequirements {
         limits: Some(lim),
         claims: None,
     }
-}
-
-/// Lowercase + replace anything outside `[a-z0-9-]` with `-`. DNS-1123
-/// label rules: 63 chars max, ends with alphanumeric.
-fn label_safe(s: &str) -> String {
-    let mut out: String = s
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() {
-                c.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .collect();
-    // Trim trailing dashes so the label ends in an alphanumeric.
-    while out.ends_with('-') {
-        out.pop();
-    }
-    out
-}
-
-/// 12-char hex projection of an arbitrary string, used to suffix Pod
-/// names so deploy_id changes produce a new Pod without colliding with
-/// the old one. Deterministic so the watcher and the launch step agree
-/// on the name. Not a cryptographic hash — collision space (2^48) is
-/// plenty for per-function uniqueness.
-fn simple_hex12(s: &str) -> String {
-    use sha2::{Digest, Sha256};
-    let mut h = Sha256::new();
-    h.update(s.as_bytes());
-    let bytes = h.finalize();
-    let hex: String = bytes.iter().take(6).map(|b| format!("{b:02x}")).collect();
-    hex
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-lambda/tests/k8s_integration.rs
+++ b/crates/fakecloud-lambda/tests/k8s_integration.rs
@@ -85,6 +85,9 @@ fn dummy_pod(name: &str, instance_label: &str) -> Pod {
     let mut labels = BTreeMap::new();
     labels.insert("fakecloud-managed-by".into(), "fakecloud".into());
     labels.insert("fakecloud-instance".into(), instance_label.into());
+    // reap_stale() now filters on the per-service label, so a Pod must
+    // carry it to be a reap candidate.
+    labels.insert("fakecloud-service".into(), "lambda".into());
     labels.insert("fakecloud-lambda".into(), "test-fn".into());
     Pod {
         metadata: ObjectMeta {

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -25,6 +25,7 @@ fakecloud-ssm = { workspace = true }
 fakecloud-s3 = { workspace = true }
 fakecloud-dynamodb = { workspace = true }
 fakecloud-lambda = { workspace = true }
+fakecloud-k8s = { workspace = true }
 fakecloud-secretsmanager = { workspace = true }
 fakecloud-logs = { workspace = true }
 fakecloud-kms = { workspace = true }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -188,14 +188,13 @@ async fn main() {
     // Reap any backing containers left behind by a previous fakecloud process
     // that was killed before it could run its own cleanup (SIGKILL, crash, OOM).
     reaper::reap_stale_containers();
-    // Lambda execution backend. FAKECLOUD_LAMBDA_BACKEND=k8s opts into
-    // the native Kubernetes Pod backend (issue #1234); anything else
-    // (or unset) auto-detects Docker/Podman.
-    let lambda_backend_choice = std::env::var("FAKECLOUD_LAMBDA_BACKEND")
-        .unwrap_or_default()
-        .to_ascii_lowercase();
+    // Lambda execution backend. FAKECLOUD_LAMBDA_BACKEND=k8s (or the
+    // global FAKECLOUD_CONTAINER_BACKEND=k8s) opts into the native
+    // Kubernetes Pod backend (issue #1234); anything else (or unset)
+    // auto-detects Docker/Podman.
+    let lambda_backend = fakecloud_k8s::backend_choice("FAKECLOUD_LAMBDA_BACKEND");
     let k8s_internal_token: Arc<String> = Arc::new(generate_k8s_internal_token());
-    let container_runtime = if lambda_backend_choice == "k8s" {
+    let container_runtime = if lambda_backend == fakecloud_k8s::Backend::K8s {
         match fakecloud_lambda::runtime::LambdaRuntime::new_k8s(
             bound_addr.port(),
             (*k8s_internal_token).clone(),
@@ -205,7 +204,7 @@ async fn main() {
             Ok(rt) => Some(Arc::new(rt)),
             Err(e) => {
                 eprintln!(
-                    "FAKECLOUD_LAMBDA_BACKEND=k8s but Kubernetes backend failed to initialize: {e}"
+                    "Kubernetes Lambda backend selected (FAKECLOUD_LAMBDA_BACKEND/FAKECLOUD_CONTAINER_BACKEND=k8s) but failed to initialize: {e}"
                 );
                 std::process::exit(1);
             }
@@ -218,7 +217,7 @@ async fn main() {
     } else {
         tracing::info!("Docker/Podman not available — Lambda Invoke will return errors for functions with code");
     }
-    let lambda_backend_is_k8s = lambda_backend_choice == "k8s";
+    let lambda_backend_is_k8s = lambda_backend == fakecloud_k8s::Backend::K8s;
     let secretsmanager_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new(
             &cli.account_id,

--- a/website/content/docs/guides/kubernetes-backend.md
+++ b/website/content/docs/guides/kubernetes-backend.md
@@ -28,6 +28,16 @@ FAKECLOUD_K8S_SELF_URL=http://fakecloud.fakecloud.svc.cluster.local:4566
 
 `FAKECLOUD_K8S_SELF_URL` must resolve from inside Lambda Pods — that's how init containers pull function code and layers from the fakecloud process. Use the in-cluster service DNS name, never `localhost` or `127.0.0.1`.
 
+### Selecting the backend
+
+Backend selection is per-service with a global fallback:
+
+- `FAKECLOUD_<SERVICE>_BACKEND=k8s|docker` — an explicit per-service override (`FAKECLOUD_LAMBDA_BACKEND`, and the same pattern for the other container-backed services). An explicit value always wins.
+- `FAKECLOUD_CONTAINER_BACKEND=k8s|docker` — a global default applied to any service whose own variable is unset. Set this once to flip the whole stack to Kubernetes.
+- Unset everywhere — Docker (the default).
+
+So `FAKECLOUD_CONTAINER_BACKEND=k8s` with `FAKECLOUD_LAMBDA_BACKEND=docker` runs everything on Kubernetes *except* Lambda, which stays on Docker.
+
 Optional env vars:
 
 | Variable | Default | Purpose |


### PR DESCRIPTION
## Summary

First batch of extending the Kubernetes execution backend (today Lambda-only, `FAKECLOUD_LAMBDA_BACKEND=k8s`, issue #1234) to the other container-backed services. This batch lays the shared foundation:

- **New `fakecloud-k8s` crate** holding everything every k8s backend needs, extracted from Lambda's k8s module:
  - `K8sClient` — namespaced kube client + Pod lifecycle: `create_pod` (stale-delete + 409 retry), `wait_for_pod_ip`, `wait_for_tcp`, `exec` (kube exec subresource, the `docker exec` equivalent), `delete_pod`, `reap_stale` (per-service label).
  - `K8sEnv` — parses `FAKECLOUD_K8S_SELF_URL` / `_NAMESPACE` / `_ECR_URL` / `_PULL_SECRET`.
  - `backend_choice` — per-service `FAKECLOUD_<SERVICE>_BACKEND` overriding a global `FAKECLOUD_CONTAINER_BACKEND`, defaulting to Docker.
  - `labels` + `names` (`label_safe`, `simple_hex12`, `pod_name`).
- **Lambda refactored onto it** — behaviour unchanged; Pods now carry `fakecloud-service=lambda` so reaping is service-scoped.
- **Global env var** — the server honours `FAKECLOUD_CONTAINER_BACKEND=k8s` as a fallback for Lambda.
- `kube` gains the `ws` feature (needed for `exec`).
- Docs: document per-service + global backend selection.

Docker stays the default everywhere, so existing e2e/conformance/tfacc are unaffected. ElastiCache/RDS/ECS k8s backends land in the following batches.

## Test plan

- `cargo test -p fakecloud-k8s` — 19 unit tests (backend selection precedence, name/label safety, exec exit-code parsing).
- `cargo test -p fakecloud-lambda --lib` — 185 existing unit tests stay green.
- `FAKECLOUD_K8S_TEST=1 cargo test -p fakecloud-lambda --features k8s-integration` — 6 integration tests run against a real `kind` cluster (client connect, `from_env`, reap foreign/own, idempotent terminate). **Verified locally on kind: 6/6 pass.**
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt` clean on touched crates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared `fakecloud-k8s` crate and a global backend selector to prep all services for a Kubernetes backend; Lambda is migrated with no behavior change, Docker stays the default. Improves k8s env parsing and readiness checks to reduce misconfig and startup hangs.

- **New Features**
  - Added `fakecloud-k8s` crate:
    - `K8sClient` (create_pod, wait_for_pod_ip, wait_for_tcp, exec, delete_pod, reap_stale).
    - `K8sEnv` (parses `FAKECLOUD_K8S_*`).
    - `backend_choice` (per-service `FAKECLOUD_<SERVICE>_BACKEND` with global `FAKECLOUD_CONTAINER_BACKEND` fallback).
    - `labels`/`names` helpers (`label_safe`, `simple_hex12`, `pod_name`).
  - Lambda k8s backend refactored to use the shared crate; Pods carry `fakecloud-service=lambda` for scoped reaping.
  - Global `FAKECLOUD_CONTAINER_BACKEND=k8s|docker` with per-service override; `kube` `ws` enabled; docs updated.

- **Bug Fixes**
  - `K8sEnv`: portless `FAKECLOUD_K8S_SELF_URL`/`_ECR_URL` fall back to the server’s bound port; empty `FAKECLOUD_K8S_NAMESPACE`/`_PULL_SECRET` are treated as unset.
  - Readiness: `wait_for_tcp` bounds each connect attempt to 2s; `wait_for_pod_ip` fails fast when a Pod hits a terminal phase even without a `podIP`.
  - Naming: `label_safe` trims leading dashes for DNS-1123 compliance.

<sup>Written for commit 362fa60f2857de3fa85548580aaaf2fdf7857679. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

