### PR TITLE
fix(lambda): treat GET /functions/ (trailing slash) as ListFunctions

### DIFF
--- a/crates/fakecloud-conformance/src/probe/rest_request.rs
+++ b/crates/fakecloud-conformance/src/probe/rest_request.rs
@@ -789,13 +789,20 @@ pub(super) fn legacy_substitute_identifiers(
                 // `GET /{Bucket}?prefix=...` doesn't collapse to `/` and
                 // hit ListBuckets (a 200 happy-path response). Uppercase
                 // + underscores violate S3's bucket naming rules, so the
-                // server reliably returns InvalidBucketName. Other
-                // services keep the empty-string collapse — their
-                // dispatchers reject empty path labels cleanly.
-                let sentinel = if service_name == "s3" {
-                    "INVALID_OMITTED_LABEL"
-                } else {
-                    ""
+                // server reliably returns InvalidBucketName.
+                //
+                // Lambda needs the same treatment: omitting `FunctionName`
+                // from `GET /functions/{FunctionName}` collapses to
+                // `GET /functions/`, which real AWS — and now fakecloud
+                // (issue #1645) — routes to `ListFunctions` (200), not a
+                // client error. A non-empty sentinel keeps the probe on
+                // the `GetFunction` route, where a nonexistent name yields
+                // the expected 4xx. Other services keep the empty-string
+                // collapse — their dispatchers reject empty path labels
+                // cleanly.
+                let sentinel = match service_name {
+                    "s3" | "lambda" => "INVALID_OMITTED_LABEL",
+                    _ => "",
                 };
                 out = out.replace(placeholder, sentinel);
             }

--- a/crates/fakecloud-e2e/tests/host_routing.rs
+++ b/crates/fakecloud-e2e/tests/host_routing.rs
@@ -67,23 +67,27 @@ async fn unsigned_lambda_list_functions_via_host_header() {
     let server = TestServer::start().await;
     let http = reqwest::Client::new();
 
-    // Use the bare `/functions` path (no trailing slash) — the trailing-
-    // slash variant now intentionally routes to `GetFunction` with an
-    // elided `FunctionName` and returns 400 (matches AWS), per #1406.
-    let resp = http
-        .get(format!("{}/2015-03-31/functions", server.endpoint()))
-        .header("Host", localstack_host("lambda.us-east-1", server.port()))
-        .send()
-        .await
-        .unwrap();
+    // Both the bare `/functions` and the trailing-slash `/functions/`
+    // forms are `ListFunctions`. Real AWS tolerates both, and botocore
+    // serialized `ListFunctions` as `GET /2015-03-31/functions/` until
+    // botocore 1.40 (mid-2025), so the whole pre-1.40 install base sends
+    // the trailing slash (issue #1645). Assert both return the list.
+    for path in ["/2015-03-31/functions", "/2015-03-31/functions/"] {
+        let resp = http
+            .get(format!("{}{path}", server.endpoint()))
+            .header("Host", localstack_host("lambda.us-east-1", server.port()))
+            .send()
+            .await
+            .unwrap();
 
-    assert_eq!(resp.status(), 200);
-    let body = resp.text().await.unwrap();
-    // Lambda returns JSON with a Functions array.
-    assert!(
-        body.contains("Functions"),
-        "expected Lambda ListFunctions JSON, got: {body}"
-    );
+        assert_eq!(resp.status(), 200, "GET {path} should be ListFunctions");
+        let body = resp.text().await.unwrap();
+        // Lambda returns JSON with a Functions array.
+        assert!(
+            body.contains("Functions"),
+            "expected Lambda ListFunctions JSON for {path}, got: {body}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/fakecloud-lambda/src/service/init.rs
+++ b/crates/fakecloud-lambda/src/service/init.rs
@@ -432,28 +432,25 @@ impl LambdaService {
 
         // NOTE: We intentionally do not try to disambiguate URLs that
         // collapsed because an httpLabel was elided (e.g.
-        // `/functions/` vs `/functions`). Real AWS treats those as
-        // the same path — both hit `ListFunctions` — and we have
-        // e2e coverage that relies on the trailing-slash behaviour
-        // (`host_routing::unsigned_lambda_list_functions_via_host_header`).
-        // Synthetic conformance probes that elide a required path
-        // identifier are inherently un-faithful to the SDK; accept
-        // the small false-positive count rather than break a real
-        // SDK convention.
+        // `/functions/` vs `/functions`). Real AWS treats both as
+        // `ListFunctions`, and botocore actually *serialized*
+        // `ListFunctions` as `GET /2015-03-31/functions/` (trailing
+        // slash) until botocore 1.40 (mid-2025) — so the entire pre-1.40
+        // install base (pinned boto3, older CLI images) sends that form
+        // (issue #1645). Routing it to `GetFunction` broke
+        // `aws lambda list-functions` for those clients with a confusing
+        // "FunctionName is required". Synthetic conformance probes that
+        // elide a required path identifier are inherently un-faithful to
+        // the SDK; the elided-FunctionName probe is steered to a sentinel
+        // path in the conformance harness instead of relying on this
+        // route, so accept both `/functions` forms as `ListFunctions`.
 
         let action = match (&req.method, segs.len(), collection, third) {
             (&Method::POST, 2, Some("functions"), _) => "CreateFunction",
-            (&Method::GET, 2, Some("functions"), _) => {
-                // `GET .../functions` is `ListFunctions`. `GET .../functions/`
-                // (trailing slash) signals a `GetFunction` call whose
-                // `FunctionName` httpLabel was elided — route there so it
-                // can reject the missing identifier.
-                if req.raw_path.ends_with("/functions/") {
-                    "GetFunction"
-                } else {
-                    "ListFunctions"
-                }
-            }
+            // Both `GET .../functions` and `GET .../functions/` are
+            // `ListFunctions` — real AWS tolerates the trailing slash and
+            // pre-1.40 botocore always sent it.
+            (&Method::GET, 2, Some("functions"), _) => "ListFunctions",
             (&Method::GET, 3, Some("functions"), _) => "GetFunction",
             (&Method::DELETE, 3, Some("functions"), _) => "DeleteFunction",
             (&Method::POST, 4, Some("functions"), Some("invocations")) => "Invoke",

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -2924,3 +2924,36 @@ async fn create_function_succeeds_without_runtime_prepull_hook() {
     let resp = svc.handle(req).await.expect("create function");
     assert_eq!(resp.status, StatusCode::CREATED);
 }
+
+/// Both `GET /2015-03-31/functions` and the trailing-slash
+/// `GET /2015-03-31/functions/` are `ListFunctions`. botocore serialized
+/// `ListFunctions` with the trailing slash until 1.40 (mid-2025), so the
+/// whole pre-1.40 install base depends on the second form (issue #1645).
+#[test]
+fn resolve_action_list_functions_both_slash_forms() {
+    let bare = make_request(Method::GET, "/2015-03-31/functions", "");
+    assert_eq!(
+        LambdaService::resolve_action(&bare).map(|(a, _)| a),
+        Some("ListFunctions")
+    );
+
+    // `path_segments` drops the empty trailing segment, so the only
+    // signal of the trailing slash is `raw_path` — set it explicitly.
+    let mut trailing = make_request(Method::GET, "/2015-03-31/functions", "");
+    trailing.raw_path = "/2015-03-31/functions/".to_string();
+    assert_eq!(
+        LambdaService::resolve_action(&trailing).map(|(a, _)| a),
+        Some("ListFunctions"),
+        "trailing-slash ListFunctions (pre-1.40 botocore) must not route to GetFunction"
+    );
+}
+
+/// A real `GetFunction` (a function name in the path) still routes to
+/// `GetFunction` — the trailing-slash fix must not regress that.
+#[test]
+fn resolve_action_get_function_with_name() {
+    let req = make_request(Method::GET, "/2015-03-31/functions/my-fn", "");
+    let (action, resource) = LambdaService::resolve_action(&req).expect("routed");
+    assert_eq!(action, "GetFunction");
+    assert_eq!(resource.as_deref(), Some("my-fn"));
+}


### PR DESCRIPTION
## Summary

Fixes #1645. botocore serialized `ListFunctions` as `GET /2015-03-31/functions/` (**trailing slash**) until botocore 1.40 (mid-2025). The entire pre-1.40 install base — pinned boto3 in deployed code, older aws-cli baked into CI images — sends that form. fakecloud routed the trailing slash to `GetFunction` with an elided `FunctionName` and returned `InvalidParameterValueException: FunctionName is required`, breaking the most basic `aws lambda list-functions` smoke test with an error that gave no hint that a client upgrade was the workaround.

### Fix
Route both `GET /2015-03-31/functions` and `GET /2015-03-31/functions/` to `ListFunctions`, matching real AWS's tolerance of both forms.

The trailing-slash special case existed only to hand the synthetic *elided-FunctionName* conformance probe a 4xx. Rather than break a route shape a decade of SDKs use for `ListFunctions`, steer the probe instead: the legacy identifier-substitution path now substitutes a non-empty invalid sentinel for an omitted **Lambda** httpLabel (exactly as it already did for S3), so the `GetFunction` negative variant lands on `/functions/<sentinel>` and gets a clean `ResourceNotFoundException`. Lambda conformance stays **24/24**.

## Test plan
- New unit tests: `resolve_action_list_functions_both_slash_forms` (both slash forms → ListFunctions) and `resolve_action_get_function_with_name` (a real GetFunction still routes correctly).
- Updated e2e `unsigned_lambda_list_functions_via_host_header` to assert **both** `/functions` and `/functions/` return the list (200).
- `cargo test -p fakecloud-conformance --test lambda` → 24/24 pass locally (binary rebuilt).
- `cargo test -p fakecloud-lambda`, `cargo test -p fakecloud-e2e --test host_routing`, `clippy --all-targets -D warnings`, `cargo fmt` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat GET /2015-03-31/functions/ (trailing slash) as ListFunctions to match AWS. This fixes `aws lambda list-functions` for pre-`botocore` 1.40 clients like `boto3` and `aws-cli` (fixes #1645).

- **Bug Fixes**
  - Route both GET /2015-03-31/functions and /2015-03-31/functions/ to ListFunctions; no longer treats the trailing slash as GetFunction.
  - In conformance, substitute a non-empty sentinel for omitted Lambda path labels (same as S3) so negative GetFunction probes hit /functions/<sentinel> and return ResourceNotFoundException.
  - Added unit and e2e tests to cover both paths and verify GetFunction with a name still routes correctly.

<sup>Written for commit e27147340d9f97b583393e4b68ee8a1113b49750. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

