### PR TITLE
feat(rds): configurable k8s Pod nodeSelector, tolerations, and annotations

### DIFF
--- a/crates/fakecloud-rds/src/runtime/k8s.rs
+++ b/crates/fakecloud-rds/src/runtime/k8s.rs
@@ -29,7 +29,7 @@ use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use parking_lot::RwLock;
 use tokio_postgres::NoTls;
 
-use fakecloud_k8s::{labels, names, K8sClient, K8sEnv};
+use fakecloud_k8s::{labels, names, K8sClient, K8sEnv, K8sPodConfig};
 
 use super::{bridge_image_tag, BackendInitError, RunningDbContainer, RuntimeError};
 
@@ -67,6 +67,10 @@ pub(super) struct K8sDb {
     /// fakecloud.
     self_url: String,
     pull_secret: Option<String>,
+    /// Global + RDS-service node selector / tolerations / annotations
+    /// applied to every DB Pod. Per-instance tag overrides are merged over
+    /// this when the Pod is built.
+    pod_config: K8sPodConfig,
     /// Built Pod spec + port per instance id, so a reboot can recreate the
     /// Pod without re-deriving the engine config.
     specs: Arc<RwLock<HashMap<String, (Pod, u16)>>>,
@@ -84,6 +88,7 @@ impl std::fmt::Debug for K8sDb {
 impl K8sDb {
     pub(super) async fn from_env(server_port: u16) -> Result<Self, BackendInitError> {
         let env = K8sEnv::from_env(server_port)?;
+        let pod_config = K8sPodConfig::resolved_base("FAKECLOUD_RDS_K8S")?;
         let client = K8sClient::connect(env.namespace.clone())
             .await
             .map_err(|e| BackendInitError::Connect(e.to_string()))?;
@@ -96,6 +101,7 @@ impl K8sDb {
             client,
             self_url: env.self_url,
             pull_secret: env.pull_secret,
+            pod_config,
             specs: Arc::new(RwLock::new(HashMap::new())),
         })
     }
@@ -111,6 +117,7 @@ impl K8sDb {
         db_name: &str,
         account_id: &str,
         region: &str,
+        tags: &std::collections::BTreeMap<String, String>,
     ) -> Result<RunningDbContainer, RuntimeError> {
         let cfg = engine_config(
             &self.self_url,
@@ -123,7 +130,7 @@ impl K8sDb {
             region,
         )?;
         let pod_name = names::pod_name(POD_PREFIX, db_instance_identifier, db_instance_identifier);
-        let pod = build_pod(
+        let mut pod = build_pod(
             self.client.namespace(),
             self.client.instance_id(),
             self.pull_secret.as_deref(),
@@ -131,6 +138,13 @@ impl K8sDb {
             db_instance_identifier,
             &cfg,
         );
+        // Global + service base with this instance's reserved-tag
+        // overrides merged over it (per-instance tags win). Applied before
+        // the spec is cached so reboots reuse the same scheduling.
+        self.pod_config
+            .clone()
+            .merge(K8sPodConfig::from_tags(tags))
+            .apply(&mut pod);
 
         self.specs
             .write()
@@ -785,6 +799,45 @@ mod tests {
             .clone()
             .unwrap();
         assert_eq!(sc.privileged, Some(true));
+    }
+
+    #[test]
+    fn pod_config_overrides_apply_to_built_pod() {
+        use std::collections::BTreeMap;
+        // Mirrors the `ensure` wiring: service base merged with the
+        // instance's reserved-tag overrides, applied to the built Pod.
+        let cfg =
+            engine_config("http://fc:4566", "postgres", "16", "u", "p", "db", "0", "r").unwrap();
+        let mut pod = build_pod("ns", "i", None, "fakecloud-rds-x", "db1", &cfg);
+        let base = K8sPodConfig {
+            node_selector: BTreeMap::from([("pool".to_string(), "db".to_string())]),
+            ..Default::default()
+        };
+        let tags = BTreeMap::from([
+            (
+                "fakecloud-k8s/node-selector".to_string(),
+                "pool=spot,disktype=ssd".to_string(),
+            ),
+            (
+                "fakecloud-k8s/annotations".to_string(),
+                "team=data".to_string(),
+            ),
+        ]);
+        base.merge(K8sPodConfig::from_tags(&tags)).apply(&mut pod);
+
+        let spec = pod.spec.unwrap();
+        let sel = spec.node_selector.unwrap();
+        // Per-instance tag overrides the base on `pool`; base-only keys survive.
+        assert_eq!(sel.get("pool").map(String::as_str), Some("spot"));
+        assert_eq!(sel.get("disktype").map(String::as_str), Some("ssd"));
+        assert_eq!(
+            pod.metadata
+                .annotations
+                .unwrap()
+                .get("team")
+                .map(String::as_str),
+            Some("data")
+        );
     }
 
     #[test]

--- a/crates/fakecloud-rds/src/runtime/mod.rs
+++ b/crates/fakecloud-rds/src/runtime/mod.rs
@@ -85,6 +85,8 @@ pub enum RuntimeError {
 pub enum BackendInitError {
     #[error(transparent)]
     Env(#[from] fakecloud_k8s::K8sEnvError),
+    #[error(transparent)]
+    PodConfig(#[from] fakecloud_k8s::K8sPodConfigError),
     #[error("failed to connect to the Kubernetes cluster: {0}")]
     Connect(String),
 }
@@ -161,8 +163,16 @@ impl RdsRuntime {
         db_name: &str,
         account_id: &str,
         region: &str,
+        tags: &[crate::state::RdsTag],
     ) -> Result<RunningDbContainer, RuntimeError> {
         if let Some(k) = &self.k8s {
+            // Per-instance Pod scheduling overrides come from the
+            // resource's reserved `fakecloud-k8s/*` tags. Ignored on the
+            // Docker backend below.
+            let tag_map: std::collections::BTreeMap<String, String> = tags
+                .iter()
+                .map(|t| (t.key.clone(), t.value.clone()))
+                .collect();
             let running = k
                 .ensure(
                     db_instance_identifier,
@@ -173,6 +183,7 @@ impl RdsRuntime {
                     db_name,
                     account_id,
                     region,
+                    &tag_map,
                 )
                 .await?;
             self.containers

--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -226,6 +226,7 @@ impl RdsService {
             let snapshot_store = self.snapshot_store.clone();
             let snapshot_lock = self.snapshot_lock.clone();
             let cluster_id_for_attach = db_cluster_identifier.clone();
+            let instance_tags = instance.tags.clone();
             tokio::spawn(async move {
                 match runtime
                     .ensure_postgres(
@@ -237,6 +238,7 @@ impl RdsService {
                         &logical_db_name_task,
                         &account_id,
                         &region,
+                        &instance_tags,
                     )
                     .await
                 {

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -361,6 +361,7 @@ impl RdsService {
             username: String,
             password: String,
             db_name: String,
+            tags: Vec<crate::state::RdsTag>,
         }
 
         let pending: Vec<Pending> = {
@@ -402,6 +403,7 @@ impl RdsService {
                             .db_name
                             .clone()
                             .unwrap_or_else(|| default_db_name(&inst.engine).to_string()),
+                        tags: inst.tags.clone(),
                     });
                 }
             }
@@ -433,6 +435,7 @@ impl RdsService {
                         &p.db_name,
                         &p.account_id,
                         &p.region,
+                        &p.tags,
                     )
                     .await
                 {
@@ -594,6 +597,7 @@ impl RdsService {
                         .unwrap_or(default_db_name(&instance.engine)),
                     &request.account_id,
                     &request.region,
+                    &instance.tags,
                 )
                 .await
             {

--- a/crates/fakecloud-rds/src/service/replicas.rs
+++ b/crates/fakecloud-rds/src/service/replicas.rs
@@ -101,6 +101,9 @@ impl RdsService {
                 &db_name,
                 &request.account_id,
                 &request.region,
+                // A read replica inherits the source instance's Pod
+                // scheduling (no separate replica tag input here).
+                &source_instance.tags,
             )
             .await
         {

--- a/crates/fakecloud-rds/src/service/restore.rs
+++ b/crates/fakecloud-rds/src/service/restore.rs
@@ -160,6 +160,7 @@ impl RdsService {
                 &db_name,
                 &request.account_id,
                 &request.region,
+                &tags,
             )
             .await
         {
@@ -330,6 +331,7 @@ impl RdsService {
                 &db_name,
                 &request.account_id,
                 &request.region,
+                &tags,
             )
             .await
         {

--- a/crates/fakecloud-rds/src/service/snapshots.rs
+++ b/crates/fakecloud-rds/src/service/snapshots.rs
@@ -444,6 +444,7 @@ impl RdsService {
                 db_name,
                 &request.account_id,
                 &request.region,
+                &tags,
             )
             .await
         {


### PR DESCRIPTION
## Summary

Wires the shared `K8sPodConfig` module (added in #1733) into the **RDS** k8s backend, so DB instance Pods honor operator-configured node selectors, tolerations, and annotations. Second of the four follow-up PRs you green-lit on #1733.

Resolution is the same three-level model as Lambda, lowest to highest precedence:

1. **Global** env: `FAKECLOUD_K8S_NODE_SELECTOR` / `_TOLERATIONS` / `_ANNOTATIONS`
2. **Per-service** env: `FAKECLOUD_RDS_K8S_NODE_SELECTOR` / `_TOLERATIONS` / `_ANNOTATIONS`
3. **Per-instance** reserved tags on the DB instance: `fakecloud-k8s/node-selector`, `fakecloud-k8s/tolerations`, `fakecloud-k8s/annotations`

Maps merge per key (higher wins); tolerations combine additively; malformed env fails fast, malformed tag warns-and-skips — all inherited from the shared module.

## Implementation

- `K8sDb` stores the global+service base (`K8sPodConfig::resolved_base("FAKECLOUD_RDS_K8S")`) at `from_env`.
- `ensure` merges the instance's reserved-tag overrides over the base and `apply`s the result to the built Pod **before it is cached**, so a reboot (which recreates from the cached spec) reuses the same scheduling.
- The DB instance's tags are plumbed to the builder through `ensure_postgres` at every launch site: create, start, crash-recovery, read-replica, restore-from-snapshot, restore-to-point-in-time, and restore-from-S3. A **read replica inherits its source instance's** scheduling (there's no separate replica tag input on that path).

## Relationship to the other PRs

- Builds on the shared `pod_config` module from #1733.
- Independent of the RDS create-time tag fix (#1740), but complementary: until #1740 lands, `CreateDBInstance` stores no tags, so per-instance scheduling on a brand-new instance takes effect after `AddTagsToResource` + a reboot. With #1740, it works at create time too. This PR needs no changes either way.

## Tests

- Unit test `pod_config_overrides_apply_to_built_pod` builds a real DB Pod via `build_pod` and asserts the merged base+tag config (node selector override + added annotation) lands on it — mirroring the `ensure` wiring.
- Full `fakecloud-rds` unit suite green; `cargo clippy` / `cargo fmt --check` clean. The k8s integration suite is feature-gated and needs a cluster (not run here).

## Docs

The general "Pod scheduling and metadata" guide section from #1733 already documents the model and the `FAKECLOUD_<SERVICE>_K8S_*` / tag conventions for all services, so no per-service doc change is needed here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable Kubernetes Pod scheduling for RDS. DB Pods now honor nodeSelector, tolerations, and annotations with a clear precedence and consistent reuse across reboots.

- **New Features**
  - Integrates shared `K8sPodConfig` into the RDS k8s backend.
  - Precedence: global `FAKECLOUD_K8S_*`, service `FAKECLOUD_RDS_K8S_*`, then per-instance tags `fakecloud-k8s/node-selector`, `fakecloud-k8s/tolerations`, `fakecloud-k8s/annotations`; per-key merge, tolerations additive; malformed env fails fast, malformed tags warn-and-skip.
  - Applies config before the Pod spec is cached, so reboots keep the same scheduling.
  - Plumbs instance tags through all launch paths (create/start/crash-recovery/read-replica/restores). Read replicas inherit the source instance’s scheduling.
  - Adds a unit test asserting the merged config lands on the built Pod.

<sup>Written for commit 5ce95bea89ec84706ea539351557bfbdb82b5bcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

