### PR TITLE
fix(cloudformation): dependency-ordered resource provisioning

### DIFF
--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -2842,6 +2842,87 @@ mod tests {
         assert!(!stack.outputs[0].value.is_empty());
     }
 
+    // Gap #3: a StateMachine that references a Lambda via DefinitionSubstitutions
+    // must provision *after* the Lambda even when it sorts/declares first, so the
+    // substitution resolves to the function name rather than leaving the logical
+    // id baked in the ASL (which broke every invoke with Lambda.ResourceNotFound).
+    #[test]
+    fn changeset_provisions_lambda_before_referencing_state_machine() {
+        let d = deps();
+        let sfn = d.stepfunctions.clone();
+        let state: SharedCloudFormationState =
+            Arc::new(RwLock::new(MultiAccountState::<CloudFormationState>::new(
+                "000000000000",
+                "us-east-1",
+                "",
+            )));
+        let svc = CloudFormationService::new(state, d);
+
+        // "Machine" sorts before "Worker", so without dependency ordering the
+        // StateMachine provisions first and bakes the unresolved logical id.
+        let template = r#"{
+            "Resources": {
+                "Machine": {
+                    "Type": "AWS::StepFunctions::StateMachine",
+                    "Properties": {
+                        "RoleArn": "arn:aws:iam::000000000000:role/sfn",
+                        "DefinitionString": "{\"StartAt\":\"T\",\"States\":{\"T\":{\"Type\":\"Task\",\"Resource\":\"${fn}\",\"End\":true}}}",
+                        "DefinitionSubstitutions": {"fn": {"Ref": "Worker"}}
+                    }
+                },
+                "Worker": {
+                    "Type": "AWS::Lambda::Function",
+                    "Properties": {
+                        "FunctionName": "workflow_dispatcher_v2-1",
+                        "Runtime": "python3.12",
+                        "Handler": "index.handler",
+                        "Role": "arn:aws:iam::000000000000:role/lambda",
+                        "Code": {"ZipFile": "def handler(e, c): return e"}
+                    }
+                }
+            }
+        }"#;
+
+        svc.handle_extra_action(&req(
+            "CreateChangeSet",
+            &[
+                ("StackName", "wf"),
+                ("ChangeSetName", "cs1"),
+                ("ChangeSetType", "CREATE"),
+                ("TemplateBody", template),
+            ],
+        ))
+        .expect("create change set");
+        svc.handle_extra_action(&req(
+            "ExecuteChangeSet",
+            &[("StackName", "wf"), ("ChangeSetName", "cs1")],
+        ))
+        .expect("execute change set");
+
+        let accounts = sfn.read();
+        let st = accounts.get("000000000000").expect("sfn account exists");
+        let machine = st
+            .state_machines
+            .values()
+            .next()
+            .expect("state machine was provisioned");
+        assert!(
+            machine.definition.contains("workflow_dispatcher_v2-1"),
+            "ASL should carry the resolved function name, got: {}",
+            machine.definition
+        );
+        assert!(
+            !machine.definition.contains("${fn}"),
+            "substitution token left unreplaced: {}",
+            machine.definition
+        );
+        assert!(
+            !machine.definition.contains("Worker"),
+            "logical id leaked into baked ASL: {}",
+            machine.definition
+        );
+    }
+
     #[test]
     fn stack_sets_instances_refactors() {
         ok("CreateStackSet", &[("StackSetName", "ss")]);

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -68,7 +68,13 @@ pub(crate) fn provision_stack_resources(
     let mut resources = Vec::new();
     let mut physical_ids: BTreeMap<String, String> = BTreeMap::new();
     let mut attributes: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
-    let mut pending: Vec<&template::ResourceDefinition> = resource_defs.iter().collect();
+    // Seed the work list in dependency order so a referenced resource is
+    // provisioned before its referrer and `Ref`/`GetAtt`/`Fn::Sub` resolve to
+    // physical ids. The fixed-point retry loop below still recovers from any
+    // residual ordering the graph can't express.
+    let order = template::dependency_order(template_body, parameters, resource_defs);
+    let mut pending: Vec<&template::ResourceDefinition> =
+        order.iter().map(|&i| &resource_defs[i]).collect();
     let max_passes = pending.len() + 1;
 
     for _ in 0..max_passes {
@@ -1759,8 +1765,14 @@ pub(crate) fn apply_resource_updates(
         .map(|r| (r.logical_id.clone(), r.attributes.clone()))
         .collect();
 
-    // Create new resources / update resources that already exist
-    for resource_def in new_resource_defs {
+    // Create new resources / update resources that already exist. Provision in
+    // dependency order so a `Ref`/`GetAtt`/`Fn::Sub`/`DependsOn` to another
+    // resource resolves to that resource's physical id rather than its bare
+    // logical id (which would otherwise get baked into derived state — e.g. a
+    // Step Functions ASL referencing a Lambda declared later in the template).
+    let order = template::dependency_order(template_body, parameters, new_resource_defs);
+    for &idx in &order {
+        let resource_def = &new_resource_defs[idx];
         let resolved_def = template::resolve_resource_properties_with_attrs(
             resource_def,
             template_body,

--- a/crates/fakecloud-cloudformation/src/template/mod.rs
+++ b/crates/fakecloud-cloudformation/src/template/mod.rs
@@ -2250,4 +2250,6 @@ pub use parser::{
     collect_import_value_names, parse_outputs, parse_template, parse_template_with_physical_ids,
     parse_template_with_resolution,
 };
-pub use resolution::{resolve_resource_properties, resolve_resource_properties_with_attrs};
+pub use resolution::{
+    dependency_order, resolve_resource_properties, resolve_resource_properties_with_attrs,
+};

--- a/crates/fakecloud-cloudformation/src/template/resolution.rs
+++ b/crates/fakecloud-cloudformation/src/template/resolution.rs
@@ -78,3 +78,312 @@ pub fn resolve_resource_properties_with_attrs(
         properties: resolved,
     })
 }
+
+/// Compute a provisioning order for `resource_defs` such that every resource is
+/// provisioned *after* the resources it references — via an explicit
+/// `DependsOn` or an implicit `Ref` / `Fn::GetAtt` / `Fn::Sub` to another
+/// resource's logical id.
+///
+/// Returns a permutation of indices into `resource_defs`. CloudFormation
+/// provisions in dependency order; FakeCloud previously provisioned in template
+/// order, so a `Ref` to a not-yet-created resource resolved to the bare logical
+/// id (the "not yet provisioned" fallback in `resolve_refs_full`) and got baked
+/// into derived state — e.g. a Step Functions ASL whose `DefinitionSubstitutions`
+/// reference a Lambda declared later in the template, leaving the logical id in
+/// the definition and failing every invoke with `Lambda.ResourceNotFoundException`.
+///
+/// The graph is built from the post-`ForEach`/post-SAM template so the logical
+/// ids and reference shapes match what provisioning actually sees. Falls back to
+/// the original order on a parse failure or a dependency cycle (which real CFN
+/// rejects outright), and breaks ties by original index so the order is
+/// deterministic.
+pub fn dependency_order(
+    template_body: &str,
+    parameters: &BTreeMap<String, String>,
+    resource_defs: &[ResourceDefinition],
+) -> Vec<usize> {
+    let n = resource_defs.len();
+    let identity = || (0..n).collect::<Vec<usize>>();
+    if n < 2 {
+        return identity();
+    }
+
+    let parse = |body: &str| -> Result<Value, ()> {
+        if body.trim_start().starts_with('{') {
+            serde_json::from_str(body).map_err(|_| ())
+        } else {
+            serde_yaml::from_str(body).map_err(|_| ())
+        }
+    };
+    let Ok(value) = parse(template_body) else {
+        return identity();
+    };
+    // Match the logical ids the rest of provisioning sees (ForEach + SAM).
+    let Ok(value) = expand_for_each(&value, &BTreeMap::new(), parameters) else {
+        return identity();
+    };
+    let value = expand_sam(&value);
+    let Some(resources_obj) = value.get("Resources").and_then(|v| v.as_object()) else {
+        return identity();
+    };
+
+    let index_of: BTreeMap<&str, usize> = resource_defs
+        .iter()
+        .enumerate()
+        .map(|(i, r)| (r.logical_id.as_str(), i))
+        .collect();
+    let known: BTreeSet<&str> = index_of.keys().copied().collect();
+
+    // deps[i] = indices that resource i must be provisioned after.
+    let mut deps: Vec<BTreeSet<usize>> = vec![BTreeSet::new(); n];
+    for (i, r) in resource_defs.iter().enumerate() {
+        let Some(raw) = resources_obj.get(&r.logical_id) else {
+            continue;
+        };
+        let mut refs: BTreeSet<String> = BTreeSet::new();
+        match raw.get("DependsOn") {
+            Some(Value::String(s)) => {
+                refs.insert(s.clone());
+            }
+            Some(Value::Array(a)) => {
+                for x in a {
+                    if let Some(s) = x.as_str() {
+                        refs.insert(s.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+        if let Some(props) = raw.get("Properties") {
+            collect_resource_refs(props, &known, &mut refs);
+        }
+        for name in refs {
+            if let Some(&j) = index_of.get(name.as_str()) {
+                if j != i {
+                    deps[i].insert(j);
+                }
+            }
+        }
+    }
+
+    // Kahn's algorithm; ready set ordered by original index for determinism.
+    let mut indeg: Vec<usize> = deps.iter().map(|d| d.len()).collect();
+    let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for (i, d) in deps.iter().enumerate() {
+        for &j in d {
+            dependents[j].push(i);
+        }
+    }
+    let mut ready: BTreeSet<usize> = (0..n).filter(|&i| indeg[i] == 0).collect();
+    let mut order: Vec<usize> = Vec::with_capacity(n);
+    while let Some(&i) = ready.iter().next() {
+        ready.remove(&i);
+        order.push(i);
+        for &j in &dependents[i] {
+            indeg[j] -= 1;
+            if indeg[j] == 0 {
+                ready.insert(j);
+            }
+        }
+    }
+    if order.len() != n {
+        // Dependency cycle — append the unresolved remainder in original order.
+        let placed: BTreeSet<usize> = order.iter().copied().collect();
+        for i in 0..n {
+            if !placed.contains(&i) {
+                order.push(i);
+            }
+        }
+    }
+    order
+}
+
+/// Recursively collect the logical ids in `known` that `value` references via
+/// `Ref`, `Fn::GetAtt`, or `Fn::Sub`.
+fn collect_resource_refs(value: &Value, known: &BTreeSet<&str>, out: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::String(name)) = map.get("Ref") {
+                if known.contains(name.as_str()) {
+                    out.insert(name.clone());
+                }
+            }
+            if let Some(g) = map.get("Fn::GetAtt") {
+                let logical = match g {
+                    Value::Array(a) => a.first().and_then(|x| x.as_str()),
+                    Value::String(s) => s.split('.').next(),
+                    _ => None,
+                };
+                if let Some(l) = logical {
+                    if known.contains(l) {
+                        out.insert(l.to_string());
+                    }
+                }
+            }
+            if let Some(s) = map.get("Fn::Sub") {
+                collect_sub_refs(s, known, out);
+            }
+            // Recurse into every value to catch nested references.
+            for v in map.values() {
+                collect_resource_refs(v, known, out);
+            }
+        }
+        Value::Array(a) => {
+            for v in a {
+                collect_resource_refs(v, known, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Extract `${LogicalId}` / `${LogicalId.Attr}` references from an `Fn::Sub`
+/// (string form or `[template, {vars}]` form), skipping the locally-defined
+/// variables and `${!Literal}` escapes.
+fn collect_sub_refs(sub: &Value, known: &BTreeSet<&str>, out: &mut BTreeSet<String>) {
+    let (template, local_vars): (Option<&str>, BTreeSet<&str>) = match sub {
+        Value::String(t) => (Some(t.as_str()), BTreeSet::new()),
+        Value::Array(a) => {
+            let t = a.first().and_then(|x| x.as_str());
+            let vars = a
+                .get(1)
+                .and_then(|x| x.as_object())
+                .map(|m| m.keys().map(|k| k.as_str()).collect())
+                .unwrap_or_default();
+            (t, vars)
+        }
+        _ => (None, BTreeSet::new()),
+    };
+    let Some(t) = template else {
+        return;
+    };
+    let mut i = 0;
+    while let Some(start) = t[i..].find("${") {
+        let abs = i + start + 2;
+        let Some(end_rel) = t[abs..].find('}') else {
+            break;
+        };
+        let token = &t[abs..abs + end_rel];
+        // `${!X}` is a literal `${X}`, not a reference.
+        if !token.starts_with('!') {
+            let logical = token.split('.').next().unwrap_or(token).trim();
+            if !local_vars.contains(logical) && known.contains(logical) {
+                out.insert(logical.to_string());
+            }
+        }
+        i = abs + end_rel + 1;
+    }
+}
+
+#[cfg(test)]
+mod dependency_order_tests {
+    use super::*;
+
+    fn rd(logical: &str, resource_type: &str) -> ResourceDefinition {
+        ResourceDefinition {
+            logical_id: logical.to_string(),
+            resource_type: resource_type.to_string(),
+            properties: serde_json::json!({}),
+        }
+    }
+
+    // The Gap #3 scenario: a StateMachine declared (and sorting) before the
+    // Lambda it references via a DefinitionSubstitutions `Ref` must provision
+    // after that Lambda, so the substitution resolves to the function name.
+    #[test]
+    fn referenced_resource_is_ordered_first() {
+        let template = r#"{
+            "Resources": {
+                "Machine": {
+                    "Type": "AWS::StepFunctions::StateMachine",
+                    "Properties": {
+                        "DefinitionString": "${fn}",
+                        "DefinitionSubstitutions": {"fn": {"Ref": "WorkerFn"}}
+                    }
+                },
+                "WorkerFn": {"Type": "AWS::Lambda::Function", "Properties": {}}
+            }
+        }"#;
+        // Template order (alphabetical, as the parser yields): Machine, WorkerFn.
+        let defs = vec![
+            rd("Machine", "AWS::StepFunctions::StateMachine"),
+            rd("WorkerFn", "AWS::Lambda::Function"),
+        ];
+        let order = dependency_order(template, &BTreeMap::new(), &defs);
+        assert_eq!(
+            order,
+            vec![1, 0],
+            "WorkerFn must be provisioned before Machine"
+        );
+    }
+
+    #[test]
+    fn get_att_sub_and_depends_on_all_create_edges() {
+        // A: referenced by B via GetAtt, by C via Fn::Sub, by D via DependsOn.
+        let template = r#"{
+            "Resources": {
+                "B": {"Type": "X", "Properties": {"V": {"Fn::GetAtt": ["A", "Arn"]}}},
+                "C": {"Type": "X", "Properties": {"V": {"Fn::Sub": "p-${A}-s"}}},
+                "D": {"Type": "X", "DependsOn": "A", "Properties": {}},
+                "A": {"Type": "X", "Properties": {}}
+            }
+        }"#;
+        let defs = vec![rd("B", "X"), rd("C", "X"), rd("D", "X"), rd("A", "X")];
+        let order = dependency_order(template, &BTreeMap::new(), &defs);
+        let pos = |name: &str| {
+            order
+                .iter()
+                .position(|&i| defs[i].logical_id == name)
+                .unwrap()
+        };
+        assert!(pos("A") < pos("B"), "GetAtt edge");
+        assert!(pos("A") < pos("C"), "Fn::Sub edge");
+        assert!(pos("A") < pos("D"), "DependsOn edge");
+    }
+
+    #[test]
+    fn independent_resources_keep_original_order() {
+        let template =
+            r#"{"Resources": {"A": {"Type": "X"}, "B": {"Type": "X"}, "C": {"Type": "X"}}}"#;
+        let defs = vec![rd("A", "X"), rd("B", "X"), rd("C", "X")];
+        assert_eq!(
+            dependency_order(template, &BTreeMap::new(), &defs),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[test]
+    fn sub_escape_and_local_vars_are_not_edges() {
+        // `${!A}` is a literal; `${V}` is a local Sub variable — neither is a
+        // dependency on resource A.
+        let template = r#"{
+            "Resources": {
+                "A": {"Type": "X", "Properties": {}},
+                "B": {"Type": "X", "Properties": {
+                    "V": {"Fn::Sub": ["${!A}-${V}", {"V": "literal"}]}
+                }}
+            }
+        }"#;
+        let defs = vec![rd("A", "X"), rd("B", "X")];
+        // No real edge → original order preserved.
+        assert_eq!(
+            dependency_order(template, &BTreeMap::new(), &defs),
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn dependency_cycle_falls_back_to_original_order() {
+        let template = r#"{
+            "Resources": {
+                "A": {"Type": "X", "Properties": {"V": {"Ref": "B"}}},
+                "B": {"Type": "X", "Properties": {"V": {"Ref": "A"}}}
+            }
+        }"#;
+        let defs = vec![rd("A", "X"), rd("B", "X")];
+        assert_eq!(
+            dependency_order(template, &BTreeMap::new(), &defs),
+            vec![0, 1]
+        );
+    }
+}

--- a/crates/fakecloud-cloudformation/src/template/resolution.rs
+++ b/crates/fakecloud-cloudformation/src/template/resolution.rs
@@ -365,7 +365,7 @@ mod dependency_order_tests {
             }
         }"#;
         let defs = vec![rd("A", "X"), rd("B", "X")];
-        // No real edge → original order preserved.
+        // No real edge -> original order preserved.
         assert_eq!(
             dependency_order(template, &BTreeMap::new(), &defs),
             vec![0, 1]

--- a/crates/fakecloud-e2e/tests/cloudformation_ecs.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_ecs.rs
@@ -284,8 +284,17 @@ async fn cfn_provisions_ecs_cluster_taskdef_service_capacity_provider() {
     assert_eq!(svc.platform_version(), Some("LATEST"));
     assert_eq!(svc.health_check_grace_period_seconds(), Some(120));
     assert!(!svc.enable_execute_command());
-    // TaskDefinition stayed at revision 1 across update.
-    assert!(svc.task_definition().unwrap().contains("cfn-task:1"));
+    // The task definition's properties changed (EphemeralStorage and
+    // RuntimePlatform were removed), so CloudFormation registers a new
+    // revision and updates the service — which `Ref`s the task definition —
+    // to point at it. With dependency-ordered provisioning the service is
+    // resolved after the task definition, so it picks up the new revision
+    // (cfn-task:2) rather than the stale cfn-task:1.
+    assert!(
+        svc.task_definition().unwrap().contains("cfn-task:2"),
+        "service should reference the re-registered task definition revision, got {:?}",
+        svc.task_definition()
+    );
 
     // Cluster Tag was rewritten by update.
     let after_clusters = ecs


### PR DESCRIPTION
**Version**: fakecloud (current `main`/`upstream/main` @ `d828a709`)

## Summary

CloudFormation provisions a stack's resources in iteration order, with no
topological ordering over `DependsOn` / `Ref` / `Fn::GetAtt` / `Fn::Sub`. When a
resource is provisioned **before** another resource it references, the reference
resolves to the **logical ID** (a placeholder) instead of the target's physical
name — and that placeholder is baked into the dependent resource permanently.

Concretely: a state machine whose `DefinitionSubstitutions` reference a Lambda via
`{"Ref": "<FnLogicalId>"}` ends up with the **logical ID** substituted into its
ASL when the state machine happens to provision first. At runtime every task fails:

```
States.TaskFailed → Lambda.ResourceNotFoundException: Function not found: <FnLogicalId>
```

`resolve_refs_full` (`crates/fakecloud-cloudformation/src/template/intrinsics.rs`,
~lines 190–199) returns the physical ID only if the target is already provisioned;
otherwise it falls back to the logical ID "and lets incremental provisioning
rewrite it" — but for values baked into a provisioned resource (a state machine
definition), nothing rewrites them, and there's no provisioning order that would
have made the target exist first.

## Reproduction

```sh
EP=http://127.0.0.1:4566
# Template where a StateMachine (declared FIRST) references a Function via
# DefinitionSubstitutions { fn: !Ref MyFn }, FunctionName fixed to e.g. my-fn-1.
aws --region us-east-1 cloudformation create-stack --endpoint-url $EP \
  --stack-name dep-order --template-body file:///tmp/dep.yaml --capabilities CAPABILITY_IAM
# Inspect the deployed definition:
aws --region us-east-1 stepfunctions describe-state-machine --endpoint-url $EP \
  --state-machine-arn <arn> --query 'definition'
# actual:   FunctionName resolves to "MyFn" (logical id)
# expected: FunctionName resolves to "my-fn-1" (the function's name)
```

## Expected

Resources provision in dependency order (topological sort over `DependsOn` plus
implicit `Ref`/`Fn::GetAtt`/`Fn::Sub` edges), so a referenced resource exists
before its referrer resolves — and references resolve to physical names/ARNs, not
logical IDs. (Real CloudFormation does this; it also rejects dependency cycles.)

## Impact

Any template where a resource is declared before something it references — very
common with SAM state machines that substitute a Lambda's name into their
definition — deploys "successfully" but is broken at runtime
(`Lambda.ResourceNotFoundException`). It's deterministic, not order-of-luck, once
the declaration order trips it.

Happy to test a branch or send a PR.

## The fix

Add a `dependency_order` topological sort in
`crates/fakecloud-cloudformation/src/template/resolution.rs` and wire it into the
changeset provisioning loop (`service.rs`), so a referenced resource is provisioned
**before** its referrer and `resolve_refs_full` returns the physical name/ARN
instead of the logical-id placeholder. Edges are drawn from explicit `DependsOn`
plus implicit `Ref` / `Fn::GetAtt` / `Fn::Sub` references (collected recursively,
honoring the `${!X}` literal escape in `Fn::Sub`).

## Design notes / alternatives considered

- **Topological provisioning order vs. a post-provision placeholder rewrite.**
  Ordering is the AWS-correct model: real CloudFormation provisions in dependency
  order, so a `Ref` always resolves to a created resource. It fixes the whole class
  of Ref-resolution bugs at the source, not just the state-machine
  `DefinitionSubstitutions` case. A post-hoc rewrite (re-scan provisioned resources
  and patch baked-in logical ids) is narrower and more fragile — it has to know
  every place a logical id might have been baked (ASL, env vars, inline policies, …)
  and re-serialize each, and still races anything that already read the wrong value.
- **Cycle handling.** The sort is Kahn's algorithm; if a cycle leaves resources
  unresolved, the remainder is appended in original declaration order (graceful
  degradation) rather than panicking. Real CloudFormation rejects dependency cycles
  outright; this never makes a cyclic template worse than today's behavior.
- **Deterministic ordering for equal-priority resources.** The ready set is ordered
  by original template index (and the graph is built with ordered `BTree*`
  collections throughout), so resources with no dependency relationship keep their
  declared order — the sort is stable and reproducible, not hash-ordered.
- **Edge sources.** `DependsOn` (explicit) plus implicit `Ref`, `Fn::GetAtt`, and
  `Fn::Sub` references, collected recursively through nested template values.

## Test plan

- `cargo test -p fakecloud-cloudformation` — `dependency_order` unit tests +
  `changeset_provisions_lambda_before_referencing_state_machine` (a StateMachine
  declared/sorting before the Lambda it references resolves to the function name,
  not the logical id, in the baked ASL).
- `cargo test -p fakecloud-e2e --test cloudformation --test cloudformation_stepfunctions --test cloudformation_sam_statemachine` — green.
- `cargo build --bin fakecloud`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` — clean.

No new/removed operations, so the conformance baseline is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provision CloudFormation resources in dependency order so references resolve to physical IDs instead of logical IDs. This matches real CFN and fixes runtime failures (e.g., Step Functions → Lambda substitutions).

- **Bug Fixes**
  - Topologically sort resources from `DependsOn`, `Ref`, `Fn::GetAtt`, and `Fn::Sub` (respects `${!}` escapes, ignores local `Fn::Sub` vars, built after `ForEach`/SAM expansion); deterministic tie-breaking, cycles fall back to template order.
  - Apply `template::dependency_order` in both `CreateStack` and change set paths (`provision_stack_resources`, `apply_resource_updates`); adds tests including the StateMachine→Lambda case and updates ECS e2e so a service `Ref`s the re-registered task definition revision (`cfn-task:2`) after update.

<sup>Written for commit f3e2a27ca96e465f9d7f0e3857a5113f1d6dfab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

