### PR TITLE
feat(ec2): real Docker/Podman-backed instances (runtime 1/3)

### DIFF
--- a/crates/fakecloud-e2e/tests/ec2_instance_runtime.rs
+++ b/crates/fakecloud-e2e/tests/ec2_instance_runtime.rs
@@ -1,0 +1,168 @@
+//! EC2 instance Docker runtime E2E: proves `RunInstances` boots a real
+//! backing container, that user-data runs at boot, and that the instance
+//! lifecycle (`Stop`/`Start`/`Terminate`) maps onto the container lifecycle.
+
+mod helpers;
+
+use base64::Engine;
+use helpers::TestServer;
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("Skipping {test}: docker not available");
+    false
+}
+
+/// Run `docker <args>` and return trimmed stdout (empty on failure).
+fn docker(args: &[&str]) -> String {
+    let out = std::process::Command::new("docker")
+        .args(args)
+        .output()
+        .expect("spawn docker");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// The container id backing an instance, via the `fakecloud-ec2=<id>` label.
+fn container_for(instance_id: &str) -> String {
+    docker(&[
+        "ps",
+        "-aq",
+        "--filter",
+        &format!("label=fakecloud-ec2={instance_id}"),
+    ])
+}
+
+#[tokio::test]
+async fn run_instances_boots_real_container_with_user_data() {
+    if !require_docker_or_skip("run_instances_boots_real_container_with_user_data") {
+        return;
+    }
+    // A tiny base image keeps the test fast; `tail -f /dev/null` keeps any
+    // image alive, so alpine works as well as the amazonlinux default.
+    std::env::set_var("FAKECLOUD_EC2_DEFAULT_IMAGE", "alpine:3");
+
+    let server = TestServer::start().await;
+    let c = server.ec2_client().await;
+
+    // User-data the runtime decodes (`base64 -d`) and runs as a root shell
+    // script at boot, exactly as cloud-init would.
+    let user_data = base64::engine::general_purpose::STANDARD.encode("echo ran > /tmp/marker\n");
+
+    let resp = c
+        .run_instances()
+        .image_id("ami-12345678")
+        .min_count(1)
+        .max_count(1)
+        .user_data(user_data)
+        .send()
+        .await
+        .unwrap();
+
+    let instances = resp.instances();
+    assert_eq!(instances.len(), 1);
+    let instance_id = instances[0].instance_id().expect("instance id").to_string();
+    assert_eq!(
+        instances[0]
+            .state()
+            .and_then(|s| s.name())
+            .map(|n| n.as_str()),
+        Some("running")
+    );
+
+    // The private IP must be the real container address, not the synthesized
+    // 10.0.0.x fallback used in metadata-only mode.
+    let private_ip = instances[0].private_ip_address().expect("private ip");
+    assert!(
+        !private_ip.starts_with("10.0.0."),
+        "expected a real container IP, got {private_ip}"
+    );
+
+    // A running container exists for this instance.
+    let container = container_for(&instance_id);
+    assert!(!container.is_empty(), "no backing container found");
+    let running = docker(&["inspect", "-f", "{{.State.Running}}", &container]);
+    assert_eq!(running, "true", "container should be running");
+
+    // User-data ran at boot (it executes asynchronously, so poll briefly).
+    let mut marker = String::new();
+    for _ in 0..40 {
+        marker = docker(&["exec", &container, "cat", "/tmp/marker"]);
+        if marker == "ran" {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    assert_eq!(
+        marker, "ran",
+        "user-data script did not run in the container"
+    );
+
+    // StopInstances stops the container.
+    c.stop_instances()
+        .instance_ids(&instance_id)
+        .send()
+        .await
+        .unwrap();
+    let mut stopped = false;
+    for _ in 0..40 {
+        if docker(&["inspect", "-f", "{{.State.Running}}", &container]) == "false" {
+            stopped = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    assert!(stopped, "container should be stopped after StopInstances");
+
+    // StartInstances brings it back.
+    c.start_instances()
+        .instance_ids(&instance_id)
+        .send()
+        .await
+        .unwrap();
+    let mut restarted = false;
+    for _ in 0..40 {
+        if docker(&["inspect", "-f", "{{.State.Running}}", &container]) == "true" {
+            restarted = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    assert!(
+        restarted,
+        "container should be running after StartInstances"
+    );
+
+    // TerminateInstances removes the container entirely.
+    c.terminate_instances()
+        .instance_ids(&instance_id)
+        .send()
+        .await
+        .unwrap();
+    let mut removed = false;
+    for _ in 0..40 {
+        if container_for(&instance_id).is_empty() {
+            removed = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    assert!(
+        removed,
+        "container should be removed after TerminateInstances"
+    );
+}

--- a/crates/fakecloud-ec2/src/lib.rs
+++ b/crates/fakecloud-ec2/src/lib.rs
@@ -7,9 +7,11 @@
 //! tagging subsystem, and the region/AZ/account-attribute describe primitives
 //! that almost every SDK client calls implicitly.
 
+pub mod runtime;
 pub mod service;
 pub mod service_helpers;
 pub mod state;
 
+pub use runtime::Ec2Runtime;
 pub use service::Ec2Service;
 pub use state::{Ec2State, SharedEc2State};

--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -1,0 +1,269 @@
+//! Backing-container runtime for EC2 instances.
+//!
+//! `RunInstances` spins a real container per instance; the instance
+//! lifecycle (`Start`/`Stop`/`Reboot`/`Terminate`) maps onto the container
+//! lifecycle, and `DescribeInstances` reports the container's real private
+//! IP. The container can run either as a local Docker/Podman container (the
+//! default) or as a native Kubernetes Pod (`FAKECLOUD_EC2_BACKEND=k8s` or the
+//! global `FAKECLOUD_CONTAINER_BACKEND=k8s`, added in a follow-up batch).
+//!
+//! The runtime is strictly additive: when no container backend is available
+//! the control plane keeps its metadata-faithful behaviour (synthesized IPs,
+//! state transitions) so every API call still succeeds. Real container
+//! backing is best-effort fidelity layered on top.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+/// Default base image an instance's container runs. AMIs don't map to a
+/// concrete OS image, so we boot a real Amazon Linux container by default
+/// (overridable via `FAKECLOUD_EC2_DEFAULT_IMAGE`, e.g. to a lighter image
+/// in CI). The container is kept alive with `tail -f /dev/null` — EC2
+/// instances are long-running hosts, not one-shot tasks. `tail` is used
+/// rather than `sleep infinity` so any base image works (busybox `sleep`
+/// rejects `infinity`).
+const DEFAULT_IMAGE_ENV: &str = "FAKECLOUD_EC2_DEFAULT_IMAGE";
+const DEFAULT_IMAGE: &str = "amazonlinux:2023";
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("container failed to start: {0}")]
+    ContainerStartFailed(String),
+}
+
+/// A running instance's backing container.
+#[derive(Debug, Clone)]
+pub struct RunningInstance {
+    /// Backend-specific handle: a Docker container id, or a Pod name.
+    pub container_id: String,
+    /// The instance's private IP — the container's address on the daemon
+    /// network (Docker) or the Pod IP (k8s).
+    pub private_ip: String,
+}
+
+/// The selected backing-container backend.
+#[derive(Debug, Clone)]
+enum InstanceBackend {
+    Docker(DockerInstances),
+}
+
+#[derive(Debug, Clone)]
+pub struct Ec2Runtime {
+    backend: InstanceBackend,
+    /// Container ids this runtime has spawned and not yet torn down, so reset
+    /// and shutdown can reap them without consulting service state.
+    tracked: Arc<RwLock<HashSet<String>>>,
+}
+
+impl Ec2Runtime {
+    /// Construct the Docker/Podman backend. Returns `None` when no container
+    /// CLI is available — callers then run in metadata-only mode.
+    pub fn new() -> Option<Self> {
+        let cli = fakecloud_core::container_net::detect_container_cli()?;
+        Some(Self {
+            backend: InstanceBackend::Docker(DockerInstances {
+                cli,
+                instance_id: format!("fakecloud-{}", std::process::id()),
+            }),
+            tracked: Arc::new(RwLock::new(HashSet::new())),
+        })
+    }
+
+    /// Name of the active backend, for logging.
+    pub fn cli_name(&self) -> &str {
+        match &self.backend {
+            InstanceBackend::Docker(d) => &d.cli,
+        }
+    }
+
+    /// Boot a container for an instance. `user_data` is the base64-encoded
+    /// user-data as received on the wire (RunInstances `UserData`), run at
+    /// boot the way cloud-init would, if present.
+    pub async fn run_instance(
+        &self,
+        instance_id: &str,
+        user_data: Option<&str>,
+    ) -> Result<RunningInstance, RuntimeError> {
+        let running = match &self.backend {
+            InstanceBackend::Docker(d) => d.run_instance(instance_id, user_data).await?,
+        };
+        self.tracked.write().insert(running.container_id.clone());
+        Ok(running)
+    }
+
+    /// Stop an instance's container (maps to `StopInstances`).
+    pub async fn stop_instance(&self, container_id: &str) {
+        match &self.backend {
+            InstanceBackend::Docker(d) => d.stop(container_id).await,
+        }
+    }
+
+    /// Start a previously-stopped container (maps to `StartInstances`).
+    /// Returns the (possibly new) private IP the container came up with.
+    pub async fn start_instance(&self, container_id: &str) -> Option<String> {
+        match &self.backend {
+            InstanceBackend::Docker(d) => d.start(container_id).await,
+        }
+    }
+
+    /// Restart an instance's container in place (maps to `RebootInstances`).
+    pub async fn reboot_instance(&self, container_id: &str) {
+        match &self.backend {
+            InstanceBackend::Docker(d) => d.reboot(container_id).await,
+        }
+    }
+
+    /// Remove an instance's container (maps to `TerminateInstances`).
+    pub async fn terminate_instance(&self, container_id: &str) {
+        self.tracked.write().remove(container_id);
+        match &self.backend {
+            InstanceBackend::Docker(d) => d.remove(container_id).await,
+        }
+    }
+
+    /// Tear down every container this runtime spawned (used on reset and
+    /// shutdown). The Docker backend leans on the shared reaper for any
+    /// container it loses track of.
+    pub async fn stop_all(&self) {
+        let ids: Vec<String> = self.tracked.write().drain().collect();
+        match &self.backend {
+            InstanceBackend::Docker(d) => {
+                for id in &ids {
+                    d.remove(id).await;
+                }
+            }
+        }
+    }
+}
+
+fn default_image() -> String {
+    std::env::var(DEFAULT_IMAGE_ENV).unwrap_or_else(|_| DEFAULT_IMAGE.to_string())
+}
+
+/// Docker/Podman backend: shells out to the container CLI.
+#[derive(Debug, Clone)]
+struct DockerInstances {
+    cli: String,
+    instance_id: String,
+}
+
+impl DockerInstances {
+    async fn run_instance(
+        &self,
+        instance_id: &str,
+        user_data: Option<&str>,
+    ) -> Result<RunningInstance, RuntimeError> {
+        let image = default_image();
+        let args: Vec<String> = vec![
+            "run".to_string(),
+            "-d".to_string(),
+            "--label".to_string(),
+            format!("fakecloud-ec2={instance_id}"),
+            "--label".to_string(),
+            format!("fakecloud-instance={}", self.instance_id),
+            image.clone(),
+            "tail".to_string(),
+            "-f".to_string(),
+            "/dev/null".to_string(),
+        ];
+
+        let output = tokio::process::Command::new(&self.cli)
+            .args(&args)
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+
+        if !output.status.success() {
+            return Err(RuntimeError::ContainerStartFailed(
+                String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            ));
+        }
+
+        let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+        // Run user-data the way cloud-init does on a real instance: decode the
+        // base64 the SDK sent and execute it as a root shell script,
+        // asynchronously at boot. Detached (`-d`) so a slow or hanging script
+        // never blocks the RunInstances response. Decoding happens inside the
+        // container (`base64 -d`) so fakecloud needs no base64 dependency and
+        // the bytes never touch the host.
+        if let Some(b64) = user_data.filter(|s| !s.is_empty()) {
+            let script = format!("printf %s '{b64}' | base64 -d | sh");
+            let _ = tokio::process::Command::new(&self.cli)
+                .args(["exec", "-d", &container_id, "sh", "-c", &script])
+                .output()
+                .await;
+        }
+
+        let private_ip = self
+            .inspect_ip(&container_id)
+            .await
+            .unwrap_or_else(|| "10.0.0.1".to_string());
+
+        Ok(RunningInstance {
+            container_id,
+            private_ip,
+        })
+    }
+
+    /// Read the container's private IP from `inspect`. Returns `None` if the
+    /// container has no address (e.g. host networking) — the caller falls
+    /// back to a synthesized IP.
+    async fn inspect_ip(&self, container_id: &str) -> Option<String> {
+        let output = tokio::process::Command::new(&self.cli)
+            .args([
+                "inspect",
+                "-f",
+                "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+                container_id,
+            ])
+            .output()
+            .await
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let ip = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if ip.is_empty() {
+            None
+        } else {
+            Some(ip)
+        }
+    }
+
+    async fn stop(&self, container_id: &str) {
+        let _ = tokio::process::Command::new(&self.cli)
+            .args(["stop", container_id])
+            .output()
+            .await;
+    }
+
+    async fn start(&self, container_id: &str) -> Option<String> {
+        let started = tokio::process::Command::new(&self.cli)
+            .args(["start", container_id])
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !started {
+            return None;
+        }
+        self.inspect_ip(container_id).await
+    }
+
+    async fn reboot(&self, container_id: &str) {
+        let _ = tokio::process::Command::new(&self.cli)
+            .args(["restart", container_id])
+            .output()
+            .await;
+    }
+
+    async fn remove(&self, container_id: &str) {
+        let _ = tokio::process::Command::new(&self.cli)
+            .args(["rm", "-f", container_id])
+            .output()
+            .await;
+    }
+}

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -95,7 +95,7 @@ fn reservation_xml(reservation_id: &str, owner: &str, instances: &[String]) -> S
     )
 }
 
-pub(crate) fn run_instances(
+pub(crate) async fn run_instances(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -124,6 +124,7 @@ pub(crate) fn run_instances(
     let key_name = req.query_params.get("KeyName").cloned();
     let subnet_id = req.query_params.get("SubnetId").cloned();
     let sg_ids = indexed_list(&req.query_params, "SecurityGroupId");
+    let user_data = req.query_params.get("UserData").map(String::as_str);
     let owner = req.account_id.clone();
     let az = format!(
         "{}a",
@@ -134,19 +135,42 @@ pub(crate) fn run_instances(
         }
     );
 
+    // Generate instance ids first, then boot a backing container per id
+    // (without holding the state lock across the awaits). When no runtime is
+    // configured, or a container fails to start, the instance falls back to a
+    // synthesized private IP and no container handle — the API still succeeds.
+    let ids: Vec<String> = (0..count).map(|_| gen_id("i")).collect();
+    let mut backing: HashMap<String, crate::runtime::RunningInstance> = HashMap::new();
+    if let Some(rt) = &svc.runtime {
+        for id in &ids {
+            match rt.run_instance(id, user_data).await {
+                Ok(running) => {
+                    backing.insert(id.clone(), running);
+                }
+                Err(e) => {
+                    tracing::warn!(instance_id = %id, error = %e, "EC2 instance container failed to start; serving metadata-only");
+                }
+            }
+        }
+    }
+
     let mut rendered = Vec::new();
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        for idx in 0..count {
-            let id = gen_id("i");
+        for (idx, id) in ids.iter().enumerate() {
+            let running = backing.remove(id);
+            let private_ip = running
+                .as_ref()
+                .map(|r| r.private_ip.clone())
+                .unwrap_or_else(|| format!("10.0.0.{}", 10 + idx));
             let inst = Instance {
                 instance_id: id.clone(),
                 image_id: image_id.clone(),
                 instance_type: instance_type.clone(),
                 state_code: 16,
                 state_name: "running".to_string(),
-                private_ip: format!("10.0.0.{}", 10 + idx),
+                private_ip,
                 public_ip: Some(format!("52.0.0.{}", 10 + idx)),
                 subnet_id: subnet_id.clone(),
                 vpc_id: None,
@@ -157,16 +181,17 @@ pub(crate) fn run_instances(
                 monitoring: false,
                 az: az.clone(),
                 launch_time: LAUNCH_TIME.to_string(),
+                container_id: running.map(|r| r.container_id),
             };
             crate::service::tags::apply_tag_specifications(
                 state,
                 &req.query_params,
-                &id,
+                id,
                 "instance",
             );
-            let tags = state.tags_for(&id).to_vec();
+            let tags = state.tags_for(id).to_vec();
             rendered.push(instance_xml(&inst, &tags, &owner));
-            state.instances.insert(id, inst);
+            state.instances.insert(id.clone(), inst);
         }
     }
     let body = reservation_xml(&reservation_id, &owner, &rendered);
@@ -190,7 +215,7 @@ fn validate_enum_instance_type(req: &AwsRequest) -> Result<(), AwsServiceError> 
     Ok(())
 }
 
-fn change_state(
+async fn change_state(
     svc: &Ec2Service,
     req: &AwsRequest,
     action: &str,
@@ -199,6 +224,9 @@ fn change_state(
 ) -> Result<AwsResponse, AwsServiceError> {
     let ids = indexed_list(&req.query_params, "InstanceId");
     let mut changes = Vec::new();
+    // Container handles of affected instances, collected under the lock and
+    // acted on afterwards so no await happens while the state lock is held.
+    let mut affected: Vec<(String, String)> = Vec::new();
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -214,6 +242,13 @@ fn change_state(
                 if new_code == 80 {
                     inst.public_ip = None;
                 }
+                if let Some(cid) = &inst.container_id {
+                    affected.push((id.clone(), cid.clone()));
+                }
+                // A terminated instance no longer has a backing container.
+                if new_code == 48 {
+                    inst.container_id = None;
+                }
             }
             changes.push(format!(
                 "{}{}{}",
@@ -223,6 +258,29 @@ fn change_state(
             ));
         }
     }
+
+    // Map the state transition onto the backing container's lifecycle.
+    if let Some(rt) = &svc.runtime {
+        for (id, cid) in &affected {
+            match new_code {
+                16 => {
+                    // StartInstances: the container may come back with a new
+                    // address; reflect it in describe output.
+                    if let Some(new_ip) = rt.start_instance(cid).await {
+                        let mut accounts = svc.state.write();
+                        let state = accounts.get_or_create(&req.account_id);
+                        if let Some(inst) = state.instances.get_mut(id) {
+                            inst.private_ip = new_ip;
+                        }
+                    }
+                }
+                80 => rt.stop_instance(cid).await,
+                48 => rt.terminate_instance(cid).await,
+                _ => {}
+            }
+        }
+    }
+
     Ok(Ec2Service::respond(
         action,
         &req.request_id,
@@ -230,29 +288,46 @@ fn change_state(
     ))
 }
 
-pub(crate) fn start_instances(
+pub(crate) async fn start_instances(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    change_state(svc, req, "StartInstances", 16, "running")
+    change_state(svc, req, "StartInstances", 16, "running").await
 }
-pub(crate) fn stop_instances(
+pub(crate) async fn stop_instances(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    change_state(svc, req, "StopInstances", 80, "stopped")
+    change_state(svc, req, "StopInstances", 80, "stopped").await
 }
-pub(crate) fn terminate_instances(
+pub(crate) async fn terminate_instances(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    change_state(svc, req, "TerminateInstances", 48, "terminated")
+    change_state(svc, req, "TerminateInstances", 48, "terminated").await
 }
 
-pub(crate) fn reboot_instances(
-    _svc: &Ec2Service,
+pub(crate) async fn reboot_instances(
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let ids = indexed_list(&req.query_params, "InstanceId");
+    let container_ids: Vec<String> = {
+        let accounts = svc.state.read();
+        match accounts.get(&req.account_id) {
+            Some(state) => ids
+                .iter()
+                .filter_map(|id| state.instances.get(id))
+                .filter_map(|i| i.container_id.clone())
+                .collect(),
+            None => Vec::new(),
+        }
+    };
+    if let Some(rt) = &svc.runtime {
+        for cid in &container_ids {
+            rt.reboot_instance(cid).await;
+        }
+    }
     Ok(Ec2Service::respond(
         "RebootInstances",
         &req.request_id,

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -40,6 +40,7 @@ use std::sync::Arc;
 use fakecloud_core::multi_account::MultiAccountState;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
+use crate::runtime::Ec2Runtime;
 use crate::state::SharedEc2State;
 
 /// Every EC2 action this build implements. The conformance audit cross-checks
@@ -861,6 +862,9 @@ pub const SUPPORTED_ACTIONS: &[&str] = &[
 /// Amazon EC2 service.
 pub struct Ec2Service {
     pub(crate) state: SharedEc2State,
+    /// Optional container runtime backing instances with real containers.
+    /// `None` runs the metadata-only control plane (no Docker/Podman/k8s).
+    pub(crate) runtime: Option<Arc<Ec2Runtime>>,
 }
 
 impl Ec2Service {
@@ -872,13 +876,24 @@ impl Ec2Service {
                 "us-east-1",
                 "",
             ))),
+            runtime: None,
         }
     }
 
     /// Construct a service over a shared state handle (used by the server so
     /// persistence/snapshots can be wired in later batches).
     pub fn with_state(state: SharedEc2State) -> Self {
-        Self { state }
+        Self {
+            state,
+            runtime: None,
+        }
+    }
+
+    /// Attach a container runtime so `RunInstances` boots real containers.
+    /// Passing `None` leaves the service in metadata-only mode.
+    pub fn with_runtime(mut self, runtime: Option<Arc<Ec2Runtime>>) -> Self {
+        self.runtime = runtime;
+        self
     }
 
     /// Clone the shared state handle so the server can expose read-only
@@ -1049,11 +1064,11 @@ impl AwsService for Ec2Service {
             "UnassignPrivateIpAddresses" => eni::unassign_private_ip_addresses(self, &request),
             "AssignIpv6Addresses" => eni::assign_ipv6_addresses(self, &request),
             "UnassignIpv6Addresses" => eni::unassign_ipv6_addresses(self, &request),
-            "RunInstances" => instance::run_instances(self, &request),
-            "StartInstances" => instance::start_instances(self, &request),
-            "StopInstances" => instance::stop_instances(self, &request),
-            "RebootInstances" => instance::reboot_instances(self, &request),
-            "TerminateInstances" => instance::terminate_instances(self, &request),
+            "RunInstances" => instance::run_instances(self, &request).await,
+            "StartInstances" => instance::start_instances(self, &request).await,
+            "StopInstances" => instance::stop_instances(self, &request).await,
+            "RebootInstances" => instance::reboot_instances(self, &request).await,
+            "TerminateInstances" => instance::terminate_instances(self, &request).await,
             "MonitorInstances" => instance::monitor_instances(self, &request),
             "UnmonitorInstances" => instance::unmonitor_instances(self, &request),
             "DescribeInstances" => instance::describe_instances(self, &request),

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -288,6 +288,10 @@ pub struct Instance {
     pub monitoring: bool,
     pub az: String,
     pub launch_time: String,
+    /// Id of the backing container/Pod, when this instance is backed by a
+    /// real container runtime. `None` in metadata-only mode.
+    #[serde(default)]
+    pub container_id: Option<String>,
 }
 
 /// An EBS volume attachment.

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -55,7 +55,7 @@ use fakecloud_cloudformation::CloudFormationService;
 use fakecloud_cloudfront::CloudFrontService;
 use fakecloud_cognito::CognitoService;
 use fakecloud_dynamodb::DynamoDbService;
-use fakecloud_ec2::Ec2Service;
+use fakecloud_ec2::{Ec2Service, SharedEc2State};
 use fakecloud_ecr::EcrService;
 use fakecloud_ecs::EcsService;
 use fakecloud_elasticache::ElastiCacheService;
@@ -364,6 +364,11 @@ async fn main() {
     let cloudfront_state: fakecloud_cloudfront::SharedCloudFrontState = Arc::new(
         parking_lot::RwLock::new(fakecloud_cloudfront::CloudFrontAccounts::new()),
     );
+    // EC2 state, created up-front so it can join `ResetState` and be cleared by
+    // `/_fakecloud/reset/ec2` (which also tears down the backing containers).
+    let ec2_state: SharedEc2State = Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("000000000000", "us-east-1", ""),
+    ));
     let route53_state: fakecloud_route53::SharedRoute53State = Arc::new(parking_lot::RwLock::new(
         fakecloud_route53::Route53Accounts::new(),
     ));
@@ -662,6 +667,21 @@ async fn main() {
     } else {
         tracing::info!("Docker/Podman not available — ECS RunTask will return TaskFailedToStart");
     }
+    // EC2 instance backing runtime (Docker/Podman). Optional: when no
+    // container CLI is present, RunInstances serves metadata-only instances so
+    // the control plane still works everywhere.
+    let ec2_runtime: Option<Arc<fakecloud_ec2::runtime::Ec2Runtime>> =
+        fakecloud_ec2::runtime::Ec2Runtime::new().map(Arc::new);
+    if let Some(ref rt) = ec2_runtime {
+        tracing::info!(
+            cli = rt.cli_name(),
+            "EC2 instance execution enabled via container runtime"
+        );
+    } else {
+        tracing::info!(
+            "Docker/Podman not available — EC2 RunInstances will serve metadata-only instances"
+        );
+    }
     // Clone state refs for internal endpoints
     let lambda_invocations_state = lambda_state.clone();
     let ses_emails_state = ses_state.clone();
@@ -752,6 +772,8 @@ async fn main() {
         rds_runtime: rds_runtime.clone(),
         elasticache_runtime: elasticache_runtime.clone(),
         ecs_runtime: ecs_runtime.clone(),
+        ec2: ec2_state.clone(),
+        ec2_runtime: ec2_runtime.clone(),
     };
     // Step 5: CloudFormation delivery (custom resources can invoke Lambda)
     let delivery_for_cf = {
@@ -1516,12 +1538,12 @@ async fn main() {
     registry.register(Arc::new(OrganizationsService::new(
         organizations_state.clone(),
     )));
-    // EC2 (ec2Query protocol). State is self-contained for now; persistence
-    // and the Docker-backed instance runtime are wired in later batches. We
-    // keep a clone of the shared state so the introspection router can expose
+    // EC2 (ec2Query protocol). Instances are backed by the optional container
+    // runtime (Docker/Podman); persistence is wired in later batches. We keep a
+    // clone of the shared state so the introspection router can expose
     // `GET /_fakecloud/ec2/instances`.
-    let ec2_service = Ec2Service::new();
-    let ec2_introspection_state = ec2_service.shared_state();
+    let ec2_service = Ec2Service::with_state(ec2_state.clone()).with_runtime(ec2_runtime.clone());
+    let ec2_introspection_state = ec2_state.clone();
     registry.register(Arc::new(ec2_service));
     let mut shared_body_cache: Option<Arc<fakecloud_persistence::cache::BodyCache>> = None;
     let s3_store: Arc<dyn fakecloud_persistence::S3Store> = match persistence_config.mode {
@@ -7398,6 +7420,9 @@ async fn main() {
         rt.stop_all().await;
     }
     if let Some(rt) = elasticache_runtime {
+        rt.stop_all().await;
+    }
+    if let Some(rt) = ec2_runtime {
         rt.stop_all().await;
     }
 }

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -47,6 +47,8 @@ pub(crate) struct ResetState {
     pub rds_runtime: Option<Arc<fakecloud_rds::runtime::RdsRuntime>>,
     pub elasticache_runtime: Option<Arc<fakecloud_elasticache::runtime::ElastiCacheRuntime>>,
     pub ecs_runtime: Option<Arc<fakecloud_ecs::runtime::EcsRuntime>>,
+    pub ec2: fakecloud_ec2::SharedEc2State,
+    pub ec2_runtime: Option<Arc<fakecloud_ec2::runtime::Ec2Runtime>>,
 }
 
 impl ResetState {
@@ -124,6 +126,13 @@ impl ResetState {
             "elasticache" => {
                 self.elasticache.write().reset();
                 if let Some(ref rt) = self.elasticache_runtime {
+                    let rt = rt.clone();
+                    tokio::spawn(async move { rt.stop_all().await });
+                }
+            }
+            "ec2" => {
+                self.ec2.write().reset();
+                if let Some(ref rt) = self.ec2_runtime {
                     let rt = rt.clone();
                     tokio::spawn(async move { rt.stop_all().await });
                 }
@@ -866,8 +875,17 @@ mod tests {
             rds_runtime: None,
             elasticache_runtime: None,
             ecs_runtime: None,
+            ec2: Arc::new(parking_lot::RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            ec2_runtime: None,
         };
 
+        state.reset_service("ec2").expect("reset ec2");
         state.reset_service("rds").expect("reset rds");
 
         assert!(state.rds.read().default_ref().instances.is_empty());

--- a/website/content/docs/services/ec2.md
+++ b/website/content/docs/services/ec2.md
@@ -9,7 +9,7 @@ fakecloud implements **767 of 767** AWS EC2 operations at 100% Smithy conformanc
 ## Supported features
 
 - **Core networking** — VPCs (+ secondary CIDRs, tenancy), DHCP option sets, subnets (+ CIDR reservations), security groups (rules, references, VPC associations), route tables, internet / egress-only / NAT gateways, and elastic IPs with transfer/move flows.
-- **Compute** — `RunInstances` and the full instance lifecycle (start/stop/reboot/terminate/monitor), instance attributes, credit specifications, metadata + maintenance options, instance types, and topology. Key pairs and placement groups. The instance control plane is metadata-faithful; **real Docker-backed instance execution is a roadmap follow-up**.
+- **Compute** — `RunInstances` and the full instance lifecycle (start/stop/reboot/terminate/monitor), instance attributes, credit specifications, metadata + maintenance options, instance types, and topology. Key pairs and placement groups. **Instances are backed by real Docker/Podman containers** — `RunInstances` boots a container per instance, runs your user-data at boot, and maps start/stop/reboot/terminate onto the container lifecycle (falling back to a metadata-only control plane when no container runtime is present).
 - **Storage** — EBS volumes (+ modifications, recycle bin), snapshots (+ copy, tier, lock, fast restores, block-public-access), AMIs (register/copy/deprecate/deregistration-protection), and EBS encryption defaults.
 - **Interfaces** — elastic network interfaces with attachments, permissions, IPv4/IPv6 address assignment, and prefix lists.
 - **Edge / advanced networking** — network ACLs, VPC peering, VPC endpoints + PrivateLink (services, connection notifications), flow logs, launch templates (+ versions), spot requests / fleets / EC2 fleets, capacity reservations (+ fleets), reserved instances, dedicated hosts.
@@ -32,6 +32,6 @@ EC2 uses the `ec2Query` protocol: form-encoded requests and flattened-XML respon
 
 ## Known limitations
 
-- **Instance execution is metadata-only** — `RunInstances` records a faithful instance, reservation, and state machine, but does not yet boot a real Docker container. Real container-backed execution (reusing the Lambda/ECS/RDS runtime) is a planned follow-up.
+- **Instances run as containers, not VMs** — `RunInstances` boots a real Docker/Podman container per instance (Amazon Linux by default, overridable via `FAKECLOUD_EC2_DEFAULT_IMAGE`) and runs user-data at boot, but it is a container, not a full virtual machine: no kernel modules, no nested virtualization, and the instance type / EBS sizing is metadata only. When no container runtime is available, the control plane degrades to a metadata-only instance so every API call still succeeds. Native Kubernetes-Pod backing (`FAKECLOUD_EC2_BACKEND=k8s`, mirroring Lambda/ECS/RDS) is a follow-up.
 - **A handful of model operations are absent from the vendored AWS SDK** (`DescribeIpamPoolAllocations`, `ModifyIpamPoolAllocation`, and the capacity-reservation cancellation-quote pair). They are implemented and conformance-probed via raw `ec2Query`, and graduate to typed SDK calls on the next SDK refresh.
 - Security-group rules and network ACLs are stored and returned faithfully but are **not enforced** against instance traffic (there is no data plane to police).


### PR DESCRIPTION
## What

`RunInstances` now boots a **real Docker/Podman container per instance** instead of serving metadata only — closing the gap between EC2's API-complete control plane and its user-confirmed "Docker-backed instances" scope.

The instance lifecycle maps onto the container lifecycle:

| EC2 op | Container action |
|--------|------------------|
| `RunInstances` | run container (Amazon Linux default), run user-data at boot, report real private IP |
| `StopInstances` | `stop` |
| `StartInstances` | `start` (re-reads new private IP) |
| `RebootInstances` | `restart` |
| `TerminateInstances` | `rm -f` |

User-data runs the way cloud-init does: the base64 the SDK sends is decoded (`base64 -d`) and executed as a root shell script inside the container, detached so a slow script never blocks the response.

## Strictly additive

When no container CLI is available the control plane **degrades to the previous metadata-only behaviour** — every API call still succeeds, and the conformance baseline is untouched (this is behaviour, not new surface). Default base image is `amazonlinux:2023`, overridable via `FAKECLOUD_EC2_DEFAULT_IMAGE`.

## Also

- EC2 finally joins the `/_fakecloud/reset` endpoint (it was never reset-wired across the 29 build batches); reset now also tears down backing containers.
- New `crates/fakecloud-ec2/src/runtime/` mirrors the ElastiCache/ECS/RDS runtime shape, ready for the k8s Pod backend in batch 2.

## Tests

`ec2_instance_runtime` (docker-gated, hard-fails in CI without docker) proves a real container boots, user-data runs, and the full stop/start/terminate container lifecycle works end-to-end. Passes locally (17.8s).

## Follow-ups (this is 1/3)

- **Batch 2:** native Kubernetes Pod backend (`FAKECLOUD_EC2_BACKEND=k8s`), mirroring Lambda/ECS/RDS.
- **Batch 3:** EBS volume mounts, console-output backed by container logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
RunInstances now launches a real Docker/Podman container per instance and maps start/stop/reboot/terminate onto the container lifecycle. User-data runs at boot; when no container CLI is available we fall back to the previous metadata-only behavior.

- **New Features**
  - Real container-backed instances: `DescribeInstances` returns the container’s private IP and state tracks a `container_id`.
  - User-data is base64-decoded and executed as a root shell script at boot, detached so it never blocks.
  - Optional runtime: defaults to metadata-only when Docker/Podman isn’t present. Default image is `amazonlinux:2023` (override with `FAKECLOUD_EC2_DEFAULT_IMAGE`).
  - Server wiring: EC2 runtime is enabled when available, and `/_fakecloud/reset/ec2` now clears EC2 state and tears down backing containers.

- **Migration**
  - No breaking changes; existing flows continue unchanged without a container runtime.
  - To enable containers, install Docker or Podman; optionally set `FAKECLOUD_EC2_DEFAULT_IMAGE` to choose a base image.

<sup>Written for commit 15add17c09f56d14e298298fad7e12e646316c48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

