### PR TITLE
fix(s3): enforce public-read on anonymous GetObject; fix SigV2-presigned auth regression

### DIFF
--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -225,7 +225,15 @@ pub async fn dispatch(
         None
     };
     let sigv4_info = header_info.or(presigned_info);
-    let access_key_id = sigv4_info.as_ref().map(|info| info.access_key.clone());
+    // SigV2 presigned URLs (`AWSAccessKeyId` + `Signature` + `Expires` query
+    // parameters) carry the access key outside the SigV4 grammar, so the SigV4
+    // parsers above return None. Recover the key here so a SigV2-presigned
+    // request is attributed to its caller instead of being treated as
+    // anonymous (which would deny it under the object read auth gate).
+    let access_key_id = sigv4_info
+        .as_ref()
+        .map(|info| info.access_key.clone())
+        .or_else(|| sigv2_presigned_access_key(&query_params));
 
     // Host-header routing hint: LocalStack-shaped
     // `<svc>.<region>.localhost.localstack.cloud[:port]`, real-AWS
@@ -1109,6 +1117,19 @@ fn sanitize_header_value(s: &str) -> String {
 /// fall through to the apigateway catch-all. Uses the already-wired
 /// `resource_policy_provider`, which resolves S3 bucket ownership from state
 /// (`Some` => the bucket exists). Returns `None` when no provider is wired.
+/// Recover the access key from a SigV2 presigned URL. AWS SigV2 presigning
+/// puts the key in the `AWSAccessKeyId` query parameter alongside `Signature`
+/// and `Expires`; all three must be present for the URL to be a SigV2 presign.
+/// Returns None for SigV4 presigns (which use `X-Amz-Credential`) or unsigned
+/// requests.
+fn sigv2_presigned_access_key(query_params: &HashMap<String, String>) -> Option<String> {
+    if query_params.contains_key("Signature") && query_params.contains_key("Expires") {
+        query_params.get("AWSAccessKeyId").cloned()
+    } else {
+        None
+    }
+}
+
 fn anonymous_s3_bucket(uri: &http::Uri, config: &DispatchConfig) -> Option<String> {
     let provider = config.resource_policy_provider.as_ref()?;
     let segment = uri.path().split('/').find(|s| !s.is_empty())?.to_string();
@@ -1211,6 +1232,39 @@ mod tests {
         // public function caches via OnceLock so only the first call
         // in the process matters; we assert the constant directly.
         assert_eq!(DEFAULT_MAX_REQUEST_BODY_BYTES, 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn sigv2_presigned_access_key_extracted_with_signature_and_expires() {
+        let mut q = HashMap::new();
+        q.insert("AWSAccessKeyId".to_string(), "AKIAEXAMPLE".to_string());
+        q.insert("Signature".to_string(), "abc%2Bdef".to_string());
+        q.insert("Expires".to_string(), "1700000000".to_string());
+        assert_eq!(
+            sigv2_presigned_access_key(&q).as_deref(),
+            Some("AKIAEXAMPLE")
+        );
+    }
+
+    #[test]
+    fn sigv2_presigned_access_key_none_without_signature_or_expires() {
+        // AWSAccessKeyId alone (e.g. a stray query param) is not a SigV2
+        // presign and must not be treated as a credential.
+        let mut q = HashMap::new();
+        q.insert("AWSAccessKeyId".to_string(), "AKIAEXAMPLE".to_string());
+        assert_eq!(sigv2_presigned_access_key(&q), None);
+
+        q.insert("Expires".to_string(), "1700000000".to_string());
+        assert_eq!(
+            sigv2_presigned_access_key(&q),
+            None,
+            "missing Signature must not qualify"
+        );
+    }
+
+    #[test]
+    fn sigv2_presigned_access_key_none_for_unsigned_request() {
+        assert_eq!(sigv2_presigned_access_key(&HashMap::new()), None);
     }
 
     #[test]

--- a/crates/fakecloud-e2e/tests/s3_anonymous_access.rs
+++ b/crates/fakecloud-e2e/tests/s3_anonymous_access.rs
@@ -105,6 +105,46 @@ async fn anonymous_get_object_iam_strict_bucket_policy() {
     assert_eq!(resp.bytes().await.unwrap().as_ref(), b"hello");
 }
 
+/// IAM strict mode: a SigV2-presigned request carries its access key in the
+/// `AWSAccessKeyId` query parameter (outside the SigV4 grammar). dispatch must
+/// recover it so the caller is attributed instead of being treated as
+/// anonymous. Without the fix (#1709) the request falls through the
+/// anonymous-read gate and is denied 403 even with a valid key.
+#[tokio::test]
+async fn sigv2_presigned_request_is_attributed_to_its_caller() {
+    let server = TestServer::start_with_env(&[("FAKECLOUD_IAM", "strict")]).await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket().bucket("probe").send().await.unwrap();
+    s3.put_object()
+        .bucket("probe")
+        .key("a.txt")
+        .body(b"hello".to_vec().into())
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let base = format!("{}/probe/a.txt", server.endpoint());
+
+    // Sanity: an unsigned anonymous GET of this private object is denied.
+    let resp = http.get(&base).send().await.unwrap();
+    assert_eq!(resp.status(), 403, "anonymous GET must be denied");
+
+    // A SigV2-presigned URL (AWSAccessKeyId + Signature + Expires) for the
+    // bucket-owning account's key is attributed to that caller and allowed.
+    // The default test credentials resolve to the default account's root.
+    let signed =
+        format!("{base}?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Signature=dummysig&Expires=9999999999");
+    let resp = http.get(&signed).send().await.unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "SigV2-presigned GET with a valid AWSAccessKeyId must be authorized"
+    );
+    assert_eq!(resp.bytes().await.unwrap().as_ref(), b"hello");
+}
+
 /// IAM strict mode: a public-read object ACL grants anonymous access, while a
 /// sibling private object in the same bucket stays denied.
 #[tokio::test]


### PR DESCRIPTION
## Summary
S3 previously served (or 404'd) anonymous unsigned object reads without consulting any public-read grant. This brings anonymous `GetObject`/`HeadObject` in line with AWS semantics and fixes a related auth gap for SigV2-presigned URLs.

## Behavior
- Anonymous (unsigned) `GetObject`/`HeadObject` succeeds **only** when a public-read grant covers the object: a bucket policy `Allow` of `s3:GetObject` to `Principal:"*"` whose `Resource` matches the object ARN, or a public-read (`AllUsers` `READ`/`FULL_CONTROL`) object or bucket ACL.
- A private existing object → **403 AccessDenied** (not 404). A genuinely missing key → **404 NoSuchKey**.
- SigV4-authed and presigned reads are unchanged. **Bugfix:** SigV2-presigned URLs (`AWSAccessKeyId`+`Signature`+`Expires`) were treated as anonymous because the access key was never lifted out of the query string; they are now recognized as authenticated.

## Implementation
- New `AwsService::claims_unsigned_rest` hook (default `false`). Header-unattributable unsigned requests are offered to each service before the API Gateway catch-all; S3 claims a `GET`/`HEAD` whose first path segment names an existing bucket. Authorization is still decided in the read handler.
- `public_access.rs`: a minimal anonymous-read evaluator (bucket policy: explicit Deny > Allow > silent; conditioned statements conservatively ignored; malformed policy = no opinion, never a silent allow). Independent of the optional full IAM evaluator.
- Bucket policies and object/bucket ACLs already persist; no change needed there.

## Tests
Unit tests for the evaluator (policy Allow/Deny, wildcards, ACL, malformed-policy safety) plus e2e coverage: anon private → 403, public-read policy → 200, public-read object ACL → 200, presigned → 200, missing key → 404.

Fixes #1707 and #1709.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes S3 SigV2-presigned GET/HEAD being treated as anonymous. We now attribute these requests by lifting `AWSAccessKeyId` from the query string when `Signature` and `Expires` are present, so valid presigned reads succeed in IAM strict mode.

- **Bug Fixes**
  - Dispatch recovers `AWSAccessKeyId` for SigV2 presigned URLs; ignores stray keys unless `Signature` and `Expires` are also present. SigV4 behavior unchanged.
  - Added unit tests for extraction and an e2e test: anonymous private GET → 403; valid SigV2-presigned GET → 200.

<sup>Written for commit 1b05e368d34cc6959aa8b0abd4e988b7dfdfc1f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

