### PR TITLE
ci(release): add fakecloud-ec2 to the crates.io publish list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
           publish fakecloud-sqs
           publish fakecloud-iam
           publish fakecloud-organizations
+          publish fakecloud-ec2            # depends on aws + core only
           publish fakecloud-lambda
           publish fakecloud-logs
           publish fakecloud-kms


### PR DESCRIPTION
## Summary
`fakecloud-ec2` was missing from release.yml's hand-maintained crate publish order. Consequence during v0.18.0:
- ec2 never published to crates.io.
- The `fakecloud` bin (depends on ec2) failed: `failed to prepare local package for uploading` (unresolvable path-dep).

v0.18.0 was recovered by publishing `fakecloud-ec2` then `fakecloud` manually from the `v0.18.0` tag (both now indexed at 0.18.0). This adds ec2 to the list (layer 3a — deps are aws + core only) so future releases publish it automatically.

## Test plan
- Next release publishes fakecloud-ec2 + fakecloud bin without manual intervention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `fakecloud-ec2` to the crates.io publish list in `.github/workflows/release.yml` so it publishes in the correct order. This prevents the `fakecloud` bin from failing with an unresolvable path dependency and removes the need for manual publishes.

<sup>Written for commit 55453e75838c9895931c2bb8da2551d1c4bc8c9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

