### PR TITLE
feat(elasticache): configurable k8s Pod nodeSelector, tolerations, and annotations

### DIFF
--- a/crates/fakecloud-elasticache/src/runtime/k8s.rs
+++ b/crates/fakecloud-elasticache/src/runtime/k8s.rs
@@ -101,6 +101,7 @@ impl K8sCache {
         resource_id: &str,
         engine: CacheEngineKind,
         rdb_path: Option<&str>,
+        tags: &std::collections::BTreeMap<String, String>,
     ) -> Result<RunningCacheContainer, RuntimeError> {
         let rdb = match rdb_path {
             Some(path) => Some(tokio::fs::read(path).await.map_err(|e| {
@@ -108,7 +109,7 @@ impl K8sCache {
             })?),
             None => None,
         };
-        self.spawn_pod_bytes(resource_id, engine, rdb).await
+        self.spawn_pod_bytes(resource_id, engine, rdb, tags).await
     }
 
     async fn spawn_pod_bytes(
@@ -116,6 +117,7 @@ impl K8sCache {
         resource_id: &str,
         engine: CacheEngineKind,
         rdb: Option<Vec<u8>>,
+        tags: &std::collections::BTreeMap<String, String>,
     ) -> Result<RunningCacheContainer, RuntimeError> {
         let pod_name = names::pod_name(POD_PREFIX, resource_id, resource_id);
         let port = engine.port();
@@ -148,10 +150,15 @@ impl K8sCache {
             internal_token: &self.internal_token,
             pull_secret: self.pull_secret.as_deref(),
         });
-        // Operator-configured global + ElastiCache-service scheduling /
-        // metadata. Every spawn path (create, serverless, replication,
-        // recovery, reboot) funnels through here, so this covers them all.
-        self.pod_config.apply(&mut pod);
+        // Operator-configured global + ElastiCache-service base, with this
+        // resource's reserved `fakecloud-k8s/*` tag overrides merged over it
+        // (per-instance wins). Every spawn path (create, serverless,
+        // replication, recovery, reboot) funnels through here, so this
+        // covers them all.
+        self.pod_config
+            .clone()
+            .merge(K8sPodConfig::from_tags(tags))
+            .apply(&mut pod);
 
         let result = self.launch(&pod, &pod_name, port, engine).await;
         // Whatever happened, the staged RDB is no longer needed: a
@@ -265,6 +272,7 @@ impl K8sCache {
         &self,
         resource_id: &str,
         running: &RunningCacheContainer,
+        tags: &std::collections::BTreeMap<String, String>,
     ) -> Result<RunningCacheContainer, RuntimeError> {
         let preserved = if matches!(running.engine, CacheEngineKind::Redis) {
             self.snapshot_live_rdb(&running.container_id).await
@@ -272,7 +280,7 @@ impl K8sCache {
             None
         };
         self.client.delete_pod(&running.container_id).await;
-        self.spawn_pod_bytes(resource_id, running.engine, preserved)
+        self.spawn_pod_bytes(resource_id, running.engine, preserved, tags)
             .await
     }
 
@@ -504,6 +512,44 @@ mod tests {
                 .get("team")
                 .map(String::as_str),
             Some("platform")
+        );
+    }
+
+    #[test]
+    fn pod_config_overrides_apply_to_built_pod() {
+        use std::collections::BTreeMap;
+        // Mirrors the spawn_pod_bytes wiring: ElastiCache-service base
+        // merged with the resource's reserved-tag overrides, applied to the
+        // built cache Pod.
+        let mut pod = build_cache_pod(ctx(None));
+        let base = K8sPodConfig {
+            node_selector: BTreeMap::from([("pool".to_string(), "cache".to_string())]),
+            ..Default::default()
+        };
+        let tags = BTreeMap::from([
+            (
+                "fakecloud-k8s/node-selector".to_string(),
+                "pool=spot,disktype=ssd".to_string(),
+            ),
+            (
+                "fakecloud-k8s/annotations".to_string(),
+                "team=data".to_string(),
+            ),
+        ]);
+        base.merge(K8sPodConfig::from_tags(&tags)).apply(&mut pod);
+
+        let spec = pod.spec.unwrap();
+        let sel = spec.node_selector.unwrap();
+        // Per-instance tag overrides the base on `pool`; base-only keys survive.
+        assert_eq!(sel.get("pool").map(String::as_str), Some("spot"));
+        assert_eq!(sel.get("disktype").map(String::as_str), Some("ssd"));
+        assert_eq!(
+            pod.metadata
+                .annotations
+                .unwrap()
+                .get("team")
+                .map(String::as_str),
+            Some("data")
         );
     }
 }

--- a/crates/fakecloud-elasticache/src/runtime/k8s.rs
+++ b/crates/fakecloud-elasticache/src/runtime/k8s.rs
@@ -22,7 +22,7 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use parking_lot::RwLock;
 
-use fakecloud_k8s::{labels, names, K8sClient, K8sEnv};
+use fakecloud_k8s::{labels, names, K8sClient, K8sEnv, K8sPodConfig};
 
 use super::{BackendInitError, CacheEngineKind, CacheExec, RunningCacheContainer, RuntimeError};
 
@@ -50,6 +50,9 @@ pub(super) struct K8sCache {
     internal_token: String,
     /// Optional `imagePullSecrets` name for private registries.
     pull_secret: Option<String>,
+    /// Global + ElastiCache-service node selector / tolerations /
+    /// annotations applied to every cache Pod.
+    pod_config: K8sPodConfig,
     pending_rdb: PendingRdb,
 }
 
@@ -68,6 +71,7 @@ impl K8sCache {
         internal_token: String,
     ) -> Result<Self, BackendInitError> {
         let env = K8sEnv::from_env(server_port)?;
+        let pod_config = K8sPodConfig::resolved_base("FAKECLOUD_ELASTICACHE_K8S")?;
         let client = K8sClient::connect(env.namespace.clone())
             .await
             .map_err(|e| BackendInitError::Connect(e.to_string()))?;
@@ -81,6 +85,7 @@ impl K8sCache {
             self_url: env.self_url,
             internal_token,
             pull_secret: env.pull_secret,
+            pod_config,
             pending_rdb: Arc::new(RwLock::new(HashMap::new())),
         })
     }
