### PR TITLE
fix(s3): reject invalid object-lock Mode/Status to close GET panic (DoS)

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -3664,6 +3664,84 @@ async fn s3_object_retention_put_get() {
     );
 }
 
+/// Regression (audit-2026-06-13): a crafted PutObjectRetention /
+/// PutObjectLegalHold body with an out-of-enum value used to be persisted
+/// verbatim and then panic the server thread when round-tripped into the
+/// `x-amz-object-lock-mode` / `x-amz-object-lock-legal-hold` response header
+/// on GET/HEAD (illegal header bytes). The value is now rejected up front with
+/// 400 MalformedXML and the server stays alive.
+#[tokio::test]
+async fn s3_object_lock_invalid_values_rejected_no_panic() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket()
+        .bucket("lock-fuzz-bucket")
+        .object_lock_enabled_for_bucket(true)
+        .send()
+        .await
+        .unwrap();
+    s3.put_object()
+        .bucket("lock-fuzz-bucket")
+        .key("obj.txt")
+        .body(ByteStream::from_static(b"data"))
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=fake";
+
+    // Retention Mode with an embedded CRLF — illegal as an HTTP header value.
+    let bad_retention = "<Retention><Mode>BAD\r\ninjected</Mode>\
+        <RetainUntilDate>2999-01-01T00:00:00Z</RetainUntilDate></Retention>";
+    let resp = http
+        .put(format!(
+            "{}/lock-fuzz-bucket/obj.txt?retention",
+            server.endpoint()
+        ))
+        .header("Authorization", auth)
+        .body(bad_retention)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        400,
+        "invalid retention Mode should be rejected, not persisted"
+    );
+
+    // Legal-hold Status outside the ON|OFF enum.
+    let bad_hold = "<LegalHold><Status>weird\r\nvalue</Status></LegalHold>";
+    let resp = http
+        .put(format!(
+            "{}/lock-fuzz-bucket/obj.txt?legal-hold",
+            server.endpoint()
+        ))
+        .header("Authorization", auth)
+        .body(bad_hold)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        400,
+        "invalid legal-hold Status should be rejected"
+    );
+
+    // The server must still be alive and the object readable — no panic, no
+    // poisoned lock from the crafted requests above.
+    let got = s3
+        .get_object()
+        .bucket("lock-fuzz-bucket")
+        .key("obj.txt")
+        .send()
+        .await
+        .expect("server should survive crafted lock values and still serve GET");
+    let body = got.body.collect().await.unwrap().into_bytes();
+    assert_eq!(&body[..], b"data");
+}
+
 #[tokio::test]
 async fn s3_object_legal_hold_put_get() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-s3/src/service/lock.rs
+++ b/crates/fakecloud-s3/src/service/lock.rs
@@ -21,6 +21,15 @@ impl S3Service {
         let version_id = req.query_params.get("versionId").cloned();
         let body_str = std::str::from_utf8(&req.body).unwrap_or("");
         let mode = extract_xml_value(body_str, "Mode");
+        // Mode is a closed enum in the S3 Object Lock schema. Reject anything
+        // else with MalformedXML (as AWS does) instead of persisting an
+        // arbitrary string that would later be round-tripped into the
+        // `x-amz-object-lock-mode` response header.
+        if let Some(ref m) = mode {
+            if m != "GOVERNANCE" && m != "COMPLIANCE" {
+                return Err(malformed_object_lock("Mode", m));
+            }
+        }
         let retain_until = extract_xml_value(body_str, "RetainUntilDate")
             .and_then(|s| s.parse::<DateTime<Utc>>().ok());
 
@@ -150,6 +159,13 @@ impl S3Service {
         let version_id = req.query_params.get("versionId").cloned();
         let body_str = std::str::from_utf8(&req.body).unwrap_or("");
         let status = extract_xml_value(body_str, "Status");
+        // LegalHold Status is a closed enum (ON | OFF); reject anything else
+        // with MalformedXML rather than persisting a header-unsafe string.
+        if let Some(ref s) = status {
+            if s != "ON" && s != "OFF" {
+                return Err(malformed_object_lock("Status", s));
+            }
+        }
 
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);
@@ -256,4 +272,21 @@ impl S3Service {
             )),
         }
     }
+}
+
+/// Build a `MalformedXML` error for an object-lock field whose value isn't a
+/// member of its closed enum (e.g. `Mode` other than GOVERNANCE/COMPLIANCE,
+/// `Status` other than ON/OFF). Matches AWS, which rejects such bodies with
+/// 400 MalformedXML.
+fn malformed_object_lock(field: &str, value: &str) -> AwsServiceError {
+    AwsServiceError::aws_error_with_fields(
+        StatusCode::BAD_REQUEST,
+        "MalformedXML",
+        "The XML you provided was not well-formed or did not validate against \
+         our published schema",
+        vec![
+            ("ArgumentName".to_string(), field.to_string()),
+            ("ArgumentValue".to_string(), value.to_string()),
+        ],
+    )
 }

