### PR TITLE
ci: matrix fail-fast, docker concurrency, fail-loud release artifacts

### DIFF
--- a/.github/workflows/docker-rds-images.yml
+++ b/.github/workflows/docker-rds-images.yml
@@ -29,6 +29,12 @@ on:
       - crates/fakecloud-rds/assets/mariadb/**
   workflow_dispatch:
 
+# Serialize builds of the same ref so concurrent runs never race to push the
+# same per-engine image tag / merged manifest into GHCR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
     tags: ["v*"]
 
+# Serialize builds of the same ref so two runs never race to push the same
+# image tag / manifest list into GHCR. Different refs (main vs a release tag)
+# push different tags, so they may still run concurrently.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -12,6 +19,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - platform: linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           name: ${{ matrix.name }}
           path: fakecloud-*.tar.gz*
+          if-no-files-found: error
 
   release:
     name: Release


### PR DESCRIPTION
## Summary

Three smaller robustness fixes:

- **`docker.yml` build matrix** — add `fail-fast: false` so a transient failure on one architecture doesn't cancel the sibling build (reported as a flake).
- **`docker.yml` + `docker-rds-images.yml`** — add per-ref `concurrency` groups (`cancel-in-progress: false`) so two runs of the same ref never race to push the same image tag / merged manifest into GHCR. Different refs (main vs a release tag) push different tags and may still run concurrently.
- **`release.yml` build** — `upload-artifact: if-no-files-found: error` so a missing platform binary fails loudly instead of silently publishing an incomplete release.

## Test plan
- All three changed workflow YAML files parse cleanly (validated locally).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve CI robustness by keeping all matrix jobs running, serializing same-ref Docker pushes, and failing releases when artifacts are missing. Prevents flaky cancels, GHCR push races, and incomplete releases.

- **Bug Fixes**
  - `docker.yml`: set `strategy.fail-fast: false` so one arch failure doesn’t cancel others.
  - `docker.yml` and `docker-rds-images.yml`: add per-ref `concurrency` with `cancel-in-progress: false` to stop same-ref runs from racing to push the same tag/manifest; different refs still run in parallel.
  - `release.yml`: set `upload-artifact.if-no-files-found: error` to fail the build when a platform binary is missing.

<sup>Written for commit 060996ef7077220ae084e09cd0a7553581a0f292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

