### PR TITLE
fix(cloudformation): resolve Outputs on changeset-executed stacks

### DIFF
--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -924,7 +924,7 @@ impl CloudFormationService {
                 // every resource as an Add when the stack starts empty, so the
                 // same code path serves both create and update; only the
                 // surfaced status differs (CREATE_* vs UPDATE_*).
-                let (update_result, sid, stack_name_owned, was_review) = {
+                let (update_result, sid, stack_name_owned, was_review, resources_snapshot) = {
                     let stack = state
                         .stacks
                         .values_mut()
@@ -968,10 +968,11 @@ impl CloudFormationService {
                         stack.notification_arns = cs_notif;
                     }
                     stack.updated_at = Some(Utc::now());
-                    if result.is_ok() {
-                        stack.outputs.clear();
-                    }
-                    (result, sid, sname, was_review)
+                    // Outputs are resolved below from the provisioned resources;
+                    // clear stale values now so a failed run leaves none behind.
+                    stack.outputs.clear();
+                    let resources_snapshot = stack.resources.clone();
+                    (result, sid, sname, was_review, resources_snapshot)
                 };
 
                 // Emit lifecycle events on the per-stack event log.
@@ -1048,6 +1049,40 @@ impl CloudFormationService {
                         "ValidationError",
                         msg,
                     ));
+                }
+
+                // Resolve the template's `Outputs` for the newly provisioned
+                // stack and persist them, mirroring CreateStack/UpdateStack.
+                // Without this, a changeset-created stack reports empty Outputs
+                // — SAM's `--resolve-s3` managed-bucket health check requires
+                // the template's `SourceBucket` output to be present in
+                // `DescribeStacks`. Resolution reads cross-stack exports, so it
+                // runs after the write lock is dropped.
+                let outputs = CloudFormationService::resolve_template_outputs(
+                    &template_body,
+                    &cs_params,
+                    &resources_snapshot,
+                    &self.state,
+                );
+                {
+                    let mut accounts = self.state.write();
+                    let state = accounts.get_or_create(&aid);
+                    if let Some(stack) = state
+                        .stacks
+                        .values_mut()
+                        .find(|s| s.stack_id == sid && s.status != "DELETE_COMPLETE")
+                    {
+                        stack.outputs = outputs.clone();
+                    }
+                    // Re-register this stack's exports so other stacks can
+                    // `Fn::ImportValue` them, as CreateStack/UpdateStack do.
+                    CloudFormationService::sync_exports_imports(
+                        state,
+                        &sid,
+                        &stack_name_owned,
+                        &outputs,
+                        &[],
+                    );
                 }
 
                 Ok(xml_response("ExecuteChangeSet", String::new(), &rid))
@@ -2669,7 +2704,7 @@ mod tests {
     }
 
     // A minimal CREATE-type change set template with one resource and one
-    // output, used by the changeset bookkeeping test below.
+    // output, used by the changeset bookkeeping tests below.
     const CS_TEMPLATE: &str = r#"{"Resources":{"Q":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"cs-q"}}},"Outputs":{"QUrl":{"Value":{"Ref":"Q"}}}}"#;
 
     // Gap #2: a CREATE change set that mints a new REVIEW_IN_PROGRESS stack must
