### PR TITLE
ci: retry flaky external downloads

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -73,7 +73,11 @@ jobs:
 
       - name: Run Node demo
         run: |
-          npm install @aws-sdk/client-sqs @aws-sdk/client-sns @aws-sdk/client-ssm @aws-sdk/client-s3 @aws-sdk/client-dynamodb @aws-sdk/client-lambda @aws-sdk/client-secrets-manager @aws-sdk/client-cloudwatch-logs @aws-sdk/client-kms
+          for i in 1 2 3; do
+            npm install @aws-sdk/client-sqs @aws-sdk/client-sns @aws-sdk/client-ssm @aws-sdk/client-s3 @aws-sdk/client-dynamodb @aws-sdk/client-lambda @aws-sdk/client-secrets-manager @aws-sdk/client-cloudwatch-logs @aws-sdk/client-kms && ok=1 && break
+            echo "npm install attempt $i failed; retrying"; sleep $((i * 5))
+          done
+          [ "${ok:-}" = 1 ] || { echo "npm install failed after 3 attempts"; exit 1; }
           node examples/node/demo.js
 
       - name: Run sample app

--- a/.github/workflows/lambda-k8s.yml
+++ b/.github/workflows/lambda-k8s.yml
@@ -49,14 +49,17 @@ jobs:
 
       - name: Pre-pull images into the cluster
         run: |
-          docker pull registry.k8s.io/pause:3.10
-          kind load docker-image registry.k8s.io/pause:3.10 --name fakecloud-k8s-test
-          docker pull redis:7-alpine
-          kind load docker-image redis:7-alpine --name fakecloud-k8s-test
-          docker pull postgres:16-alpine
-          kind load docker-image postgres:16-alpine --name fakecloud-k8s-test
-          docker pull busybox:1.36
-          kind load docker-image busybox:1.36 --name fakecloud-k8s-test
+          pull() {
+            for i in 1 2 3; do
+              docker pull "$1" && return 0
+              echo "docker pull $1 attempt $i failed; retrying"; sleep $((i * 5))
+            done
+            echo "docker pull $1 failed after 3 attempts"; return 1
+          }
+          for img in registry.k8s.io/pause:3.10 redis:7-alpine postgres:16-alpine busybox:1.36; do
+            pull "$img"
+            kind load docker-image "$img" --name fakecloud-k8s-test
+          done
 
       - name: Lambda K8s integration tests
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,7 +44,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo install cargo-audit
+      - name: Install cargo-audit
+        run: |
+          for i in 1 2 3; do
+            cargo install cargo-audit && ok=1 && break
+            echo "cargo install cargo-audit attempt $i failed; retrying"; sleep $((i * 5))
+          done
+          [ "${ok:-}" = 1 ] || { echo "cargo install cargo-audit failed after 3 attempts"; exit 1; }
       # RUSTSEC-2026-0098/0099/0104 (rustls-webpki 0.101.x) reach us only
       # through rustls 0.21 -> aws-smithy-http-client. Our own rustls-webpki
       # 0.103.x is already on the patched release (0.103.13+); we can't drop

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,7 +25,12 @@ jobs:
 
       - name: Install Zola
         run: |
-          curl -fsSL https://github.com/getzola/zola/releases/download/v0.22.1/zola-v0.22.1-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          url=https://github.com/getzola/zola/releases/download/v0.22.1/zola-v0.22.1-x86_64-unknown-linux-gnu.tar.gz
+          for i in 1 2 3; do
+            curl -fsSL "$url" | tar xz && ok=1 && break
+            echo "zola download attempt $i failed; retrying"; sleep $((i * 5))
+          done
+          [ "${ok:-}" = 1 ] || { echo "zola download failed after 3 attempts"; exit 1; }
           sudo mv zola /usr/local/bin/
 
       - name: Build


### PR DESCRIPTION
## Summary

Transient network blips on single-attempt external fetches showed up as red CI (a recent `tfacc` main failure died in tool setup before tests even ran). Wraps the raw `run:` fetches in a 3-attempt retry with linear backoff, failing only if all attempts fail:

- `website.yml` — zola release tarball (`curl | tar`)
- `security.yml` — `cargo install cargo-audit`
- `examples.yml` — `npm install @aws-sdk/*`
- `lambda-k8s.yml` — `docker pull` of the 4 pre-pulled cluster images

GitHub's default shell already runs with `-eo pipefail`, so a failed `curl` in a pipe is detected. SHA-pinned `uses:` setup actions are left as-is (they have internal download retries).

## Test plan
- All four changed workflow YAML files parse cleanly (validated locally).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 3-attempt retries with 5/10/15s backoff for external downloads in CI to reduce flakes. Steps only fail after all attempts, improving reliability in the website, security, examples, and lambda-k8s workflows.

- **Bug Fixes**
  - `website.yml`: Retry Zola tarball download (`curl | tar`).
  - `security.yml`: Retry `cargo install cargo-audit`.
  - `examples.yml`: Retry `npm install` of `@aws-sdk/*`.
  - `lambda-k8s.yml`: Retry `docker pull` for pre-pulled images, then load into kind.

<sup>Written for commit d4e6070d8936f26c160aa27056366a6b43934841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

