### PR TITLE
fix(s3): serve anonymous GetObject for public-read bucket policy/ACL (#1707)

### DIFF
--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -422,6 +422,28 @@ pub trait IamPolicyEvaluator: Send + Sync {
         session_policies: &[String],
         scps: Option<&[String]>,
     ) -> IamDecision;
+
+    /// Evaluate `action` for an **anonymous** (unsigned) caller against a
+    /// resource-based policy in isolation. Anonymous requests carry no
+    /// identity, so the resource policy is the sole authorization source:
+    /// the request is allowed only if the policy explicitly grants the
+    /// action to a wildcard principal (`Principal:"*"` / `{"AWS":"*"}`).
+    ///
+    /// `resource_policy_json` is the raw policy document (S3 bucket policy
+    /// today); `None` or a non-public policy yields [`IamDecision::ImplicitDeny`].
+    /// ACL-based public grants are evaluated separately by the dispatcher
+    /// via [`ResourcePolicyProvider::public_acl_allows`].
+    ///
+    /// The default implementation returns [`IamDecision::ImplicitDeny`] so
+    /// evaluators that don't support anonymous access never silently grant.
+    fn evaluate_anonymous(
+        &self,
+        _action: &IamAction,
+        _context: &ConditionContext,
+        _resource_policy_json: Option<&str>,
+    ) -> IamDecision {
+        IamDecision::ImplicitDeny
+    }
 }
 
 /// Abstraction over "given a principal, return the inherited SCP
@@ -480,6 +502,20 @@ pub trait ResourcePolicyProvider: Send + Sync {
     /// the dispatcher parse it from the ARN. Default `None`.
     fn resource_owner_account(&self, _service: &str, _resource_arn: &str) -> Option<String> {
         None
+    }
+
+    /// Whether a **public-read ACL** on `resource_arn` grants `action` to
+    /// an anonymous (unsigned) caller. Distinct from a bucket policy: S3
+    /// ACLs are a separate grant surface, so an object/bucket with an
+    /// `AllUsers` group grant is publicly readable even without a bucket
+    /// policy. `action` is the bare AWS action name (`"GetObject"`,
+    /// `"ListBucket"`, …).
+    ///
+    /// Implementations must honor `PublicAccessBlock` (a bucket with
+    /// `IgnorePublicAcls` set is not public via ACL). Default `false` so
+    /// providers that don't model ACLs never grant anonymous access.
+    fn public_acl_allows(&self, _service: &str, _resource_arn: &str, _action: &str) -> bool {
+        false
     }
 }
 
@@ -594,6 +630,12 @@ impl ResourcePolicyProvider for MultiResourcePolicyProvider {
         self.providers
             .iter()
             .find_map(|p| p.resource_owner_account(service, resource_arn))
+    }
+
+    fn public_acl_allows(&self, service: &str, resource_arn: &str, action: &str) -> bool {
+        self.providers
+            .iter()
+            .any(|p| p.public_acl_allows(service, resource_arn, action))
     }
 }
 

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -106,6 +106,19 @@ pub async fn dispatch(
                         action: String::new(),
                         protocol: AwsProtocol::Rest,
                     }
+                } else if let Some(bucket) = anonymous_s3_bucket(&parts.uri, &config) {
+                    // Unsigned request whose first path segment names an
+                    // existing S3 bucket: an anonymous path-style S3 access
+                    // (e.g. serving a public-read object to a browser). Without
+                    // this it would fall through to the apigateway catch-all
+                    // below and 404 with "Stage not found" (#1707). Authorization
+                    // for the anonymous caller still runs in the IAM block.
+                    tracing::debug!(bucket = %bucket, "routing unsigned request to S3 (existing bucket)");
+                    protocol::DetectedRequest {
+                        service: "s3".to_string(),
+                        action: String::new(),
+                        protocol: AwsProtocol::Rest,
+                    }
                 } else if !parts.uri.path().starts_with("/_") {
                     // Requests without AWS auth that don't match any service might be
                     // API Gateway execute API calls (plain HTTP without signatures).
@@ -638,6 +651,75 @@ pub async fn dispatch(
                         );
                     }
                 }