--- a/crates/fakecloud-s3/src/service/objects/read.rs
+++ b/crates/fakecloud-s3/src/service/objects/read.rs
@@ -2,6 +2,18 @@
 
 use super::*;
 
+/// Insert a response header from a possibly-untrusted string, silently
+/// skipping it when the value isn't a legal HTTP header value rather than
+/// panicking. Object-lock mode / legal-hold originate from XML request
+/// bodies (and persisted state), so a crafted value must never crash the
+/// read path. AWS itself only ever stores the validated enum values, so a
+/// well-behaved object always round-trips its header.
+fn insert_str_header(headers: &mut HeaderMap, name: &'static str, value: &str) {
+    if let Ok(v) = value.parse::<http::header::HeaderValue>() {
+        headers.insert(name, v);
+    }
+}
+
 impl S3Service {
     pub(crate) fn get_object(
         &self,
@@ -137,7 +149,7 @@ impl S3Service {
 
         // Object lock headers
         if let Some(ref mode) = obj.lock_mode {
-            headers.insert("x-amz-object-lock-mode", mode.parse().unwrap());
+            insert_str_header(&mut headers, "x-amz-object-lock-mode", mode);
         }
         if let Some(ref until) = obj.lock_retain_until {
             headers.insert(
@@ -146,7 +158,7 @@ impl S3Service {
             );
         }
         if let Some(ref hold) = obj.lock_legal_hold {
-            headers.insert("x-amz-object-lock-legal-hold", hold.parse().unwrap());
+            insert_str_header(&mut headers, "x-amz-object-lock-legal-hold", hold);
         }
         if let Some(ongoing) = obj.restore_ongoing {
             let rv = if ongoing {
@@ -483,7 +495,7 @@ impl S3Service {
 
         // Object lock headers
         if let Some(ref mode) = obj.lock_mode {
-            headers.insert("x-amz-object-lock-mode", mode.parse().unwrap());
+            insert_str_header(&mut headers, "x-amz-object-lock-mode", mode);
         }
         if let Some(ref until) = obj.lock_retain_until {
             headers.insert(
@@ -492,7 +504,7 @@ impl S3Service {
             );
         }
         if let Some(ref hold) = obj.lock_legal_hold {
-            headers.insert("x-amz-object-lock-legal-hold", hold.parse().unwrap());
+            insert_str_header(&mut headers, "x-amz-object-lock-legal-hold", hold);
         }
         if let Some(ongoing) = obj.restore_ongoing {
             let restore_val = if ongoing {


### PR DESCRIPTION
## Summary

`fc-quality-audit` (2026-06-13) surfaced a reachable, unauthenticated-input **server-crash DoS** in S3 Object Lock.

`PutObjectRetention` / `PutObjectLegalHold` extract `Mode` / `Status` straight from the XML request body (`extract_xml_value`) and persist them verbatim — **no enum validation**. On a later `GET`/`HEAD`, the stored value is round-tripped into the `x-amz-object-lock-mode` / `x-amz-object-lock-legal-hold` response header via `.parse::<HeaderValue>().unwrap()`. A value containing bytes illegal in an HTTP header (e.g. `CRLF`) **panics the request thread**.

(Note: the audit's two carried-forward "CRITICAL wire-format unwraps" in bedrock-agent-runtime/stepfunctions turned out to be false positives — they live inside `#[cfg(test)] mod tests`, not production. This is the real one.)

### Fix
- **Root cause:** validate `Mode ∈ {GOVERNANCE, COMPLIANCE}` and `Status ∈ {ON, OFF}` on input, returning `400 MalformedXML` exactly as AWS does.
- **Defense-in-depth:** object-lock response headers now go through a skip-if-invalid helper (mirroring the existing `x-amz-meta-*` loop) so persisted/loaded garbage can never panic the read path. Static/numeric header inserts stay infallible `.unwrap()`.

## Test plan
- New E2E `s3_object_lock_invalid_values_rejected_no_panic`: drives crafted CRLF `Mode`/`Status` over raw HTTP, asserts `400` for both and that the server is still alive + serving `GET` afterward.
- Existing object-lock / legal-hold E2E + s3 unit tests pass unchanged.
- `cargo clippy -p fakecloud-s3 --all-targets -- -D warnings` clean; `cargo fmt --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid S3 Object Lock Mode/Status and harden header writes to prevent a GET/HEAD panic (unauthenticated DoS). We now return 400 MalformedXML for out-of-enum values, matching AWS.

- **Bug Fixes**
  - Validate `Mode` in {GOVERNANCE, COMPLIANCE} and `Status` in {ON, OFF} on `PutObjectRetention` and `PutObjectLegalHold`.
  - Write `x-amz-object-lock-mode` and `x-amz-object-lock-legal-hold` via a safe helper that skips invalid values instead of panicking.
  - Add an E2E regression test with CRLF-injected values; asserts 400 and confirms server stays responsive.

<sup>Written for commit db0ac1b5a5b68170b7505c54918729fa46f23633. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

