### PR TITLE
fix(lambda): URL-path-safe deploy ids for k8s init-container artifact URLs

### DIFF
--- a/crates/fakecloud-lambda/src/runtime/facade.rs
+++ b/crates/fakecloud-lambda/src/runtime/facade.rs
@@ -32,16 +32,29 @@ struct WarmEntry {
 /// Compute the warm-instance key for a function with its current layer
 /// set. Stable across calls — layer ARNs are immutable in AWS, so the
 /// hash of their bytes is the right cache key.
+///
+/// Encoded with `URL_SAFE_NO_PAD` so the result never contains `/`, `+`,
+/// or `=`. The id is spliced raw into the init-container artifact URL
+/// (`.../_internal/code/{account}/{function}/{deploy}.zip`) and into the
+/// `fakecloud-deploy-id` Pod label; standard base64's `/` would grow an
+/// extra URL path segment, break the axum route match, and wedge the Pod
+/// in a cold-start loop for ~49% of deploys (issue #1643).
 fn deploy_id_for(func: &LambdaFunction, layers: &[Vec<u8>]) -> String {
+    deploy_id_from(&func.code_sha256, layers)
+}
+
+/// Pure core of [`deploy_id_for`], split out so the URL-path-safety
+/// invariant can be tested without constructing a full `LambdaFunction`.
+fn deploy_id_from(code_sha256: &str, layers: &[Vec<u8>]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(func.code_sha256.as_bytes());
+    hasher.update(code_sha256.as_bytes());
     for bytes in layers {
         let mut layer_hasher = Sha256::new();
         layer_hasher.update(bytes);
         hasher.update(b":");
         hasher.update(layer_hasher.finalize());
     }
-    base64::engine::general_purpose::STANDARD.encode(hasher.finalize())
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hasher.finalize())
 }
 
 pub struct LambdaRuntime {
@@ -363,5 +376,46 @@ impl LambdaRuntime {
             tracing::info!(function = %name, "stopping idle Lambda runtime instance");
             self.stop_container(&name).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deploy_id_from;
+
+    /// The deploy id is spliced raw into the init-container artifact URL
+    /// path and into a Pod label, so it must never contain characters
+    /// that standard base64 emits (`/`, `+`, `=`). Standard base64
+    /// produced `/` for ~49% of code hashes (issue #1643); sweep a wide
+    /// range of inputs to catch any regression back to a non-URL-safe
+    /// alphabet.
+    #[test]
+    fn deploy_id_is_url_path_safe() {
+        for i in 0..2_000u32 {
+            // Vary both the code hash and the layer set.
+            let code_sha256 = format!("sha256-seed-{i}-{}", i.wrapping_mul(2_654_435_761));
+            let layers: Vec<Vec<u8>> = if i % 3 == 0 {
+                vec![format!("layer-{i}").into_bytes()]
+            } else {
+                vec![]
+            };
+            let id = deploy_id_from(&code_sha256, &layers);
+            assert!(
+                !id.contains('/') && !id.contains('+') && !id.contains('='),
+                "deploy id {id:?} (seed {i}) is not URL-path-safe"
+            );
+        }
+    }
+
+    /// Same inputs must always map to the same deploy id — the value is a
+    /// warm-pool cache key, so instability would defeat reuse.
+    #[test]
+    fn deploy_id_is_stable() {
+        let layers = vec![b"layer-a".to_vec(), b"layer-b".to_vec()];
+        let a = deploy_id_from("abc123", &layers);
+        let b = deploy_id_from("abc123", &layers);
+        assert_eq!(a, b);
+        assert_ne!(a, deploy_id_from("abc124", &layers));
+        assert_ne!(a, deploy_id_from("abc123", &[]));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1643. The k8s Lambda backend computes a warm-pool `deploy_id` and splices it **raw** into the init-container artifact URL (`.../\_internal/code/{account}/{function}/{deploy}.zip`) and into the `fakecloud-deploy-id` Pod label. The id was **standard** base64, whose alphabet includes `/` and `+`. A `/` in the digest (probability `1 − (63/64)^43 ≈ 49%` per deploy) grows an extra URL path segment, so the axum route `/{account_id}/{function_name}/{deploy}` stops matching, `wget` gets a 400, the init container fails, and the Pod loops in cold start forever. Whether a given function worked was a coin flip on its code hash.

### Fix
Encode the deploy id with `URL_SAFE_NO_PAD` (`-`/`_` for `+`/`/`, no `=` padding) so it is always literal-safe in a URL path segment and a label.

Safe to change outright: the id only feeds (a) the in-memory warm-pool key, (b) the artifact URL, (c) the `label_safe()`-wrapped Pod label. Nothing persists the old encoding across restarts, and orphan cleanup matches on the `fakecloud-instance` label, not the deploy id — no migration concern. The server side already ignores the `{deploy}` segment (`_deploy` in `serve_code`), so artifact serving is unaffected.

Split the pure core into `deploy_id_from` so the safety invariant is testable without a full `LambdaFunction`.

## Test plan
- New unit tests: `deploy_id_is_url_path_safe` sweeps 2000 inputs asserting no `/`, `+`, `=` (standard base64 would have failed this ~49% of the time); `deploy_id_is_stable` asserts identical inputs map to identical ids and distinct inputs differ.
- `cargo test -p fakecloud-lambda`, `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings`, `cargo fmt` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make deploy IDs URL-path safe in the k8s Lambda backend to stop init-container downloads from breaking and pods from looping on cold start. Switch to URL-safe base64 (no padding) and add tests.

- **Bug Fixes**
  - Use `URL_SAFE_NO_PAD` for deploy IDs so no `/`, `+`, or `=` appears in `/_internal/code/{account}/{function}/{deploy}.zip` URLs or the `fakecloud-deploy-id` label.
  - Extract `deploy_id_from(...)` for testability; add tests for URL-safety across many inputs and for id stability.
  - No migration needed: IDs are only used in warm-pool keys, the artifact URL, and a label; the server ignores the `{deploy}` path segment.

<sup>Written for commit 20db4f5a742d0563dcf3d348eb1b16c198cc33ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

