### PR TITLE
fix(rds): port runtime onto shared container_net to close #1539 podman/in-container bugs

### DIFF
--- a/crates/fakecloud-core/src/container_net.rs
+++ b/crates/fakecloud-core/src/container_net.rs
@@ -107,7 +107,8 @@ impl HostNetworking {
     /// the process environment.
     pub fn detect(cli: &str) -> Self {
         let (host_alias, add_host_arg) = resolve_host_alias(cli);
-        let sibling_host = resolve_sibling_host(std::env::var("FAKECLOUD_IN_CONTAINER").ok());
+        let sibling_host =
+            resolve_sibling_host(&host_alias, std::env::var("FAKECLOUD_IN_CONTAINER").ok());
         Self {
             host_alias,
             add_host_arg,
@@ -159,15 +160,20 @@ pub fn resolve_host_alias(cli: &str) -> (String, Option<String>) {
 /// touching the process's real environment.
 ///
 /// - `Some("1")` / `Some("true")` (case-insensitive) -> fakecloud is in a
-///   container, siblings live on `host.docker.internal:<port>`.
+///   container; the siblings publish their ports on the host's daemon and
+///   are reachable at the same host alias the spawned containers use to
+///   reach fakecloud — `host.docker.internal` under docker,
+///   `host.containers.internal` under podman. Hardcoding
+///   `host.docker.internal` here broke podman, whose gvproxy network only
+///   resolves `host.containers.internal` (issue #1539 follow-up).
 /// - anything else, including `None` -> fakecloud runs on the host,
 ///   siblings live on `127.0.0.1:<port>`.
-pub fn resolve_sibling_host(env_value: Option<String>) -> String {
+pub fn resolve_sibling_host(host_alias: &str, env_value: Option<String>) -> String {
     let in_container = env_value
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
     if in_container {
-        "host.docker.internal".to_string()
+        host_alias.to_string()
     } else {
         "127.0.0.1".to_string()
     }
@@ -218,25 +224,58 @@ mod tests {
 
     #[test]
     fn resolve_sibling_host_defaults_to_loopback() {
-        assert_eq!(resolve_sibling_host(None), "127.0.0.1");
-        assert_eq!(resolve_sibling_host(Some(String::new())), "127.0.0.1");
-        assert_eq!(resolve_sibling_host(Some("0".to_string())), "127.0.0.1");
-        assert_eq!(resolve_sibling_host(Some("false".to_string())), "127.0.0.1");
+        assert_eq!(
+            resolve_sibling_host("host.docker.internal", None),
+            "127.0.0.1"
+        );
+        assert_eq!(
+            resolve_sibling_host("host.docker.internal", Some(String::new())),
+            "127.0.0.1"
+        );
+        assert_eq!(
+            resolve_sibling_host("host.docker.internal", Some("0".to_string())),
+            "127.0.0.1"
+        );
+        assert_eq!(
+            resolve_sibling_host("host.containers.internal", Some("false".to_string())),
+            "127.0.0.1"
+        );
     }
 
     #[test]
-    fn resolve_sibling_host_uses_docker_internal_when_in_container() {
+    fn resolve_sibling_host_uses_host_alias_when_in_container() {
+        // Docker: siblings reachable at host.docker.internal.
         assert_eq!(
-            resolve_sibling_host(Some("1".to_string())),
+            resolve_sibling_host("host.docker.internal", Some("1".to_string())),
             "host.docker.internal"
         );
         assert_eq!(
-            resolve_sibling_host(Some("true".to_string())),
+            resolve_sibling_host("host.docker.internal", Some("true".to_string())),
             "host.docker.internal"
         );
         assert_eq!(
-            resolve_sibling_host(Some("TRUE".to_string())),
+            resolve_sibling_host("host.docker.internal", Some("TRUE".to_string())),
             "host.docker.internal"
+        );
+        // Podman: must use host.containers.internal, NOT host.docker.internal
+        // (issue #1539 follow-up — gvproxy only resolves the containers alias).
+        assert_eq!(
+            resolve_sibling_host("host.containers.internal", Some("1".to_string())),
+            "host.containers.internal"
+        );
+    }
+
+    #[test]
+    fn detect_wires_sibling_host_to_podman_alias_in_container() {
+        // Full path: a podman binary in a container must advertise siblings
+        // at host.containers.internal. resolve_host_alias drives host_alias,
+        // which resolve_sibling_host then reuses.
+        let (alias, add_host) = resolve_host_alias("podman");
+        assert_eq!(alias, "host.containers.internal");
+        assert_eq!(add_host, None);
+        assert_eq!(
+            resolve_sibling_host(&alias, Some("1".to_string())),
+            "host.containers.internal"
         );
     }
 

--- a/crates/fakecloud-elasticache/src/runtime/mod.rs
+++ b/crates/fakecloud-elasticache/src/runtime/mod.rs
@@ -511,9 +511,13 @@ impl DockerCache {
     }
 
     async fn wait_for_redis(&self, host_port: u16) -> Result<(), RuntimeError> {
+        // Probe the same address clients reach the published port at:
+        // 127.0.0.1 on the host, host.docker.internal /
+        // host.containers.internal when fakecloud is containerized (#1539).
+        let host = &self.net.sibling_host;
         for _ in 0..40 {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            if tokio::net::TcpStream::connect(format!("127.0.0.1:{host_port}"))
+            if tokio::net::TcpStream::connect(format!("{host}:{host_port}"))
                 .await
                 .is_ok()
             {
@@ -528,10 +532,11 @@ impl DockerCache {
 
     async fn wait_for_memcached(&self, host_port: u16) -> Result<(), RuntimeError> {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let host = &self.net.sibling_host;
         for _ in 0..40 {
             tokio::time::sleep(Duration::from_millis(500)).await;
             let Ok(mut stream) =
-                tokio::net::TcpStream::connect(format!("127.0.0.1:{host_port}")).await
+                tokio::net::TcpStream::connect(format!("{host}:{host_port}")).await
             else {
                 continue;
             };

--- a/crates/fakecloud-lambda/src/runtime/docker.rs
+++ b/crates/fakecloud-lambda/src/runtime/docker.rs
@@ -58,63 +58,25 @@ impl DockerBackend {
     /// `server_port` is the port the main fakecloud server bound to; used
     /// to resolve `PackageType=Image` ECR URIs against fakecloud ECR.
     pub fn auto_detect(server_port: u16) -> Option<Self> {
-        let cli = if let Ok(cli) = std::env::var("FAKECLOUD_CONTAINER_CLI") {
-            if std::process::Command::new(&cli)
-                .arg("info")
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false)
-            {
-                cli
-            } else {
-                return None;
-            }
-        } else if is_cli_available("docker") {
-            "docker".to_string()
-        } else if is_cli_available("podman") {
-            "podman".to_string()
-        } else {
-            return None;
-        };
-
+        // Container-to-host networking (CLI detection, host alias,
+        // --add-host injection, and the in-container sibling address) all
+        // come from the shared `fakecloud-core::container_net` helper so the
+        // four container-spawning runtimes (Lambda/ECS/RDS/ElastiCache) can't
+        // drift apart on the issue #1539 fix. `detect_container_cli` honors
+        // `FAKECLOUD_CONTAINER_CLI` and prefers docker then podman, returning
+        // `None` when neither is usable.
+        let cli = fakecloud_core::container_net::detect_container_cli()?;
         let instance_id = format!("fakecloud-{}", std::process::id());
-
-        let (host_alias, add_host_arg) = if is_podman_binary(&cli) {
-            // Podman ships `host.containers.internal` as a built-in container
-            // DNS entry on every supported platform; injecting `host-gateway`
-            // on macOS fails because rootless podman's gvproxy doesn't
-            // expose the magic alias (issue #1539).
-            ("host.containers.internal".to_string(), None)
-        } else if cfg!(target_os = "linux") {
-            // Bare docker on Linux: resolve the bridge gateway IP and add
-            // an explicit alias. `host.docker.internal:host-gateway` only
-            // works on Docker Desktop; native Linux docker has no such
-            // magic.
-            let ip = detect_bridge_gateway(&cli).unwrap_or_else(|| "172.17.0.1".to_string());
-            (
-                "host.docker.internal".to_string(),
-                Some(format!("host.docker.internal:{ip}")),
-            )
-        } else {
-            // Docker Desktop on Mac/Windows: `host-gateway` is a Docker
-            // Desktop-only alias that resolves to the host's IP.
-            (
-                "host.docker.internal".to_string(),
-                Some("host.docker.internal:host-gateway".to_string()),
-            )
-        };
+        let net = fakecloud_core::container_net::HostNetworking::detect(&cli);
 
         let docker_config = build_local_registry_docker_config(server_port).map(Arc::new);
-        let sibling_host = resolve_sibling_host(std::env::var("FAKECLOUD_IN_CONTAINER").ok());
         Some(Self {
             cli,
             instance_id,
-            host_alias,
-            add_host_arg,
+            host_alias: net.host_alias,
+            add_host_arg: net.add_host_arg,
             server_port,
-            sibling_host,
+            sibling_host: net.sibling_host,
             docker_config,
         })
     }
@@ -624,74 +586,6 @@ pub fn extract_zip(zip_bytes: &[u8], dest: &Path) -> Result<(), RuntimeError> {
     Ok(())
 }
 
-/// Detect the Docker bridge gateway IP on Linux. Returns None if detection fails.
-fn detect_bridge_gateway(cli: &str) -> Option<String> {
-    let output = std::process::Command::new(cli)
-        .args([
-            "network",
-            "inspect",
-            "bridge",
-            "--format",
-            "{{range .IPAM.Config}}{{.Gateway}}{{end}}",
-        ])
-        .output()
-        .ok()?;
-
-    if output.status.success() {
-        let gateway = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !gateway.is_empty() && gateway.contains('.') {
-            tracing::info!(
-                gateway = %gateway,
-                "Detected Docker bridge gateway for Lambda containers"
-            );
-            return Some(gateway);
-        }
-    }
-    None
-}
-
-/// Decide what loopback address fakecloud uses to reach the *sibling*
-/// Lambda containers it just spawned. Pure helper so the env-var
-/// parsing can be tested without touching the process's real
-/// environment (which would race with parallel tests).
-///
-/// - `Some("1")` or `Some("true")` -> fakecloud is in a container,
-///   sibling published ports live on `host.docker.internal:<port>`.
-/// - Anything else, including `None` -> fakecloud runs on the host,
-///   sibling ports live on `127.0.0.1:<port>`.
-fn resolve_sibling_host(env_value: Option<String>) -> String {
-    let in_container = env_value
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-    if in_container {
-        "host.docker.internal".to_string()
-    } else {
-        "127.0.0.1".to_string()
-    }
-}
-
-fn is_cli_available(name: &str) -> bool {
-    std::process::Command::new(name)
-        .arg("info")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
-/// True when `cli` is podman or a podman-compatible binary. Matches on the
-/// filename component so absolute paths (`/opt/homebrew/bin/podman`) and
-/// wrappers (`podman-remote`) both register as podman. Docker Desktop's
-/// compatibility CLI is named `docker`, so this check is safe.
-fn is_podman_binary(cli: &str) -> bool {
-    std::path::Path::new(cli)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(|n| n.contains("podman"))
-        .unwrap_or(false)
-}
-
 fn build_local_registry_docker_config(server_port: u16) -> Option<TempDir> {
     let dir = TempDir::new().ok()?;
     let auth = base64::engine::general_purpose::STANDARD.encode("AWS:fakecloud-lambda-runtime");
@@ -782,50 +676,6 @@ mod tests {
             Some("public.ecr.aws/lambda/dotnet:10".to_string())
         );
         assert_eq!(runtime_to_image("unknown"), None);
-    }
-
-    #[test]
-    fn is_podman_binary_matches_bare_name() {
-        assert!(is_podman_binary("podman"));
-        assert!(is_podman_binary("podman-remote"));
-    }
-
-    #[test]
-    fn is_podman_binary_matches_absolute_path() {
-        assert!(is_podman_binary("/opt/homebrew/bin/podman"));
-        assert!(is_podman_binary("/usr/local/bin/podman-remote"));
-    }
-
-    #[test]
-    fn is_podman_binary_rejects_docker() {
-        assert!(!is_podman_binary("docker"));
-        assert!(!is_podman_binary("/usr/local/bin/docker"));
-        // Docker Desktop's compatibility CLI is `docker`, not `podman`.
-        assert!(!is_podman_binary("docker-credential-helper"));
-    }
-
-    #[test]
-    fn resolve_sibling_host_defaults_to_loopback() {
-        assert_eq!(resolve_sibling_host(None), "127.0.0.1");
-        assert_eq!(resolve_sibling_host(Some("".to_string())), "127.0.0.1");
-        assert_eq!(resolve_sibling_host(Some("0".to_string())), "127.0.0.1");
-        assert_eq!(resolve_sibling_host(Some("false".to_string())), "127.0.0.1");
-    }
-
-    #[test]
-    fn resolve_sibling_host_uses_docker_internal_when_in_container() {
-        assert_eq!(
-            resolve_sibling_host(Some("1".to_string())),
-            "host.docker.internal"
-        );
-        assert_eq!(
-            resolve_sibling_host(Some("true".to_string())),
-            "host.docker.internal"
-        );
-        assert_eq!(
-            resolve_sibling_host(Some("TRUE".to_string())),
-            "host.docker.internal"
-        );
     }
 
     #[test]

--- a/crates/fakecloud-rds/src/runtime/mod.rs
+++ b/crates/fakecloud-rds/src/runtime/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use fakecloud_core::container_net::{detect_container_cli, HostNetworking};
 use parking_lot::RwLock;
 use tokio_postgres::NoTls;
 
@@ -55,7 +56,12 @@ pub struct RdsRuntime {
     cli: String,
     containers: RwLock<HashMap<String, RunningDbContainer>>,
     instance_id: String,
-    host_ip: String,
+    /// Container-to-host networking resolved from the shared
+    /// `fakecloud-core::container_net` helper (issue #1539): the host alias
+    /// the spawned DB container uses to reach fakecloud, the `--add-host`
+    /// flag (None under podman), and the sibling address fakecloud uses to
+    /// reach the DB it just spawned. Unused on the k8s backend.
+    net: HostNetworking,
     server_port: u16,
     image_cache: RwLock<HashMap<String, Arc<tokio::sync::Mutex<bool>>>>,
     /// `Some` when running on the Kubernetes backend; the public methods
@@ -85,34 +91,20 @@ pub enum BackendInitError {
 
 impl RdsRuntime {
     pub fn new(server_port: u16) -> Option<Self> {
-        let cli = if let Ok(cli) = std::env::var("FAKECLOUD_CONTAINER_CLI") {
-            if cli_available(&cli) {
-                cli
-            } else {
-                return None;
-            }
-        } else if cli_available("docker") {
-            "docker".to_string()
-        } else if cli_available("podman") {
-            "podman".to_string()
-        } else {
-            return None;
-        };
-
-        // Match Lambda runtime container-to-host networking: Linux uses the
-        // bridge gateway IP directly, macOS/Windows use Docker Desktop's
-        // host-gateway alias. Containers reach fakecloud at host.docker.internal.
-        let host_ip = if cfg!(target_os = "linux") {
-            detect_bridge_gateway(&cli).unwrap_or_else(|| "172.17.0.1".to_string())
-        } else {
-            "host-gateway".to_string()
-        };
+        // CLI detection, host alias, `--add-host` injection, and the
+        // in-container sibling address all come from the shared
+        // `container_net` helper so RDS can't drift from Lambda/ECS/
+        // ElastiCache on the issue #1539 fix (podman gets no `--add-host`
+        // and the `host.containers.internal` alias; macOS docker gets
+        // `host-gateway`; Linux docker gets the resolved bridge IP).
+        let cli = detect_container_cli()?;
+        let net = HostNetworking::detect(&cli);
 
         Some(Self {
             cli,
             containers: RwLock::new(HashMap::new()),
             instance_id: format!("fakecloud-{}", std::process::id()),
-            host_ip,
+            net,
             server_port,
             image_cache: RwLock::new(HashMap::new()),
             k8s: None,
@@ -128,7 +120,14 @@ impl RdsRuntime {
             cli: String::new(),
             containers: RwLock::new(HashMap::new()),
             instance_id: format!("fakecloud-{}", std::process::id()),
-            host_ip: String::new(),
+            // Docker networking is unused on the k8s backend (Pod addresses
+            // come from `K8sDb`); a host-loopback default keeps the field
+            // populated without affecting behavior.
+            net: HostNetworking {
+                host_alias: String::new(),
+                add_host_arg: None,
+                sibling_host: "127.0.0.1".to_string(),
+            },
             server_port,
             image_cache: RwLock::new(HashMap::new()),
             k8s: Some(db),
@@ -199,8 +198,8 @@ impl RdsRuntime {
                     format!("POSTGRES_PASSWORD={password}"),
                     format!("POSTGRES_DB={db_name}"),
                     format!(
-                        "FAKECLOUD_ENDPOINT=http://host.docker.internal:{}",
-                        self.server_port
+                        "FAKECLOUD_ENDPOINT=http://{}:{}",
+                        self.net.host_alias, self.server_port
                     ),
                     format!("FAKECLOUD_ACCOUNT_ID={account_id}"),
                     format!("FAKECLOUD_REGION={region}"),
@@ -221,8 +220,8 @@ impl RdsRuntime {
                     format!("MYSQL_PASSWORD={password}"),
                     format!("MYSQL_DATABASE={db_name}"),
                     format!(
-                        "FAKECLOUD_ENDPOINT=http://host.docker.internal:{}",
-                        self.server_port
+                        "FAKECLOUD_ENDPOINT=http://{}:{}",
+                        self.net.host_alias, self.server_port
                     ),
                     format!("FAKECLOUD_ACCOUNT_ID={account_id}"),
                     format!("FAKECLOUD_REGION={region}"),
@@ -244,8 +243,8 @@ impl RdsRuntime {
                     format!("MARIADB_PASSWORD={password}"),
                     format!("MARIADB_DATABASE={db_name}"),
                     format!(
-                        "FAKECLOUD_ENDPOINT=http://host.docker.internal:{}",
-                        self.server_port
+                        "FAKECLOUD_ENDPOINT=http://{}:{}",
+                        self.net.host_alias, self.server_port
                     ),
                     format!("FAKECLOUD_ACCOUNT_ID={account_id}"),
                     format!("FAKECLOUD_REGION={region}"),
@@ -320,12 +319,13 @@ impl RdsRuntime {
         }
 
         // Bridge-aware engines (postgres aws_lambda, mysql/mariadb
-        // fakecloud_post UDF) call back into fakecloud over HTTP. Wire
-        // the host gateway alias so the in-container code can resolve
-        // host.docker.internal on every platform.
+        // fakecloud_post UDF) call back into fakecloud over HTTP. Inject the
+        // host-gateway `--add-host` mapping so the in-container code can
+        // resolve the host alias. No-op under podman, which provides
+        // `host.containers.internal` natively — passing `host-gateway` there
+        // fails with "host containers internal IP address is empty" (#1539).
         if bridge_engine_version.is_some() {
-            args.push("--add-host".to_string());
-            args.push(format!("host.docker.internal:{}", self.host_ip));
+            self.net.push_add_host_args(&mut args);
         }
 
         for env_var in env_vars {
@@ -398,7 +398,10 @@ impl RdsRuntime {
         let running = RunningDbContainer {
             container_id,
             host_port,
-            endpoint_address: "127.0.0.1".to_string(),
+            // 127.0.0.1 on the host; host.docker.internal /
+            // host.containers.internal when fakecloud is itself
+            // containerized (issue #1539).
+            endpoint_address: self.net.sibling_host.clone(),
             endpoint_port: host_port,
         };
         self.containers
@@ -492,7 +495,7 @@ impl RdsRuntime {
         let running = RunningDbContainer {
             container_id: running.container_id,
             host_port,
-            endpoint_address: "127.0.0.1".to_string(),
+            endpoint_address: self.net.sibling_host.clone(),
             endpoint_port: host_port,
         };
         self.containers
@@ -545,7 +548,8 @@ impl RdsRuntime {
         for _ in 0..40 {
             tokio::time::sleep(Duration::from_millis(500)).await;
             let connection_string = format!(
-                "host=127.0.0.1 port={host_port} user={username} password={password} dbname={db_name}"
+                "host={} port={host_port} user={username} password={password} dbname={db_name}",
+                self.net.sibling_host
             );
             if let Ok((client, connection)) =
                 tokio_postgres::connect(&connection_string, NoTls).await
@@ -576,7 +580,7 @@ impl RdsRuntime {
 
         for attempt in 1..=40 {
             let opts = OptsBuilder::default()
-                .ip_or_hostname("127.0.0.1")
+                .ip_or_hostname(self.net.sibling_host.as_str())
                 .tcp_port(host_port)
                 .user(Some(username))
                 .pass(Some(password))
@@ -677,8 +681,9 @@ impl RdsRuntime {
     /// listener may bind a moment after the readiness log line.
     async fn wait_for_tcp(&self, host_port: u16, deadline_secs: u64) -> Result<(), RuntimeError> {
         let deadline = std::time::Instant::now() + Duration::from_secs(deadline_secs);
+        let host = self.net.sibling_host.as_str();
         while std::time::Instant::now() < deadline {
-            if tokio::net::TcpStream::connect(("127.0.0.1", host_port))
+            if tokio::net::TcpStream::connect((host, host_port))
                 .await
                 .is_ok()
             {
@@ -687,8 +692,8 @@ impl RdsRuntime {
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
         Err(RuntimeError::ContainerStartFailed(format!(
-            "TCP probe to 127.0.0.1:{} did not succeed within {}s",
-            host_port, deadline_secs
+            "TCP probe to {}:{} did not succeed within {}s",
+            host, host_port, deadline_secs
         )))
     }
 
@@ -1150,40 +1155,6 @@ impl RdsRuntime {
 
         Ok(())
     }
-}
-
-fn cli_available(cli: &str) -> bool {
-    std::process::Command::new(cli)
-        .arg("info")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
-}
-
-/// On Linux Docker bridge networks, ask the daemon for the bridge
-/// gateway IP so containers can reach the host's loopback. macOS and
-/// Windows use the magic `host-gateway` alias instead.
-fn detect_bridge_gateway(cli: &str) -> Option<String> {
-    let output = std::process::Command::new(cli)
-        .args([
-            "network",
-            "inspect",
-            "bridge",
-            "--format",
-            "{{range .IPAM.Config}}{{.Gateway}}{{end}}",
-        ])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let gateway = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if gateway.is_empty() || !gateway.contains('.') {
-        return None;
-    }
-    Some(gateway)
 }
 
 /// Build the prebuilt-image reference for a given engine + major


### PR DESCRIPTION
## Summary

RDS was the only container-spawning service never migrated to `fakecloud-core::container_net`, so it still reproduced both headline #1539 bugs (Tier-0 of the 2026-06-13 bug-hunt report):

- **podman `--add-host` rejection** — RDS passed `--add-host host.docker.internal:host-gateway` to podman on every non-Linux target with no `is_podman_binary` check. Rootless podman's gvproxy rejects it ("host containers internal IP address is empty"), so `CreateDBInstance`/`StartDBInstance` failed on macOS podman.
- **in-container `127.0.0.1`** — RDS advertised a hardcoded `127.0.0.1` endpoint and ran readiness probes against `127.0.0.1`, both wrong when fakecloud itself runs containerized (`FAKECLOUD_IN_CONTAINER=1`): the sibling DB publishes on the host daemon, reachable via the host alias, not loopback.

This ports `RdsRuntime` onto the shared `HostNetworking` helper (CLI detection, host alias, `--add-host` injection, sibling address), exactly as ECS/ElastiCache already are. `FAKECLOUD_ENDPOINT`, `--add-host`, the advertised `endpoint_address`, and every readiness probe now go through the one resolver.

Additional fixes folded in (same root cause / drift class):
- **`container_net::resolve_sibling_host` is now podman-aware** — when fakecloud is containerized the sibling address is the host alias, so podman gets `host.containers.internal` instead of `host.docker.internal` (gvproxy only resolves the containers alias). New unit coverage for the podman in-container path.
- **Lambda Docker backend migrated onto the shared helper**, deleting its duplicate detect/alias/sibling-host helpers so the four runtimes can't drift apart again (the whole point of `container_net`).
- **ElastiCache readiness probes** for redis/memcached now use `net.sibling_host` instead of a hardcoded `127.0.0.1`.

## Test plan

- `cargo clippy -p fakecloud-core -p fakecloud-rds -p fakecloud-elasticache -p fakecloud-lambda --all-targets -- -D warnings` — clean.
- `cargo test -p fakecloud-core -p fakecloud-rds -p fakecloud-lambda --lib` — all pass, including new `container_net` unit tests asserting the podman in-container sibling host resolves to `host.containers.internal`.
- Behavior for docker-on-host (the CI path) is unchanged: `sibling_host` stays `127.0.0.1`, `--add-host` still injected for docker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports RDS onto the shared `fakecloud-core::container_net` to fix podman `--add-host` failures and wrong in-container endpoints (#1539). Unifies container networking across RDS, Lambda, and ElastiCache so endpoints and probes resolve through one helper.

- **Bug Fixes**
  - RDS no longer passes `--add-host host.docker.internal:host-gateway` to podman and now uses `host.containers.internal` automatically; docker paths still inject the right mapping.
  - RDS and ElastiCache readiness probes and advertised endpoints now use `sibling_host`; `FAKECLOUD_ENDPOINT` is built from the resolved host alias.

- **Refactors**
  - Migrated the Lambda Docker backend to `container_net` and removed duplicate CLI/alias/sibling-host logic; `resolve_sibling_host` now uses the host alias and adds podman unit tests.

<sup>Written for commit 35bfba9de89c2800be9bb383bebf3fecfa48d6f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

