### PR TITLE
fix(docker): bump bundled docker CLI to 29.5.3 (Trivy CVE-2026-42504)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG TARGETARCH
 # bakes the Go stdlib into the binary, so a stale toolchain trips the
 # image's Trivy CRITICAL/HIGH gate (27.5.1 shipped go1.22.11, flagged by
 # CVE-2025-68121). 29.5.2 ships go1.26.3, which clears the gate.
-ARG DOCKER_CLI_VERSION=29.5.2
+ARG DOCKER_CLI_VERSION=29.5.3
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates \
     && case "$TARGETARCH" in \


### PR DESCRIPTION
## Summary
The Docker workflow's Trivy scan went red on `main` after a brand-new HIGH advisory landed: **CVE-2026-42504** (Go stdlib MIME-header decode DoS) in the bundled `docker` CLI binary, which 29.5.2 builds with Go 1.26.3.

Docker **29.5.3** is built with **Go 1.26.4** (the fixed release) — verified locally with `go version -m`. Bumping clears the CRITICAL/HIGH gate. Same remediation pattern as the prior 29.5.2 bump.

This is an external transitive CVE in the vendored docker CLI, unrelated to any service code.

## Test plan
- Docker workflow Trivy scan goes green (0 HIGH/CRITICAL).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the bundled `docker` CLI to 29.5.3 to remediate CVE-2026-42504 flagged by Trivy and restore the Docker workflow to green. 29.5.3 is built with Go 1.26.4, replacing 29.5.2 which used Go 1.26.3.

<sup>Written for commit c499821411bdbf44abf933c283d46b22ca5c0147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

