### PR TITLE
fix(cloudformation): resolve Lambda alias Ref to ARN and accept qualified ESM FunctionName

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/lambda.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/lambda.rs
@@ -795,7 +795,12 @@ impl ResourceProvisioner {
                 },
             );
         }
-        Ok(ProvisionResult::new(key).with("AliasArn", alias_arn))
+        // Expose the alias ARN as the physical id so `Ref` on the alias
+        // resolves to the ARN, like real CloudFormation. The internal
+        // `aliases` / `provisioned_concurrency` maps stay keyed by
+        // `{function}:{alias}` (`key`); update/delete recover that key
+        // from the ARN physical id via `alias_state_key`.
+        Ok(ProvisionResult::new(alias_arn.clone()).with("AliasArn", alias_arn))
     }
 
     /// Update an existing Lambda Alias in place. FunctionVersion,
@@ -821,17 +826,18 @@ impl ResourceProvisioner {
             .to_string();
         let routing_config = props.get("RoutingConfig").cloned();
 
+        // `existing.physical_id` is the alias ARN; the maps are keyed by
+        // `{function}:{alias}`.
+        let key = alias_state_key(&existing.physical_id);
+
         let mut accounts = self.lambda_state.write();
         let state = accounts.get_or_create(&self.account_id);
-        let alias = state
-            .aliases
-            .get_mut(&existing.physical_id)
-            .ok_or_else(|| {
-                format!(
-                    "Alias {} does not exist in lambda state",
-                    existing.physical_id
-                )
-            })?;
+        let alias = state.aliases.get_mut(&key).ok_or_else(|| {
+            format!(
+                "Alias {} does not exist in lambda state",
+                existing.physical_id
+            )
+        })?;
         alias.function_version = function_version;
         alias.description = description;
         alias.routing_config = routing_config;
@@ -847,7 +853,7 @@ impl ResourceProvisioner {
         {
             Some(cnt) => {
                 state.provisioned_concurrency.insert(
-                    existing.physical_id.clone(),
+                    key.clone(),
                     fakecloud_lambda::ProvisionedConcurrencyConfig {
                         requested: cnt,
                         allocated: cnt,
@@ -857,16 +863,20 @@ impl ResourceProvisioner {
                 );
             }
             None => {
-                state.provisioned_concurrency.remove(&existing.physical_id);
+                state.provisioned_concurrency.remove(&key);
             }
         }
         Ok(ProvisionResult::new(existing.physical_id.clone()).with("AliasArn", alias_arn))
     }
 
     pub(super) fn delete_lambda_alias(&self, physical_id: &str) -> Result<(), String> {
+        // `physical_id` is the alias ARN; the maps are keyed by
+        // `{function}:{alias}`.
+        let key = alias_state_key(physical_id);
         let mut accounts = self.lambda_state.write();
         let state = accounts.get_or_create(&self.account_id);
-        state.aliases.remove(physical_id);
+        state.aliases.remove(&key);
+        state.provisioned_concurrency.remove(&key);
         Ok(())
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -390,18 +390,40 @@ fn parse_log_group_name(input: &str) -> String {
     input.to_string()
 }
 
-/// Pull the function name out of either a bare name or a Lambda
-/// function ARN. CFN passes `{Ref: SomeFunction}` which resolves to the
-/// function name today, but `{Fn::GetAtt: [F, Arn]}` resolves to the
-/// full ARN; both shapes need to land at the same map key.
+/// Pull the bare function name out of any shape AWS accepts for a Lambda
+/// `FunctionName`: a name, a partial ARN, or a full ARN — each optionally
+/// `:qualified` with an alias or version. CFN feeds this `{Ref: SomeFunction}`
+/// (resolves to a name, or — for an alias — the alias ARN), `{Fn::GetAtt:
+/// [F, Arn]}` (full ARN), or a literal; all shapes must land at the same map
+/// key. Function names cannot contain `:`, so any trailing `:segment` on a
+/// non-ARN input is always a qualifier.
 fn parse_lambda_function_name(input: &str) -> String {
+    // Full ARN: arn:aws:lambda:region:account:function:name[:qualifier]
     if let Some(rest) = input.strip_prefix("arn:aws:lambda:") {
         if let Some(after) = rest.split(":function:").nth(1) {
-            // Trim trailing `:qualifier` (alias / version).
             return after.split(':').next().unwrap_or(after).to_string();
         }
     }
-    input.to_string()
+    // Partial ARN: account:function:name[:qualifier]
+    if let Some(after) = input.split(":function:").nth(1) {
+        return after.split(':').next().unwrap_or(after).to_string();
+    }
+    // Bare name, optionally qualified: name[:qualifier]
+    input.split(':').next().unwrap_or(input).to_string()
+}
+
+/// Recover the internal `{function}:{alias}` key used by the lambda
+/// state's `aliases` / `provisioned_concurrency` maps from an alias
+/// resource's physical id. The physical id is the alias ARN
+/// (`arn:aws:lambda:region:account:function:name:alias`); a legacy bare
+/// `name:alias` value is returned unchanged.
+fn alias_state_key(physical_id: &str) -> String {
+    if let Some(rest) = physical_id.strip_prefix("arn:aws:lambda:") {
+        if let Some(after) = rest.split(":function:").nth(1) {
+            return after.to_string();
+        }
+    }
+    physical_id.to_string()
 }
 
 /// All AWS::Lambda::Function CFN properties parsed and pre-defaulted into
@@ -7249,5 +7271,46 @@ mod tests {
         assert_eq!(sr.physical_id, "primary|my-ps");
 
         prov.delete_resource(&sr.clone()).unwrap();
+    }
+
+    #[test]
+    fn parse_lambda_function_name_handles_every_shape() {
+        // Plain name, unqualified — passes through.
+        assert_eq!(parse_lambda_function_name("my-func"), "my-func");
+        // Bare name with an alias/version qualifier (what `Ref` on an
+        // alias used to feed the ESM create path).
+        assert_eq!(parse_lambda_function_name("my-func:live"), "my-func");
+        assert_eq!(parse_lambda_function_name("my-func:42"), "my-func");
+        // Full ARN, unqualified and qualified.
+        assert_eq!(
+            parse_lambda_function_name("arn:aws:lambda:us-east-1:123456789012:function:my-func"),
+            "my-func"
+        );
+        assert_eq!(
+            parse_lambda_function_name(
+                "arn:aws:lambda:us-east-1:123456789012:function:my-func:live"
+            ),
+            "my-func"
+        );
+        // Partial ARN, unqualified and qualified.
+        assert_eq!(
+            parse_lambda_function_name("123456789012:function:my-func"),
+            "my-func"
+        );
+        assert_eq!(
+            parse_lambda_function_name("123456789012:function:my-func:live"),
+            "my-func"
+        );
+    }
+
+    #[test]
+    fn alias_state_key_recovers_internal_key_from_arn() {
+        // Alias ARN -> `{function}:{alias}` internal map key.
+        assert_eq!(
+            alias_state_key("arn:aws:lambda:us-east-1:123456789012:function:my-func:live"),
+            "my-func:live"
+        );
+        // Legacy bare `name:alias` physical id is returned unchanged.
+        assert_eq!(alias_state_key("my-func:live"), "my-func:live");
     }
 }

--- a/crates/fakecloud-cloudformation/src/template/mod.rs
+++ b/crates/fakecloud-cloudformation/src/template/mod.rs
@@ -786,6 +786,20 @@ Resources:
     }
 
     #[test]
+    fn ref_on_lambda_alias_resolves_to_alias_arn() {
+        // `Ref` returns a resource's physical id; the Lambda alias
+        // provisioner exposes the alias ARN as its physical id, so
+        // `Ref` on the alias yields the ARN — like real CloudFormation,
+        // and what the ESM create path needs to find the function.
+        let (p, r, mut ids, attrs) = empty();
+        let alias_arn = "arn:aws:lambda:us-east-1:123456789012:function:my-func:live";
+        ids.insert("Alias".to_string(), alias_arn.to_string());
+        let v: Value = serde_json::from_str(r#"{"Ref": "Alias"}"#).unwrap();
+        let resolved = resolve_refs(&v, &p, &r, &ids, &attrs);
+        assert_eq!(resolved, Value::String(alias_arn.to_string()));
+    }
+
+    #[test]
     fn fn_split_emits_array() {
         let (p, r, ids, attrs) = empty();
         let v: Value = serde_json::from_str(r#"{"Fn::Split": [",", "a,b,c"]}"#).unwrap();

--- a/crates/fakecloud-e2e/tests/cloudformation_lambda_alias_esm.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_lambda_alias_esm.rs
@@ -1,0 +1,140 @@
+//! Regression: a stack combining `AWS::Lambda::Alias` with an
+//! `AWS::Lambda::EventSourceMapping` whose `FunctionName` is
+//! `{"Ref": "<AliasLogicalId>"}` (the expanded-CFN shape of a SAM function
+//! using `AutoPublishAlias` + `Events`). This used to fail permanently with
+//! "Function <name>:live does not exist yet" because (a) `Ref` on the alias
+//! resolved to `name:alias` instead of the alias ARN and (b)
+//! `parse_lambda_function_name` didn't strip the trailing qualifier. The
+//! function is never invoked, so no container runtime is needed.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": "cfn-alias-esm-role",
+        "AssumeRolePolicyDocument": {"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}
+      }
+    },
+    "Func": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "FunctionName": "cfn-alias-esm-func",
+        "Runtime": "nodejs18.x",
+        "Handler": "index.handler",
+        "Role": {"Fn::GetAtt": ["Role", "Arn"]},
+        "Code": {"ZipFile": "exports.handler = async () => ({ ok: true });"}
+      }
+    },
+    "Queue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {"QueueName": "cfn-alias-esm-queue"}
+    },
+    "Version": {
+      "Type": "AWS::Lambda::Version",
+      "Properties": {
+        "FunctionName": {"Ref": "Func"},
+        "Description": "v1 snapshot"
+      }
+    },
+    "Alias": {
+      "Type": "AWS::Lambda::Alias",
+      "Properties": {
+        "FunctionName": {"Ref": "Func"},
+        "Name": "live",
+        "FunctionVersion": {"Fn::GetAtt": ["Version", "Version"]}
+      }
+    },
+    "Esm": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "FunctionName": {"Ref": "Alias"},
+        "EventSourceArn": {"Fn::GetAtt": ["Queue", "Arn"]},
+        "BatchSize": 5,
+        "Enabled": true
+      }
+    }
+  },
+  "Outputs": {
+    "FuncName": {"Value": {"Ref": "Func"}},
+    "AliasArn": {"Value": {"Ref": "Alias"}},
+    "EsmId": {"Value": {"Ref": "Esm"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_event_source_mapping_referencing_lambda_alias_provisions() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let lambda = aws_sdk_lambda::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("cfn-alias-esm-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityNamedIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    // The whole point: the stack reaches CREATE_COMPLETE instead of rolling
+    // back on the "Function cfn-alias-esm-func:live does not exist" error.
+    let described = cfn
+        .describe_stacks()
+        .stack_name("cfn-alias-esm-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    // `Ref` on the alias yields the alias ARN, like real CloudFormation.
+    let mut func_name = None;
+    let mut alias_arn = None;
+    let mut esm_id = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("FuncName") => func_name = o.output_value().map(String::from),
+            Some("AliasArn") => alias_arn = o.output_value().map(String::from),
+            Some("EsmId") => esm_id = o.output_value().map(String::from),
+            _ => {}
+        }
+    }
+    let func_name = func_name.expect("FuncName output");
+    let alias_arn = alias_arn.expect("AliasArn output");
+    let esm_id = esm_id.expect("EsmId output");
+    assert_eq!(func_name, "cfn-alias-esm-func");
+    assert!(
+        alias_arn.starts_with("arn:aws:lambda:")
+            && alias_arn.ends_with(":function:cfn-alias-esm-func:live"),
+        "Ref on the alias should resolve to the alias ARN, got {alias_arn}"
+    );
+
+    // The ESM exists and is wired to the underlying function (the qualifier
+    // was stripped to resolve to the function, matching AWS).
+    let listed = lambda
+        .list_event_source_mappings()
+        .function_name(&func_name)
+        .send()
+        .await
+        .expect("list_event_source_mappings");
+    let mapping = listed
+        .event_source_mappings()
+        .iter()
+        .find(|m| m.uuid() == Some(esm_id.as_str()))
+        .expect("ESM present for the function");
+    assert!(
+        mapping
+            .function_arn()
+            .expect("function_arn")
+            .ends_with(":function:cfn-alias-esm-func"),
+        "ESM should resolve to the underlying function, got {:?}",
+        mapping.function_arn()
+    );
+}


### PR DESCRIPTION
Fixes #1682.

## Problem

A stack combining `AWS::Lambda::Alias` with an `AWS::Lambda::EventSourceMapping` whose
`FunctionName` is `{"Ref": "<AliasLogicalId>"}` (the expanded-CFN shape of a SAM function
using `AutoPublishAlias` + `Events`) fails permanently with:

```
ValidationError: Failed to create resource <esm>: Function <name>:live
does not exist yet — retry once it has been provisioned
```

Two compounding root causes:

1. **`Ref` on `AWS::Lambda::Alias` resolved to `name:alias`, not the alias ARN.** The alias
   provisioner returned the physical id `"{function}:{alias}"`; real CloudFormation returns
   the alias **ARN** for `Ref` on a Lambda alias.
2. **`parse_lambda_function_name` only stripped the qualifier from full ARNs.** The bare
   `name:alias` fed by (1) passed through unchanged, so the ESM existence check
   `state.functions.contains_key(&function_name)` looked up `name:alias` in a map keyed by
   bare names and never matched.

## Fix

- **Alias `Ref` → ARN** (`resource_provisioner/lambda.rs`): `create_lambda_alias` now
  exposes the alias **ARN** as its physical id. The internal `aliases` /
  `provisioned_concurrency` maps stay keyed by `{function}:{alias}`; the update/delete paths
  recover that key from the ARN via a new `alias_state_key` helper.
- **`parse_lambda_function_name`** (`resource_provisioner/mod.rs`): also strips a trailing
  `:qualifier` from bare names and partial ARNs, so an ESM `FunctionName` may be a name,
  partial ARN, or full ARN — each optionally qualified — all resolving to the underlying
  function.

Either fix alone unblocks the template; both are included to match AWS.

## Tests

- **Unit**: `parse_lambda_function_name` across all five shapes; `alias_state_key` ARN→key
  recovery; `Ref` on a Lambda alias resolves to the ARN (intrinsics).
- **E2E** (`crates/fakecloud-e2e/tests/cloudformation_lambda_alias_esm.rs`): a Role +
  Function + SQS Queue + Version + Alias + EventSourceMapping (`FunctionName: {"Ref":
  "Alias"}`) stack reaches `CREATE_COMPLETE`, the alias `Ref` yields the ARN, and the ESM
  resolves to the underlying function via `list_event_source_mappings`.

## Validation

- `cargo test -p fakecloud-cloudformation` (205 passed)
- `cargo build --bin fakecloud`
- `cargo test -p fakecloud-e2e --test cloudformation_lambda_alias_esm --test cfn_lambda_aux`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CloudFormation to return the alias ARN for `Ref` on `AWS::Lambda::Alias`, and allow `AWS::Lambda::EventSourceMapping` to accept qualified `FunctionName`. This unblocks SAM stacks using `AutoPublishAlias` + `Events` that failed with “Function name:alias does not exist”.

- **Bug Fixes**
  - Alias `Ref` now resolves to the alias ARN by exposing the ARN as the alias physical ID; update/delete recover `{function}:{alias}` via a new helper.
  - `parse_lambda_function_name` strips a trailing qualifier from names, partial ARNs, and full ARNs to resolve to the bare function.
  - State updates for aliases and provisioned concurrency consistently use the recovered key.
  - Added unit and e2e tests to confirm alias `Ref` → ARN and ESM resolves to the underlying function.

<sup>Written for commit b1f073028600cd54cd208d5e22a50e4fca9fff80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

