### PR TITLE
fix(rds): persist Tags supplied to CreateDBInstance

### DIFF
--- a/crates/fakecloud-rds/src/runtime/mod.rs
+++ b/crates/fakecloud-rds/src/runtime/mod.rs
@@ -142,6 +142,28 @@ impl RdsRuntime {
         }
     }
 
+    /// Test-only runtime that needs no container daemon. Handler tests that
+    /// only assert the synchronously-stored "creating" placeholder (e.g.
+    /// create-time tag persistence) just need `require_runtime` to return
+    /// `Some`; the async container-start that follows fails harmlessly in
+    /// the background and never touches the asserted fields.
+    #[cfg(test)]
+    pub(crate) fn new_stub() -> Self {
+        Self {
+            cli: "true".to_string(),
+            containers: RwLock::new(HashMap::new()),
+            instance_id: format!("fakecloud-{}", std::process::id()),
+            net: HostNetworking {
+                host_alias: String::new(),
+                add_host_arg: None,
+                sibling_host: "127.0.0.1".to_string(),
+            },
+            server_port: 0,
+            image_cache: RwLock::new(HashMap::new()),
+            k8s: None,
+        }
+    }
+
     /// Sweep DB Pods orphaned by a previous process (k8s only; no-op on
     /// the Docker backend, which the shared container reaper handles).
     pub async fn reap_stale(&self) {

--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -79,6 +79,11 @@ impl RdsService {
         let copy_tags_to_snapshot =
             parse_optional_bool(optional_query_param(request, "CopyTagsToSnapshot").as_deref())?;
         let db_cluster_identifier = optional_query_param(request, "DBClusterIdentifier");
+        // Tags supplied at create time. Real RDS applies these to the new
+        // instance immediately (they show up in DescribeDBInstances /
+        // ListTagsForResource without a follow-up AddTagsToResource call),
+        // so persist them on the instance rather than dropping them.
+        let request_tags = parse_tags(request)?;
 
         validate_create_request(
             &db_instance_identifier,
@@ -146,7 +151,7 @@ impl RdsService {
                 master_user_password: master_user_password.clone(),
                 container_id: String::new(),
                 host_port: 0,
-                tags: Vec::new(),
+                tags: request_tags,
                 read_replica_source_db_instance_identifier: None,
                 read_replica_db_instance_identifiers: Vec::new(),
                 vpc_security_group_ids,

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -2152,6 +2152,51 @@ async fn create_db_instance_unsupported_engine_errors() {
     assert!(svc.create_db_instance(&req).await.is_err());
 }
 
+#[tokio::test]
+async fn create_db_instance_persists_request_tags() {
+    // Real RDS applies create-time `Tags` immediately. The stub runtime
+    // lets the handler reach the synchronously-stored "creating"
+    // placeholder without a container daemon; the background start fails
+    // harmlessly and never touches `tags`.
+    let svc = make_service().with_runtime(Arc::new(crate::runtime::RdsRuntime::new_stub()));
+    let req = request(
+        "CreateDBInstance",
+        &[
+            ("DBInstanceIdentifier", "tagged-db"),
+            ("Engine", "postgres"),
+            ("DBInstanceClass", "db.t3.micro"),
+            ("AllocatedStorage", "20"),
+            ("MasterUsername", "admin"),
+            ("MasterUserPassword", "secretpass"),
+            ("Tags.Tag.1.Key", "env"),
+            ("Tags.Tag.1.Value", "prod"),
+            ("Tags.Tag.2.Key", "owner"),
+            ("Tags.Tag.2.Value", "platform"),
+        ],
+    );
+    svc.create_db_instance(&req).await.expect("create ok");
+
+    let accounts = svc.state.read();
+    let state = accounts.default_ref();
+    let inst = state
+        .instances
+        .get("tagged-db")
+        .expect("placeholder stored");
+    assert_eq!(
+        inst.tags,
+        vec![
+            RdsTag {
+                key: "env".to_string(),
+                value: "prod".to_string()
+            },
+            RdsTag {
+                key: "owner".to_string(),
+                value: "platform".to_string()
+            },
+        ]
+    );
+}
+
 // ── restore_db_instance_from_db_snapshot ──
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

`CreateDBInstance` silently drops the `Tags` supplied in the request: the new instance is stored with an empty tag set, so create-time tags only appear in `DescribeDBInstances` / `ListTagsForResource` after a follow-up `AddTagsToResource` call. Real RDS applies create-time tags immediately, and the restore/replica paths in fakecloud already do (`build_restored_instance` writes the parsed tags onto the new instance). `CreateDBInstance` was the outlier.

This parses the request `Tags` with the existing `parse_tags` helper and stores them on the new instance.

## Why a separate PR

This came up while drafting the k8s Pod-scheduling follow-ups to #1733 (per-instance scheduling reads a resource's tags, and for RDS there were none at create time). As discussed there, it's a standalone correctness fix rather than part of the scheduling wiring, so it gets its own review/changelog line.

## Change

- `create_db_instance` now calls `parse_tags(request)?` and stores the result on the placeholder `DbInstance` instead of `Vec::new()`.

## Behavior before / after

```sh
aws rds create-db-instance --db-instance-identifier db1 --engine postgres \
  --db-instance-class db.t3.micro --tags Key=env,Value=prod
aws rds list-tags-for-resource --resource-name arn:aws:rds:...:db:db1
```

- Before: returns no tags (the `env=prod` tag was dropped).
- After: returns `env=prod`, matching real RDS.

## Tests

- New unit test `create_db_instance_persists_request_tags` drives the create handler and asserts the stored instance carries the create-time tags. It uses a small `#[cfg(test)]` stub runtime (`RdsRuntime::new_stub`) so the handler's `require_runtime` check passes without a container daemon; the create happy-path was previously only exercised in the docker-dependent e2e suite. The post-create background container start fails harmlessly in the stub and never touches `tags`.
- Full `fakecloud-rds` unit suite green; `cargo clippy` and `cargo fmt --check` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `CreateDBInstance` dropping request `Tags`. Create-time tags are now parsed and saved on the new instance, so they appear immediately in `DescribeDBInstances` and `ListTagsForResource`, matching AWS.

- **Bug Fixes**
  - Persist request tags on the placeholder instance; previously they only showed up after `AddTagsToResource`.
  - Added a unit test and a test-only runtime stub to verify create-time tag persistence.

<sup>Written for commit 1fe3db5cf00a04a68cb1fc0448fd6011c816292c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

