### PR TITLE
fix(cloudformation): full AWS::StepFunctions::StateMachine provisioner

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1788,6 +1788,48 @@ impl ResourceProvisioner {
             .map_err(|e| format!("S3 read failed: {e}"))
     }
 
+    /// Read a specific object version's bytes. Used when a CFN property
+    /// pins an S3 object `Version` (e.g.
+    /// `DefinitionS3Location.Version`), so the exact referenced body is
+    /// loaded rather than whatever is current. Falls through the current
+    /// object and the version history.
+    fn read_s3_object_version_bytes(
+        &self,
+        bucket: &str,
+        key: &str,
+        version_id: &str,
+    ) -> Result<Vec<u8>, String> {
+        let mut accounts = self.s3_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let body_ref = {
+            let b = state
+                .buckets
+                .get(bucket)
+                .ok_or_else(|| format!("S3 bucket {bucket} does not exist"))?;
+            let from_current = b
+                .objects
+                .get(key)
+                .filter(|o| o.version_id.as_deref() == Some(version_id))
+                .map(|o| o.body.clone());
+            from_current
+                .or_else(|| {
+                    b.object_versions.get(key).and_then(|versions| {
+                        versions
+                            .iter()
+                            .find(|o| o.version_id.as_deref() == Some(version_id))
+                            .map(|o| o.body.clone())
+                    })
+                })
+                .ok_or_else(|| {
+                    format!("S3 object s3://{bucket}/{key} version {version_id} does not exist")
+                })?
+        };
+        state
+            .read_body(&body_ref)
+            .map(|b| b.to_vec())
+            .map_err(|e| format!("S3 read failed: {e}"))
+    }
+
     /// Build a canonical Lambda resource-policy statement from a CFN
     /// `AWS::Lambda::Permission` `Properties` map and append it to the
     /// function's stored policy. Shared by create + update so the same

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1260,6 +1260,9 @@ impl ResourceProvisioner {
             "AWS::CloudWatch::Dashboard" => {
                 Some(self.update_cloudwatch_dashboard(existing, new_def)?)
             }
+            "AWS::StepFunctions::StateMachine" => {
+                Some(self.update_sfn_state_machine(existing, new_def)?)
+            }
             _ => None,
         };
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/stepfunctions.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/stepfunctions.rs
@@ -32,16 +32,7 @@ impl ResourceProvisioner {
             .unwrap_or("STANDARD");
         let machine_type = StateMachineType::parse(machine_type_str)
             .ok_or_else(|| format!("Invalid StateMachineType: {machine_type_str}"))?;
-        let definition = props
-            .get("DefinitionString")
-            .and_then(|v| v.as_str())
-            .map(String::from)
-            .or_else(|| {
-                props
-                    .get("Definition")
-                    .map(|v| serde_json::to_string(v).unwrap_or_default())
-            })
-            .ok_or("Definition or DefinitionString is required")?;
+        let definition = self.resolve_sfn_definition(props)?;
         let logging_configuration = props.get("LoggingConfiguration").cloned();
         let tracing_configuration = props.get("TracingConfiguration").cloned();
 
@@ -76,6 +67,100 @@ impl ResourceProvisioner {
             .with("Arn", arn.clone())
             .with("Name", name)
             .with("StateMachineRevisionId", "INITIAL"))
+    }
+
+    /// Resolve a state machine's ASL definition from any of the three
+    /// CloudFormation forms, then apply `DefinitionSubstitutions`.
+    ///
+    /// - `DefinitionString` — inline ASL string.
+    /// - `Definition` — inline ASL as a JSON object.
+    /// - `DefinitionS3Location` — `{Bucket, Key, Version}` pointing at an
+    ///   ASL document in S3 (what `sam package` and raw-CFN setups emit);
+    ///   the object lives in fakecloud's own S3, so fetch it back.
+    ///
+    /// `DefinitionSubstitutions` is a map whose `${key}` tokens are
+    /// replaced in the resolved definition — the conventional way SAM/CFN
+    /// state machines reference sibling resources (function names, ARNs).
+    fn resolve_sfn_definition(&self, props: &serde_json::Value) -> Result<String, String> {
+        let mut definition = if let Some(s) = props.get("DefinitionString").and_then(|v| v.as_str())
+        {
+            s.to_string()
+        } else if let Some(v) = props.get("Definition") {
+            serde_json::to_string(v).map_err(|e| format!("invalid Definition: {e}"))?
+        } else if let Some(loc) = props.get("DefinitionS3Location") {
+            let bucket = loc
+                .get("Bucket")
+                .and_then(|v| v.as_str())
+                .ok_or("DefinitionS3Location.Bucket is required")?;
+            let key = loc
+                .get("Key")
+                .and_then(|v| v.as_str())
+                .ok_or("DefinitionS3Location.Key is required")?;
+            let bytes = self.read_s3_object_bytes(bucket, key)?;
+            String::from_utf8(bytes)
+                .map_err(|e| format!("DefinitionS3Location body is not valid UTF-8: {e}"))?
+        } else {
+            return Err(
+                "Definition, DefinitionString, or DefinitionS3Location is required".to_string(),
+            );
+        };
+
+        if let Some(subs) = props
+            .get("DefinitionSubstitutions")
+            .and_then(|v| v.as_object())
+        {
+            for (key, value) in subs {
+                let replacement = match value {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    serde_json::Value::Bool(b) => b.to_string(),
+                    other => serde_json::to_string(other).unwrap_or_default(),
+                };
+                definition = definition.replace(&format!("${{{key}}}"), &replacement);
+            }
+        }
+
+        Ok(definition)
+    }
+
+    pub(super) fn update_sfn_state_machine(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let arn = existing.physical_id.clone();
+        let definition = self.resolve_sfn_definition(props)?;
+
+        let mut accounts = self.stepfunctions_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let sm = state
+            .state_machines
+            .get_mut(&arn)
+            .ok_or_else(|| format!("State machine {arn} not found"))?;
+
+        // CloudFormation propagates definition + the other mutable
+        // properties on stack update; the SDK's UpdateStateMachine does the
+        // same. Re-stamp the revision id so describe-state-machine reflects
+        // that the definition changed.
+        sm.definition = definition;
+        if let Some(role) = props.get("RoleArn").and_then(|v| v.as_str()) {
+            sm.role_arn = role.to_string();
+        }
+        if let Some(logging) = props.get("LoggingConfiguration") {
+            sm.logging_configuration = Some(logging.clone());
+        }
+        if let Some(tracing) = props.get("TracingConfiguration") {
+            sm.tracing_configuration = Some(tracing.clone());
+        }
+        sm.revision_id = Uuid::new_v4().to_string();
+        sm.update_date = Utc::now();
+        let name = sm.name.clone();
+
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Arn", arn)
+            .with("Name", name)
+            .with("StateMachineRevisionId", "UPDATED"))
     }
 
     pub(super) fn delete_sfn_state_machine(&self, physical_id: &str) -> Result<(), String> {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/stepfunctions.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/stepfunctions.rs
@@ -96,7 +96,12 @@ impl ResourceProvisioner {
                 .get("Key")
                 .and_then(|v| v.as_str())
                 .ok_or("DefinitionS3Location.Key is required")?;
-            let bytes = self.read_s3_object_bytes(bucket, key)?;
+            // Honor a pinned object Version so a version-pinned template
+            // loads the exact body it referenced, not whatever is current.
+            let bytes = match loc.get("Version").and_then(|v| v.as_str()) {
+                Some(version) => self.read_s3_object_version_bytes(bucket, key, version)?,
+                None => self.read_s3_object_bytes(bucket, key)?,
+            };
             String::from_utf8(bytes)
                 .map_err(|e| format!("DefinitionS3Location body is not valid UTF-8: {e}"))?
         } else {
@@ -147,12 +152,10 @@ impl ResourceProvisioner {
         if let Some(role) = props.get("RoleArn").and_then(|v| v.as_str()) {
             sm.role_arn = role.to_string();
         }
-        if let Some(logging) = props.get("LoggingConfiguration") {
-            sm.logging_configuration = Some(logging.clone());
-        }
-        if let Some(tracing) = props.get("TracingConfiguration") {
-            sm.tracing_configuration = Some(tracing.clone());
-        }
+        // Set unconditionally so dropping a property in the updated template
+        // clears it, rather than leaving the previous value stale.
+        sm.logging_configuration = props.get("LoggingConfiguration").cloned();
+        sm.tracing_configuration = props.get("TracingConfiguration").cloned();
         sm.revision_id = Uuid::new_v4().to_string();
         sm.update_date = Utc::now();
         let name = sm.name.clone();

--- a/crates/fakecloud-e2e/tests/cloudformation_stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_stepfunctions.rs
@@ -273,3 +273,92 @@ async fn cfn_state_machine_update_propagates_definition() {
         sm.definition()
     );
 }
+
+/// A pinned `DefinitionS3Location.Version` must load that exact object
+/// version, not whatever is current (issue #1647 review follow-up).
+#[tokio::test]
+async fn cfn_state_machine_reads_pinned_s3_definition_version() {
+    use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
+
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let s3 = server.s3_client().await;
+    let sfn = aws_sdk_sfn::Client::new(&server.aws_config().await);
+
+    s3.create_bucket()
+        .bucket("asl-versions")
+        .send()
+        .await
+        .unwrap();
+    s3.put_bucket_versioning()
+        .bucket("asl-versions")
+        .versioning_configuration(
+            VersioningConfiguration::builder()
+                .status(BucketVersioningStatus::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // v1 is the definition we will pin; v2 becomes current.
+    let v1 = r#"{"StartAt":"V1","States":{"V1":{"Type":"Succeed"}}}"#;
+    let v2 = r#"{"StartAt":"V2","States":{"V2":{"Type":"Succeed"}}}"#;
+    let put1 = s3
+        .put_object()
+        .bucket("asl-versions")
+        .key("def.json")
+        .body(ByteStream::from(v1.as_bytes().to_vec()))
+        .send()
+        .await
+        .unwrap();
+    let version_id = put1
+        .version_id()
+        .expect("versioned put returns a version id");
+    s3.put_object()
+        .bucket("asl-versions")
+        .key("def.json")
+        .body(ByteStream::from(v2.as_bytes().to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    let template = format!(
+        r#"{{
+          "Resources": {{
+            "SM": {{
+              "Type": "AWS::StepFunctions::StateMachine",
+              "Properties": {{
+                "StateMachineName": "ver-sm",
+                "RoleArn": "arn:aws:iam::000000000000:role/r",
+                "DefinitionS3Location": {{"Bucket": "asl-versions", "Key": "def.json", "Version": "{version_id}"}}
+              }}
+            }}
+          }}
+        }}"#
+    );
+
+    cfn.create_stack()
+        .stack_name("ver-stack")
+        .template_body(template)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let sm = sfn
+        .describe_state_machine()
+        .state_machine_arn("arn:aws:states:us-east-1:123456789012:stateMachine:ver-sm")
+        .send()
+        .await
+        .expect("describe_state_machine");
+    assert!(
+        sm.definition().contains("\"V1\""),
+        "pinned version body not loaded: {}",
+        sm.definition()
+    );
+    assert!(
+        !sm.definition().contains("\"V2\""),
+        "current (unpinned) body was loaded instead of the pinned version: {}",
+        sm.definition()
+    );
+}

--- a/crates/fakecloud-e2e/tests/cloudformation_stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_stepfunctions.rs
@@ -3,6 +3,7 @@
 mod helpers;
 
 use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use aws_sdk_s3::primitives::ByteStream;
 use helpers::TestServer;
 
 const TEMPLATE: &str = r#"{
@@ -102,4 +103,173 @@ async fn cfn_provisions_stepfunctions_resources() {
         .send()
         .await;
     assert!(sm_after.is_err(), "state machine should be gone");
+}
+
+/// Gap 2 (issue #1647): `DefinitionSubstitutions` must replace `${token}`
+/// placeholders in the definition. This is how SAM/CFN state machines
+/// reference sibling Lambda functions; leaving the literal `${...}` in
+/// place breaks executions later.
+#[tokio::test]
+async fn cfn_state_machine_applies_definition_substitutions() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let sfn = aws_sdk_sfn::Client::new(&server.aws_config().await);
+
+    let template = r#"{
+      "Resources": {
+        "SM": {
+          "Type": "AWS::StepFunctions::StateMachine",
+          "Properties": {
+            "StateMachineName": "subs-sm",
+            "RoleArn": "arn:aws:iam::000000000000:role/r",
+            "DefinitionString": "{\"StartAt\":\"T\",\"States\":{\"T\":{\"Type\":\"Task\",\"Resource\":\"arn:aws:states:::lambda:invoke\",\"Parameters\":{\"FunctionName\":\"${function_name}\"},\"End\":true}}}",
+            "DefinitionSubstitutions": {"function_name": "my-real-function"}
+          }
+        }
+      },
+      "Outputs": {"Arn": {"Value": {"Ref": "SM"}}}
+    }"#;
+
+    cfn.create_stack()
+        .stack_name("subs-stack")
+        .template_body(template)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let sm = sfn
+        .describe_state_machine()
+        .state_machine_arn("arn:aws:states:us-east-1:123456789012:stateMachine:subs-sm")
+        .send()
+        .await
+        .expect("describe_state_machine");
+    assert!(
+        sm.definition().contains("my-real-function"),
+        "substitution not applied: {}",
+        sm.definition()
+    );
+    assert!(
+        !sm.definition().contains("${function_name}"),
+        "literal placeholder left behind: {}",
+        sm.definition()
+    );
+}
+
+/// Gap 1 (issue #1647): `DefinitionS3Location` must be fetched from S3 and
+/// used as the definition, like `sam package` produces.
+#[tokio::test]
+async fn cfn_state_machine_reads_definition_from_s3() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let s3 = server.s3_client().await;
+    let sfn = aws_sdk_sfn::Client::new(&server.aws_config().await);
+
+    let asl = r#"{"StartAt":"Done","States":{"Done":{"Type":"Succeed"}}}"#;
+    s3.create_bucket().bucket("asl-defs").send().await.unwrap();
+    s3.put_object()
+        .bucket("asl-defs")
+        .key("def.json")
+        .body(ByteStream::from(asl.as_bytes().to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    let template = r#"{
+      "Resources": {
+        "SM": {
+          "Type": "AWS::StepFunctions::StateMachine",
+          "Properties": {
+            "StateMachineName": "s3-sm",
+            "RoleArn": "arn:aws:iam::000000000000:role/r",
+            "DefinitionS3Location": {"Bucket": "asl-defs", "Key": "def.json"}
+          }
+        }
+      }
+    }"#;
+
+    cfn.create_stack()
+        .stack_name("s3-def-stack")
+        .template_body(template)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let sm = sfn
+        .describe_state_machine()
+        .state_machine_arn("arn:aws:states:us-east-1:123456789012:stateMachine:s3-sm")
+        .send()
+        .await
+        .expect("describe_state_machine");
+    assert!(
+        sm.definition().contains("\"Done\""),
+        "S3 definition not used: {}",
+        sm.definition()
+    );
+}
+
+/// Gap 3 (issue #1647): a stack update with a changed `DefinitionString`
+/// must propagate to the live state machine (UpdateStateMachine is now
+/// invoked on update), not silently keep executing the stale ASL.
+#[tokio::test]
+async fn cfn_state_machine_update_propagates_definition() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let sfn = aws_sdk_sfn::Client::new(&server.aws_config().await);
+
+    let template_a = r#"{
+      "Resources": {
+        "SM2": {
+          "Type": "AWS::StepFunctions::StateMachine",
+          "Properties": {
+            "StateMachineName": "upd-sm",
+            "RoleArn": "arn:aws:iam::000000000000:role/r",
+            "DefinitionString": "{\"StartAt\":\"A\",\"States\":{\"A\":{\"Type\":\"Succeed\"}}}"
+          }
+        }
+      }
+    }"#;
+    let template_b = r#"{
+      "Resources": {
+        "SM2": {
+          "Type": "AWS::StepFunctions::StateMachine",
+          "Properties": {
+            "StateMachineName": "upd-sm",
+            "RoleArn": "arn:aws:iam::000000000000:role/r",
+            "DefinitionString": "{\"StartAt\":\"B\",\"States\":{\"B\":{\"Type\":\"Succeed\"}}}"
+          }
+        }
+      }
+    }"#;
+
+    cfn.create_stack()
+        .stack_name("upd-stack")
+        .template_body(template_a)
+        .send()
+        .await
+        .expect("create_stack");
+
+    cfn.update_stack()
+        .stack_name("upd-stack")
+        .template_body(template_b)
+        .send()
+        .await
+        .expect("update_stack");
+
+    let arn = "arn:aws:states:us-east-1:123456789012:stateMachine:upd-sm";
+    let sm = sfn
+        .describe_state_machine()
+        .state_machine_arn(arn)
+        .send()
+        .await
+        .expect("describe_state_machine");
+    assert!(
+        sm.definition().contains("\"StartAt\":\"B\""),
+        "stack update did not propagate the new definition: {}",
+        sm.definition()
+    );
+    assert!(
+        !sm.definition().contains("\"StartAt\":\"A\""),
+        "stale definition still present: {}",
+        sm.definition()
+    );
 }


