### PR TITLE
fix(stepfunctions): faithful lambda:invoke optimized integration

### DIFF
--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1862,6 +1862,33 @@ async fn invoke_lambda_direct(
             let response_str = String::from_utf8_lossy(&bytes);
             let value: Value =
                 serde_json::from_str(&response_str).unwrap_or(json!(response_str.to_string()));
+
+            // The Lambda runtime returns HTTP 200 even for unhandled function
+            // errors, encoding the failure in the payload as
+            // `{"errorMessage", "errorType", "stackTrace"}`. The delivery trait
+            // only conveys bytes, so the payload is the only available signal —
+            // the same heuristic the Lambda service uses for async destination
+            // routing. Mirror real AWS: a function error fails the task with the
+            // function's `errorType` as the Error and the serialized payload as
+            // the Cause, which is exactly what makes Retry/Catch on custom
+            // exception names work.
+            //
+            // Require BOTH `errorType` and `errorMessage` (not either) to avoid
+            // misreading a legitimate success payload that merely happens to
+            // contain one of those field names as a function error.
+            if let Some(obj) = value.as_object() {
+                if obj.contains_key("errorType") && obj.contains_key("errorMessage") {
+                    let error_type = obj
+                        .get("errorType")
+                        .and_then(Value::as_str)
+                        .unwrap_or("Exception")
+                        .to_string();
+                    let cause = serde_json::to_string(&value)
+                        .expect("serde_json::Value serialization is infallible");
+                    return Err((error_type, cause));
+                }
+            }
+
             Ok(value)
         }
         Some(Err(e)) => Err(("States.TaskFailed".to_string(), e)),

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1096,7 +1096,24 @@ async fn invoke_resource(
         } else {
             input.clone()
         };
-        return invoke_lambda_direct(function_name, &payload, delivery, timeout_seconds).await;
+        // The optimized `lambda:invoke` integration returns the AWS Invoke API
+        // response envelope, not the bare function output — `ResultSelector`
+        // expressions like `{"value.$": "$.Payload"}` depend on it. Wrap only
+        // the successful result; error results (function errors and transport
+        // failures) pass through unchanged, since a failed lambda:invoke task
+        // has no result envelope on AWS. The direct-ARN path above
+        // intentionally stays unwrapped — there real AWS returns the bare
+        // payload. `SdkHttpMetadata`/`SdkResponseMetadata` are omitted; real
+        // templates select `Payload`/`StatusCode`.
+        return invoke_lambda_direct(function_name, &payload, delivery, timeout_seconds)
+            .await
+            .map(|payload| {
+                json!({
+                    "ExecutedVersion": "$LATEST",
+                    "Payload": payload,
+                    "StatusCode": 200,
+                })
+            });
     }
 
     if resource.starts_with("arn:aws:states:::sqs:sendMessage") {

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1891,7 +1891,22 @@ async fn invoke_lambda_direct(
 
             Ok(value)
         }
-        Some(Err(e)) => Err(("States.TaskFailed".to_string(), e)),
+        Some(Err(e)) => {
+            // Failures of the Lambda Invoke API call itself surface on real AWS
+            // with `Lambda.`-prefixed error names (`Lambda.ServiceException`,
+            // `Lambda.SdkClientException`, `Lambda.Unknown`, ...) — never
+            // `States.TaskFailed` — and those are the names AWS documents for
+            // Retry rules. The delivery error is an unstructured string with
+            // the outcome flattened, so the honest default is `Lambda.Unknown`
+            // ("outcome unknown"). The one case we can cheaply distinguish is a
+            // missing function, which AWS reports as
+            // `Lambda.ResourceNotFoundException`.
+            if e.starts_with("Function not found") {
+                Err(("Lambda.ResourceNotFoundException".to_string(), e))
+            } else {
+                Err(("Lambda.Unknown".to_string(), e))
+            }
+        }
         None => {
             // No runtime available — return empty result
             Ok(json!({}))

--- a/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
@@ -1586,3 +1586,77 @@ fn lambda_transport_error_fails_as_lambda_unknown() {
         assert_eq!(exec.error.as_deref(), Some("Lambda.Unknown"));
     });
 }
