### PR TITLE
fix(lambda,ec2,dynamodb,glue): implement stubbed write-read asymmetric ops

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/global_tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/global_tables.rs
@@ -32,6 +32,8 @@ impl DynamoDbService {
                 r["RegionName"].as_str().map(|rn| ReplicaDescription {
                     region_name: rn.to_string(),
                     replica_status: "ACTIVE".to_string(),
+                    read_capacity_auto_scaling: None,
+                    write_capacity_auto_scaling: None,
                 })
             })
             .collect::<Vec<_>>();
@@ -215,6 +217,8 @@ impl DynamoDbService {
                         gt.replication_group.push(ReplicaDescription {
                             region_name: region.to_string(),
                             replica_status: "ACTIVE".to_string(),
+                            read_capacity_auto_scaling: None,
+                            write_capacity_auto_scaling: None,
                         });
                     }
                 }

--- a/crates/fakecloud-dynamodb/src/service/streams.rs
+++ b/crates/fakecloud-dynamodb/src/service/streams.rs
@@ -53,11 +53,20 @@ impl DynamoDbService {
         let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let table = get_table(&state.tables, table_name)?;
 
+        // Replicas come from the global-table replication group (created via
+        // CreateGlobalTable / UpdateTable ReplicaUpdates). The global-table
+        // name equals the table name in AWS.
+        let replicas = state
+            .global_tables
+            .get(table_name)
+            .map(|gt| replica_auto_scaling_list(&gt.replication_group))
+            .unwrap_or_default();
+
         Self::ok_json(json!({
             "TableAutoScalingDescription": {
                 "TableName": table.name,
                 "TableStatus": table.status,
-                "Replicas": []
+                "Replicas": replicas
             }
         }))
     }
@@ -69,16 +78,57 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
 
-        let accounts = self.state.read();
-        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
-        let table = get_table(&state.tables, table_name)?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        // Validate the table exists (returns ResourceNotFound otherwise).
+        let (name, status) = {
+            let table = get_table(&state.tables, table_name)?;
+            (table.name.clone(), table.status.clone())
+        };
+
+        // Persist the supplied autoscaling settings onto the matching replicas
+        // in the global-table replication group, then reflect them on read.
+        if let Some(gt) = state.global_tables.get_mut(table_name) {
+            if let Some(updates) = body["ReplicaUpdates"].as_array() {
+                for update in updates {
+                    let region = update["RegionName"].as_str().unwrap_or_default();
+                    if let Some(replica) = gt
+                        .replication_group
+                        .iter_mut()
+                        .find(|r| r.region_name == region)
+                    {
+                        if let Some(read) =
+                            update.get("ReplicaProvisionedReadCapacityAutoScalingUpdate")
+                        {
+                            replica.read_capacity_auto_scaling =
+                                Some(auto_scaling_description(read));
+                        }
+                    }
+                }
+            }
+        }
+        // A table-level write-capacity autoscaling update applies to every
+        // replica per AWS semantics.
+        if let Some(write) = body.get("ProvisionedWriteCapacityAutoScalingUpdate") {
+            if let Some(gt) = state.global_tables.get_mut(table_name) {
+                let desc = auto_scaling_description(write);
+                for replica in gt.replication_group.iter_mut() {
+                    replica.write_capacity_auto_scaling = Some(desc.clone());
+                }
+            }
+        }
+
+        let replicas = state
+            .global_tables
+            .get(table_name)
+            .map(|gt| replica_auto_scaling_list(&gt.replication_group))
+            .unwrap_or_default();
 
         Self::ok_json(json!({
             "TableAutoScalingDescription": {
-                "TableName": table.name,
-                "TableStatus": table.status,
-                "Replicas": []
+                "TableName": name,
+                "TableStatus": status,
+                "Replicas": replicas
             }
         }))
     }
@@ -315,4 +365,71 @@ impl DynamoDbService {
             "ContributorInsightsSummaries": summaries
         }))
     }
+}
+
+/// Build the `Replicas` list (`ReplicaAutoScalingDescription[]`) from a
+/// global-table replication group, emitting any persisted autoscaling
+/// settings.
+fn replica_auto_scaling_list(
+    replicas: &[crate::state::ReplicaDescription],
+) -> Vec<Value> {
+    replicas
+        .iter()
+        .map(|r| {
+            let mut item = json!({
+                "RegionName": r.region_name,
+                "ReplicaStatus": r.replica_status,
+            });
+            let obj = item.as_object_mut().expect("json object");
+            if let Some(read) = &r.read_capacity_auto_scaling {
+                obj.insert(
+                    "ReplicaProvisionedReadCapacityAutoScalingSettings".into(),
+                    read.clone(),
+                );
+            }
+            if let Some(write) = &r.write_capacity_auto_scaling {
+                obj.insert(
+                    "ReplicaProvisionedWriteCapacityAutoScalingSettings".into(),
+                    write.clone(),
+                );
+            }
+            item
+        })
+        .collect()
+}
+
+/// Convert an `AutoScalingSettingsUpdate` (from the request) into the
+/// `AutoScalingSettingsDescription` shape returned on read.
+fn auto_scaling_description(update: &Value) -> Value {
+    let mut desc = serde_json::Map::new();
+    if let Some(v) = update.get("MinimumUnits") {
+        desc.insert("MinimumUnits".into(), v.clone());
+    }
+    if let Some(v) = update.get("MaximumUnits") {
+        desc.insert("MaximumUnits".into(), v.clone());
+    }
+    if let Some(v) = update.get("AutoScalingDisabled") {
+        desc.insert("AutoScalingDisabled".into(), v.clone());
+    }
+    if let Some(v) = update.get("AutoScalingRoleArn") {
+        desc.insert("AutoScalingRoleArn".into(), v.clone());
+    }
+    // Echo the scaling policy configuration as a description entry.
+    if let Some(policy) = update.get("ScalingPolicyUpdate") {
+        let mut p = serde_json::Map::new();
+        if let Some(name) = policy.get("PolicyName") {
+            p.insert("PolicyName".into(), name.clone());
+        }
+        if let Some(cfg) = policy.get("TargetTrackingScalingPolicyConfiguration") {
+            p.insert(
+                "TargetTrackingScalingPolicyConfiguration".into(),
+                cfg.clone(),
+            );
+        }
+        desc.insert(
+            "ScalingPolicies".into(),
+            Value::Array(vec![Value::Object(p)]),
+        );
+    }
+    Value::Object(desc)
 }

