### PR TITLE
feat(ec2): configurable k8s Pod nodeSelector, tolerations, and annotations

### DIFF
--- a/crates/fakecloud-ec2/src/runtime/k8s.rs
+++ b/crates/fakecloud-ec2/src/runtime/k8s.rs
@@ -82,6 +82,7 @@ impl K8sInstances {
         instance_id: &str,
         image: &str,
         user_data: Option<&str>,
+        tags: &std::collections::BTreeMap<String, String>,
     ) -> Result<RunningInstance, RuntimeError> {
         let seq = self.spawn_seq.fetch_add(1, Ordering::Relaxed);
         let pod_name = names::pod_name(POD_PREFIX, instance_id, &format!("{instance_id}-{seq}"));
@@ -94,10 +95,14 @@ impl K8sInstances {
             user_data,
             pull_secret: self.pull_secret.as_deref(),
         });
-        // Operator-configured global + EC2-service scheduling / metadata.
-        // Every spawn (RunInstances, and Start/Reboot recreate) goes
-        // through here, so this covers them all.
-        self.pod_config.apply(&mut pod);
+        // Operator-configured global + EC2-service base, with this
+        // instance's reserved `fakecloud-k8s/*` tag overrides merged over it
+        // (per-instance wins). Every spawn (RunInstances, and Start/Reboot
+        // recreate) goes through here, so this covers them all.
+        self.pod_config
+            .clone()
+            .merge(K8sPodConfig::from_tags(tags))
+            .apply(&mut pod);
 
         self.client
             .create_pod(&pod)
@@ -299,6 +304,43 @@ mod tests {
             spec.node_selector.unwrap().get("pool").map(String::as_str),
             Some("ec2")
         );