+
+// Case 5: lambda:invoke wraps the function output in the AWS response
+// envelope, so a ResultSelector picking `$.Payload` sees the function output
+// and the raw task result carries StatusCode: 200.
+#[test]
+fn lambda_invoke_wraps_result_in_envelope() {
+    let state = make_state();
+    let arn = arn_for("lambda-envelope");
+    let (bus, _calls) = StubLambda::bus(vec![Ok(br#"{"answer":42}"#.to_vec())]);
+    let def = lambda_invoke_def(json!({
+        "ResultSelector": { "value.$": "$.Payload", "status.$": "$.StatusCode" }
+    }));
+    drive_with_delivery(&state, &arn, def, Some("{}"), bus);
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        assert_eq!(output["value"]["answer"], json!(42));
+        assert_eq!(output["status"], json!(200));
+    });
+}
+
+// Case 6: the direct-ARN path returns the bare payload (no envelope), matching
+// real AWS where only the optimized lambda:invoke integration wraps the result.
+#[test]
+fn lambda_direct_arn_is_not_wrapped() {
+    let state = make_state();
+    let arn = arn_for("lambda-direct");
+    let (bus, _calls) = StubLambda::bus(vec![Ok(br#"{"answer":42}"#.to_vec())]);
+    let def = json!({
+        "StartAt": "T",
+        "States": {
+            "T": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:us-east-1:123456789012:function:fn",
+                "End": true
+            }
+        }
+    });
+    drive_with_delivery(&state, &arn, def, Some("{}"), bus);
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        assert_eq!(output, json!({ "answer": 42 }));
+    });
+}
+
+// Case 7: plain success payloads still pass through — objects lacking both
+// error keys, and non-object (string) payloads.
+#[test]
+fn lambda_plain_payloads_pass_through() {
+    // Object containing only one of the error field names is NOT an error.
+    let state = make_state();
+    let arn = arn_for("lambda-one-key");
+    let (bus, _c) = StubLambda::bus(vec![Ok(br#"{"errorType":"NotReallyAnError"}"#.to_vec())]);
+    drive_with_delivery(&state, &arn, lambda_invoke_def(json!({})), Some("{}"), bus);
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        assert_eq!(output["Payload"]["errorType"], json!("NotReallyAnError"));
+    });
+
+    // A bare string payload passes through inside the envelope.
+    let state = make_state();
+    let arn = arn_for("lambda-string");
+    let (bus, _c) = StubLambda::bus(vec![Ok(b"\"hello\"".to_vec())]);
+    drive_with_delivery(&state, &arn, lambda_invoke_def(json!({})), Some("{}"), bus);
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        assert_eq!(output["Payload"], json!("hello"));
+    });
+}

--- a/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
@@ -1550,3 +1550,39 @@ fn lambda_catch_on_custom_error_type_routes() {
             .contains("errorMessage"));
     });
 }
+
+// Case 4a: a transport error surfaces as Lambda.Unknown and is retryable.
+#[test]
+fn lambda_transport_error_is_lambda_unknown_and_retryable() {
+    let state = make_state();
+    let arn = arn_for("lambda-transport-retry");
+    let (bus, calls) = StubLambda::bus(vec![
+        Err("invocation failed: error sending request for url".to_string()),
+        Ok(br#"{"ok":true}"#.to_vec()),
+    ]);
+    let def = lambda_invoke_def(json!({
+        "Retry": [{ "ErrorEquals": ["Lambda.Unknown"], "MaxAttempts": 2, "IntervalSeconds": 0 }]
+    }));
+    drive_with_delivery(&state, &arn, def, Some("{}"), bus);
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+    });
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
+// Case 4b: without a retry the transport error fails with Lambda.Unknown.
+#[test]
+fn lambda_transport_error_fails_as_lambda_unknown() {
+    let state = make_state();
+    let arn = arn_for("lambda-transport-fail");
+    let (bus, _calls) = StubLambda::bus(vec![Err(
+        "invocation failed: error sending request for url".to_string(),
+    )]);
+    drive_with_delivery(&state, &arn, lambda_invoke_def(json!({})), Some("{}"), bus);
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Failed);
+        assert_eq!(exec.error.as_deref(), Some("Lambda.Unknown"));
+    });
+}

--- a/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
@@ -1404,3 +1404,149 @@ fn fail_state_with_explicit_error_and_cause() {
     let err = read_exec(&state, &arn, |e| e.error.clone().unwrap_or_default());
     assert_eq!(err, "MyError");
 }