--- a/crates/fakecloud-dynamodb/src/service/streams.rs
+++ b/crates/fakecloud-dynamodb/src/service/streams.rs
@@ -370,9 +370,7 @@ impl DynamoDbService {
 /// Build the `Replicas` list (`ReplicaAutoScalingDescription[]`) from a
 /// global-table replication group, emitting any persisted autoscaling
 /// settings.
-fn replica_auto_scaling_list(
-    replicas: &[crate::state::ReplicaDescription],
-) -> Vec<Value> {
+fn replica_auto_scaling_list(replicas: &[crate::state::ReplicaDescription]) -> Vec<Value> {
     replicas
         .iter()
         .map(|r| {

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -236,6 +236,14 @@ pub struct GlobalTableDescription {
 pub struct ReplicaDescription {
     pub region_name: String,
     pub replica_status: String,
+    /// Per-replica provisioned-read-capacity autoscaling settings, as supplied
+    /// via `UpdateTableReplicaAutoScaling`. Round-tripped through
+    /// `DescribeTableReplicaAutoScaling` as `AutoScalingSettingsDescription`.
+    #[serde(default)]
+    pub read_capacity_auto_scaling: Option<serde_json::Value>,
+    /// Per-replica provisioned-write-capacity autoscaling settings.
+    #[serde(default)]
+    pub write_capacity_auto_scaling: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -2185,6 +2185,130 @@ async fn dynamodb_global_table_replicates_writes() {
 }
 
 #[tokio::test]
+async fn dynamodb_replica_auto_scaling_reflects_global_table_replicas() {
+    use aws_sdk_dynamodb::types::{
+        AutoScalingSettingsUpdate, ReplicaAutoScalingUpdate,
+    };
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("ScaleTbl")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // No replicas yet -> empty replica list.
+    let resp = client
+        .describe_table_replica_auto_scaling()
+        .table_name("ScaleTbl")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp
+        .table_auto_scaling_description()
+        .unwrap()
+        .replicas()
+        .is_empty());
+
+    // Create the global table with two replicas.
+    client
+        .create_global_table()
+        .global_table_name("ScaleTbl")
+        .replication_group(Replica::builder().region_name("us-east-1").build())
+        .replication_group(Replica::builder().region_name("eu-west-1").build())
+        .send()
+        .await
+        .unwrap();
+
+    // Describe now reflects the configured replicas (was always empty: 1.4).
+    let resp = client
+        .describe_table_replica_auto_scaling()
+        .table_name("ScaleTbl")
+        .send()
+        .await
+        .unwrap();
+    let regions: Vec<&str> = resp
+        .table_auto_scaling_description()
+        .unwrap()
+        .replicas()
+        .iter()
+        .filter_map(|r| r.region_name())
+        .collect();
+    assert!(regions.contains(&"us-east-1"), "regions={regions:?}");
+    assert!(regions.contains(&"eu-west-1"), "regions={regions:?}");
+
+    // Update autoscaling settings for one replica; they must persist + reflect.
+    let updated = client
+        .update_table_replica_auto_scaling()
+        .table_name("ScaleTbl")
+        .replica_updates(
+            ReplicaAutoScalingUpdate::builder()
+                .region_name("us-east-1")
+                .replica_provisioned_read_capacity_auto_scaling_update(
+                    AutoScalingSettingsUpdate::builder()
+                        .minimum_units(5)
+                        .maximum_units(50)
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let use1 = updated
+        .table_auto_scaling_description()
+        .unwrap()
+        .replicas()
+        .iter()
+        .find(|r| r.region_name() == Some("us-east-1"))
+        .unwrap();
+    let read = use1
+        .replica_provisioned_read_capacity_auto_scaling_settings()
+        .unwrap();
+    assert_eq!(read.minimum_units(), Some(5));
+    assert_eq!(read.maximum_units(), Some(50));
+
+    // Re-describe: the persisted settings survive.
+    let resp = client
+        .describe_table_replica_auto_scaling()
+        .table_name("ScaleTbl")
+        .send()
+        .await
+        .unwrap();
+    let use1 = resp
+        .table_auto_scaling_description()
+        .unwrap()
+        .replicas()
+        .iter()
+        .find(|r| r.region_name() == Some("us-east-1"))
+        .unwrap();
+    assert_eq!(
+        use1.replica_provisioned_read_capacity_auto_scaling_settings()
+            .unwrap()
+            .maximum_units(),
+        Some(50)
+    );
+}
+
+#[tokio::test]
 async fn dynamodb_contributor_insights_tracks_access() {
     let server = TestServer::start().await;
     let client = server.dynamodb_client().await;

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -2186,9 +2186,7 @@ async fn dynamodb_global_table_replicates_writes() {
 
 #[tokio::test]
 async fn dynamodb_replica_auto_scaling_reflects_global_table_replicas() {
-    use aws_sdk_dynamodb::types::{
-        AutoScalingSettingsUpdate, ReplicaAutoScalingUpdate,
-    };
+    use aws_sdk_dynamodb::types::{AutoScalingSettingsUpdate, ReplicaAutoScalingUpdate};
     let server = TestServer::start().await;
     let client = server.dynamodb_client().await;
 

--- a/crates/fakecloud-e2e/tests/ec2_image_reserved.rs
+++ b/crates/fakecloud-e2e/tests/ec2_image_reserved.rs
@@ -202,7 +202,9 @@ async fn reserved_instances_listings_persist_and_describe() {
         .await
         .unwrap();
     assert_eq!(
-        described.reserved_instances_listings()[0].status().map(|s| s.as_str()),
+        described.reserved_instances_listings()[0]
+            .status()
+            .map(|s| s.as_str()),
         Some("cancelled")
     );
 }

--- a/crates/fakecloud-e2e/tests/ec2_image_reserved.rs
+++ b/crates/fakecloud-e2e/tests/ec2_image_reserved.rs
@@ -1,0 +1,249 @@
+//! EC2 round-trip E2E for image attributes and reserved-instance
+//! listings/modifications — proving writes persist and reflect on read
+//! (bug-hunt 2026-06-13 findings 1.2 and 1.5).
+
+mod helpers;
+
+use helpers::TestServer;
+
+async fn make_ami(c: &aws_sdk_ec2::Client) -> String {
+    c.register_image()
+        .name("ami-roundtrip")
+        .send()
+        .await
+        .unwrap()
+        .image_id()
+        .unwrap()
+        .to_string()
+}
+
+#[tokio::test]
+async fn modify_image_attribute_launch_permission_round_trips() {
+    use aws_sdk_ec2::types::{LaunchPermission, LaunchPermissionModifications, OperationType};
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let id = make_ami(&c).await;
+
+    // Add a cross-account share.
+    c.modify_image_attribute()
+        .image_id(&id)
+        .launch_permission(
+            LaunchPermissionModifications::builder()
+                .add(LaunchPermission::builder().user_id("111122223333").build())
+                .add(LaunchPermission::builder().user_id("444455556666").build())
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // DescribeImageAttribute must reflect the added permissions.
+    let r = c
+        .describe_image_attribute()
+        .image_id(&id)
+        .attribute(aws_sdk_ec2::types::ImageAttributeName::LaunchPermission)
+        .send()
+        .await
+        .unwrap();
+    let users: Vec<&str> = r
+        .launch_permissions()
+        .iter()
+        .filter_map(|p| p.user_id())
+        .collect();
+    assert!(users.contains(&"111122223333"), "users={users:?}");
+    assert!(users.contains(&"444455556666"), "users={users:?}");
+
+    // Remove one.
+    c.modify_image_attribute()
+        .image_id(&id)
+        .launch_permission(
+            LaunchPermissionModifications::builder()
+                .remove(LaunchPermission::builder().user_id("111122223333").build())
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let r = c
+        .describe_image_attribute()
+        .image_id(&id)
+        .attribute(aws_sdk_ec2::types::ImageAttributeName::LaunchPermission)
+        .send()
+        .await
+        .unwrap();
+    let users: Vec<&str> = r
+        .launch_permissions()
+        .iter()
+        .filter_map(|p| p.user_id())
+        .collect();
+    assert!(!users.contains(&"111122223333"), "users={users:?}");
+    assert!(users.contains(&"444455556666"), "users={users:?}");
+
+    // The `all` group makes the AMI public.
+    c.modify_image_attribute()
+        .image_id(&id)
+        .operation_type(OperationType::Add)
+        .launch_permission(
+            LaunchPermissionModifications::builder()
+                .add(LaunchPermission::builder().group("all".into()).build())
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let imgs = c.describe_images().image_ids(&id).send().await.unwrap();
+    assert_eq!(imgs.images()[0].public(), Some(true));
+
+    // ResetImageAttribute clears launch permissions.
+    c.reset_image_attribute()
+        .image_id(&id)
+        .attribute(aws_sdk_ec2::types::ResetImageAttributeName::LaunchPermission)
+        .send()
+        .await
+        .unwrap();
+    let r = c
+        .describe_image_attribute()
+        .image_id(&id)
+        .attribute(aws_sdk_ec2::types::ImageAttributeName::LaunchPermission)
+        .send()
+        .await
+        .unwrap();
+    assert!(r.launch_permissions().is_empty());
+}
+
+#[tokio::test]
+async fn modify_image_attribute_description_round_trips() {
+    use aws_sdk_ec2::types::AttributeValue;
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let id = make_ami(&c).await;
+
+    c.modify_image_attribute()
+        .image_id(&id)
+        .description(AttributeValue::builder().value("a new description").build())
+        .send()
+        .await
+        .unwrap();
+    let r = c
+        .describe_image_attribute()
+        .image_id(&id)
+        .attribute(aws_sdk_ec2::types::ImageAttributeName::Description)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.description().and_then(|d| d.value()),
+        Some("a new description")
+    );
+}
+
+#[tokio::test]
+async fn reserved_instances_listings_persist_and_describe() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+
+    // Purchase an RI first so the listing references a real id.
+    let ri = c
+        .purchase_reserved_instances_offering()
+        .reserved_instances_offering_id("offering-1")
+        .instance_count(1)
+        .send()
+        .await
+        .unwrap()
+        .reserved_instances_id()
+        .unwrap()
+        .to_string();
+
+    let created = c
+        .create_reserved_instances_listing()
+        .reserved_instances_id(&ri)
+        .instance_count(1)
+        .client_token("tok-1")
+        .send()
+        .await
+        .unwrap();
+    let listing_id = created.reserved_instances_listings()[0]
+        .reserved_instances_listing_id()
+        .unwrap()
+        .to_string();
+
+    // DescribeReservedInstancesListings must return the created listing.
+    let described = c
+        .describe_reserved_instances_listings()
+        .send()
+        .await
+        .unwrap();
+    let ids: Vec<&str> = described
+        .reserved_instances_listings()
+        .iter()
+        .filter_map(|l| l.reserved_instances_listing_id())
+        .collect();
+    assert!(ids.contains(&listing_id.as_str()), "ids={ids:?}");
+
+    // Filter by listing id.
+    let filtered = c
+        .describe_reserved_instances_listings()
+        .reserved_instances_listing_id(&listing_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(filtered.reserved_instances_listings().len(), 1);
+
+    // Cancel flips status to cancelled and persists.
+    c.cancel_reserved_instances_listing()
+        .reserved_instances_listing_id(&listing_id)
+        .send()
+        .await
+        .unwrap();
+    let described = c
+        .describe_reserved_instances_listings()
+        .reserved_instances_listing_id(&listing_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described.reserved_instances_listings()[0].status().map(|s| s.as_str()),
+        Some("cancelled")
+    );
+}
+
+#[tokio::test]
+async fn reserved_instances_modifications_persist_and_describe() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+
+    let ri = c
+        .purchase_reserved_instances_offering()
+        .reserved_instances_offering_id("offering-1")
+        .instance_count(1)
+        .send()
+        .await
+        .unwrap()
+        .reserved_instances_id()
+        .unwrap()
+        .to_string();
+
+    let modified = c
+        .modify_reserved_instances()
+        .reserved_instances_ids(&ri)
+        .client_token("modtok")
+        .send()
+        .await
+        .unwrap();
+    let mod_id = modified
+        .reserved_instances_modification_id()
+        .unwrap()
+        .to_string();
+
+    let described = c
+        .describe_reserved_instances_modifications()
+        .send()
+        .await
+        .unwrap();
+    let ids: Vec<&str> = described
+        .reserved_instances_modifications()
+        .iter()
+        .filter_map(|m| m.reserved_instances_modification_id())
+        .collect();
+    assert!(ids.contains(&mod_id.as_str()), "ids={ids:?}");
+}

--- a/crates/fakecloud-e2e/tests/glue.rs
+++ b/crates/fakecloud-e2e/tests/glue.rs
@@ -573,7 +573,10 @@ async fn create_script_reflects_dag_nodes() {
     assert!(py.contains("database = \"warehouse\""), "py=\n{py}");
     // The edge must wire the sink to its upstream source.
     assert!(py.contains("frame = datasource0"), "py=\n{py}");
-    assert!(resp.scala_code().unwrap_or_default().contains("val datasink0"));
+    assert!(resp
+        .scala_code()
+        .unwrap_or_default()
+        .contains("val datasink0"));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/glue.rs
+++ b/crates/fakecloud-e2e/tests/glue.rs
@@ -518,3 +518,221 @@ async fn table_in_missing_database_returns_not_found() {
         .expect_err("missing db");
     assert!(err.into_service_error().is_entity_not_found_exception());
 }
+
+#[tokio::test]
+async fn create_script_reflects_dag_nodes() {
+    use aws_sdk_glue::types::{CodeGenEdge, CodeGenNode, CodeGenNodeArg};
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    let resp = glue
+        .create_script()
+        .dag_nodes(
+            CodeGenNode::builder()
+                .id("datasource0")
+                .node_type("DataSource")
+                .args(
+                    CodeGenNodeArg::builder()
+                        .name("database")
+                        .value("warehouse")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .dag_nodes(
+            CodeGenNode::builder()
+                .id("datasink0")
+                .node_type("DataSink")
+                .args(
+                    CodeGenNodeArg::builder()
+                        .name("name")
+                        .value("sink")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .dag_edges(
+            CodeGenEdge::builder()
+                .source("datasource0")
+                .target("datasink0")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create script");
+
+    let py = resp.python_script().unwrap_or_default();
+    // Script must reference the actual nodes, not be a constant.
+    assert!(py.contains("datasource0 = DataSource.apply"), "py=\n{py}");
+    assert!(py.contains("datasink0 = DataSink.apply"), "py=\n{py}");
+    assert!(py.contains("database = \"warehouse\""), "py=\n{py}");
+    // The edge must wire the sink to its upstream source.
+    assert!(py.contains("frame = datasource0"), "py=\n{py}");
+    assert!(resp.scala_code().unwrap_or_default().contains("val datasink0"));
+}
+
+#[tokio::test]
+async fn get_dataflow_graph_round_trips_script() {
+    use aws_sdk_glue::types::{CodeGenNode, CodeGenNodeArg};
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    // Generate a script, then parse it back into a DAG.
+    let script = glue
+        .create_script()
+        .dag_nodes(
+            CodeGenNode::builder()
+                .id("src")
+                .node_type("DataSource")
+                .args(
+                    CodeGenNodeArg::builder()
+                        .name("database")
+                        .value("db")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .python_script()
+        .unwrap()
+        .to_string();
+
+    let graph = glue
+        .get_dataflow_graph()
+        .python_script(script)
+        .send()
+        .await
+        .expect("dataflow graph");
+    let ids: Vec<&str> = graph.dag_nodes().iter().map(|n| n.id()).collect();
+    assert!(ids.contains(&"src"), "ids={ids:?}");
+}
+
+#[tokio::test]
+async fn get_mapping_derives_from_table_schema() {
+    use aws_sdk_glue::types::CatalogEntry;
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    glue.create_database()
+        .database_input(DatabaseInput::builder().name("m_db").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+    glue.create_table()
+        .database_name("m_db")
+        .table_input(table_input("orders"))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = glue
+        .get_mapping()
+        .source(
+            CatalogEntry::builder()
+                .database_name("m_db")
+                .table_name("orders")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("get mapping");
+    let paths: Vec<&str> = resp
+        .mapping()
+        .iter()
+        .filter_map(|m| m.source_path())
+        .collect();
+    // Mapping must reflect the table's columns, not be empty.
+    assert!(paths.contains(&"id"), "paths={paths:?}");
+    assert!(paths.contains(&"amount"), "paths={paths:?}");
+}
+
+#[tokio::test]
+async fn list_and_describe_entity_reflect_catalog() {
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    glue.create_database()
+        .database_input(DatabaseInput::builder().name("e_db").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+    glue.create_table()
+        .database_name("e_db")
+        .table_input(table_input("orders"))
+        .send()
+        .await
+        .unwrap();
+
+    // ListEntities reflects catalog tables.
+    let listed = glue.list_entities().send().await.expect("list entities");
+    let names: Vec<&str> = listed
+        .entities()
+        .iter()
+        .filter_map(|e| e.entity_name())
+        .collect();
+    assert!(names.contains(&"orders"), "names={names:?}");
+
+    // DescribeEntity returns the table's columns as fields.
+    let described = glue
+        .describe_entity()
+        .connection_name("conn")
+        .entity_name("orders")
+        .send()
+        .await
+        .expect("describe entity");
+    let field_names: Vec<&str> = described
+        .fields()
+        .iter()
+        .filter_map(|f| f.field_name())
+        .collect();
+    assert!(field_names.contains(&"id"), "fields={field_names:?}");
+    assert!(field_names.contains(&"amount"), "fields={field_names:?}");
+}
+
+#[tokio::test]
+async fn test_connection_named_must_exist() {
+    use aws_sdk_glue::types::ConnectionInput;
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    // A missing connection is a real error, not a fake empty success.
+    let err = glue
+        .test_connection()
+        .connection_name("nope")
+        .send()
+        .await
+        .expect_err("missing connection");
+    assert!(err.into_service_error().is_entity_not_found_exception());
+
+    // After creating it, the test succeeds.
+    glue.create_connection()
+        .connection_input(
+            ConnectionInput::builder()
+                .name("real-conn")
+                .connection_type(aws_sdk_glue::types::ConnectionType::Jdbc)
+                .connection_properties(
+                    aws_sdk_glue::types::ConnectionPropertyKey::JdbcConnectionUrl,
+                    "jdbc:postgresql://host:5432/db",
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    glue.test_connection()
+        .connection_name("real-conn")
+        .send()
+        .await
+        .expect("test existing connection");
+}

--- a/crates/fakecloud-ec2/src/service/image.rs
+++ b/crates/fakecloud-ec2/src/service/image.rs
@@ -288,8 +288,12 @@ fn launch_permission_mods(
         let mut i = 1usize;
         loop {
             let base = format!("LaunchPermission.{op}.{i}");
-            let user = params.get(&format!("{base}.UserId")).filter(|v| !v.is_empty());
-            let group = params.get(&format!("{base}.Group")).filter(|v| !v.is_empty());
+            let user = params
+                .get(&format!("{base}.UserId"))
+                .filter(|v| !v.is_empty());
+            let group = params
+                .get(&format!("{base}.Group"))
+                .filter(|v| !v.is_empty());
             if user.is_none() && group.is_none() {
                 break;
             }
@@ -388,11 +392,7 @@ pub(crate) fn modify_image_attribute(
     // ── launchPermission ──
     let (add_u, add_g, rem_u, rem_g) = launch_permission_mods(&req.query_params);
     let legacy_lp = attribute == Some("launchPermission");
-    if !add_u.is_empty()
-        || !add_g.is_empty()
-        || !rem_u.is_empty()
-        || !rem_g.is_empty()
-        || legacy_lp
+    if !add_u.is_empty() || !add_g.is_empty() || !rem_u.is_empty() || !rem_g.is_empty() || legacy_lp
     {
         validate_enum(&req.query_params, "OperationType", &["add", "remove"])?;
         // Legacy UserId.N / UserGroup.N form keyed by OperationType.
@@ -422,7 +422,8 @@ pub(crate) fn modify_image_attribute(
                 img.launch_permission_groups.push(g);
             }
         }
-        img.launch_permission_users.retain(|u| !rem_users.contains(u));
+        img.launch_permission_users
+            .retain(|u| !rem_users.contains(u));
         img.launch_permission_groups
             .retain(|g| !rem_groups.contains(g));
         // The `all` group makes the AMI public, matching AWS.

--- a/crates/fakecloud-ec2/src/service/image.rs
+++ b/crates/fakecloud-ec2/src/service/image.rs
@@ -39,7 +39,7 @@ fn image_xml(i: &Image, tags: &[Tag], owner: &str) -> String {
         ec2_elem("virtualizationType", "hvm"),
         ec2_elem("hypervisor", "xen"),
         ec2_elem("platformDetails", "Linux/UNIX"),
-        ec2_elem("bootMode", "uefi"),
+        ec2_elem("bootMode", i.boot_mode.as_deref().unwrap_or("uefi")),
         format_args!(
             "<deregistrationProtection>{}</deregistrationProtection>",
             if i.deregistration_protection {
@@ -66,6 +66,9 @@ fn build_image(name: String, description: String, source_instance_id: Option<Str
         in_recycle_bin: false,
         deprecation_time: None,
         deregistration_protection: false,
+        launch_permission_users: Vec::new(),
+        launch_permission_groups: Vec::new(),
+        boot_mode: None,
     }
 }
 
@@ -262,20 +265,100 @@ const IMG_ATTRS: &[&str] = &[
     "deregistrationProtection",
 ];
 
+/// XML for a single `launchPermission` item.
+fn launch_permission_item(user_id: Option<&str>, group: Option<&str>) -> String {
+    let mut inner = String::new();
+    if let Some(u) = user_id {
+        inner.push_str(&ec2_elem("userId", u));
+    }
+    if let Some(g) = group {
+        inner.push_str(&ec2_elem("group", g));
+    }
+    format!("<item>{inner}</item>")
+}
+
+/// Collect `LaunchPermission.{Add,Remove}.N.{UserId,Group}` modifications.
+/// Returns (added_users, added_groups, removed_users, removed_groups).
+fn launch_permission_mods(
+    params: &std::collections::HashMap<String, String>,
+) -> (Vec<String>, Vec<String>, Vec<String>, Vec<String>) {
+    let collect = |op: &str| -> (Vec<String>, Vec<String>) {
+        let mut users = Vec::new();
+        let mut groups = Vec::new();
+        let mut i = 1usize;
+        loop {
+            let base = format!("LaunchPermission.{op}.{i}");
+            let user = params.get(&format!("{base}.UserId")).filter(|v| !v.is_empty());
+            let group = params.get(&format!("{base}.Group")).filter(|v| !v.is_empty());
+            if user.is_none() && group.is_none() {
+                break;
+            }
+            if let Some(u) = user {
+                users.push(u.clone());
+            }
+            if let Some(g) = group {
+                groups.push(g.clone());
+            }
+            i += 1;
+        }
+        (users, groups)
+    };
+    let (add_u, add_g) = collect("Add");
+    let (rem_u, rem_g) = collect("Remove");
+    (add_u, add_g, rem_u, rem_g)
+}
+
 pub(crate) fn describe_image_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "ImageId")?;
     let attr = require(&req.query_params, "Attribute")?;
     validate_enum(&req.query_params, "Attribute", IMG_ATTRS)?;
+
+    let accounts = svc.state.read();
+    let empty = Ec2State::new(&req.account_id, &req.region);
+    let state = accounts.get(&req.account_id).unwrap_or(&empty);
+    let img = state
+        .images
+        .get(&id)
+        .ok_or_else(|| crate::service_helpers::not_found("InvalidAMIID.NotFound", &id))?;
+
     let attr_xml = match attr.as_str() {
-        "description" => "<description><value>ami</value></description>".to_string(),
-        "launchPermission" => ec2_list("launchPermission", &[]),
+        "description" => format!(
+            "<description>{}</description>",
+            ec2_elem("value", &img.description)
+        ),
+        "launchPermission" => {
+            let mut items: Vec<String> = img
+                .launch_permission_users
+                .iter()
+                .map(|u| launch_permission_item(Some(u), None))
+                .collect();
+            items.extend(
+                img.launch_permission_groups
+                    .iter()
+                    .map(|g| launch_permission_item(None, Some(g))),
+            );
+            format!("<launchPermission>{}</launchPermission>", items.join(""))
+        }
         "productCodes" => ec2_list("productCodes", &[]),
         "blockDeviceMapping" => ec2_list("blockDeviceMapping", &[]),
-        "bootMode" => "<bootMode><value>uefi</value></bootMode>".to_string(),
-        _ => String::new(),
+        "bootMode" => format!(
+            "<bootMode><value>{}</value></bootMode>",
+            img.boot_mode.as_deref().unwrap_or("uefi")
+        ),
+        // kernel/ramdisk/sriovNetSupport/tpmSupport/uefiData/lastLaunchedTime/
+        // imdsSupport: AWS returns the element with no inner <value> when unset.
+        "deregistrationProtection" => format!(
+            "<deregistrationProtection><value>{}</value></deregistrationProtection>",
+            if img.deregistration_protection {
+                "enabled"
+            } else {
+                "disabled"
+            }
+        ),
+        other => format!("<{other}/>"),
     };
     Ok(Ec2Service::respond(
         "DescribeImageAttribute",
@@ -285,11 +368,89 @@ pub(crate) fn describe_image_attribute(
 }
 
 pub(crate) fn modify_image_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "ImageId")?;
-    validate_enum(&req.query_params, "OperationType", &["add", "remove"])?;
+    let id = require(&req.query_params, "ImageId")?;
+
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create(&req.account_id);
+    let img = state
+        .images
+        .get_mut(&id)
+        .ok_or_else(|| crate::service_helpers::not_found("InvalidAMIID.NotFound", &id))?;
+
+    // The `Attribute` form (Attribute + Value + OperationType) and the
+    // structured `LaunchPermission`/`Description` forms are mutually
+    // exclusive in a single call; support both.
+    let attribute = req.query_params.get("Attribute").map(String::as_str);
+
+    // ── launchPermission ──
+    let (add_u, add_g, rem_u, rem_g) = launch_permission_mods(&req.query_params);
+    let legacy_lp = attribute == Some("launchPermission");
+    if !add_u.is_empty()
+        || !add_g.is_empty()
+        || !rem_u.is_empty()
+        || !rem_g.is_empty()
+        || legacy_lp
+    {
+        validate_enum(&req.query_params, "OperationType", &["add", "remove"])?;
+        // Legacy UserId.N / UserGroup.N form keyed by OperationType.
+        let (mut add_users, mut add_groups, mut rem_users, mut rem_groups) =
+            (add_u, add_g, rem_u, rem_g);
+        if legacy_lp {
+            let users = indexed_list(&req.query_params, "UserId");
+            let groups = indexed_list(&req.query_params, "UserGroup");
+            match req.query_params.get("OperationType").map(String::as_str) {
+                Some("remove") => {
+                    rem_users.extend(users);
+                    rem_groups.extend(groups);
+                }
+                _ => {
+                    add_users.extend(users);
+                    add_groups.extend(groups);
+                }
+            }
+        }
+        for u in add_users {
+            if !img.launch_permission_users.contains(&u) {
+                img.launch_permission_users.push(u);
+            }
+        }
+        for g in add_groups {
+            if !img.launch_permission_groups.contains(&g) {
+                img.launch_permission_groups.push(g);
+            }
+        }
+        img.launch_permission_users.retain(|u| !rem_users.contains(u));
+        img.launch_permission_groups
+            .retain(|g| !rem_groups.contains(g));
+        // The `all` group makes the AMI public, matching AWS.
+        img.public = img.launch_permission_groups.iter().any(|g| g == "all");
+    }
+
+    // ── description ──
+    if let Some(d) = req
+        .query_params
+        .get("Description.Value")
+        .or_else(|| req.query_params.get("Description"))
+    {
+        img.description = d.clone();
+    } else if attribute == Some("description") {
+        if let Some(v) = req.query_params.get("Value") {
+            img.description = v.clone();
+        }
+    }
+
+    // ── bootMode ──
+    if let Some(b) = req.query_params.get("BootMode.Value") {
+        img.boot_mode = Some(b.clone());
+    } else if attribute == Some("bootMode") {
+        if let Some(v) = req.query_params.get("Value") {
+            img.boot_mode = Some(v.clone());
+        }
+    }
+
     Ok(Ec2Service::respond(
         "ModifyImageAttribute",
         &req.request_id,
@@ -298,12 +459,20 @@ pub(crate) fn modify_image_attribute(
 }
 
 pub(crate) fn reset_image_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "ImageId")?;
+    let id = require(&req.query_params, "ImageId")?;
     require(&req.query_params, "Attribute")?;
     validate_enum(&req.query_params, "Attribute", &["launchPermission"])?;
+    {
+        let mut accounts = svc.state.write();
+        if let Some(img) = accounts.get_or_create(&req.account_id).images.get_mut(&id) {
+            img.launch_permission_users.clear();
+            img.launch_permission_groups.clear();
+            img.public = false;
+        }
+    }
     Ok(Ec2Service::respond(
         "ResetImageAttribute",
         &req.request_id,

--- a/crates/fakecloud-ec2/src/service/reserved.rs
+++ b/crates/fakecloud-ec2/src/service/reserved.rs
@@ -6,7 +6,10 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{gen_id, indexed_list, require, validate_enum, validate_max_results};
-use crate::state::{DedicatedHost, Ec2State, ReservedInstances, Tag};
+use crate::state::{
+    DedicatedHost, Ec2State, ReservedInstances, ReservedInstancesListing,
+    ReservedInstancesModification, Tag,
+};
 
 const FIXED_TIME: &str = "2024-01-01T00:00:00.000Z";
 
@@ -198,76 +201,188 @@ pub(crate) fn purchase_reserved_instances_offering(
     ))
 }
 
-fn listing_xml(listing_id: &str, ri_id: &str) -> String {
+fn listing_xml(l: &ReservedInstancesListing) -> String {
     format!(
-        "{}{}<status>active</status><statusMessage>ACTIVE</statusMessage>{}{}{}{}",
-        ec2_elem("reservedInstancesListingId", listing_id),
-        ec2_elem("reservedInstancesId", ri_id),
+        "{}{}<status>{}</status><statusMessage>{}</statusMessage>{}{}{}{}{}",
+        ec2_elem("reservedInstancesListingId", &l.listing_id),
+        ec2_elem("reservedInstancesId", &l.reserved_instances_id),
+        l.status,
+        l.status_message,
         ec2_elem("createDate", FIXED_TIME),
         ec2_elem("updateDate", FIXED_TIME),
+        ec2_elem("clientToken", &l.client_token),
         ec2_list("instanceCounts", &[]),
         ec2_list("priceSchedules", &[]),
     )
 }
 
 pub(crate) fn create_reserved_instances_listing(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let ri = require(&req.query_params, "ReservedInstancesId")?;
-    require(&req.query_params, "InstanceCount")?;
-    require(&req.query_params, "ClientToken")?;
-    let item = listing_xml(&gen_id("ril"), &ri);
+    let count: i64 = require(&req.query_params, "InstanceCount")?
+        .parse()
+        .unwrap_or(1);
+    let client_token = require(&req.query_params, "ClientToken")?;
+    let listing = ReservedInstancesListing {
+        listing_id: gen_id("ril"),
+        reserved_instances_id: ri,
+        instance_count: count,
+        client_token,
+        status: "active".to_string(),
+        status_message: "ACTIVE".to_string(),
+    };
+    let xml = listing_xml(&listing);
+    {
+        let mut accounts = svc.state.write();
+        accounts
+            .get_or_create(&req.account_id)
+            .reserved_instances_listings
+            .insert(listing.listing_id.clone(), listing);
+    }
     Ok(Ec2Service::respond(
         "CreateReservedInstancesListing",
         &req.request_id,
-        &ec2_list("reservedInstancesListingsSet", &[item]),
+        &ec2_list("reservedInstancesListingsSet", &[xml]),
     ))
 }
 
 pub(crate) fn cancel_reserved_instances_listing(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "ReservedInstancesListingId")?;
-    let item = listing_xml(&id, "ri-cancelled");
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create(&req.account_id);
+    // Cancel the persisted listing if present; AWS returns the (now cancelled)
+    // listing either way, so synthesize one for ids we never created.
+    let listing = match state.reserved_instances_listings.get_mut(&id) {
+        Some(listing) => {
+            listing.status = "cancelled".to_string();
+            listing.status_message = "CANCELLED".to_string();
+            listing.clone()
+        }
+        None => ReservedInstancesListing {
+            listing_id: id.clone(),
+            reserved_instances_id: "ri-cancelled".to_string(),
+            instance_count: 0,
+            client_token: String::new(),
+            status: "cancelled".to_string(),
+            status_message: "CANCELLED".to_string(),
+        },
+    };
+    let xml = listing_xml(&listing);
     Ok(Ec2Service::respond(
         "CancelReservedInstancesListing",
         &req.request_id,
-        &ec2_list("reservedInstancesListingsSet", &[item]),
+        &ec2_list("reservedInstancesListingsSet", &[xml]),
     ))
 }
 
 pub(crate) fn describe_reserved_instances_listings(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    // AWS supports filtering by `ReservedInstancesListingId` and
+    // `ReservedInstancesId` (single scalar params, not indexed lists).
+    let want_listing = req
+        .query_params
+        .get("ReservedInstancesListingId")
+        .filter(|v| !v.is_empty());
+    let want_ri = req
+        .query_params
+        .get("ReservedInstancesId")
+        .filter(|v| !v.is_empty());
+    let accounts = svc.state.read();
+    let empty = Ec2State::new(&req.account_id, &req.region);
+    let state = accounts.get(&req.account_id).unwrap_or(&empty);
+    let mut items: Vec<String> = state
+        .reserved_instances_listings
+        .values()
+        .filter(|l| want_listing.map(|w| w == &l.listing_id).unwrap_or(true))
+        .filter(|l| want_ri.map(|w| w == &l.reserved_instances_id).unwrap_or(true))
+        .map(listing_xml)
+        .collect();
+    items.sort();
     Ok(Ec2Service::respond(
         "DescribeReservedInstancesListings",
         &req.request_id,
-        &ec2_list("reservedInstancesListingsSet", &[]),
+        &ec2_list("reservedInstancesListingsSet", &items),
     ))
 }
 
+fn modification_xml(m: &ReservedInstancesModification) -> String {
+    let ids: Vec<String> = m
+        .reserved_instances_ids
+        .iter()
+        .map(|id| format!("<item>{}</item>", ec2_elem("reservedInstancesId", id)))
+        .collect();
+    format!(
+        "{}{}<status>{}</status>{}{}{}{}",
+        ec2_elem("reservedInstancesModificationId", &m.modification_id),
+        ec2_elem("clientToken", &m.client_token),
+        m.status,
+        ec2_elem("createDate", FIXED_TIME),
+        ec2_elem("updateDate", FIXED_TIME),
+        ec2_elem("effectiveDate", FIXED_TIME),
+        format_args!(
+            "<reservedInstancesSet>{}</reservedInstancesSet>",
+            ids.join("")
+        ),
+    )
+}
+
 pub(crate) fn describe_reserved_instances_modifications(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let want = indexed_list(&req.query_params, "ReservedInstancesModificationId");
+    let accounts = svc.state.read();
+    let empty = Ec2State::new(&req.account_id, &req.region);
+    let state = accounts.get(&req.account_id).unwrap_or(&empty);
+    let mut items: Vec<String> = state
+        .reserved_instances_modifications
+        .values()
+        .filter(|m| want.is_empty() || want.contains(&m.modification_id))
+        .map(modification_xml)
+        .collect();
+    items.sort();
     Ok(Ec2Service::respond(
         "DescribeReservedInstancesModifications",
         &req.request_id,
-        &ec2_list("reservedInstancesModificationsSet", &[]),
+        &ec2_list("reservedInstancesModificationsSet", &items),
     ))
 }
 
 pub(crate) fn modify_reserved_instances(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let reserved_instances_ids = indexed_list(&req.query_params, "ReservedInstancesId");
+    let client_token = req
+        .query_params
+        .get("ClientToken")
+        .cloned()
+        .unwrap_or_default();
+    let modification = ReservedInstancesModification {
+        modification_id: gen_id("rimod"),
+        reserved_instances_ids,
+        status: "processing".to_string(),
+        client_token,
+    };
+    let mod_id = modification.modification_id.clone();
+    {
+        let mut accounts = svc.state.write();
+        accounts
+            .get_or_create(&req.account_id)
+            .reserved_instances_modifications
+            .insert(mod_id.clone(), modification);
+    }
     Ok(Ec2Service::respond(
         "ModifyReservedInstances",
         &req.request_id,
-        &ec2_elem("reservedInstancesModificationId", &gen_id("rimod")),
+        &ec2_elem("reservedInstancesModificationId", &mod_id),
     ))
 }
 

--- a/crates/fakecloud-ec2/src/service/reserved.rs
+++ b/crates/fakecloud-ec2/src/service/reserved.rs
@@ -301,7 +301,11 @@ pub(crate) fn describe_reserved_instances_listings(
         .reserved_instances_listings
         .values()
         .filter(|l| want_listing.map(|w| w == &l.listing_id).unwrap_or(true))
-        .filter(|l| want_ri.map(|w| w == &l.reserved_instances_id).unwrap_or(true))
+        .filter(|l| {
+            want_ri
+                .map(|w| w == &l.reserved_instances_id)
+                .unwrap_or(true)
+        })
         .map(listing_xml)
         .collect();
     items.sort();

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -358,6 +358,17 @@ pub struct Image {
     pub deprecation_time: Option<String>,
     #[serde(default)]
     pub deregistration_protection: bool,
+    /// `launchPermission` — AWS account ids the AMI is explicitly shared with
+    /// (cross-account share via `ModifyImageAttribute`).
+    #[serde(default)]
+    pub launch_permission_users: Vec<String>,
+    /// `launchPermission` groups — only `all` is valid in AWS (public share).
+    #[serde(default)]
+    pub launch_permission_groups: Vec<String>,
+    /// `bootMode` — `legacy-bios` | `uefi` | `uefi-preferred`. `None` reports
+    /// the default `uefi`; settable via `ModifyImageAttribute`.
+    #[serde(default)]
+    pub boot_mode: Option<String>,
 }
 
 /// A network ACL entry (rule).
@@ -524,6 +535,28 @@ pub struct ReservedInstances {
     pub duration: i64,
     pub fixed_price: String,
     pub usage_price: String,
+}
+
+/// A Reserved Instances listing in the Reserved Instance Marketplace.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReservedInstancesListing {
+    pub listing_id: String,
+    pub reserved_instances_id: String,
+    pub instance_count: i64,
+    pub client_token: String,
+    /// `active` | `cancelled` | `closed`.
+    pub status: String,
+    pub status_message: String,
+}
+
+/// A Reserved Instances modification request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReservedInstancesModification {
+    pub modification_id: String,
+    pub reserved_instances_ids: Vec<String>,
+    /// `processing` | `fulfilled` | `failed`.
+    pub status: String,
+    pub client_token: String,
 }
 
 /// A Dedicated Host.
@@ -949,6 +982,10 @@ pub struct Ec2State {
     pub capacity_reservation_fleets: HashMap<String, String>,
     #[serde(default)]
     pub reserved_instances: HashMap<String, ReservedInstances>,
+    #[serde(default)]
+    pub reserved_instances_listings: HashMap<String, ReservedInstancesListing>,
+    #[serde(default)]
+    pub reserved_instances_modifications: HashMap<String, ReservedInstancesModification>,
     #[serde(default)]
     pub dedicated_hosts: HashMap<String, DedicatedHost>,
     #[serde(default)]

--- a/crates/fakecloud-glue/src/connections.rs
+++ b/crates/fakecloud-glue/src/connections.rs
@@ -142,10 +142,7 @@ impl GlueService {
         })))
     }
 
-    pub(crate) fn test_connection(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
+    pub(crate) fn test_connection(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         // AWS accepts either a named, already-created connection
         // (`ConnectionName`) or an inline `TestConnectionInput`. Validate that
         // one of them is present and resolvable, then return the empty success
@@ -164,7 +161,11 @@ impl GlueService {
             // Inline test input: require the connection type + properties that
             // a real connection attempt needs, mirroring AWS validation.
             let input = req_present(&body, "TestConnectionInput")?;
-            if input.get("ConnectionType").and_then(|v| v.as_str()).is_none() {
+            if input
+                .get("ConnectionType")
+                .and_then(|v| v.as_str())
+                .is_none()
+            {
                 return Err(missing("TestConnectionInput.ConnectionType"));
             }
             req_present(input, "ConnectionProperties")?;

--- a/crates/fakecloud-glue/src/connections.rs
+++ b/crates/fakecloud-glue/src/connections.rs
@@ -144,8 +144,31 @@ impl GlueService {
 
     pub(crate) fn test_connection(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        // AWS accepts either a named, already-created connection
+        // (`ConnectionName`) or an inline `TestConnectionInput`. Validate that
+        // one of them is present and resolvable, then return the empty success
+        // body AWS sends. A missing named connection is a real error.
+        let body = req.json_body();
+        if let Some(name) = body.get("ConnectionName").and_then(|v| v.as_str()) {
+            let accounts = self.state.read();
+            let exists = accounts
+                .get(&req.account_id)
+                .map(|s| s.connections.contains_key(name))
+                .unwrap_or(false);
+            if !exists {
+                return Err(entity_not_found(format!("Connection {name} not found")));
+            }
+        } else {
+            // Inline test input: require the connection type + properties that
+            // a real connection attempt needs, mirroring AWS validation.
+            let input = req_present(&body, "TestConnectionInput")?;
+            if input.get("ConnectionType").and_then(|v| v.as_str()).is_none() {
+                return Err(missing("TestConnectionInput.ConnectionType"));
+            }
+            req_present(input, "ConnectionProperties")?;
+        }
         Ok(AwsResponse::ok_json(json!({})))
     }
 

--- a/crates/fakecloud-glue/src/tail.rs
+++ b/crates/fakecloud-glue/src/tail.rs
@@ -1223,33 +1223,95 @@ impl GlueService {
 
     // ===================== schema/script generation & search =====================
 
-    pub(crate) fn create_script(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    pub(crate) fn create_script(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let nodes = body["DagNodes"].as_array().cloned().unwrap_or_default();
+        let edges = body["DagEdges"].as_array().cloned().unwrap_or_default();
+        let language = body["Language"].as_str().unwrap_or("PYTHON");
+        let (python, scala) = generate_script(&nodes, &edges);
+        // AWS returns only the field for the requested language, but the
+        // response shape carries both; emit the requested one and leave the
+        // other populated too (real Glue returns both when both render).
+        let _ = language;
         Ok(AwsResponse::ok_json(json!({
-            "PythonScript": "# generated\n", "ScalaCode": "// generated\n",
+            "PythonScript": python,
+            "ScalaCode": scala,
         })))
     }
 
     pub(crate) fn get_plan(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        req_present(&body, "Mapping")?;
-        req_present(&body, "Source")?;
+        let mapping = req_present(&body, "Mapping")?.clone();
+        let source = req_present(&body, "Source")?.clone();
+        let sinks = body["Sinks"].as_array().cloned().unwrap_or_default();
+        let language = body["Language"].as_str().unwrap_or("PYTHON");
+        let (python, scala) = generate_plan(&source, &sinks, &mapping);
+        let _ = language;
         Ok(AwsResponse::ok_json(json!({
-            "PythonScript": "# plan\n", "ScalaCode": "// plan\n",
+            "PythonScript": python,
+            "ScalaCode": scala,
         })))
     }
 
     pub(crate) fn get_mapping(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        req_present(&body, "Source")?;
-        Ok(AwsResponse::ok_json(json!({ "Mapping": [] })))
+        let source = req_present(&body, "Source")?;
+        // Derive a MappingEntry per column of the source table's schema in the
+        // catalog (identity mapping source -> sink), matching how Glue proposes
+        // a default mapping from the discovered schema.
+        let db = source["DatabaseName"].as_str().unwrap_or_default();
+        let table_name = source["TableName"].as_str().unwrap_or_default();
+        let sink = body["Sinks"]
+            .as_array()
+            .and_then(|s| s.first())
+            .cloned()
+            .unwrap_or_else(|| source.clone());
+        let target_table = sink["TableName"].as_str().unwrap_or(table_name);
+
+        let accounts = self.state.read();
+        let mapping: Vec<Value> = accounts
+            .get(&req.account_id)
+            .and_then(|s| s.dbs_in(&req.region))
+            .and_then(|dbs| dbs.get(db))
+            .and_then(|d| d.tables.get(table_name))
+            .map(|t| {
+                t.storage_descriptor
+                    .as_ref()
+                    .map(|sd| {
+                        sd.columns
+                            .iter()
+                            .map(|col| {
+                                json!({
+                                    "SourceTable": table_name,
+                                    "SourcePath": col.name,
+                                    "SourceType": col.column_type,
+                                    "TargetTable": target_table,
+                                    "TargetPath": col.name,
+                                    "TargetType": col.column_type,
+                                })
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default();
+        Ok(AwsResponse::ok_json(json!({ "Mapping": mapping })))
     }
 
     pub(crate) fn get_dataflow_graph(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        // Parse the submitted PySpark script back into a DAG: every
+        // `id = Class.apply(...)` assignment becomes a node and dataflow
+        // references between them become edges. This mirrors Glue's
+        // round-trip between CreateScript and GetDataflowGraph.
+        let script = body["PythonScript"].as_str().unwrap_or_default();
+        let (nodes, edges) = parse_dataflow_graph(script);
         Ok(AwsResponse::ok_json(json!({
-            "DagNodes": [], "DagEdges": [],
+            "DagNodes": nodes,
+            "DagEdges": edges,
         })))
     }
 
@@ -1272,12 +1334,55 @@ impl GlueService {
     pub(crate) fn describe_entity(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         req_str(&body, "ConnectionName")?;
-        req_str(&body, "EntityName")?;
-        Ok(AwsResponse::ok_json(json!({ "Fields": [] })))
+        let entity_name = req_str(&body, "EntityName")?.to_string();
+        // Glue's connector entities map onto the catalog: an entity name
+        // corresponds to a table (the connector surfaces its objects as
+        // catalog-shaped entities). Derive the entity's fields from the
+        // matching table's columns wherever one exists, else describe a
+        // single key field so the entity is non-empty and reflects the input.
+        let accounts = self.state.read();
+        let fields: Vec<Value> = accounts
+            .get(&req.account_id)
+            .and_then(|s| s.dbs_in(&req.region))
+            .and_then(|dbs| {
+                dbs.values()
+                    .flat_map(|d| d.tables.values())
+                    .find(|t| t.name == entity_name)
+            })
+            .and_then(|t| t.storage_descriptor.as_ref())
+            .map(|sd| {
+                sd.columns
+                    .iter()
+                    .map(|c| field_json(&c.name, &c.column_type))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_else(|| vec![field_json("Id", "string")]);
+        Ok(AwsResponse::ok_json(json!({ "Fields": fields })))
     }
 
-    pub(crate) fn list_entities(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        Ok(AwsResponse::ok_json(json!({ "Entities": [] })))
+    pub(crate) fn list_entities(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        // List the catalog's tables as connector entities (each catalog table
+        // is an addressable entity), reflecting real catalog state instead of
+        // a hardcoded empty list.
+        let accounts = self.state.read();
+        let entities: Vec<Value> = accounts
+            .get(&req.account_id)
+            .and_then(|s| s.dbs_in(&req.region))
+            .map(|dbs| {
+                dbs.values()
+                    .flat_map(|d| d.tables.values())
+                    .map(|t| {
+                        json!({
+                            "EntityName": t.name,
+                            "Label": t.name,
+                            "IsParentEntity": false,
+                            "Category": "TABLE",
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(AwsResponse::ok_json(json!({ "Entities": entities })))
     }
 
     pub(crate) fn get_entity_records(
@@ -1285,9 +1390,29 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        req_str(&body, "EntityName")?;
+        let entity_name = req_str(&body, "EntityName")?.to_string();
         req_present(&body, "Limit")?;
-        Ok(AwsResponse::ok_json(json!({ "Records": [] })))
+        // Records are the partition rows of the matching catalog table,
+        // projected as a record document keyed by partition values. Tables
+        // without partitions yield no records (an empty but accurate result),
+        // matching a connector entity that currently holds no rows.
+        let accounts = self.state.read();
+        let records: Vec<Value> = accounts
+            .get(&req.account_id)
+            .and_then(|s| s.dbs_in(&req.region))
+            .and_then(|dbs| {
+                dbs.values()
+                    .flat_map(|d| d.tables.values())
+                    .find(|t| t.name == entity_name)
+            })
+            .map(|t| {
+                t.partitions
+                    .values()
+                    .map(|p| json!({ "Values": p.values }))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(AwsResponse::ok_json(json!({ "Records": records })))
     }
 
     // ===================== catalog import =====================
@@ -1376,4 +1501,162 @@ fn part_values_string(body: &Value, field: &str) -> String {
                 .join("\u{1f}")
         })
         .unwrap_or_default()
+}
+
+/// Build a connector-entity `Field` document from a column name + type.
+fn field_json(name: &str, field_type: &str) -> Value {
+    json!({
+        "FieldName": name,
+        "Label": name,
+        "FieldType": field_type,
+        "IsPrimaryKey": false,
+        "IsNullable": true,
+        "IsRetrievable": true,
+        "IsFilterable": true,
+    })
+}
+
+/// Render a single CodeGenNode arg as a `name="value"` (or `name=value` for
+/// params) fragment.
+fn node_arg(arg: &Value) -> Option<String> {
+    let name = arg.get("Name")?.as_str()?;
+    let value = arg.get("Value").and_then(|v| v.as_str()).unwrap_or("");
+    let is_param = arg.get("Param").and_then(|v| v.as_bool()).unwrap_or(false);
+    if is_param {
+        Some(format!("{name} = {value}"))
+    } else {
+        Some(format!("{name} = \"{value}\""))
+    }
+}
+
+/// Generate PySpark + Scala scripts from a Glue ETL DAG (`DagNodes`/`DagEdges`).
+/// Each node becomes a `var = NodeType.apply(...)` statement that references
+/// its upstream nodes per the edges, exactly as Glue's code generator does.
+fn generate_script(nodes: &[Value], edges: &[Value]) -> (String, String) {
+    let mut python = String::from(
+        "import sys\nfrom awsglue.transforms import *\nfrom awsglue.context import GlueContext\nfrom pyspark.context import SparkContext\n\nglueContext = GlueContext(SparkContext.getOrCreate())\n",
+    );
+    let mut scala = String::from(
+        "import com.amazonaws.services.glue.GlueContext\nimport com.amazonaws.services.glue.util.GlueArgParser\nimport org.apache.spark.SparkContext\n\nval glueContext = new GlueContext(SparkContext.getOrCreate())\n",
+    );
+
+    for node in nodes {
+        let id = node.get("Id").and_then(|v| v.as_str()).unwrap_or("node");
+        let node_type = node
+            .get("NodeType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("DataSource");
+        // Upstream node ids feeding this node.
+        let upstream: Vec<&str> = edges
+            .iter()
+            .filter(|e| e.get("Target").and_then(|v| v.as_str()) == Some(id))
+            .filter_map(|e| e.get("Source").and_then(|v| v.as_str()))
+            .collect();
+        let args: Vec<String> = node
+            .get("Args")
+            .and_then(|v| v.as_array())
+            .map(|a| a.iter().filter_map(node_arg).collect())
+            .unwrap_or_default();
+        let mut all_args = args.clone();
+        if !upstream.is_empty() {
+            all_args.push(format!("frame = {}", upstream.join(", ")));
+        }
+        let arg_str = all_args.join(", ");
+        python.push_str(&format!("{id} = {node_type}.apply({arg_str})\n"));
+        scala.push_str(&format!("val {id} = {node_type}.apply({arg_str})\n"));
+    }
+    (python, scala)
+}
+
+/// Generate scripts for `GetPlan` from the source/sinks/mapping inputs.
+fn generate_plan(source: &Value, sinks: &[Value], mapping: &Value) -> (String, String) {
+    let src_db = source.get("DatabaseName").and_then(|v| v.as_str()).unwrap_or("");
+    let src_tbl = source.get("TableName").and_then(|v| v.as_str()).unwrap_or("");
+    let mut python = format!(
+        "import sys\nfrom awsglue.transforms import *\nfrom awsglue.context import GlueContext\nfrom pyspark.context import SparkContext\n\nglueContext = GlueContext(SparkContext.getOrCreate())\ndatasource = glueContext.create_dynamic_frame.from_catalog(database = \"{src_db}\", table_name = \"{src_tbl}\")\n",
+    );
+    let mut scala = format!(
+        "import com.amazonaws.services.glue.GlueContext\nimport org.apache.spark.SparkContext\n\nval glueContext = new GlueContext(SparkContext.getOrCreate())\nval datasource = glueContext.getCatalogSource(database = \"{src_db}\", tableName = \"{src_tbl}\").getDynamicFrame()\n",
+    );
+    if let Some(maps) = mapping.as_array() {
+        let tuples: Vec<String> = maps
+            .iter()
+            .filter_map(|m| {
+                let sp = m.get("SourcePath").and_then(|v| v.as_str())?;
+                let st = m.get("SourceType").and_then(|v| v.as_str()).unwrap_or("string");
+                let tp = m.get("TargetPath").and_then(|v| v.as_str()).unwrap_or(sp);
+                let tt = m.get("TargetType").and_then(|v| v.as_str()).unwrap_or(st);
+                Some(format!("(\"{sp}\", \"{st}\", \"{tp}\", \"{tt}\")"))
+            })
+            .collect();
+        if !tuples.is_empty() {
+            python.push_str(&format!(
+                "applymapping = ApplyMapping.apply(frame = datasource, mappings = [{}])\n",
+                tuples.join(", ")
+            ));
+            scala.push_str(&format!(
+                "val applymapping = datasource.applyMapping(mappings = Seq({}))\n",
+                tuples.join(", ")
+            ));
+        }
+    }
+    for sink in sinks {
+        let sdb = sink.get("DatabaseName").and_then(|v| v.as_str()).unwrap_or("");
+        let stbl = sink.get("TableName").and_then(|v| v.as_str()).unwrap_or("");
+        python.push_str(&format!(
+            "glueContext.write_dynamic_frame.from_catalog(frame = applymapping, database = \"{sdb}\", table_name = \"{stbl}\")\n",
+        ));
+        scala.push_str(&format!(
+            "glueContext.getCatalogSink(database = \"{sdb}\", tableName = \"{stbl}\").writeDynamicFrame(applymapping)\n",
+        ));
+    }
+    (python, scala)
+}
+
+/// Parse a generated PySpark script back into a DAG. Recognises
+/// `id = NodeType.apply(...)` statements as nodes and `frame = a, b` arg
+/// references as edges, the inverse of [`generate_script`].
+fn parse_dataflow_graph(script: &str) -> (Vec<Value>, Vec<Value>) {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    let mut line_number = 0i64;
+    for line in script.lines() {
+        line_number += 1;
+        let trimmed = line.trim();
+        let Some((lhs, rhs)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let id = lhs.trim();
+        let rhs = rhs.trim();
+        // Match `NodeType.apply(...)`.
+        let Some(apply_idx) = rhs.find(".apply(") else {
+            continue;
+        };
+        let node_type = &rhs[..apply_idx];
+        if id.is_empty() || node_type.is_empty() || node_type.contains(' ') {
+            continue;
+        }
+        nodes.push(json!({
+            "Id": id,
+            "NodeType": node_type,
+            "Args": [],
+            "LineNumber": line_number,
+        }));
+        // Edges: `frame = a, b` inside the call references upstream node ids.
+        if let Some(fidx) = rhs.find("frame = ") {
+            let after = &rhs[fidx + "frame = ".len()..];
+            let inner = after.trim_end_matches(')');
+            for src in inner.split(',') {
+                let src = src.trim();
+                if !src.is_empty() && !src.contains('"') {
+                    edges.push(json!({
+                        "Source": src,
+                        "Target": id,
+                        "TargetParameter": "frame",
+                    }));
+                }
+            }
+        }
+    }
+    (nodes, edges)
 }

--- a/crates/fakecloud-glue/src/tail.rs
+++ b/crates/fakecloud-glue/src/tail.rs
@@ -1570,8 +1570,14 @@ fn generate_script(nodes: &[Value], edges: &[Value]) -> (String, String) {
 
 /// Generate scripts for `GetPlan` from the source/sinks/mapping inputs.
 fn generate_plan(source: &Value, sinks: &[Value], mapping: &Value) -> (String, String) {
-    let src_db = source.get("DatabaseName").and_then(|v| v.as_str()).unwrap_or("");
-    let src_tbl = source.get("TableName").and_then(|v| v.as_str()).unwrap_or("");
+    let src_db = source
+        .get("DatabaseName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let src_tbl = source
+        .get("TableName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     let mut python = format!(
         "import sys\nfrom awsglue.transforms import *\nfrom awsglue.context import GlueContext\nfrom pyspark.context import SparkContext\n\nglueContext = GlueContext(SparkContext.getOrCreate())\ndatasource = glueContext.create_dynamic_frame.from_catalog(database = \"{src_db}\", table_name = \"{src_tbl}\")\n",
     );
@@ -1583,7 +1589,10 @@ fn generate_plan(source: &Value, sinks: &[Value], mapping: &Value) -> (String, S
             .iter()
             .filter_map(|m| {
                 let sp = m.get("SourcePath").and_then(|v| v.as_str())?;
-                let st = m.get("SourceType").and_then(|v| v.as_str()).unwrap_or("string");
+                let st = m
+                    .get("SourceType")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("string");
                 let tp = m.get("TargetPath").and_then(|v| v.as_str()).unwrap_or(sp);
                 let tt = m.get("TargetType").and_then(|v| v.as_str()).unwrap_or(st);
                 Some(format!("(\"{sp}\", \"{st}\", \"{tp}\", \"{tt}\")"))
@@ -1601,7 +1610,10 @@ fn generate_plan(source: &Value, sinks: &[Value], mapping: &Value) -> (String, S
         }
     }
     for sink in sinks {
-        let sdb = sink.get("DatabaseName").and_then(|v| v.as_str()).unwrap_or("");
+        let sdb = sink
+            .get("DatabaseName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         let stbl = sink.get("TableName").and_then(|v| v.as_str()).unwrap_or("");
         python.push_str(&format!(
             "glueContext.write_dynamic_frame.from_catalog(frame = applymapping, database = \"{sdb}\", table_name = \"{stbl}\")\n",

--- a/crates/fakecloud-lambda/src/extras/mod.rs
+++ b/crates/fakecloud-lambda/src/extras/mod.rs
@@ -982,41 +982,29 @@ impl LambdaService {
         if let Some(n) = body.get("TumblingWindowInSeconds").and_then(|v| v.as_i64()) {
             esm.tumbling_window_in_seconds = Some(n);
         }
-        let mut body_json = json!({
-            "UUID": esm.uuid,
-            "FunctionArn": esm.function_arn,
-            "EventSourceArn": esm.event_source_arn,
-            "BatchSize": esm.batch_size,
-            "State": "Enabled",
-            "StateTransitionReason": "USER_INITIATED",
-            "LastModified": chrono::Utc::now().timestamp() as f64,
-        });
-        let obj = body_json.as_object_mut().expect("json! built object");
-        if !esm.filter_patterns.is_empty() {
-            obj.insert(
-                "FilterCriteria".into(),
-                json!({
-                    "Filters": esm
-                        .filter_patterns
-                        .iter()
-                        .map(|p| json!({"Pattern": p}))
-                        .collect::<Vec<_>>(),
-                }),
-            );
+        // Enabled toggles the ESM State between Enabled/Disabled. AWS
+        // momentarily returns Enabling/Disabling but settles to the terminal
+        // state; we report the terminal state directly since there's no poller
+        // lag to model.
+        if let Some(enabled) = body.get("Enabled").and_then(|v| v.as_bool()) {
+            esm.enabled = enabled;
+            esm.state = if enabled { "Enabled" } else { "Disabled" }.to_string();
         }
-        if !esm.function_response_types.is_empty() {
-            obj.insert(
-                "FunctionResponseTypes".into(),
-                json!(esm.function_response_types),
-            );
+        // SourceAccessConfigurations (Kafka/MQ/MSK VPC + auth config). Replace
+        // wholesale when provided so credential/subnet updates actually persist
+        // rather than vanishing silently (1.1).
+        if let Some(sac) = body
+            .get("SourceAccessConfigurations")
+            .and_then(|v| v.as_array())
+        {
+            esm.source_access_configurations = sac.clone();
         }
-        if let Some(w) = esm.maximum_batching_window_in_seconds {
-            obj.insert("MaximumBatchingWindowInSeconds".into(), json!(w));
-        }
-        if let Some(p) = esm.parallelization_factor {
-            obj.insert("ParallelizationFactor".into(), json!(p));
-        }
-        ok(body_json)
+        esm.last_modified = chrono::Utc::now();
+        // Reuse the shared serializer so Update echoes the same full field set
+        // (State, SourceAccessConfigurations, KMSKeyArn, DestinationConfig,
+        // MetricsConfig, MaximumRetryAttempts, ...) that Create/Get/List emit.
+        let response = self.event_source_mapping_json(esm);
+        ok(response)
     }
 
     fn region_for(&self, account_id: &str) -> String {

--- a/crates/fakecloud-lambda/src/service_event_sources.rs
+++ b/crates/fakecloud-lambda/src/service_event_sources.rs
@@ -280,7 +280,7 @@ impl LambdaService {
         ))
     }
 
-    pub(super) fn event_source_mapping_json(&self, mapping: &EventSourceMapping) -> Value {
+    pub(crate) fn event_source_mapping_json(&self, mapping: &EventSourceMapping) -> Value {
         // EventSourceMappingArn is the EventSourceArn variant prefixed with
         // the mapping uuid; AWS started returning it in 2024 so newer SDKs
         // expect to round-trip it.

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1411,7 +1411,10 @@ async fn update_event_source_mapping_persists_enabled_and_sac() {
     let resp = svc.handle(req).await.unwrap();
     let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(v["State"], "Disabled");
-    assert_eq!(v["SourceAccessConfigurations"][0]["URI"], "arn:aws:secretsmanager:us-east-1:123456789012:secret:x");
+    assert_eq!(
+        v["SourceAccessConfigurations"][0]["URI"],
+        "arn:aws:secretsmanager:us-east-1:123456789012:secret:x"
+    );
 
     // Re-enable round-trips back to Enabled.
     let req = make_request(

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1359,6 +1359,71 @@ async fn create_event_source_mapping_round_trips_advanced_fields() {
     assert_eq!(v["Topics"][0], "t1");
 }
 
+#[tokio::test]
+async fn update_event_source_mapping_persists_enabled_and_sac() {
+    // Disabling via Update must flip State to "Disabled" (was hardcoded
+    // "Enabled") and SourceAccessConfigurations must persist + reflect on Get
+    // (1.1). KMSKeyArn/DestinationConfig must round-trip via Update too.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "esm-upd").await;
+
+    let create = json!({
+        "FunctionName": "esm-upd",
+        "EventSourceArn": "arn:aws:sqs:us-east-1:123456789012:queue1",
+        "BatchSize": 10,
+        "Enabled": true,
+    });
+    let req = make_request(
+        Method::POST,
+        "/2015-03-31/event-source-mappings",
+        &create.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let uuid = v["UUID"].as_str().unwrap().to_string();
+    assert_eq!(v["State"], "Enabled");
+
+    // Update: disable + set SourceAccessConfigurations + KMSKeyArn.
+    let update = json!({
+        "Enabled": false,
+        "SourceAccessConfigurations": [
+            {"Type": "BASIC_AUTH", "URI": "arn:aws:secretsmanager:us-east-1:123456789012:secret:x"}
+        ],
+        "KMSKeyArn": "arn:aws:kms:us-east-1:123456789012:key/upd",
+    });
+    let req = make_request(
+        Method::PUT,
+        &format!("/2015-03-31/event-source-mappings/{uuid}"),
+        &update.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v["State"], "Disabled");
+    assert_eq!(v["SourceAccessConfigurations"][0]["Type"], "BASIC_AUTH");
+    assert_eq!(v["KMSKeyArn"], "arn:aws:kms:us-east-1:123456789012:key/upd");
+
+    // Get back: changes must have persisted.
+    let req = make_request(
+        Method::GET,
+        &format!("/2015-03-31/event-source-mappings/{uuid}"),
+        "",
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v["State"], "Disabled");
+    assert_eq!(v["SourceAccessConfigurations"][0]["URI"], "arn:aws:secretsmanager:us-east-1:123456789012:secret:x");
+
+    // Re-enable round-trips back to Enabled.
+    let req = make_request(
+        Method::PUT,
+        &format!("/2015-03-31/event-source-mappings/{uuid}"),
+        &json!({"Enabled": true}).to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v["State"], "Enabled");
+}
+
 struct StubS3 {
     object: std::sync::Mutex<std::collections::HashMap<String, Vec<u8>>>,
 }


### PR DESCRIPTION
## Summary

Implements real behavior for the bug-hunt 2026-06-13 Tier-1 stub cluster (findings 1.1, 1.2, 1.4, 1.5, 1.6) — ops that persisted nothing on write and/or returned canned/empty data on read. No stubs: every write now persists to state and reflects on read, matching the AWS response shape.

- **Lambda 1.1 — UpdateEventSourceMapping** now reads + persists `Enabled` (State flips `Enabled`/`Disabled` instead of a hardcoded `"Enabled"`) and `SourceAccessConfigurations`, and reuses the shared `event_source_mapping_json` serializer so Update echoes the full field set (`KMSKeyArn`/`DestinationConfig`/`MetricsConfig`/`MaximumRetryAttempts`/...) exactly like Create/Get/List.
- **EC2 1.2 — Describe/ModifyImageAttribute** now back the AMI's `launchPermission` (user ids + groups), `description`, `bootMode`, and `deregistrationProtection`. Modify persists launch-permission add/remove (both the structured `LaunchPermission.Add.N.*` form and the legacy `UserId.N`/`UserGroup.N`+`OperationType` form), description, and bootMode; the `all` group flips the image public. Describe reads them back per the requested `Attribute`. ResetImageAttribute clears permissions.
- **EC2 1.5 — Reserved Instances listings/modifications** are now persisted in EC2 state. `DescribeReservedInstancesListings` / `DescribeReservedInstancesModifications` return them (with id / RI filtering where AWS supports it); Create/Cancel/Modify persist. Cancel of an unknown id still synthesizes a cancelled listing to preserve existing conformance.
- **DynamoDB 1.4 — Describe/UpdateTableReplicaAutoScaling** reflect the global-table replication group (created via CreateGlobalTable / UpdateTable ReplicaUpdates) and round-trip per-replica provisioned read/write autoscaling settings.
- **Glue 1.6** — `CreateScript`/`GetPlan` generate real PySpark + Scala from the DAG `DagNodes`/`DagEdges` (nodes become `id = NodeType.apply(...)`, edges wire `frame = upstream`); `GetDataflowGraph` parses a script back into a DAG; `GetMapping` derives `MappingEntry`s from the source table's catalog schema; `ListEntities`/`DescribeEntity`/`GetEntityRecords` reflect catalog tables/columns/partitions; `TestConnection` validates the named or inline connection (real `EntityNotFoundException` on a missing connection instead of `{}`).

## Test plan

All round-trip (write -> read) tests, run green; affected conformance tests re-run green (no conformance test modified).

- Lambda unit test `update_event_source_mapping_persists_enabled_and_sac` — disable via Update -> Get shows `State: Disabled` + persisted SAC + KMSKeyArn; re-enable round-trips back.
- e2e `ec2_image_reserved.rs`:
  - `modify_image_attribute_launch_permission_round_trips` — add/remove user ids, `all` group makes public, Reset clears.
  - `modify_image_attribute_description_round_trips`.
  - `reserved_instances_listings_persist_and_describe` — Create -> Describe (+ id filter) -> Cancel reflects `cancelled`.
  - `reserved_instances_modifications_persist_and_describe`.
- e2e `dynamodb.rs::dynamodb_replica_auto_scaling_reflects_global_table_replicas` — empty before global table, replicas appear after CreateGlobalTable, autoscaling Update persists + re-Describe shows it.
- e2e `glue.rs`: `create_script_reflects_dag_nodes`, `get_dataflow_graph_round_trips_script`, `get_mapping_derives_from_table_schema`, `list_and_describe_entity_reflect_catalog`, `test_connection_named_must_exist`.
- `cargo fmt`; `cargo clippy -p fakecloud-lambda -p fakecloud-ec2 -p fakecloud-dynamodb -p fakecloud-glue --all-targets -- -D warnings` clean; `--lib` tests for all four crates green; relevant ec2/dynamodb/glue/lambda conformance tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes write→read mismatches across Lambda, EC2, DynamoDB, and Glue so updates persist and describes/lists return real state. Brings stubs in line with AWS behavior for image attributes, reserved instances, table replica autoscaling, and Glue script/metadata APIs.

- **Bug Fixes**
  - Lambda (1.1): `UpdateEventSourceMapping` now persists `Enabled` and `SourceAccessConfigurations`, flips `State` between Enabled/Disabled, and echoes the full field set like Create/Get/List.
  - EC2 (1.2, 1.5): AMI `launchPermission` (users/groups), `description`, `bootMode`, and `deregistrationProtection` now persist and round-trip; `all` group sets AMI public; `ResetImageAttribute` clears permissions. Reserved Instances listings/modifications are stored; Describe supports id/RI filters; Cancel marks listings cancelled (synthesizes when id is unknown).
  - DynamoDB (1.4): `Describe/UpdateTableReplicaAutoScaling` now reflect global-table replicas and persist per-replica read/write autoscaling settings, returned on subsequent describes.
  - Glue (1.6): `CreateScript`/`GetPlan` generate real PySpark/Scala from DAGs; `GetDataflowGraph` parses scripts back to a DAG; `GetMapping` derives from catalog schemas; `ListEntities`/`DescribeEntity`/`GetEntityRecords` surface catalog tables/columns/partitions; `TestConnection` validates named or inline input and errors when the connection is missing.

<sup>Written for commit 7a7cdc693b8b46b88511bde98d4c1d5da1a45a04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

