### PR TITLE
feat(cloudformation): expand AWS::Serverless::StateMachine in the SAM transform

### DIFF
--- a/crates/fakecloud-cloudformation/src/template/for_each.rs
+++ b/crates/fakecloud-cloudformation/src/template/for_each.rs
@@ -277,6 +277,68 @@ pub(super) fn expand_sam(value: &Value) -> Value {
                 }
                 new_resources.insert(logical_id.clone(), Value::Object(layer_resource));
             }
+            "AWS::Serverless::StateMachine" => {
+                let mut sfn_props = if let Some(p) = properties.as_object() {
+                    p.clone()
+                } else {
+                    serde_json::Map::new()
+                };
+                // `Definition` (inline ASL object) passes through unchanged —
+                // the native provisioner's resolve_sfn_definition reads it
+                // directly. `DefinitionSubstitutions` likewise passes through.
+                // Map `DefinitionUri` onto `DefinitionS3Location`, reusing the
+                // same `s3://bucket/key` parsing the Function arm uses for
+                // CodeUri. SAM also allows the object form
+                // `{Bucket, Key, Version}`, which maps over verbatim.
+                if let Some(uri) = sfn_props.get("DefinitionUri").cloned() {
+                    sfn_props.remove("DefinitionUri");
+                    let location = if let Some(s) = uri.as_str() {
+                        if let Some(stripped) = s.strip_prefix("s3://") {
+                            let parts: Vec<&str> = stripped.splitn(2, '/').collect();
+                            if parts.len() == 2 {
+                                json!({"Bucket": parts[0], "Key": parts[1]})
+                            } else {
+                                json!({"Bucket": "sam", "Key": s})
+                            }
+                        } else {
+                            json!({"Bucket": "sam", "Key": s})
+                        }
+                    } else {
+                        // Already an object form: {Bucket, Key, Version}.
+                        uri
+                    };
+                    sfn_props.insert("DefinitionS3Location".to_string(), location);
+                }
+                // `Role` (ARN) → `RoleArn`.
+                if let Some(role) = sfn_props.remove("Role") {
+                    sfn_props.insert("RoleArn".to_string(), role);
+                }
+                // `Name` → `StateMachineName`.
+                if let Some(name) = sfn_props.remove("Name") {
+                    sfn_props.insert("StateMachineName".to_string(), name);
+                }
+                // SAM `Type` (STANDARD|EXPRESS) → native `StateMachineType`.
+                if let Some(machine_type) = sfn_props.remove("Type") {
+                    sfn_props.insert("StateMachineType".to_string(), machine_type);
+                }
+                // TODO: expand `Events` (Api/Schedule/EventBridge/SQS/etc.)
+                // into the corresponding trigger resources. Deferred — the
+                // state machine itself expands and provisions without it.
+                sfn_props.remove("Events");
+
+                let mut sfn_resource = serde_json::Map::new();
+                sfn_resource.insert(
+                    "Type".to_string(),
+                    json!("AWS::StepFunctions::StateMachine"),
+                );
+                sfn_resource.insert("Properties".to_string(), Value::Object(sfn_props));
+                for (k, v) in resource_obj {
+                    if k != "Type" && k != "Properties" {
+                        sfn_resource.insert(k.clone(), v.clone());
+                    }
+                }
+                new_resources.insert(logical_id.clone(), Value::Object(sfn_resource));
+            }
             _ => {
                 new_resources.insert(logical_id.clone(), resource.clone());
             }
@@ -359,5 +421,87 @@ pub(super) fn substitute_loop_vars_in_value(
                 .collect(),
         ),
         other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_sam_statemachine_inline_definition() {
+        let template = json!({
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "MySM": {
+                    "Type": "AWS::Serverless::StateMachine",
+                    "DependsOn": "SomeOtherResource",
+                    "Properties": {
+                        "Definition": {
+                            "StartAt": "Done",
+                            "States": {"Done": {"Type": "Succeed"}}
+                        },
+                        "DefinitionSubstitutions": {"fn": "my-fn"},
+                        "Role": "arn:aws:iam::123456789012:role/sfn-role",
+                        "Name": "my-state-machine",
+                        "Type": "EXPRESS"
+                    }
+                }
+            }
+        });
+
+        let expanded = expand_sam(&template);
+        let resource = &expanded["Resources"]["MySM"];
+
+        assert_eq!(resource["Type"], json!("AWS::StepFunctions::StateMachine"));
+
+        let props = &resource["Properties"];
+        assert_eq!(
+            props["RoleArn"],
+            json!("arn:aws:iam::123456789012:role/sfn-role")
+        );
+        assert_eq!(props["StateMachineName"], json!("my-state-machine"));
+        assert_eq!(props["StateMachineType"], json!("EXPRESS"));
+        // Inline definition carries over unchanged for the provisioner to read.
+        assert_eq!(
+            props["Definition"],
+            json!({"StartAt": "Done", "States": {"Done": {"Type": "Succeed"}}})
+        );
+        // DefinitionSubstitutions passes through.
+        assert_eq!(props["DefinitionSubstitutions"], json!({"fn": "my-fn"}));
+        // SAM-only keys are gone.
+        assert!(props.get("Role").is_none());
+        assert!(props.get("Name").is_none());
+        // Resource-level metadata is preserved.
+        assert_eq!(resource["DependsOn"], json!("SomeOtherResource"));
+    }
+
+    #[test]
+    fn expand_sam_statemachine_definition_uri() {
+        let template = json!({
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "MySM": {
+                    "Type": "AWS::Serverless::StateMachine",
+                    "Properties": {
+                        "DefinitionUri": "s3://my-bucket/path/to/def.asl.json",
+                        "Role": "arn:aws:iam::123456789012:role/sfn-role"
+                    }
+                }
+            }
+        });
+
+        let expanded = expand_sam(&template);
+        let props = &expanded["Resources"]["MySM"]["Properties"];
+
+        assert_eq!(
+            props["DefinitionS3Location"],
+            json!({"Bucket": "my-bucket", "Key": "path/to/def.asl.json"})
+        );
+        assert!(props.get("DefinitionUri").is_none());
+        assert_eq!(
+            props["RoleArn"],
+            json!("arn:aws:iam::123456789012:role/sfn-role")
+        );
     }
 }

