### PR TITLE
feat(lambda): configurable k8s Pod nodeSelector, tolerations, and annotations

### DIFF
--- a/crates/fakecloud-k8s/src/lib.rs
+++ b/crates/fakecloud-k8s/src/lib.rs
@@ -13,8 +13,10 @@
 //! Backend selection (`FAKECLOUD_CONTAINER_BACKEND` /
 //! `FAKECLOUD_<SERVICE>_BACKEND`) lives in [`backend`]. The kube client
 //! wrapper and Pod lifecycle live in [`client`]. Env parsing
-//! (`FAKECLOUD_K8S_*`) lives in [`env`]. Naming + label conventions live
-//! in [`names`] and [`labels`].
+//! (`FAKECLOUD_K8S_*`) lives in [`env`]. Operator-configurable Pod
+//! scheduling/metadata (node selector, tolerations, annotations) lives in
+//! [`pod_config`]. Naming + label conventions live in [`names`] and
+//! [`labels`].
 //!
 //! See `website/content/docs/guides/kubernetes-backend.md` for the
 //! operator-facing setup (ServiceAccount, RBAC, Deployment yaml).
@@ -24,7 +26,9 @@ pub mod client;
 pub mod env;
 pub mod labels;
 pub mod names;
+pub mod pod_config;
 
 pub use backend::{backend_choice, Backend};
 pub use client::{ExecOutput, K8sClient, K8sError};
 pub use env::{K8sEnv, K8sEnvError};
+pub use pod_config::{K8sPodConfig, K8sPodConfigError};

