### PR TITLE
fix(dynamodb): support legacy KeyConditions/QueryFilter Query parameters

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
@@ -382,6 +382,178 @@ pub(crate) fn evaluate_size_comparison(
     })
 }
 
+/// Which legacy condition family is being translated. `KeyConditions`
+/// (the `Query` key) accept only the comparison + range operators a key
+/// condition allows; the filter families (`QueryFilter` / `ScanFilter`)
+/// accept the broader operator set the FilterExpression evaluator supports.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LegacyConditionRole {
+    Key,
+    Filter,
+}
+
+/// Translate a legacy `KeyConditions` / `QueryFilter` / `ScanFilter` map into
+/// the equivalent expression string, hoisting attribute names into `#leg*`
+/// placeholders and values into `:legv*` placeholders in the supplied
+/// expr-attr maps so the result can be fed straight through the existing
+/// `evaluate_key_condition` / `evaluate_filter_expression` machinery.
+///
+/// AWS deprecated these parameters in 2014 in favor of the expression API,
+/// but real DynamoDB and every SDK still accept them — this is a parity
+/// translation, not new evaluation logic. Entries are AND-ed together
+/// (the only join AWS supports for the legacy form). Iteration is in sorted
+/// attribute-name order so the synthesized expression is deterministic.
+pub(crate) fn translate_legacy_conditions(
+    conditions: &serde_json::Map<String, Value>,
+    role: LegacyConditionRole,
+    names: &mut HashMap<String, String>,
+    values: &mut HashMap<String, Value>,
+) -> Result<String, AwsServiceError> {
+    // Role-specific placeholder tag so the key-condition and filter
+    // translations in a single Query don't clobber each other's entries in
+    // the shared expr-attr maps.
+    let tag = match role {
+        LegacyConditionRole::Key => "k",
+        LegacyConditionRole::Filter => "f",
+    };
+
+    let mut entries: Vec<(&String, &Value)> = conditions.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+
+    let mut fragments: Vec<String> = Vec::with_capacity(entries.len());
+    for (idx, (attr, spec)) in entries.iter().enumerate() {
+        let operator = spec
+            .get("ComparisonOperator")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                legacy_validation_err(format!(
+                    "ComparisonOperator is required for the condition on attribute {attr}"
+                ))
+            })?;
+        let value_list: &[Value] = spec
+            .get("AttributeValueList")
+            .and_then(|v| v.as_array())
+            .map(|a| a.as_slice())
+            .unwrap_or(&[]);
+
+        // Hoist the attribute name into a collision-safe placeholder.
+        let name_ph = format!("#leg{tag}{idx}");
+        names.insert(name_ph.clone(), (*attr).clone());
+
+        // Hoist each operand value into its own placeholder.
+        let mut value_phs: Vec<String> = Vec::with_capacity(value_list.len());
+        for (vi, v) in value_list.iter().enumerate() {
+            let ph = format!(":legv{tag}{idx}_{vi}");
+            values.insert(ph.clone(), v.clone());
+            value_phs.push(ph);
+        }
+
+        fragments.push(build_legacy_fragment(&name_ph, operator, &value_phs, role)?);
+    }
+
+    Ok(fragments.join(" AND "))
+}
+
+fn legacy_validation_err(message: String) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationException", message)
+}
+
+/// Build the expression fragment for a single legacy condition entry.
+fn build_legacy_fragment(
+    name_ph: &str,
+    operator: &str,
+    values: &[String],
+    role: LegacyConditionRole,
+) -> Result<String, AwsServiceError> {
+    // Operators a key condition may use; everything else is filter-only.
+    let key_ok = matches!(
+        operator,
+        "EQ" | "LE" | "LT" | "GE" | "GT" | "BEGINS_WITH" | "BETWEEN"
+    );
+    if role == LegacyConditionRole::Key && !key_ok {
+        return Err(legacy_validation_err(format!(
+            "Unsupported operator on KeyConditions: {operator}"
+        )));
+    }
+
+    let want = |n: usize| -> Result<(), AwsServiceError> {
+        if values.len() == n {
+            Ok(())
+        } else {
+            Err(legacy_validation_err(format!(
+                "ComparisonOperator {operator} requires {n} value(s) in AttributeValueList, got {}",
+                values.len()
+            )))
+        }
+    };
+
+    let frag = match operator {
+        "EQ" => {
+            want(1)?;
+            format!("{name_ph} = {}", values[0])
+        }
+        "NE" => {
+            want(1)?;
+            format!("{name_ph} <> {}", values[0])
+        }
+        "LE" => {
+            want(1)?;
+            format!("{name_ph} <= {}", values[0])
+        }
+        "LT" => {
+            want(1)?;
+            format!("{name_ph} < {}", values[0])
+        }
+        "GE" => {
+            want(1)?;
+            format!("{name_ph} >= {}", values[0])
+        }
+        "GT" => {
+            want(1)?;
+            format!("{name_ph} > {}", values[0])
+        }
+        "BEGINS_WITH" => {
+            want(1)?;
+            format!("begins_with({name_ph}, {})", values[0])
+        }
+        "BETWEEN" => {
+            want(2)?;
+            format!("{name_ph} BETWEEN {} AND {}", values[0], values[1])
+        }
+        "CONTAINS" => {
+            want(1)?;
+            format!("contains({name_ph}, {})", values[0])
+        }
+        "NOT_CONTAINS" => {
+            want(1)?;
+            format!("NOT contains({name_ph}, {})", values[0])
+        }
+        "NOT_NULL" => {
+            want(0)?;
+            format!("attribute_exists({name_ph})")
+        }
+        "NULL" => {
+            want(0)?;
+            format!("attribute_not_exists({name_ph})")
+        }
+        "IN" => {
+            if values.is_empty() {
+                return Err(legacy_validation_err(
+                    "ComparisonOperator IN requires at least one value in AttributeValueList"
+                        .to_string(),
+                ));
+            }
+            format!("{name_ph} IN ({})", values.join(", "))
+        }
+        other => {
+            return Err(legacy_validation_err(format!(
+                "Unsupported ComparisonOperator: {other}"
+            )));
+        }
+    };
+    Ok(frag)
+}
+
 pub(crate) fn evaluate_filter_expression(
     expr: &str,
     item: &HashMap<String, AttributeValue>,
@@ -418,4 +590,171 @@ pub(crate) fn evaluate_filter_expression(
     }
 
     evaluate_single_filter_condition(trimmed, item, expr_attr_names, expr_attr_values)
+}
+
+#[cfg(test)]
+mod legacy_translation_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn item(pairs: &[(&str, Value)]) -> HashMap<String, AttributeValue> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    fn conditions(v: Value) -> serde_json::Map<String, Value> {
+        v.as_object().unwrap().clone()
+    }
+
+    #[test]
+    fn key_conditions_eq_and_begins_with() {
+        let mut names = HashMap::new();
+        let mut values = HashMap::new();
+        let expr = translate_legacy_conditions(
+            &conditions(json!({
+                "pk": {"AttributeValueList": [{"S": "a"}], "ComparisonOperator": "EQ"},
+                "sk": {"AttributeValueList": [{"S": "ord#"}], "ComparisonOperator": "BEGINS_WITH"},
+            })),
+            LegacyConditionRole::Key,
+            &mut names,
+            &mut values,
+        )
+        .unwrap();
+
+        // Sorted attribute order: pk (#legk0) before sk (#legk1).
+        assert_eq!(
+            expr,
+            "#legk0 = :legvk0_0 AND begins_with(#legk1, :legvk1_0)"
+        );
+
+        let matching = item(&[("pk", json!({"S": "a"})), ("sk", json!({"S": "ord#1"}))]);
+        let wrong_pk = item(&[("pk", json!({"S": "b"})), ("sk", json!({"S": "ord#1"}))]);
+        let wrong_sk = item(&[("pk", json!({"S": "a"})), ("sk", json!({"S": "x"}))]);
+        assert!(evaluate_key_condition(&expr, &matching, &names, &values));
+        assert!(!evaluate_key_condition(&expr, &wrong_pk, &names, &values));
+        assert!(!evaluate_key_condition(&expr, &wrong_sk, &names, &values));
+    }
+
+    #[test]
+    fn key_conditions_between_maps_correctly() {
+        let mut names = HashMap::new();
+        let mut values = HashMap::new();
+        let expr = translate_legacy_conditions(
+            &conditions(json!({
+                "n": {
+                    "AttributeValueList": [{"N": "10"}, {"N": "20"}],
+                    "ComparisonOperator": "BETWEEN",
+                },
+            })),
+            LegacyConditionRole::Key,
+            &mut names,
+            &mut values,
+        )
+        .unwrap();
+        assert_eq!(expr, "#legk0 BETWEEN :legvk0_0 AND :legvk0_1");
+
+        let inside = item(&[("n", json!({"N": "15"}))]);
+        let below = item(&[("n", json!({"N": "5"}))]);
+        let above = item(&[("n", json!({"N": "25"}))]);
+        assert!(evaluate_key_condition(&expr, &inside, &names, &values));
+        assert!(!evaluate_key_condition(&expr, &below, &names, &values));
+        assert!(!evaluate_key_condition(&expr, &above, &names, &values));
+    }
+
+    #[test]
+    fn filter_operators_ne_contains_not_null() {
+        let mut names = HashMap::new();
+        let mut values = HashMap::new();
+        let expr = translate_legacy_conditions(
+            &conditions(json!({
+                "color": {"AttributeValueList": [{"S": "red"}], "ComparisonOperator": "NE"},
+                "tags": {"AttributeValueList": [{"S": "vip"}], "ComparisonOperator": "CONTAINS"},
+                "zzz": {"ComparisonOperator": "NOT_NULL"},
+            })),
+            LegacyConditionRole::Filter,
+            &mut names,
+            &mut values,
+        )
+        .unwrap();
+        // Sorted: color (#legf0), tags (#legf1), zzz (#legf2).
+        assert_eq!(
+            expr,
+            "#legf0 <> :legvf0_0 AND contains(#legf1, :legvf1_0) AND attribute_exists(#legf2)"
+        );
+
+        let hit = item(&[
+            ("color", json!({"S": "blue"})),
+            ("tags", json!({"SS": ["vip", "x"]})),
+            ("zzz", json!({"S": "present"})),
+        ]);
+        let miss_color = item(&[
+            ("color", json!({"S": "red"})),
+            ("tags", json!({"SS": ["vip"]})),
+            ("zzz", json!({"S": "present"})),
+        ]);
+        let miss_zzz = item(&[
+            ("color", json!({"S": "blue"})),
+            ("tags", json!({"SS": ["vip"]})),
+        ]);
+        assert!(evaluate_filter_expression(&expr, &hit, &names, &values));
+        assert!(!evaluate_filter_expression(
+            &expr,
+            &miss_color,
+            &names,
+            &values
+        ));
+        assert!(!evaluate_filter_expression(
+            &expr, &miss_zzz, &names, &values
+        ));
+    }
+
+    #[test]
+    fn unknown_operator_rejected() {
+        let mut names = HashMap::new();
+        let mut values = HashMap::new();
+        let err = translate_legacy_conditions(
+            &conditions(json!({
+                "a": {"AttributeValueList": [{"S": "x"}], "ComparisonOperator": "WAT"},
+            })),
+            LegacyConditionRole::Filter,
+            &mut names,
+            &mut values,
+        )
+        .unwrap_err();
+        assert!(format!("{err:?}").contains("Unsupported ComparisonOperator"));
+    }
+
+    #[test]
+    fn wrong_value_count_rejected() {
+        let mut names = HashMap::new();
+        let mut values = HashMap::new();
+        let err = translate_legacy_conditions(
+            &conditions(json!({
+                "n": {"AttributeValueList": [{"N": "10"}], "ComparisonOperator": "BETWEEN"},
+            })),
+            LegacyConditionRole::Key,
+            &mut names,
+            &mut values,
+        )
+        .unwrap_err();
+        assert!(format!("{err:?}").contains("requires 2 value"));
+    }
+
+    #[test]
+    fn key_role_rejects_filter_only_operator() {
+        let mut names = HashMap::new();
+        let mut values = HashMap::new();
+        let err = translate_legacy_conditions(
+            &conditions(json!({
+                "a": {"AttributeValueList": [{"S": "x"}], "ComparisonOperator": "CONTAINS"},
+            })),
+            LegacyConditionRole::Key,
+            &mut names,
+            &mut values,
+        )
+        .unwrap_err();
+        assert!(format!("{err:?}").contains("Unsupported operator on KeyConditions"));
+    }
 }

