### PR TITLE
fix(ec2): update k8s_integration test for run_instance tags arg

### DIFF
--- a/.github/workflows/lambda-k8s.yml
+++ b/.github/workflows/lambda-k8s.yml
@@ -8,6 +8,7 @@ on:
       - 'crates/fakecloud-elasticache/**'
       - 'crates/fakecloud-rds/**'
       - 'crates/fakecloud-ecs/**'
+      - 'crates/fakecloud-ec2/**'
       - 'crates/fakecloud-k8s/**'
       - '.github/workflows/lambda-k8s.yml'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - 'crates/fakecloud-elasticache/**'
       - 'crates/fakecloud-rds/**'
       - 'crates/fakecloud-ecs/**'
+      - 'crates/fakecloud-ec2/**'
       - 'crates/fakecloud-k8s/**'
       - '.github/workflows/lambda-k8s.yml'
   workflow_dispatch:

--- a/crates/fakecloud-ec2/tests/k8s_integration.rs
+++ b/crates/fakecloud-ec2/tests/k8s_integration.rs
@@ -159,7 +159,11 @@ async fn instance_lifecycle_boots_pod_runs_user_data_and_recreates_on_start() {
 
     // RunInstances boots a Pod and runs user-data at boot.
     let running = rt
-        .run_instance(instance_id, Some(USER_DATA_B64))
+        .run_instance(
+            instance_id,
+            Some(USER_DATA_B64),
+            &std::collections::BTreeMap::new(),
+        )
         .await
         .expect("run_instance");
     let pod = running.container_id.clone();


### PR DESCRIPTION
## Summary

The `K8s Backends` workflow is red on `main`. #1744 added a `tags: &BTreeMap<String, String>` parameter to `Ec2Runtime::run_instance` (for Pod nodeSelector/tolerations/annotations derived from instance tags), but the EC2 `k8s_integration` test still called the old 2-arg signature.

That test is gated behind the `k8s-integration` feature, which normal CI doesn't compile, so the break only surfaced in the kind-cluster `K8s Backends` job:

```
error[E0061]: this method takes 3 arguments but 2 arguments were supplied
  --> crates/fakecloud-ec2/tests/k8s_integration.rs:162:10
```

Fix: pass an empty tags map to match the new signature.

## Test plan
- `cargo test -p fakecloud-ec2 --features k8s-integration --test k8s_integration --no-run` compiles clean locally
- K8s Backends workflow goes green on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix EC2 k8s_integration test to match the new `run_instance` signature by passing an empty tags `BTreeMap`, resolving the compile error behind the `k8s-integration` feature. Also update the K8s Backends workflow to trigger on `crates/fakecloud-ec2/**` changes so EC2 breaks are caught in CI.

<sup>Written for commit 160779b7a4644e5f3ff916cd36855e8c21fd41e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