+            } else if aws_request.access_key_id.is_none() {
+                // Truly anonymous (unsigned) caller — no Authorization header at
+                // all. No identity policies exist, so authorization rests
+                // entirely on the resource policy (a bucket policy granting
+                // `Principal:"*"`) and public-read ACLs — mirroring AWS, which
+                // denies anonymous requests unless the resource is explicitly
+                // made public. Without this an anonymous request that reached an
+                // iam_enforceable service in enforcement mode would bypass
+                // authorization entirely.
+                //
+                // A request that carried an Authorization header but whose
+                // credential did not resolve (principal `None` with
+                // `access_key_id` `Some`) is intentionally left alone here: with
+                // SigV4 verification off, fakecloud does not reject unverified
+                // signed requests, and turning them into anonymous denials would
+                // change long-standing behavior.
+                if let Some(iam_action) = service.iam_action_for(&aws_request) {
+                    let now = chrono::Utc::now();
+                    let mut condition_context = ConditionContext {
+                        aws_source_ip: remote_addr.map(|sa| sa.ip()),
+                        aws_current_time: Some(now),
+                        aws_epoch_time: Some(now.timestamp()),
+                        aws_secure_transport: Some(is_secure_transport(&aws_request.headers)),
+                        aws_requested_region: Some(aws_request.region.clone()),
+                        ..Default::default()
+                    };
+                    condition_context.service_keys =
+                        service.iam_condition_keys_for(&aws_request, &iam_action);
+                    let resource_policy_json = config
+                        .resource_policy_provider
+                        .as_ref()
+                        .and_then(|p| p.resource_policy(&detected.service, &iam_action.resource));
+                    let policy_allows = evaluator
+                        .evaluate_anonymous(
+                            &iam_action,
+                            &condition_context,
+                            resource_policy_json.as_deref(),
+                        )
+                        .is_allow();
+                    let acl_allows = config.resource_policy_provider.as_ref().is_some_and(|p| {
+                        p.public_acl_allows(
+                            &detected.service,
+                            &iam_action.resource,
+                            iam_action.action,
+                        )
+                    });
+                    if !policy_allows && !acl_allows {
+                        tracing::warn!(
+                            target: "fakecloud::iam::audit",
+                            service = %detected.service,
+                            action = %iam_action.action_string(),
+                            resource = %iam_action.resource,
+                            resource_policy_present = resource_policy_json.is_some(),
+                            mode = %config.iam_mode,
+                            request_id = %request_id,
+                            "anonymous request denied: no public bucket policy or ACL grants the action"
+                        );
+                        if config.iam_mode.is_strict() {
+                            return build_error_response(
+                                StatusCode::FORBIDDEN,
+                                "AccessDenied",
+                                "Access Denied",
+                                &request_id,
+                                detected.protocol,
+                            );
+                        }
+                        // Soft mode: audit log emitted; fall through to the handler.
+                    }
+                }
             }
         }
     }
