### PR TITLE
feat(ec2): GetConsoleOutput backed by container logs (runtime 3/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,6 +3593,7 @@ name = "fakecloud-ec2"
 version = "0.19.1"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "fakecloud-aws",

--- a/crates/fakecloud-e2e/tests/ec2_instance_runtime.rs
+++ b/crates/fakecloud-e2e/tests/ec2_instance_runtime.rs
@@ -60,8 +60,10 @@ async fn run_instances_boots_real_container_with_user_data() {
     let c = server.ec2_client().await;
 
     // User-data the runtime decodes (`base64 -d`) and runs as a root shell
-    // script at boot, exactly as cloud-init would.
-    let user_data = base64::engine::general_purpose::STANDARD.encode("echo ran > /tmp/marker\n");
+    // script at boot, exactly as cloud-init would. It echoes to stdout (which
+    // GetConsoleOutput surfaces) and writes a marker file (exec'd to verify).
+    let user_data = base64::engine::general_purpose::STANDARD
+        .encode("echo CONSOLE_HELLO_FROM_USERDATA\necho ran > /tmp/marker\n");
 
     let resp = c
         .run_instances()
@@ -110,6 +112,32 @@ async fn run_instances_boots_real_container_with_user_data() {
     assert_eq!(
         marker, "ran",
         "user-data script did not run in the container"
+    );
+
+    // GetConsoleOutput returns the container's console log (base64), which must
+    // include what user-data printed to stdout at boot.
+    let mut console = String::new();
+    for _ in 0..40 {
+        let out = c
+            .get_console_output()
+            .instance_id(&instance_id)
+            .send()
+            .await
+            .unwrap();
+        if let Some(b64) = out.output() {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(b64)
+                .expect("console output is valid base64");
+            console = String::from_utf8_lossy(&decoded).into_owned();
+            if console.contains("CONSOLE_HELLO_FROM_USERDATA") {
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    assert!(
+        console.contains("CONSOLE_HELLO_FROM_USERDATA"),
+        "GetConsoleOutput should surface user-data stdout, got: {console:?}"
     );
 
     // StopInstances stops the container.

--- a/crates/fakecloud-ec2/Cargo.toml
+++ b/crates/fakecloud-ec2/Cargo.toml
@@ -12,6 +12,7 @@ fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-k8s = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 http = { workspace = true }
 k8s-openapi = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/fakecloud-ec2/src/runtime/k8s.rs
+++ b/crates/fakecloud-ec2/src/runtime/k8s.rs
@@ -117,6 +117,16 @@ impl K8sInstances {
         self.client.delete_pod(pod_name).await;
     }
 
+    /// The instance container's logs (the k8s equivalent of `docker logs`).
+    /// `None` if the Pod log can't be read.
+    pub(super) async fn logs(&self, pod_name: &str) -> Option<Vec<u8>> {
+        self.client
+            .pod_logs(pod_name, Some(CONTAINER))
+            .await
+            .ok()
+            .map(String::into_bytes)
+    }
+
     pub(super) async fn reap_stale(&self) {
         self.client.reap_stale(SERVICE).await;
     }

--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -245,6 +245,17 @@ impl Ec2Runtime {
         }
     }
 
+    /// The backing container's console log — its combined stdout/stderr, which
+    /// includes anything user-data printed at boot (maps to `GetConsoleOutput`).
+    /// `None` for an unbacked instance or when logs can't be read.
+    pub async fn console_output(&self, instance_id: &str) -> Option<Vec<u8>> {
+        let handle = self.handle_of(instance_id)?;
+        match &self.backend {
+            InstanceBackend::Docker(d) => d.logs(&handle).await,
+            InstanceBackend::K8s(k) => k.logs(&handle).await,
+        }
+    }
+
     fn handle_of(&self, instance_id: &str) -> Option<String> {
         self.instances
             .read()
@@ -387,5 +398,23 @@ impl DockerInstances {
             .args(["rm", "-f", container_id])
             .output()
             .await;
+    }
+
+    /// The container's combined stdout+stderr (`docker logs`). `None` if the
+    /// command fails; an empty log is `Some(vec![])`.
+    async fn logs(&self, container_id: &str) -> Option<Vec<u8>> {
+        let output = tokio::process::Command::new(&self.cli)
+            .args(["logs", container_id])
+            .output()
+            .await
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        // `docker logs` writes the container's stdout to ours and its stderr to
+        // ours; concatenate so the console output carries both streams.
+        let mut buf = output.stdout;
+        buf.extend_from_slice(&output.stderr);
+        Some(buf)
     }
 }

--- a/crates/fakecloud-ec2/src/service/ice.rs
+++ b/crates/fakecloud-ec2/src/service/ice.rs
@@ -236,15 +236,25 @@ pub(crate) fn get_serial_console_access_status(
 
 // ---- console + password ----
 
-pub(crate) fn get_console_output(
-    _svc: &Ec2Service,
+pub(crate) async fn get_console_output(
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    use base64::Engine;
     let id = require(&req.query_params, "InstanceId")?;
+    // Real GetConsoleOutput returns the console log base64-encoded. Back it
+    // with the instance container's logs (which include any user-data boot
+    // output); empty when the instance has no backing container.
+    let output = match &svc.runtime {
+        Some(rt) => rt.console_output(&id).await.unwrap_or_default(),
+        None => Vec::new(),
+    };
+    let encoded = base64::engine::general_purpose::STANDARD.encode(output);
     let body = format!(
-        "{}<timestamp>{}</timestamp><output></output>",
+        "{}<timestamp>{}</timestamp><output>{}</output>",
         ec2_elem("instanceId", &id),
-        FIXED_TIME
+        FIXED_TIME,
+        encoded
     );
     Ok(Ec2Service::respond(
         "GetConsoleOutput",

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -2001,7 +2001,7 @@ impl AwsService for Ec2Service {
             "EnableSerialConsoleAccess" => ice::enable_serial_console_access(self, &request),
             "DisableSerialConsoleAccess" => ice::disable_serial_console_access(self, &request),
             "GetSerialConsoleAccessStatus" => ice::get_serial_console_access_status(self, &request),
-            "GetConsoleOutput" => ice::get_console_output(self, &request),
+            "GetConsoleOutput" => ice::get_console_output(self, &request).await,
             "GetConsoleScreenshot" => ice::get_console_screenshot(self, &request),
             "GetPasswordData" => ice::get_password_data(self, &request),
             "AdvertiseByoipCidr" => rest::advertise_byoip_cidr(self, &request),

--- a/website/content/docs/services/ec2.md
+++ b/website/content/docs/services/ec2.md
@@ -19,7 +19,7 @@ fakecloud implements **767 of 767** AWS EC2 operations at 100% Smithy conformanc
 - **Verified Access** — instances, trust providers (+ attach/detach), groups, endpoints, policies (group + endpoint), logging configuration, and client-config export.
 - **Network Insights** — reachability paths + analyses and access scopes + scope analyses (content, findings).
 - **Outpost / hybrid** — carrier gateways, CoIP pools + CIDRs, local-gateway route tables, routes, VPC + virtual-interface-group associations, virtual interfaces, and groups.
-- **Access & diagnostics** — EC2 Instance Connect endpoints, fast launch, serial-console access, console output / screenshot, and password data.
+- **Access & diagnostics** — EC2 Instance Connect endpoints, fast launch, serial-console access, console output / screenshot, and password data. `GetConsoleOutput` returns the instance container's real console log (its combined stdout/stderr, including anything user-data printed at boot), base64-encoded as on AWS.
 - **Cross-cutting** — tag specifications on create, `CreateTags` / `DeleteTags` / `DescribeTags`, `Filter.N` filtering, and `MaxResults` / `NextToken` pagination across every `Describe*`.
 
 ## Protocol


### PR DESCRIPTION
## What

`GetConsoleOutput` now returns the backing container's **real console log** — its combined stdout/stderr, including anything user-data printed at boot — base64-encoded exactly as AWS returns it, instead of an empty `<output>`.

Works on both backends: `docker logs` (Docker) and the Pod log API (k8s). Metadata-only instances (no container runtime) still return an empty log, so the control plane works everywhere.

This completes the EC2 instance runtime: instances are real containers (B1 Docker / B2 k8s), and now their console is observable too.

## EBS volumes: deliberately not implemented

An EC2 instance here is a container, not a VM with block devices — attaching a volume into a running container isn't possible, and a faked mount would be a stub (against the project's no-stubs rule). EBS volumes stay metadata-only.

## Tests

`ec2_instance_runtime` e2e extended: user-data echoes to stdout, then `GetConsoleOutput` is base64-decoded and asserted to contain it. Passes locally.

## Wraps the series

- 1/3 #1730 — Docker/Podman-backed instances
- 2/3 #1731 — native Kubernetes Pod backend
- 3/3 (this) — console output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GetConsoleOutput now returns the instance container’s real console log (combined stdout/stderr) base64-encoded like AWS, instead of an empty value. Works on Docker and Kubernetes; metadata-only instances still return an empty log.

- New Features
  - `GetConsoleOutput` surfaces the container’s combined stdout/stderr (includes user-data output).
  - Supports Docker (`docker logs`) and Kubernetes Pod logs; e2e updated to assert user-data appears; docs note the behavior.

- Dependencies
  - Added `base64` for encoding console logs.

<sup>Written for commit ee9376bdfe774ff0cdbc9821b329fef3d1c3d55a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

