### PR TITLE
chore(release): bump workspace to v0.17.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,7 @@ jobs:
           publish fakecloud-aws
           publish fakecloud-sdk
           publish fakecloud-persistence
+          publish fakecloud-k8s   # only external deps (kube/k8s-openapi); dependents: lambda/elasticache/rds/ecs/server
 
           # Layer 2: depends on fakecloud-aws
           publish fakecloud-core

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4128,7 +4128,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4263,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -101,171 +101,171 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.16.0")
+    testImplementation("dev.fakecloud:fakecloud:0.17.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.16.0</version>
+    <version>0.17.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.16.0"
+version = "0.17.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.16.0"
+version = "0.17.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release v0.17.0. Headline: the **Kubernetes execution backend now covers the whole container-backed stack** — Lambda, ElastiCache, RDS, and ECS all run as native Pods with `FAKECLOUD_CONTAINER_BACKEND=k8s` (per-service overrides too). Docker stays the default. Shipped across PRs #1625-#1629.

### Bumps (canonical set)
- `Cargo.toml`: `[workspace.package] version` + all 43 `[workspace.dependencies.fakecloud-*]` pins → `0.17.0`.
- `Cargo.lock` regenerated.
- SDKs: `sdks/typescript/package.json`, `sdks/python/pyproject.toml`, `sdks/java/build.gradle.kts` + `README.md` → `0.17.0` (PHP/Go versioned by tag).
- `release.yml`: new `fakecloud-k8s` crate added to the publish order (Layer 1 — only external deps; precedes lambda/elasticache/rds/ecs/server).

## Test plan
- `cargo fmt --check`, `cargo clippy --workspace -- -D warnings` clean.
- `cargo check --workspace` green at 0.17.0; lockfile updated.
- Tag `v0.17.0` after merge triggers the publish workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.17.0. The Kubernetes execution backend now runs Lambda, ElastiCache, RDS, and ECS as native Pods when `FAKECLOUD_CONTAINER_BACKEND=k8s`.

- **Dependencies**
  - Bumped workspace and all `fakecloud-*` crates to 0.17.0; regenerated `Cargo.lock`.
  - Updated SDK versions: `sdks/typescript` (`fakecloud`), `sdks/python` (`fakecloud`), and Java (`build.gradle.kts` and README) to 0.17.0.
  - Updated release workflow to publish `fakecloud-k8s` in Layer 1 before its dependents.

<sup>Written for commit 585d6049b293e43b58385176f15146362584cf15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