@@ -1017,6 +1099,23 @@ fn sanitize_header_value(s: &str) -> String {
 /// request. Populates the 10 global condition keys from the resolved
 /// principal + the HTTP request. Service-specific keys are deferred to
 /// a follow-up batch and left empty.
+/// For an unsigned request that no other detection rule claimed, return the
+/// bucket name when the first path segment names an existing S3 bucket.
+///
+/// fakecloud serves every service from one endpoint, so an anonymous
+/// path-style S3 request (`GET /bucket/key`, no SigV4) is indistinguishable
+/// from an API Gateway execute-api call by headers alone. Bucket existence is
+/// the disambiguator: if the segment is a real bucket, route to S3; otherwise
+/// fall through to the apigateway catch-all. Uses the already-wired
+/// `resource_policy_provider`, which resolves S3 bucket ownership from state
+/// (`Some` => the bucket exists). Returns `None` when no provider is wired.
+fn anonymous_s3_bucket(uri: &http::Uri, config: &DispatchConfig) -> Option<String> {
+    let provider = config.resource_policy_provider.as_ref()?;
+    let segment = uri.path().split('/').find(|s| !s.is_empty())?.to_string();
+    let arn = format!("arn:aws:s3:::{segment}");
+    provider.resource_owner_account("s3", &arn).map(|_| segment)
+}
+
 fn build_condition_context(
     principal: &Principal,
     remote_addr: Option<SocketAddr>,

--- a/crates/fakecloud-e2e/tests/s3_anonymous_access.rs
+++ b/crates/fakecloud-e2e/tests/s3_anonymous_access.rs
@@ -1,0 +1,152 @@
+//! Anonymous (unsigned) S3 access to public buckets/objects (#1707).
+//!
+//! An object created via `put_object` and reachable by a SigV4 presigned GET
+//! used to 404 on a plain anonymous `GET /bucket/key` — the unsigned request
+//! fell through service detection to the apigateway catch-all ("Stage not
+//! found"). These tests pin the routing fix (default mode) and the
+//! authorization behavior under `--iam strict` (public bucket policy / ACL
+//! grant access; private objects are denied).
+
+mod helpers;
+
+use aws_sdk_s3::types::ObjectCannedAcl;
+use helpers::TestServer;
+
+const PUBLIC_READ_POLICY: &str = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::probe/*"}]}"#;
+
+/// Default mode: an anonymous GET serves the object (fakecloud is permissive
+/// by default), both before and after a public-read bucket policy. The bug was
+/// a 404 here; this is the core regression test for #1707.
+#[tokio::test]
+async fn anonymous_get_object_default_mode_serves_object() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket().bucket("probe").send().await.unwrap();
+    s3.put_object()
+        .bucket("probe")
+        .key("a.txt")
+        .body(b"hello".to_vec().into())
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/probe/a.txt", server.endpoint());
+
+    // Before any policy: permissive default mode still serves it.
+    let resp = http.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 200, "anonymous GET should return 200");
+    assert_eq!(resp.bytes().await.unwrap().as_ref(), b"hello");
+
+    // After a public-read bucket policy: still 200.
+    s3.put_bucket_policy()
+        .bucket("probe")
+        .policy(PUBLIC_READ_POLICY)
+        .send()
+        .await
+        .unwrap();
+    let resp = http.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.bytes().await.unwrap().as_ref(), b"hello");
+}
+
+/// Routing only claims unsigned requests whose first path segment is an
+/// existing bucket. A request for a nonexistent bucket must still fall through
+/// to the apigateway catch-all (404), unchanged.
+#[tokio::test]
+async fn anonymous_get_nonexistent_bucket_falls_through() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!("{}/ghostbucket/x.txt", server.endpoint()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+/// IAM strict mode: an anonymous GET of a private object is denied (403);
+/// after a public-read bucket policy it succeeds (200).
+#[tokio::test]
+async fn anonymous_get_object_iam_strict_bucket_policy() {
+    let server = TestServer::start_with_env(&[("FAKECLOUD_IAM", "strict")]).await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket().bucket("probe").send().await.unwrap();
+    s3.put_object()
+        .bucket("probe")
+        .key("a.txt")
+        .body(b"hello".to_vec().into())
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/probe/a.txt", server.endpoint());
+
+    // Private: anonymous access denied.
+    let resp = http.get(&url).send().await.unwrap();
+    assert_eq!(
+        resp.status(),
+        403,
+        "anonymous GET of a private object must be denied in IAM strict mode"
+    );
+
+    // Public-read bucket policy: anonymous access allowed.
+    s3.put_bucket_policy()
+        .bucket("probe")
+        .policy(PUBLIC_READ_POLICY)
+        .send()
+        .await
+        .unwrap();
+    let resp = http.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.bytes().await.unwrap().as_ref(), b"hello");
+}
+
+/// IAM strict mode: a public-read object ACL grants anonymous access, while a
+/// sibling private object in the same bucket stays denied.
+#[tokio::test]
+async fn anonymous_get_object_iam_strict_public_acl() {
+    let server = TestServer::start_with_env(&[("FAKECLOUD_IAM", "strict")]).await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket().bucket("probe").send().await.unwrap();
+    s3.put_object()
+        .bucket("probe")
+        .key("public.txt")
+        .body(b"world".to_vec().into())
+        .acl(ObjectCannedAcl::PublicRead)
+        .send()
+        .await
+        .unwrap();
+    s3.put_object()
+        .bucket("probe")
+        .key("private.txt")
+        .body(b"secret".to_vec().into())
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+
+    let resp = http
+        .get(format!("{}/probe/public.txt", server.endpoint()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "public-read ACL object must be readable"
+    );
+    assert_eq!(resp.bytes().await.unwrap().as_ref(), b"world");
+
+    let resp = http
+        .get(format!("{}/probe/private.txt", server.endpoint()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 403, "private object must stay denied");
+}

--- a/crates/fakecloud-iam/src/policy_evaluator.rs
+++ b/crates/fakecloud-iam/src/policy_evaluator.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use fakecloud_core::auth::{
-    ConditionContext, IamAction, IamDecision, IamPolicyEvaluator, Principal,
+    ConditionContext, IamAction, IamDecision, IamPolicyEvaluator, Principal, PrincipalType,
 };
 
 use crate::evaluator::{self, Decision, EvalRequest};
@@ -96,6 +96,48 @@ impl IamPolicyEvaluator for IamPolicyEvaluatorImpl {
             &request,
             resource_account_id,
         ))
+    }
+
+    fn evaluate_anonymous(
+        &self,
+        action: &IamAction,
+        context: &ConditionContext,
+        resource_policy_json: Option<&str>,
+    ) -> IamDecision {
+        // Anonymous callers carry no identity; only the resource policy can
+        // grant access, and only via a wildcard principal. Evaluate the
+        // bucket policy in isolation against a synthetic anonymous principal
+        // — `evaluate_resource_policy_only` matches `Principal:"*"`
+        // (`PrincipalRef::AnyAws`) while an account-root or specific-ARN
+        // grant fails to match the empty anonymous identity, exactly as AWS
+        // treats unsigned requests.
+        let Some(json) = resource_policy_json else {
+            return IamDecision::ImplicitDeny;
+        };
+        let anonymous = anonymous_principal();
+        let request = EvalRequest {
+            principal: &anonymous,
+            action: action.action_string(),
+            resource: action.resource.clone(),
+            context: context.clone(),
+        };
+        let policy = evaluator::PolicyDocument::parse(json);
+        decision_to_core(evaluator::evaluate_resource_policy_only(&policy, &request))
+    }
+}
+
+/// A synthetic principal standing in for an unsigned (anonymous) caller.
+/// It has no account and an empty ARN, so only a wildcard `Principal:"*"`
+/// resource-policy statement matches it — account-root and specific-ARN
+/// grants do not, matching how real AWS authorizes anonymous requests.
+fn anonymous_principal() -> Principal {
+    Principal {
+        arn: String::new(),
+        user_id: String::new(),
+        account_id: String::new(),
+        principal_type: PrincipalType::Unknown,
+        source_identity: None,
+        tags: None,
     }
 }
 
@@ -477,6 +519,57 @@ mod tests {
             ),
             IamDecision::Allow
         );
+    }
+
+    #[test]
+    fn anonymous_allowed_by_wildcard_resource_policy() {
+        let eval = IamPolicyEvaluatorImpl::new(setup());
+        let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}"#;
+        assert_eq!(
+            eval.evaluate_anonymous(
+                &s3_get_object_action(),
+                &ConditionContext::default(),
+                Some(policy)
+            ),
+            IamDecision::Allow
+        );
+    }
+
+    #[test]
+    fn anonymous_denied_without_resource_policy() {
+        let eval = IamPolicyEvaluatorImpl::new(setup());
+        assert_eq!(
+            eval.evaluate_anonymous(&s3_get_object_action(), &ConditionContext::default(), None),
+            IamDecision::ImplicitDeny
+        );
+    }
+
+    #[test]
+    fn anonymous_denied_when_policy_grants_specific_account() {
+        // A bucket policy that grants a named account root — not "*" — must not
+        // let an anonymous (identity-less) caller through.
+        let eval = IamPolicyEvaluatorImpl::new(setup());
+        let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:root"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}"#;
+        assert_eq!(
+            eval.evaluate_anonymous(
+                &s3_get_object_action(),
+                &ConditionContext::default(),
+                Some(policy)
+            ),
+            IamDecision::ImplicitDeny
+        );
+    }
+
+    #[test]
+    fn anonymous_explicit_deny_in_resource_policy() {
+        let eval = IamPolicyEvaluatorImpl::new(setup());
+        let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}"#;
+        let decision = eval.evaluate_anonymous(
+            &s3_get_object_action(),
+            &ConditionContext::default(),
+            Some(policy),
+        );
+        assert!(!decision.is_allow());
     }
 
     #[test]

--- a/crates/fakecloud-s3/src/resource_policy.rs
+++ b/crates/fakecloud-s3/src/resource_policy.rs
@@ -71,6 +71,85 @@ impl ResourcePolicyProvider for S3ResourcePolicyProvider {
         mas.find_account(|s| s.buckets.contains_key(bucket_name))
             .map(|a| a.to_string())
     }
+
+    fn public_acl_allows(&self, service: &str, resource_arn: &str, action: &str) -> bool {
+        if !service.eq_ignore_ascii_case("s3") {
+            return false;
+        }
+        // Which canned grant satisfies the action: object-read actions need
+        // an object (or bucket) ACL; bucket-list actions need a bucket ACL.
+        let needs_object = match action {
+            "GetObject" | "GetObjectVersion" | "HeadObject" => true,
+            "ListBucket" | "ListObjects" | "ListObjectsV2" | "ListObjectVersions" => false,
+            // Other actions are not granted anonymously via a public-read ACL.
+            _ => return false,
+        };
+        let Some(bucket_name) = parse_bucket_name(resource_arn) else {
+            return false;
+        };
+        let mas = self.state.read();
+        let Some(acct) = mas.find_account(|s| s.buckets.contains_key(bucket_name)) else {
+            return false;
+        };
+        let Some(state) = mas.get(acct) else {
+            return false;
+        };
+        let Some(bucket) = state.buckets.get(bucket_name) else {
+            return false;
+        };
+        // PublicAccessBlock.IgnorePublicAcls makes public ACLs inert, so a
+        // bucket with it set is never publicly readable via ACL — matching
+        // the read-path gate in objects/read.rs and AWS behavior.
+        if let Some(xml) = bucket.public_access_block.as_ref() {
+            if crate::service::config::PublicAccessBlockFlags::parse(xml).ignore_public_acls {
+                return false;
+            }
+        }
+        if needs_object {
+            let key = object_key(resource_arn);
+            let object_grants = key.and_then(|k| {
+                bucket.objects.get(k).map(|o| &o.acl_grants).or_else(|| {
+                    bucket
+                        .object_versions
+                        .get(k)
+                        .and_then(|v| v.last())
+                        .map(|o| &o.acl_grants)
+                })
+            });
+            if let Some(grants) = object_grants {
+                if grants_all_users_read(grants) {
+                    return true;
+                }
+            }
+        }
+        // Bucket-level READ grant covers list actions, and also serves as a
+        // fallback public-read for object GETs when the bucket ACL is public.
+        grants_all_users_read(&bucket.acl_grants)
+    }
+}
+
+/// Extract the object key (everything after the first `/`) from an S3 ARN
+/// like `arn:aws:s3:::bucket/path/to/key`. Returns `None` for bucket-level
+/// ARNs that carry no key.
+fn object_key(arn: &str) -> Option<&str> {
+    let rest = arn.strip_prefix("arn:aws:s3:::")?;
+    rest.split_once('/')
+        .map(|(_, key)| key)
+        .filter(|k| !k.is_empty())
+}
+
+/// True iff the grant set grants READ (or FULL_CONTROL) to the `AllUsers`
+/// group — the canned `public-read` shape that makes content readable by
+/// anonymous callers. `AuthenticatedUsers` is intentionally excluded: it
+/// grants to any *authenticated* AWS principal, not to anonymous callers.
+fn grants_all_users_read(grants: &[crate::state::AclGrant]) -> bool {
+    grants.iter().any(|g| {
+        g.grantee_type == "Group"
+            && g.grantee_uri
+                .as_deref()
+                .is_some_and(|u| u.contains("acs.amazonaws.com/groups/global/AllUsers"))
+            && matches!(g.permission.as_str(), "READ" | "FULL_CONTROL")
+    })
 }
 
 /// Extract the bucket name from an S3 ARN.
@@ -108,6 +187,86 @@ mod tests {
         b.policy = policy.map(|p| p.to_string());
         s.buckets.insert(name.to_string(), b);
         Arc::new(RwLock::new(mas))
+    }
+
+    fn public_read_grant() -> crate::state::AclGrant {
+        crate::state::AclGrant {
+            grantee_type: "Group".to_string(),
+            grantee_id: None,
+            grantee_display_name: None,
+            grantee_uri: Some("http://acs.amazonaws.com/groups/global/AllUsers".to_string()),
+            permission: "READ".to_string(),
+        }
+    }
+
+    /// Build state with a single bucket holding one object, applying the
+    /// supplied bucket/object ACL grants and optional PublicAccessBlock XML.
+    fn state_with_object(
+        bucket: &str,
+        key: &str,
+        object_grants: Vec<crate::state::AclGrant>,
+        bucket_grants: Vec<crate::state::AclGrant>,
+        pab: Option<&str>,
+    ) -> SharedS3State {
+        let mut mas: fakecloud_core::multi_account::MultiAccountState<S3State> =
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", "");
+        let s = mas.get_or_create("123456789012");
+        let mut b = S3Bucket::new(bucket, "us-east-1", "owner");
+        b.acl_grants = bucket_grants;
+        b.public_access_block = pab.map(|p| p.to_string());
+        let mut obj = crate::state::S3Object {
+            key: key.to_string(),
+            ..Default::default()
+        };
+        obj.acl_grants = object_grants;
+        b.objects.insert(key.to_string(), obj);
+        s.buckets.insert(bucket.to_string(), b);
+        Arc::new(RwLock::new(mas))
+    }
+
+    #[test]
+    fn public_acl_allows_get_object_with_public_read_object_acl() {
+        let state = state_with_object("b", "k.txt", vec![public_read_grant()], vec![], None);
+        let provider = S3ResourcePolicyProvider::new(state);
+        assert!(provider.public_acl_allows("s3", "arn:aws:s3:::b/k.txt", "GetObject"));
+    }
+
+    #[test]
+    fn public_acl_allows_get_object_with_public_read_bucket_acl() {
+        let state = state_with_object("b", "k.txt", vec![], vec![public_read_grant()], None);
+        let provider = S3ResourcePolicyProvider::new(state);
+        assert!(provider.public_acl_allows("s3", "arn:aws:s3:::b/k.txt", "GetObject"));
+    }
+
+    #[test]
+    fn public_acl_denies_private_object() {
+        let state = state_with_object("b", "k.txt", vec![], vec![], None);
+        let provider = S3ResourcePolicyProvider::new(state);
+        assert!(!provider.public_acl_allows("s3", "arn:aws:s3:::b/k.txt", "GetObject"));
+    }
+
+    #[test]
+    fn public_acl_ignored_when_public_access_block_set() {
+        let pab = "<PublicAccessBlockConfiguration><IgnorePublicAcls>true</IgnorePublicAcls></PublicAccessBlockConfiguration>";
+        let state = state_with_object("b", "k.txt", vec![public_read_grant()], vec![], Some(pab));
+        let provider = S3ResourcePolicyProvider::new(state);
+        assert!(!provider.public_acl_allows("s3", "arn:aws:s3:::b/k.txt", "GetObject"));
+    }
+
+    #[test]
+    fn public_acl_list_bucket_uses_bucket_acl() {
+        let state = state_with_object("b", "k.txt", vec![], vec![public_read_grant()], None);
+        let provider = S3ResourcePolicyProvider::new(state);
+        assert!(provider.public_acl_allows("s3", "arn:aws:s3:::b", "ListBucket"));
+        // A bucket-only public ACL does not expose unrelated write actions.
+        assert!(!provider.public_acl_allows("s3", "arn:aws:s3:::b/k.txt", "PutObject"));
+    }
+
+    #[test]
+    fn public_acl_false_for_non_s3_service() {
+        let state = state_with_object("b", "k.txt", vec![public_read_grant()], vec![], None);
+        let provider = S3ResourcePolicyProvider::new(state);
+        assert!(!provider.public_acl_allows("sqs", "arn:aws:s3:::b/k.txt", "GetObject"));
     }
 
     #[test]

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -21,7 +21,7 @@ use crate::state::{AclGrant, S3Bucket, S3Object, SharedS3State};
 mod access_points;
 mod acl;
 mod buckets;
-mod config;
+pub(crate) mod config;
 mod lock;
 mod multipart;
 mod notifications;

--- a/website/content/docs/services/s3.md
+++ b/website/content/docs/services/s3.md
@@ -21,6 +21,7 @@ fakecloud implements **107 of 107** S3 operations at 100% Smithy conformance.
 - **S3 Select** — real `SelectObjectContent` over CSV/JSON via EventStream framing (`Records`, `Stats`, `End` messages).
 - **Object Lambda** — `WriteGetObjectResponse` actually stores the transformed body + metadata against the original request token; the next `GetObject` on the access point returns the transformed payload.
 - **Public Access Block** — `IgnorePublicAcls` is enforced on `GetObject`; public-read ACL grants are ignored when the bucket-level block is set.
+- **Anonymous access** — unsigned `GET`/`HEAD` requests (`GET /bucket/key` with no SigV4) reach S3 directly, so you can serve static assets / CDN origins straight from a bucket. In the default (no-IAM) mode they're served permissively; under `--iam soft|strict` an anonymous request is authorized only when a bucket policy grants the action to `Principal:"*"` or a public-read ACL (`AllUsers`) is set, denied otherwise.
 - **ACL ownership modes** — `BucketOwnerEnforced` disables ACLs entirely (all ACL writes rejected, reads return owner-only).
 
 ## Protocol


### PR DESCRIPTION
## Summary

Fixes #1707. An anonymous (unsigned) `GET /bucket/key` returned **HTTP 404** (`{"message":"Stage not found: ..."}`) even after a public-read bucket policy and object ACL were set, while a SigV4 **presigned** GET returned 200. Real AWS serves the object anonymously once public-read is applied.

Root cause (reproduced against v0.19.0): the unsigned request carries no `Authorization` header, no `X-Amz-Credential`, and a plain `Host`, so `detect_service` returns `None` and dispatch's catch-all routed it to **apigateway** instead of S3. The presigned GET worked only because its `X-Amz-Credential` carries the `s3` scope.

Two gaps, both addressed here:

1. **No anonymous object-GET routing** — unsigned requests never reached the S3 handler.
2. **bucket policy / ACL not consulted for anonymous** — once routed, anonymous requests would bypass authorization in IAM-enforcement mode.

## Changes

- **Routing** (`dispatch.rs`): when service detection fails, route the request to S3 if its first path segment names an existing bucket (probed via the already-wired `resource_policy_provider`), before the apigateway fallback. Method-agnostic (anonymous GET/HEAD/list). Nonexistent buckets still fall through to apigateway unchanged.
- **Anonymous authorization** (`dispatch.rs` + traits): under `--iam soft|strict`, a truly unsigned request is authorized via
  - `IamPolicyEvaluator::evaluate_anonymous` — bucket policy granting `Principal:"*"` (wraps the existing `evaluate_resource_policy_only`), and
  - `ResourcePolicyProvider::public_acl_allows` — public-read (`AllUsers`) object/bucket ACL, honoring `PublicAccessBlock.IgnorePublicAcls`.

  Denied (403 `AccessDenied`) in strict mode otherwise; soft mode audit-logs and falls through. Default (no-IAM) mode stays permissive. Requests that carried an `Authorization` header but didn't resolve to a principal keep prior behavior (not treated as anonymous).

## Test plan

- Unit: `evaluate_anonymous` (wildcard allow / scoped-account deny / no-policy deny / explicit deny); `public_acl_allows` (object & bucket public-read, private deny, PAB-ignored, list vs write, non-s3).
- E2E `s3_anonymous_access.rs`: default mode serves object (before & after policy); nonexistent bucket → 404; IAM strict denies private (403), allows public bucket policy (200) and public-read ACL (200), keeps sibling private object denied.
- Reran S3 + IAM enforcement e2e suites (s3, access points, introspection, iam_enforcement{,_abac,_boundary,_session_policy}, sigv4, iam) — all green. `cargo clippy --workspace --all-targets -D warnings` clean; `cargo fmt` applied.
- Verified the issue's exact Python repro: anonymous GET now returns `200 b"hello"`.

## Docs

Added an "Anonymous access" bullet to `website/content/docs/services/s3.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix anonymous S3 access so unsigned path-style requests reach S3 and return 200 for public objects, matching AWS. Also enforce public access under IAM via bucket policy `Principal:"*"` and public-read ACLs.

- **Bug Fixes**
  - Route unsigned requests to S3 when the first path segment is an existing bucket; avoids API Gateway 404s ("Stage not found").
  - Nonexistent buckets still fall through to the API Gateway fallback.

- **New Features**
  - IAM enforcement for anonymous callers: allow only when a bucket policy grants `Principal:"*"` or an `AllUsers` public-read ACL exists; honor Public Access Block; strict mode denies otherwise; soft mode audits; default mode stays permissive.
  - Added unit and e2e tests for routing and policy/ACL checks, plus docs note on anonymous access.

<sup>Written for commit 12ec80bde8faa7a05d08934c05f354a923e5402e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