--- a/crates/fakecloud-k8s/src/pod_config.rs
+++ b/crates/fakecloud-k8s/src/pod_config.rs
@@ -1,0 +1,552 @@
+//! Operator-configurable Pod scheduling + metadata shared by every
+//! FakeCloud k8s backend.
+//!
+//! Lets operators attach a `nodeSelector`, taint `tolerations`, and
+//! arbitrary `annotations` to the Pods FakeCloud creates, without each
+//! service re-implementing the parsing and application. Each of the three
+//! is resolvable at three levels, lowest to highest precedence:
+//!
+//! 1. Global env  - `FAKECLOUD_K8S_<KEY>`
+//! 2. Service env - `FAKECLOUD_<SERVICE>_K8S_<KEY>`
+//!    (e.g. `FAKECLOUD_LAMBDA_K8S_NODE_SELECTOR`)
+//! 3. Per-instance tag - a reserved tag on the resource itself
+//!    (e.g. a Lambda function tag `fakecloud-k8s/node-selector`)
+//!
+//! A backend reads the global+service base once at startup with
+//! [`K8sPodConfig::resolved_base`], then per-Pod merges the resource's
+//! tags over it with [`K8sPodConfig::merge`] + [`K8sPodConfig::from_tags`]
+//! and writes the result onto the built Pod with [`K8sPodConfig::apply`].
+//!
+//! Value formats:
+//! - `NODE_SELECTOR` / `ANNOTATIONS`: a flat `key=value,key=value` map.
+//! - `TOLERATIONS`: a JSON array of k8s `Toleration` objects.
+//!
+//! Merge semantics across the three levels: the maps (node selector,
+//! annotations) union per key, with the higher level winning on a key
+//! clash; tolerations combine additively (a Pod tolerates the union of
+//! taints), dropping exact duplicates. This mirrors the repo's SAM
+//! Globals convention (maps deep-merge, list-typed keys combine).
+//!
+//! Error handling is asymmetric on purpose: a malformed *env* value fails
+//! fast at startup (an operator typo should be loud), but a malformed
+//! per-instance *tag* is warned about and ignored for that field -- a bad
+//! tag must never make a single resource un-runnable.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::{Pod, Toleration};
+
+/// Reserved per-instance tag key carrying a `key=value,key=value`
+/// node-selector for this resource's Pod.
+pub const TAG_NODE_SELECTOR: &str = "fakecloud-k8s/node-selector";
+/// Reserved per-instance tag key carrying a JSON array of `Toleration`s.
+pub const TAG_TOLERATIONS: &str = "fakecloud-k8s/tolerations";
+/// Reserved per-instance tag key carrying `key=value,key=value`
+/// annotations merged onto this resource's Pod.
+pub const TAG_ANNOTATIONS: &str = "fakecloud-k8s/annotations";
+
+/// The global env prefix every service's base config inherits from.
+const GLOBAL_PREFIX: &str = "FAKECLOUD_K8S";
+
+/// Resolved node selector, tolerations, and annotations for a Pod.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct K8sPodConfig {
+    /// `spec.nodeSelector` entries.
+    pub node_selector: BTreeMap<String, String>,
+    /// `spec.tolerations` entries.
+    pub tolerations: Vec<Toleration>,
+    /// `metadata.annotations` entries.
+    pub annotations: BTreeMap<String, String>,
+}
+
+/// Errors parsing the `FAKECLOUD_*_K8S_*` Pod configuration. Only env
+/// parsing fails fast; per-instance tags warn and fall back instead.
+#[derive(Debug, thiserror::Error)]
+pub enum K8sPodConfigError {
+    #[error("{0} is not a valid JSON array of Tolerations: {1}")]
+    InvalidTolerations(String, String),
+}
+
+impl K8sPodConfig {
+    /// Read a single env level. `prefix` is the part before the key, e.g.
+    /// `FAKECLOUD_K8S` (global) or `FAKECLOUD_LAMBDA_K8S` (service). Reads
+    /// `{prefix}_NODE_SELECTOR`, `{prefix}_TOLERATIONS`, and
+    /// `{prefix}_ANNOTATIONS`. Empty/whitespace values are treated as
+    /// unset; malformed tolerations JSON fails fast.
+    pub fn from_env_prefix(prefix: &str) -> Result<Self, K8sPodConfigError> {
+        let node_selector = env_value(prefix, "NODE_SELECTOR")
+            .map(|raw| parse_kv_map(&raw))
+            .unwrap_or_default();
+        let annotations = env_value(prefix, "ANNOTATIONS")
+            .map(|raw| parse_kv_map(&raw))
+            .unwrap_or_default();
+        let tolerations = match env_value(prefix, "TOLERATIONS") {
+            Some(raw) => parse_tolerations(&raw).map_err(|e| {
+                K8sPodConfigError::InvalidTolerations(format!("{prefix}_TOLERATIONS"), e)
+            })?,
+            None => Vec::new(),
+        };
+        Ok(Self {
+            node_selector,
+            tolerations,
+            annotations,
+        })
+    }
+
+    /// The global+service base for a backend: the global
+    /// `FAKECLOUD_K8S_*` config with the per-service
+    /// `{service_prefix}_*` config merged over it. Call once at backend
+    /// startup and keep the result; merge per-instance tags over it later.
+    pub fn resolved_base(service_prefix: &str) -> Result<Self, K8sPodConfigError> {
+        let global = Self::from_env_prefix(GLOBAL_PREFIX)?;
+        let service = Self::from_env_prefix(service_prefix)?;
+        Ok(global.merge(service))
+    }
+
+    /// Build a config from a resource's reserved tags. Malformed
+    /// tolerations are warned about and dropped (a bad tag must not make
+    /// the resource un-runnable); the other fields still parse.
+    pub fn from_tags(tags: &BTreeMap<String, String>) -> Self {
+        let node_selector = tags
+            .get(TAG_NODE_SELECTOR)
+            .map(|raw| parse_kv_map(raw))
+            .unwrap_or_default();
+        let annotations = tags
+            .get(TAG_ANNOTATIONS)
+            .map(|raw| parse_kv_map(raw))
+            .unwrap_or_default();
+        let tolerations = match tags.get(TAG_TOLERATIONS) {
+            Some(raw) => parse_tolerations(raw).unwrap_or_else(|e| {
+                tracing::warn!(
+                    tag = TAG_TOLERATIONS,
+                    error = %e,
+                    "ignoring malformed per-instance tolerations tag"
+                );
+                Vec::new()
+            }),
+            None => Vec::new(),
+        };
+        Self {
+            node_selector,
+            tolerations,
+            annotations,
+        }
+    }
+
+    /// Merge `higher` (higher precedence) over `self`. Map keys from
+    /// `higher` win on a clash; tolerations combine additively, dropping
+    /// exact duplicates.
+    pub fn merge(mut self, higher: Self) -> Self {
+        self.node_selector.extend(higher.node_selector);
+        self.annotations.extend(higher.annotations);
+        for tol in higher.tolerations {
+            if !self.tolerations.contains(&tol) {
+                self.tolerations.push(tol);
+            }
+        }
+        self
+    }
+
+    /// True when nothing is configured, so [`apply`](Self::apply) is a
+    /// no-op.
+    pub fn is_empty(&self) -> bool {
+        self.node_selector.is_empty() && self.tolerations.is_empty() && self.annotations.is_empty()
+    }
+
+    /// Write this config onto an already-built Pod: merge the node
+    /// selector and tolerations into `spec` and the annotations into
+    /// `metadata`. Existing entries are preserved (annotation keys this
+    /// config sets win; tolerations are added without duplicating). Safe
+    /// when `spec` is `None` -- node selector/tolerations are simply
+    /// skipped, annotations still land on the metadata.
+    pub fn apply(&self, pod: &mut Pod) {
+        if let Some(spec) = pod.spec.as_mut() {
+            if !self.node_selector.is_empty() {
+                spec.node_selector
+                    .get_or_insert_with(BTreeMap::new)
+                    .extend(self.node_selector.clone());
+            }
+            if !self.tolerations.is_empty() {
+                let tolerations = spec.tolerations.get_or_insert_with(Vec::new);
+                for tol in &self.tolerations {
+                    if !tolerations.contains(tol) {
+                        tolerations.push(tol.clone());
+                    }
+                }
+            }
+        }
+        if !self.annotations.is_empty() {
+            pod.metadata
+                .annotations
+                .get_or_insert_with(BTreeMap::new)
+                .extend(self.annotations.clone());
+        }
+    }
+}
+
+/// Read `{prefix}_{suffix}` from the environment, treating
+/// empty/whitespace as unset (matches the `FAKECLOUD_K8S_*` convention in
+/// [`super::env`]).
+fn env_value(prefix: &str, suffix: &str) -> Option<String> {
+    std::env::var(format!("{prefix}_{suffix}"))
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+}
+
+/// Parse a flat `key=value,key=value` map. Entries are trimmed; empty
+/// entries, entries without `=`, and entries with an empty key are
+/// skipped. A repeated key keeps the last value.
+fn parse_kv_map(raw: &str) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
+    for entry in raw.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        if let Some((key, value)) = entry.split_once('=') {
+            let key = key.trim();
+            if key.is_empty() {
+                continue;
+            }
+            map.insert(key.to_string(), value.trim().to_string());
+        }
+    }
+    map
+}
+
+/// Parse a JSON array of k8s `Toleration` objects.
+fn parse_tolerations(raw: &str) -> Result<Vec<Toleration>, String> {
+    serde_json::from_str::<Vec<Toleration>>(raw).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    fn toleration(key: &str, effect: &str) -> Toleration {
+        Toleration {
+            key: Some(key.to_string()),
+            operator: Some("Exists".to_string()),
+            effect: Some(effect.to_string()),
+            ..Toleration::default()
+        }
+    }
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    // --- parse_kv_map -------------------------------------------------
+
+    #[test]
+    fn parse_kv_map_empty_is_empty() {
+        assert!(parse_kv_map("").is_empty());
+        assert!(parse_kv_map("   ").is_empty());
+    }
+
+    #[test]
+    fn parse_kv_map_single_and_multiple() {
+        assert_eq!(parse_kv_map("a=b"), map(&[("a", "b")]));
+        assert_eq!(parse_kv_map("a=b,c=d"), map(&[("a", "b"), ("c", "d")]));
+    }
+
+    #[test]
+    fn parse_kv_map_trims_whitespace() {
+        assert_eq!(
+            parse_kv_map(" a = b , c=d "),
+            map(&[("a", "b"), ("c", "d")])
+        );
+    }
+
+    #[test]
+    fn parse_kv_map_skips_trailing_comma_and_malformed_entries() {
+        // trailing comma, an entry with no '=', and an empty-key entry.
+        assert_eq!(
+            parse_kv_map("a=b,,bad,=v,c=d,"),
+            map(&[("a", "b"), ("c", "d")])
+        );
+    }
+
+    #[test]
+    fn parse_kv_map_duplicate_key_keeps_last() {
+        assert_eq!(parse_kv_map("a=b,a=c"), map(&[("a", "c")]));
+    }
+
+    #[test]
+    fn parse_kv_map_value_may_contain_equals() {
+        assert_eq!(parse_kv_map("a=b=c"), map(&[("a", "b=c")]));
+    }
+
+    // --- parse_tolerations --------------------------------------------
+
+    #[test]
+    fn parse_tolerations_valid() {
+        let raw = r#"[{"key":"dedicated","operator":"Equal","value":"gpu","effect":"NoSchedule"}]"#;
+        let tols = parse_tolerations(raw).unwrap();
+        assert_eq!(tols.len(), 1);
+        assert_eq!(tols[0].key.as_deref(), Some("dedicated"));
+        assert_eq!(tols[0].value.as_deref(), Some("gpu"));
+        assert_eq!(tols[0].effect.as_deref(), Some("NoSchedule"));
+    }
+
+    #[test]
+    fn parse_tolerations_invalid_errors() {
+        assert!(parse_tolerations("not json").is_err());
+        // A JSON object (not an array) is also rejected.
+        assert!(parse_tolerations(r#"{"key":"x"}"#).is_err());
+    }
+
+    // --- merge --------------------------------------------------------
+
+    #[test]
+    fn merge_maps_higher_wins_per_key() {
+        let base = K8sPodConfig {
+            node_selector: map(&[("disktype", "ssd"), ("zone", "a")]),
+            annotations: map(&[("team", "core")]),
+            ..Default::default()
+        };
+        let higher = K8sPodConfig {
+            node_selector: map(&[("disktype", "nvme")]),
+            annotations: map(&[("team", "infra"), ("env", "dev")]),
+            ..Default::default()
+        };
+        let merged = base.merge(higher);
+        assert_eq!(
+            merged.node_selector,
+            map(&[("disktype", "nvme"), ("zone", "a")])
+        );
+        assert_eq!(
+            merged.annotations,
+            map(&[("team", "infra"), ("env", "dev")])
+        );
+    }
+
+    #[test]
+    fn merge_tolerations_additive_and_deduped() {
+        let base = K8sPodConfig {
+            tolerations: vec![toleration("a", "NoSchedule")],
+            ..Default::default()
+        };
+        let higher = K8sPodConfig {
+            tolerations: vec![toleration("a", "NoSchedule"), toleration("b", "NoExecute")],
+            ..Default::default()
+        };
+        let merged = base.merge(higher);
+        assert_eq!(
+            merged.tolerations,
+            vec![toleration("a", "NoSchedule"), toleration("b", "NoExecute")]
+        );
+    }
+
+    // --- from_tags ----------------------------------------------------
+
+    #[test]
+    fn from_tags_parses_all_three() {
+        let tags = map(&[
+            (TAG_NODE_SELECTOR, "disktype=ssd"),
+            (TAG_ANNOTATIONS, "team=core"),
+            (
+                TAG_TOLERATIONS,
+                r#"[{"key":"a","operator":"Exists","effect":"NoSchedule"}]"#,
+            ),
+        ]);
+        let cfg = K8sPodConfig::from_tags(&tags);
+        assert_eq!(cfg.node_selector, map(&[("disktype", "ssd")]));
+        assert_eq!(cfg.annotations, map(&[("team", "core")]));
+        assert_eq!(cfg.tolerations, vec![toleration("a", "NoSchedule")]);
+    }
+
+    #[test]
+    fn from_tags_absent_is_empty() {
+        assert!(K8sPodConfig::from_tags(&BTreeMap::new()).is_empty());
+    }
+
+    #[test]
+    fn from_tags_malformed_tolerations_warns_and_skips_but_keeps_other_fields() {
+        let tags = map(&[
+            (TAG_NODE_SELECTOR, "disktype=ssd"),
+            (TAG_TOLERATIONS, "not json"),
+        ]);
+        let cfg = K8sPodConfig::from_tags(&tags);
+        assert_eq!(cfg.node_selector, map(&[("disktype", "ssd")]));
+        assert!(cfg.tolerations.is_empty());
+    }
+
+    // --- apply --------------------------------------------------------
+
+    fn pod_with_spec() -> Pod {
+        Pod {
+            spec: Some(k8s_openapi::api::core::v1::PodSpec::default()),
+            ..Pod::default()
+        }
+    }
+
+    #[test]
+    fn apply_sets_all_three_fields() {
+        let cfg = K8sPodConfig {
+            node_selector: map(&[("disktype", "ssd")]),
+            tolerations: vec![toleration("a", "NoSchedule")],
+            annotations: map(&[("team", "core")]),
+        };
+        let mut pod = pod_with_spec();
+        cfg.apply(&mut pod);
+        let spec = pod.spec.unwrap();
+        assert_eq!(spec.node_selector.unwrap(), map(&[("disktype", "ssd")]));
+        assert_eq!(
+            spec.tolerations.unwrap(),
+            vec![toleration("a", "NoSchedule")]
+        );
+        assert_eq!(pod.metadata.annotations.unwrap(), map(&[("team", "core")]));
+    }
+
+    #[test]
+    fn apply_merges_into_existing_annotations() {
+        let cfg = K8sPodConfig {
+            annotations: map(&[("team", "core")]),
+            ..Default::default()
+        };
+        let mut pod = pod_with_spec();
+        pod.metadata.annotations = Some(map(&[("existing", "1")]));
+        cfg.apply(&mut pod);
+        assert_eq!(
+            pod.metadata.annotations.unwrap(),
+            map(&[("existing", "1"), ("team", "core")])
+        );
+    }
+
+    #[test]
+    fn apply_empty_config_is_noop() {
+        let mut pod = pod_with_spec();
+        K8sPodConfig::default().apply(&mut pod);
+        let spec = pod.spec.unwrap();
+        assert!(spec.node_selector.is_none());
+        assert!(spec.tolerations.is_none());
+        assert!(pod.metadata.annotations.is_none());
+    }
+
+    #[test]
+    fn apply_without_spec_still_sets_annotations() {
+        let cfg = K8sPodConfig {
+            node_selector: map(&[("disktype", "ssd")]),
+            annotations: map(&[("team", "core")]),
+            ..Default::default()
+        };
+        let mut pod = Pod::default();
+        cfg.apply(&mut pod);
+        assert!(pod.spec.is_none());
+        assert_eq!(pod.metadata.annotations.unwrap(), map(&[("team", "core")]));
+    }
+
+    // --- env parsing (process-global; serialized) ---------------------
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    const ENV_KEYS: &[&str] = &[
+        "FAKECLOUD_K8S_NODE_SELECTOR",
+        "FAKECLOUD_K8S_TOLERATIONS",
+        "FAKECLOUD_K8S_ANNOTATIONS",
+        "FAKECLOUD_LAMBDA_K8S_NODE_SELECTOR",
+        "FAKECLOUD_LAMBDA_K8S_TOLERATIONS",
+        "FAKECLOUD_LAMBDA_K8S_ANNOTATIONS",
+    ];
+
+    struct EnvGuard(Vec<(String, Option<String>)>);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.0 {
+                match v {
+                    Some(v) => std::env::set_var(k, v),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    fn with_env(set: &[(&str, &str)], f: impl FnOnce()) {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _restore = EnvGuard(
+            ENV_KEYS
+                .iter()
+                .map(|k| (k.to_string(), std::env::var(k).ok()))
+                .collect(),
+        );
+        for k in ENV_KEYS {
+            std::env::remove_var(k);
+        }
+        for (k, v) in set {
+            std::env::set_var(k, v);
+        }
+        f();
+    }
+
+    #[test]
+    fn from_env_prefix_reads_all_three() {
+        with_env(
+            &[
+                ("FAKECLOUD_K8S_NODE_SELECTOR", "disktype=ssd"),
+                ("FAKECLOUD_K8S_ANNOTATIONS", "team=core"),
+                (
+                    "FAKECLOUD_K8S_TOLERATIONS",
+                    r#"[{"key":"a","operator":"Exists","effect":"NoSchedule"}]"#,
+                ),
+            ],
+            || {
+                let cfg = K8sPodConfig::from_env_prefix("FAKECLOUD_K8S").unwrap();
+                assert_eq!(cfg.node_selector, map(&[("disktype", "ssd")]));
+                assert_eq!(cfg.annotations, map(&[("team", "core")]));
+                assert_eq!(cfg.tolerations, vec![toleration("a", "NoSchedule")]);
+            },
+        );
+    }
+
+    #[test]
+    fn from_env_prefix_unset_is_empty() {
+        with_env(&[], || {
+            assert!(K8sPodConfig::from_env_prefix("FAKECLOUD_K8S")
+                .unwrap()
+                .is_empty());
+        });
+    }
+
+    #[test]
+    fn from_env_prefix_blank_value_treated_as_unset() {
+        with_env(&[("FAKECLOUD_K8S_NODE_SELECTOR", "   ")], || {
+            assert!(K8sPodConfig::from_env_prefix("FAKECLOUD_K8S")
+                .unwrap()
+                .node_selector
+                .is_empty());
+        });
+    }
+
+    #[test]
+    fn from_env_prefix_invalid_tolerations_fails_fast() {
+        with_env(&[("FAKECLOUD_K8S_TOLERATIONS", "not json")], || {
+            let err = K8sPodConfig::from_env_prefix("FAKECLOUD_K8S").unwrap_err();
+            assert!(
+                matches!(err, K8sPodConfigError::InvalidTolerations(var, _) if var == "FAKECLOUD_K8S_TOLERATIONS")
+            );
+        });
+    }
+
+    #[test]
+    fn resolved_base_merges_service_over_global() {
+        with_env(
+            &[
+                ("FAKECLOUD_K8S_NODE_SELECTOR", "disktype=ssd,zone=a"),
+                ("FAKECLOUD_LAMBDA_K8S_NODE_SELECTOR", "disktype=nvme"),
+            ],
+            || {
+                let cfg = K8sPodConfig::resolved_base("FAKECLOUD_LAMBDA_K8S").unwrap();
+                // service overrides disktype, global zone survives.
+                assert_eq!(
+                    cfg.node_selector,
+                    map(&[("disktype", "nvme"), ("zone", "a")])
+                );
+            },
+        );
+    }
+}

--- a/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
@@ -18,7 +18,7 @@ pub mod spec;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use fakecloud_k8s::{K8sClient, K8sEnv, K8sEnvError};
+use fakecloud_k8s::{K8sClient, K8sEnv, K8sEnvError, K8sPodConfig, K8sPodConfigError};
 
 use super::backend::{BackendHandle, LambdaBackend, RuntimeError, WarmInstance};
 use crate::state::LambdaFunction;
@@ -28,12 +28,19 @@ use spec::{build_pod_spec, unique_pod_name, PodSpecContext};
 /// touches Lambda Pods.
 const SERVICE: &str = "lambda";
 
+/// Env prefix for Lambda-scoped Pod config overrides
+/// (`FAKECLOUD_LAMBDA_K8S_NODE_SELECTOR`, etc.). Merged over the global
+/// `FAKECLOUD_K8S_*` config.
+const POD_CONFIG_PREFIX: &str = "FAKECLOUD_LAMBDA_K8S";
+
 /// Errors that can prevent the K8s backend from initializing. Surfaced
 /// to the operator at fakecloud startup; never silently swallowed.
 #[derive(Debug, thiserror::Error)]
 pub enum K8sBackendError {
     #[error(transparent)]
     Env(#[from] K8sEnvError),
+    #[error(transparent)]
+    PodConfig(#[from] K8sPodConfigError),
     #[error("failed to connect to the Kubernetes cluster: {0}")]
     Connect(String),
 }
@@ -58,6 +65,10 @@ pub struct K8sBackend {
     /// Optional `imagePullSecrets` reference for image-package functions
     /// that pull from a registry needing credentials.
     pull_secret: Option<String>,
+    /// Global + Lambda-service node selector / tolerations / annotations
+    /// applied to every Lambda Pod. Per-function tag overrides are merged
+    /// over this at launch time.
+    pod_config: K8sPodConfig,
 }
 
 impl K8sBackend {
@@ -70,6 +81,7 @@ impl K8sBackend {
         internal_token: String,
     ) -> Result<Self, K8sBackendError> {
         let env = K8sEnv::from_env(default_ecr_port)?;
+        let pod_config = K8sPodConfig::resolved_base(POD_CONFIG_PREFIX)?;
         let client = K8sClient::connect(env.namespace.clone())
             .await
             .map_err(|e| K8sBackendError::Connect(e.to_string()))?;
@@ -89,6 +101,7 @@ impl K8sBackend {
             ecr_port: env.ecr_port,
             internal_token,
             pull_secret: env.pull_secret,
+            pod_config,
         })
     }
 }
@@ -132,6 +145,14 @@ impl LambdaBackend for K8sBackend {
         // `unique_pod_name`).
         let pod_name = unique_pod_name(&func.function_name, deploy_id);
         pod.metadata.name = Some(pod_name.clone());
+
+        // Apply operator-configured scheduling/metadata: global +
+        // service base with this function's reserved-tag overrides merged
+        // over it (per-function tags win).
+        self.pod_config
+            .clone()
+            .merge(K8sPodConfig::from_tags(&func.tags))
+            .apply(&mut pod);
 
         self.client
             .create_pod(&pod)

--- a/crates/fakecloud-lambda/src/runtime/k8s/spec.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/spec.rs
@@ -597,6 +597,46 @@ mod tests {
     }
 
     #[test]
+    fn per_function_tags_override_base_pod_config() {
+        use fakecloud_k8s::K8sPodConfig;
+        use std::collections::BTreeMap;
+
+        // Backend base (global + service env): one node-selector key.
+        let base = K8sPodConfig {
+            node_selector: BTreeMap::from([
+                ("disktype".to_string(), "ssd".to_string()),
+                ("zone".to_string(), "a".to_string()),
+            ]),
+            ..Default::default()
+        };
+
+        // Function carries a reserved tag overriding disktype and adding
+        // an annotation.
+        let mut f = zip_function("my-fn");
+        f.tags
+            .insert("fakecloud-k8s/node-selector".into(), "disktype=nvme".into());
+        f.tags
+            .insert("fakecloud-k8s/annotations".into(), "team=core".into());
+
+        let mut pod = build_pod_spec(&f, "d", &ctx()).unwrap();
+        // Mirror the launch() contract: base merged with per-function tags.
+        base.merge(K8sPodConfig::from_tags(&f.tags)).apply(&mut pod);
+
+        let selector = pod.spec.unwrap().node_selector.unwrap();
+        // Tag wins on disktype; the base-only zone key survives.
+        assert_eq!(selector.get("disktype").map(String::as_str), Some("nvme"));
+        assert_eq!(selector.get("zone").map(String::as_str), Some("a"));
+        assert_eq!(
+            pod.metadata
+                .annotations
+                .unwrap()
+                .get("team")
+                .map(String::as_str),
+            Some("core")
+        );
+    }
+
+    #[test]
     fn restart_policy_never() {
         let f = zip_function("my-fn");
         let pod = build_pod_spec(&f, "d", &ctx()).unwrap();

--- a/website/content/docs/guides/kubernetes-backend.md
+++ b/website/content/docs/guides/kubernetes-backend.md
@@ -186,6 +186,8 @@ aws lambda create-function \
 
 A malformed env value (e.g. invalid tolerations JSON) fails fast at fakecloud startup so a typo is loud. A malformed per-instance *tag* is logged and ignored for that field, so a bad tag never makes a single resource un-runnable. Per-instance tags only take effect when present at the resource's creation time; tags added later (`TagResource` / `add-tags-to-resource`) don't retroactively re-schedule a running Pod — recreate the resource to pick them up.
 
+The `fakecloud-k8s/*` tags are ordinary resource tags — fakecloud reads them but does not strip them, so they remain visible in `ListTags` / `list-tags-for-resource` output and count toward the resource's AWS tag limit (e.g. 50 for Lambda) like any other tag.
+
 ## ElastiCache backend
 
 Set `FAKECLOUD_ELASTICACHE_BACKEND=k8s` (or the global `FAKECLOUD_CONTAINER_BACKEND=k8s`) to run cache clusters, replication groups, and serverless caches as native Pods instead of Docker containers.

--- a/website/content/docs/guides/kubernetes-backend.md
+++ b/website/content/docs/guides/kubernetes-backend.md
@@ -151,6 +151,41 @@ spec:
 - Pods carry labels `fakecloud-managed-by=fakecloud`, `fakecloud-instance=<pid>`, `fakecloud-lambda=<function>`, `fakecloud-deploy-id=<hash>` so you can `kubectl get pods -l fakecloud-managed-by=fakecloud`.
 - Pods run with whatever default security context your cluster's `PodSecurityPolicy` / `PodSecurityAdmission` enforces — no `privileged`, no special capabilities. The fakecloud Pod itself also doesn't need privileged.
 
+## Pod scheduling and metadata
+
+Real clusters often need fakecloud's Pods to carry a `nodeSelector` (pin workloads to a node pool), taint `tolerations` (run on tainted/spot nodes), or `annotations` (cost allocation, mesh sidecar injection, scrape config). You can attach all three at three levels, lowest to highest precedence:
+
+1. **Global** — `FAKECLOUD_K8S_NODE_SELECTOR` / `FAKECLOUD_K8S_TOLERATIONS` / `FAKECLOUD_K8S_ANNOTATIONS`, applied to every fakecloud Pod across all k8s-backed services.
+2. **Per-service** — `FAKECLOUD_<SERVICE>_K8S_<KEY>` (e.g. `FAKECLOUD_LAMBDA_K8S_NODE_SELECTOR`, `FAKECLOUD_RDS_K8S_TOLERATIONS`), applied to that service's Pods.
+3. **Per-instance** — a reserved tag on the individual resource (Lambda function, DB instance, cache cluster, ECS task, EC2 instance): `fakecloud-k8s/node-selector`, `fakecloud-k8s/tolerations`, `fakecloud-k8s/annotations`.
+
+Value formats are the same at every level:
+
+- `NODE_SELECTOR` / `ANNOTATIONS`: a flat `key=value,key=value` map.
+- `TOLERATIONS`: a JSON array of Kubernetes [`Toleration`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) objects.
+
+Merge across the levels: the maps (node selector, annotations) union per key, and a higher level overrides only the keys it sets — lower-level keys survive. Tolerations combine additively (a Pod tolerates the union of all configured taints), dropping exact duplicates.
+
+```sh
+# Global: keep every fakecloud Pod off the default node pool.
+FAKECLOUD_K8S_NODE_SELECTOR=fakecloud=true
+FAKECLOUD_K8S_TOLERATIONS='[{"key":"fakecloud","operator":"Exists","effect":"NoSchedule"}]'
+
+# Service: send all Lambda Pods to the burst pool, with a cost-center annotation.
+FAKECLOUD_LAMBDA_K8S_NODE_SELECTOR=pool=burst
+FAKECLOUD_LAMBDA_K8S_ANNOTATIONS=cost-center=lambda
+```
+
+```sh
+# Per-instance: this one function pins to GPU nodes (overrides the service/global
+# node selector for the `accelerator` key) via a tag at create time.
+aws lambda create-function \
+  --tags 'fakecloud-k8s/node-selector=accelerator=nvidia,fakecloud-k8s/annotations=team=ml' \
+  ... # other create-function args
+```
+
+A malformed env value (e.g. invalid tolerations JSON) fails fast at fakecloud startup so a typo is loud. A malformed per-instance *tag* is logged and ignored for that field, so a bad tag never makes a single resource un-runnable. Per-instance tags only take effect when present at the resource's creation time; tags added later (`TagResource` / `add-tags-to-resource`) don't retroactively re-schedule a running Pod — recreate the resource to pick them up.
+
 ## ElastiCache backend
 
 Set `FAKECLOUD_ELASTICACHE_BACKEND=k8s` (or the global `FAKECLOUD_CONTAINER_BACKEND=k8s`) to run cache clusters, replication groups, and serverless caches as native Pods instead of Docker containers.

--- a/website/content/docs/reference/configuration.md
+++ b/website/content/docs/reference/configuration.md
@@ -28,6 +28,9 @@ fakecloud is configured via CLI flags or environment variables. Flags take prece
 |                      | `FAKECLOUD_K8S_SELF_URL`    | —                  | In-cluster URL of the fakecloud Service (e.g. `http://fakecloud.fakecloud.svc.cluster.local:4566`). Required for the K8s backend — Pods fetch artifacts from and call back to this URL. |
 |                      | `FAKECLOUD_K8S_ECR_URL`     | host of `_SELF_URL`| Override the host:port the K8s backend rewrites AWS private-ECR URIs to. Defaults to the host of `FAKECLOUD_K8S_SELF_URL`. |
 |                      | `FAKECLOUD_K8S_PULL_SECRET` | unset              | Name of a `kubernetes.io/dockerconfigjson` Secret used as `imagePullSecrets` for Pods pulling private images. |
+|                      | `FAKECLOUD_K8S_NODE_SELECTOR` | unset            | `key=value,key=value` node selector applied to every fakecloud Pod. Per-service override: `FAKECLOUD_<SERVICE>_K8S_NODE_SELECTOR` (e.g. `FAKECLOUD_LAMBDA_K8S_NODE_SELECTOR`). See [Kubernetes backend](/docs/guides/kubernetes-backend/#pod-scheduling-and-metadata). |
+|                      | `FAKECLOUD_K8S_TOLERATIONS` | unset              | JSON array of k8s `Toleration` objects applied to every fakecloud Pod. Per-service override: `FAKECLOUD_<SERVICE>_K8S_TOLERATIONS`. |
+|                      | `FAKECLOUD_K8S_ANNOTATIONS` | unset              | `key=value,key=value` annotations added to every fakecloud Pod. Per-service override: `FAKECLOUD_<SERVICE>_K8S_ANNOTATIONS`. |
 |                      | `FAKECLOUD_MAX_REQUEST_BODY_BYTES` | `1073741824` | Max bytes a buffered request body can absorb before fakecloud returns 413. Default 1 GiB. Streaming routes (S3 `PutObject` / `UploadPart`, ECR OCI blob upload `PATCH` / `PUT`) bypass this cap entirely — they spool the raw HTTP body to disk instead of buffering it all in RAM. Raise this only when stress-testing buffered requests past 1 GiB. |
 
 ## Examples


### PR DESCRIPTION
Thanks again, @vieiralucas, for your quick review and release on all the previous updates to the k8s backend for lambdas. These are the last minor improvements that would help this fit perfectly into our pipelines. We currently segregate feature environments and testing CI runners onto node pools that allow spot nodes. By providing a mechanism to set tolerations and node selectors, we can make sure the lambda pods land on the same nodes as the rest of the feature env stack. I don't currently have a need to set any of these options per lambda, but I could see situations where other users may find that helpful.

I haven't had a chance to test out the k8s backend for any of the other services, but I plan to experiment with those sometime in the near future and will certainly let you know if we hit any issues with them. Since this change makes some design decisions and isn't strictly necessary for us to use fakecloud, I wanted to get your input or input from anyone else in the community who may have opinions. If the environment variables and tag overrides sound good, I can open the other MRs immediately.

## Summary

Adds operator-configurable Pod **node selectors**, **taint tolerations**, and **arbitrary annotations** to the Kubernetes backend, starting with **Lambda**. Each of the three is resolvable at three levels, lowest to highest precedence:

1. **Global** env: `FAKECLOUD_K8S_NODE_SELECTOR` / `FAKECLOUD_K8S_TOLERATIONS` / `FAKECLOUD_K8S_ANNOTATIONS` (apply to every fakecloud Pod)
2. **Per-service** env: `FAKECLOUD_LAMBDA_K8S_NODE_SELECTOR` / `_TOLERATIONS` / `_ANNOTATIONS`
3. **Per-function** reserved tags: `fakecloud-k8s/node-selector`, `fakecloud-k8s/tolerations`, `fakecloud-k8s/annotations`

The shared parsing/merge/apply logic lives in a new `fakecloud-k8s` `pod_config` module (`K8sPodConfig`) so the remaining k8s-backed services can reuse it unchanged.

## Motivation

When fakecloud runs the k8s backend in a real cluster, operators routinely need to steer where the spawned Pods land and how they're annotated: pin them to a node pool (`nodeSelector`), let them run on tainted/spot nodes (`tolerations`), or attach metadata for cost allocation / mesh sidecar injection / scrape config (`annotations`). Today the backend sets none of these, so there's no way to influence scheduling of the Pods fakecloud creates. This adds that control without changing any default behavior (unset = no-op).

## What this PR adds

### Configuration model and precedence

`global env  ->  service env  ->  per-instance tag`, applied lowest-to-highest. A backend reads the global+service base once at startup; the per-function tags are merged over it at launch.

- **Maps** (`node_selector`, `annotations`): union per key; a higher level overrides only the keys it sets, lower-level keys survive.
- **Tolerations** (list): combine **additively** across levels (a Pod tolerates the union of taints), dropping exact duplicates. This mirrors the repo's existing SAM Globals convention (maps deep-merge, list-typed keys combine additively).

### Value formats

- `NODE_SELECTOR` / `ANNOTATIONS`: a flat `key=value,key=value` map.
- `TOLERATIONS`: a JSON array of Kubernetes `Toleration` objects, parsed via `serde_json` straight into `k8s_openapi`'s `Toleration` type (full field fidelity, no hand-rolled list parser).

### Error handling (deliberately asymmetric)

- A malformed **env** value (e.g. invalid tolerations JSON) **fails fast** at fakecloud startup, so an operator typo is loud.
- A malformed per-instance **tag** is **logged and ignored for that field**, so a bad tag can never make a single function un-runnable.

### Example

```sh
# Global: keep every fakecloud Pod off the default node pool.
FAKECLOUD_K8S_NODE_SELECTOR=fakecloud=true
FAKECLOUD_K8S_TOLERATIONS='[{"key":"fakecloud","operator":"Exists","effect":"NoSchedule"}]'

# Service: send all Lambda Pods to the burst pool, with a cost-center annotation.
FAKECLOUD_LAMBDA_K8S_NODE_SELECTOR=pool=burst
FAKECLOUD_LAMBDA_K8S_ANNOTATIONS=cost-center=lambda
```

```sh
# Per-function: this one function pins to GPU nodes (overrides the service/global
# nodeSelector for that key) via a tag at create time.
aws lambda create-function \
  --tags 'fakecloud-k8s/node-selector=accelerator=nvidia,fakecloud-k8s/annotations=team=ml' \
  ...
```

## Scope / non-goals

- **Resource requests/limits are intentionally untouched.** Lambda already derives memory `requests`==`limits` from the function's `MemorySize`; this PR does not change that.
- **Affinity / anti-affinity is intentionally excluded.** It maps to no real AWS Lambda behavior, and its semantics vary widely across schedulers/autoscalers, which makes it an easy footgun for someone just getting started with the k8s backend. Easy to add later behind the same `apply` pattern if there's demand.

## Implementation notes

- New `crates/fakecloud-k8s/src/pod_config.rs`: `K8sPodConfig { node_selector, tolerations, annotations }` plus `from_env_prefix`, `resolved_base(service_prefix)`, `from_tags`, `merge`, and `apply(&mut Pod)`. Re-exported from the crate root.
- Lambda backend stores the global+service base at `from_env` (`K8sPodConfig::resolved_base("FAKECLOUD_LAMBDA_K8S")`) and, at launch, merges the function's tags over it and applies the result to the built Pod before `create_pod`.
- `apply` mutates the already-built Pod, so the per-service Pod builders don't change signature -- which keeps the follow-up service PRs small.

## Tests

- 22 unit tests for `pod_config` covering: `key=value` map parsing edge cases (whitespace, trailing comma, missing `=`, empty key, duplicate key, value containing `=`); valid/invalid tolerations JSON; `merge` precedence (maps per-key override, tolerations additive + dedupe); `from_tags` warn-and-skip on malformed input; `apply` (each field set/unset, annotation union with pre-existing, empty no-op, `spec: None`); and env parsing incl. global+service resolution and fail-fast on bad tolerations.
- A Lambda test asserting a per-function tag overrides the global/service base and reaches the built Pod.
- All existing `fakecloud-lambda` k8s unit tests still pass; `cargo clippy` and `cargo fmt --check` clean on both crates; full workspace test suite (excluding the docker-dependent e2e crate) green.

## Docs

- New "Pod scheduling and metadata" section in `website/content/docs/guides/kubernetes-backend.md` (env vars, tag keys, formats, precedence, merge rules, and the create-time-tag caveat).
- New rows in `website/content/docs/reference/configuration.md`.

---

## Coming next: the same for the other four k8s backends

We have the same change drafted for **RDS, ElastiCache, ECS, and EC2**, all built on the shared `pod_config` module and the identical `global -> service -> per-instance-tag` model (`FAKECLOUD_RDS_K8S_*`, `FAKECLOUD_ELASTICACHE_K8S_*`, `FAKECLOUD_ECS_K8S_*`, `FAKECLOUD_EC2_K8S_*`, plus the same `fakecloud-k8s/*` tags). We'd like your input on one design point before we open them, so we land them the way you'd prefer rather than asking you to redo it.

For those four services, the only extra work versus Lambda is wiring each Pod-builder to read the resource's tags (Lambda already had the function in scope at build time; the others currently receive only an identifier). That plumbing is uniform and needed regardless.

### The one open question: RDS create-time tags

While drafting these we found a relevant asymmetry in how create-time `Tags` are persisted today:

| Service | Persists tags from the **create** call? | Persists later `AddTags`/`TagResource`? |
| --- | --- | --- |
| Lambda | yes | yes |
| ElastiCache | yes | yes |
| ECS (`RunTask`) | yes (incl. `propagateTags`) | yes |
| EC2 (`RunInstances`) | yes (`TagSpecifications`) | yes |
| **RDS (`CreateDBInstance`)** | **no -- request `Tags` are dropped** | yes |

So for ElastiCache/ECS/EC2, per-instance scheduling will work at create time as soon as we wire the builder. For **RDS**, because `CreateDBInstance` discards the request's `Tags` today, per-instance scheduling at create won't work unless we also make `CreateDBInstance` persist its `Tags`. Two ways to go:

- **(A) Also fix RDS `CreateDBInstance` to persist `Tags`.** Small, isolated, and arguably just more AWS-correct (real RDS applies create-time tags). Per-instance scheduling then works uniformly at create across all five services. We'd run the full workspace suite to confirm no regression, and could split the tag-persistence fix into its own PR if you'd rather review it separately.
- **(B) Leave RDS tag persistence as-is.** Only wire the builder to read whatever tags are in state. RDS per-instance scheduling then applies only after `AddTagsToResource` (+ a reboot to recreate the Pod), consistent with the "recreate to pick up tags" caveat in the docs. The other four still work at create.

We lean toward (A), but it's your call.

### A couple of smaller choices we'd value your opinion on

- **Tag key namespace:** we used `fakecloud-k8s/node-selector` (etc.). Happy to change the prefix/spelling if you have a convention you prefer.
- **Tolerations merge:** we chose additive-union across the three levels (to match the SAM Globals list-merge convention). If you'd rather a higher level fully *replace* lower-level tolerations, that's a one-line change.
- **Per-instance tags at create vs. recreate:** the current behavior is that tags added after creation (via `AddTags`) only affect the Pod on the next recreate/reboot, which we documented as a caveat. Shout if you'd prefer different semantics.

Happy to open the four follow-up PRs immediately once you've weighed in on the above (especially the RDS question).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds operator-configurable Kubernetes Pod scheduling and metadata for Lambda: set `nodeSelector`, `tolerations`, and `annotations` via env and per-function tags to steer where Pods run. Defaults stay the same; only applies when set. Docs clarify that `fakecloud-k8s/*` tags remain visible and count toward tag limits.

- **New Features**
  - Configure Pod `nodeSelector`, `tolerations`, and `annotations` for k8s Lambda Pods.
  - Precedence: global `FAKECLOUD_K8S_*` → service `FAKECLOUD_LAMBDA_K8S_*` → per-function tags (`fakecloud-k8s/node-selector`, `fakecloud-k8s/tolerations`, `fakecloud-k8s/annotations`).
  - Merge: maps union per key; tolerations additive with dedupe. Formats: `key=value,key=value` for maps; tolerations as a JSON array of Kubernetes `Toleration`. Unset = no-op.
  - Robustness: bad env fails at startup; bad per-function tag is logged and ignored.
  - Shared logic in `fakecloud-k8s` as `K8sPodConfig` for reuse. Docs note `fakecloud-k8s/*` tags show up in tag listings and count toward AWS tag limits.

<sup>Written for commit 0fb6c0032aa368eff1fc5a92bac44492754c5ed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