### PR DESCRIPTION
## Summary

Fixes #1647. The CloudFormation provisioner for `AWS::StepFunctions::StateMachine` had three gaps — two of them silent.

### Gap 1 — DefinitionS3Location not supported
Only inline `Definition`/`DefinitionString` were accepted; the standard `DefinitionS3Location` (`{Bucket, Key, Version}`) that `sam package` and raw-CFN setups produce was rejected with *"Definition or DefinitionString is required"*. The object is in fakecloud's own S3, so we fetch it back.

### Gap 2 — DefinitionSubstitutions not applied (silent)
`${token}` placeholders are now substituted from the `DefinitionSubstitutions` map before the definition is stored. Previously the state machine kept literal `${function_name}` and executions broke later — this is the conventional way SAM/CFN state machines reference sibling Lambda functions.

### Gap 3 — stack updates didn't propagate (silent)
A changed `DefinitionString` reported `UPDATE_COMPLETE` but `describe-state-machine` still returned the original ASL — the update path was never wired. Added `update_sfn_state_machine` (re-resolves the definition + substitutions, re-stamps the revision id) and dispatched it from `update_resource`.

Definition resolution + substitution is shared by create and update via `resolve_sfn_definition`.

## Test plan
- New e2e (real SDK, end-to-end): `cfn_state_machine_applies_definition_substitutions`, `cfn_state_machine_reads_definition_from_s3` (real S3 upload), `cfn_state_machine_update_propagates_definition`. Plus the existing `cfn_provisions_stepfunctions_resources` still passes — 4/4.
- `cargo test -p fakecloud-cloudformation` (202 pass), `clippy --all-targets -D warnings`, `cargo fmt` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CloudFormation provisioner for `AWS::StepFunctions::StateMachine` so S3-based definitions (including version-pinned) and `${token}` substitutions work, and stack updates actually update the state machine and its mutable props. This restores SAM/CFN compatibility and makes `describe-state-machine` reflect changes.

- **Bug Fixes**
  - Support `DefinitionS3Location` (including `Version`) by reading the ASL from fakecloud S3.
  - Apply `DefinitionSubstitutions` to replace `${token}` before storing the definition.
  - Propagate stack updates: re-resolve the definition, update mutable props (set `LoggingConfiguration`/`TracingConfiguration` unconditionally so removals clear), and re-stamp the revision ID.

<sup>Written for commit 662c0f757d40c8dcb84eff49481657ac51479117. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

