### PR TITLE
feat(cloudformation): provision SQS/SNS/S3 policy resources

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -824,6 +824,17 @@ impl ProvisionResult {
     }
 }
 
+/// Extract a resource policy's `PolicyDocument` property as a JSON string,
+/// accepting either an inline object or an already-serialized string. Shared by
+/// the SQS/SNS/S3 resource-policy provisioners.
+fn policy_document_string(props: &serde_json::Value) -> Result<String, String> {
+    match props.get("PolicyDocument") {
+        Some(serde_json::Value::String(s)) => Ok(s.clone()),
+        Some(other) => Ok(other.to_string()),
+        None => Err("PolicyDocument is required".to_string()),
+    }
+}
+
 /// Holds references to all service states so CloudFormation can provision resources.
 pub struct ResourceProvisioner {
     pub sqs_state: SharedSqsState,
@@ -903,7 +914,9 @@ impl ResourceProvisioner {
     pub fn create_resource(&self, resource: &ResourceDefinition) -> Result<StackResource, String> {
         let result = match resource.resource_type.as_str() {
             "AWS::SQS::Queue" => self.create_sqs_queue(resource),
+            "AWS::SQS::QueuePolicy" => self.create_sqs_queue_policy(resource),
             "AWS::SNS::Topic" => self.create_sns_topic(resource),
+            "AWS::SNS::TopicPolicy" => self.create_sns_topic_policy(resource),
             "AWS::SNS::Subscription" => self.create_sns_subscription(resource),
             "AWS::SSM::Parameter" => self.create_ssm_parameter(resource),
             "AWS::IAM::Role" => self.create_iam_role(resource),
@@ -919,6 +932,7 @@ impl ResourceProvisioner {
             "AWS::IAM::ServiceLinkedRole" => self.create_iam_service_linked_role(resource),
             "AWS::IAM::VirtualMFADevice" => self.create_iam_virtual_mfa_device(resource),
             "AWS::S3::Bucket" => self.create_s3_bucket(resource),
+            "AWS::S3::BucketPolicy" => self.create_s3_bucket_policy(resource),
             "AWS::Events::Rule" => self.create_eventbridge_rule(resource),
             "AWS::Events::Connection" => self.create_eventbridge_connection(resource),
             "AWS::Events::ApiDestination" => self.create_eventbridge_api_destination(resource),
@@ -1263,6 +1277,9 @@ impl ResourceProvisioner {
             "AWS::StepFunctions::StateMachine" => {
                 Some(self.update_sfn_state_machine(existing, new_def)?)
             }
+            "AWS::SQS::QueuePolicy" => Some(self.update_sqs_queue_policy(existing, new_def)?),
+            "AWS::SNS::TopicPolicy" => Some(self.update_sns_topic_policy(existing, new_def)?),
+            "AWS::S3::BucketPolicy" => Some(self.update_s3_bucket_policy(existing, new_def)?),
             _ => None,
         };
 
@@ -1391,7 +1408,9 @@ impl ResourceProvisioner {
     pub fn delete_resource(&self, resource: &StackResource) -> Result<(), String> {
         match resource.resource_type.as_str() {
             "AWS::SQS::Queue" => self.delete_sqs_queue(&resource.physical_id),
+            "AWS::SQS::QueuePolicy" => self.delete_sqs_queue_policy(&resource.physical_id),
             "AWS::SNS::Topic" => self.delete_sns_topic(&resource.physical_id),
+            "AWS::SNS::TopicPolicy" => self.delete_sns_topic_policy(&resource.physical_id),
             "AWS::SNS::Subscription" => self.delete_sns_subscription(&resource.physical_id),
             "AWS::SSM::Parameter" => self.delete_ssm_parameter(&resource.physical_id),
             "AWS::IAM::Role" => self.delete_iam_role(&resource.physical_id),
@@ -1413,6 +1432,7 @@ impl ResourceProvisioner {
                 self.delete_iam_virtual_mfa_device(&resource.physical_id)
             }
             "AWS::S3::Bucket" => self.delete_s3_bucket(&resource.physical_id),
+            "AWS::S3::BucketPolicy" => self.delete_s3_bucket_policy(&resource.physical_id),
             "AWS::Events::Rule" => self.delete_eventbridge_rule(&resource.physical_id),
             "AWS::Events::Connection" => self.delete_eventbridge_connection(&resource.physical_id),
             "AWS::Events::EventBus" => self.delete_eventbridge_event_bus(&resource.physical_id),
@@ -6276,6 +6296,141 @@ mod tests {
         let sr = prov.create_resource(&res).unwrap();
         assert_eq!(sr.physical_id, "my-bucket");
         prov.delete_resource(&sr).unwrap();
+    }
+
+    #[test]
+    fn sqs_queue_policy_stored_on_queue_and_cleared_on_delete() {
+        let prov = make_provisioner();
+        let queue = prov
+            .create_resource(&make_resource(
+                "AWS::SQS::Queue",
+                "Q",
+                serde_json::json!({"QueueName": "q1"}),
+            ))
+            .unwrap();
+        // `Queues` carries the queue URL — what `Ref` resolves to.
+        let policy = make_resource(
+            "AWS::SQS::QueuePolicy",
+            "QP",
+            serde_json::json!({
+                "Queues": [queue.physical_id.clone()],
+                "PolicyDocument": {"Version": "2012-10-17", "Statement": [{
+                    "Effect": "Allow",
+                    "Principal": {"Service": "sns.amazonaws.com"},
+                    "Action": "sqs:SendMessage",
+                    "Resource": "*"
+                }]}
+            }),
+        );
+        let sr = prov.create_resource(&policy).unwrap();
+
+        {
+            let mut accounts = prov.sqs_state.write();
+            let state = accounts.get_or_create(&prov.account_id);
+            let stored = state.queues[&queue.physical_id]
+                .attributes
+                .get("Policy")
+                .expect("policy stored on queue");
+            assert!(stored.contains("sqs:SendMessage"));
+        }
+
+        prov.delete_resource(&sr).unwrap();
+        {
+            let mut accounts = prov.sqs_state.write();
+            let state = accounts.get_or_create(&prov.account_id);
+            assert!(!state.queues[&queue.physical_id]
+                .attributes
+                .contains_key("Policy"));
+        }
+    }
+
+    #[test]
+    fn sns_topic_policy_stored_on_topic_and_cleared_on_delete() {
+        let prov = make_provisioner();
+        let topic = prov
+            .create_resource(&make_resource(
+                "AWS::SNS::Topic",
+                "T",
+                serde_json::json!({"TopicName": "t1"}),
+            ))
+            .unwrap();
+        let policy = make_resource(
+            "AWS::SNS::TopicPolicy",
+            "TP",
+            serde_json::json!({
+                "Topics": [topic.physical_id.clone()],
+                "PolicyDocument": {"Version": "2012-10-17", "Statement": [{
+                    "Effect": "Allow",
+                    "Principal": {"Service": "events.amazonaws.com"},
+                    "Action": "sns:Publish",
+                    "Resource": "*"
+                }]}
+            }),
+        );
+        let sr = prov.create_resource(&policy).unwrap();
+
+        {
+            let mut accounts = prov.sns_state.write();
+            let state = accounts.get_or_create(&prov.account_id);
+            let stored = state.topics[&topic.physical_id]
+                .attributes
+                .get("Policy")
+                .expect("policy stored on topic");
+            assert!(stored.contains("sns:Publish"));
+        }
+
+        prov.delete_resource(&sr).unwrap();
+        {
+            let mut accounts = prov.sns_state.write();
+            let state = accounts.get_or_create(&prov.account_id);
+            assert!(!state.topics[&topic.physical_id]
+                .attributes
+                .contains_key("Policy"));
+        }
+    }
+
+    #[test]
+    fn s3_bucket_policy_stored_on_bucket_and_cleared_on_delete() {
+        let prov = make_provisioner();
+        let bucket = prov
+            .create_resource(&make_resource(
+                "AWS::S3::Bucket",
+                "B",
+                serde_json::json!({"BucketName": "b1"}),
+            ))
+            .unwrap();
+        let policy = make_resource(
+            "AWS::S3::BucketPolicy",
+            "BP",
+            serde_json::json!({
+                "Bucket": bucket.physical_id.clone(),
+                "PolicyDocument": {"Version": "2012-10-17", "Statement": [{
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": "s3:GetObject",
+                    "Resource": "arn:aws:s3:::b1/*"
+                }]}
+            }),
+        );
+        let sr = prov.create_resource(&policy).unwrap();
+        assert_eq!(sr.physical_id, "b1-policy");
+
+        {
+            let mut accounts = prov.s3_state.write();
+            let state = accounts.get_or_create(&prov.account_id);
+            let stored = state.buckets[&bucket.physical_id]
+                .policy
+                .as_ref()
+                .expect("policy stored on bucket");
+            assert!(stored.contains("s3:GetObject"));
+        }
+
+        prov.delete_resource(&sr).unwrap();
+        {
+            let mut accounts = prov.s3_state.write();
+            let state = accounts.get_or_create(&prov.account_id);
+            assert!(state.buckets[&bucket.physical_id].policy.is_none());
+        }
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/s3.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/s3.rs
@@ -65,4 +65,76 @@ impl ResourceProvisioner {
         state.buckets.remove(physical_id);
         Ok(())
     }
+
+    // --- S3 BucketPolicy ---
+    //
+    // AWS::S3::BucketPolicy stores the PolicyDocument on `bucket.policy` — the
+    // same field PutBucketPolicy writes — so GetBucketPolicy round-trips it.
+    // The `Bucket` property is a single Ref already resolved to the bucket name
+    // (which is the bucket's physical id). The policy resource's physical id is
+    // `{bucket}-policy`; delete strips the suffix to recover the bucket name.
+
+    pub(super) fn create_s3_bucket_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let bucket_name = s3_policy_bucket_name(&resource.properties)?;
+        let policy = policy_document_string(&resource.properties)?;
+
+        let mut __s3_mas = self.s3_state.write();
+        let state = __s3_mas.get_or_create(&self.account_id);
+        let bucket = state
+            .buckets
+            .get_mut(&bucket_name)
+            .ok_or_else(|| format!("Bucket {bucket_name} not yet provisioned"))?;
+        bucket.policy = Some(policy);
+        Ok(ProvisionResult::new(format!("{bucket_name}-policy")))
+    }
+
+    pub(super) fn update_s3_bucket_policy(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let bucket_name = s3_policy_bucket_name(&resource.properties)?;
+        let policy = policy_document_string(&resource.properties)?;
+
+        let mut __s3_mas = self.s3_state.write();
+        let state = __s3_mas.get_or_create(&self.account_id);
+        // If the policy was moved to a different bucket, clear the old one.
+        let old_bucket = existing
+            .physical_id
+            .strip_suffix("-policy")
+            .unwrap_or(&existing.physical_id);
+        if old_bucket != bucket_name {
+            if let Some(bucket) = state.buckets.get_mut(old_bucket) {
+                bucket.policy = None;
+            }
+        }
+        let bucket = state
+            .buckets
+            .get_mut(&bucket_name)
+            .ok_or_else(|| format!("Bucket {bucket_name} not yet provisioned"))?;
+        bucket.policy = Some(policy);
+        Ok(ProvisionResult::new(format!("{bucket_name}-policy")))
+    }
+
+    pub(super) fn delete_s3_bucket_policy(&self, physical_id: &str) -> Result<(), String> {
+        let bucket_name = physical_id.strip_suffix("-policy").unwrap_or(physical_id);
+        let mut __s3_mas = self.s3_state.write();
+        let state = __s3_mas.get_or_create(&self.account_id);
+        if let Some(bucket) = state.buckets.get_mut(bucket_name) {
+            bucket.policy = None;
+        }
+        Ok(())
+    }
+}
+
+/// Resolve the `Bucket` property (a Ref already resolved to the bucket name).
+fn s3_policy_bucket_name(props: &serde_json::Value) -> Result<String, String> {
+    props
+        .get("Bucket")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "Bucket is required".to_string())
 }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
@@ -115,4 +115,96 @@ impl ResourceProvisioner {
         state.subscriptions.remove(physical_id);
         Ok(())
     }
+
+    // --- SNS TopicPolicy ---
+    //
+    // AWS::SNS::TopicPolicy stores the PolicyDocument as the `Policy` attribute
+    // on each referenced topic, so a subsequent GetTopicAttributes round-trips
+    // it. The `Topics` property is a list of topic ARNs (Refs are resolved to
+    // physical ids before we run). The physical id encodes those ARNs
+    // (newline-joined) so delete can locate and clear each topic.
+
+    pub(super) fn create_sns_topic_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let topic_arns = sns_policy_topic_arns(&resource.properties)?;
+        let policy = policy_document_string(&resource.properties)?;
+
+        let mut __sns_mas = self.sns_state.write();
+        let state = __sns_mas.get_or_create(&self.account_id);
+        for arn in &topic_arns {
+            let topic = state
+                .topics
+                .get_mut(arn)
+                .ok_or_else(|| format!("Topic {arn} not yet provisioned"))?;
+            topic
+                .attributes
+                .insert("Policy".to_string(), policy.clone());
+        }
+        Ok(ProvisionResult::new(topic_arns.join("\n")))
+    }
+
+    pub(super) fn update_sns_topic_policy(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let old_arns: Vec<String> = existing
+            .physical_id
+            .split('\n')
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+        let new_arns = sns_policy_topic_arns(&resource.properties)?;
+        let policy = policy_document_string(&resource.properties)?;
+
+        let mut __sns_mas = self.sns_state.write();
+        let state = __sns_mas.get_or_create(&self.account_id);
+        for arn in &old_arns {
+            if !new_arns.contains(arn) {
+                if let Some(topic) = state.topics.get_mut(arn) {
+                    topic.attributes.remove("Policy");
+                }
+            }
+        }
+        for arn in &new_arns {
+            let topic = state
+                .topics
+                .get_mut(arn)
+                .ok_or_else(|| format!("Topic {arn} not yet provisioned"))?;
+            topic
+                .attributes
+                .insert("Policy".to_string(), policy.clone());
+        }
+        Ok(ProvisionResult::new(new_arns.join("\n")))
+    }
+
+    pub(super) fn delete_sns_topic_policy(&self, physical_id: &str) -> Result<(), String> {
+        let mut __sns_mas = self.sns_state.write();
+        let state = __sns_mas.get_or_create(&self.account_id);
+        for arn in physical_id.split('\n').filter(|s| !s.is_empty()) {
+            if let Some(topic) = state.topics.get_mut(arn) {
+                topic.attributes.remove("Policy");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resolve the `Topics` property (a list of Refs already resolved to topic
+/// ARNs) into a list of topic ARNs.
+fn sns_policy_topic_arns(props: &serde_json::Value) -> Result<Vec<String>, String> {
+    let topics = props
+        .get("Topics")
+        .and_then(|v| v.as_array())
+        .ok_or("Topics is required")?;
+    let arns: Vec<String> = topics
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect();
+    if arns.is_empty() {
+        return Err("Topics must contain at least one topic".to_string());
+    }
+    Ok(arns)
 }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sqs.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sqs.rs
@@ -88,4 +88,99 @@ impl ResourceProvisioner {
         }
         Ok(())
     }
+
+    // --- SQS QueuePolicy ---
+    //
+    // AWS::SQS::QueuePolicy doesn't create a standalone object; it stores the
+    // PolicyDocument as the `Policy` attribute on each referenced queue, so a
+    // subsequent GetQueueAttributes round-trips it. The `Queues` property is a
+    // list of queue URLs (Refs are already resolved to physical ids by the
+    // time we run). The physical id encodes those URLs (newline-joined, a char
+    // that can't appear in a URL) so delete can locate and clear each queue.
+
+    pub(super) fn create_sqs_queue_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let queue_urls = sqs_policy_queue_urls(&resource.properties)?;
+        let policy = policy_document_string(&resource.properties)?;
+
+        let mut __sqs_mas = self.sqs_state.write();
+        let state = __sqs_mas.get_or_create(&self.account_id);
+        for url in &queue_urls {
+            let queue = state
+                .queues
+                .get_mut(url)
+                .ok_or_else(|| format!("Queue {url} not yet provisioned"))?;
+            queue
+                .attributes
+                .insert("Policy".to_string(), policy.clone());
+        }
+        Ok(ProvisionResult::new(queue_urls.join("\n")))
+    }
+
+    pub(super) fn update_sqs_queue_policy(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        // Clear the policy from queues that are no longer referenced, then
+        // (re)apply to the current set.
+        let old_urls: Vec<String> = existing
+            .physical_id
+            .split('\n')
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+        let new_urls = sqs_policy_queue_urls(&resource.properties)?;
+        let policy = policy_document_string(&resource.properties)?;
+
+        let mut __sqs_mas = self.sqs_state.write();
+        let state = __sqs_mas.get_or_create(&self.account_id);
+        for url in &old_urls {
+            if !new_urls.contains(url) {
+                if let Some(queue) = state.queues.get_mut(url) {
+                    queue.attributes.remove("Policy");
+                }
+            }
+        }
+        for url in &new_urls {
+            let queue = state
+                .queues
+                .get_mut(url)
+                .ok_or_else(|| format!("Queue {url} not yet provisioned"))?;
+            queue
+                .attributes
+                .insert("Policy".to_string(), policy.clone());
+        }
+        Ok(ProvisionResult::new(new_urls.join("\n")))
+    }
+
+    pub(super) fn delete_sqs_queue_policy(&self, physical_id: &str) -> Result<(), String> {
+        let mut __sqs_mas = self.sqs_state.write();
+        let state = __sqs_mas.get_or_create(&self.account_id);
+        for url in physical_id.split('\n').filter(|s| !s.is_empty()) {
+            if let Some(queue) = state.queues.get_mut(url) {
+                queue.attributes.remove("Policy");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resolve the `Queues` property (a list of Refs already resolved to queue
+/// URLs) into a list of queue URLs.
+fn sqs_policy_queue_urls(props: &serde_json::Value) -> Result<Vec<String>, String> {
+    let queues = props
+        .get("Queues")
+        .and_then(|v| v.as_array())
+        .ok_or("Queues is required")?;
+    let urls: Vec<String> = queues
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect();
+    if urls.is_empty() {
+        return Err("Queues must contain at least one queue".to_string());
+    }
+    Ok(urls)
 }

--- a/crates/fakecloud-e2e/tests/cloudformation_resource_policies.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_resource_policies.rs
@@ -1,0 +1,229 @@
+//! CloudFormation provisioners for resource-policy types:
+//! AWS::SQS::QueuePolicy, AWS::SNS::TopicPolicy, AWS::S3::BucketPolicy.
+//! Each stores the PolicyDocument on its parent resource so the parent
+//! service's Get API round-trips it.
+
+mod helpers;
+
+use aws_sdk_sqs::types::QueueAttributeName;
+use helpers::TestServer;
+
+fn output<'a>(stack: &'a aws_sdk_cloudformation::types::Stack, key: &str) -> Option<&'a str> {
+    stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some(key))
+        .and_then(|o| o.output_value())
+}
+
+const QUEUE_POLICY_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Q": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "cfn-qp-queue"}},
+    "QP": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "Queues": [{"Ref": "Q"}],
+        "PolicyDocument": {"Version": "2012-10-17", "Statement": [{
+          "Effect": "Allow",
+          "Principal": {"Service": "sns.amazonaws.com"},
+          "Action": "sqs:SendMessage",
+          "Resource": "*"
+        }]}
+      }
+    }
+  },
+  "Outputs": {"QueueUrl": {"Value": {"Ref": "Q"}}}
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_sqs_queue_policy() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let sqs = server.sqs_client().await;
+
+    cfn.create_stack()
+        .stack_name("qp-stack")
+        .template_body(QUEUE_POLICY_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("qp-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+    let queue_url = output(stack, "QueueUrl")
+        .expect("QueueUrl output")
+        .to_string();
+
+    let attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(QueueAttributeName::Policy)
+        .send()
+        .await
+        .expect("get_queue_attributes");
+    let policy = attrs
+        .attributes()
+        .and_then(|m| m.get(&QueueAttributeName::Policy))
+        .expect("Policy attribute present");
+    assert!(
+        policy.contains("sqs:SendMessage"),
+        "queue policy should round-trip: {policy}"
+    );
+
+    cfn.delete_stack()
+        .stack_name("qp-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+    let after = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .send()
+        .await;
+    assert!(after.is_err(), "queue should be gone after stack deletion");
+}
+
+const TOPIC_POLICY_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "T": {"Type": "AWS::SNS::Topic", "Properties": {"TopicName": "cfn-tp-topic"}},
+    "TP": {
+      "Type": "AWS::SNS::TopicPolicy",
+      "Properties": {
+        "Topics": [{"Ref": "T"}],
+        "PolicyDocument": {"Version": "2012-10-17", "Statement": [{
+          "Effect": "Allow",
+          "Principal": {"Service": "events.amazonaws.com"},
+          "Action": "sns:Publish",
+          "Resource": "*"
+        }]}
+      }
+    }
+  },
+  "Outputs": {"TopicArn": {"Value": {"Ref": "T"}}}
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_sns_topic_policy() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let sns = server.sns_client().await;
+
+    cfn.create_stack()
+        .stack_name("tp-stack")
+        .template_body(TOPIC_POLICY_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("tp-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+    let topic_arn = output(stack, "TopicArn")
+        .expect("TopicArn output")
+        .to_string();
+
+    let attrs = sns
+        .get_topic_attributes()
+        .topic_arn(&topic_arn)
+        .send()
+        .await
+        .expect("get_topic_attributes");
+    let policy = attrs
+        .attributes()
+        .and_then(|m| m.get("Policy"))
+        .expect("Policy attribute present");
+    assert!(
+        policy.contains("sns:Publish"),
+        "topic policy should round-trip: {policy}"
+    );
+
+    cfn.delete_stack()
+        .stack_name("tp-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+}
+
+const BUCKET_POLICY_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "B": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "cfn-bp-bucket"}},
+    "BP": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {"Ref": "B"},
+        "PolicyDocument": {"Version": "2012-10-17", "Statement": [{
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::cfn-bp-bucket/*"
+        }]}
+      }
+    }
+  },
+  "Outputs": {"BucketName": {"Value": {"Ref": "B"}}}
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_s3_bucket_policy() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let s3 = server.s3_client().await;
+
+    cfn.create_stack()
+        .stack_name("bp-stack")
+        .template_body(BUCKET_POLICY_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("bp-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+    let bucket = output(stack, "BucketName")
+        .expect("BucketName output")
+        .to_string();
+
+    let policy = s3
+        .get_bucket_policy()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("get_bucket_policy");
+    assert!(
+        policy
+            .policy()
+            .map(|s| s.contains("s3:GetObject"))
+            .unwrap_or(false),
+        "bucket policy should round-trip"
+    );
+
+    cfn.delete_stack()
+        .stack_name("bp-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+    let after = s3.get_bucket_policy().bucket(&bucket).send().await;
+    assert!(
+        after.is_err(),
+        "bucket policy should be gone after deletion"
+    );
+}

--- a/website/content/docs/services/cloudformation.md
+++ b/website/content/docs/services/cloudformation.md
@@ -85,11 +85,11 @@ Resources of these types create real backing state in the corresponding fakeclou
 - **Organizations** — `Organization`, `OrganizationalUnit`, `Account`, `Policy`, `ResourcePolicy`
 - **RDS** — `DBInstance`, `DBCluster`, `DBParameterGroup`, `DBClusterParameterGroup`, `DBSubnetGroup`, `DBSecurityGroup`, `OptionGroup`, `DBProxy`, `EventSubscription`
 - **Route 53** — `HostedZone`, `RecordSet`, `HealthCheck`, `DNSSEC`, `KeySigningKey`
-- **S3** — `Bucket`
+- **S3** — `Bucket`, `BucketPolicy`
 - **Secrets Manager** — `Secret`, `ResourcePolicy`, `RotationSchedule`, `SecretTargetAttachment`
 - **SES v2** — `EmailIdentity`, `ConfigurationSet`, `ConfigurationSetEventDestination`, `ContactList`, `DedicatedIpPool`, `ReceiptFilter`, `ReceiptRule`, `ReceiptRuleSet`, `Template`, `VdmAttributes`
-- **SNS** — `Topic`, `Subscription`
-- **SQS** — `Queue`
+- **SNS** — `Topic`, `TopicPolicy`, `Subscription`
+- **SQS** — `Queue`, `QueuePolicy`
 - **SSM** — `Parameter`
 - **Step Functions** — `StateMachine`, `StateMachineVersion`, `StateMachineAlias`, `Activity`
 - **WAFv2** — `WebACL`, `WebACLAssociation`, `IPSet`, `RegexPatternSet`, `RuleGroup`, `LoggingConfiguration`


### PR DESCRIPTION
Fixes #1688 (Part 1).

## What

Adds CloudFormation provisioners (create / update / delete) for the three most
common resource-policy types, which previously hard-failed stack creation with
`ValidationError: Unsupported resource type`:

- `AWS::SQS::QueuePolicy`
- `AWS::SNS::TopicPolicy`
- `AWS::S3::BucketPolicy`

Each follows the existing `EventBusPolicy` / SecretsManager `ResourcePolicy` /
ECR `RepositoryPolicy` pattern: rather than creating a standalone object, it
stores the `PolicyDocument` on its parent resource, so a subsequent `Get`
round-trips it.

| Type | Parent (resolved `Ref`) | Storage | Round-trips via |
|---|---|---|---|
| `QueuePolicy` | queue URL | `queue.attributes["Policy"]` | `GetQueueAttributes` |
| `TopicPolicy` | topic ARN | `topic.attributes["Policy"]` | `GetTopicAttributes` |
| `BucketPolicy` | bucket name | `bucket.policy` | `GetBucketPolicy` |

The SQS/SNS physical id encodes the referenced parent URLs/ARNs (newline-joined,
a char that can't appear in them) so delete can locate and clear each parent;
S3 uses `{bucket}-policy`. Enforcement isn't attempted (IAM is off by default).

## Tests

- **Unit** (`resource_provisioner/mod.rs`): one test per type asserting the
  policy is stored on the parent and cleared on delete.
- **E2E** (`crates/fakecloud-e2e/tests/cloudformation_resource_policies.rs`):
  one test per type — stack reaches `CREATE_COMPLETE`, the policy round-trips
  through the parent service's Get API, and teardown succeeds.
- Docs: added the three types to the supported-resources list in
  `website/content/docs/services/cloudformation.md`.

Validation run locally:

```
cargo test -p fakecloud-cloudformation     # 205 passed
cargo build --bin fakecloud
cargo test -p fakecloud-e2e --test cloudformation_resource_policies   # 3 passed
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo fmt --all --check                                  # clean
```

## Question for maintainers — Part 2 (scoped out of this PR)

The issue also notes that genuinely-unknown resource types **hard-fail** stack
creation (e.g. `AWS::CloudFormation::WaitConditionHandle`), even though the
parity-matrix docs describe unknown types as *"recorded but has no underlying
resource."* This PR intentionally **does not** change that behavior — it keeps
unknown types failing — because making them non-fatal is a broader behavioral
change that masks genuine template typos.

Would you prefer unknown resource types to become non-fatal no-ops (matching the
docs), or to keep failing? Happy to follow up with that change in a separate PR
if you want it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for provisioning resource policies for SQS, SNS, and S3 so stacks with `AWS::SQS::QueuePolicy`, `AWS::SNS::TopicPolicy`, and `AWS::S3::BucketPolicy` now create, update, and delete successfully. Policies are stored on parent resources and round-trip via their Get APIs; tests and docs updated. Fixes #1688 (Part 1).

- **New Features**
  - Provisioners for `AWS::SQS::QueuePolicy`, `AWS::SNS::TopicPolicy`, `AWS::S3::BucketPolicy`.
  - Stores `PolicyDocument` on parent:
    - `QueuePolicy` -> queue attributes["Policy"] (GetQueueAttributes)
    - `TopicPolicy` -> topic attributes["Policy"] (GetTopicAttributes)
    - `BucketPolicy` -> bucket.policy (GetBucketPolicy)
  - Physical IDs allow cleanup:
    - SQS/SNS: newline-joined parent URLs/ARNs; S3: `{bucket}-policy`.
  - Covered by unit and E2E tests; docs list the new supported types.

<sup>Written for commit 098edd15f1d294bae97cb292a211e79baab887ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