+
+// ── Task: lambda:invoke integration — function errors, transport, envelope ──
+
+use fakecloud_core::delivery::{DeliveryBus, LambdaDelivery};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Stub `LambdaDelivery` that returns canned results, one per call. Once the
+/// canned list is exhausted it repeats the last entry — so "fail once, then
+/// succeed forever" needs only two entries.
+struct StubLambda {
+    responses: Vec<Result<Vec<u8>, String>>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl StubLambda {
+    fn bus(responses: Vec<Result<Vec<u8>, String>>) -> (Arc<DeliveryBus>, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let stub = Arc::new(StubLambda {
+            responses,
+            calls: calls.clone(),
+        });
+        (Arc::new(DeliveryBus::new().with_lambda(stub)), calls)
+    }
+}
+
+impl LambdaDelivery for StubLambda {
+    fn invoke_lambda(
+        &self,
+        _function_arn: &str,
+        _payload: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>, String>> + Send>> {
+        let idx = self.calls.fetch_add(1, Ordering::SeqCst);
+        let resp = self
+            .responses
+            .get(idx)
+            .or_else(|| self.responses.last())
+            .cloned()
+            .unwrap_or_else(|| Ok(b"{}".to_vec()));
+        Box::pin(async move { resp })
+    }
+}
+
+fn drive_with_delivery(
+    state: &SharedStepFunctionsState,
+    arn: &str,
+    def: Value,
+    input: Option<&str>,
+    delivery: Arc<DeliveryBus>,
+) {
+    create_execution(state, arn, input.map(|s| s.to_string()));
+    let fut = execute_state_machine(
+        state.clone(),
+        arn.to_string(),
+        def.to_string(),
+        input.map(|s| s.to_string()),
+        Some(delivery),
+        None,
+        None,
+        None,
+    );
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    rt.block_on(fut);
+}
+
+/// A single `lambda:invoke` Task ending the machine, with optional Retry/Catch.
+fn lambda_invoke_def(extra: Value) -> Value {
+    let mut task = json!({
+        "Type": "Task",
+        "Resource": "arn:aws:states:::lambda:invoke",
+        "Parameters": { "FunctionName": "fn" },
+        "End": true
+    });
+    if let (Some(task_obj), Some(extra_obj)) = (task.as_object_mut(), extra.as_object()) {
+        for (k, v) in extra_obj {
+            task_obj.insert(k.clone(), v.clone());
+        }
+    }
+    json!({ "StartAt": "T", "States": { "T": task } })
+}
+
+// Case 1: a function error fails the task with the errorType as the Error.
+#[test]
+fn lambda_function_error_fails_task_with_error_type() {
+    let state = make_state();
+    let arn = arn_for("lambda-fn-error");
+    let (bus, calls) = StubLambda::bus(vec![Ok(
+        br#"{"errorMessage":"boom","errorType":"MyCustomError","stackTrace":[]}"#.to_vec(),
+    )]);
+    drive_with_delivery(&state, &arn, lambda_invoke_def(json!({})), Some("{}"), bus);
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Failed);
+        assert_eq!(exec.error.as_deref(), Some("MyCustomError"));
+        assert!(exec.cause.as_deref().unwrap().contains("errorMessage"));
+    });
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+// Case 2: Retry on a custom errorType fires and the second attempt succeeds.
+#[test]
+fn lambda_retry_on_custom_error_type_succeeds() {
+    let state = make_state();
+    let arn = arn_for("lambda-retry");
+    let (bus, calls) = StubLambda::bus(vec![
+        Ok(br#"{"errorMessage":"boom","errorType":"MyCustomError"}"#.to_vec()),
+        Ok(br#"{"ok":true}"#.to_vec()),
+    ]);
+    let def = lambda_invoke_def(json!({
+        "Retry": [{ "ErrorEquals": ["MyCustomError"], "MaxAttempts": 2, "IntervalSeconds": 0 }]
+    }));
+    drive_with_delivery(&state, &arn, def, Some("{}"), bus);
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+    });
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
+// Case 3: Catch on the errorType routes into the handler with Error/Cause.
+#[test]
+fn lambda_catch_on_custom_error_type_routes() {
+    let state = make_state();
+    let arn = arn_for("lambda-catch");
+    let (bus, _calls) = StubLambda::bus(vec![Ok(
+        br#"{"errorMessage":"boom","errorType":"MyCustomError"}"#.to_vec(),
+    )]);
+    let def = lambda_invoke_def(json!({
+        "Catch": [{ "ErrorEquals": ["MyCustomError"], "Next": "Handler", "ResultPath": "$.err" }]
+    }));
+    let mut def = def;
+    def["States"]["Handler"] = json!({ "Type": "Pass", "End": true });
+    drive_with_delivery(&state, &arn, def, Some(r#"{"orig":"v"}"#), bus);
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        assert_eq!(output["err"]["Error"], json!("MyCustomError"));
+        assert!(output["err"]["Cause"]
+            .as_str()
+            .unwrap()
+            .contains("errorMessage"));
+    });
+}


### PR DESCRIPTION
**Version**: fakecloud (current `main` @ `d828a709`)

## Summary

The Step Functions `arn:aws:states:::lambda:invoke` optimized integration diverges
from AWS in three related ways, all in `invoke_lambda_direct` and the
`lambda:invoke` dispatch arm in
`crates/fakecloud-stepfunctions/src/interpreter.rs`:

1. **Lambda function errors are reported as task success.** The Lambda runtime
   returns HTTP 200 with an `{errorMessage, errorType, stackTrace}` body for an
   unhandled function error. The interpreter treats that as a successful task
   result, so the function's `errorType` never becomes the task's Error — `Retry`
   and `Catch` clauses keyed on it (e.g. a custom `RetryableServerException`) never
   fire, and the workflow proceeds on a silently-failed step.

2. **Invocation/transport failures map to `States.TaskFailed`.** When the invoke
   itself fails (transport error, function not found, etc.), the task fails with
   `States.TaskFailed`. AWS surfaces these as `Lambda.*` error names
   (`Lambda.ServiceException`, `Lambda.Unknown`, …), which are what `Retry` rules
   are written against — so retryable failures aren't retried.

3. **Successful results are not wrapped in the AWS response envelope.** The
   optimized integration returns the bare function payload instead of
   `{ExecutedVersion, Payload, StatusCode}`. Templates that select `$.Payload`
   (the AWS-documented shape) get `null`, corrupting every downstream step that
   reads the previous task's output.

## Reproduction

```sh
EP=http://127.0.0.1:4566
# A Lambda whose handler raises a custom exception (returns 200 + errorType body).
# A state machine Task invoking it via the optimized integration with a Retry on
# the custom error name and ResultSelector: { "v.$": "$.Payload" }.
aws --endpoint-url $EP stepfunctions get-execution-history --execution-arn <arn>
```

Observed vs AWS:
- **Function error:** fakecloud → `TaskSucceeded` with the error JSON as output;
  AWS → `TaskFailed` with `error = <errorType>`, `Retry`/`Catch` fire.
- **Transport failure:** fakecloud → `States.TaskFailed`; AWS → `Lambda.Unknown`
  (retryable).
- **Success envelope:** fakecloud → output is the bare payload, `$.Payload` →
  `null`; AWS → output is `{ExecutedVersion, Payload, StatusCode}`.

## Expected

The optimized `lambda:invoke` integration matches AWS:
- A 200 response carrying `errorType`/`errorMessage` fails the task with the
  function's `errorType` as the Error and the payload as the Cause (so `Retry`/
  `Catch` match it).