+        assert_eq!(
+            pod.metadata
+                .annotations
+                .unwrap()
+                .get("team")
+                .map(String::as_str),
+            Some("infra")
+        );
+    }
+
+    #[test]
+    fn pod_config_overrides_apply_to_built_pod() {
+        use std::collections::BTreeMap;
+        // Mirrors the spawn_pod wiring: EC2-service base merged with the
+        // instance's reserved-tag overrides, applied to the built Pod.
+        let mut pod = build_instance_pod(ctx(None));
+        let base = K8sPodConfig {
+            node_selector: BTreeMap::from([("pool".to_string(), "ec2".to_string())]),
+            ..Default::default()
+        };
+        let tags = BTreeMap::from([
+            (
+                "fakecloud-k8s/node-selector".to_string(),
+                "pool=spot,disktype=ssd".to_string(),
+            ),
+            (
+                "fakecloud-k8s/annotations".to_string(),
+                "team=infra".to_string(),
+            ),
+        ]);
+        base.merge(K8sPodConfig::from_tags(&tags)).apply(&mut pod);
+
+        let spec = pod.spec.unwrap();
+        let sel = spec.node_selector.unwrap();
+        // Per-instance tag overrides the base on `pool`; base-only keys survive.
+        assert_eq!(sel.get("pool").map(String::as_str), Some("spot"));
+        assert_eq!(sel.get("disktype").map(String::as_str), Some("ssd"));
         assert_eq!(
             pod.metadata
                 .annotations

--- a/crates/fakecloud-ec2/src/runtime/k8s.rs
+++ b/crates/fakecloud-ec2/src/runtime/k8s.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use k8s_openapi::api::core::v1::{Container, LocalObjectReference, Pod, PodSpec};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-use fakecloud_k8s::{labels, names, K8sClient, K8sEnv};
+use fakecloud_k8s::{labels, names, K8sClient, K8sEnv, K8sPodConfig};
 
 use super::{boot_command, BackendInitError, RunningInstance, RuntimeError};
 
@@ -36,6 +36,9 @@ pub(super) struct K8sInstances {
     client: K8sClient,
     /// Optional `imagePullSecrets` name for private registries.
     pull_secret: Option<String>,
+    /// Global + EC2-service node selector / tolerations / annotations
+    /// applied to every instance Pod.
+    pod_config: K8sPodConfig,
     /// Monotonic counter making each spawned Pod name unique. `Start`/`Reboot`
     /// recreate an instance's Pod while the previous one may still be
     /// `Terminating`; a fresh name avoids a name collision with it (the old
@@ -62,9 +65,11 @@ impl K8sInstances {
             self_url = %env.self_url,
             "K8s EC2 backend initialized"
         );
+        let pod_config = K8sPodConfig::resolved_base("FAKECLOUD_EC2_K8S")?;
         Ok(Self {
             client,
             pull_secret: env.pull_secret,
+            pod_config,
             spawn_seq: Arc::new(AtomicU64::new(0)),
         })
     }
@@ -80,7 +85,7 @@ impl K8sInstances {
     ) -> Result<RunningInstance, RuntimeError> {
         let seq = self.spawn_seq.fetch_add(1, Ordering::Relaxed);
         let pod_name = names::pod_name(POD_PREFIX, instance_id, &format!("{instance_id}-{seq}"));
-        let pod = build_instance_pod(InstancePodContext {
+        let mut pod = build_instance_pod(InstancePodContext {
             pod_name: &pod_name,
             namespace: self.client.namespace(),
             instance_id_label: self.client.instance_id(),
@@ -89,6 +94,10 @@ impl K8sInstances {
             user_data,
             pull_secret: self.pull_secret.as_deref(),
         });
+        // Operator-configured global + EC2-service scheduling / metadata.
+        // Every spawn (RunInstances, and Start/Reboot recreate) goes
+        // through here, so this covers them all.
+        self.pod_config.apply(&mut pod);
 
         self.client
             .create_pod(&pod)
@@ -270,5 +279,33 @@ mod tests {
         let pod = build_instance_pod(c);
         let secrets = pod.spec.unwrap().image_pull_secrets.unwrap();
         assert_eq!(secrets[0].name, "reg-secret");
+    }
+
+    #[test]
+    fn pod_config_base_applies_to_built_pod() {
+        use std::collections::BTreeMap;
+        // The global + service env base (resolved at from_env) is applied
+        // to every instance Pod in spawn_pod; this asserts the apply
+        // contract over a built instance Pod.
+        let mut pod = build_instance_pod(ctx(None));
+        let cfg = K8sPodConfig {
+            node_selector: BTreeMap::from([("pool".to_string(), "ec2".to_string())]),
+            annotations: BTreeMap::from([("team".to_string(), "infra".to_string())]),
+            ..Default::default()
+        };
+        cfg.apply(&mut pod);
+        let spec = pod.spec.unwrap();
+        assert_eq!(
+            spec.node_selector.unwrap().get("pool").map(String::as_str),
+            Some("ec2")
+        );
+        assert_eq!(
+            pod.metadata
+                .annotations
+                .unwrap()
+                .get("team")
+                .map(String::as_str),
+            Some("infra")
+        );
     }
 }

--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -20,7 +20,7 @@
 
 mod k8s;
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -75,6 +75,11 @@ struct InstanceRecord {
     image: String,
     /// Base64 user-data to re-run on recreate, if any.
     user_data: Option<String>,
+    /// The instance's tags, captured at `RunInstances`. Reserved
+    /// `fakecloud-k8s/*` entries drive per-instance Pod scheduling and must
+    /// survive a k8s `Start`/`Reboot` recreate, so they're stored here
+    /// rather than re-read from the control plane.
+    tags: BTreeMap<String, String>,
 }
 
 /// The selected backing-container backend.
@@ -133,11 +138,12 @@ impl Ec2Runtime {
         &self,
         instance_id: &str,
         user_data: Option<&str>,
+        tags: &BTreeMap<String, String>,
     ) -> Result<RunningInstance, RuntimeError> {
         let image = default_image();
         let running = match &self.backend {
             InstanceBackend::Docker(d) => d.run_instance(instance_id, &image, user_data).await?,
-            InstanceBackend::K8s(k) => k.spawn_pod(instance_id, &image, user_data).await?,
+            InstanceBackend::K8s(k) => k.spawn_pod(instance_id, &image, user_data, tags).await?,
         };
         self.instances.write().insert(
             instance_id.to_string(),
@@ -145,6 +151,7 @@ impl Ec2Runtime {
                 handle: running.container_id.clone(),
                 image,
                 user_data: user_data.map(str::to_string),
+                tags: tags.clone(),
             },
         );
         Ok(running)
@@ -180,7 +187,12 @@ impl Ec2Runtime {
             }
             InstanceBackend::K8s(k) => {
                 let running = k
-                    .spawn_pod(instance_id, &record.image, record.user_data.as_deref())
+                    .spawn_pod(
+                        instance_id,
+                        &record.image,
+                        record.user_data.as_deref(),
+                        &record.tags,
+                    )
                     .await
                     .ok()?;
                 self.update_handle(instance_id, &running.container_id);
@@ -203,7 +215,12 @@ impl Ec2Runtime {
             InstanceBackend::K8s(k) => {
                 k.delete_pod(&record.handle).await;
                 let running = k
-                    .spawn_pod(instance_id, &record.image, record.user_data.as_deref())
+                    .spawn_pod(
+                        instance_id,
+                        &record.image,
+                        record.user_data.as_deref(),
+                        &record.tags,
+                    )
                     .await
                     .ok()?;
                 self.update_handle(instance_id, &running.container_id);

--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -48,6 +48,8 @@ pub enum RuntimeError {
 pub enum BackendInitError {
     #[error(transparent)]
     Env(#[from] fakecloud_k8s::K8sEnvError),
+    #[error(transparent)]
+    PodConfig(#[from] fakecloud_k8s::K8sPodConfigError),
     #[error("failed to connect to the Kubernetes cluster: {0}")]
     Connect(String),
 }

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -140,10 +140,15 @@ pub(crate) async fn run_instances(
     // configured, or a container fails to start, the instance falls back to a
     // synthesized private IP and no container handle — the API still succeeds.
     let ids: Vec<String> = (0..count).map(|_| gen_id("i")).collect();
+    // Reserved `fakecloud-k8s/*` scheduling tags are read from the request's
+    // TagSpecification here, before the backing Pod is built: instance tags
+    // are written to state only after the container boots (below), so the
+    // k8s backend can't read them back at spawn time.
+    let instance_tags = crate::service::tags::tag_specifications_for(&req.query_params, "instance");
     let mut backing: HashMap<String, crate::runtime::RunningInstance> = HashMap::new();
     if let Some(rt) = &svc.runtime {
         for id in &ids {
-            match rt.run_instance(id, user_data).await {
+            match rt.run_instance(id, user_data, &instance_tags).await {
                 Ok(running) => {
                     backing.insert(id.clone(), running);
                 }

--- a/crates/fakecloud-ec2/src/service/tags.rs
+++ b/crates/fakecloud-ec2/src/service/tags.rs
@@ -53,6 +53,33 @@ pub(crate) fn apply_tag_specifications(
     }
 }
 
+/// Read-only counterpart of `apply_tag_specifications`: collect the tags a
+/// request's `TagSpecification.N` blocks target at `resource_type` into a
+/// map, without writing them to state. Used by `RunInstances` to resolve an
+/// instance's reserved `fakecloud-k8s/*` scheduling tags before the backing
+/// Pod is built — create-time tags are only persisted to state after the
+/// container boots, so the boot path can't read them back from `Ec2State`.
+pub(crate) fn tag_specifications_for(
+    params: &HashMap<String, String>,
+    resource_type: &str,
+) -> std::collections::BTreeMap<String, String> {
+    let mut out = std::collections::BTreeMap::new();
+    let mut i = 1usize;
+    loop {
+        let rt_key = format!("TagSpecification.{i}.ResourceType");
+        let Some(rt) = params.get(&rt_key) else {
+            break;
+        };
+        if rt == resource_type {
+            for (key, value) in parse_tag_pairs(params, &format!("TagSpecification.{i}.Tag")) {
+                out.insert(key, value.unwrap_or_default());
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
 pub(crate) fn create_tags(
     svc: &Ec2Service,
     req: &AwsRequest,


### PR DESCRIPTION
## Summary

Wires the shared `K8sPodConfig` module (#1733) into the **EC2** k8s backend, so instance Pods honor operator-configured node selectors, tolerations, and annotations. Last of the four follow-ups you green-lit.

- **Global** env: `FAKECLOUD_K8S_NODE_SELECTOR` / `_TOLERATIONS` / `_ANNOTATIONS`
- **Per-service** env: `FAKECLOUD_EC2_K8S_NODE_SELECTOR` / `_TOLERATIONS` / `_ANNOTATIONS`

The service base (global merged with the EC2-service overrides) is resolved once at `from_env` and applied in `spawn_pod` — the single chokepoint every spawn goes through (`RunInstances`, and the `Start`/`Reboot` recreate path) — so all instance Pods get the configured scheduling/metadata uniformly.

## Per-instance tags: deferred (scoping note)

Like ElastiCache (#1742), EC2 stores tags in a separate by-ARN map (`Ec2State.tags`) rather than on the `Instance` struct, so threading per-instance `fakecloud-k8s/*` tag overrides down to the builder is a larger, separate change. This PR delivers the global + per-service levels (which cover the cluster-wide scheduling use case — pinning instances to a node pool / tolerating spot taints). Per-instance overrides can follow using the same `K8sPodConfig::from_tags` + `merge` helpers; happy to fold that in if you'd prefer.

(For contrast: Lambda, RDS, and ECS keep tags on the resource struct, so those PRs wired per-instance overrides too.)

## Tests

- Unit test asserting the resolved config applies (node selector + annotation) to a built instance Pod.
- Full `fakecloud-ec2` unit suite green; `cargo clippy` / `cargo fmt --check` clean. K8s integration suite is feature-gated (needs a cluster); not run here.

## Docs

The "Pod scheduling and metadata" section from #1733 already documents the env-var model and the `FAKECLOUD_<SERVICE>_K8S_*` convention for all services.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable Kubernetes Pod scheduling and metadata to the EC2 backend. Instance Pods now honor node selectors, tolerations, and annotations from env vars and per-instance `fakecloud-k8s/*` tags on every spawn.

- **New Features**
  - Merges `K8sPodConfig` from global `FAKECLOUD_K8S_*`, per-service `FAKECLOUD_EC2_K8S_*`, and per-instance `fakecloud-k8s/*` tag overrides.
  - Resolves the base at init and applies it in `spawn_pod` for `RunInstances`, `Start`, and `Reboot`.
  - Parses overrides from `RunInstances` `TagSpecification` and stores them on the instance so recreates reuse the same scheduling.
  - Extends `BackendInitError` with `K8sPodConfigError` for invalid config.

<sup>Written for commit 46809ea4c1064f3fa4ffd2178fe33277aefaf00c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

