### PR TITLE
fix(dynamodb): evaluate NOT( without a trailing space in condition expressions

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/expression_corpus_tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/expression_corpus_tests.rs
@@ -297,6 +297,9 @@ fn filter_sdk_compound_shapes() {
         ),
         ("not-true", "NOT (a = :99)", true),
         ("not-false", "NOT (a = :1)", false),
+        // No-space `NOT(` form (python_dynamodb_lock / hand-written).
+        ("not-true-no-space", "NOT(a = :99)", true),
+        ("not-false-no-space", "NOT(a = :1)", false),
         (
             "and-of-or",
             "((a = :1) OR (a = :99)) AND ((b = :2) OR (b = :99))",

--- a/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
@@ -412,9 +412,18 @@ pub(crate) fn evaluate_filter_expression(
         return evaluate_filter_expression(stripped, item, expr_attr_names, expr_attr_values);
     }
 
-    // Handle NOT prefix (case-insensitive)
-    if trimmed.len() > 4 && trimmed[..4].eq_ignore_ascii_case("NOT ") {
-        return !evaluate_filter_expression(&trimmed[4..], item, expr_attr_names, expr_attr_values);
+    // Handle NOT prefix (case-insensitive). Accept both `NOT (...)` and the
+    // no-space `NOT(...)` that python_dynamodb_lock and hand-written expressions
+    // emit — mirroring extract_function_arg's func( / func ( tolerance. Requiring
+    // the char after `NOT` to be whitespace or `(` avoids misparsing an identifier
+    // like `NOTanattr`.
+    if let Some(rest) = trimmed
+        .get(..3)
+        .filter(|p| p.eq_ignore_ascii_case("NOT"))
+        .map(|_| &trimmed[3..])
+        .filter(|after| after.starts_with(|c: char| c.is_ascii_whitespace() || c == '('))
+    {
+        return !evaluate_filter_expression(rest, item, expr_attr_names, expr_attr_values);
     }
 
     evaluate_single_filter_condition(trimmed, item, expr_attr_names, expr_attr_values)

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -1819,6 +1819,34 @@ fn test_evaluate_condition_not_operator() {
 }
 
 #[test]
+fn test_evaluate_condition_not_no_space() {
+    // `NOT(` with no space between the keyword and `(` is what
+    // python_dynamodb_lock and most hand-written expressions emit. It must be
+    // tokenized identically to `NOT (...)`.
+    let item = cond_item(&[("state", "active")]);
+    let names = cond_names(&[("#s", "state"), ("#pk", "pk"), ("#sk", "sk")]);
+    let values = cond_values(&[]);
+
+    // NOT(attribute_exists(#s)) on a missing item => NOT false => true
+    assert!(evaluate_condition("NOT(attribute_exists(#s))", None, &names, &values).is_ok());
+    // ...on an existing item => NOT true => false
+    assert!(evaluate_condition("NOT(attribute_exists(#s))", Some(&item), &names, &values).is_err());
+
+    // The python_dynamodb_lock acquire form on a missing item => passes.
+    assert!(evaluate_condition(
+        "NOT(attribute_exists(#pk) AND attribute_exists(#sk))",
+        None,
+        &names,
+        &values
+    )
+    .is_ok());
+
+    // Regression guard: the spaced form still behaves as before.
+    assert!(evaluate_condition("NOT (attribute_exists(#s))", None, &names, &values).is_ok());
+    assert!(evaluate_condition("NOT attribute_exists(#s)", Some(&item), &names, &values).is_err());
+}
+
+#[test]
 fn test_evaluate_condition_begins_with() {
     // After unification, conditions support begins_with via
     // evaluate_single_filter_condition (previously only filters had it).

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -768,6 +768,63 @@ async fn dynamodb_condition_expression() {
 }
 
 #[tokio::test]
+async fn dynamodb_condition_expression_not_attribute_exists() {
+    // python_dynamodb_lock acquires with `NOT(attribute_exists(...))` (no space).
+    // On a missing key this must succeed; on an existing key it must fail with
+    // ConditionalCheckFailedException.
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("NotCondTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Missing key: NOT(attribute_exists(id)) => NOT false => true => succeeds.
+    client
+        .put_item()
+        .table_name("NotCondTable")
+        .item("id", AttributeValue::S("lock".to_string()))
+        .condition_expression("NOT(attribute_exists(id))")
+        .send()
+        .await
+        .unwrap();
+
+    // Now the key exists: same condition => NOT true => false => fails.
+    let result = client
+        .put_item()
+        .table_name("NotCondTable")
+        .item("id", AttributeValue::S("lock".to_string()))
+        .condition_expression("NOT(attribute_exists(id))")
+        .send()
+        .await;
+    let err =
+        result.expect_err("put on existing key must fail the NOT(attribute_exists) condition");
+    assert!(
+        err.into_service_error()
+            .is_conditional_check_failed_exception(),
+        "expected ConditionalCheckFailedException"
+    );
+}
+
+#[tokio::test]
 async fn dynamodb_nested_projection_on_list_element() {
     let server = TestServer::start().await;
     let client = server.dynamodb_client().await;


### PR DESCRIPTION
## Summary

A conditional `PutItem` whose `ConditionExpression` wraps `attribute_exists` in `NOT(...)`
(no space) raised `ConditionalCheckFailedException` **even when no item exists at the key**.
On real DynamoDB, `attribute_exists` on a missing item is `false`, so `NOT(attribute_exists(pk))`
is `true` and the put should succeed.

The cause is the `NOT`-prefix tokenizer in `evaluate_filter_expression`
(`crates/fakecloud-dynamodb/src/service/helpers/conditions.rs`), which only matched `NOT`
followed by a literal trailing space (`"NOT "`). For `NOT(...)`: it isn't split on AND/OR (the
operator is inside the parens), `strip_outer_parens` leaves it unchanged (it starts with `N`),
it fails the `"NOT "` check, and falls through to the single-condition evaluator, which matches
nothing and returns `false`.

This breaks `python_dynamodb_lock`, which acquires with exactly
`NOT(attribute_exists(#pk) AND attribute_exists(#sk))` — every acquire reads the spurious
failure as "lock held" and retries forever.

Closes #1680.

## Fix

Recognize a case-insensitive `NOT` prefix followed by **whitespace or `(`**, then recurse on
the remainder with its parentheses intact — mirroring the `func(` / `func (` tolerance
`extract_function_arg` already applies in the same file. Requiring the char after `NOT` to be
whitespace or `(` avoids misparsing an identifier like `NOTanattr`; the bare string `"NOT"`
also doesn't match.

## Tests

- **Unit** (`service/tests.rs`, `test_evaluate_condition_not_no_space`): no-space
  `NOT(attribute_exists(#s))` on missing vs existing items, the
  `NOT(attribute_exists(#pk) AND attribute_exists(#sk))` lock form, and a spaced-form
  regression guard.
- **Corpus** (`service/expression_corpus_tests.rs`): no-space `NOT(...)` cases added to the
  SDK-shape expression corpus.
- **E2E** (`fakecloud-e2e/tests/dynamodb.rs`,
  `dynamodb_condition_expression_not_attribute_exists`): `NOT(attribute_exists(id))` succeeds
  on an empty table, then fails with `ConditionalCheckFailedException` on the now-existing key.

## Validation

- `cargo test -p fakecloud-dynamodb` — 285 passed
- `cargo test -p fakecloud-e2e --test dynamodb` — 64 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing of NOT(...) in DynamoDB condition expressions so `NOT(attribute_exists(...))` works without a space, matching AWS behavior and preventing false ConditionalCheckFailedException (affecting `python_dynamodb_lock`).

- Bug Fixes
  - Treat `NOT` (case-insensitive) as a prefix when followed by whitespace or `(`; avoids misparsing identifiers like `NOTanattr`.
  - Recurse on the remainder with parentheses intact; spaced forms remain unchanged.
  - Added unit, corpus, and E2E tests for `NOT(attribute_exists(...))` on missing vs existing items.

<sup>Written for commit 5bf976acdfeec5b8b7bc84a63c719d650b9994de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

