### PR TITLE
ci(sdk-go): bump golangci-lint timeout to 5m

### DIFF
--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -56,6 +56,8 @@ jobs:
       - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           working-directory: sdks/go
+          args: --timeout=5m
       - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           working-directory: sdks/go/e2e
+          args: --timeout=5m

--- a/sdks/go/ec2.go
+++ b/sdks/go/ec2.go
@@ -2,7 +2,8 @@ package fakecloud
 
 import "context"
 
-// EC2Client provides access to EC2 introspection endpoints.
+// EC2Client provides access to EC2 introspection endpoints
+// (the fakecloud `/_fakecloud/ec2/*` surface).
 type EC2Client struct {
 	fc *FakeCloud
 }


### PR DESCRIPTION
## Summary
The EC2 introspection work added `aws-sdk-go-v2/service/ec2` (a large package) to the Go SDK e2e module. golangci-lint's default 1-minute timeout is exceeded while type-checking it, so the SDK Go workflow went red on main with `level=error msg="Timeout exceeded"` (exit code 4) — a lint-runner timeout, not a code defect (`go build`/`go vet` pass).

Both golangci-lint steps now pass `--timeout=5m`.

## Test plan
- SDK Go workflow lint steps complete within budget and go green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `golangci-lint` timeout to 5m for both `sdks/go` and `sdks/go/e2e` lint steps to prevent timeouts when linting the e2e module that depends on `aws-sdk-go-v2/service/ec2`. Add a small doc-comment tweak in `sdks/go/ec2.go` to trigger the path-filtered workflow and validate the change.

<sup>Written for commit 960b9bb7eca495c664b1f5afc139e74086f990be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

