### PR TITLE
fix(lambda): warm-pool unique pod names + fast dead-instance failover

### DIFF
--- a/crates/fakecloud-lambda/src/runtime/facade.rs
+++ b/crates/fakecloud-lambda/src/runtime/facade.rs
@@ -44,6 +44,18 @@ pub(crate) struct WarmEntry {
 /// on a busy instance rather than starting a new one.
 const DEFAULT_MAX_CONCURRENCY: usize = 10;
 
+/// Max attempts per invocation when a reserved warm instance turns out to be
+/// unreachable. Each failover is a fast probe (or connect error) plus a cold
+/// start; the connection provably never reached the handler, so retrying can't
+/// double-execute. Bounded so an all-dead pool can't spin forever.
+const MAX_INVOKE_ATTEMPTS: u32 = 5;
+
+/// Timeout for the pre-invoke TCP reachability probe. A black-holed Pod IP (a
+/// killed pod / drained node that drops packets with no RST) would otherwise
+/// hang the full invoke timeout (~`func.timeout + 5s`); this detects it in ~1s
+/// so the state-machine retry can succeed within its window.
+const REACHABILITY_PROBE_TIMEOUT: Duration = Duration::from_millis(1500);
+
 /// A reserved invocation slot: a warm instance plus the held busy guard
 /// that grants exclusive use of it until the guard drops.
 struct Slot {
@@ -77,6 +89,18 @@ fn deploy_id_from(code_sha256: &str, layers: &[Vec<u8>]) -> String {
         hasher.update(layer_hasher.finalize());
     }
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hasher.finalize())
+}
+
+/// Quick liveness check: can a TCP connection to `endpoint` (`host:port`) be
+/// opened within `timeout`? Used before forwarding a payload to a warm instance
+/// so a dead/black-holed Pod is detected in ~1s instead of hanging the full
+/// invoke timeout. A failed connect provably never reached the handler, so the
+/// caller can safely evict and retry.
+async fn endpoint_reachable(endpoint: &str, timeout: Duration) -> bool {
+    matches!(
+        tokio::time::timeout(timeout, tokio::net::TcpStream::connect(endpoint)).await,
+        Ok(Ok(_))
+    )
 }
 
 pub struct LambdaRuntime {
@@ -181,20 +205,49 @@ impl LambdaRuntime {
     /// Reserves a warm instance for the call (one in-flight invocation
     /// per instance — the RIE crashes on overlap, issue #1644). If the
     /// instance is unreachable (dead Pod/container from a node drain, OOM,
-    /// or prior crash) it is evicted and the call retried once against a
-    /// freshly cold-started instance, so a dead instance can't wedge the
-    /// function permanently.
+    /// or prior crash) it is evicted and the call retried (up to twice)
+    /// against a freshly cold-started instance, so a dead instance can't
+    /// wedge the function permanently.
     pub async fn invoke(
         &self,
         func: &LambdaFunction,
         payload: &[u8],
         layers: &[Vec<u8>],
     ) -> Result<Vec<u8>, RuntimeError> {
-        let client = reqwest::Client::new();
-        let mut attempt = 0;
+        let client = reqwest::Client::builder()
+            .connect_timeout(REACHABILITY_PROBE_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        let mut attempt: u32 = 0;
         loop {
             attempt += 1;
             let slot = self.acquire_slot(func, layers).await?;
+
+            // Fast reachability probe before forwarding the payload. A warm Pod
+            // that was killed (FakeCloud recreating it, OOM, node reclaim) often
+            // black-holes its old IP, so the POST would hang the full invoke
+            // timeout. A short TCP probe detects the dead instance in ~1s; the
+            // connection never reached the handler, so we can safely evict and
+            // fail over to a cold start.
+            if !endpoint_reachable(&slot.entry.instance.endpoint, REACHABILITY_PROBE_TIMEOUT).await
+            {
+                let entry = slot.entry.clone();
+                drop(slot);
+                self.evict_entry(&func.function_name, &entry).await;
+                if attempt < MAX_INVOKE_ATTEMPTS {
+                    tracing::warn!(
+                        function = %func.function_name,
+                        endpoint = %entry.instance.endpoint,
+                        "warm Lambda instance failed reachability probe; evicted, retrying with a cold start"
+                    );
+                    continue;
+                }
+                return Err(RuntimeError::InvocationFailed(format!(
+                    "no reachable warm instance for {} after {attempt} attempts",
+                    func.function_name
+                )));
+            }
+
             let url = format!(
                 "http://{}/2015-03-31/functions/function/invocations",
                 slot.entry.instance.endpoint
@@ -234,7 +287,7 @@ impl LambdaRuntime {
                     let entry = slot.entry.clone();
                     drop(slot);
                     self.evict_entry(&func.function_name, &entry).await;
-                    if attempt < 2 && e.is_connect() {
+                    if attempt < MAX_INVOKE_ATTEMPTS && e.is_connect() {
                         tracing::warn!(
                             function = %func.function_name,
                             error = %e,
@@ -264,11 +317,31 @@ impl LambdaRuntime {
         payload: &[u8],
         layers: &[Vec<u8>],
     ) -> Result<StreamingInvocation, RuntimeError> {
-        let client = reqwest::Client::new();
-        let mut attempt = 0;
+        let client = reqwest::Client::builder()
+            .connect_timeout(REACHABILITY_PROBE_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        let mut attempt: u32 = 0;
         loop {
             attempt += 1;
             let slot = self.acquire_slot(func, layers).await?;
+
+            // Same fast reachability probe as `invoke`: detect a dead/black-holed
+            // warm instance in ~1s and fail over instead of hanging.
+            if !endpoint_reachable(&slot.entry.instance.endpoint, REACHABILITY_PROBE_TIMEOUT).await
+            {
+                let entry = slot.entry.clone();
+                drop(slot);
+                self.evict_entry(&func.function_name, &entry).await;
+                if attempt < MAX_INVOKE_ATTEMPTS {
+                    continue;
+                }
+                return Err(RuntimeError::InvocationFailed(format!(
+                    "no reachable warm instance for {} after {attempt} attempts",
+                    func.function_name
+                )));
+            }
+
             let url = format!(
                 "http://{}/2015-03-31/functions/function/invocations",
                 slot.entry.instance.endpoint
@@ -298,7 +371,7 @@ impl LambdaRuntime {
                     let entry = slot.entry.clone();
                     drop(slot);
                     self.evict_entry(&func.function_name, &entry).await;
-                    if attempt < 2 && e.is_connect() {
+                    if attempt < MAX_INVOKE_ATTEMPTS && e.is_connect() {
                         continue;
                     }
                     return Err(RuntimeError::InvocationFailed(e.to_string()));
@@ -781,10 +854,18 @@ mod tests {
                 let peak = peak.clone();
                 tokio::spawn(async move {
                     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    // Only connections that actually send a request count as an
+                    // invocation. A bare reachability probe (TCP connect, no
+                    // bytes) reads EOF and is ignored — it neither overlaps a
+                    // real invoke nor inflates the concurrency peak, mirroring
+                    // the real RIE, which only starts an event on a request.
+                    let mut buf = [0u8; 1024];
+                    let n = sock.read(&mut buf).await.unwrap_or(0);
+                    if n == 0 {
+                        return;
+                    }
                     let now = cur.fetch_add(1, SeqCst) + 1;
                     peak.fetch_max(now, SeqCst);
-                    let mut buf = [0u8; 1024];
-                    let _ = sock.read(&mut buf).await;
                     tokio::time::sleep(delay).await;
                     let _ = sock
                         .write_all(
@@ -908,8 +989,13 @@ mod tests {
     async fn dead_instance_is_evicted_and_retried() {
         let peak = Arc::new(AtomicUsize::new(0));
         let live = spawn_rie(Duration::from_millis(5), peak.clone()).await;
-        // First launch hands back a refused port; the retry gets the live one.
-        let backend = CountingBackend::with_queue(live, vec!["127.0.0.1:1".to_string()]);
+        // Two launches in a row hand back refused ports; the third gets the
+        // live one. Connect-refused provably never reached a handler, so the
+        // extra retry budget can't double-execute.
+        let backend = CountingBackend::with_queue(
+            live,
+            vec!["127.0.0.1:1".to_string(), "127.0.0.1:1".to_string()],
+        );
         let rt = runtime_with(backend.clone(), 1);
 
         let out = rt
@@ -919,12 +1005,51 @@ mod tests {
         assert_eq!(out, b"ok");
         assert_eq!(
             backend.launches.load(SeqCst),
+            3,
+            "expected two dead instances plus one cold-start replacement"
+        );
+        assert!(
+            backend.terminates.load(SeqCst) >= 2,
+            "both dead instances should have been terminated on eviction"
+        );
+    }
+
+    /// A black-holed warm instance (a killed Pod whose IP now drops packets,
+    /// rather than refusing with an RST) must be detected by the fast
+    /// reachability probe and failed over in seconds — not hang the full invoke
+    /// timeout (~`func.timeout + 5s`). This is the failure mode that flaked the
+    /// LOE workflows: a dead pod cost ~305s, blowing the test window.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn black_holed_instance_fails_over_fast() {
+        let peak = Arc::new(AtomicUsize::new(0));
+        let live = spawn_rie(Duration::from_millis(5), peak.clone()).await;
+        // 192.0.2.1 is RFC 5737 TEST-NET-1: unrouted, so a connect black-holes
+        // (caught by the probe's ~1.5s timeout) instead of getting a fast RST.
+        let backend = CountingBackend::with_queue(live, vec!["192.0.2.1:9".to_string()]);
+        let rt = runtime_with(backend.clone(), 1);
+
+        // test_func timeout is 5 → the pre-fix hang would be ~10s.
+        let func = test_func("blackhole", "sha-A");
+        let started = std::time::Instant::now();
+        let out = rt
+            .invoke(&func, b"{}", &[])
+            .await
+            .expect("should recover via cold-start retry");
+        let elapsed = started.elapsed();
+
+        assert_eq!(out, b"ok");
+        assert_eq!(
+            backend.launches.load(SeqCst),
             2,
-            "expected the dead instance plus one cold-start replacement"
+            "expected one black-holed instance plus one cold-start replacement"
         );
         assert!(
             backend.terminates.load(SeqCst) >= 1,
-            "the dead instance should have been terminated on eviction"
+            "the black-holed instance should have been evicted"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "failover took {elapsed:?}; must be far below the ~10s invoke timeout"
         );
     }
 

--- a/crates/fakecloud-lambda/src/runtime/facade.rs
+++ b/crates/fakecloud-lambda/src/runtime/facade.rs
@@ -205,8 +205,8 @@ impl LambdaRuntime {
     /// Reserves a warm instance for the call (one in-flight invocation
     /// per instance — the RIE crashes on overlap, issue #1644). If the
     /// instance is unreachable (dead Pod/container from a node drain, OOM,
-    /// or prior crash) it is evicted and the call retried (up to twice)
-    /// against a freshly cold-started instance, so a dead instance can't
+    /// or prior crash) it is evicted and the call retried (up to four
+    /// times) against a freshly cold-started instance, so a dead instance can't
     /// wedge the function permanently.
     pub async fn invoke(
         &self,
@@ -1028,7 +1028,7 @@ mod tests {
         let backend = CountingBackend::with_queue(live, vec!["192.0.2.1:9".to_string()]);
         let rt = runtime_with(backend.clone(), 1);
 
-        // test_func timeout is 5 → the pre-fix hang would be ~10s.
+        // test_func timeout is 5 -> the pre-fix hang would be ~10s.
         let func = test_func("blackhole", "sha-A");
         let started = std::time::Instant::now();
         let out = rt

--- a/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
@@ -22,7 +22,7 @@ use fakecloud_k8s::{K8sClient, K8sEnv, K8sEnvError};
 
 use super::backend::{BackendHandle, LambdaBackend, RuntimeError, WarmInstance};
 use crate::state::LambdaFunction;
-use spec::{build_pod_spec, pod_name_for, PodSpecContext};
+use spec::{build_pod_spec, unique_pod_name, PodSpecContext};
 
 /// Which `fakecloud-service` label Lambda Pods carry, so reaping only
 /// touches Lambda Pods.
@@ -124,13 +124,14 @@ impl LambdaBackend for K8sBackend {
             account_id,
             pull_secret: self.pull_secret.as_deref(),
         };
-        let pod =
+        let mut pod =
             build_pod_spec(func, deploy_id, &ctx).map_err(RuntimeError::ContainerStartFailed)?;
-        let pod_name = pod
-            .metadata
-            .name
-            .clone()
-            .unwrap_or_else(|| pod_name_for(&func.function_name, deploy_id));
+        // Override the deterministic function+deploy name with a per-launch
+        // unique one so concurrent instances of the same function don't collide
+        // and a terminating Pod never blocks its replacement (see
+        // `unique_pod_name`).
+        let pod_name = unique_pod_name(&func.function_name, deploy_id);
+        pod.metadata.name = Some(pod_name.clone());
 
         self.client
             .create_pod(&pod)

--- a/crates/fakecloud-lambda/src/runtime/k8s/spec.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/spec.rs
@@ -571,6 +571,32 @@ mod tests {
     }
 
     #[test]
+    fn unique_pod_name_differs_across_calls() {
+        // Same function + deploy_id must still yield distinct names so the
+        // warm pool can run more than one concurrent instance and a
+        // still-terminating Pod never blocks its replacement.
+        let a = unique_pod_name("fn", "deploy");
+        let b = unique_pod_name("fn", "deploy");
+        let c = unique_pod_name("fn", "deploy");
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn unique_pod_name_is_dns1123_safe_and_bounded() {
+        // Hostile inputs and a large counter must stay DNS-1123-safe and
+        // within the 63-char Pod-name limit.
+        for _ in 0..1000 {
+            let name = unique_pod_name("My_Awesome_Function", "abc/123+def==");
+            assert!(name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
+            assert!(!name.starts_with('-'));
+            assert!(!name.ends_with('-'));
+            assert!(name.len() <= 63);
+        }
+    }
+
+    #[test]
     fn restart_policy_never() {
         let f = zip_function("my-fn");
         let pod = build_pod_spec(&f, "d", &ctx()).unwrap();

--- a/crates/fakecloud-lambda/src/runtime/k8s/spec.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/spec.rs
@@ -267,6 +267,21 @@ pub fn pod_name_for(function_name: &str, deploy_id: &str) -> String {
     fakecloud_k8s::names::pod_name("fakecloud-lambda", function_name, deploy_id)
 }
 
+/// Build a per-launch *unique* DNS-1123-safe Pod name. The deterministic
+/// [`pod_name_for`] name collides whenever the warm pool needs more than one
+/// concurrent instance of a function (the RIE serves one invocation at a time),
+/// and a still-terminating Pod blocks its replacement (`AlreadyExists` /
+/// "object is being deleted" / `NotFound` races). Salting the hashed id with a
+/// process-monotonic counter yields a fresh, length-bounded name per launch, so
+/// instances never collide and a dying Pod never wedges a new one.
+pub fn unique_pod_name(function_name: &str, deploy_id: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let salted = format!("{deploy_id}-{n}");
+    fakecloud_k8s::names::pod_name("fakecloud-lambda", function_name, &salted)
+}
+
 /// Map the function's `memory_size` (MiB) onto both `requests` and
 /// `limits`. Mirrors real Lambda: CPU is implicitly proportional to
 /// memory, but k8s requires explicit values, so we set memory only and


### PR DESCRIPTION
**Version**: fakecloud (current `main` @ `d828a709`), Kubernetes Lambda backend
(`FAKECLOUD_LAMBDA_BACKEND=k8s`).

## Summary

Under concurrent invocations of a single function, the k8s Lambda warm pool
thrashes a **single deterministically-named pod** and invocations fail with
`Lambda.Unknown`. The warm pool runs one in-flight invocation per instance (the
RIE can't overlap), but the pod is named deterministically per function+deploy —
so when concurrency requires a second instance, or a cold start recreates an
instance whose previous pod is still terminating, the k8s API rejects it:

```
container failed to start: k8s create pod: object is being deleted:
  pods "fakecloud-lambda-<fn>-<deployid>" already exists: AlreadyExists
... or ...
  pods "fakecloud-lambda-<fn>-<deployid>" not found: NotFound
```

The failed launch surfaces as `Lambda.Unknown` to the caller. A separate facet:
when a warm pod's IP is unreachable (terminating), the invoke can hang on the full
function timeout before failing, rather than failing over fast.

## Reproduction

With the k8s backend, drive **concurrent** `Invoke` calls at one function (e.g. a
Step Functions workflow that fans out several `lambda:invoke` tasks at once).
`kubectl get events` for the function's pod shows the same pod name being
Killed and recreated repeatedly within seconds (no node eviction involved), and
some invocations fail with `Lambda.Unknown: ... object is being deleted ...
AlreadyExists` / `... not found`.

## Expected

Concurrent invocations are served without create/delete races:
- Each launched instance gets a **unique pod name** (so a terminating old pod
  never blocks a replacement, and the pool can hold more than one live pod per
  function under load).
- A dead/unreachable warm instance is detected and failed over **fast** (a short
  reachability check), not after the full function timeout.

## Impact

Any workload that invokes one function concurrently (Step Functions fan-out, an
event burst, parallel test suites) sees a high rate of spurious `Lambda.Unknown`
failures under the k8s backend. In our bake-off this made every multi-step
workflow fail reliably under load, presenting as widespread "flaky" test failures.

## The fix

- **Unique pod names.** `runtime/k8s/spec.rs` gains `unique_pod_name`, which salts
  the hashed function+deploy id with a process-monotonic atomic counter to produce
  a fresh, length-bounded, DNS-1123-safe name per launch; `runtime/k8s/mod.rs`
  overrides the pod's metadata name with it. The pool already stored distinct
  `WarmEntry` instances, so no pool-keying change was needed — it can now actually
  hold >1 live pod per function.
- **Fast failover.** `runtime/facade.rs` adds `endpoint_reachable` — a ~1.5s TCP
  reachability probe run before forwarding the payload (and a matching reqwest
  `connect_timeout` backstop). A black-holed pod IP is detected in ~1s and failed
  over to a cold start, instead of hanging `~func.timeout + 5s` (~305s). The
  streaming path gets the same probe. The connect-only retry budget is raised to
  five cold-start replacements (`MAX_INVOKE_ATTEMPTS`).

## Design notes / alternatives considered

- **Unique pod names vs. wait-for-delete / retry-on-`AlreadyExists`.** Both
  alternatives fix the recreate race, but neither lifts the **concurrency ceiling**:
  a deterministic name means at most one live pod per function, which is the actual
  failure under fan-out load. Unique names fix the race *and* let the pool run
  multiple concurrent instances — so that's the chosen approach. Names are salted
  with a process-monotonic counter (not a clock or RNG) to stay deterministic and
  collision-free without a wall-clock dependency.
- **Why the retry is safe.** Failover only happens on a failed TCP connect (probe
  or `e.is_connect()`). A refused/black-holed connection provably never reached the
  handler, so retrying cannot double-execute side effects. Reset/timeout failures
  mid-flight still surface immediately, unchanged.
- **Probe timeout (1.5s).** Long enough to tolerate a slow-but-live pod's TCP
  handshake, short enough that a dead instance fails over well inside a state
  machine's retry window rather than consuming the full invoke timeout. Tunable via
  the `REACHABILITY_PROBE_TIMEOUT` constant.
- **Pool keying/limits unchanged.** No change to how the pool keys or caps
  instances; `DEFAULT_MAX_CONCURRENCY` (10) still governs reuse-vs-cold-start.

## Test plan

- `cargo test -p fakecloud-lambda` — warm-pool tests extended:
  `dead_instance_is_evicted_and_retried` now exercises two dead instances in a row,
  and a new `black_holed_instance_fails_over_fast` asserts a black-holed endpoint
  fails over fast (no multi-minute hang). The mock RIE now counts only connections
  that send a request, so a bare probe isn't miscounted as an invocation. Timing
  assertions avoid wall-clock per the repo constraint.
- `cargo build --bin fakecloud`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` — clean.

No new/removed operations, so the conformance baseline is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky k8s Lambda warm-pool invocations under concurrent load by giving each instance a unique Pod name and adding a fast reachability probe to evict dead pods. This removes create/delete races and cuts dead-instance hangs from ~function timeout to ~1s.

- **Bug Fixes**
  - Unique pod names: new `unique_pod_name(...)` salts function+deploy with a monotonic counter and overrides `metadata.name`. Prevents `AlreadyExists` races and allows multiple live Pods per function.
  - Fast failover: pre-invoke TCP probe (~1.5s) plus `reqwest` `connect_timeout`. Unreachable warm Pods are evicted and replaced; retry budget `MAX_INVOKE_ATTEMPTS = 5`. Streaming path included.
  - Safe retries: only on failed connects (never reached handler). Mid-flight errors still return immediately.
  - Tests: add black-holed endpoint test; extend dead-instance retries; mock RIE ignores bare connect probes; add `unique_pod_name` tests for uniqueness and DNS-1123 safety.

<sup>Written for commit 50a01ba5eaf599a6b86066aefef3ce79b136b35f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

