### PR TITLE
fix(cloudformation): support changeset-driven deploys (deploy/SAM/CDK)

### DIFF
--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -596,8 +596,7 @@ impl CloudFormationService {
                     let mut accounts = self.state.write();
                     let state = accounts.get_or_create(&aid);
                     if let Some(sid) = &found {
-                        if let Some(stack) =
-                            state.stacks.values_mut().find(|s| &s.stack_id == sid)
+                        if let Some(stack) = state.stacks.values_mut().find(|s| &s.stack_id == sid)
                         {
                             if stack.status == "REVIEW_IN_PROGRESS" {
                                 stack.status = "CREATE_COMPLETE".to_string();

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -20,7 +20,7 @@ use fakecloud_aws::xml::xml_escape;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::CloudFormationService;
-use crate::state::StackResource;
+use crate::state::{Stack, StackResource};
 use crate::template;
 
 const NS: &str = "http://cloudformation.amazonaws.com/doc/2010-05-15/";
@@ -127,7 +127,49 @@ fn require_collection(
     }
 }
 
+/// Extract `(bucket, key)` from a CloudFormation `TemplateURL`. Handles
+/// both path-style (`https://s3.us-east-1.amazonaws.com/bucket/key`, or a
+/// fakecloud endpoint `http://127.0.0.1:4566/bucket/key`) and
+/// virtual-hosted (`https://bucket.s3.amazonaws.com/key`) forms, and
+/// drops any query string. Returns `None` if the shape isn't recognized.
+fn parse_s3_url(url: &str) -> Option<(String, String)> {
+    let rest = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
+    let (host, after) = rest.split_once('/')?;
+    let path = after.split(['?', '#']).next().unwrap_or(after);
+    // Virtual-hosted: `<bucket>.s3...`. The `.s3` guard avoids treating a
+    // path-style host like `s3.amazonaws.com` (no leading bucket) as one.
+    if let Some(idx) = host.find(".s3") {
+        let bucket = &host[..idx];
+        if !bucket.is_empty() {
+            return Some((bucket.to_string(), path.to_string()));
+        }
+    }
+    // Path-style: first path segment is the bucket, the rest is the key.
+    let (bucket, key) = path.split_once('/')?;
+    if bucket.is_empty() || key.is_empty() {
+        return None;
+    }
+    Some((bucket.to_string(), key.to_string()))
+}
+
 impl CloudFormationService {
+    /// Resolve a CloudFormation `TemplateURL` against fakecloud's own S3.
+    /// `sam deploy`, `aws cloudformation deploy`, and CDK upload the
+    /// template to S3 and pass its URL; the object is in fakecloud's S3 by
+    /// the time the change set is created, so read it back. Returns `None`
+    /// if the URL can't be parsed or the object isn't present.
+    fn fetch_template_from_url(&self, account_id: &str, url: &str) -> Option<String> {
+        let (bucket, key) = parse_s3_url(url)?;
+        let mut accounts = self.deps.s3.write();
+        let state = accounts.get_or_create(account_id);
+        let body_ref = {
+            let b = state.buckets.get(&bucket)?;
+            b.objects.get(&key)?.body.clone()
+        };
+        let bytes = state.read_body(&body_ref).ok()?;
+        String::from_utf8(bytes.to_vec()).ok()
+    }
+
     pub(crate) fn handle_extra_action(
         &self,
         req: &AwsRequest,
@@ -148,7 +190,30 @@ impl CloudFormationService {
                     .get("ChangeSetName")
                     .ok_or_else(|| missing("ChangeSetName"))?
                     .clone();
-                let template_body = params.get("TemplateBody").cloned().unwrap_or_default();
+                // `aws cloudformation deploy`, SAM, and CDK pass the template
+                // by `TemplateURL` (always, once an S3 bucket is configured),
+                // not inline `TemplateBody`. The template is already in
+                // fakecloud's own S3 at this point, so fetch it back instead
+                // of storing an empty template and silently no-op'ing at
+                // execute time (issue #1646).
+                let template_body = {
+                    let inline = params.get("TemplateBody").cloned().unwrap_or_default();
+                    if inline.trim().is_empty() {
+                        params
+                            .get("TemplateURL")
+                            .and_then(|url| self.fetch_template_from_url(&aid, url))
+                            .unwrap_or(inline)
+                    } else {
+                        inline
+                    }
+                };
+                // `ChangeSetType` is `CREATE` for first-time deploys (the
+                // stack doesn't exist yet) and `UPDATE`/`IMPORT` otherwise.
+                // AWS defaults an unset value to `UPDATE`.
+                let change_set_type = params
+                    .get("ChangeSetType")
+                    .map(|s| s.to_ascii_uppercase())
+                    .unwrap_or_else(|| "UPDATE".to_string());
 
                 let cs_params = CloudFormationService::extract_parameters(&params);
                 let cs_tags = CloudFormationService::extract_tags(&params);
@@ -302,6 +367,31 @@ impl CloudFormationService {
                 });
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
+                // A `CREATE`-type change set against a not-yet-existing stack
+                // leaves the stack in `REVIEW_IN_PROGRESS` on AWS; executing
+                // the change set is what actually creates it. Materialize that
+                // placeholder stack now so `ExecuteChangeSet` (and the
+                // existence probes `aws cloudformation deploy` / SAM run) find
+                // it (issue #1646).
+                if change_set_type == "CREATE" && stack_lookup.is_none() {
+                    state
+                        .stacks
+                        .entry(stack_name.clone())
+                        .or_insert_with(|| Stack {
+                            name: stack_name.clone(),
+                            stack_id: stack_id_str.clone(),
+                            template: String::new(),
+                            status: "REVIEW_IN_PROGRESS".to_string(),
+                            resources: Vec::new(),
+                            parameters: BTreeMap::new(),
+                            tags: BTreeMap::new(),
+                            created_at: Utc::now(),
+                            updated_at: None,
+                            description: None,
+                            notification_arns: Vec::new(),
+                            outputs: Vec::new(),
+                        });
+                }
                 store(&mut state.extras, "change_sets").insert(id.clone(), entry);
                 Ok(xml_response(
                     "CreateChangeSet",
@@ -458,18 +548,6 @@ impl CloudFormationService {
                 let stack_name = entry["StackName"].as_str().unwrap_or("").to_string();
                 let template_body = entry["TemplateBody"].as_str().unwrap_or("").to_string();
 
-                // No template stored: nothing to apply, just mark executed.
-                if template_body.trim().is_empty() {
-                    let mut accounts = self.state.write();
-                    let state = accounts.get_or_create(&aid);
-                    if let Some(m) = state.extras.get_mut("change_sets") {
-                        if let Some(e) = m.get_mut(&cs_id) {
-                            e["ExecutionStatus"] = json!("EXECUTE_COMPLETE");
-                        }
-                    }
-                    return Ok(xml_response("ExecuteChangeSet", String::new(), &rid));
-                }
-
                 let cs_tags: BTreeMap<String, String> = entry["Tags"]
                     .as_object()
                     .map(|m| {
@@ -495,7 +573,7 @@ impl CloudFormationService {
                     })
                     .unwrap_or_default();
 
-                let found_stack_id = {
+                let found: Option<String> = {
                     let accounts = self.state.read();
                     accounts.get(&aid).and_then(|s| {
                         s.stacks
@@ -506,8 +584,39 @@ impl CloudFormationService {
                             })
                             .map(|st| st.stack_id.clone())
                     })
+                };
+
+                // Empty change set: nothing to provision. Finalize a
+                // `REVIEW_IN_PROGRESS` stack (a CREATE change set with no
+                // resources still creates the — empty — stack) and mark the
+                // change set executed. This also covers synthetic route
+                // probes that execute a change set without ever creating a
+                // stack.
+                if template_body.trim().is_empty() {
+                    let mut accounts = self.state.write();
+                    let state = accounts.get_or_create(&aid);
+                    if let Some(sid) = &found {
+                        if let Some(stack) =
+                            state.stacks.values_mut().find(|s| &s.stack_id == sid)
+                        {
+                            if stack.status == "REVIEW_IN_PROGRESS" {
+                                stack.status = "CREATE_COMPLETE".to_string();
+                                stack.updated_at = Some(Utc::now());
+                            }
+                        }
+                    }
+                    if let Some(m) = state.extras.get_mut("change_sets") {
+                        if let Some(e) = m.get_mut(&cs_id) {
+                            e["ExecutionStatus"] = json!("EXECUTE_COMPLETE");
+                        }
+                    }
+                    return Ok(xml_response("ExecuteChangeSet", String::new(), &rid));
                 }
-                .ok_or_else(|| {
+
+                // A non-empty template needs a target stack: a
+                // `REVIEW_IN_PROGRESS` placeholder for CREATE, or a live
+                // stack for UPDATE. A missing stack is a real error.
+                let found_stack_id = found.ok_or_else(|| {
                     AwsServiceError::aws_error(
                         StatusCode::BAD_REQUEST,
                         "ValidationError",
@@ -534,16 +643,33 @@ impl CloudFormationService {
                     .entry("AWS::URLSuffix".to_string())
                     .or_insert_with(|| "amazonaws.com".to_string());
 
-                let parsed = template::parse_template(&template_body, &cs_params).map_err(|e| {
-                    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
-                })?;
+                // An empty body (a CREATE change set with no resources, or a
+                // probe with a placeholder template) parses to an empty
+                // template rather than erroring, mirroring CreateStack.
+                let parsed = if template_body.trim().is_empty() {
+                    template::ParsedTemplate {
+                        description: None,
+                        resources: Vec::new(),
+                        outputs: Vec::new(),
+                    }
+                } else {
+                    template::parse_template(&template_body, &cs_params).map_err(|e| {
+                        AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
+                    })?
+                };
 
                 let provisioner = self.provisioner(&found_stack_id, &aid, &req.region);
 
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
 
-                let (update_result, sid, stack_name_owned) = {
+                // A stack still in `REVIEW_IN_PROGRESS` was minted by a
+                // `CREATE` change set and has no resources yet — executing the
+                // change set creates it. `apply_resource_updates` provisions
+                // every resource as an Add when the stack starts empty, so the
+                // same code path serves both create and update; only the
+                // surfaced status differs (CREATE_* vs UPDATE_*).
+                let (update_result, sid, stack_name_owned, was_review) = {
                     let stack = state
                         .stacks
                         .values_mut()
@@ -555,7 +681,13 @@ impl CloudFormationService {
                                 format!("Stack [{stack_name}] does not exist"),
                             )
                         })?;
-                    stack.status = "UPDATE_IN_PROGRESS".to_string();
+                    let was_review = stack.status == "REVIEW_IN_PROGRESS";
+                    stack.status = if was_review {
+                        "CREATE_IN_PROGRESS"
+                    } else {
+                        "UPDATE_IN_PROGRESS"
+                    }
+                    .to_string();
                     let result = crate::service::apply_resource_updates(
                         stack,
                         &parsed.resources,
@@ -566,11 +698,13 @@ impl CloudFormationService {
                     let sid = stack.stack_id.clone();
                     let sname = stack.name.clone();
                     stack.template = template_body.clone();
-                    stack.status = if result.is_err() {
-                        "UPDATE_ROLLBACK_COMPLETE".to_string()
-                    } else {
-                        "UPDATE_COMPLETE".to_string()
-                    };
+                    stack.status = match (was_review, result.is_err()) {
+                        (true, false) => "CREATE_COMPLETE",
+                        (true, true) => "ROLLBACK_COMPLETE",
+                        (false, false) => "UPDATE_COMPLETE",
+                        (false, true) => "UPDATE_ROLLBACK_COMPLETE",
+                    }
+                    .to_string();
                     stack.parameters = cs_params.clone();
                     if !cs_tags.is_empty() {
                         stack.tags = cs_tags;
@@ -582,16 +716,25 @@ impl CloudFormationService {
                     if result.is_ok() {
                         stack.outputs.clear();
                     }
-                    (result, sid, sname)
+                    (result, sid, sname, was_review)
                 };
 
                 // Emit lifecycle events on the per-stack event log.
+                let (in_progress, complete, failed) = if was_review {
+                    ("CREATE_IN_PROGRESS", "CREATE_COMPLETE", "ROLLBACK_COMPLETE")
+                } else {
+                    (
+                        "UPDATE_IN_PROGRESS",
+                        "UPDATE_COMPLETE",
+                        "UPDATE_ROLLBACK_COMPLETE",
+                    )
+                };
                 crate::service::record_stack_status_event(
                     state,
                     &sid,
                     &stack_name_owned,
                     "AWS::CloudFormation::Stack",
-                    "UPDATE_IN_PROGRESS",
+                    in_progress,
                 );
                 let final_status = match &update_result {
                     Ok(changes) => {
@@ -601,9 +744,9 @@ impl CloudFormationService {
                             &stack_name_owned,
                             changes,
                         );
-                        "UPDATE_COMPLETE"
+                        complete
                     }
-                    Err(_) => "UPDATE_ROLLBACK_COMPLETE",
+                    Err(_) => failed,
                 };
                 crate::service::record_stack_status_event(
                     state,
@@ -1835,6 +1978,7 @@ impl CloudFormationService {
 
 #[cfg(test)]
 mod tests {
+    use super::parse_s3_url;
     use crate::service::{CloudFormationDeps, CloudFormationService};
     use crate::state::{CloudFormationState, SharedCloudFormationState};
     use fakecloud_core::delivery::DeliveryBus;
@@ -1844,6 +1988,33 @@ mod tests {
     use parking_lot::RwLock;
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    #[test]
+    fn parse_s3_url_handles_path_and_virtual_hosted() {
+        // Path-style against a fakecloud endpoint (what TemplateURL looks
+        // like locally) — key keeps its embedded slashes.
+        assert_eq!(
+            parse_s3_url("http://127.0.0.1:4566/bucket/deploy/template.json"),
+            Some(("bucket".to_string(), "deploy/template.json".to_string()))
+        );
+        // Path-style against real AWS S3 host.
+        assert_eq!(
+            parse_s3_url("https://s3.us-east-1.amazonaws.com/my-bucket/key.yaml"),
+            Some(("my-bucket".to_string(), "key.yaml".to_string()))
+        );
+        // Virtual-hosted style.
+        assert_eq!(
+            parse_s3_url("https://my-bucket.s3.amazonaws.com/key.yaml"),
+            Some(("my-bucket".to_string(), "key.yaml".to_string()))
+        );
+        // Query string (e.g. ?versionId=...) is dropped.
+        assert_eq!(
+            parse_s3_url("https://s3.amazonaws.com/b/k.json?versionId=abc"),
+            Some(("b".to_string(), "k.json".to_string()))
+        );
+        // Not an object URL (no key).
+        assert_eq!(parse_s3_url("https://s3.amazonaws.com/bucket-only"), None);
+    }
 
     fn deps() -> CloudFormationDeps {
         use fakecloud_dynamodb::DynamoDbState;

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -367,30 +367,55 @@ impl CloudFormationService {
                 });
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
-                // A `CREATE`-type change set against a not-yet-existing stack
-                // leaves the stack in `REVIEW_IN_PROGRESS` on AWS; executing
-                // the change set is what actually creates it. Materialize that
-                // placeholder stack now so `ExecuteChangeSet` (and the
-                // existence probes `aws cloudformation deploy` / SAM run) find
-                // it (issue #1646).
-                if change_set_type == "CREATE" && stack_lookup.is_none() {
-                    state
+                // A `CREATE`-type change set leaves the stack in
+                // `REVIEW_IN_PROGRESS` on AWS; executing it is what actually
+                // creates the stack. Materialize that placeholder now so
+                // `ExecuteChangeSet` (and the existence probes that
+                // `aws cloudformation deploy` / SAM run) find it (issue #1646).
+                if change_set_type == "CREATE" {
+                    // Status of any non-deleted stack already keyed by this
+                    // name. A `DELETE_COMPLETE` leftover counts as absent.
+                    let live_status = state
                         .stacks
-                        .entry(stack_name.clone())
-                        .or_insert_with(|| Stack {
-                            name: stack_name.clone(),
-                            stack_id: stack_id_str.clone(),
-                            template: String::new(),
-                            status: "REVIEW_IN_PROGRESS".to_string(),
-                            resources: Vec::new(),
-                            parameters: BTreeMap::new(),
-                            tags: BTreeMap::new(),
-                            created_at: Utc::now(),
-                            updated_at: None,
-                            description: None,
-                            notification_arns: Vec::new(),
-                            outputs: Vec::new(),
-                        });
+                        .get(&stack_name)
+                        .filter(|s| s.status != "DELETE_COMPLETE")
+                        .map(|s| s.status.clone());
+                    match live_status.as_deref() {
+                        // Fresh name, or a stale DELETE_COMPLETE entry to
+                        // replace: insert the placeholder.
+                        None => {
+                            state.stacks.insert(
+                                stack_name.clone(),
+                                Stack {
+                                    name: stack_name.clone(),
+                                    stack_id: stack_id_str.clone(),
+                                    template: String::new(),
+                                    status: "REVIEW_IN_PROGRESS".to_string(),
+                                    resources: Vec::new(),
+                                    parameters: BTreeMap::new(),
+                                    tags: BTreeMap::new(),
+                                    created_at: Utc::now(),
+                                    updated_at: None,
+                                    description: None,
+                                    notification_arns: Vec::new(),
+                                    outputs: Vec::new(),
+                                },
+                            );
+                        }
+                        // Already in review (an earlier CREATE change set):
+                        // additional CREATE change sets are allowed; keep the
+                        // existing placeholder.
+                        Some("REVIEW_IN_PROGRESS") => {}
+                        // A fully created stack exists — AWS rejects a CREATE
+                        // change set against it instead of silently updating.
+                        Some(_) => {
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "AlreadyExistsException",
+                                format!("Stack [{stack_name}] already exists"),
+                            ));
+                        }
+                    }
                 }
                 store(&mut state.extras, "change_sets").insert(id.clone(), entry);
                 Ok(xml_response(

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -373,12 +373,18 @@ impl CloudFormationService {
                 // `ExecuteChangeSet` (and the existence probes that
                 // `aws cloudformation deploy` / SAM run) find it (issue #1646).
                 if change_set_type == "CREATE" {
-                    // Status of any non-deleted stack already keyed by this
-                    // name. A `DELETE_COMPLETE` leftover counts as absent.
+                    // Status of any non-deleted stack matching this StackName.
+                    // `StackName` may be a name *or* a stack id, so match both
+                    // (otherwise a CREATE against an existing stack referenced
+                    // by id slips past the AlreadyExists check). A
+                    // `DELETE_COMPLETE` leftover counts as absent.
                     let live_status = state
                         .stacks
-                        .get(&stack_name)
-                        .filter(|s| s.status != "DELETE_COMPLETE")
+                        .values()
+                        .find(|s| {
+                            (s.name == stack_name || s.stack_id == stack_name)
+                                && s.status != "DELETE_COMPLETE"
+                        })
                         .map(|s| s.status.clone());
                     match live_status.as_deref() {
                         // Fresh name, or a stale DELETE_COMPLETE entry to

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -907,12 +907,25 @@ impl CloudFormationService {
                 .collect()
         };
 
-        // DescribeStacks declares no errors; a synthetic conformance probe
-        // querying a placeholder `StackName="test"` previously tripped an
-        // undeclared `ValidationError`. Drop the not-found check and return
-        // an empty list — callers can distinguish "absent" from "exists" by
-        // the response payload.
-        let _ = stack_name;
+        // When an explicit `StackName` is supplied but matches nothing,
+        // real AWS returns `ValidationError: Stack with id <name> does not
+        // exist` — deploy tooling (the SAM CLI `--resolve-s3` bootstrap,
+        // `aws cloudformation deploy`) probes stack existence by catching
+        // that error, and an empty `{"Stacks": []}` makes SAM crash with an
+        // `IndexError` and `deploy` take the wrong (update) path (issue
+        // #1646). DescribeStacks declares no errors in Smithy, but the
+        // `AnyError` conformance expectation accepts any AWS-shaped 4xx, so
+        // returning `ValidationError` here stays conformant. A nameless
+        // call still lists all stacks (empty is valid).
+        if let Some(ref name) = stack_name {
+            if stacks.is_empty() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!("Stack with id {name} does not exist"),
+                ));
+            }
+        }
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -2112,17 +2125,27 @@ mod tests {
     }
 
     #[test]
-    fn describe_stacks_nonexistent_returns_empty() {
-        // DescribeStacks declares no errors. Querying an unknown
-        // StackName now returns an empty result instead of an
-        // undeclared `ValidationError`.
+    fn describe_stacks_nonexistent_errors() {
+        // Querying an explicit, unknown StackName returns AWS's
+        // `ValidationError: Stack with id <name> does not exist` so deploy
+        // tools that probe stack existence (SAM, `aws cloudformation
+        // deploy`) get the signal they expect (issue #1646).
         let svc = make_service();
         let mut params = HashMap::new();
         params.insert("StackName".to_string(), "ghost".to_string());
         let req = make_request("DescribeStacks", params);
-        let resp = svc.describe_stacks(&req).expect("ghost is empty");
-        let b = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
-        assert!(b.contains("DescribeStacksResult"));
+        match svc.describe_stacks(&req) {
+            Ok(_) => panic!("ghost stack must return an error, not an empty list"),
+            Err(e) => {
+                assert_eq!(e.status(), StatusCode::BAD_REQUEST);
+                assert_eq!(e.code(), "ValidationError");
+                assert!(
+                    e.message().contains("does not exist"),
+                    "got: {}",
+                    e.message()
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/fakecloud-e2e/tests/cloudformation_execute_change_set.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_execute_change_set.rs
@@ -1,5 +1,7 @@
 mod helpers;
 
+use aws_sdk_cloudformation::types::ChangeSetType;
+use aws_sdk_s3::primitives::ByteStream;
 use helpers::TestServer;
 
 #[tokio::test]
@@ -330,5 +332,171 @@ async fn execute_change_set_emits_stack_events_and_lists_resources() {
         rows.iter()
             .any(|(l, s)| l == "cs-events-stack" && s == "UPDATE_IN_PROGRESS"),
         "expected stack UPDATE_IN_PROGRESS, got {rows:?}"
+    );
+}
+
+/// `aws cloudformation deploy`, SAM, and CDK create first-time stacks
+/// through a `ChangeSetType=CREATE` change set, not raw CreateStack. The
+/// stack must materialize in `REVIEW_IN_PROGRESS` and be created on
+/// execute (issue #1646, gap 1). DescribeStacks on the not-yet-created
+/// stack must return an error so the tools' existence probe works (gap 3).
+#[tokio::test]
+async fn create_type_change_set_creates_stack_on_execute() {
+    let server = TestServer::start().await;
+    let cf = server.cloudformation_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Gap 3: probing a stack that doesn't exist yet must error, not
+    // return an empty list (SAM/`deploy` catch this to branch create-vs-update).
+    let probe = cf
+        .describe_stacks()
+        .stack_name("cs-create-stack")
+        .send()
+        .await;
+    assert!(
+        probe.is_err(),
+        "DescribeStacks on a missing stack must error, got {probe:?}"
+    );
+
+    let template = r#"{
+        "Resources": {
+            "NewQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {"QueueName": "cs-create-queue"}
+            }
+        }
+    }"#;
+
+    cf.create_change_set()
+        .stack_name("cs-create-stack")
+        .change_set_name("create-cs")
+        .change_set_type(ChangeSetType::Create)
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    // The stack now exists in REVIEW_IN_PROGRESS (no resources yet).
+    let review = cf
+        .describe_stacks()
+        .stack_name("cs-create-stack")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        review.stacks()[0].stack_status().map(|s| s.as_str()),
+        Some("REVIEW_IN_PROGRESS"),
+    );
+    assert!(
+        !sqs.list_queues()
+            .send()
+            .await
+            .unwrap()
+            .queue_urls()
+            .iter()
+            .any(|u| u.contains("cs-create-queue")),
+        "queue must not exist before the change set executes"
+    );
+
+    cf.execute_change_set()
+        .stack_name("cs-create-stack")
+        .change_set_name("create-cs")
+        .send()
+        .await
+        .unwrap();
+
+    // Stack created; the queue is provisioned.
+    let created = cf
+        .describe_stacks()
+        .stack_name("cs-create-stack")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        created.stacks()[0].stack_status().map(|s| s.as_str()),
+        Some("CREATE_COMPLETE"),
+    );
+    assert!(
+        sqs.list_queues()
+            .send()
+            .await
+            .unwrap()
+            .queue_urls()
+            .iter()
+            .any(|u| u.contains("cs-create-queue")),
+        "queue should be created after executing the CREATE change set"
+    );
+}
+
+/// SAM always — and `aws cloudformation deploy`/CDK for large templates —
+/// pass the template by `TemplateURL` pointing at an object in S3. The
+/// change set must fetch it (issue #1646, gap 2) rather than store an
+/// empty template and silently no-op on execute.
+#[tokio::test]
+async fn create_change_set_resolves_template_url() {
+    let server = TestServer::start().await;
+    let cf = server.cloudformation_client().await;
+    let s3 = server.s3_client().await;
+    let sns = server.sns_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "UrlTopic": {
+                "Type": "AWS::SNS::Topic",
+                "Properties": {"TopicName": "cs-url-topic"}
+            }
+        }
+    }"#;
+
+    s3.create_bucket()
+        .bucket("cfn-templates")
+        .send()
+        .await
+        .unwrap();
+    s3.put_object()
+        .bucket("cfn-templates")
+        .key("deploy/template.json")
+        .body(ByteStream::from(template.as_bytes().to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    let template_url = format!("{}/cfn-templates/deploy/template.json", server.endpoint());
+
+    cf.create_change_set()
+        .stack_name("cs-url-stack")
+        .change_set_name("url-cs")
+        .change_set_type(ChangeSetType::Create)
+        .template_url(&template_url)
+        .send()
+        .await
+        .unwrap();
+
+    cf.execute_change_set()
+        .stack_name("cs-url-stack")
+        .change_set_name("url-cs")
+        .send()
+        .await
+        .unwrap();
+
+    let stacks = cf
+        .describe_stacks()
+        .stack_name("cs-url-stack")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        stacks.stacks()[0].stack_status().map(|s| s.as_str()),
+        Some("CREATE_COMPLETE"),
+    );
+    assert!(
+        sns.list_topics()
+            .send()
+            .await
+            .unwrap()
+            .topics()
+            .iter()
+            .any(|t| t.topic_arn().is_some_and(|a| a.contains("cs-url-topic"))),
+        "the TemplateURL-sourced topic should be provisioned"
     );
 }

--- a/crates/fakecloud-e2e/tests/cloudformation_execute_change_set.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_execute_change_set.rs
@@ -500,3 +500,38 @@ async fn create_change_set_resolves_template_url() {
         "the TemplateURL-sourced topic should be provisioned"
     );
 }
+
+/// A `ChangeSetType=CREATE` change set against a stack that already exists
+/// must be rejected (AWS: AlreadyExistsException), not silently executed
+/// as an UPDATE.
+#[tokio::test]
+async fn create_type_change_set_rejected_for_existing_stack() {
+    let server = TestServer::start().await;
+    let cf = server.cloudformation_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "Q": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "cs-exists-q"}}
+        }
+    }"#;
+
+    cf.create_stack()
+        .stack_name("cs-exists-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    let err = cf
+        .create_change_set()
+        .stack_name("cs-exists-stack")
+        .change_set_name("dup-create")
+        .change_set_type(ChangeSetType::Create)
+        .template_body(template)
+        .send()
+        .await;
+    assert!(
+        err.is_err(),
+        "CREATE change set against an existing stack must be rejected, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1646. `aws cloudformation deploy`, the AWS SAM CLI, and CDK all create and update stacks through **changesets**, not raw `CreateStack`/`UpdateStack`. Three gaps combined so that none of those tools could deploy a stack — only hand-rolled `CreateStack` with an inline `TemplateBody` worked.

### Gap 1 — ExecuteChangeSet only did UPDATE
A `ChangeSetType=CREATE` change set now materializes the target stack in `REVIEW_IN_PROGRESS` at `CreateChangeSet` time; `ExecuteChangeSet` then provisions it (`apply_resource_updates` treats an empty starting stack as all-adds) and surfaces `CREATE_IN_PROGRESS`/`CREATE_COMPLETE` status and events.

### Gap 2 — CreateChangeSet ignored TemplateURL (silent no-op)
SAM *always* passes `TemplateURL` once an S3 bucket is configured (deploy/CDK do for large templates). The change set stored an empty template and `ExecuteChangeSet` took its "nothing to apply" path — success reported, nothing deployed, `sam deploy` hangs. The template is in fakecloud's own S3 by then, so we fetch it back (path-style + virtual-hosted URLs, query-string tolerant).

### Gap 3 — DescribeStacks returned an empty list for a missing stack
Tools probe stack existence by catching `ValidationError`. `{"Stacks": []}` made SAM's `--resolve-s3` bootstrap crash with `IndexError` and `deploy` take the wrong (update) branch. We now return AWS's `ValidationError: Stack with id <name> does not exist` for an explicitly-named missing stack; a nameless `DescribeStacks` still lists all stacks.

## Test plan
- New e2e (real SDK, end-to-end): `create_type_change_set_creates_stack_on_execute` (CREATE change set → REVIEW_IN_PROGRESS → execute → CREATE_COMPLETE + resource provisioned; also asserts the missing-stack probe errors) and `create_change_set_resolves_template_url` (uploads a template to S3, deploys via `TemplateURL`).
- Unit: `parse_s3_url` (path-style/virtual-hosted/query/negative); `describe_stacks_nonexistent_errors` now asserts the ValidationError.
- `cargo test -p fakecloud-conformance --test cloudformation` → **7/7** (the empty-template route probe still succeeds — empty change sets are a graceful no-op).
- `cargo test -p fakecloud-cloudformation` (202 pass), e2e changeset suite (5 pass), `clippy --all-targets -D warnings`, `cargo fmt` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full support for CloudFormation change set deploys so `aws cloudformation deploy`, SAM CLI, and CDK can create and update stacks correctly. Fixes #1646 by adding CREATE change set support, resolving `TemplateURL` from fakecloud S3, and returning AWS-style errors for missing stacks.

- **Bug Fixes**
  - `ExecuteChangeSet` supports `ChangeSetType=CREATE`: `CreateChangeSet` inserts a `REVIEW_IN_PROGRESS` placeholder; execute provisions resources with `CREATE_*` events; empty change sets finalize to `CREATE_COMPLETE`.
  - `CreateChangeSet` resolves `TemplateURL` from fakecloud S3 (path-style or virtual-hosted; query-safe) instead of storing an empty template, preventing silent no-ops.
  - `DescribeStacks` with a named, missing stack returns `ValidationError: Stack with id <name> does not exist`; nameless calls still list all stacks.
  - `ChangeSetType=CREATE` is rejected for an existing stack with `AlreadyExistsException` (matches by stack name or stack id); re-creates after `DELETE_COMPLETE` are allowed, and additional CREATE change sets are allowed while the stack is `REVIEW_IN_PROGRESS`.

<sup>Written for commit 96f58dec35e361ed578adc7351601adda4898335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

