### PR TITLE
ci: free hosted-tool cache + large packages to fix E2E disk-full flake

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -47,11 +47,11 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
           android: true
           dotnet: true
           haskell: true
-          large-packages: false
+          large-packages: true
           docker-images: false
           swap-storage: true
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,11 +75,11 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
           android: true
           dotnet: true
           haskell: true
-          large-packages: false
+          large-packages: true
           docker-images: false
           swap-storage: true
 
@@ -110,11 +110,11 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
           android: true
           dotnet: true
           haskell: true
-          large-packages: false
+          large-packages: true
           docker-images: false
           swap-storage: true
 

--- a/.github/workflows/tfacc.yml
+++ b/.github/workflows/tfacc.yml
@@ -79,11 +79,11 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
           android: true
           dotnet: true
           haskell: true
-          large-packages: false
+          large-packages: true
           docker-images: false
           swap-storage: true
 


### PR DESCRIPTION
## Summary

The `lambda-runtimes-*` E2E partitions (and occasionally conformance/tfacc and even non-Docker partitions) intermittently fail with:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/.../Worker_*.log'
```

This is runner-host disk exhaustion — the runner can't even write its own `_diag` log. Pulling several large language-runtime Docker images on a single partition exhausts disk despite the existing `free-disk-space` + `docker system prune` steps. In the last PR wave it hit 6 of 8 unrelated PRs and required multiple full CI reruns.

## Fix

Reclaim the two largest unused areas in every `free-disk-space` step:

- **`tool-cache: true`** — removes `/opt/hostedtoolcache` (~8GB of preinstalled Python/Node/Go/Ruby versions we don't use; rust is installed fresh by `rust-toolchain` afterward, and tfacc's `setup-go`/`setup-terraform` run *after* free-disk and reinstall what they need).
- **`large-packages: true`** — removes ~5GB of apt packages (browsers, cloud CLIs, etc.).

Applied to all four `free-disk-space` steps: `e2e.yml` (both), `conformance.yml`, `tfacc.yml`.

No code change; jobs that need a toolchain install it after the free-disk step.

## Test plan

- This PR runs the full E2E/conformance/tfacc matrix with its own modified workflow (`pull_request` uses the PR's workflow version), so green CI here *is* the validation that the extra freeing doesn't break any job and that the lambda-runtime partitions no longer disk-full.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix intermittent "No space left on device" CI failures by expanding disk cleanup on GitHub runners. E2E, conformance, and tfacc jobs now reclaim ~13GB before pulling large runtime images.

- **Bug Fixes**
  - Turn on `tool-cache: true` (~8GB) and `large-packages: true` (~5GB) in `jlumbroso/free-disk-space`.
  - Apply to both free-disk steps in e2e, and to conformance and tfacc workflows.
  - No code changes; required toolchains reinstall after cleanup.

<sup>Written for commit 510db70024a04b960e59d11ff19e6b39708ecaca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