--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -11,7 +11,8 @@ use super::{
     build_consumed_capacity, compare_attribute_values, evaluate_filter_expression,
     evaluate_key_condition, extract_key_for_schema, get_table, item_matches_key,
     parse_expression_attribute_names, parse_expression_attribute_values, parse_key_map,
-    project_item, require_str, return_consumed_mode, DynamoDbService,
+    project_item, require_str, return_consumed_mode, translate_legacy_conditions, DynamoDbService,
+    LegacyConditionRole,
 };
 
 impl DynamoDbService {
@@ -25,24 +26,43 @@ impl DynamoDbService {
         let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
-        let expr_attr_names = parse_expression_attribute_names(&body);
-        let expr_attr_values = parse_expression_attribute_values(&body);
+        let mut expr_attr_names = parse_expression_attribute_names(&body);
+        let mut expr_attr_values = parse_expression_attribute_values(&body);
 
-        let key_condition = body["KeyConditionExpression"].as_str();
-        // Query REQUIRES a key condition. Without one, AWS rejects the
-        // request rather than scanning the whole table — returning every
-        // item on a missing KeyConditionExpression is a silent
-        // wrong-result bug (bug-audit 2026-05-28, 1.1). The legacy
-        // `KeyConditions`/`QueryFilter` parameters are not supported here,
-        // so an absent KeyConditionExpression is always invalid.
-        if key_condition.map(str::trim).unwrap_or("").is_empty() {
-            return Err(AwsServiceError::aws_error(
-                http::StatusCode::BAD_REQUEST,
-                "ValidationException",
-                "Either the KeyConditions or KeyConditionExpression parameter must be specified in the request.",
-            ));
-        }
-        let filter_expression = body["FilterExpression"].as_str();
+        // Query REQUIRES a key condition. Accept either the modern
+        // `KeyConditionExpression` or the legacy `KeyConditions` parameter
+        // (AWS-deprecated in 2014 but still accepted by real DynamoDB and
+        // every SDK), which we translate into the equivalent expression and
+        // evaluate through the same machinery. Without any key condition,
+        // AWS rejects the request rather than scanning the whole table —
+        // returning every item would be a silent wrong-result bug
+        // (bug-audit 2026-05-28, 1.1).
+        let key_condition = resolve_legacy_or_expression(
+            &body,
+            "KeyConditionExpression",
+            "KeyConditions",
+            LegacyConditionRole::Key,
+            &mut expr_attr_names,
+            &mut expr_attr_values,
+        )?;
+        let key_condition = match key_condition {
+            Some(kc) if !kc.trim().is_empty() => kc,
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    http::StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Either the KeyConditions or KeyConditionExpression parameter must be specified in the request.",
+                ));
+            }
+        };
+        let filter_expression = resolve_legacy_or_expression(
+            &body,
+            "FilterExpression",
+            "QueryFilter",
+            LegacyConditionRole::Filter,
+            &mut expr_attr_names,
+            &mut expr_attr_values,
+        )?;
         let scan_forward = body["ScanIndexForward"].as_bool().unwrap_or(true);
         let limit = body["Limit"].as_i64().map(|l| l as usize);
         let index_name = body["IndexName"].as_str();