- Invoke-layer failures surface as `Lambda.*` error names.
- Successful task output is `{ExecutedVersion, Payload, StatusCode}`; error results
  are not wrapped (matching AWS, where a failed `lambda:invoke` task has no result
  envelope).

## Impact

Any SAM/Step Functions app that fans work out through a dispatcher Lambda is
affected: function errors are swallowed, retryable failures aren't retried, and
`$.Payload`-based result wiring breaks — so multi-step workflows silently produce
wrong/empty output instead of failing or retrying as designed.

## The fix

Three focused commits on the `lambda:invoke` path in `interpreter.rs`:

1. **Function errors → task errors.** In `invoke_lambda_direct`, a 200 payload
   carrying **both** `errorType` and `errorMessage` now fails the task with that
   `errorType` as the Error and the serialized payload as the Cause. Requiring both
   keys avoids misreading a legitimate success payload that merely contains one of
   those field names.
2. **Transport failures → `Lambda.*`.** Invoke-layer failures map to
   `Lambda.Unknown` (the honest default for an unstructured delivery error), with
   `Function not found` surfaced as `Lambda.ResourceNotFoundException`.
3. **Success envelope.** The optimized-integration dispatch arm wraps a successful
   result in `{ExecutedVersion: "$LATEST", Payload, StatusCode: 200}`. Error
   results pass through unwrapped (AWS has no result envelope on a failed task),
   and the direct-ARN path intentionally stays unwrapped (bare payload, matching
   AWS).

They edit the same arm and share one test stub, so they ship together.

## Test plan

- `cargo test -p fakecloud-stepfunctions` — 173 passed. New unit cases cover:
  function-error→task-error, Retry-on-custom-errorType fires, transport→
  `Lambda.Unknown`, `$.Payload` envelope, non-error passthrough.
- `cargo test -p fakecloud-e2e --test stepfunctions --test cloudformation_stepfunctions --test stepfunctions_task_token --test stepfunctions_persistence`
  — 77 passed, 0 failed, 2 ignored.
- `cargo build --bin fakecloud`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` — clean.

No new/removed operations, so the conformance baseline is unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Step Functions `arn:aws:states:::lambda:invoke` optimized integration with AWS so retries and result paths work correctly. Function errors now fail the task, invoke-layer failures use `Lambda.*` error names, and successful results return the AWS response envelope.

- **Bug Fixes**
  - Function error payloads (200 with `errorType` and `errorMessage`) now fail the task: Error=`<errorType>`, Cause=payload; `Retry`/`Catch` on custom errors now work.
  - Invoke/transport failures map to AWS names: default `Lambda.Unknown`; `Function not found` → `Lambda.ResourceNotFoundException`.
  - Successful results are wrapped as `{ExecutedVersion: "$LATEST", Payload, StatusCode: 200}`; direct-ARN invocations stay unwrapped; error results are not wrapped.

<sup>Written for commit ab4e36d3b066925b65de074798b1c8321d13f136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

