### PR TITLE
fix(lambda): scale warm instances per function and evict dead ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,6 +3882,7 @@ dependencies = [
  "fakecloud-core",
  "fakecloud-k8s",
  "fakecloud-persistence",
+ "futures-util",
  "http 1.4.0",
  "k8s-openapi",
  "kube",

--- a/crates/fakecloud-lambda/Cargo.toml
+++ b/crates/fakecloud-lambda/Cargo.toml
@@ -23,6 +23,7 @@ uuid = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 tokio = { workspace = true }
+futures-util = "0.3"
 reqwest = { workspace = true }
 tracing = { workspace = true }
 zip = { workspace = true }

--- a/crates/fakecloud-lambda/src/runtime/backend.rs
+++ b/crates/fakecloud-lambda/src/runtime/backend.rs
@@ -50,6 +50,13 @@ pub struct WarmInstance {
 /// terminal `InvokeComplete` frame.
 pub struct StreamingInvocation {
     pub(crate) resp: reqwest::Response,
+    /// Holds the warm instance's per-instance busy lock for the lifetime
+    /// of the stream. The RIE handles exactly one event at a time, so the
+    /// slot must stay reserved until the caller finishes draining the
+    /// response; dropping this guard frees the instance for the next
+    /// invocation. `None` only in unit tests that build the wrapper
+    /// directly.
+    pub(crate) _slot_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
 }
 
 impl StreamingInvocation {

--- a/crates/fakecloud-lambda/src/runtime/facade.rs
+++ b/crates/fakecloud-lambda/src/runtime/facade.rs
@@ -223,14 +223,18 @@ impl LambdaRuntime {
                     };
                 }
                 Err(e) => {
-                    // Transport-level failure: the request didn't reach a
-                    // live RIE (connection refused to a dead Pod, reset,
-                    // timeout). Evict the instance and cold-start a
-                    // replacement once.
+                    // Transport-level failure. Evict the suspect instance.
+                    // Only retry when the connection was never
+                    // established (`is_connect` — e.g. refused by a dead
+                    // Pod): then the request provably never reached the
+                    // function, so a cold-start retry can't double-execute
+                    // it. A reset/timeout mid-flight may have already run
+                    // the handler, so surface those instead of risking a
+                    // duplicate invoke.
                     let entry = slot.entry.clone();
                     drop(slot);
                     self.evict_entry(&func.function_name, &entry).await;
-                    if attempt < 2 {
+                    if attempt < 2 && e.is_connect() {
                         tracing::warn!(
                             function = %func.function_name,
                             error = %e,
@@ -288,10 +292,13 @@ impl LambdaRuntime {
                     });
                 }
                 Err(e) => {
+                    // Same connect-only retry policy as `invoke`: retry
+                    // only when the connection never established, so a
+                    // half-run handler isn't invoked twice.
                     let entry = slot.entry.clone();
                     drop(slot);
                     self.evict_entry(&func.function_name, &entry).await;
-                    if attempt < 2 {
+                    if attempt < 2 && e.is_connect() {
                         continue;
                     }
                     return Err(RuntimeError::InvocationFailed(e.to_string()));
@@ -378,23 +385,37 @@ impl LambdaRuntime {
             return Ok(Slot { entry, guard });
         }
 
-        // (3) At capacity: release the startup lock and queue on a busy
-        // instance — whichever frees up first serves this invocation.
+        // (3) At capacity: release the startup lock and wait for whichever
+        // current instance frees up *first*. Racing every instance's lock
+        // (rather than blocking on a fixed one) avoids convoying every
+        // queued caller onto pool[0] while a different instance goes idle.
         drop(startup_guard);
-        let entry = {
+        let candidates: Vec<Arc<WarmEntry>> = {
             let map = self.instances.read();
             map.get(&func.function_name)
-                .and_then(|pool| pool.iter().find(|e| e.deploy_id == deploy_id).cloned())
+                .map(|pool| {
+                    pool.iter()
+                        .filter(|e| e.deploy_id == deploy_id)
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default()
         };
-        let entry = entry.ok_or_else(|| {
-            RuntimeError::InvocationFailed(format!(
+        if candidates.is_empty() {
+            return Err(RuntimeError::InvocationFailed(format!(
                 "no warm instance available for {}",
                 func.function_name
-            ))
-        })?;
-        let guard = entry.busy.clone().lock_owned().await;
-        *entry.last_used.write() = Instant::now();
-        Ok(Slot { entry, guard })
+            )));
+        }
+        let waiters = candidates.into_iter().map(|entry| {
+            Box::pin(async move {
+                let guard = entry.busy.clone().lock_owned().await;
+                Slot { entry, guard }
+            })
+        });
+        let (slot, _idx, _rest) = futures_util::future::select_all(waiters).await;
+        *slot.entry.last_used.write() = Instant::now();
+        Ok(slot)
     }
 
     /// Try to reserve a free, current-deploy instance without launching.

--- a/crates/fakecloud-lambda/src/runtime/facade.rs
+++ b/crates/fakecloud-lambda/src/runtime/facade.rs
@@ -27,6 +27,28 @@ struct WarmEntry {
     /// order. Layers mutate `/opt`, so a layer change invalidates the
     /// warm instance even when the function code is unchanged.
     deploy_id: String,
+    /// Held for the duration of a single invocation against this
+    /// instance. The AWS Runtime Interface Emulator (and real Lambda)
+    /// handles exactly one event per execution environment at a time;
+    /// the RIE's `rapidcore` server nil-pointer-derefs and the process
+    /// exits if two invokes overlap (issue #1644). Acquiring this lock
+    /// before forwarding guarantees one in-flight event per instance,
+    /// and lets the pool pick a *free* instance via `try_lock`.
+    busy: Arc<tokio::sync::Mutex<()>>,
+}
+
+/// Default cap on warm instances per function. Real Lambda scales
+/// execution environments with concurrent demand; we bound it so a
+/// burst can't spawn unbounded containers/Pods. Override with
+/// `FAKECLOUD_LAMBDA_MAX_CONCURRENCY`. Beyond the cap, invocations queue
+/// on a busy instance rather than starting a new one.
+const DEFAULT_MAX_CONCURRENCY: usize = 10;
+
+/// A reserved invocation slot: a warm instance plus the held busy guard
+/// that grants exclusive use of it until the guard drops.
+struct Slot {
+    entry: Arc<WarmEntry>,
+    guard: tokio::sync::OwnedMutexGuard<()>,
 }
 
 /// Compute the warm-instance key for a function with its current layer
@@ -59,9 +81,16 @@ fn deploy_id_from(code_sha256: &str, layers: &[Vec<u8>]) -> String {
 
 pub struct LambdaRuntime {
     backend: Arc<dyn LambdaBackend>,
-    instances: RwLock<HashMap<String, WarmEntry>>,
-    /// Serializes runtime startup per function to prevent duplicate instances.
+    /// Per-function pool of warm instances. Each instance serves one
+    /// invocation at a time (its `busy` lock); the pool grows on demand
+    /// up to `max_concurrency`, and the idle reaper trims it.
+    instances: RwLock<HashMap<String, Vec<Arc<WarmEntry>>>>,
+    /// Serializes runtime startup per function to prevent duplicate
+    /// instances racing into the pool when several cold invokes arrive
+    /// together.
     starting: RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    /// Cap on warm instances per function.
+    max_concurrency: usize,
 }
 
 impl LambdaRuntime {
@@ -69,10 +98,16 @@ impl LambdaRuntime {
     /// auto-detection should use [`Self::auto_detect_docker`] or
     /// [`Self::new`].
     pub fn from_backend(backend: Arc<dyn LambdaBackend>) -> Self {
+        let max_concurrency = std::env::var("FAKECLOUD_LAMBDA_MAX_CONCURRENCY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n >= 1)
+            .unwrap_or(DEFAULT_MAX_CONCURRENCY);
         Self {
             backend,
             instances: RwLock::new(HashMap::new()),
             starting: RwLock::new(HashMap::new()),
+            max_concurrency,
         }
     }
 
@@ -142,30 +177,71 @@ impl LambdaRuntime {
     /// ZIPs are extracted into `/opt` of the runtime sandbox; AWS base
     /// images already include `/opt/python`, `/opt/nodejs/node_modules`,
     /// `/opt/lib`, and `/opt/bin` on the right import paths.
+    ///
+    /// Reserves a warm instance for the call (one in-flight invocation
+    /// per instance — the RIE crashes on overlap, issue #1644). If the
+    /// instance is unreachable (dead Pod/container from a node drain, OOM,
+    /// or prior crash) it is evicted and the call retried once against a
+    /// freshly cold-started instance, so a dead instance can't wedge the
+    /// function permanently.
     pub async fn invoke(
         &self,
         func: &LambdaFunction,
         payload: &[u8],
         layers: &[Vec<u8>],
     ) -> Result<Vec<u8>, RuntimeError> {
-        let endpoint = self.ensure_warm_instance(func, layers).await?;
-
-        let url = format!("http://{endpoint}/2015-03-31/functions/function/invocations");
         let client = reqwest::Client::new();
-        let resp = client
-            .post(&url)
-            .body(payload.to_vec())
-            .timeout(Duration::from_secs(func.timeout as u64 + 5))
-            .send()
-            .await
-            .map_err(|e| RuntimeError::InvocationFailed(e.to_string()))?;
-
-        let body = resp
-            .bytes()
-            .await
-            .map_err(|e| RuntimeError::InvocationFailed(e.to_string()))?;
-
-        Ok(body.to_vec())
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let slot = self.acquire_slot(func, layers).await?;
+            let url = format!(
+                "http://{}/2015-03-31/functions/function/invocations",
+                slot.entry.instance.endpoint
+            );
+            let send = client
+                .post(&url)
+                .body(payload.to_vec())
+                .timeout(Duration::from_secs(func.timeout as u64 + 5))
+                .send()
+                .await;
+            match send {
+                Ok(resp) => {
+                    let body = resp.bytes().await;
+                    *slot.entry.last_used.write() = Instant::now();
+                    return match body {
+                        Ok(b) => Ok(b.to_vec()),
+                        Err(e) => {
+                            // Response failed mid-stream — the instance is
+                            // suspect. Evict it but don't retry: the
+                            // function already ran and may have side effects.
+                            let entry = slot.entry.clone();
+                            drop(slot);
+                            self.evict_entry(&func.function_name, &entry).await;
+                            Err(RuntimeError::InvocationFailed(e.to_string()))
+                        }
+                    };
+                }
+                Err(e) => {
+                    // Transport-level failure: the request didn't reach a
+                    // live RIE (connection refused to a dead Pod, reset,
+                    // timeout). Evict the instance and cold-start a
+                    // replacement once.
+                    let entry = slot.entry.clone();
+                    drop(slot);
+                    self.evict_entry(&func.function_name, &entry).await;
+                    if attempt < 2 {
+                        tracing::warn!(
+                            function = %func.function_name,
+                            error = %e,
+                            "warm Lambda instance unreachable; evicted, retrying with a cold start"
+                        );
+                        continue;
+                    }
+                    return Err(RuntimeError::InvocationFailed(e.to_string()));
+                }
+            }
+        }
     }
 
     /// Invoke a Lambda function and yield the raw HTTP body as a stream
@@ -174,36 +250,70 @@ impl LambdaRuntime {
     /// preserves the chunk boundaries the function emitted. Buffered
     /// handlers come back as a single chunk, which is still a valid
     /// streamed response.
+    ///
+    /// The reserved instance's busy guard travels with the returned
+    /// [`StreamingInvocation`] so the slot stays held until the caller
+    /// finishes draining the stream.
     pub async fn invoke_streaming(
         &self,
         func: &LambdaFunction,
         payload: &[u8],
         layers: &[Vec<u8>],
     ) -> Result<StreamingInvocation, RuntimeError> {
-        let endpoint = self.ensure_warm_instance(func, layers).await?;
-
-        let url = format!("http://{endpoint}/2015-03-31/functions/function/invocations");
         let client = reqwest::Client::new();
-        let resp = client
-            .post(&url)
-            .body(payload.to_vec())
-            .timeout(Duration::from_secs(func.timeout as u64 + 5))
-            .send()
-            .await
-            .map_err(|e| RuntimeError::InvocationFailed(e.to_string()))?;
-
-        Ok(StreamingInvocation { resp })
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let slot = self.acquire_slot(func, layers).await?;
+            let url = format!(
+                "http://{}/2015-03-31/functions/function/invocations",
+                slot.entry.instance.endpoint
+            );
+            let send = client
+                .post(&url)
+                .body(payload.to_vec())
+                .timeout(Duration::from_secs(func.timeout as u64 + 5))
+                .send()
+                .await;
+            match send {
+                Ok(resp) => {
+                    *slot.entry.last_used.write() = Instant::now();
+                    let Slot {
+                        entry: _entry,
+                        guard,
+                    } = slot;
+                    return Ok(StreamingInvocation {
+                        resp,
+                        _slot_guard: Some(guard),
+                    });
+                }
+                Err(e) => {
+                    let entry = slot.entry.clone();
+                    drop(slot);
+                    self.evict_entry(&func.function_name, &entry).await;
+                    if attempt < 2 {
+                        continue;
+                    }
+                    return Err(RuntimeError::InvocationFailed(e.to_string()));
+                }
+            }
+        }
     }
 
-    /// Resolve a warm instance for `func`, launching one if its
-    /// fingerprint doesn't match (or there isn't one yet). Returns the
-    /// invocation endpoint. Shared by `invoke` and `invoke_streaming`
-    /// so both paths use the same warm-pool logic.
-    async fn ensure_warm_instance(
+    /// Reserve a warm instance to run exactly one invocation, returning a
+    /// held busy guard that grants exclusive use until it drops. Shared
+    /// by `invoke` and `invoke_streaming`.
+    ///
+    /// Order of preference: (1) a free, current-deploy instance already
+    /// in the pool; (2) a freshly launched instance, if the pool is below
+    /// `max_concurrency`; (3) queue on a busy current-deploy instance.
+    /// Instances whose `deploy_id` no longer matches the function's
+    /// current code+layers are torn down before sizing the pool.
+    async fn acquire_slot(
         &self,
         func: &LambdaFunction,
         layers: &[Vec<u8>],
-    ) -> Result<String, RuntimeError> {
+    ) -> Result<Slot, RuntimeError> {
         let is_image = func.package_type == "Image";
         if !is_image && func.code_zip.is_none() {
             return Err(RuntimeError::NoCodeZip(func.function_name.clone()));
@@ -211,21 +321,13 @@ impl LambdaRuntime {
 
         let deploy_id = deploy_id_for(func, layers);
 
-        let endpoint = {
-            let entries = self.instances.read();
-            entries.get(&func.function_name).and_then(|e| {
-                if e.deploy_id == deploy_id {
-                    *e.last_used.write() = Instant::now();
-                    Some(e.instance.endpoint.clone())
-                } else {
-                    None
-                }
-            })
-        };
-        if let Some(ep) = endpoint {
-            return Ok(ep);
+        // (1) Fast path: a free instance already running the right deploy.
+        if let Some(slot) = self.try_take_free(&func.function_name, &deploy_id) {
+            return Ok(slot);
         }
 
+        // Serialize launch decisions per function so a burst of cold
+        // invokes doesn't each push the pool past the cap.
         let startup_lock = {
             let mut starting = self.starting.write();
             starting
@@ -233,45 +335,160 @@ impl LambdaRuntime {
                 .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
                 .clone()
         };
-        let _guard = startup_lock.lock().await;
+        let startup_guard = startup_lock.lock().await;
 
-        // Re-check after acquiring lock — another task may have launched it.
-        let existing = {
-            let entries = self.instances.read();
-            entries
-                .get(&func.function_name)
-                .filter(|e| e.deploy_id == deploy_id)
-                .map(|e| {
-                    *e.last_used.write() = Instant::now();
-                    e.instance.endpoint.clone()
-                })
-        };
-        if let Some(ep) = existing {
-            return Ok(ep);
+        // Re-check under the startup lock — another task may have freed or
+        // launched an instance while we waited.
+        if let Some(slot) = self.try_take_free(&func.function_name, &deploy_id) {
+            return Ok(slot);
         }
 
-        self.stop_container(&func.function_name).await;
+        // Tear down any instances left over from a previous deploy.
+        self.evict_stale_deploy(&func.function_name, &deploy_id)
+            .await;
 
-        let instance = self
-            .backend
-            .launch(func, func.code_zip.as_deref(), layers, &deploy_id)
-            .await?;
-        let endpoint = instance.endpoint.clone();
-        let entry = WarmEntry {
-            instance,
-            last_used: RwLock::new(Instant::now()),
-            deploy_id,
+        let pool_len = self
+            .instances
+            .read()
+            .get(&func.function_name)
+            .map_or(0, |v| v.len());
+
+        // (2) Room to grow: launch a fresh instance and reserve it.
+        if pool_len < self.max_concurrency {
+            let instance = self
+                .backend
+                .launch(func, func.code_zip.as_deref(), layers, &deploy_id)
+                .await?;
+            let entry = Arc::new(WarmEntry {
+                instance,
+                last_used: RwLock::new(Instant::now()),
+                deploy_id,
+                busy: Arc::new(tokio::sync::Mutex::new(())),
+            });
+            let guard = entry
+                .busy
+                .clone()
+                .try_lock_owned()
+                .expect("freshly created busy lock is uncontended");
+            self.instances
+                .write()
+                .entry(func.function_name.clone())
+                .or_default()
+                .push(entry.clone());
+            return Ok(Slot { entry, guard });
+        }
+
+        // (3) At capacity: release the startup lock and queue on a busy
+        // instance — whichever frees up first serves this invocation.
+        drop(startup_guard);
+        let entry = {
+            let map = self.instances.read();
+            map.get(&func.function_name)
+                .and_then(|pool| pool.iter().find(|e| e.deploy_id == deploy_id).cloned())
         };
-        self.instances
-            .write()
-            .insert(func.function_name.clone(), entry);
-        Ok(endpoint)
+        let entry = entry.ok_or_else(|| {
+            RuntimeError::InvocationFailed(format!(
+                "no warm instance available for {}",
+                func.function_name
+            ))
+        })?;
+        let guard = entry.busy.clone().lock_owned().await;
+        *entry.last_used.write() = Instant::now();
+        Ok(Slot { entry, guard })
     }
 
-    /// Stop and remove a warm instance for a specific function.
+    /// Try to reserve a free, current-deploy instance without launching.
+    /// Returns `None` if every matching instance is busy (or there are
+    /// none).
+    fn try_take_free(&self, function_name: &str, deploy_id: &str) -> Option<Slot> {
+        let map = self.instances.read();
+        let pool = map.get(function_name)?;
+        for entry in pool {
+            if entry.deploy_id != deploy_id {
+                continue;
+            }
+            if let Ok(guard) = entry.busy.clone().try_lock_owned() {
+                *entry.last_used.write() = Instant::now();
+                return Some(Slot {
+                    entry: entry.clone(),
+                    guard,
+                });
+            }
+        }
+        None
+    }
+
+    /// Remove one specific instance from a function's pool and terminate
+    /// it. Used when an invocation finds the instance unreachable.
+    async fn evict_entry(&self, function_name: &str, target: &Arc<WarmEntry>) {
+        let removed = {
+            let mut map = self.instances.write();
+            match map.get_mut(function_name) {
+                Some(pool) => {
+                    let removed = pool
+                        .iter()
+                        .position(|e| Arc::ptr_eq(e, target))
+                        .map(|pos| pool.remove(pos));
+                    if pool.is_empty() {
+                        map.remove(function_name);
+                    }
+                    removed
+                }
+                None => None,
+            }
+        };
+        if let Some(entry) = removed {
+            tracing::info!(
+                function = %function_name,
+                handle = ?entry.instance.handle,
+                "evicting unreachable Lambda runtime instance"
+            );
+            self.backend.terminate(&entry.instance.handle).await;
+        }
+    }
+
+    /// Tear down every instance in a function's pool whose `deploy_id`
+    /// no longer matches the current code+layers fingerprint.
+    async fn evict_stale_deploy(&self, function_name: &str, deploy_id: &str) {
+        let stale: Vec<Arc<WarmEntry>> = {
+            let mut map = self.instances.write();
+            match map.get_mut(function_name) {
+                Some(pool) => {
+                    let mut stale = Vec::new();
+                    pool.retain(|e| {
+                        if e.deploy_id == deploy_id {
+                            true
+                        } else {
+                            stale.push(e.clone());
+                            false
+                        }
+                    });
+                    if pool.is_empty() {
+                        map.remove(function_name);
+                    }
+                    stale
+                }
+                None => Vec::new(),
+            }
+        };
+        for entry in stale {
+            tracing::info!(
+                function = %function_name,
+                handle = ?entry.instance.handle,
+                "stopping stale-deploy Lambda runtime instance"
+            );
+            self.backend.terminate(&entry.instance.handle).await;
+        }
+    }
+
+    /// Stop and remove every warm instance for a specific function.
     pub async fn stop_container(&self, function_name: &str) {
-        let entry = self.instances.write().remove(function_name);
-        if let Some(entry) = entry {
+        let pool = self
+            .instances
+            .write()
+            .remove(function_name)
+            .unwrap_or_default();
+        for entry in pool {
             tracing::info!(
                 function = %function_name,
                 handle = ?entry.instance.handle,
@@ -283,36 +500,37 @@ impl LambdaRuntime {
 
     /// Stop and remove all warm instances (used on server shutdown or reset).
     pub async fn stop_all(&self) {
-        let entries: Vec<(String, WarmInstance)> = {
-            let mut map = self.instances.write();
-            map.drain().map(|(name, e)| (name, e.instance)).collect()
-        };
-        for (name, instance) in entries {
-            tracing::info!(
-                function = %name,
-                handle = ?instance.handle,
-                "stopping Lambda runtime instance (cleanup)"
-            );
-            self.backend.terminate(&instance.handle).await;
+        let pools: Vec<(String, Vec<Arc<WarmEntry>>)> =
+            { self.instances.write().drain().collect() };
+        for (name, pool) in pools {
+            for entry in pool {
+                tracing::info!(
+                    function = %name,
+                    handle = ?entry.instance.handle,
+                    "stopping Lambda runtime instance (cleanup)"
+                );
+                self.backend.terminate(&entry.instance.handle).await;
+            }
         }
     }
 
     /// List all warm instances and their metadata for introspection.
+    /// One row per running instance — a function scaled to several warm
+    /// instances appears once per instance.
     pub fn list_warm_containers(
         &self,
         lambda_state: &crate::state::SharedLambdaState,
     ) -> Vec<serde_json::Value> {
         let entries = self.instances.read();
         let accounts = lambda_state.read();
-        entries
-            .iter()
-            .map(|(name, entry)| {
-                let runtime = accounts
-                    .iter()
-                    .find_map(|(_, state)| state.functions.get(name).map(|f| f.runtime.clone()))
-                    .unwrap_or_default();
-                let last_used = entry.last_used.read();
-                let idle_secs = last_used.elapsed().as_secs();
+        let mut rows = Vec::new();
+        for (name, pool) in entries.iter() {
+            let runtime = accounts
+                .iter()
+                .find_map(|(_, state)| state.functions.get(name).map(|f| f.runtime.clone()))
+                .unwrap_or_default();
+            for entry in pool {
+                let idle_secs = entry.last_used.read().elapsed().as_secs();
                 let mut row = serde_json::json!({
                     "functionName": name,
                     "runtime": runtime,
@@ -332,26 +550,30 @@ impl LambdaRuntime {
                         );
                     }
                 }
-                row
-            })
-            .collect()
+                rows.push(row);
+            }
+        }
+        rows
     }
 
-    /// Evict (stop and remove) the warm instance for a specific function.
-    /// Returns true if an instance was found and evicted.
+    /// Evict (stop and remove) every warm instance for a specific
+    /// function. Returns true if at least one instance was evicted.
     pub async fn evict_container(&self, function_name: &str) -> bool {
-        let entry = self.instances.write().remove(function_name);
-        if let Some(entry) = entry {
+        let pool = self
+            .instances
+            .write()
+            .remove(function_name)
+            .unwrap_or_default();
+        let found = !pool.is_empty();
+        for entry in pool {
             tracing::info!(
                 function = %function_name,
                 handle = ?entry.instance.handle,
                 "evicting Lambda runtime instance via simulation API"
             );
             self.backend.terminate(&entry.instance.handle).await;
-            true
-        } else {
-            false
         }
+        found
     }
 
     /// Background loop that stops instances idle longer than `ttl`.
@@ -364,17 +586,31 @@ impl LambdaRuntime {
     }
 
     async fn cleanup_idle(&self, ttl: Duration) {
-        let expired: Vec<String> = {
-            let entries = self.instances.read();
-            entries
-                .iter()
-                .filter(|(_, e)| e.last_used.read().elapsed() > ttl)
-                .map(|(name, _)| name.clone())
-                .collect()
+        // Reap individual instances that are both idle past the TTL and
+        // currently free (a busy instance is mid-invocation, so its
+        // `last_used` is fresh anyway — the `try_lock` check just avoids
+        // racing a slot that's about to be used).
+        let expired: Vec<(String, Arc<WarmEntry>)> = {
+            let mut map = self.instances.write();
+            let mut out = Vec::new();
+            for (name, pool) in map.iter_mut() {
+                let mut i = 0;
+                while i < pool.len() {
+                    let idle = pool[i].last_used.read().elapsed() > ttl;
+                    let free = pool[i].busy.try_lock().is_ok();
+                    if idle && free {
+                        out.push((name.clone(), pool.remove(i)));
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            map.retain(|_, pool| !pool.is_empty());
+            out
         };
-        for name in expired {
+        for (name, entry) in expired {
             tracing::info!(function = %name, "stopping idle Lambda runtime instance");
-            self.stop_container(&name).await;
+            self.backend.terminate(&entry.instance.handle).await;
         }
     }
 }
@@ -417,5 +653,272 @@ mod tests {
         assert_eq!(a, b);
         assert_ne!(a, deploy_id_from("abc124", &layers));
         assert_ne!(a, deploy_id_from("abc123", &[]));
+    }
+
+    // ---- warm-pool concurrency + eviction (issue #1644) ----
+
+    use super::LambdaRuntime;
+    use crate::runtime::backend::{BackendHandle, LambdaBackend, RuntimeError, WarmInstance};
+    use crate::state::LambdaFunction;
+    use parking_lot::RwLock;
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
+
+    /// Backend double: counts launches/terminates and hands out endpoints
+    /// from a queue (falling back to `default_endpoint`), so a test can
+    /// inject a dead endpoint followed by a live one.
+    struct CountingBackend {
+        endpoints: StdMutex<VecDeque<String>>,
+        default_endpoint: String,
+        launches: AtomicUsize,
+        terminates: AtomicUsize,
+    }
+
+    impl CountingBackend {
+        fn new(default_endpoint: impl Into<String>) -> Arc<Self> {
+            Arc::new(Self {
+                endpoints: StdMutex::new(VecDeque::new()),
+                default_endpoint: default_endpoint.into(),
+                launches: AtomicUsize::new(0),
+                terminates: AtomicUsize::new(0),
+            })
+        }
+        fn with_queue(default_endpoint: impl Into<String>, queue: Vec<String>) -> Arc<Self> {
+            Arc::new(Self {
+                endpoints: StdMutex::new(queue.into()),
+                default_endpoint: default_endpoint.into(),
+                launches: AtomicUsize::new(0),
+                terminates: AtomicUsize::new(0),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LambdaBackend for CountingBackend {
+        fn name(&self) -> &str {
+            "test"
+        }
+        async fn launch(
+            &self,
+            _func: &LambdaFunction,
+            _code_zip: Option<&[u8]>,
+            _layers: &[Vec<u8>],
+            _deploy_id: &str,
+        ) -> Result<WarmInstance, RuntimeError> {
+            let n = self.launches.fetch_add(1, SeqCst);
+            let endpoint = self
+                .endpoints
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| self.default_endpoint.clone());
+            Ok(WarmInstance {
+                endpoint,
+                handle: BackendHandle::Container {
+                    id: format!("c{n}"),
+                },
+            })
+        }
+        async fn terminate(&self, _handle: &BackendHandle) {
+            self.terminates.fetch_add(1, SeqCst);
+        }
+    }
+
+    /// Spin a minimal in-process "RIE": one TCP accept loop that records
+    /// the peak number of simultaneously-open connections, holds each
+    /// request for `delay`, then returns a tiny 200. The peak directly
+    /// observes how many invocations overlapped on the instance(s) it
+    /// backs. Returns the `host:port` to use as a warm endpoint.
+    async fn spawn_rie(delay: Duration, peak: Arc<AtomicUsize>) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let cur = Arc::new(AtomicUsize::new(0));
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                let cur = cur.clone();
+                let peak = peak.clone();
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let now = cur.fetch_add(1, SeqCst) + 1;
+                    peak.fetch_max(now, SeqCst);
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    tokio::time::sleep(delay).await;
+                    let _ = sock
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                        )
+                        .await;
+                    let _ = sock.flush().await;
+                    cur.fetch_sub(1, SeqCst);
+                });
+            }
+        });
+        format!("{addr}")
+    }
+
+    fn runtime_with(backend: Arc<CountingBackend>, max_concurrency: usize) -> Arc<LambdaRuntime> {
+        Arc::new(LambdaRuntime {
+            backend,
+            instances: RwLock::new(HashMap::new()),
+            starting: RwLock::new(HashMap::new()),
+            max_concurrency,
+        })
+    }
+
+    fn test_func(name: &str, sha: &str) -> LambdaFunction {
+        serde_json::from_value(serde_json::json!({
+            "function_name": name,
+            "function_arn": format!("arn:aws:lambda:us-east-1:123456789012:function:{name}"),
+            "runtime": "python3.12",
+            "role": "arn:aws:iam::123456789012:role/r",
+            "handler": "index.handler",
+            "description": "",
+            "timeout": 5,
+            "memory_size": 128,
+            "code_sha256": sha,
+            "code_size": 1,
+            "version": "$LATEST",
+            "last_modified": "2020-01-01T00:00:00Z",
+            "tags": {},
+            "environment": {},
+            "architectures": ["x86_64"],
+            "package_type": "Zip",
+            "code_zip": [1, 2, 3],
+            "policy": null
+        }))
+        .expect("build test LambdaFunction")
+    }
+
+    /// The core of #1644: with one warm instance, a burst of concurrent
+    /// invocations must be serialized onto it — never delivered in
+    /// parallel (which segfaults the real RIE). Peak overlap must be 1.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_invokes_are_serialized_on_a_single_instance() {
+        let peak = Arc::new(AtomicUsize::new(0));
+        let endpoint = spawn_rie(Duration::from_millis(40), peak.clone()).await;
+        let backend = CountingBackend::new(endpoint);
+        let rt = runtime_with(backend.clone(), 1);
+        let func = test_func("conc", "sha-A");
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let rt = rt.clone();
+            let func = func.clone();
+            handles.push(tokio::spawn(
+                async move { rt.invoke(&func, b"{}", &[]).await },
+            ));
+        }
+        for h in handles {
+            h.await.unwrap().expect("invoke ok");
+        }
+
+        assert_eq!(
+            peak.load(SeqCst),
+            1,
+            "concurrent invokes overlapped on a single RIE instance"
+        );
+        assert_eq!(
+            backend.launches.load(SeqCst),
+            1,
+            "max_concurrency=1 must launch exactly one instance"
+        );
+    }
+
+    /// Under load the pool grows beyond one instance but never past the
+    /// cap, so genuine concurrency is served (AWS semantics) without an
+    /// unbounded container/Pod fan-out.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn pool_scales_under_load_and_respects_cap() {
+        let peak = Arc::new(AtomicUsize::new(0));
+        let endpoint = spawn_rie(Duration::from_millis(60), peak.clone()).await;
+        let backend = CountingBackend::new(endpoint);
+        let rt = runtime_with(backend.clone(), 4);
+        let func = test_func("scale", "sha-A");
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let rt = rt.clone();
+            let func = func.clone();
+            handles.push(tokio::spawn(
+                async move { rt.invoke(&func, b"{}", &[]).await },
+            ));
+        }
+        for h in handles {
+            h.await.unwrap().expect("invoke ok");
+        }
+
+        let launched = backend.launches.load(SeqCst);
+        assert!(
+            (2..=4).contains(&launched),
+            "expected the pool to scale within the cap, launched={launched}"
+        );
+        assert!(
+            peak.load(SeqCst) > 1,
+            "expected concurrent forwards across the scaled pool"
+        );
+    }
+
+    /// An unreachable instance (dead Pod/container) must be evicted and
+    /// the invocation retried against a fresh cold start, instead of
+    /// wedging the function forever.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dead_instance_is_evicted_and_retried() {
+        let peak = Arc::new(AtomicUsize::new(0));
+        let live = spawn_rie(Duration::from_millis(5), peak.clone()).await;
+        // First launch hands back a refused port; the retry gets the live one.
+        let backend = CountingBackend::with_queue(live, vec!["127.0.0.1:1".to_string()]);
+        let rt = runtime_with(backend.clone(), 1);
+
+        let out = rt
+            .invoke(&test_func("dead", "sha-A"), b"{}", &[])
+            .await
+            .expect("should recover via cold-start retry");
+        assert_eq!(out, b"ok");
+        assert_eq!(
+            backend.launches.load(SeqCst),
+            2,
+            "expected the dead instance plus one cold-start replacement"
+        );
+        assert!(
+            backend.terminates.load(SeqCst) >= 1,
+            "the dead instance should have been terminated on eviction"
+        );
+    }
+
+    /// Changing the function's code (a new deploy id) tears down the
+    /// stale warm instance before serving against a fresh one.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn deploy_change_evicts_stale_instance() {
+        let peak = Arc::new(AtomicUsize::new(0));
+        let endpoint = spawn_rie(Duration::from_millis(5), peak.clone()).await;
+        let backend = CountingBackend::new(endpoint);
+        let rt = runtime_with(backend.clone(), 2);
+
+        rt.invoke(&test_func("upd", "sha-A"), b"{}", &[])
+            .await
+            .unwrap();
+        rt.invoke(&test_func("upd", "sha-B"), b"{}", &[])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            backend.launches.load(SeqCst),
+            2,
+            "a new deploy id should launch a fresh instance"
+        );
+        assert!(
+            backend.terminates.load(SeqCst) >= 1,
+            "the stale-deploy instance should have been torn down"
+        );
+        // Exactly one current instance remains in the pool.
+        let pool_len = rt.instances.read().get("upd").map_or(0, |v| v.len());
+        assert_eq!(pool_len, 1);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1644. The runtime facade kept **one** warm instance per function and forwarded every concurrent `Invoke` to it in parallel. The AWS Runtime Interface Emulator (and real Lambda) handles **one event per execution environment at a time**; overlapping invokes nil-pointer-deref `rapidcore` and the process exits (code 2), killing the Pod/container. The crashed instance was then **never evicted** from the warm pool, so every later invocation routed to the dead endpoint forever — a permanent outage from a single burst of parallel traffic (i.e. any normal integration/E2E suite). Single sequential invokes worked, making it maddening to repro.

### Fix — a per-function pool with AWS-style semantics
- Each warm instance carries a per-instance **busy lock**; an invocation reserves a *free* instance (`try_lock`) before forwarding, so a given instance never sees two in-flight events.
- The pool **scales on demand** up to `FAKECLOUD_LAMBDA_MAX_CONCURRENCY` (default 10); past the cap, invocations queue on a busy instance. The existing startup mutex still prevents launch stampedes; the idle reaper trims individual idle+free instances.
- On a **transport error** the instance is evicted from the pool and the call **retried once** against a fresh cold start, so node drains, OOM kills, and crashes self-heal instead of wedging the function (problem 2, which bites independently of concurrency).
- Streaming invocations carry their busy guard inside `StreamingInvocation` so the slot stays reserved until the stream drains.

Backend-agnostic facade — fixes both the **Docker** and **Kubernetes** backends. Together with #1643 (merged), this closes out the two issues warprat flagged between the k8s backend and solid CI use.

## Test plan
- New unit tests drive an in-process RIE simulator that records peak connection overlap:
  - `concurrent_invokes_are_serialized_on_a_single_instance` — cap=1, 8 concurrent invokes, asserts peak overlap == 1 (the crash condition) and exactly one launch.
  - `pool_scales_under_load_and_respects_cap` — cap=4, 8 concurrent invokes, asserts 2–4 instances launched and real concurrent forwarding.
  - `dead_instance_is_evicted_and_retried` — first instance endpoint refuses; asserts the call recovers via cold-start retry, dead instance terminated.
  - `deploy_change_evicts_stale_instance` — a new code hash tears down the stale instance, leaving one current instance.
- `cargo test -p fakecloud-lambda` (191 pass), `clippy --all-targets -D warnings`, `cargo fmt` all clean.
- Documents `FAKECLOUD_LAMBDA_MAX_CONCURRENCY` in the configuration reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1644. Adds a per-function warm pool with AWS-style one-event-per-instance semantics to stop RIE crashes and wedged functions under parallel load.

- **Bug Fixes**
  - Serialize invokes per instance to prevent overlapping requests and rapidcore crashes.
  - Evict unreachable instances; retry once only on connection-establishment failures to avoid duplicate execution.
  - Remove stale instances on deploy changes; works for both Docker and Kubernetes.

- **New Features**
  - Per-function pool that scales on demand up to `FAKECLOUD_LAMBDA_MAX_CONCURRENCY` (default 10); beyond the cap, invocations wait and take whichever instance frees first.
  - Streaming invokes keep their reserved slot until the stream finishes.
  - Idle reaper trims individual idle+free instances.

<sup>Written for commit 34f4753c1a3d3d7c49b4938f40dc73894b6708f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