@@ -132,7 +137,7 @@ impl K8sCache {
             None
         };
 
-        let pod = build_cache_pod(CachePodContext {
+        let mut pod = build_cache_pod(CachePodContext {
             pod_name: &pod_name,
             namespace: self.client.namespace(),
             instance_id: self.client.instance_id(),
@@ -143,6 +148,10 @@ impl K8sCache {
             internal_token: &self.internal_token,
             pull_secret: self.pull_secret.as_deref(),
         });
+        // Operator-configured global + ElastiCache-service scheduling /
+        // metadata. Every spawn path (create, serverless, replication,
+        // recovery, reboot) funnels through here, so this covers them all.
+        self.pod_config.apply(&mut pod);
 
         let result = self.launch(&pod, &pod_name, port, engine).await;
         // Whatever happened, the staged RDB is no longer needed: a
@@ -468,5 +477,33 @@ mod tests {
         let pod = build_cache_pod(c);
         let secrets = pod.spec.unwrap().image_pull_secrets.unwrap();
         assert_eq!(secrets[0].name, "reg-secret");
+    }
+
+    #[test]
+    fn pod_config_base_applies_to_built_pod() {
+        use std::collections::BTreeMap;
+        // The global + service env base (resolved at from_env) is applied
+        // to every cache Pod in spawn_pod_bytes; this asserts the apply
+        // contract over a built cache Pod.
+        let mut pod = build_cache_pod(ctx(None));
+        let cfg = K8sPodConfig {
+            node_selector: BTreeMap::from([("pool".to_string(), "cache".to_string())]),
+            annotations: BTreeMap::from([("team".to_string(), "platform".to_string())]),
+            ..Default::default()
+        };
+        cfg.apply(&mut pod);
+        let spec = pod.spec.unwrap();
+        assert_eq!(
+            spec.node_selector.unwrap().get("pool").map(String::as_str),
+            Some("cache")
+        );
+        assert_eq!(
+            pod.metadata
+                .annotations
+                .unwrap()
+                .get("team")
+                .map(String::as_str),
+            Some("platform")
+        );
     }
 }

--- a/crates/fakecloud-elasticache/src/runtime/mod.rs
+++ b/crates/fakecloud-elasticache/src/runtime/mod.rs
@@ -89,6 +89,8 @@ pub enum RuntimeError {
 pub enum BackendInitError {
     #[error(transparent)]
     Env(#[from] fakecloud_k8s::K8sEnvError),
+    #[error(transparent)]
+    PodConfig(#[from] fakecloud_k8s::K8sPodConfigError),
     #[error("failed to connect to the Kubernetes cluster: {0}")]
     Connect(String),
 }

--- a/crates/fakecloud-elasticache/src/runtime/mod.rs
+++ b/crates/fakecloud-elasticache/src/runtime/mod.rs
@@ -10,7 +10,7 @@
 
 mod k8s;
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -174,6 +174,7 @@ impl ElastiCacheRuntime {
         &self,
         resource_id: &str,
         rdb_path: Option<&str>,
+        tags: &BTreeMap<String, String>,
     ) -> Result<RunningCacheContainer, RuntimeError> {
         let running = match &self.backend {
             CacheBackend::Docker(d) => {
@@ -181,7 +182,7 @@ impl ElastiCacheRuntime {
                     .await?
             }
             CacheBackend::K8s(k) => {
-                k.spawn_pod(resource_id, CacheEngineKind::Redis, rdb_path)
+                k.spawn_pod(resource_id, CacheEngineKind::Redis, rdb_path, tags)
                     .await?
             }
         };
@@ -194,6 +195,7 @@ impl ElastiCacheRuntime {
     pub async fn ensure_memcached(
         &self,
         resource_id: &str,
+        tags: &BTreeMap<String, String>,
     ) -> Result<RunningCacheContainer, RuntimeError> {
         let running = match &self.backend {
             CacheBackend::Docker(d) => {
@@ -201,7 +203,7 @@ impl ElastiCacheRuntime {
                     .await?
             }
             CacheBackend::K8s(k) => {
-                k.spawn_pod(resource_id, CacheEngineKind::Memcached, None)
+                k.spawn_pod(resource_id, CacheEngineKind::Memcached, None, tags)
                     .await?
             }
         };
@@ -224,7 +226,11 @@ impl ElastiCacheRuntime {
     /// Restart the underlying backing instance, mirroring real
     /// ElastiCache's RebootCacheCluster behaviour. Returns `Unavailable`
     /// if the resource has no live instance tracked here.
-    pub async fn restart_container(&self, resource_id: &str) -> Result<(), RuntimeError> {
+    pub async fn restart_container(
+        &self,
+        resource_id: &str,
+        tags: &BTreeMap<String, String>,
+    ) -> Result<(), RuntimeError> {
         let running = {
             let containers = self.containers.read();
             containers.get(resource_id).cloned()
@@ -236,7 +242,9 @@ impl ElastiCacheRuntime {
                 // A Pod can't be restarted in place; recreate it,
                 // preserving Redis data by snapshotting it across the
                 // recreate. The new Pod keeps the same deterministic name.
-                let updated = k.reboot_pod(resource_id, &running).await?;
+                // Per-instance scheduling tags are re-applied to the fresh
+                // Pod so a reboot keeps the resource's node placement.
+                let updated = k.reboot_pod(resource_id, &running, tags).await?;
                 self.containers
                     .write()
                     .insert(resource_id.to_string(), updated);

--- a/crates/fakecloud-elasticache/src/service/clusters.rs
+++ b/crates/fakecloud-elasticache/src/service/clusters.rs
@@ -265,11 +265,17 @@ impl ElastiCacheService {
             let account_id = request.account_id.clone();
             let id = cache_cluster_id.clone();
             let is_memcached = engine == ENGINE_MEMCACHED;
+            // Reserved `fakecloud-k8s/*` scheduling tags for this cluster's
+            // Pod, from the create-time tags (ignored on the Docker backend).
+            let pod_tags: std::collections::BTreeMap<String, String> =
+                tags.iter().cloned().collect();
             tokio::spawn(async move {
                 let result = if is_memcached {
-                    runtime.ensure_memcached(&id).await
+                    runtime.ensure_memcached(&id, &pod_tags).await
                 } else {
-                    runtime.ensure_redis(&id, rdb_path.as_deref()).await
+                    runtime
+                        .ensure_redis(&id, rdb_path.as_deref(), &pod_tags)
+                        .await
                 };
                 let mut stop_container = false;
                 {
@@ -491,7 +497,7 @@ impl ElastiCacheService {
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let id = required_query_param(request, "CacheClusterId")?;
-        let xml = {
+        let (xml, pod_tags) = {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
             let cluster = state.cache_clusters.get_mut(&id).ok_or_else(|| {
@@ -502,14 +508,23 @@ impl ElastiCacheService {
                 )
             })?;
             cluster.cache_cluster_status = "rebooting cache cluster nodes".to_string();
-            cache_cluster_xml(cluster, true)
+            let arn = cluster.arn.clone();
+            let xml = cache_cluster_xml(cluster, true);
+            // Re-apply this cluster's reserved `fakecloud-k8s/*` scheduling
+            // tags to the recreated Pod (ignored on the Docker backend).
+            let pod_tags: std::collections::BTreeMap<String, String> = state
+                .tags
+                .get(&arn)
+                .map(|t| t.iter().cloned().collect())
+                .unwrap_or_default();
+            (xml, pod_tags)
         };
         // Restart the underlying engine container so a real client
         // observes the reboot. Best-effort: if no runtime is wired up
         // (eg. tests, environments without docker) the API call still
         // reflects the rebooting state.
         if let Some(runtime) = &self.runtime {
-            if let Err(error) = runtime.restart_container(&id).await {
+            if let Err(error) = runtime.restart_container(&id, &pod_tags).await {
                 tracing::warn!(
                     cluster_id = %id,
                     %error,

--- a/crates/fakecloud-elasticache/src/service/mod.rs
+++ b/crates/fakecloud-elasticache/src/service/mod.rs
@@ -284,10 +284,25 @@ impl ElastiCacheService {
             let snapshot_store = self.snapshot_store.clone();
             let snapshot_lock = self.snapshot_lock.clone();
             tokio::spawn(async move {
+                // Re-derive this cluster's reserved `fakecloud-k8s/*`
+                // scheduling tags from persisted state so the recreated Pod
+                // keeps its node placement across a restart.
+                let pod_tags: std::collections::BTreeMap<String, String> = {
+                    let accounts = state.read();
+                    accounts
+                        .get(&c.account_id)
+                        .and_then(|s| {
+                            s.cache_clusters
+                                .get(&c.id)
+                                .and_then(|cl| s.tags.get(&cl.arn))
+                        })
+                        .map(|t| t.iter().cloned().collect())
+                        .unwrap_or_default()
+                };
                 let result = if c.engine == "memcached" {
-                    runtime.ensure_memcached(&c.id).await
+                    runtime.ensure_memcached(&c.id, &pod_tags).await
                 } else {
-                    runtime.ensure_redis(&c.id, None).await
+                    runtime.ensure_redis(&c.id, None, &pod_tags).await
                 };
                 match result {
                     Ok(running) => {
@@ -332,10 +347,24 @@ impl ElastiCacheService {
             let snapshot_store = self.snapshot_store.clone();
             let snapshot_lock = self.snapshot_lock.clone();
             tokio::spawn(async move {
+                // Re-derive this group's reserved `fakecloud-k8s/*`
+                // scheduling tags from persisted state for the recreated Pod.
+                let pod_tags: std::collections::BTreeMap<String, String> = {
+                    let accounts = state.read();
+                    accounts
+                        .get(&r.account_id)
+                        .and_then(|s| {
+                            s.replication_groups
+                                .get(&r.id)
+                                .and_then(|rg| s.tags.get(&rg.arn))
+                        })
+                        .map(|t| t.iter().cloned().collect())
+                        .unwrap_or_default()
+                };
                 let result = if r.engine == "memcached" {
-                    runtime.ensure_memcached(&r.id).await
+                    runtime.ensure_memcached(&r.id, &pod_tags).await
                 } else {
-                    runtime.ensure_redis(&r.id, None).await
+                    runtime.ensure_redis(&r.id, None, &pod_tags).await
                 };
                 match result {
                     Ok(running) => {
@@ -379,7 +408,21 @@ impl ElastiCacheService {
             let snapshot_store = self.snapshot_store.clone();
             let snapshot_lock = self.snapshot_lock.clone();
             tokio::spawn(async move {
-                match runtime.ensure_redis(&s.name, None).await {
+                // Re-derive this serverless cache's reserved `fakecloud-k8s/*`
+                // scheduling tags from persisted state for the recreated Pod.
+                let pod_tags: std::collections::BTreeMap<String, String> = {
+                    let accounts = state.read();
+                    accounts
+                        .get(&s.account_id)
+                        .and_then(|st| {
+                            st.serverless_caches
+                                .get(&s.name)
+                                .and_then(|c| st.tags.get(&c.arn))
+                        })
+                        .map(|t| t.iter().cloned().collect())
+                        .unwrap_or_default()
+                };
+                match runtime.ensure_redis(&s.name, None, &pod_tags).await {
                     Ok(running) => {
                         {
                             let mut accounts = state.write();

--- a/crates/fakecloud-elasticache/src/service/replication.rs
+++ b/crates/fakecloud-elasticache/src/service/replication.rs
@@ -265,8 +265,14 @@ impl ElastiCacheService {
             let account_id = request.account_id.clone();
             let id = replication_group_id.clone();
             let cluster_enabled_flag = cluster_enabled;
+            // Reserved `fakecloud-k8s/*` scheduling tags from the create
+            // request (ignored on the Docker backend).
+            let pod_tags: std::collections::BTreeMap<String, String> =
+                tags.iter().cloned().collect();
             tokio::spawn(async move {
-                let result = runtime.ensure_redis(&id, rdb_path.as_deref()).await;
+                let result = runtime
+                    .ensure_redis(&id, rdb_path.as_deref(), &pod_tags)
+                    .await;
                 let mut stop_container = false;
                 {
                     let mut accounts = state.write();

--- a/crates/fakecloud-elasticache/src/service/serverless.rs
+++ b/crates/fakecloud-elasticache/src/service/serverless.rs
@@ -123,8 +123,12 @@ impl ElastiCacheService {
             let snapshot_lock = self.snapshot_lock.clone();
             let account_id = request.account_id.clone();
             let name = serverless_cache_name.clone();
+            // Reserved `fakecloud-k8s/*` scheduling tags from the create
+            // request (ignored on the Docker backend).
+            let pod_tags: std::collections::BTreeMap<String, String> =
+                tags.iter().cloned().collect();
             tokio::spawn(async move {
-                let result = runtime.ensure_redis(&name, None).await;
+                let result = runtime.ensure_redis(&name, None, &pod_tags).await;
                 let mut stop_container = false;
                 {
                     let mut accounts = state.write();


### PR DESCRIPTION
## Summary

Wires the shared `K8sPodConfig` module (#1733) into the **ElastiCache** k8s backend, so cache Pods honor operator-configured node selectors, tolerations, and annotations. Third of the four follow-ups you green-lit.

- **Global** env: `FAKECLOUD_K8S_NODE_SELECTOR` / `_TOLERATIONS` / `_ANNOTATIONS`
- **Per-service** env: `FAKECLOUD_ELASTICACHE_K8S_NODE_SELECTOR` / `_TOLERATIONS` / `_ANNOTATIONS`

The service base (global merged with the ElastiCache-service overrides) is resolved once at `from_env` and applied in `spawn_pod_bytes` — the single chokepoint that **every** spawn path funnels through (CreateCacheCluster, serverless, replication groups, crash-recovery, and RebootCacheCluster), so all of them are covered uniformly with no per-call-site changes.

## Per-instance tags: deferred (scoping note)

Lambda (#1733) and RDS (#1741) also support per-instance overrides via `fakecloud-k8s/*` tags, because their tags live on the resource struct and are in scope at Pod-build time. ElastiCache stores tags in a separate by-ARN map (`ElastiCacheState.tags`), so threading per-instance tags down to the builder is a larger, separate change across the create/serverless/replication/recovery/reboot paths. This PR delivers the global + per-service levels (which cover the cluster-wide scheduling use case); per-instance tag overrides for ElastiCache can follow using the same `K8sPodConfig::from_tags` + `merge` helpers. Happy to do that follow-up if you'd like it in this PR instead.

## Tests

- Unit test asserting the resolved config applies (node selector + annotation) to a built cache Pod.
- Full `fakecloud-elasticache` unit suite green; `cargo clippy` / `cargo fmt --check` clean. K8s integration suite is feature-gated (needs a cluster); not run here.

## Docs

The general "Pod scheduling and metadata" section added in #1733 already covers the env-var model and the `FAKECLOUD_<SERVICE>_K8S_*` convention for all services.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable scheduling and metadata for ElastiCache k8s Pods via `K8sPodConfig`. Pods now honor global and per-service env defaults and per-instance `fakecloud-k8s/*` tag overrides across all spawn paths, including reboot and recovery.

- **New Features**
  - Builds a base from `FAKECLOUD_K8S_*` and `FAKECLOUD_ELASTICACHE_K8S_*`.
  - Merges per-instance `fakecloud-k8s/node-selector`, `fakecloud-k8s/tolerations`, and `fakecloud-k8s/annotations` over the base (per-instance wins).
  - Applies config in the spawn chokepoint for create, serverless, replication, recovery, and reboot; reboot/recovery re-derive tags from state to keep node placement.

- **Migration**
  - To control scheduling/annotations, set `FAKECLOUD_K8S_*` or `FAKECLOUD_ELASTICACHE_K8S_*`, and optionally add `fakecloud-k8s/*` tags on resources.
  - No other changes; Docker backend ignores these settings.

<sup>Written for commit 58fdf04f6b982686d8e3d470e6d3c3d0eb3971f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

