### PR TITLE
ci: relocate cargo target to /mnt to kill disk-full flake

### DIFF
--- a/.github/actions/free-disk/action.yml
+++ b/.github/actions/free-disk/action.yml
@@ -1,0 +1,42 @@
+name: Free disk space
+description: >-
+  Frees disk on the GitHub-hosted runner and relocates the cargo `target`
+  directory onto the larger ephemeral `/mnt` disk. Prevents the recurring
+  "No space left on device" CI flake where the Rust `target` dir fills the
+  72G root filesystem. Run this AFTER actions/checkout and BEFORE
+  Swatinem/rust-cache so the restored cache and all build output land on /mnt
+  while every existing `target/...` path keeps working through the symlink.
+runs:
+  using: composite
+  steps:
+    - name: Reclaim runner disk
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        # Keep docker images: jobs that need them pull on demand, and removing
+        # the preinstalled set costs more time than it reclaims here.
+        docker-images: false
+        swap-storage: true
+
+    - name: Relocate cargo target dir to /mnt
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "=== disk before target relocation ==="
+        df -h / /mnt || df -h /
+        target="$GITHUB_WORKSPACE/target"
+        # If a real target dir already exists (e.g. from a partial restore),
+        # move its contents so nothing is lost, then replace it with a symlink.
+        sudo mkdir -p /mnt/target
+        sudo chown "$USER" /mnt/target
+        if [ -d "$target" ] && [ ! -L "$target" ]; then
+          rsync -a "$target/" /mnt/target/ || true
+          rm -rf "$target"
+        fi
+        ln -sfn /mnt/target "$target"
+        echo "target -> $(readlink -f "$target")"
+        df -h / /mnt || df -h /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.94"
@@ -51,6 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
@@ -61,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,18 +44,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,6 +44,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
@@ -72,18 +73,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -107,18 +98,8 @@ jobs:
       NEXTEST_PARTITION: ${{ matrix.partition }}
       INSTALL_PODMAN: ${{ matrix.install_podman }}
     steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/tfacc.yml
+++ b/.github/workflows/tfacc.yml
@@ -44,6 +44,7 @@ jobs:
       shards: ${{ steps.m.outputs.shards }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
@@ -76,18 +77,8 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.tfacc-matrix.outputs.shards) }}
     steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5


### PR DESCRIPTION
## Summary

Second fix for the recurring **"No space left on device"** CI flake. Where Batch 1 (#1724) shrinks `target` by stripping third-party debuginfo, this adds headroom by moving the build output onto the runner's larger ephemeral `/mnt` disk.

Introduces a reusable composite action `.github/actions/free-disk` that:
1. Runs `jlumbroso/free-disk-space` (SHA-pinned, same config as before).
2. Symlinks `$GITHUB_WORKSPACE/target` -> `/mnt/target`, so all existing `target/...` paths (rust-cache restore, `upload-artifact target/debug/fakecloud`) keep working while bytes land on the big disk.

Applied to the jobs that actually build the heavy **test-profile** graph (hundreds of test binaries) where the 45G `target` appeared: `ci` (msrv/clippy/test), `e2e` (build + partition-check + partitions), `conformance`, `tfacc`. Per-job inline `free-disk-space` blocks are replaced by the shared action. `release.yml` build is intentionally excluded — it runs on macOS runners where `/mnt` and the Linux free-disk action don't exist, and uses `--release` (no test debuginfo) so it never hit this.

## Test plan
- All changed workflow YAML + the composite parse cleanly (validated locally).
- CI E2E/conformance/tfacc disk-diagnostics steps should now show `target` on `/mnt` with ample headroom.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Rust build output to the runner’s larger `/mnt` disk to stop “No space left on device” CI flakes. Adds a reusable `.github/actions/free-disk` action and applies it to the heavy Linux jobs while keeping existing `target/...` paths working via a symlink.

- **Bug Fixes**
  - Introduced `.github/actions/free-disk` that runs `jlumbroso/free-disk-space` and symlinks `$GITHUB_WORKSPACE/target` to `/mnt/target` (compatible with `Swatinem/rust-cache` and artifact paths).
  - Applied to `ci` (msrv/clippy/test), `e2e` (build/partition tasks), `conformance`, and `tfacc`; `release.yml` is excluded (macOS, uses `--release`).

<sup>Written for commit cef73230c8dc03a5a65ca12dfa54e1a3ab2929e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