@@ -106,11 +126,7 @@ impl DynamoDbService {
         let mut matched: Vec<&HashMap<String, AttributeValue>> = items_to_scan
             .iter()
             .filter(|item| {
-                if let Some(kc) = key_condition {
-                    evaluate_key_condition(kc, item, &expr_attr_names, &expr_attr_values)
-                } else {
-                    true
-                }
+                evaluate_key_condition(&key_condition, item, &expr_attr_names, &expr_attr_values)
             })
             .collect();
 
@@ -221,7 +237,7 @@ impl DynamoDbService {
 
         let scanned_count = matched.len();
 
-        if let Some(filter) = filter_expression {
+        if let Some(filter) = filter_expression.as_deref() {
             matched.retain(|item| {
                 evaluate_filter_expression(filter, item, &expr_attr_names, &expr_attr_values)
             });
@@ -323,9 +339,18 @@ impl DynamoDbService {
         let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
-        let expr_attr_names = parse_expression_attribute_names(&body);
-        let expr_attr_values = parse_expression_attribute_values(&body);
-        let filter_expression = body["FilterExpression"].as_str();
+        let mut expr_attr_names = parse_expression_attribute_names(&body);
+        let mut expr_attr_values = parse_expression_attribute_values(&body);
+        // Accept the legacy `ScanFilter` parameter alongside the modern
+        // `FilterExpression` (same parity rationale as Query's QueryFilter).
+        let filter_expression = resolve_legacy_or_expression(
+            &body,
+            "FilterExpression",
+            "ScanFilter",
+            LegacyConditionRole::Filter,
+            &mut expr_attr_names,
+            &mut expr_attr_values,
+        )?;
         let limit = body["Limit"].as_i64().map(|l| l as usize);
         let exclusive_start_key: Option<HashMap<String, AttributeValue>> =
             parse_key_map(&body["ExclusiveStartKey"]);
@@ -445,7 +470,7 @@ impl DynamoDbService {
 
         let scanned_count = matched.len();
 
-        if let Some(filter) = filter_expression {
+        if let Some(filter) = filter_expression.as_deref() {
             matched.retain(|item| {
                 evaluate_filter_expression(filter, item, &expr_attr_names, &expr_attr_values)
             });
@@ -535,6 +560,46 @@ impl DynamoDbService {
         }
 
         Self::ok_json(result)
+    }
+}
+
+/// Resolve an expression-API parameter (`KeyConditionExpression` /
+/// `FilterExpression`) against its legacy non-expression counterpart
+/// (`KeyConditions` / `QueryFilter` / `ScanFilter`) for one role.
+///
+/// Returns the expression string to evaluate, or `None` when neither form
+/// was supplied (callers decide whether that's an error). When only the
+/// legacy form is present it is translated and its placeholders are injected
+/// into `names`/`values`. Supplying both forms for the same role is rejected,
+/// matching real DynamoDB.
+fn resolve_legacy_or_expression(
+    body: &Value,
+    expression_param: &str,
+    legacy_param: &str,
+    role: LegacyConditionRole,
+    names: &mut HashMap<String, String>,
+    values: &mut HashMap<String, Value>,
+) -> Result<Option<String>, AwsServiceError> {
+    let expression = body[expression_param]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let legacy = body[legacy_param].as_object().filter(|m| !m.is_empty());
+
+    match (expression, legacy) {
+        (Some(_), Some(_)) => Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            format!(
+                "Can not use both expression and non-expression parameters in the same request: \
+                 Non-expression parameters: {{{legacy_param}}} Expression parameters: {{{expression_param}}}"
+            ),
+        )),
+        (Some(expr), None) => Ok(Some(expr.to_string())),
+        (None, Some(legacy)) => Ok(Some(translate_legacy_conditions(
+            legacy, role, names, values,
+        )?)),
+        (None, None) => Ok(None),
     }
 }
 

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -4900,3 +4900,268 @@ async fn dynamodb_partiql_execute_statement_emits_stream_record() {
         .iter()
         .all(|r| r.event_name().unwrap().as_str() == "INSERT"));
 }
+
+/// Helper: create a simple HASH-only table with partition key `pk`.
+async fn create_pk_table(client: &aws_sdk_dynamodb::Client, name: &str) {
+    client
+        .create_table()
+        .table_name(name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+}
+
+/// The canonical repro: a legacy `KeyConditions` Query (EQ on the hash key)
+/// must return the same item as the equivalent `KeyConditionExpression`.
+/// `KeyConditions` was AWS-deprecated in 2014 but is still accepted by real
+/// DynamoDB and every SDK — this is a parity fix.
+#[tokio::test]
+async fn dynamodb_query_legacy_key_conditions_eq() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+    create_pk_table(&client, "t").await;
+
+    client
+        .put_item()
+        .table_name("t")
+        .item("pk", AttributeValue::S("a".to_string()))
+        .item("v", AttributeValue::S("1".to_string()))
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_item()
+        .table_name("t")
+        .item("pk", AttributeValue::S("b".to_string()))
+        .item("v", AttributeValue::S("2".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    let output = server
+        .aws_cli(&[
+            "dynamodb",
+            "query",
+            "--table-name",
+            "t",
+            "--key-conditions",
+            r#"{"pk":{"AttributeValueList":[{"S":"a"}],"ComparisonOperator":"EQ"}}"#,
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "legacy KeyConditions query failed: {}",
+        output.stderr_text()
+    );
+    let json = output.stdout_json();
+    assert_eq!(json["Count"].as_i64().unwrap(), 1);
+    assert_eq!(json["Items"][0]["pk"]["S"].as_str().unwrap(), "a");
+    assert_eq!(json["Items"][0]["v"]["S"].as_str().unwrap(), "1");
+}
+
+/// Legacy `KeyConditions` on a composite key: EQ on the hash plus
+/// BEGINS_WITH on the sort key.
+#[tokio::test]
+async fn dynamodb_query_legacy_key_conditions_begins_with() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+    client
+        .create_table()
+        .table_name("orders")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("sk")
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("sk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    for sk in ["ord#1", "ord#2", "shp#1"] {
+        client
+            .put_item()
+            .table_name("orders")
+            .item("pk", AttributeValue::S("u1".to_string()))
+            .item("sk", AttributeValue::S(sk.to_string()))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let output = server
+        .aws_cli(&[
+            "dynamodb",
+            "query",
+            "--table-name",
+            "orders",
+            "--key-conditions",
+            r#"{"pk":{"AttributeValueList":[{"S":"u1"}],"ComparisonOperator":"EQ"},"sk":{"AttributeValueList":[{"S":"ord#"}],"ComparisonOperator":"BEGINS_WITH"}}"#,
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "legacy composite KeyConditions query failed: {}",
+        output.stderr_text()
+    );
+    let json = output.stdout_json();
+    assert_eq!(json["Count"].as_i64().unwrap(), 2);
+    let sks: Vec<&str> = json["Items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["sk"]["S"].as_str().unwrap())
+        .collect();
+    assert_eq!(sks, vec!["ord#1", "ord#2"]);
+}
+
+/// Legacy `QueryFilter` (a non-key filter) must apply on top of the key
+/// condition, mirroring `FilterExpression`.
+#[tokio::test]
+async fn dynamodb_query_legacy_query_filter() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+    create_pk_table(&client, "t").await;
+
+    for (pk, color) in [("a", "red"), ("b", "red"), ("c", "blue")] {
+        client
+            .put_item()
+            .table_name("t")
+            .item("pk", AttributeValue::S(pk.to_string()))
+            .item("color", AttributeValue::S(color.to_string()))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let output = server
+        .aws_cli(&[
+            "dynamodb",
+            "query",
+            "--table-name",
+            "t",
+            "--key-conditions",
+            r#"{"pk":{"AttributeValueList":[{"S":"a"}],"ComparisonOperator":"EQ"}}"#,
+            "--query-filter",
+            r#"{"color":{"AttributeValueList":[{"S":"blue"}],"ComparisonOperator":"EQ"}}"#,
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "legacy QueryFilter query failed: {}",
+        output.stderr_text()
+    );
+    let json = output.stdout_json();
+    // pk=a is the only key match, but its color is red, so the filter drops it.
+    assert_eq!(json["Count"].as_i64().unwrap(), 0);
+    assert_eq!(json["ScannedCount"].as_i64().unwrap(), 1);
+}
+
+/// Legacy `ScanFilter` on Scan must behave like `FilterExpression`.
+#[tokio::test]
+async fn dynamodb_scan_legacy_scan_filter() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+    create_pk_table(&client, "t").await;
+
+    for (pk, color) in [("a", "red"), ("b", "blue"), ("c", "red")] {
+        client
+            .put_item()
+            .table_name("t")
+            .item("pk", AttributeValue::S(pk.to_string()))
+            .item("color", AttributeValue::S(color.to_string()))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let output = server
+        .aws_cli(&[
+            "dynamodb",
+            "scan",
+            "--table-name",
+            "t",
+            "--scan-filter",
+            r#"{"color":{"AttributeValueList":[{"S":"red"}],"ComparisonOperator":"EQ"}}"#,
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "legacy ScanFilter scan failed: {}",
+        output.stderr_text()
+    );
+    let json = output.stdout_json();
+    assert_eq!(json["Count"].as_i64().unwrap(), 2);
+}
+
+/// Mixing the legacy and expression forms for the same role is rejected by
+/// real DynamoDB; we must reject it too.
+#[tokio::test]
+async fn dynamodb_query_rejects_mixed_key_condition_forms() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+    create_pk_table(&client, "t").await;
+
+    let output = server
+        .aws_cli(&[
+            "dynamodb",
+            "query",
+            "--table-name",
+            "t",
+            "--key-condition-expression",
+            "pk = :v",
+            "--expression-attribute-values",
+            r#"{":v":{"S":"a"}}"#,
+            "--key-conditions",
+            r#"{"pk":{"AttributeValueList":[{"S":"a"}],"ComparisonOperator":"EQ"}}"#,
+        ])
+        .await;
+    assert!(
+        !output.success(),
+        "mixing KeyConditions + KeyConditionExpression must be rejected"
+    );
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.contains("ValidationException")
+            && stderr.contains("both expression and non-expression"),
+        "unexpected error: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes #1685.

## What

`Query` and `Scan` only implemented the expression API (`KeyConditionExpression` /
`FilterExpression`). The legacy `KeyConditions` / `QueryFilter` / `ScanFilter` parameters were
ignored, and `Query` rejected the request with a message that ironically named the parameter
the caller *did* supply:

```
ValidationException: Either the KeyConditions or KeyConditionExpression
parameter must be specified in the request.
```

## Why (parity, not endorsement)

AWS deprecated `KeyConditions`/`QueryFilter` in **2014** in favor of the expression API, but
never removed them — real DynamoDB and every official SDK still accept them today, and they
remain common in long-lived and pinned-SDK codebases (AWS never forced a migration). Since
fakecloud's premise is high-fidelity AWS behavior, silently rejecting input real DynamoDB
accepts is a parity gap regardless of the parameter's age.

## How

Translate the legacy form at the request boundary into the equivalent expression string —
hoisting attribute names into `#`-placeholders and values into `:`-placeholders in the
existing expr-attr maps — then feed it through the existing `evaluate_key_condition` /
`evaluate_filter_expression` machinery. **No evaluation logic changes.**

Operator mapping: `EQ`→`=`, `LE`→`<=`, `LT`→`<`, `GE`→`>=`, `GT`→`>`, `NE`→`<>`,
`BEGINS_WITH`→`begins_with(...)`, `BETWEEN`→`x BETWEEN :lo AND :hi`, `CONTAINS`/`NOT_CONTAINS`,
`NULL`/`NOT_NULL`→`attribute_not_exists`/`attribute_exists`, `IN`. Entries are AND-ed. Mixing
the legacy and expression forms for the same role is rejected (matching AWS); an absent key
condition keeps the original error.

## Scope

Covers `KeyConditions` + `QueryFilter` (Query) and `ScanFilter` (Scan). `Expected` (conditional
writes) and `AttributesToGet` (legacy projection) are the same family and a sensible follow-up,
but deferred here to keep the change focused.

## Tests

- **Unit** (`conditions.rs`): the translation helper directly — `EQ` + `BEGINS_WITH`, `BETWEEN`,
  filter-only operators, and error cases (unknown operator, wrong arg count, key-role rejecting
  a filter-only operator).
- **E2E** (`dynamodb.rs`, via the `aws` CLI, which emits the legacy wire shape): the canonical
  `--key-conditions` repro, a composite `EQ`+`BEGINS_WITH` query, `--query-filter`,
  `--scan-filter`, and the mixed-form rejection.

Validated: `cargo test -p fakecloud-dynamodb` (290 ok), `cargo test -p fakecloud-e2e dynamodb`
(68 ok), `cargo clippy --workspace --all-targets -- -D warnings` (clean), `cargo fmt --all --check` (clean).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for DynamoDB legacy `KeyConditions`, `QueryFilter`, and `ScanFilter` by translating them into expression syntax. Restores AWS parity for Query/Scan and fixes rejections of valid legacy requests; evaluation logic is unchanged.

- **Bug Fixes**
  - Query/Scan now accept legacy params and translate them to `KeyConditionExpression`/`FilterExpression` with placeholders, then evaluate via existing code.
  - Mixing legacy and expression forms for the same role is rejected with a `ValidationException`, matching AWS.
  - Query still requires a key condition; missing conditions are rejected (no silent full-table scan).
  - Added unit and E2E tests (via `aws` CLI) covering key conditions, non-key filters, and mixed-form rejection.

<sup>Written for commit ed1aa290b08101c8b8c5118cb8727f4317a8159a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

