### PR TITLE
fix(sqs): return message to source queue when redrive target ARN is unresolvable

### DIFF
--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -654,12 +654,25 @@ impl SqsService {
 
         // Move messages to DLQ — also with at-rest bodies untouched,
         // since the DLQ may have its own SSE settings and a downstream
-        // receive call decrypts what's there.
+        // receive call decrypts what's there. If the redrive target ARN
+        // doesn't resolve to a known queue (DLQ deleted, ARN typo), the
+        // message is returned to the source queue instead of being
+        // dropped — real SQS never destroys a message over a
+        // misconfigured redrive target.
         for (dlq_arn, mut msg) in dlq_messages.into_iter() {
+            msg.receipt_handle = None;
+            msg.visible_at = None;
             if let Some(dlq) = state.queues.values_mut().find(|q| q.arn == dlq_arn) {
-                msg.receipt_handle = None;
-                msg.visible_at = None;
                 dlq.messages.push_back(msg);
+            } else {
+                tracing::warn!(
+                    queue = %queue_arn,
+                    dlq_arn = %dlq_arn,
+                    "redrive target queue not found; returning message to source queue"
+                );
+                if let Some(source) = state.queues.values_mut().find(|q| q.arn == queue_arn) {
+                    source.messages.push_back(msg);
+                }
             }
         }
 

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -1232,6 +1232,41 @@ fn list_dead_letter_source_queues_finds_sources() {
     assert!(urls[0].as_str().unwrap().contains("src-q"));
 }
 
+#[test]
+fn redrive_with_unresolvable_dlq_arn_keeps_message_on_source_queue() {
+    // A RedrivePolicy whose deadLetterTargetArn doesn't resolve (DLQ deleted,
+    // ARN typo) must not destroy over-limit messages: real SQS keeps them on
+    // the source queue. Previously the redrive move silently dropped them.
+    let svc = make_service();
+    let src_url = create_queue_url(&svc, "bad-dlq-src");
+    let redrive = json!({
+        "deadLetterTargetArn": "arn:aws:sqs:us-east-1:000000000000:no-such-dlq",
+        "maxReceiveCount": "1"
+    })
+    .to_string();
+    svc.set_queue_attributes(&make_request(
+        "SetQueueAttributes",
+        json!({ "QueueUrl": src_url, "Attributes": { "RedrivePolicy": redrive } }),
+    ))
+    .unwrap();
+    send_msg(&svc, &src_url, "survivor");
+
+    // First receive delivers (receive_count 1 == max); the second crosses
+    // maxReceiveCount and routes the message through the redrive path.
+    assert_eq!(receive_msgs(&svc, &src_url, 1).len(), 1);
+    assert_eq!(receive_msgs(&svc, &src_url, 1).len(), 0);
+
+    // The message survives on the source queue instead of vanishing.
+    let attrs = body_json(
+        svc.get_queue_attributes(&make_request(
+            "GetQueueAttributes",
+            json!({ "QueueUrl": src_url, "AttributeNames": ["ApproximateNumberOfMessages"] }),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(attrs["Attributes"]["ApproximateNumberOfMessages"], "1");
+}
+
 // ── Error branch tests ──
 
 #[test]


### PR DESCRIPTION
Fixes #1675.

## Problem

In the ReceiveMessage redrive path, over-limit messages are collected into `dlq_messages` and then moved to the DLQ via an ARN lookup. When `deadLetterTargetArn` doesn't resolve to any known queue (DLQ deleted, ARN typo), `find()` misses and the loop body does nothing — but the message has already been removed from the source queue, so it is silently destroyed.

Real SQS never destroys a message over a misconfigured redrive target: it stays on the source queue and continues to be redelivered.

## Fix

On a failed DLQ lookup, return the message to the source queue (handle/visibility cleared, body untouched) and emit a `tracing::warn!`. Chose the non-destructive runtime fallback over validate-at-policy-set (which AWS also does) to keep the change minimal — happy to add SetQueueAttributes-time validation as a follow-up if you'd prefer that behavior.

`force_dlq()` in `simulation.rs` already guards this case (checks DLQ existence up front, returns 0) and needed no change.

## Test

`redrive_with_unresolvable_dlq_arn_keeps_message_on_source_queue` — send → receive past `maxReceiveCount` with an unresolvable ARN → message survives on the source queue (`ApproximateNumberOfMessages == 1`). Verified red without the fix, green with it. Full crate suite: 154 passed; `cargo fmt --check` and `clippy --all-targets` clean on the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SQS redrive so messages aren’t lost when the DLQ ARN can’t be resolved. On lookup failure, the message is returned to the source queue (handle/visibility cleared) and a warning is logged, matching AWS behavior.

<sup>Written for commit ee57b47bb13a3ec7ade88a59b5b06a1486d7af5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

