### PR TITLE
fix(persistence): ignore lost+found and other benign entries in the empty-dir check

### DIFF
--- a/crates/fakecloud-e2e/tests/persistence_lost_found.rs
+++ b/crates/fakecloud-e2e/tests/persistence_lost_found.rs
@@ -1,0 +1,25 @@
+mod helpers;
+
+use helpers::TestServer;
+
+/// A freshly provisioned ext4 PV always contains a `lost+found` directory at its
+/// root. Mounting such a volume directly at `--data-path` used to trip the
+/// emptiness guard and crash-loop the server on first start. The guard must now
+/// ignore `lost+found` and still initialize a fresh store.
+#[tokio::test]
+async fn persistence_starts_with_lost_found_in_data_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir(tmp.path().join("lost+found")).unwrap();
+
+    // If the emptiness guard rejected `lost+found`, the server would refuse to
+    // start and this would panic.
+    let server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.sqs_client().await;
+
+    // Server initialized as a fresh store and serves requests.
+    let list = client.list_queues().send().await.unwrap();
+    assert!(
+        list.queue_urls().is_empty(),
+        "fresh data dir should start with no queues",
+    );
+}

--- a/crates/fakecloud-persistence/src/version.rs
+++ b/crates/fakecloud-persistence/src/version.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -6,6 +7,21 @@ use thiserror::Error;
 
 pub const FORMAT_VERSION: u32 = 1;
 pub const VERSION_FILE_NAME: &str = "fakecloud.version.toml";
+
+/// Filesystem artifacts that may exist in an otherwise-empty data directory and
+/// must not count toward the "non-empty" emptiness check — e.g. ext4 always creates
+/// `lost+found` at the root of a freshly formatted volume, and NetApp exposes
+/// `.snapshot`. Dot-prefixed names are also ignored (see [`is_benign_entry`]).
+const IGNORED_DIR_ENTRIES: &[&str] = &["lost+found", ".snapshot"];
+
+/// Whether a directory entry is a benign filesystem artifact that should not make
+/// the data directory count as "non-empty".
+fn is_benign_entry(name: &OsStr) -> bool {
+    match name.to_str() {
+        Some(s) => s.starts_with('.') || IGNORED_DIR_ENTRIES.contains(&s),
+        None => false, // non-UTF8 name => treat as a real entry, be conservative
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FormatVersion {
@@ -93,11 +109,14 @@ pub fn ensure_version_file(dir: &Path, fakecloud_version: &str) -> Result<(), Ve
         return check_version_file(dir);
     }
     if dir.exists() {
-        let mut entries = std::fs::read_dir(dir).map_err(|source| VersionError::Io {
-            path: dir.to_path_buf(),
-            source,
-        })?;
-        if entries.next().is_some() {
+        let has_real_entry = std::fs::read_dir(dir)
+            .map_err(|source| VersionError::Io {
+                path: dir.to_path_buf(),
+                source,
+            })?
+            .filter_map(Result::ok)
+            .any(|entry| !is_benign_entry(&entry.file_name()));
+        if has_real_entry {
             return Err(VersionError::NonEmptyDirectoryWithoutVersionFile {
                 dir: dir.to_path_buf(),
                 file: VERSION_FILE_NAME.to_string(),
@@ -127,6 +146,36 @@ mod tests {
             err,
             VersionError::NonEmptyDirectoryWithoutVersionFile { .. }
         );
+    }
+
+    #[test]
+    fn ensure_ok_when_dir_has_only_lost_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("lost+found")).unwrap();
+        ensure_version_file(tmp.path(), "test").unwrap();
+        assert!(tmp.path().join(VERSION_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn ensure_ok_when_dir_has_only_dotfiles() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".DS_Store"), b"junk").unwrap();
+        std::fs::create_dir(tmp.path().join(".snapshot")).unwrap();
+        ensure_version_file(tmp.path(), "test").unwrap();
+        assert!(tmp.path().join(VERSION_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn ensure_rejects_real_file_alongside_lost_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("lost+found")).unwrap();
+        std::fs::write(tmp.path().join("data.bin"), b"real data").unwrap();
+        let err = ensure_version_file(tmp.path(), "test").unwrap_err();
+        assert!(matches!(
+            err,
+            VersionError::NonEmptyDirectoryWithoutVersionFile { .. }
+        ));
+        assert!(!tmp.path().join(VERSION_FILE_NAME).exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

With `FAKECLOUD_STORAGE_MODE=persistent` and `--data-path` pointed at the **root of a freshly provisioned PV**, fakecloud refuses to start:

```
persistence data directory /var/lib/fakecloud is not empty but has no
fakecloud.version.toml file. Refusing to initialize it: either point
--data-path at an empty directory or restore the missing version file.
```

The directory is "not empty" only because a freshly formatted ext4 volume always contains a `lost+found` directory. On EKS with a default gp3/ext4 PVC mounted directly at the data path, this is a guaranteed crash loop on first start.

The emptiness guard in `ensure_version_file` (`crates/fakecloud-persistence/src/version.rs`) treated *any* directory entry as "non-empty".

Closes #1690.

## Fix

`ensure_version_file` now skips an allowlist of benign filesystem artifacts before deciding the data directory is non-empty:

- `lost+found` (ext4) and `.snapshot` (NetApp), via a small named `IGNORED_DIR_ENTRIES` constant that's easy to extend;
- any dot-prefixed name (`.DS_Store`, `.kubernetes-mount-*`, etc.) via an `is_benign_entry` helper. Non-UTF8 names are conservatively treated as real entries.

The guard still fires — and initialization is still refused — when a genuine, non-allowlisted entry (e.g. a real data file) exists without a version file. The version-file format check and the format-mismatch path are unchanged.

## Test plan

- **Unit** (`crates/fakecloud-persistence/src/version.rs`):
  - dir with only `lost+found` → `ensure_version_file` succeeds and writes the version file;
  - dir with only dot-prefixed entries (`.DS_Store`, `.snapshot`) → succeeds;
  - dir with `lost+found` **plus** a real data file (no version file) → still rejected with `NonEmptyDirectoryWithoutVersionFile`;
  - existing tests (empty dir succeeds; stray real file rejected) still pass.
- **E2E** (`crates/fakecloud-e2e/tests/persistence_lost_found.rs`): create a tempdir containing only `lost+found`, `TestServer::start_persistent(...)`, then assert `list_queues()` is empty — proving the server boots instead of crash-looping and initializes a fresh store.

Validation run locally:

```sh
cargo test -p fakecloud-persistence            # 69 passed (incl. 3 new)
cargo build --bin fakecloud
cargo test -p fakecloud-e2e persistence        # green
cargo test -p fakecloud-e2e --test persistence_lost_found  # 1 passed
cargo clippy --workspace --all-targets -- -D warnings      # clean
cargo fmt --all --check                        # clean
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix startup failure in persistent mode by ignoring benign filesystem entries during the empty-dir check. The server now initializes a fresh store when `--data-path` is a newly provisioned volume.

- **Bug Fixes**
  - Updated `ensure_version_file` to ignore `lost+found`, `.snapshot`, and dot-prefixed names; non-UTF8 names still count as real entries.
  - Still refuses initialization if any non-ignored entry exists without `fakecloud.version.toml`; format checks unchanged.
  - Added unit and E2E tests to verify startup succeeds with only `lost+found` present.

<sup>Written for commit 3cb7932538430ba4d9485c22b588e4f2475da6f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