@@ -2763,6 +2798,48 @@ mod tests {
         for w in ts.windows(2) {
             assert!(w[1] > w[0], "timestamps not strictly increasing: {w:?}");
         }
+    }
+
+    // Gap #1: tags set on CreateChangeSet and outputs declared in the template
+    // must both survive ExecuteChangeSet and appear on the created stack (sam's
+    // managed-bucket health check requires Tags + Outputs in DescribeStacks).
+    #[test]
+    fn execute_change_set_persists_tags_and_outputs() {
+        let svc = svc();
+        svc.handle_extra_action(&req(
+            "CreateChangeSet",
+            &[
+                ("StackName", "cs-stack"),
+                ("ChangeSetName", "cs1"),
+                ("ChangeSetType", "CREATE"),
+                ("TemplateBody", CS_TEMPLATE),
+                ("Tags.member.1.Key", "ManagedStackSource"),
+                ("Tags.member.1.Value", "AwsSamCli"),
+            ],
+        ))
+        .expect("create change set");
+        svc.handle_extra_action(&req(
+            "ExecuteChangeSet",
+            &[("StackName", "cs-stack"), ("ChangeSetName", "cs1")],
+        ))
+        .expect("execute change set");
+
+        let accounts = svc.state.read();
+        let stack = accounts
+            .get("000000000000")
+            .unwrap()
+            .stacks
+            .get("cs-stack")
+            .unwrap();
+        assert_eq!(stack.status, "CREATE_COMPLETE");
+        assert_eq!(
+            stack.tags.get("ManagedStackSource").map(String::as_str),
+            Some("AwsSamCli"),
+            "changeset Tags dropped on execute"
+        );
+        assert_eq!(stack.outputs.len(), 1, "changeset Outputs not resolved");
+        assert_eq!(stack.outputs[0].key, "QUrl");
+        assert!(!stack.outputs[0].value.is_empty());
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -465,7 +465,7 @@ impl CloudFormationService {
     /// Sync `state.exports` and `state.imports` after a stack create or
     /// update. Removes any exports / imports the stack used to own and
     /// re-adds the current-revision set.
-    fn sync_exports_imports(
+    pub(crate) fn sync_exports_imports(
         state: &mut CloudFormationState,
         stack_id: &str,
         stack_name: &str,
@@ -514,7 +514,7 @@ impl CloudFormationService {
     /// has been provisioned. `resources` is the post-create / post-update
     /// vec; we rebuild the physical-id and attribute maps from it before
     /// invoking the template parser.
-    fn resolve_template_outputs(
+    pub(crate) fn resolve_template_outputs(
         template_body: &str,
         parameters: &BTreeMap<String, String>,
         resources: &[StackResource],

--- a/crates/fakecloud-e2e/tests/cloudformation_execute_change_set.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_execute_change_set.rs
@@ -428,6 +428,76 @@ async fn create_type_change_set_creates_stack_on_execute() {
     );
 }
 
+/// A stack created via the change-set path must resolve its `Outputs` on
+/// execute, exactly like `CreateStack`/`UpdateStack` do. `sam deploy
+/// --resolve-s3` reads these Outputs back after the changeset executes; an
+/// empty Outputs list there fails the deploy health check (#1716).
+#[tokio::test]
+async fn create_type_change_set_resolves_outputs_on_execute() {
+    let server = TestServer::start().await;
+    let cf = server.cloudformation_client().await;
+
+    let template = r#"{
+        "Resources": {
+            "OutQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {"QueueName": "cs-output-queue"}
+            }
+        },
+        "Outputs": {
+            "QueueUrl": {
+                "Value": {"Ref": "OutQueue"},
+                "Description": "URL of the provisioned queue"
+            }
+        }
+    }"#;
+
+    cf.create_change_set()
+        .stack_name("cs-output-stack")
+        .change_set_name("create-out-cs")
+        .change_set_type(ChangeSetType::Create)
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    cf.execute_change_set()
+        .stack_name("cs-output-stack")
+        .change_set_name("create-out-cs")
+        .send()
+        .await
+        .unwrap();
+
+    let described = cf
+        .describe_stacks()
+        .stack_name("cs-output-stack")
+        .send()
+        .await
+        .unwrap();
+    let stack = &described.stacks()[0];
+    assert_eq!(
+        stack.stack_status().map(|s| s.as_str()),
+        Some("CREATE_COMPLETE")
+    );
+
+    let outputs = stack.outputs();
+    let queue_out = outputs
+        .iter()
+        .find(|o| o.output_key() == Some("QueueUrl"))
+        .expect("changeset-executed stack must expose its Outputs");
+    assert!(
+        queue_out
+            .output_value()
+            .is_some_and(|v| v.contains("cs-output-queue")),
+        "Ref output should resolve to the provisioned queue URL, got {:?}",
+        queue_out.output_value()
+    );
+    assert_eq!(
+        queue_out.description(),
+        Some("URL of the provisioned queue")
+    );
+}
+
 /// SAM always — and `aws cloudformation deploy`/CDK for large templates —
 /// pass the template by `TemplateURL` pointing at an object in S3. The
 /// change set must fetch it (issue #1646, gap 2) rather than store an


### PR DESCRIPTION
**Version**: fakecloud (current `main`/`upstream/main` @ `d828a709`)

## Summary

A stack created and executed via `CreateChangeSet` + `ExecuteChangeSet` comes back
from `DescribeStacks` with **no `Outputs`**. The template's `Outputs` section is
never resolved on the changeset-execute path, so callers that rely on stack outputs
get nothing.

This breaks the SAM CLI's `--resolve-s3` managed-bucket bootstrap: `sam deploy
--resolve-s3` creates the `aws-sam-cli-managed-default` stack (via a changeset),
then `DescribeStacks` and requires the `SourceBucket` **Output** to confirm the
bucket. With no Outputs, sam rejects the bucket it just created:

```
Error: Stack aws-sam-cli-managed-default is missing Tags and/or Outputs
information and therefore not in a healthy state (Current state:CREATE_COMPLETE).
```

(Tags are already carried correctly through changeset execution; Outputs are the
missing half.)

## Reproduction

```sh
EP=http://127.0.0.1:4566
cat > /tmp/out.yaml <<'EOF'
Resources:
  Q: { Type: "AWS::SQS::Queue" }
Outputs:
  QueueUrl: { Value: !Ref Q }
EOF
aws --region us-east-1 cloudformation create-change-set --endpoint-url $EP \
  --stack-name cs-out --change-set-name cs1 --change-set-type CREATE \
  --template-body file:///tmp/out.yaml
aws --region us-east-1 cloudformation execute-change-set --endpoint-url $EP \
  --stack-name cs-out --change-set-name cs1
aws --region us-east-1 cloudformation describe-stacks --endpoint-url $EP \
  --stack-name cs-out --query 'Stacks[0].Outputs'
# actual:   null / []      expected: [{"OutputKey":"QueueUrl","OutputValue":"<url>"}]
```

## Expected

`ExecuteChangeSet` resolves the template's `Outputs` (and re-registers any exports),
so `DescribeStacks` returns them — matching a plain `CreateStack`, which already
resolves Outputs.

## Impact

`sam deploy --resolve-s3` can't bootstrap its artifact bucket against fakecloud, and
any tooling that reads stack Outputs after a changeset deploy gets nothing.

Happy to test a branch or send a PR.

## The fix

On the `ExecuteChangeSet` path in `crates/fakecloud-cloudformation/src/extras.rs`,
resolve the template's `Outputs` and persist them on the stack the same way
`CreateStack`/`UpdateStack` already do, and re-register the stack's exports so
cross-stack `Fn::ImportValue` keeps working. To avoid duplicating that logic,
`resolve_template_outputs` and `sync_exports_imports` in `service.rs` are made
`pub(crate)` so the changeset handler can reuse them. `describe_stacks_response`
already serializes `<Outputs>` once the stack carries them. Tags already survived
(`ExecuteChangeSet` reads them from the stored changeset entry, not the execute
request) — a regression test now pins that too.

## Test plan

- `cargo test -p fakecloud-cloudformation` — unit tests green.
- `cargo test -p fakecloud-e2e --test cloudformation_execute_change_set --test cloudformation`
  — green; a changeset create+execute now returns its template `Outputs` from
  `DescribeStacks`, and Tags are pinned.
- `cargo build --bin fakecloud`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` — clean.

No new/removed operations, so the conformance baseline is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves CloudFormation Outputs for change-set-executed stacks and re-registers exports. Keeps Tags and Outputs visible in DescribeStacks, restoring SAM CLI `--resolve-s3` bootstrap and cross-stack imports.

- **Bug Fixes**
  - Resolve and persist template Outputs during ExecuteChangeSet using a snapshot of provisioned resources; clear stale Outputs on failure.
  - Re-register stack exports after execute so `Fn::ImportValue` works for change-set-created stacks.
  - Expose `resolve_template_outputs` and `sync_exports_imports` as `pub(crate)` for reuse; add unit and e2e tests verifying Tags survive and Outputs (including descriptions) are returned.

<sup>Written for commit dd0c1950d125276ecc7c18742277ba809f0ca251. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

