### PR TITLE
feat(cloudformation): record unmodelled resource types instead of failing the stack

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1150,7 +1150,24 @@ impl ResourceProvisioner {
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
-            other => Err(format!("Unsupported resource type: {other}")),
+            other => {
+                // No provisioner for this type. Real CloudFormation provisions
+                // many resource types fakecloud doesn't model, and SAM/CDK
+                // output routinely includes ones like
+                // `AWS::CloudFormation::WaitConditionHandle`; failing the whole
+                // stack on each would block otherwise-valid templates. Match the
+                // documented contract (docs/services/cloudformation.md): accept
+                // and record the resource as provisioned with no backing state.
+                // Dependent operations that need real state may still fail —
+                // that is the honest outcome. The physical id is the logical id
+                // so `Ref` on the resource resolves to a stable value.
+                tracing::warn!(
+                    resource_type = %other,
+                    logical_id = %resource.logical_id,
+                    "CloudFormation: no provisioner for resource type; recording it as provisioned with no backing state"
+                );
+                Ok(ProvisionResult::new(resource.logical_id.clone()))
+            }
         };
 
         let is_custom = resource.resource_type.starts_with("Custom::")
@@ -1755,7 +1772,10 @@ impl ResourceProvisioner {
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
-            other => Err(format!("Unsupported resource type: {other}")),
+            // No provisioner for this type — it was recorded with no backing
+            // state at create time (see `create_resource`), so there is nothing
+            // to delete. Succeed so stack teardown isn't blocked.
+            _ => Ok(()),
         }
     }
 
@@ -6043,6 +6063,26 @@ mod tests {
     }
 
     #[test]
