### PR TITLE
fix(cloudformation): stack events for changeset-created stacks

### DIFF
--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -534,6 +534,21 @@ impl CloudFormationService {
                                     outputs: Vec::new(),
                                 },
                             );
+                            // Real CloudFormation emits a stack event when a
+                            // CREATE change set puts a new stack into
+                            // `REVIEW_IN_PROGRESS`. Record it so the event log
+                            // is non-empty between CreateChangeSet and
+                            // ExecuteChangeSet: `sam deploy` reads the most
+                            // recent event as a marker (`get_last_event_time`)
+                            // and unconditionally indexes `[0]`, throwing an
+                            // `IndexError` if the list is empty.
+                            crate::service::record_stack_status_event(
+                                state,
+                                &stack_id_str,
+                                &stack_name,
+                                "AWS::CloudFormation::Stack",
+                                "REVIEW_IN_PROGRESS",
+                            );
                         }
                         // Already in review (an earlier CREATE change set):
                         // additional CREATE change sets are allowed; keep the
@@ -2651,6 +2666,50 @@ mod tests {
             !xml.contains("MyOrg::MyHook::Hook"),
             "unknown id must not echo the recorded hook: {xml}"
         );
+    }
+
+    // A minimal CREATE-type change set template with one resource and one
+    // output, used by the changeset bookkeeping test below.
+    const CS_TEMPLATE: &str = r#"{"Resources":{"Q":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"cs-q"}}},"Outputs":{"QUrl":{"Value":{"Ref":"Q"}}}}"#;
+
+    // Gap #2: a CREATE change set that mints a new REVIEW_IN_PROGRESS stack must
+    // record a stack event, so `DescribeStackEvents` is non-empty before the
+    // change set is executed (sam's `get_last_event_time` indexes `[0]`).
+    #[test]
+    fn create_change_set_records_review_in_progress_event() {
+        let svc = svc();
+        svc.handle_extra_action(&req(
+            "CreateChangeSet",
+            &[
+                ("StackName", "cs-events"),
+                ("ChangeSetName", "cs1"),
+                ("ChangeSetType", "CREATE"),
+                ("TemplateBody", CS_TEMPLATE),
+            ],
+        ))
+        .expect("create change set");
+
+        // The event log must carry exactly the REVIEW_IN_PROGRESS stack event.
+        {
+            let accounts = svc.state.read();
+            let acct = accounts.get("000000000000").unwrap();
+            let total: usize = acct.events.values().map(|v| v.len()).sum();
+            assert_eq!(total, 1, "expected one event after CreateChangeSet");
+            let ev = acct.events.values().next().unwrap().last().unwrap();
+            assert_eq!(ev["ResourceStatus"].as_str(), Some("REVIEW_IN_PROGRESS"));
+            assert_eq!(
+                ev["ResourceType"].as_str(),
+                Some("AWS::CloudFormation::Stack")
+            );
+        }
+
+        // And DescribeStackEvents surfaces it rather than an empty list.
+        let resp = svc
+            .handle_extra_action(&req("DescribeStackEvents", &[("StackName", "cs-events")]))
+            .expect("describe stack events");
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(!body.contains("<StackEvents/>"), "events list was empty");
+        assert!(body.contains("REVIEW_IN_PROGRESS"), "body: {body}");
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -2712,6 +2712,59 @@ mod tests {
         assert!(body.contains("REVIEW_IN_PROGRESS"), "body: {body}");
     }
 
+    // Gap #2b: a stack that provisions within one wall-clock second must still
+    // produce strictly-increasing, sub-second event timestamps — sam's
+    // deploy-wait only registers completion on an event strictly later than the
+    // REVIEW_IN_PROGRESS marker, so equal whole-second timestamps hang it.
+    #[test]
+    fn changeset_stack_events_have_monotonic_subsecond_timestamps() {
+        let svc = svc();
+        svc.handle_extra_action(&req(
+            "CreateChangeSet",
+            &[
+                ("StackName", "cs-fast"),
+                ("ChangeSetName", "cs1"),
+                ("ChangeSetType", "CREATE"),
+                ("TemplateBody", CS_TEMPLATE),
+            ],
+        ))
+        .expect("create change set");
+        svc.handle_extra_action(&req(
+            "ExecuteChangeSet",
+            &[("StackName", "cs-fast"), ("ChangeSetName", "cs1")],
+        ))
+        .expect("execute change set");
+
+        let accounts = svc.state.read();
+        let acct = accounts.get("000000000000").unwrap();
+        let stack_id = acct.stacks.get("cs-fast").unwrap().stack_id.clone();
+        let events = acct.events.get(&stack_id).expect("stack has events");
+
+        // The full create lifecycle: REVIEW_IN_PROGRESS marker through the
+        // terminal CREATE_COMPLETE, several events deep, all within one second.
+        assert!(events.len() >= 3, "expected several lifecycle events");
+        let ts: Vec<&str> = events
+            .iter()
+            .map(|e| e["Timestamp"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            events.first().unwrap()["ResourceStatus"].as_str(),
+            Some("REVIEW_IN_PROGRESS")
+        );
+        assert_eq!(
+            events.last().unwrap()["ResourceStatus"].as_str(),
+            Some("CREATE_COMPLETE")
+        );
+        // Millisecond precision (fractional seconds) and strictly increasing.
+        // The fixed-width rfc3339 millis format sorts lexicographically by time.
+        for t in &ts {
+            assert!(t.contains('.'), "timestamp lacks sub-second precision: {t}");
+        }
+        for w in ts.windows(2) {
+            assert!(w[1] > w[0], "timestamps not strictly increasing: {w:?}");
+        }
+    }
+
     #[test]
     fn stack_sets_instances_refactors() {
         ok("CreateStackSet", &[("StackSetName", "ss")]);

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -1879,7 +1879,38 @@ pub(crate) fn record_event(
             .map(|d| d.as_nanos())
             .unwrap_or(0)
     );
-    let entry = json!({
+    let log = state.events.entry(stack_id.to_string()).or_default();
+
+    // Timestamps must be sub-second AND strictly increasing within a stack's
+    // event log. `sam`'s deploy-wait reads the REVIEW_IN_PROGRESS marker's
+    // timestamp and then only registers events whose `Timestamp` is strictly
+    // greater; a fast stack that provisions within one second would otherwise
+    // stamp its REVIEW_IN_PROGRESS marker and terminal CREATE_COMPLETE
+    // identically, so sam never sees completion and polls until it times out.
+    // Use millisecond precision and bump by 1ms when the clock hasn't advanced
+    // past the previous event, guaranteeing a strict order.
+    // Truncate to the stored (millisecond) resolution before comparing, so the
+    // strict-ordering check isn't fooled by sub-millisecond bits that vanish on
+    // serialization (two events in the same millisecond would otherwise both
+    // serialize identically despite `now > prev` holding at full precision).
+    let now = chrono::DateTime::from_timestamp_millis(Utc::now().timestamp_millis())
+        .unwrap_or_else(Utc::now);
+    let timestamp = match log.last().and_then(|e| e["Timestamp"].as_str()) {
+        Some(prev) => match chrono::DateTime::parse_from_rfc3339(prev) {
+            Ok(prev) => {
+                let prev = prev.with_timezone(&Utc);
+                if now > prev {
+                    now
+                } else {
+                    prev + chrono::Duration::milliseconds(1)
+                }
+            }
+            Err(_) => now,
+        },
+        None => now,
+    };
+
+    log.push(json!({
         "EventId": event_id,
         "StackId": stack_id,
         "StackName": stack_name,
@@ -1887,13 +1918,8 @@ pub(crate) fn record_event(
         "PhysicalResourceId": physical_id,
         "ResourceType": resource_type,
         "ResourceStatus": status,
-        "Timestamp": Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-    });
-    state
-        .events
-        .entry(stack_id.to_string())
-        .or_default()
-        .push(entry);
+        "Timestamp": timestamp.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+    }));
 }
 
 /// Emits IN_PROGRESS + COMPLETE event pairs for every resource change


### PR DESCRIPTION
**Version**: fakecloud (current `main`/`upstream/main` @ `d828a709`)

## Summary

Two related stack-event defects break the SAM CLI's deploy-progress wait:

1. **`CreateChangeSet` records no event when it mints a new stack.** A `CREATE`
   changeset creates the stack in `REVIEW_IN_PROGRESS` but logs no stack event, so
   `DescribeStackEvents` is empty until `ExecuteChangeSet`. `sam deploy` calls
   `get_last_event_time` **before** executing — it does
   `describe_stack_events(...)["StackEvents"][0]["Timestamp"]` — and crashes:
   ```
   Error: list index out of range   (samcli/lib/deploy/deployer.py get_last_event_time)
   ```
   AWS emits a `REVIEW_IN_PROGRESS` stack event when the review stack is created,
   so the list is never empty.

2. **Stack event timestamps are whole-second.** Events recorded within the same
   second share an identical timestamp. `sam`'s wait marks the last-seen event and
   advances only on events with a **strictly later** timestamp; a stack that
   provisions within one second has its terminal `CREATE_COMPLETE` at the same
   timestamp as the marker, so sam never registers completion and hangs until the
   job times out.

These compose: fix (1) so the list isn't empty, and (2) so the recorded events are
distinguishable — together they make `sam deploy`'s wait work on fast stacks.

## Reproduction

```sh
EP=http://127.0.0.1:4566
cat > /tmp/cs.yaml <<'EOF'
Resources: { Q: { Type: "AWS::SQS::Queue" } }
EOF
aws --region us-east-1 cloudformation create-change-set --endpoint-url $EP \
  --stack-name cs-ev --change-set-name cs1 --change-set-type CREATE \
  --template-body file:///tmp/cs.yaml
# BEFORE: empty. AFTER: one REVIEW_IN_PROGRESS event.
aws --region us-east-1 cloudformation describe-stack-events --endpoint-url $EP \
  --stack-name cs-ev
aws --region us-east-1 cloudformation execute-change-set --endpoint-url $EP \
  --stack-name cs-ev --change-set-name cs1
# AFTER: event Timestamps are strictly increasing (sub-second), REVIEW_IN_PROGRESS
# < ... < CREATE_COMPLETE, even though it all happened within one second.
aws --region us-east-1 cloudformation describe-stack-events --endpoint-url $EP \
  --stack-name cs-ev --query 'StackEvents[].Timestamp'
```

## Expected

- Creating a stack via `CreateChangeSet` emits a `REVIEW_IN_PROGRESS`
  `AWS::CloudFormation::Stack` event immediately.
- Stack event timestamps are sub-second and strictly monotonic within a stack, so
  consecutive events (esp. the pre-execute marker vs. the terminal event) are
  distinguishable.

## Impact

`sam deploy` against fakecloud either crashes with `IndexError` (empty events
before execute) or hangs forever waiting for completion on any stack that
provisions within one second. Both make plain `sam deploy` unusable.

Happy to test a branch or send a PR.

## The fix

Two commits, shipped together because the second is what makes the first usable on
fast stacks:

1. **Record `REVIEW_IN_PROGRESS` on changeset-created stacks.** The `CreateChangeSet`
   new-stack path in `crates/fakecloud-cloudformation/src/extras.rs` now records an
   initial `REVIEW_IN_PROGRESS` `AWS::CloudFormation::Stack` event via the existing
   `record_stack_status_event` helper, so `DescribeStackEvents` is non-empty before
   `ExecuteChangeSet` (sam's `get_last_event_time` indexes `[0]`).
2. **Sub-second, strictly-monotonic timestamps.** `record_stack_*_event` in
   `service.rs` now stamps millisecond-precision timestamps and bumps by 1ms when
   the clock hasn't advanced past the previous event, and serializes fractional
   seconds. The precision trap is handled: `now` is truncated to the stored
   (millisecond) resolution **before** comparing against the previous value, so the
   strict-ordering guarantee matches what's actually serialized (two events in the
   same millisecond would otherwise serialize identically despite `now > prev` at
   full precision). This makes a fast changeset's `REVIEW_IN_PROGRESS` marker
   strictly earlier than its terminal `CREATE_COMPLETE`.

## Test plan

- `cargo test -p fakecloud-cloudformation` — 215 passed, including
  `create_change_set_records_review_in_progress_event` (≥1 `REVIEW_IN_PROGRESS`
  event) and `changeset_stack_events_have_monotonic_subsecond_timestamps` (full
  create lifecycle within one second, strictly-increasing sub-second timestamps).
  Timing assertions avoid wall-clock per the repo constraint.
- `cargo test -p fakecloud-e2e --test cloudformation_execute_change_set --test cloudformation` — 6 + 15 passed.
- `cargo build --bin fakecloud`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` — clean.

No new/removed operations, so the conformance baseline is unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CloudFormation stack events for stacks created via CreateChangeSet by emitting a `REVIEW_IN_PROGRESS` event and using millisecond, strictly increasing timestamps. This prevents `sam deploy` from crashing on empty events and from hanging on fast stacks.

- **Bug Fixes**
  - Record a `REVIEW_IN_PROGRESS` `AWS::CloudFormation::Stack` event when a CREATE-type change set creates a new stack, so `DescribeStackEvents` is not empty before `ExecuteChangeSet`.
  - Stamp stack events with millisecond precision and guarantee strictly monotonic ordering (bump by 1ms when needed), with fractional seconds serialized in responses.

<sup>Written for commit 106499dbdcd6eae38dbacc7f17395e26c976861d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