--- a/crates/fakecloud-cloudformation/src/template/resolution.rs
+++ b/crates/fakecloud-cloudformation/src/template/resolution.rs
@@ -35,6 +35,12 @@ pub fn resolve_resource_properties_with_attrs(
     // Re-expand ForEach so the resource we look up matches the post-
     // expansion logical IDs from the original parse.
     let value = expand_for_each(&value, &BTreeMap::new(), parameters)?;
+    // Re-apply the SAM transform too: the original parse rewrote SAM
+    // resources (e.g. AWS::Serverless::StateMachine -> the native
+    // AWS::StepFunctions::StateMachine, Role -> RoleArn). Without this the
+    // properties get re-read from the raw SAM resource and the native
+    // provisioner sees SAM property names it doesn't understand.
+    let value = expand_sam(&value);
 
     let resources_obj = value
         .get("Resources")

--- a/crates/fakecloud-e2e/tests/cloudformation_sam_statemachine.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_sam_statemachine.rs
@@ -1,0 +1,87 @@
+//! SAM transform expands `AWS::Serverless::StateMachine` into a native
+//! `AWS::StepFunctions::StateMachine` so a SAM app with Step Functions can
+//! deploy through fakecloud CloudFormation without a local aws-sam-translator
+//! pre-transform.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::Capability;
+use helpers::TestServer;
+
+/// SAM template from FAKECLOUD-UPSTREAM-BATCH.md §3: an inline ASL
+/// `Definition` plus a `Role`, under `Transform: AWS::Serverless-2016-10-31`.
+/// An `Outputs` block surfaces the state machine ARN via `Ref`.
+const TEMPLATE: &str = r#"
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MySM:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: sam-sm
+      Definition:
+        StartAt: Done
+        States:
+          Done:
+            Type: Succeed
+      Role: arn:aws:iam::123456789012:role/sfn-role
+Outputs:
+  Arn:
+    Value:
+      Ref: MySM
+"#;
+
+#[tokio::test]
+async fn sam_transform_expands_state_machine() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let sfn = aws_sdk_sfn::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("sam-sm-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("sam-sm-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(
+        stack.stack_status().unwrap().as_str(),
+        "CREATE_COMPLETE",
+        "SAM state machine stack should reach CREATE_COMPLETE"
+    );
+
+    let sm_arn = stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some("Arn"))
+        .and_then(|o| o.output_value())
+        .expect("Arn output");
+    assert!(
+        sm_arn.contains(":stateMachine:sam-sm"),
+        "state machine arn format: {sm_arn}"
+    );
+
+    // The expanded native resource is a real state machine reachable via the
+    // Step Functions SDK, carrying the role and the inline definition.
+    let sm = sfn
+        .describe_state_machine()
+        .state_machine_arn(sm_arn)
+        .send()
+        .await
+        .expect("describe_state_machine");
+    assert_eq!(sm.name(), "sam-sm");
+    assert_eq!(sm.role_arn(), "arn:aws:iam::123456789012:role/sfn-role");
+    assert!(
+        sm.definition().contains("\"Done\""),
+        "inline definition not carried over: {}",
+        sm.definition()
+    );
+}

--- a/website/content/docs/services/cloudformation.md
+++ b/website/content/docs/services/cloudformation.md
@@ -21,7 +21,7 @@ Query protocol. Form-encoded body, `Action` parameter, XML responses. Templates 
 - **`Fn::If`** — evaluated inline anywhere a value can appear, including inside resource properties, output values, and nested intrinsics. The `AWS::NoValue` pseudo-parameter prunes the surrounding key.
 - **`Fn::And` / `Fn::Or`** — accept 1-10 sub-conditions and short-circuit on the first decisive value, matching AWS's documented evaluation order.
 - **Outputs** — `Outputs.*.Export.Name` registers entries in an account-wide exports registry; `Fn::ImportValue` substitutes them at provision time. Unknown export names fail the create/update with a `ValidationError` ("No export named X found"), and `DeleteStack` blocks while another live stack still imports an export.
