### PR TITLE
feat(sdk,introspection): expose EC2 instance backing container id

### DIFF
--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -37,6 +37,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Isolate from ci.yml's same-named `test` job, which caches a
+          # `./target` symlink (free-disk relocates it to /mnt); restoring it
+          # here would dangle and break `cargo build`.
+          shared-key: sdk
       - name: Build fakecloud
         run: cargo build --release
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -32,6 +32,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Isolate from ci.yml's same-named `test` job, which caches a
+          # `./target` symlink (free-disk relocates it to /mnt); restoring it
+          # here would dangle and break `cargo build`.
+          shared-key: sdk
 
       - name: Build fakecloud
         run: cargo build --release

--- a/.github/workflows/sdk-php.yml
+++ b/.github/workflows/sdk-php.yml
@@ -32,6 +32,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Isolate from ci.yml's same-named `test` job, which caches a
+          # `./target` symlink (free-disk relocates it to /mnt); restoring it
+          # here would dangle and break `cargo build`.
+          shared-key: sdk
 
       - name: Build fakecloud
         run: cargo build --release

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -49,6 +49,12 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Isolate from the `test` job in ci.yml: that job shares the same
+          # `github.job` name and caches a `./target` symlink (relocated to
+          # /mnt by the free-disk action). Without free-disk here, restoring
+          # that symlink dangles and `cargo build` fails to create `target`.
+          shared-key: sdk
       - name: Build fakecloud
         run: cargo build --release
         working-directory: .

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -32,6 +32,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Isolate from ci.yml's same-named `test` job, which caches a
+          # `./target` symlink (free-disk relocates it to /mnt); restoring it
+          # here would dangle and break `cargo build`.
+          shared-key: sdk
 
       - name: Build fakecloud
         run: cargo build --release

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -2337,9 +2337,9 @@ pub struct Elbv2WafCountsResponse {
 // ── EC2 instances (introspection) ───────────────────────────────────
 
 /// A single EC2 instance as surfaced by `GET /_fakecloud/ec2/instances`.
-/// Instances are metadata-faithful today (Docker-backed execution is a
-/// roadmap follow-up), so this mirrors the control-plane view without
-/// leaking runtime-internal fields.
+/// One EC2 instance's control-plane view, plus the backing container handle
+/// when the instance is backed by a real container runtime (Docker container
+/// id or Kubernetes Pod name); `container_id` is `None` in metadata-only mode.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Ec2Instance {
@@ -2357,6 +2357,10 @@ pub struct Ec2Instance {
     pub security_group_ids: Vec<String>,
     pub availability_zone: String,
     pub launch_time: String,
+    /// Backing container id (Docker) or Pod name (k8s); `None` when the
+    /// instance runs metadata-only (no container runtime available).
+    #[serde(default)]
+    pub container_id: Option<String>,
 }
 
 /// Response body for `GET /_fakecloud/ec2/instances`.

--- a/crates/fakecloud-server/src/introspection.rs
+++ b/crates/fakecloud-server/src/introspection.rs
@@ -555,6 +555,7 @@ pub(crate) fn ec2_instance_response(
         security_group_ids: instance.security_group_ids.clone(),
         availability_zone: instance.az.clone(),
         launch_time: instance.launch_time.clone(),
+        container_id: instance.container_id.clone(),
     }
 }
 

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -71,6 +71,9 @@ type EC2Instance struct {
 	SecurityGroupIDs []string `json:"securityGroupIds"`
 	AvailabilityZone string   `json:"availabilityZone"`
 	LaunchTime       string   `json:"launchTime"`
+	// ContainerID is the backing Docker container id or Kubernetes Pod name,
+	// or nil when the instance runs metadata-only (no container runtime).
+	ContainerID *string `json:"containerId"`
 }
 
 type EC2InstancesResponse struct {

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -70,7 +70,8 @@ public final class Types {
             String keyName,
             List<String> securityGroupIds,
             String availabilityZone,
-            String launchTime) {}
+            String launchTime,
+            String containerId) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Ec2InstancesResponse(List<Ec2Instance> instances) {}

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -140,6 +140,8 @@ final class Ec2Instance
         public readonly array $securityGroupIds,
         public readonly string $availabilityZone,
         public readonly string $launchTime,
+        /** Backing Docker container id or Kubernetes Pod name; null when metadata-only. */
+        public readonly ?string $containerId,
     ) {}
 
     public static function fromArray(array $data): self
@@ -157,6 +159,7 @@ final class Ec2Instance
             $data['securityGroupIds'] ?? [],
             $data['availabilityZone'],
             $data['launchTime'],
+            $data['containerId'] ?? null,
         );
     }
 }

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -134,6 +134,9 @@ class Ec2Instance:
     subnet_id: Optional[str] = None
     vpc_id: Optional[str] = None
     key_name: Optional[str] = None
+    #: Backing Docker container id or Kubernetes Pod name; ``None`` when the
+    #: instance runs metadata-only (no container runtime).
+    container_id: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> Ec2Instance:

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -173,6 +173,9 @@ def test_ec2_instances(fc: FakeCloudSync, fakecloud_url: str) -> None:
     assert instance.instance_type == "t3.micro"
     assert instance.private_ip
     assert isinstance(instance.security_group_ids, list)
