### PR TITLE
chore(release): bump workspace to v0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3457,7 +3457,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4008,7 +4008,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -101,175 +101,175 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.19.0"
+version = "0.19.1"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.19.0")
+    testImplementation("dev.fakecloud:fakecloud:0.19.1")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.19.0</version>
+    <version>0.19.1</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.19.0"
+version = "0.19.1"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.19.0"
+version = "0.19.1"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release. All changes since v0.19.0 are bug fixes / correctness:

- **s3**: attribute SigV2-presigned requests via `AWSAccessKeyId` query param (#1710)
- **stepfunctions**: faithful `lambda:invoke` optimized integration — function errors, `Lambda.*` error names, response envelope (#1711)
- **lambda**: warm-pool unique pod names + fast dead-instance failover (#1713)
- **cloudformation**: stack events for changeset-created stacks (#1717); resolve Outputs on changeset-executed stacks (#1715); SAM Globals applied in server-side transform with deep-merge maps + additive lists (#1721); dependency-ordered resource provisioning (#1719)

No new services / ops / endpoints / SDK methods — patch bump.

## Test plan

- Version bumped across Cargo.toml (workspace + all fakecloud-* pins), Cargo.lock, and TS/Python/Java SDKs.
- No leftover `0.19.0` in bumped files; no non-fakecloud dep shared the old version.
- release.yml publish list already covers every published crate (no new crates).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump workspace and SDKs to v0.19.1. Patch-only release that rolls up correctness fixes; no new services, ops, or SDK methods.

- **Bug Fixes**
  - S3: attribute SigV2-presigned requests via AWSAccessKeyId query param.
  - Step Functions: faithful lambda:invoke optimized integration (function errors, Lambda.* error names, response envelope).
  - Lambda: warm-pool unique pod names and faster failover on dead instances.
  - CloudFormation: stack events for change set-created stacks; resolve Outputs after change set execution; SAM Globals applied server-side with deep-merge maps and additive lists; dependency-ordered provisioning.

- **Dependencies**
  - Bump all `fakecloud-*` crates and SDKs to `0.19.1` (Rust workspace, `sdks/typescript`, `sdks/python`, `sdks/java`).

<sup>Written for commit 089e88bed0551ca92844593e35eba2c3926449cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

