### PR TITLE
test(e2e): poll for SQS delivery instead of one-shot receive

### DIFF
--- a/crates/fakecloud-e2e/tests/cross_service.rs
+++ b/crates/fakecloud-e2e/tests/cross_service.rs
@@ -1078,17 +1078,11 @@ async fn logs_subscription_filter_delivers_to_sqs() {
         .await
         .unwrap();
 
-    // Receive message from SQS
-    let recv = sqs
-        .receive_message()
-        .queue_url(&queue_url)
-        .max_number_of_messages(10)
-        .wait_time_seconds(1)
-        .send()
-        .await
-        .unwrap();
-
-    let messages = recv.messages().to_vec();
+    // Receive message from SQS. Poll up to a deadline rather than a single
+    // 1s receive so delivery latency under parallel CI load can't flake the
+    // assertion.
+    let messages =
+        helpers::sqs_receive_at_least(&sqs, &queue_url, 1, std::time::Duration::from_secs(5)).await;
     assert_eq!(messages.len(), 1, "expected exactly one SQS message");
 
     // Decode the payload: base64 -> gzip -> JSON

--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -2951,15 +2951,12 @@ async fn sfn_task_sqs_send_message() {
     let status = wait_for_execution(&sfn, start.execution_arn()).await;
     assert_eq!(status, "SUCCEEDED");
 
-    // Verify the message was delivered to SQS
-    let receive = sqs
-        .receive_message()
-        .queue_url(queue_url)
-        .send()
-        .await
-        .unwrap();
-
-    let messages = receive.messages();
+    // Verify the message was delivered to SQS. Poll rather than a single
+    // short-poll receive: SendMessage completes before the execution reports
+    // SUCCEEDED, but a one-shot receive can still race the enqueue under
+    // parallel CI load.
+    let messages =
+        helpers::sqs_receive_at_least(&sqs, queue_url, 1, std::time::Duration::from_secs(5)).await;
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].body().unwrap(), "hello from step functions");
 }
@@ -3326,15 +3323,10 @@ async fn sfn_task_sqs_with_dynamic_parameters() {
     let status = wait_for_execution(&sfn, start.execution_arn()).await;
     assert_eq!(status, "SUCCEEDED");
 
-    // Verify the dynamic message was sent
-    let receive = sqs
-        .receive_message()
-        .queue_url(queue_url)
-        .send()
-        .await
-        .unwrap();
-
-    let messages = receive.messages();
+    // Verify the dynamic message was sent. Poll rather than a one-shot receive
+    // to avoid racing the enqueue under parallel CI load.
+    let messages =
+        helpers::sqs_receive_at_least(&sqs, queue_url, 1, std::time::Duration::from_secs(5)).await;
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].body().unwrap(), "dynamic message content");
 }
@@ -3480,25 +3472,18 @@ async fn sfn_cross_service_workflow_sqs_then_choice() {
     let status = wait_for_execution(&sfn, start.execution_arn()).await;
     assert_eq!(status, "SUCCEEDED");
 
-    // Verify high-priority queue got the right message
-    let receive = sqs
-        .receive_message()
-        .queue_url(high_url)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(receive.messages().len(), 1);
-    assert_eq!(receive.messages()[0].body().unwrap(), "urgent order");
+    // Verify high-priority queue got the right message. Poll to avoid racing
+    // the enqueue under parallel CI load.
+    let high =
+        helpers::sqs_receive_at_least(&sqs, high_url, 1, std::time::Duration::from_secs(5)).await;
+    assert_eq!(high.len(), 1);
+    assert_eq!(high[0].body().unwrap(), "urgent order");
 
-    // Verify low-priority queue got the right message
-    let receive = sqs
-        .receive_message()
-        .queue_url(low_url)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(receive.messages().len(), 1);
-    assert_eq!(receive.messages()[0].body().unwrap(), "regular order");
+    // Verify low-priority queue got the right message.
+    let low =
+        helpers::sqs_receive_at_least(&sqs, low_url, 1, std::time::Duration::from_secs(5)).await;
+    assert_eq!(low.len(), 1);
+    assert_eq!(low[0].body().unwrap(), "regular order");
 }
 
 /// Kick off an execution whose interpreter path previously panicked (empty
@@ -3895,13 +3880,8 @@ async fn sfn_aws_sdk_sqs_send_message() {
         "expected MessageId in output, got {output:?}"
     );
 
-    let receive = sqs
-        .receive_message()
-        .queue_url(queue_url)
-        .send()
-        .await
-        .unwrap();
-    let messages = receive.messages();
+    let messages =
+        helpers::sqs_receive_at_least(&sqs, queue_url, 1, std::time::Duration::from_secs(5)).await;
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].body().unwrap(), "hello-via-aws-sdk-sqs");
 }


### PR DESCRIPTION
## Summary

Removes a parallel-load flake class in the E2E suite. Several stepfunctions / cross_service tests did a single short-poll `receive_message` immediately after an execution reported `SUCCEEDED`, then asserted exactly one message. `SendMessage` completes before the execution finishes, but a one-shot receive can still race the enqueue under parallel nextest load.

Switches those spots to the repo's existing `helpers::sqs_receive_at_least` poll helper (5s deadline) — behaviour-preserving (still asserts the expected count + body), just resilient to delivery latency. Left untouched: fixed sleeps that wait for wall-clock to advance or assert a negative (those are robust against slow CI and can't be improved by polling).

## Test plan
- `cargo test -p fakecloud-e2e --test stepfunctions --test cross_service --no-run` compiles clean.
- `cargo fmt --all -- --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch E2E tests to poll SQS for message delivery instead of a one-shot receive to eliminate flakiness in parallel CI. Behavior is unchanged: tests still assert the expected message count and body.

- **Bug Fixes**
  - Replaced `receive_message` with `helpers::sqs_receive_at_least` (5s deadline) in `stepfunctions.rs` and `cross_service.rs`; left fixed sleeps and negative assertions as-is.

<sup>Written for commit 0739bb59d8feee4146ecdcb3b7a058624b1bcb0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

