### PR TITLE
build: strip third-party debuginfo to fix disk-full CI flake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,17 @@ sqlparser = "0.61"
 [profile.test]
 debug = "line-tables-only"
 
+# Third-party dependencies (every `aws-sdk-*` and friends — ~210 crates) dominate
+# the `target` dir size and CI compile time. We don't debug into them, so strip
+# their debuginfo entirely while keeping line tables for our own crates. This is
+# the root-cause fix for the recurring "No space left on device" CI flake, where
+# the test `target` dir alone reached 45G and filled the 72G runner disk.
+[profile.test.package."*"]
+debug = false
+
+[profile.dev.package."*"]
+debug = false
+
 [workspace.dependencies.tokio]
 version = "1"
 features = [ "macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs",]


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring **"No space left on device"** CI flake (seen in E2E partitions like `lambda-api` and `lambda-runtimes-nodejs`). Disk diagnostics showed `/dev/root` at 100% with the cargo `target` dir alone at **45G**. `jlumbroso/free-disk-space` only frees `/`; `target` grew past whatever it reclaimed.

The bulk of that 45G is debuginfo for the ~210 third-party crates (every `aws-sdk-*` and friends). We never debug into them, so this strips their debuginfo via package overrides on the `test` and `dev` profiles, while keeping `line-tables-only` for our own crates (preserving backtraces in fakecloud code).

Benefits:
- Shrinks `target` on **every** Rust CI job (e2e, ci/llvm-cov, conformance, tfacc, sdk-*, release, parity) — universal, no per-workflow edits.
- Faster compiles locally and in CI (less debuginfo to emit/link).

First of a series killing CI flakiness at the root.

## Test plan
- `cargo build --bin fakecloud` compiles clean with the new profile overrides (verified locally).
- CI E2E partitions should now show healthy disk headroom in the disk-diagnostics step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip third-party debuginfo in Rust `test`/`dev` builds to fix disk-full CI failures and speed up builds. Implemented via `debug = false` in `[profile.test.package."*"]` and `[profile.dev.package."*"]`, while our crates keep `debug = "line-tables-only"` for backtraces—shrinking `target` size significantly (notably `aws-sdk-*`).

<sup>Written for commit c9a97d7617fa3956c4e2bf8f1f197b42cfcea6c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