+    fn unknown_resource_type_records_instead_of_failing() {
+        let prov = make_provisioner();
+        // A real AWS type fakecloud has no provisioner for. It must NOT fail
+        // the stack — it's recorded as provisioned with no backing state, and
+        // `Ref` (its physical id) resolves to a stable value (the logical id).
+        let sr = prov
+            .create_resource(&make_resource(
+                "AWS::CloudFormation::WaitConditionHandle",
+                "Handle",
+                serde_json::json!({}),
+            ))
+            .expect("unknown resource type should record, not fail");
+        assert_eq!(sr.physical_id, "Handle");
+        assert_eq!(sr.status, "CREATE_COMPLETE");
+        // Teardown of a recorded no-op resource also succeeds.
+        prov.delete_resource(&sr)
+            .expect("delete no-op should succeed");
+    }
+
+    #[test]
     fn sns_subscription_rejects_nonexistent_topic() {
         let prov = make_provisioner();
         let resource = make_resource(
@@ -6524,10 +6564,14 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_resource_type_fails() {
+    fn unsupported_resource_type_is_recorded_not_failed() {
+        // An unmodelled type is recorded as provisioned (no backing state)
+        // rather than failing the stack — see
+        // `unknown_resource_type_records_instead_of_failing`.
         let prov = make_provisioner();
         let res = make_resource("AWS::NonExistent::Thing", "X", serde_json::json!({}));
-        assert!(prov.create_resource(&res).is_err());
+        let sr = prov.create_resource(&res).unwrap();
+        assert_eq!(sr.physical_id, "X");
     }
 
     #[test]
@@ -6571,10 +6615,13 @@ mod tests {
     // ── additional resource types ──
 
     #[test]
-    fn unsupported_resource_type_errors() {
+    fn unsupported_resource_type_recorded_with_logical_id() {
+        // Recorded, not failed; physical id is the logical id so `Ref` resolves.
         let prov = make_provisioner();
         let res = make_resource("AWS::FooBar::Thing", "X", serde_json::json!({}));
-        assert!(prov.create_resource(&res).is_err());
+        let sr = prov.create_resource(&res).unwrap();
+        assert_eq!(sr.physical_id, "X");
+        assert_eq!(sr.status, "CREATE_COMPLETE");
     }
 
     #[test]

--- a/crates/fakecloud-e2e/tests/cloudformation_unknown_resource_type.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_unknown_resource_type.rs
@@ -60,7 +60,10 @@ async fn unknown_resource_type_does_not_fail_stack() {
         .find(|o| o.output_key() == Some("HandleRef"))
         .and_then(|o| o.output_value())
         .expect("HandleRef output");
-    assert!(!handle_ref.is_empty(), "Ref on the unmodelled resource should resolve");
+    assert!(
+        !handle_ref.is_empty(),
+        "Ref on the unmodelled resource should resolve"
+    );
 
     // The recorded resource is reported as provisioned.
     let resources = cfn

--- a/crates/fakecloud-e2e/tests/cloudformation_unknown_resource_type.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_unknown_resource_type.rs
@@ -1,0 +1,88 @@
+//! A resource type fakecloud has no provisioner for must not fail the whole
+//! stack. Real CloudFormation provisions many types fakecloud doesn't model
+//! (and SAM/CDK output routinely includes ones like
+//! `AWS::CloudFormation::WaitConditionHandle`). The documented contract
+//! (docs/services/cloudformation.md) is that such types are accepted and
+//! recorded as provisioned with no backing state, so the stack still reaches
+//! CREATE_COMPLETE and `Ref` on the resource resolves.
+
+mod helpers;
+
+use helpers::TestServer;
+
+/// A stack pairing a real, provisioned resource (an SQS queue) with a type
+/// fakecloud doesn't model (`WaitConditionHandle`). `Ref` on the unmodelled
+/// resource is surfaced as an output.
+const TEMPLATE: &str = r#"
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  Handle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+  Queue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: unknown-type-queue
+Outputs:
+  HandleRef:
+    Value:
+      Ref: Handle
+"#;
+
+#[tokio::test]
+async fn unknown_resource_type_does_not_fail_stack() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+
+    cfn.create_stack()
+        .stack_name("unknown-type-stack")
+        .template_body(TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("unknown-type-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(
+        stack.stack_status().unwrap().as_str(),
+        "CREATE_COMPLETE",
+        "a stack with an unmodelled resource type should still complete"
+    );
+
+    // `Ref` on the unmodelled resource resolves to a stable physical id.
+    let handle_ref = stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some("HandleRef"))
+        .and_then(|o| o.output_value())
+        .expect("HandleRef output");
+    assert!(!handle_ref.is_empty(), "Ref on the unmodelled resource should resolve");
+
+    // The recorded resource is reported as provisioned.
+    let resources = cfn
+        .describe_stack_resources()
+        .stack_name("unknown-type-stack")
+        .send()
+        .await
+        .expect("describe_stack_resources");
+    let handle = resources
+        .stack_resources()
+        .iter()
+        .find(|r| r.logical_resource_id() == Some("Handle"))
+        .expect("Handle resource recorded");
+    assert_eq!(
+        handle.resource_status().unwrap().as_str(),
+        "CREATE_COMPLETE"
+    );
+
+    // Teardown succeeds even though the resource has no backing state.
+    cfn.delete_stack()
+        .stack_name("unknown-type-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+}

--- a/website/content/docs/services/cloudformation.md
+++ b/website/content/docs/services/cloudformation.md
@@ -58,7 +58,7 @@ Full control plane: `CreateStackSet`, `UpdateStackSet`, `DeleteStackSet`, `Descr
 
 ## Resource provisioners
 
-Resources of these types create real backing state in the corresponding fakecloud service. Other resource types are accepted and recorded but don't allocate underlying state — your stack still reports them as provisioned, but dependent operations may fail.
+Resources of these types create real backing state in the corresponding fakecloud service. Any other resource type — including real AWS types fakecloud doesn't model (e.g. `AWS::CloudFormation::WaitConditionHandle`) — is accepted and recorded as provisioned without allocating underlying state, rather than failing the stack; `Ref` on it resolves to its logical ID. Dependent operations that need real backing state may still fail.
 
 - **API Gateway v1** — `RestApi`, `Resource`, `Method`, `Model`, `RequestValidator`, `Authorizer`, `Deployment`, `Stage`, `ApiKey`, `UsagePlan`, `UsagePlanKey`, `DomainName`, `BasePathMapping`, `GatewayResponse`
 - **API Gateway v2** — `Api`, `Stage`, `Route`, `RouteResponse`, `Integration`, `IntegrationResponse`, `Authorizer`, `Deployment`, `Model`, `DomainName`, `ApiMapping`, `VpcLink`


### PR DESCRIPTION
## Summary

Resolves the open question from #1689 (the #1688 "Part 2"): what should happen when a CloudFormation template contains a resource type fakecloud has no provisioner for?

Previously `create_resource` returned an error for any unmodelled type, which the stack loop turned into **CREATE_FAILED**. That blocks otherwise-valid templates — real CloudFormation provisions many types fakecloud doesn't model, and SAM/CDK output routinely includes ones like `AWS::CloudFormation::WaitConditionHandle`.

It also already **contradicted the documented contract** in `docs/services/cloudformation.md`:

> Other resource types are accepted and recorded but don't allocate underlying state — your stack still reports them as provisioned, but dependent operations may fail.

This makes the code match the doc (and real AWS for valid-but-unmodelled types).

## Changes

- **`create_resource`** — an unmodelled type is recorded as provisioned with no backing state; physical id = logical id so `Ref` resolves; emits a `tracing::warn!` so the gap is observable.
- **`delete_resource`** — unmodelled type is a no-op (nothing to delete) so teardown isn't blocked.
- **`update_resource`** — already returned `Ok(None)` for these; unchanged.
- Doc wording clarified to state the resource is recorded rather than failing, and `Ref` resolves to the logical ID.

The trade-off (raised in #1689): non-fatal recording can mask a genuine template typo. This matches the documented design and real AWS's behavior for types it does provision; the `warn!` records it.

## Test plan

- **Unit** (`resource_provisioner/mod.rs`): create records an unmodelled type with physical id = logical id + `CREATE_COMPLETE`, delete is a no-op; the two prior `unsupported_resource_type_*` tests are flipped from asserting failure to asserting recording.
- **E2E** (`cloudformation_unknown_resource_type.rs`): a stack pairing `AWS::CloudFormation::WaitConditionHandle` with a real `AWS::SQS::Queue` reaches `CREATE_COMPLETE`, `Ref` on the unmodelled resource resolves, it's reported provisioned, and `DeleteStack` succeeds.
- `cargo test -p fakecloud-cloudformation` (211 passed), clippy + fmt clean, E2E test compiles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record unmodeled CloudFormation resource types as provisioned instead of failing the stack. This keeps valid templates working and aligns with our docs and AWS; `Ref` now resolves and deletion works.

- **New Features**
  - Unmodeled types are recorded as provisioned with no backing state; physical ID = logical ID; emits a warning log.
  - `delete_resource` is a no-op for these types; `update_resource` behavior unchanged.
  - Docs updated to state the behavior; unit and E2E tests added in `fakecloud-cloudformation` and `fakecloud-e2e`.

<sup>Written for commit 66b967ae7629d5eed762f5d283bf0249a09b39c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

