### PR TITLE
feat(ecs): configurable k8s Pod nodeSelector, tolerations, and annotations

### DIFF
--- a/crates/fakecloud-ecs/src/runtime/k8s.rs
+++ b/crates/fakecloud-ecs/src/runtime/k8s.rs
@@ -37,7 +37,7 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use parking_lot::RwLock;
 
-use fakecloud_k8s::{labels, names, K8sClient, K8sEnv};
+use fakecloud_k8s::{labels, names, K8sClient, K8sEnv, K8sPodConfig};
 
 use super::{
     build_container_plans, finalize_stopped_multi, mark_pull_started, mark_pull_stopped,
@@ -54,6 +54,8 @@ const POD_PREFIX: &str = "fakecloud-ecs";
 pub enum BackendInitError {
     #[error(transparent)]
     Env(#[from] fakecloud_k8s::K8sEnvError),
+    #[error(transparent)]
+    PodConfig(#[from] fakecloud_k8s::K8sPodConfigError),
     #[error("failed to connect to the Kubernetes cluster: {0}")]
     Connect(String),
 }
@@ -65,6 +67,10 @@ pub(super) struct K8sTaskBackend {
     ecr_host: String,
     ecr_port: u16,
     pull_secret: Option<String>,
+    /// Global + ECS-service node selector / tolerations / annotations
+    /// applied to every task Pod. Per-task tag overrides are merged over
+    /// this when the Pod is built.
+    pod_config: K8sPodConfig,
     /// task_id -> Pod name, so StopTask/stop_all can find the Pod.
     pods: RwLock<HashMap<String, String>>,
 }
@@ -81,6 +87,7 @@ impl std::fmt::Debug for K8sTaskBackend {
 impl K8sTaskBackend {
     pub(super) async fn from_env(server_port: u16) -> Result<Self, BackendInitError> {
         let env = K8sEnv::from_env(server_port)?;
+        let pod_config = K8sPodConfig::resolved_base("FAKECLOUD_ECS_K8S")?;
         let client = K8sClient::connect(env.namespace.clone())
             .await
             .map_err(|e| BackendInitError::Connect(e.to_string()))?;
@@ -95,6 +102,7 @@ impl K8sTaskBackend {
             ecr_host: env.ecr_host,
             ecr_port: env.ecr_port,
             pull_secret: env.pull_secret,
+            pod_config,
             pods: RwLock::new(HashMap::new()),
         })
     }
@@ -179,8 +187,24 @@ impl EcsRuntime {
             resolved.push((plan, env));
         }
 
+        // Per-task Pod scheduling overrides come from the task's reserved
+        // `fakecloud-k8s/*` tags, merged over the global + ECS-service base.
+        let task_tags: std::collections::BTreeMap<String, String> = {
+            let accounts = state.read();
+            accounts
+                .get(account_id)
+                .and_then(|s| s.tasks.get(task_id))
+                .map(|t| {
+                    t.tags
+                        .iter()
+                        .map(|tag| (tag.key.clone(), tag.value.clone()))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+
         let pod_name = names::pod_name(POD_PREFIX, task_id, task_id);
-        let (pod, container_map) = build_task_pod(
+        let (mut pod, container_map) = build_task_pod(
             &pod_name,
             backend.client.namespace(),
             backend.client.instance_id(),
@@ -190,6 +214,11 @@ impl EcsRuntime {
             task_id,
             &resolved,
         );
+        backend
+            .pod_config
+            .clone()
+            .merge(K8sPodConfig::from_tags(&task_tags))
+            .apply(&mut pod);
 
         backend
             .pods
@@ -751,6 +780,43 @@ mod tests {
             "task-1",
             resolved,
         )
+    }
+
+    #[test]
+    fn pod_config_overrides_apply_to_built_task_pod() {
+        use std::collections::BTreeMap;
+        // Mirrors the k8s_run_task_inner wiring: ECS-service base merged
+        // with the task's reserved-tag overrides, applied to the task Pod.
+        let (mut pod, _map) = build(&[(plan("app", true), vec![])]);
+        let base = K8sPodConfig {
+            node_selector: BTreeMap::from([("pool".to_string(), "tasks".to_string())]),
+            ..Default::default()
+        };
+        let tags = BTreeMap::from([
+            (
+                "fakecloud-k8s/node-selector".to_string(),
+                "pool=spot".to_string(),
+            ),
+            (
+                "fakecloud-k8s/annotations".to_string(),
+                "team=batch".to_string(),
+            ),
+        ]);
+        base.merge(K8sPodConfig::from_tags(&tags)).apply(&mut pod);
+
+        let spec = pod.spec.unwrap();
+        assert_eq!(
+            spec.node_selector.unwrap().get("pool").map(String::as_str),
+            Some("spot")
+        );
+        assert_eq!(
+            pod.metadata
+                .annotations
+                .unwrap()
+                .get("team")
+                .map(String::as_str),
+            Some("batch")
+        );
     }
 
     fn rc(name: &str, essential: bool, exit: Option<i64>) -> RunningContainer {


### PR DESCRIPTION
## Summary

Wires the shared `K8sPodConfig` module (#1733) into the **ECS** k8s backend, so task Pods honor operator-configured node selectors, tolerations, and annotations — at all three levels:

1. **Global** env: `FAKECLOUD_K8S_NODE_SELECTOR` / `_TOLERATIONS` / `_ANNOTATIONS`
2. **Per-service** env: `FAKECLOUD_ECS_K8S_NODE_SELECTOR` / `_TOLERATIONS` / `_ANNOTATIONS`
3. **Per-task** reserved tags on the task: `fakecloud-k8s/node-selector`, `fakecloud-k8s/tolerations`, `fakecloud-k8s/annotations`

ECS task tags live on the `Task` itself and are in scope at Pod-build time (`RunTask` already parses and stores them, including `propagateTags`), so per-task overrides are wired here just like Lambda (#1733) and RDS (#1741).

## Implementation

- `K8sTaskBackend` resolves the global+service base (`K8sPodConfig::resolved_base("FAKECLOUD_ECS_K8S")`) at `from_env`.
- `k8s_run_task_inner` reads the task's tags from state, merges them over the base (per-task tags win), and applies the result to the task Pod before it is created. A task maps to exactly one Pod, so this single chokepoint covers it.

## Tests

- Unit test `pod_config_overrides_apply_to_built_task_pod` builds a task Pod and asserts the merged base+tag config (node-selector override + added annotation) lands on it.
- Full `fakecloud-ecs` unit suite green; `cargo clippy` / `cargo fmt --check` clean. K8s integration suite is feature-gated (needs a cluster); not run here.

## Docs

The "Pod scheduling and metadata" section from #1733 already documents the model and conventions for all services.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable Kubernetes Pod nodeSelector, tolerations, and annotations for ECS task Pods. Operators can set global/service defaults via env and override per task with tags for predictable scheduling and metadata.

- **New Features**
  - Integrated shared `K8sPodConfig` into the ECS Kubernetes backend and applied it when building the task Pod.
  - Supports env defaults: `FAKECLOUD_K8S_NODE_SELECTOR|_TOLERATIONS|_ANNOTATIONS` and service-scoped `FAKECLOUD_ECS_K8S_*`.
  - Allows per-task overrides via tags `fakecloud-k8s/node-selector`, `fakecloud-k8s/tolerations`, `fakecloud-k8s/annotations` (per-task wins).

<sup>Written for commit d3b1c60d66fb2d1c18cae7bb96ae038867fd2783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