-- **`Transform: AWS::Serverless-2016-10-31`** — SAM templates are expanded into native CloudFormation resources before provisioning: `AWS::Serverless::Function` -> `AWS::Lambda::Function` (+ role, event sources), `AWS::Serverless::Api` -> `AWS::ApiGateway::RestApi` + deployment, `AWS::Serverless::SimpleTable` -> `AWS::DynamoDB::Table`.
+- **`Transform: AWS::Serverless-2016-10-31`** — SAM templates are expanded into native CloudFormation resources before provisioning: `AWS::Serverless::Function` -> `AWS::Lambda::Function` (+ role, event sources), `AWS::Serverless::Api` -> `AWS::ApiGateway::RestApi` + deployment, `AWS::Serverless::HttpApi` -> `AWS::ApiGatewayV2::Api`, `AWS::Serverless::SimpleTable` -> `AWS::DynamoDB::Table`, `AWS::Serverless::LayerVersion` -> `AWS::Lambda::LayerVersion`, `AWS::Serverless::StateMachine` -> `AWS::StepFunctions::StateMachine`.
 
 ## Stack lifecycle
 


### PR DESCRIPTION
Closes #1684.

## What

The server-side SAM transform expanded `AWS::Serverless::Function`, `Api`, `HttpApi`, `SimpleTable`, and `LayerVersion`, but had no `AWS::Serverless::StateMachine` arm — so a SAM app with Step Functions failed `CreateStack` with `Unsupported resource type: AWS::Serverless::StateMachine`. The native `AWS::StepFunctions::StateMachine` provisioner already works (#1654), so this just maps the SAM resource onto it.

## Changes

- **`template/for_each.rs`** — new `AWS::Serverless::StateMachine` arm in `expand_sam`, modeled on the `Function` arm. Maps:
  - `Definition` (inline ASL) → passthrough (the native provisioner reads it directly)
  - `DefinitionUri` (`s3://bucket/key`, or the object form) → `DefinitionS3Location {Bucket, Key}`
  - `DefinitionSubstitutions` → passthrough
  - `Role` → `RoleArn`, `Name` → `StateMachineName`, `Type` → `StateMachineType`
  - resource-level keys (`DependsOn`, `Condition`, `Metadata`, …) preserved
- **`template/resolution.rs`** — apply `expand_sam` in `resolve_resource_properties_with_attrs` too. This path re-reads the template to resolve a resource's properties at **provision time** and previously only re-applied `expand_for_each`. Without the SAM transform here, the resource *type* was rewritten but the *properties* were re-read raw, so the provisioner saw `Role` instead of `RoleArn` and failed with `RoleArn is required`. (This also hardens the pre-existing Function/Api/etc. arms against the same latent provision-time gap.)

## Tests

- **Unit** (`for_each.rs`): inline-`Definition` + `Role` case (asserts type rewrite, `RoleArn`, definition carry-over, metadata preservation) and a `DefinitionUri` → `DefinitionS3Location` case.
- **E2E** (`cloudformation_sam_statemachine.rs`): `create_stack` with the SAM template from the issue, asserts `CREATE_COMPLETE`, and verifies the state machine (name, role, definition) via the Step Functions SDK.

Validated: `cargo test -p fakecloud-cloudformation`, `cargo build --bin fakecloud`, the CFN e2e binaries (`cloudformation`, `cloudformation_stepfunctions`, `cloudformation_persistence`, `cloudformation_execute_change_set`, `cloudformation_sam_statemachine`), `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo fmt --all --check`.

## Deferred

`Events` (Api/Schedule/EventBridge/SQS/etc. triggers) is out of scope and left as a `// TODO` — the state machine resource itself expands and provisions without it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SAM support for `AWS::Serverless::StateMachine` by expanding it to `AWS::StepFunctions::StateMachine` so SAM apps with Step Functions deploy correctly. Also re-applies the SAM transform at provision time and updates docs to list `HttpApi`, `LayerVersion`, and `StateMachine` expansions.

- **New Features**
  - Maps `Role`→`RoleArn`, `Name`→`StateMachineName`, `Type`→`StateMachineType`.
  - Maps `DefinitionUri` to `DefinitionS3Location` (supports `s3://...` and object form); `Definition` and `DefinitionSubstitutions` pass through.
  - Preserves resource-level attributes like `DependsOn`, `Condition`, and `Metadata`.
  - Docs: CloudFormation page now lists SAM expansions for `AWS::Serverless::HttpApi`, `LayerVersion`, and `StateMachine`.
  - `Events` expansion is deferred; the state machine provisions without it.

- **Bug Fixes**
  - Applies the SAM transform in provision-time property resolution so native property names are used.
  - Adds unit and e2e tests for inline definitions, S3 URIs, and successful stack creation.

<sup>Written for commit 29d8ed9314761f54764e8a799ef0b459caa6eeac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

