### PR TITLE
docs(config): document FAKECLOUD_LAMBDA_MAX_CONCURRENCY

### DIFF
--- a/website/content/docs/reference/configuration.md
+++ b/website/content/docs/reference/configuration.md
@@ -21,6 +21,7 @@ fakecloud is configured via CLI flags or environment variables. Flags take prece
 |                      | `FAKECLOUD_ECS_BACKEND`     | inherits global    | Per-service override for ECS task execution (`k8s` or `docker`). |
 |                      | `FAKECLOUD_RDS_BACKEND`     | inherits global    | Per-service override for RDS DB instances (`k8s` or `docker`). |
 |                      | `FAKECLOUD_ELASTICACHE_BACKEND` | inherits global| Per-service override for ElastiCache (`k8s` or `docker`). |
+|                      | `FAKECLOUD_LAMBDA_MAX_CONCURRENCY` | `10`        | Max warm instances kept per Lambda function. Each instance serves one invocation at a time (the runtime emulator can't handle concurrent events); the pool scales up to this cap under concurrent load, then queues. Raise for higher per-function concurrency. |
 |                      | `FAKECLOUD_K8S_NAMESPACE`   | `default`          | Namespace fakecloud creates Pods in. Only honored on the K8s backend. |
 |                      | `FAKECLOUD_K8S_SELF_URL`    | —                  | In-cluster URL of the fakecloud Service (e.g. `http://fakecloud.fakecloud.svc.cluster.local:4566`). Required for the K8s backend — Pods fetch artifacts from and call back to this URL. |
 |                      | `FAKECLOUD_K8S_ECR_URL`     | host of `_SELF_URL`| Override the host:port the K8s backend rewrites AWS private-ECR URIs to. Defaults to the host of `FAKECLOUD_K8S_SELF_URL`. |


### PR DESCRIPTION
## Summary
Documents the `FAKECLOUD_LAMBDA_MAX_CONCURRENCY` env var in the configuration reference. It shipped with the Lambda warm-pool scaling fix (#1651) but its doc row was lost to a stray edit before that PR was cut.

## Test plan
Docs only — no code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing configuration reference for `FAKECLOUD_LAMBDA_MAX_CONCURRENCY`, which caps warm Lambda instances per function (default 10).
Under concurrent load the pool scales up to this cap, then queues; raise it for higher per-function concurrency.

<sup>Written for commit e820fb1ac07087b3b89a3b0e065ead45958c2dea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