+    # Backing container id (Docker) / Pod name (k8s), or None when the
+    # instance runs metadata-only (no container runtime in the test env).
+    assert instance.container_id is None or isinstance(instance.container_id, str)
 
 
 # ── ElastiCache ───────────────────────────────────────────────────────

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -61,6 +61,8 @@ export interface Ec2Instance {
   securityGroupIds: string[];
   availabilityZone: string;
   launchTime: string;
+  /** Backing Docker container id or Kubernetes Pod name; null when metadata-only. */
+  containerId: string | null;
 }
 
 export interface Ec2InstancesResponse {

--- a/sdks/typescript/tests/e2e.test.ts
+++ b/sdks/typescript/tests/e2e.test.ts
@@ -176,6 +176,12 @@ describe("ec2", () => {
     expect(instance!.privateIp.length).toBeGreaterThan(0);
     expect(instance!.availabilityZone.length).toBeGreaterThan(0);
     expect(Array.isArray(instance!.securityGroupIds)).toBe(true);
+    // Backing container id (Docker) / Pod name (k8s), or null when the
+    // instance runs metadata-only (no container runtime in the test env).
+    expect(
+      instance!.containerId === null ||
+        typeof instance!.containerId === "string",
+    ).toBe(true);
   });
 });
 

--- a/website/content/docs/services/ec2.md
+++ b/website/content/docs/services/ec2.md
@@ -28,7 +28,7 @@ EC2 uses the `ec2Query` protocol: form-encoded requests and flattened-XML respon
 
 ## Introspection
 
-- `GET /_fakecloud/ec2/instances` — list every fakecloud-managed EC2 instance across all account partitions with its control-plane metadata (`instanceId`, `imageId`, `instanceType`, `state`, `privateIp`, `publicIp`, `subnetId`, `vpcId`, `keyName`, `securityGroupIds`, `availabilityZone`, `launchTime`). Lets tests assert on instance state without re-parsing `DescribeInstances` XML. Exposed through every fakecloud introspection SDK — `fc.ec2().getInstances()` (Go/Java/TS/PHP), `fc.ec2.get_instances()` (Python), `fc.ec2().get_instances()` (Rust).
+- `GET /_fakecloud/ec2/instances` — list every fakecloud-managed EC2 instance across all account partitions with its control-plane metadata (`instanceId`, `imageId`, `instanceType`, `state`, `privateIp`, `publicIp`, `subnetId`, `vpcId`, `keyName`, `securityGroupIds`, `availabilityZone`, `launchTime`) plus `containerId` — the backing Docker container id or Kubernetes Pod name, or `null` when the instance runs metadata-only (no container runtime). Lets tests assert on instance state (and which container backs it) without re-parsing `DescribeInstances` XML. Exposed through every fakecloud introspection SDK — `fc.ec2().getInstances()` (Go/Java/TS/PHP), `fc.ec2.get_instances()` (Python), `fc.ec2().get_instances()` (Rust).
 
 ## Known limitations
 


### PR DESCRIPTION
## Summary

The EC2 instance runtime (#1730/#1731/#1732) backs each instance with a real Docker container or Kubernetes Pod, but the `/_fakecloud/ec2/instances` introspection response and the SDK types still described instances as metadata-only. This surfaces the **backing handle** so callers can see which container/Pod backs an instance — and whether it's backed at all.

First of two batches teaching the non-core surfaces about the EC2 runtime (this one = SDKs + introspection; next = website/llms.txt/parity).

- `types::Ec2Instance` (shared by the Rust SDK and the server introspection response) gains `container_id: Option<String>`; stale "metadata-faithful roadmap" doc comment fixed.
- `ec2_instance_response` populates it.
- All introspection SDKs gain the field: Go (`*string`), Python (`Optional[str]`), TypeScript (`string | null`), Java (record component), PHP (nullable ctor arg). `null`/`None`/`nil` when the instance runs metadata-only.
- ec2 service docs: introspection field list documents `containerId`.

## Test plan

- Rust: `cargo build`/`clippy` on `fakecloud` + `fakecloud-sdk` green.
- Go builds (`go build ./...`), Python parses; PHP/Java/TS validated by the SDK CI job.
- TS + Python e2e tests assert the new field is `null`-or-string.
- Field is additive + nullable, so deserialization stays backward-compatible (no SDK constructs `Ec2Instance` literally).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the backing container/Pod for EC2 instances in introspection and all SDKs so callers can see which container backs an instance, or if it’s metadata-only.

- **New Features**
  - Added `containerId` to `GET /_fakecloud/ec2/instances`; server populates it from the runtime.
  - SDKs: Rust `Option<String>`, Go `*string`, Python `Optional[str]`, TypeScript `string | null`, Java record field, PHP nullable arg.
  - Docs list `containerId`; TS/Python tests assert null-or-string.

- **Bug Fixes**
  - CI: SDK workflows use a dedicated `shared-key` for `Swatinem/rust-cache` to avoid `ci.yml` `test` cache collisions and the dangling `./target` symlink that broke `cargo build`.

<sup>Written for commit 8088ec268208f0a7f556f542fab7399577d3503c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

