### PR TITLE
ci: relocate container storage to /mnt to kill the lambda-runtimes disk-full flake

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,6 +127,35 @@ jobs:
         if: matrix.install_podman
         run: sudo apt-get update && sudo apt-get install -y podman
 
+      # The lambda-runtimes partitions pull several large language-runtime
+      # images and stack container layers during the run, which can exhaust the
+      # root filesystem even after free-disk-space (the recurring "No space left
+      # on device" flake). Move container storage onto the runner's much larger
+      # ephemeral /mnt disk so image/layer growth no longer fills `/`.
+      - name: Relocate container storage to /mnt
+        run: |
+          echo "=== disk before relocation ==="; df -h / /mnt || df -h /
+          # Docker: move data-root to /mnt and symlink so the daemon config and
+          # any preinstalled images are preserved.
+          sudo systemctl stop docker docker.socket || true
+          sudo mkdir -p /mnt/docker
+          if [ -d /var/lib/docker ] && [ ! -L /var/lib/docker ]; then
+            sudo rsync -a /var/lib/docker/ /mnt/docker/ || true
+            sudo rm -rf /var/lib/docker
+          fi
+          sudo ln -sfn /mnt/docker /var/lib/docker
+          sudo systemctl start docker
+          # Podman (rootless): point graphroot/runroot at /mnt as well.
+          if [ "$INSTALL_PODMAN" = "true" ]; then
+            sudo mkdir -p /mnt/podman-storage /mnt/podman-run
+            sudo chown -R "$USER" /mnt/podman-storage /mnt/podman-run
+            mkdir -p ~/.config/containers
+            printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/podman-storage"\nrunroot = "/mnt/podman-run"\n' > ~/.config/containers/storage.conf
+          fi
+          echo "=== docker info root + disk after ==="
+          docker info --format '{{.DockerRootDir}}' || true
+          df -h / /mnt || df -h /
+
       - name: Prune container state before tests
         run: |
           docker system prune -af --volumes || true


### PR DESCRIPTION
## Problem

`E2E Tests` keeps failing on `main` (and PRs) with:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/.../Worker_*.log'
```

on the heaviest `lambda-runtimes-*` partitions (latest: `lambda-runtimes-python` on main `f5151b60`). #1692 (freeing the hosted-tool cache + large packages) cut this from systemic to an occasional tail, but the python/ruby/provided/dotnet partitions still exhaust the **root** filesystem — they pull several large language-runtime images and stack container layers during the run, all under `/var/lib/docker` on `/`.

## Fix

Move container storage onto the runner's much larger ephemeral **`/mnt`** disk (~70GB) before any images are pulled:

- **Docker**: stop the daemon, `rsync` `/var/lib/docker` → `/mnt/docker`, symlink, restart — preserves daemon config + preinstalled images.
- **Podman** partitions: point `graphroot`/`runroot` at `/mnt` via `storage.conf`.

Image/layer growth now lands on `/mnt` instead of `/`, so the heavy partitions stop running out of space. Complements the freeing in #1692.

## Test plan

This PR runs the full E2E matrix with its own workflow version (`pull_request` uses the PR's workflow), so green E2E here — specifically the `lambda-runtimes-python`/`ruby`/`provided`/`dotnet` partitions passing — validates the relocation. The added step logs `docker info` root dir + `df -h` before/after for confirmation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relocates container storage to `/mnt` in E2E to stop the “No space left on device” flakes in lambda-runtimes jobs. Heavy images now use the larger ephemeral disk instead of the root filesystem.

- **Bug Fixes**
  - Docker: move data-root to `/mnt` via rsync + symlink and restart the daemon to preserve config and preinstalled images.
  - Podman: set `graphroot` and `runroot` to `/mnt` via `storage.conf`.
  - Add logs for `docker info` root dir and `df -h` before/after to confirm the relocation.

<sup>Written for commit 12d65f20e7545748bfdd4310e7f9e60a0a79b06a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

