### PR TITLE
fix(s3): reject control chars in bucket-default SSE config to close GetObject panic (DoS)

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -3802,8 +3802,20 @@ async fn s3_bucket_default_sse_invalid_values_no_panic() {
     );
 
     // The server is still alive: a legitimate bucket-default KMS config sets,
-    // applies to a no-SSE object PUT, and round-trips cleanly on GET.
-    let arn = "arn:aws:kms:us-east-1:000000000000:key/abcd-1234";
+    // applies to a no-SSE object PUT, and round-trips cleanly on GET. Use a
+    // real KMS key so the encrypt path on PutObject succeeds — a non-existent
+    // key id correctly fails with KMS.NotFound at encrypt time.
+    let kms = aws_sdk_kms::Client::new(&server.aws_config().await);
+    let arn = kms
+        .create_key()
+        .send()
+        .await
+        .expect("create kms key")
+        .key_metadata()
+        .and_then(|m| m.arn())
+        .expect("key arn")
+        .to_string();
+    let arn = arn.as_str();
     s3.put_bucket_encryption()
         .bucket("sse-fuzz-bucket")
         .server_side_encryption_configuration(

--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -3742,6 +3742,114 @@ async fn s3_object_lock_invalid_values_rejected_no_panic() {
     assert_eq!(&body[..], b"data");
 }
 
+/// Regression (bug-audit 2026-06-13 2.1/2.2): a PutBucketEncryption body with
+/// a control byte in `<KMSMasterKeyID>` (or `<SSEAlgorithm>`) used to be
+/// persisted verbatim, applied as the object default on a no-SSE PutObject,
+/// then panic the server when round-tripped into the
+/// `x-amz-server-side-encryption-aws-kms-key-id` /
+/// `x-amz-server-side-encryption` response headers on GET/HEAD — a dropped
+/// connection (the #1539 failure mode) on a *later* request than the one that
+/// planted the poison. The crafted config is now rejected with 400 up front,
+/// the server stays alive, and a legitimate KMS key id still round-trips.
+#[tokio::test]
+async fn s3_bucket_default_sse_invalid_values_no_panic() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket()
+        .bucket("sse-fuzz-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=fake";
+
+    // PutBucketEncryption with a newline embedded in KMSMasterKeyID — a legal
+    // XML body byte but illegal as an HTTP header value.
+    let poison = "<ServerSideEncryptionConfiguration><Rule>\
+        <ApplyServerSideEncryptionByDefault><SSEAlgorithm>aws:kms</SSEAlgorithm>\
+        <KMSMasterKeyID>bad\nkey</KMSMasterKeyID>\
+        </ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>";
+    let resp = http
+        .put(format!("{}/sse-fuzz-bucket?encryption", server.endpoint()))
+        .header("Authorization", auth)
+        .body(poison)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        400,
+        "control char in KMSMasterKeyID should be rejected, not persisted"
+    );
+
+    // Likewise a junk SSEAlgorithm (outside the closed enum) is rejected.
+    let bad_algo = "<ServerSideEncryptionConfiguration><Rule>\
+        <ApplyServerSideEncryptionByDefault><SSEAlgorithm>x\ny</SSEAlgorithm>\
+        </ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>";
+    let resp = http
+        .put(format!("{}/sse-fuzz-bucket?encryption", server.endpoint()))
+        .header("Authorization", auth)
+        .body(bad_algo)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        400,
+        "invalid SSEAlgorithm should be rejected"
+    );
+
+    // The server is still alive: a legitimate bucket-default KMS config sets,
+    // applies to a no-SSE object PUT, and round-trips cleanly on GET.
+    let arn = "arn:aws:kms:us-east-1:000000000000:key/abcd-1234";
+    s3.put_bucket_encryption()
+        .bucket("sse-fuzz-bucket")
+        .server_side_encryption_configuration(
+            aws_sdk_s3::types::ServerSideEncryptionConfiguration::builder()
+                .rules(
+                    aws_sdk_s3::types::ServerSideEncryptionRule::builder()
+                        .apply_server_side_encryption_by_default(
+                            aws_sdk_s3::types::ServerSideEncryptionByDefault::builder()
+                                .sse_algorithm(aws_sdk_s3::types::ServerSideEncryption::AwsKms)
+                                .kms_master_key_id(arn)
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("a valid bucket-default KMS config must be accepted");
+
+    s3.put_object()
+        .bucket("sse-fuzz-bucket")
+        .key("obj.txt")
+        .body(ByteStream::from_static(b"data"))
+        .send()
+        .await
+        .unwrap();
+
+    let got = s3
+        .get_object()
+        .bucket("sse-fuzz-bucket")
+        .key("obj.txt")
+        .send()
+        .await
+        .expect("server should survive crafted SSE config and still serve GET");
+    assert_eq!(
+        got.ssekms_key_id().map(|s| s.to_string()),
+        Some(arn.to_string()),
+        "valid bucket-default KMS key id must round-trip on GET"
+    );
+    let body = got.body.collect().await.unwrap().into_bytes();
+    assert_eq!(&body[..], b"data");
+}
+
 #[tokio::test]
 async fn s3_object_legal_hold_put_get() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-s3/src/service/config/encryption.rs
+++ b/crates/fakecloud-s3/src/service/config/encryption.rs
@@ -12,6 +12,40 @@ impl S3Service {
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        // Validate the SSE config fields *before* persisting. The stored
+        // body is later round-tripped, field-by-field, into the object
+        // default-encryption headers on PutObject and ultimately into the
+        // `x-amz-server-side-encryption` / `-aws-kms-key-id` *response*
+        // headers on a later GET/HEAD. A control byte here (all bytes
+        // 0x00-0x1F are legal XML body bytes but illegal HTTP header bytes)
+        // would otherwise be persisted verbatim and crash the read path —
+        // a reachable, unauthenticated-input DoS (bug-audit 2026-06-13 2.1/2.2).
+        if let Some(algo) = extract_xml_value(&body_str, "SSEAlgorithm") {
+            // SSEAlgorithm is a closed enum; AWS returns MalformedXML for
+            // anything outside it.
+            if algo != "AES256" && algo != "aws:kms" && algo != "aws:kms:dsse" {
+                return Err(malformed_encryption("SSEAlgorithm", &algo));
+            }
+        }
+        if let Some(kid) = extract_xml_value(&body_str, "KMSMasterKeyID") {
+            // A real KMS key id / ARN / alias never contains control
+            // characters. Reject any value that isn't a legal HTTP header
+            // value rather than persisting a string that would later panic
+            // the GET/HEAD response path. AWS rejects a malformed key id with
+            // KMS.KMSInvalidStateException / InvalidArgument; InvalidArgument
+            // is the closest stable shape here.
+            if kid.parse::<http::header::HeaderValue>().is_err() {
+                return Err(AwsServiceError::aws_error_with_fields(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidArgument",
+                    "The KMSMasterKeyID is not a valid KMS key id, ARN, or alias",
+                    vec![
+                        ("ArgumentName".to_string(), "KMSMasterKeyID".to_string()),
+                        ("ArgumentValue".to_string(), kid.clone()),
+                    ],
+                ));
+            }
+        }
         // aws:kms / aws:kms:dsse rules require KMSMasterKeyID — AWS
         // rejects these with InvalidArgument when the field is
         // missing or empty, since the bucket would otherwise have
@@ -108,4 +142,21 @@ impl S3Service {
             .map_err(crate::service::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
+}
+
+/// Build a `MalformedXML` error for a bucket-encryption field whose value
+/// isn't a member of its closed enum (e.g. an `SSEAlgorithm` other than
+/// AES256/aws:kms/aws:kms:dsse). Matches AWS, which rejects such bodies with
+/// 400 MalformedXML.
+fn malformed_encryption(field: &str, value: &str) -> AwsServiceError {
+    AwsServiceError::aws_error_with_fields(
+        StatusCode::BAD_REQUEST,
+        "MalformedXML",
+        "The XML you provided was not well-formed or did not validate against \
+         our published schema",
+        vec![
+            ("ArgumentName".to_string(), field.to_string()),
+            ("ArgumentValue".to_string(), value.to_string()),
+        ],
+    )
 }

--- a/crates/fakecloud-s3/src/service/objects/read.rs
+++ b/crates/fakecloud-s3/src/service/objects/read.rs
@@ -130,14 +130,18 @@ impl S3Service {
             );
         }
 
-        // SSE headers - only when explicitly set
+        // SSE headers - only when explicitly set. The algorithm / kms key id
+        // can originate from a bucket-default-encryption XML body
+        // (PutBucketEncryption), so a crafted value must never crash the read
+        // path; skip-if-invalid mirrors the object-lock guards below.
         if let Some(algo) = &obj.sse_algorithm {
-            headers.insert("x-amz-server-side-encryption", algo.parse().unwrap());
+            insert_str_header(&mut headers, "x-amz-server-side-encryption", algo);
         }
         if let Some(kid) = &obj.sse_kms_key_id {
-            headers.insert(
+            insert_str_header(
+                &mut headers,
                 "x-amz-server-side-encryption-aws-kms-key-id",
-                kid.parse().unwrap(),
+                kid,
             );
         }
         if let Some(true) = obj.bucket_key_enabled {
@@ -476,14 +480,17 @@ impl S3Service {
             headers.insert("x-amz-version-id", vid.parse().unwrap());
         }
 
-        // SSE headers
+        // SSE headers. As in get_object above, these can carry a
+        // bucket-default value sourced from an XML body, so insert through the
+        // skip-if-invalid helper rather than .parse().unwrap().
         if let Some(algo) = &obj.sse_algorithm {
-            headers.insert("x-amz-server-side-encryption", algo.parse().unwrap());
+            insert_str_header(&mut headers, "x-amz-server-side-encryption", algo);
         }
         if let Some(kid) = &obj.sse_kms_key_id {
-            headers.insert(
+            insert_str_header(
+                &mut headers,
                 "x-amz-server-side-encryption-aws-kms-key-id",
-                kid.parse().unwrap(),
+                kid,
             );
         }
         if let Some(true) = obj.bucket_key_enabled {

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -4063,6 +4063,117 @@ fn put_bucket_encryption_aws_kms_requires_kms_master_key_id() {
 }
 
 #[test]
+fn put_bucket_encryption_rejects_control_char_in_kms_key_id() {
+    // Regression (bug-audit 2026-06-13 2.1): a control byte (newline) in the
+    // bucket-default KMSMasterKeyID used to be persisted verbatim, applied as
+    // an object default on PutObject, then panic the GET/HEAD response path
+    // when round-tripped into x-amz-server-side-encryption-aws-kms-key-id.
+    // It must now be rejected up front with 400, not a panic.
+    let svc = make_service();
+    seed_bucket(&svc, "kmsfuzz");
+
+    let body = b"<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>aws:kms</SSEAlgorithm><KMSMasterKeyID>bad\nkey</KMSMasterKeyID></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>";
+    let req = make_request(Method::PUT, "/kmsfuzz", &[("encryption", "")], body);
+    let err = match svc.put_bucket_encryption("123456789012", &req, "kmsfuzz") {
+        Err(e) => e,
+        Ok(_) => panic!("control char in KMSMasterKeyID should be rejected"),
+    };
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+
+    // A NUL byte is likewise rejected.
+    let body = b"<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>aws:kms</SSEAlgorithm><KMSMasterKeyID>k\x00id</KMSMasterKeyID></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>";
+    let req = make_request(Method::PUT, "/kmsfuzz", &[("encryption", "")], body);
+    assert!(
+        svc.put_bucket_encryption("123456789012", &req, "kmsfuzz")
+            .is_err(),
+        "NUL byte in KMSMasterKeyID should be rejected"
+    );
+
+    // A legitimate KMS key ARN still round-trips and persists.
+    let arn = "arn:aws:kms:us-east-1:123456789012:key/abcd-1234";
+    let body = format!(
+        "<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>aws:kms</SSEAlgorithm><KMSMasterKeyID>{arn}</KMSMasterKeyID></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>"
+    );
+    let req = make_request(
+        Method::PUT,
+        "/kmsfuzz",
+        &[("encryption", "")],
+        body.as_bytes(),
+    );
+    svc.put_bucket_encryption("123456789012", &req, "kmsfuzz")
+        .expect("a valid KMS key ARN must be accepted");
+}
+
+#[test]
+fn put_bucket_encryption_rejects_invalid_sse_algorithm() {
+    // Regression (bug-audit 2026-06-13 2.2): SSEAlgorithm is a closed enum.
+    // A garbage value (including one carrying a control char) used to be
+    // stored verbatim and later panic the GET response header. AWS returns
+    // MalformedXML for an unknown algorithm.
+    let svc = make_service();
+    seed_bucket(&svc, "algofuzz");
+
+    let body = b"<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>x\ny</SSEAlgorithm></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>";
+    let req = make_request(Method::PUT, "/algofuzz", &[("encryption", "")], body);
+    let err = match svc.put_bucket_encryption("123456789012", &req, "algofuzz") {
+        Err(e) => e,
+        Ok(_) => panic!("invalid SSEAlgorithm should be rejected"),
+    };
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+
+    // AES256 still accepted.
+    let body = b"<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>AES256</SSEAlgorithm></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>";
+    let req = make_request(Method::PUT, "/algofuzz", &[("encryption", "")], body);
+    svc.put_bucket_encryption("123456789012", &req, "algofuzz")
+        .expect("AES256 is a valid SSEAlgorithm");
+}
+
+#[tokio::test]
+async fn bucket_default_kms_key_round_trips_on_get_without_panic() {
+    // End-to-end of the fixed path: a valid bucket-default KMS config is
+    // applied to an object PUT with no SSE headers and surfaces cleanly on
+    // GET — no dropped connection, and the key id is returned verbatim.
+    let svc = make_service();
+    seed_bucket(&svc, "kmsdef");
+
+    let arn = "arn:aws:kms:us-east-1:123456789012:key/abcd-1234";
+    let enc = format!(
+        "<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>aws:kms</SSEAlgorithm><KMSMasterKeyID>{arn}</KMSMasterKeyID></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>"
+    );
+    let enc_req = make_request(
+        Method::PUT,
+        "/kmsdef",
+        &[("encryption", "")],
+        enc.as_bytes(),
+    );
+    svc.put_bucket_encryption("123456789012", &enc_req, "kmsdef")
+        .unwrap();
+
+    let put_req = make_request(Method::PUT, "/kmsdef/obj", &[], b"data");
+    svc.put_object("123456789012", &put_req, "kmsdef", "obj")
+        .await
+        .unwrap();
+
+    let get_req = make_request(Method::GET, "/kmsdef/obj", &[], b"");
+    let resp = svc
+        .get_object("123456789012", &get_req, "kmsdef", "obj")
+        .unwrap();
+    assert_eq!(
+        resp.headers
+            .get("x-amz-server-side-encryption-aws-kms-key-id")
+            .and_then(|v| v.to_str().ok()),
+        Some(arn),
+        "valid bucket-default KMS key id must round-trip on GET"
+    );
+    assert_eq!(
+        resp.headers
+            .get("x-amz-server-side-encryption")
+            .and_then(|v| v.to_str().ok()),
+        Some("aws:kms")
+    );
+}
+
+#[test]
 fn get_bucket_policy_status_uses_real_json_parse() {
     // Substring scan would falsely flag a Description string as
     // public. Real JSON parse only flags actual Principal=*.


### PR DESCRIPTION
## Summary

Closes a CRITICAL, trivially-triggerable, unauthenticated S3 DoS (bug-audit 2026-06-13, findings 2.1/2.2).

`PutBucketEncryption` stored the request XML body verbatim, never validating the charset of `KMSMasterKeyID` / `SSEAlgorithm`. On a later `PutObject` with no SSE headers the bucket default was applied via `extract_xml_value` and persisted even when the key didn't resolve. A subsequent `GET`/`HEAD` round-tripped the stored value into the `x-amz-server-side-encryption` / `x-amz-server-side-encryption-aws-kms-key-id` response headers via `.parse::<HeaderValue>().unwrap()`. A value carrying a byte that's illegal in an HTTP header (a literal newline or NUL — all legal XML body bytes) panicked the request task and dropped the connection (`connection closed before we received a valid response`), deferred to a *different, later* request than the one that planted the poison. Same failure mode as #1539 / the object-lock panic fixed in `db0ac1b5`, but entering through an XML body field instead of a header (header-sourced siblings are safe — hyper pre-validates header bytes).

Two layers, matching the object-lock fix (`db0ac1b5`):

1. **Root cause — validate at ingestion (`put_bucket_encryption`).** `SSEAlgorithm` must be one of `AES256` / `aws:kms` / `aws:kms:dsse`, else `400 MalformedXML` (as AWS). `KMSMasterKeyID` must be a legal HTTP header value (rejecting control bytes), else `400 InvalidArgument`.
2. **Defense in depth — guard the sinks (`read.rs`).** The two SSE response-header sinks in `get_object` / `head_object` now insert through the existing skip-if-invalid `insert_str_header` helper instead of `.parse().unwrap()`, so any value persisted before this fix (or from any other path) can never panic the read path.

Scope check: multipart `CreateMultipartUpload` reads SSE only from (hyper-validated) request headers and does not apply the bucket default, so the ingestion fix covers every write path that feeds the sink. No files touched outside the s3 crate + e2e tests.

## Test plan

- `cargo fmt` (s3 + e2e)
- `cargo build -p fakecloud-s3` — clean
- `cargo clippy -p fakecloud-s3 --all-targets -- -D warnings` — clean
- `cargo test -p fakecloud-s3` — 336 passed, incl. 3 new unit tests:
  - `put_bucket_encryption_rejects_control_char_in_kms_key_id` (newline + NUL rejected 400; valid ARN accepted)
  - `put_bucket_encryption_rejects_invalid_sse_algorithm` (junk rejected 400; `AES256` accepted)
  - `bucket_default_kms_key_round_trips_on_get_without_panic` (PutBucketEncryption -> PutObject no-SSE -> GET returns the key id cleanly)
- `cargo build -p fakecloud-e2e --tests` — compiles. New e2e regression `s3_bucket_default_sse_invalid_values_no_panic` drives crafted `?encryption` bodies over raw HTTP, asserts `400` + server liveness, then confirms a legitimate bucket-default KMS config round-trips on GET. (E2E needs Docker/a running server to execute; verified it compiles.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an unauthenticated DoS where invalid bytes in bucket-default SSE config were echoed into GET/HEAD response headers and crashed the server. We now validate `SSEAlgorithm` and `KMSMasterKeyID` on `PutBucketEncryption` and guard header insertion so legacy bad data can’t panic.

- **Bug Fixes**
  - Validate on ingestion: `SSEAlgorithm` must be `AES256`, `aws:kms`, or `aws:kms:dsse` (400 MalformedXML). `KMSMasterKeyID` must be a valid HTTP header value (rejects control chars; 400 InvalidArgument).
  - Harden reads: `get_object` and `head_object` insert SSE headers via the skip-if-invalid helper instead of `.parse().unwrap()`, so pre-existing bad data can’t crash the request.
  - Tests: Added unit and e2e regressions to reject newline/NUL in KMS key IDs and junk algorithms; e2e now provisions a real KMS key so a valid bucket-default config applies on PUT and round-trips on GET without dropping the connection.

<sup>Written for commit ef87541e931c7be36b722ff00257d9b8c9678676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

