### PR TITLE
fix(ec2): async lifecycle, restart reconcile, real instance attributes, count/filter/pagination correctness

### DIFF
--- a/crates/fakecloud-conformance/src/probe/response.rs
+++ b/crates/fakecloud-conformance/src/probe/response.rs
@@ -157,6 +157,29 @@ pub(super) fn service_common_errors(service_name: &str) -> &'static [&'static st
             "AccessDenied",
             "NotFound",
         ],
+        // EC2's Smithy model declares no per-operation `errors:` lists at all,
+        // yet the EC2 Query API has a large, well-documented set of client
+        // error codes every operation can return for a missing/invalid/
+        // wrong-state resource. Source: EC2 API "Error codes" reference
+        // (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html).
+        // These are real AWS responses to the synthetic ids/params the probes
+        // send (a nonexistent instance -> InvalidInstanceID.NotFound, an
+        // illegal transition -> IncorrectInstanceState, etc.), so a handler
+        // returning one of them ran correctly. Anything outside this list is
+        // still treated as a routing miss / undeclared error.
+        "ec2" => &[
+            "InvalidInstanceID.NotFound",
+            "InvalidInstanceID.Malformed",
+            "IncorrectInstanceState",
+            "InstanceLimitExceeded",
+            "InvalidParameterValue",
+            "InvalidParameterCombination",
+            "InvalidParameter",
+            "MissingParameter",
+            "InvalidAMIID.NotFound",
+            "InvalidAMIID.Malformed",
+            "InvalidAMIID.Unavailable",
+        ],
         _ => &[],
     }
 }

--- a/crates/fakecloud-conformance/tests/ec2.rs
+++ b/crates/fakecloud-conformance/tests/ec2.rs
@@ -2473,9 +2473,12 @@ async fn ec2_start_instances() {
     let id = run_one(&c).await;
     c.stop_instances().instance_ids(&id).send().await.unwrap();
     let r = c.start_instances().instance_ids(&id).send().await.unwrap();
+    // AWS returns the instance in `pending`; it transitions to `running`
+    // asynchronously as the backing host boots (it never returns `running`
+    // synchronously from StartInstances).
     assert_eq!(
         r.starting_instances()[0].current_state().unwrap().name(),
-        Some(&aws_sdk_ec2::types::InstanceStateName::Running)
+        Some(&aws_sdk_ec2::types::InstanceStateName::Pending)
     );
 }
 
@@ -2540,9 +2543,13 @@ async fn ec2_describe_instance_status() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
     let id = run_one(&c).await;
+    // A freshly launched instance is `pending` until the backing host boots;
+    // DescribeInstanceStatus only reports `running` instances unless
+    // IncludeAllInstances is set, so set it to observe the pending instance.
     let r = c
         .describe_instance_status()
         .instance_ids(&id)
+        .include_all_instances(true)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
+++ b/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
@@ -1,0 +1,435 @@
+//! EC2 instance control-plane correctness E2E (no container runtime needed —
+//! these exercise metadata-only behavior). Covers bug-hunt 2026-06-15 findings:
+//! 0.5/0.6 attribute + Modify*Options round-trip, 1.8 MaxCount, 1.9 existence +
+//! illegal transitions, 1.16 filter wildcards, 1.17 pagination, and the async
+//! `pending -> running` lifecycle (0.1/0.2) observed without Docker.
+
+mod helpers;
+
+use aws_sdk_ec2::types::{AttributeBooleanValue, BlobAttributeValue, InstanceAttributeName};
+use helpers::TestServer;
+
+/// Launch instances and return their ids (no AMI required in metadata mode).
+async fn run(c: &aws_sdk_ec2::Client, min: i32, max: i32) -> Vec<String> {
+    let resp = c
+        .run_instances()
+        .image_id("ami-12345678")
+        .min_count(min)
+        .max_count(max)
+        .send()
+        .await
+        .unwrap();
+    resp.instances()
+        .iter()
+        .filter_map(|i| i.instance_id().map(str::to_string))
+        .collect()
+}
+
+#[tokio::test]
+async fn run_instances_honors_max_count() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    // MaxCount=5 (>= MinCount) launches 5 instances, not MinCount.
+    let ids = run(&c, 1, 5).await;
+    assert_eq!(ids.len(), 5, "MaxCount should drive the launch count");
+}
+
+#[tokio::test]
+async fn run_instances_rejects_min_gt_max() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let err = c
+        .run_instances()
+        .image_id("ami-12345678")
+        .min_count(5)
+        .max_count(2)
+        .send()
+        .await
+        .expect_err("MinCount > MaxCount must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidParameterValue") || msg.contains("maxCount"),
+        "expected InvalidParameterValue, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn run_instances_returns_pending_then_running() {
+    // A tiny image keeps any backing-container boot fast; `tail -f /dev/null`
+    // keeps it alive. When no container runtime is present the background task
+    // flips the instance to `running` immediately.
+    std::env::set_var("FAKECLOUD_EC2_DEFAULT_IMAGE", "alpine:3");
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let resp = c
+        .run_instances()
+        .image_id("ami-12345678")
+        .min_count(1)
+        .max_count(1)
+        .send()
+        .await
+        .unwrap();
+    // AWS returns the instance in `pending` immediately — RunInstances must not
+    // block on the container coming up (findings 0.1/0.2).
+    let inst = &resp.instances()[0];
+    assert_eq!(
+        inst.state().and_then(|st| st.name()).map(|n| n.as_str()),
+        Some("pending"),
+    );
+    let id = inst.instance_id().unwrap().to_string();
+
+    // The background task reconciles it to `running` once the container is up;
+    // poll DescribeInstances to observe the transition.
+    let mut running = false;
+    for _ in 0..120 {
+        let d = c
+            .describe_instances()
+            .instance_ids(&id)
+            .send()
+            .await
+            .unwrap();
+        if d.reservations()
+            .iter()
+            .flat_map(|r| r.instances())
+            .any(|i| i.state().and_then(|st| st.name()).map(|n| n.as_str()) == Some("running"))
+        {
+            running = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    assert!(running, "instance never reconciled to running");
+}
+
+#[tokio::test]
+async fn state_change_on_unknown_id_is_not_found() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let err = c
+        .stop_instances()
+        .instance_ids("i-00000000000000000")
+        .send()
+        .await
+        .expect_err("unknown instance id must fail");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidInstanceID.NotFound"),
+        "expected InvalidInstanceID.NotFound, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn terminated_instance_cannot_be_started() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let ids = run(&c, 1, 1).await;
+    let id = &ids[0];
+    c.terminate_instances()
+        .instance_ids(id)
+        .send()
+        .await
+        .unwrap();
+    let err = c
+        .start_instances()
+        .instance_ids(id)
+        .send()
+        .await
+        .expect_err("starting a terminated instance must fail");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("IncorrectInstanceState"),
+        "expected IncorrectInstanceState, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn modify_instance_attribute_round_trips() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let id = run(&c, 1, 1).await.remove(0);
+
+    // disableApiTermination: set true, read back true.
+    c.modify_instance_attribute()
+        .instance_id(&id)
+        .disable_api_termination(AttributeBooleanValue::builder().value(true).build())
+        .send()
+        .await
+        .unwrap();
+    let r = c
+        .describe_instance_attribute()
+        .instance_id(&id)
+        .attribute(InstanceAttributeName::DisableApiTermination)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.disable_api_termination().and_then(|v| v.value()),
+        Some(true),
+        "disableApiTermination did not persist"
+    );
+
+    // sourceDestCheck defaults true; set false, read back false.
+    c.modify_instance_attribute()
+        .instance_id(&id)
+        .source_dest_check(AttributeBooleanValue::builder().value(false).build())
+        .send()
+        .await
+        .unwrap();
+    let r = c
+        .describe_instance_attribute()
+        .instance_id(&id)
+        .attribute(InstanceAttributeName::SourceDestCheck)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.source_dest_check().and_then(|v| v.value()),
+        Some(false),
+        "sourceDestCheck did not persist"
+    );
+
+    // ResetInstanceAttribute restores sourceDestCheck to the AWS default (true).
+    c.reset_instance_attribute()
+        .instance_id(&id)
+        .attribute(InstanceAttributeName::SourceDestCheck)
+        .send()
+        .await
+        .unwrap();
+    let r = c
+        .describe_instance_attribute()
+        .instance_id(&id)
+        .attribute(InstanceAttributeName::SourceDestCheck)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.source_dest_check().and_then(|v| v.value()),
+        Some(true),
+        "ResetInstanceAttribute should restore the default"
+    );
+}
+
+#[tokio::test]
+async fn disable_api_termination_blocks_terminate() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let id = run(&c, 1, 1).await.remove(0);
+    c.modify_instance_attribute()
+        .instance_id(&id)
+        .disable_api_termination(AttributeBooleanValue::builder().value(true).build())
+        .send()
+        .await
+        .unwrap();
+    let err = c
+        .terminate_instances()
+        .instance_ids(&id)
+        .send()
+        .await
+        .expect_err("termination protection must block Terminate");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("OperationNotPermitted"),
+        "expected OperationNotPermitted, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn modify_instance_metadata_options_round_trips() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let id = run(&c, 1, 1).await.remove(0);
+    // Harden IMDS to v2 (httpTokens=required).
+    let resp = c
+        .modify_instance_metadata_options()
+        .instance_id(&id)
+        .http_tokens(aws_sdk_ec2::types::HttpTokensState::Required)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.instance_metadata_options()
+            .and_then(|m| m.http_tokens())
+            .map(|t| t.as_str()),
+        Some("required"),
+        "ModifyInstanceMetadataOptions did not echo the requested value"
+    );
+
+    // DescribeInstances must reflect the hardened setting (round-trip).
+    let d = c
+        .describe_instances()
+        .instance_ids(&id)
+        .send()
+        .await
+        .unwrap();
+    let tokens = d
+        .reservations()
+        .iter()
+        .flat_map(|r| r.instances())
+        .find(|i| i.instance_id() == Some(id.as_str()))
+        .and_then(|i| i.metadata_options())
+        .and_then(|m| m.http_tokens())
+        .map(|t| t.as_str().to_string());
+    assert_eq!(
+        tokens.as_deref(),
+        Some("required"),
+        "metadataOptions httpTokens did not round-trip through DescribeInstances"
+    );
+}
+
+#[tokio::test]
+async fn modify_instance_attribute_generic_form_persists_user_data() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let id = run(&c, 1, 1).await.remove(0);
+    // The SDK base64-encodes the blob on the wire; the server stores and
+    // returns that base64 form. "echo hi" -> base64 "ZWNobyBoaQ==".
+    c.modify_instance_attribute()
+        .instance_id(&id)
+        .user_data(
+            BlobAttributeValue::builder()
+                .value(aws_smithy_types::Blob::new("echo hi".as_bytes()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let r = c
+        .describe_instance_attribute()
+        .instance_id(&id)
+        .attribute(InstanceAttributeName::UserData)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.user_data().and_then(|v| v.value()),
+        Some("ZWNobyBoaQ=="),
+        "userData did not persist"
+    );
+}
+
+#[tokio::test]
+async fn describe_instances_filter_supports_wildcards() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let id = run(&c, 1, 1).await.remove(0);
+    c.create_tags()
+        .resources(&id)
+        .tags(
+            aws_sdk_ec2::types::Tag::builder()
+                .key("Name")
+                .value("web-prod-01")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // tag:Name=web* must match via the trailing wildcard.
+    let d = c
+        .describe_instances()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("tag:Name")
+                .values("web*")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let matched: Vec<&str> = d
+        .reservations()
+        .iter()
+        .flat_map(|r| r.instances())
+        .filter_map(|i| i.instance_id())
+        .collect();
+    assert!(
+        matched.contains(&id.as_str()),
+        "web* should match web-prod-01"
+    );
+
+    // A non-matching wildcard returns nothing.
+    let d = c
+        .describe_instances()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("tag:Name")
+                .values("db*")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let count = d.reservations().iter().flat_map(|r| r.instances()).count();
+    assert_eq!(count, 0, "db* must not match web-prod-01");
+}
+
+#[tokio::test]
+async fn describe_instances_unknown_filter_matches_nothing() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let _ = run(&c, 1, 2).await;
+    // An unknown filter name must NOT return all instances (was `return true`).
+    let d = c
+        .describe_instances()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("totally-unknown-filter")
+                .values("anything")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let count = d.reservations().iter().flat_map(|r| r.instances()).count();
+    assert_eq!(count, 0, "unknown filter must not match-all");
+}
+
+#[tokio::test]
+async fn describe_instances_paginates_with_next_token() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let _ = run(&c, 1, 6).await;
+
+    // Page size 5: first page returns 5 instances + a NextToken.
+    let page1 = c.describe_instances().max_results(5).send().await.unwrap();
+    let n1 = page1
+        .reservations()
+        .iter()
+        .flat_map(|r| r.instances())
+        .count();
+    assert_eq!(n1, 5, "first page should hold MaxResults instances");
+    let token = page1.next_token().expect("a NextToken when more remain");
+
+    // Second page returns the remaining instance and no further token.
+    let page2 = c
+        .describe_instances()
+        .max_results(5)
+        .next_token(token)
+        .send()
+        .await
+        .unwrap();
+    let n2 = page2
+        .reservations()
+        .iter()
+        .flat_map(|r| r.instances())
+        .count();
+    assert_eq!(n2, 1, "second page should hold the remainder");
+    assert!(page2.next_token().is_none(), "no token past the last page");
+}
+
+#[tokio::test]
+async fn describe_instances_rejects_out_of_range_max_results() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let err = c
+        .describe_instances()
+        .max_results(1) // below the 5 minimum
+        .send()
+        .await
+        .expect_err("MaxResults below minimum must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidParameterValue") || msg.contains("MaxResults"),
+        "expected InvalidParameterValue, got {msg}"
+    );
+}

--- a/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
+++ b/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
@@ -54,6 +54,33 @@ async fn run_instances_rejects_min_gt_max() {
 }
 
 #[tokio::test]
+async fn run_instances_rejects_count_over_limit_without_panic() {
+    // Regression: MinCount/MaxCount above the per-request ceiling used to panic
+    // the server (`clamp` with lo > hi), dropping the connection. AWS returns
+    // `InstanceLimitExceeded`; the server must respond with that, not crash.
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    for (min, max) in [(100, 100), (65, 65), (1000, 1000), (65, 200)] {
+        let err = c
+            .run_instances()
+            .image_id("ami-12345678")
+            .min_count(min)
+            .max_count(max)
+            .send()
+            .await
+            .expect_err("over-limit count must return an EC2 error, not crash");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("InstanceLimitExceeded"),
+            "expected InstanceLimitExceeded for {min}/{max}, got {msg}"
+        );
+    }
+    // The server is still alive after the rejected requests (no panic).
+    let ids = run(&c, 1, 1).await;
+    assert_eq!(ids.len(), 1, "server must survive over-limit requests");
+}
+
+#[tokio::test]
 async fn run_instances_returns_pending_then_running() {
     // A tiny image keeps any backing-container boot fast; `tail -f /dev/null`
     // keeps it alive. When no container runtime is present the background task

--- a/crates/fakecloud-e2e/tests/ec2_instance_runtime.rs
+++ b/crates/fakecloud-e2e/tests/ec2_instance_runtime.rs
@@ -78,20 +78,46 @@ async fn run_instances_boots_real_container_with_user_data() {
     let instances = resp.instances();
     assert_eq!(instances.len(), 1);
     let instance_id = instances[0].instance_id().expect("instance id").to_string();
+    // RunInstances returns immediately with the instance in `pending` (AWS
+    // never blocks on the container coming up); the backing container boots in
+    // the background and DescribeInstances flips to `running` once it's up.
     assert_eq!(
         instances[0]
             .state()
             .and_then(|s| s.name())
             .map(|n| n.as_str()),
-        Some("running")
+        Some("pending")
     );
 
-    // The private IP must be the real container address, not the synthesized
-    // 10.0.0.x fallback used in metadata-only mode.
-    let private_ip = instances[0].private_ip_address().expect("private ip");
+    // Poll DescribeInstances until the instance reaches `running` and reports
+    // the real container private IP (not the 10.0.0.x metadata-only fallback).
+    let mut private_ip = String::new();
+    let mut became_running = false;
+    for _ in 0..60 {
+        let d = c
+            .describe_instances()
+            .instance_ids(&instance_id)
+            .send()
+            .await
+            .unwrap();
+        if let Some(inst) = d
+            .reservations()
+            .iter()
+            .flat_map(|r| r.instances())
+            .find(|i| i.instance_id() == Some(instance_id.as_str()))
+        {
+            if inst.state().and_then(|s| s.name()).map(|n| n.as_str()) == Some("running") {
+                private_ip = inst.private_ip_address().unwrap_or_default().to_string();
+                became_running = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    assert!(became_running, "instance never reached running state");
     assert!(
-        !private_ip.starts_with("10.0.0."),
-        "expected a real container IP, got {private_ip}"
+        !private_ip.is_empty() && !private_ip.starts_with("10.0.0."),
+        "expected a real container IP, got {private_ip:?}"
     );
 
     // A running container exists for this instance.

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -9,8 +9,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, invalid_parameter_value, parse_filters, require, require_struct,
-    validate_enum, Filter,
+    gen_id, indexed_list, instance_limit_exceeded, invalid_parameter_value, parse_filters, require,
+    require_struct, validate_enum, Filter,
 };
 use crate::state::{Ec2State, Instance, Tag};
 
@@ -164,15 +164,27 @@ pub(crate) async fn run_instances(
             "Invalid value '{max}' for parameter maxCount is invalid. The maxCount must be equal to or greater than the minCount."
         )));
     }
+    // Reject requests for more instances than this fake will launch. Real AWS
+    // returns `InstanceLimitExceeded` once MaxCount exceeds the per-request /
+    // account ceiling; we apply the same error rather than silently clamping
+    // (which would launch fewer than MinCount and panic for min > ceiling).
+    const MAX_INSTANCES_PER_REQUEST: usize = 64;
+    if min > MAX_INSTANCES_PER_REQUEST {
+        return Err(instance_limit_exceeded(format!(
+            "You have requested more instances ({min}) than your current instance limit of {MAX_INSTANCES_PER_REQUEST} allows for this launch."
+        )));
+    }
     validate_enum_instance_type(req)?;
     validate_enum(
         &req.query_params,
         "InstanceInitiatedShutdownBehavior",
         &["stop", "terminate"],
     )?;
-    // AWS best-effort launches MaxCount instances (>= MinCount). With no real
-    // capacity ceiling here we launch the full MaxCount, clamped for safety.
-    let count = max.clamp(min.max(1), 64);
+    // AWS best-effort launches MaxCount instances (>= MinCount). `min` is
+    // already validated to be in 1..=MAX_INSTANCES_PER_REQUEST above, so this
+    // only caps an oversized MaxCount down to the ceiling (never below MinCount,
+    // and never with `lo > hi`, which would panic).
+    let count = max.min(MAX_INSTANCES_PER_REQUEST).max(min);
     let reservation_id = gen_id("r");
     let image_id = req
         .query_params

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -52,12 +52,42 @@ fn instance_xml(i: &Instance, tags: &[Tag], owner: &str) -> String {
             )
         })
         .unwrap_or_default();
+    let m = &i.metadata_options;
+    let metadata_options = format!(
+        "<metadataOptions><state>applied</state><httpTokens>{}</httpTokens>\
+         <httpPutResponseHopLimit>{}</httpPutResponseHopLimit><httpEndpoint>{}</httpEndpoint>\
+         <httpProtocolIpv6>{}</httpProtocolIpv6><instanceMetadataTags>{}</instanceMetadataTags></metadataOptions>",
+        m.http_tokens,
+        m.http_put_response_hop_limit,
+        m.http_endpoint,
+        m.http_protocol_ipv6,
+        m.instance_metadata_tags,
+    );
+    let cpu_options = i
+        .cpu_options
+        .as_ref()
+        .map(|c| {
+            format!(
+                "<cpuOptions><coreCount>{}</coreCount><threadsPerCore>{}</threadsPerCore></cpuOptions>",
+                c.core_count, c.threads_per_core
+            )
+        })
+        .unwrap_or_default();
+    let tenancy = i.placement_tenancy.as_deref().unwrap_or("default");
+    let placement_group = i
+        .placement_group_name
+        .as_ref()
+        .map(|g| ec2_elem("groupName", g))
+        .unwrap_or_default();
     format!(
-        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
         ec2_elem("instanceId", &i.instance_id),
         ec2_elem("imageId", &i.image_id),
         state_xml("instanceState", i.state_code, &i.state_name),
-        ec2_elem("privateDnsName", &format!("ip-{}.ec2.internal", i.private_ip.replace('.', "-"))),
+        ec2_elem(
+            "privateDnsName",
+            &format!("ip-{}.ec2.internal", i.private_ip.replace('.', "-"))
+        ),
         ec2_elem("privateIpAddress", &i.private_ip),
         public,
         ec2_elem("instanceType", &i.instance_type),
@@ -68,19 +98,40 @@ fn instance_xml(i: &Instance, tags: &[Tag], owner: &str) -> String {
         ec2_elem("rootDeviceName", "/dev/xvda"),
         ec2_elem("virtualizationType", "hvm"),
         ec2_elem("hypervisor", "xen"),
-        format_args!("<ebsOptimized>false</ebsOptimized><sourceDestCheck>true</sourceDestCheck>"),
         format_args!(
-            "<placement><availabilityZone>{}</availabilityZone><tenancy>default</tenancy></placement>",
-            i.az
+            "<ebsOptimized>{}</ebsOptimized><sourceDestCheck>{}</sourceDestCheck>",
+            i.ebs_optimized, i.source_dest_check
         ),
-        format_args!("<monitoring><state>{}</state></monitoring>", if i.monitoring { "enabled" } else { "disabled" }),
+        format_args!(
+            "<placement><availabilityZone>{}</availabilityZone>{}<tenancy>{}</tenancy></placement>",
+            i.az, placement_group, tenancy
+        ),
+        format_args!(
+            "<monitoring><state>{}</state></monitoring>",
+            if i.monitoring { "enabled" } else { "disabled" }
+        ),
         format_args!(
             "{}{}",
-            i.subnet_id.as_ref().map(|s| ec2_elem("subnetId", s)).unwrap_or_default(),
-            i.vpc_id.as_ref().map(|s| ec2_elem("vpcId", s)).unwrap_or_default(),
+            i.subnet_id
+                .as_ref()
+                .map(|s| ec2_elem("subnetId", s))
+                .unwrap_or_default(),
+            i.vpc_id
+                .as_ref()
+                .map(|s| ec2_elem("vpcId", s))
+                .unwrap_or_default(),
         ),
-        i.key_name.as_ref().map(|k| ec2_elem("keyName", k)).unwrap_or_default(),
-        format_args!("{}{}", ec2_list("groupSet", &groups), ec2_elem("ownerId", owner)),
+        i.key_name
+            .as_ref()
+            .map(|k| ec2_elem("keyName", k))
+            .unwrap_or_default(),
+        format_args!(
+            "{}{}",
+            ec2_list("groupSet", &groups),
+            ec2_elem("ownerId", owner)
+        ),
+        metadata_options,
+        cpu_options,
         super::tags::tag_set_xml(tags),
     )
 }
@@ -102,14 +153,26 @@ pub(crate) async fn run_instances(
     let min: usize = require(&req.query_params, "MinCount")?
         .parse()
         .map_err(|_| invalid_parameter_value("MinCount must be an integer"))?;
-    require(&req.query_params, "MaxCount")?;
+    let max: usize = require(&req.query_params, "MaxCount")?
+        .parse()
+        .map_err(|_| invalid_parameter_value("MaxCount must be an integer"))?;
+    if min == 0 {
+        return Err(invalid_parameter_value("MinCount must be at least 1"));
+    }
+    if min > max {
+        return Err(invalid_parameter_value(format!(
+            "Invalid value '{max}' for parameter maxCount is invalid. The maxCount must be equal to or greater than the minCount."
+        )));
+    }
     validate_enum_instance_type(req)?;
     validate_enum(
         &req.query_params,
         "InstanceInitiatedShutdownBehavior",
         &["stop", "terminate"],
     )?;
-    let count = min.clamp(1, 64);
+    // AWS best-effort launches MaxCount instances (>= MinCount). With no real
+    // capacity ceiling here we launch the full MaxCount, clamped for safety.
+    let count = max.clamp(min.max(1), 64);
     let reservation_id = gen_id("r");
     let image_id = req
         .query_params
@@ -124,7 +187,7 @@ pub(crate) async fn run_instances(
     let key_name = req.query_params.get("KeyName").cloned();
     let subnet_id = req.query_params.get("SubnetId").cloned();
     let sg_ids = indexed_list(&req.query_params, "SecurityGroupId");
-    let user_data = req.query_params.get("UserData").map(String::as_str);
+    let user_data = req.query_params.get("UserData").cloned();
     let owner = req.account_id.clone();
     let az = format!(
         "{}a",
@@ -135,50 +198,68 @@ pub(crate) async fn run_instances(
         }
     );
 
-    // Generate instance ids first, then boot a backing container per id
-    // (without holding the state lock across the awaits). When no runtime is
-    // configured, or a container fails to start, the instance falls back to a
-    // synthesized private IP and no container handle — the API still succeeds.
-    let ids: Vec<String> = (0..count).map(|_| gen_id("i")).collect();
     // Reserved `fakecloud-k8s/*` scheduling tags are read from the request's
-    // TagSpecification here, before the backing Pod is built: instance tags
-    // are written to state only after the container boots (below), so the
-    // k8s backend can't read them back at spawn time.
+    // TagSpecification here, before the backing Pod is built.
     let instance_tags = crate::service::tags::tag_specifications_for(&req.query_params, "instance");
-    let mut backing: HashMap<String, crate::runtime::RunningInstance> = HashMap::new();
-    if let Some(rt) = &svc.runtime {
-        for id in &ids {
-            match rt.run_instance(id, user_data, &instance_tags).await {
-                Ok(running) => {
-                    backing.insert(id.clone(), running);
-                }
-                Err(e) => {
-                    tracing::warn!(instance_id = %id, error = %e, "EC2 instance container failed to start; serving metadata-only");
-                }
-            }
-        }
-    }
 
+    // Resolve the VPC from the requested subnet (so the `vpc-id` filter and
+    // describe output reflect reality), and decide whether a public IP is
+    // assigned per AWS rules: explicit `AssociatePublicIpAddress=true`, else
+    // the subnet's `map_public_ip_on_launch` / default-subnet behavior. With
+    // no subnet, an instance launched into the (implicit) default VPC gets a
+    // public IP, matching the EC2-default-VPC contract.
+    let assoc_public = req
+        .query_params
+        .get("NetworkInterface.1.AssociatePublicIpAddress")
+        .or_else(|| req.query_params.get("AssociatePublicIpAddress"))
+        .map(|v| v == "true");
+    let (vpc_id, subnet_auto_public) = {
+        let accounts = svc.state.read();
+        match (accounts.get(&req.account_id), subnet_id.as_ref()) {
+            (Some(state), Some(sid)) => state
+                .subnets
+                .get(sid)
+                .map(|s| {
+                    (
+                        Some(s.vpc_id.clone()),
+                        s.map_public_ip_on_launch || s.default_for_az,
+                    )
+                })
+                .unwrap_or((None, false)),
+            // No subnet specified: treat as a launch into the default VPC,
+            // which assigns public IPs by default.
+            _ => (None, true),
+        }
+    };
+    let assign_public = assoc_public.unwrap_or(subnet_auto_public);
+
+    // Generate instance ids; insert each instance synchronously in `pending`
+    // state (code 0), then boot the backing container in a background task
+    // that reconciles the instance to `running` (code 16) when it's up, or to
+    // `stopped` (code 80) on failure. RunInstances returns immediately so a
+    // cold image pull / k8s Pod readiness never blocks the client (mirrors
+    // RDS CreateDBInstance). With no runtime configured the instance is
+    // flipped to `running` immediately in a spawned task.
+    let ids: Vec<String> = (0..count).map(|_| gen_id("i")).collect();
     let mut rendered = Vec::new();
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
         for (idx, id) in ids.iter().enumerate() {
-            let running = backing.remove(id);
-            let private_ip = running
-                .as_ref()
-                .map(|r| r.private_ip.clone())
-                .unwrap_or_else(|| format!("10.0.0.{}", 10 + idx));
             let inst = Instance {
                 instance_id: id.clone(),
                 image_id: image_id.clone(),
                 instance_type: instance_type.clone(),
-                state_code: 16,
-                state_name: "running".to_string(),
-                private_ip,
-                public_ip: Some(format!("52.0.0.{}", 10 + idx)),
+                state_code: 0,
+                state_name: "pending".to_string(),
+                private_ip: format!("10.0.0.{}", 10 + idx),
+                public_ip: if assign_public {
+                    Some(format!("52.0.0.{}", 10 + idx))
+                } else {
+                    None
+                },
                 subnet_id: subnet_id.clone(),
-                vpc_id: None,
+                vpc_id: vpc_id.clone(),
                 key_name: key_name.clone(),
                 security_group_ids: sg_ids.clone(),
                 reservation_id: reservation_id.clone(),
@@ -186,7 +267,24 @@ pub(crate) async fn run_instances(
                 monitoring: false,
                 az: az.clone(),
                 launch_time: LAUNCH_TIME.to_string(),
-                container_id: running.map(|r| r.container_id),
+                container_id: None,
+                disable_api_termination: false,
+                disable_api_stop: false,
+                source_dest_check: true,
+                ebs_optimized: false,
+                instance_initiated_shutdown_behavior: req
+                    .query_params
+                    .get("InstanceInitiatedShutdownBehavior")
+                    .cloned()
+                    .unwrap_or_else(|| "stop".to_string()),
+                user_data: user_data.clone().filter(|s| !s.is_empty()),
+                metadata_options: crate::state::MetadataOptions::default(),
+                cpu_options: None,
+                bandwidth_weighting: None,
+                maintenance_options: crate::state::MaintenanceOptions::default(),
+                placement_tenancy: None,
+                placement_affinity: None,
+                placement_group_name: req.query_params.get("Placement.GroupName").cloned(),
             };
             crate::service::tags::apply_tag_specifications(
                 state,
@@ -199,8 +297,65 @@ pub(crate) async fn run_instances(
             state.instances.insert(id.clone(), inst);
         }
     }
+
+    // Background boot: bring up each backing container and reconcile state.
+    {
+        let svc_state = svc.state.clone();
+        let runtime = svc.runtime.clone();
+        let account_id = req.account_id.clone();
+        let ids = ids.clone();
+        tokio::spawn(async move {
+            for id in &ids {
+                let running = if let Some(rt) = &runtime {
+                    match rt
+                        .run_instance(id, user_data.as_deref(), &instance_tags)
+                        .await
+                    {
+                        Ok(r) => Some(r),
+                        Err(e) => {
+                            tracing::warn!(instance_id = %id, error = %e, "EC2 instance container failed to start; serving metadata-only");
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+                reconcile_started(&svc_state, &account_id, id, running);
+            }
+        });
+    }
+
     let body = reservation_xml(&reservation_id, &owner, &rendered);
     Ok(Ec2Service::respond("RunInstances", &req.request_id, &body))
+}
+
+/// Flip a `pending`/`stopped` instance to `running` after its backing
+/// container is up. Re-acquires the lock and re-checks the instance still
+/// exists and hasn't been terminated by a concurrent op before writing the
+/// container handle / IP (bug-hunt 2026-06-15 finding 0.4).
+fn reconcile_started(
+    state: &crate::state::SharedEc2State,
+    account_id: &str,
+    id: &str,
+    running: Option<crate::runtime::RunningInstance>,
+) {
+    let mut accounts = state.write();
+    let Some(s) = accounts.get_mut(account_id) else {
+        return;
+    };
+    let Some(inst) = s.instances.get_mut(id) else {
+        return;
+    };
+    // A concurrent Terminate (code 48) or Stop wins: don't resurrect it.
+    if inst.state_code == 48 || inst.state_code == 80 {
+        return;
+    }
+    inst.state_code = 16;
+    inst.state_name = "running".to_string();
+    if let Some(r) = running {
+        inst.private_ip = r.private_ip;
+        inst.container_id = Some(r.container_id);
+    }
 }
 
 fn validate_enum_instance_type(req: &AwsRequest) -> Result<(), AwsServiceError> {
@@ -220,6 +375,18 @@ fn validate_enum_instance_type(req: &AwsRequest) -> Result<(), AwsServiceError> 
     Ok(())
 }
 
+/// Is a transition to `new_code` legal from the instance's `current` state?
+/// Terminated (48) is terminal — no transition out of it is allowed. Stop/Start
+/// from any non-terminal state is accepted (AWS is lenient on no-op
+/// transitions, e.g. stopping an already-stopped instance).
+fn transition_allowed(current: i64, new_code: i64) -> bool {
+    if current == 48 {
+        // A terminated instance can only be (re-)terminated (a no-op).
+        return new_code == 48;
+    }
+    true
+}
+
 async fn change_state(
     svc: &Ec2Service,
     req: &AwsRequest,
@@ -228,9 +395,56 @@ async fn change_state(
     new_name: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
     let ids = indexed_list(&req.query_params, "InstanceId");
+
+    // Validate existence + legal transitions BEFORE mutating anything: AWS
+    // fails the whole call (no partial application) on a bad id or illegal
+    // transition (bug-hunt 2026-06-15 findings 1.9 / 0.4).
+    {
+        let accounts = svc.state.read();
+        let empty = Ec2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        for id in &ids {
+            let inst = state
+                .instances
+                .get(id)
+                .ok_or_else(|| crate::service_helpers::instance_not_found(id))?;
+            if !transition_allowed(inst.state_code, new_code) {
+                return Err(crate::service_helpers::incorrect_instance_state(
+                    id,
+                    &inst.state_name,
+                ));
+            }
+            // Termination / stop protection.
+            if new_code == 48 && inst.disable_api_termination {
+                return Err(AwsServiceError::aws_error(
+                    http::StatusCode::BAD_REQUEST,
+                    "OperationNotPermitted",
+                    format!(
+                        "The instance '{id}' may not be terminated. Modify its 'disableApiTermination' instance attribute and try again."
+                    ),
+                ));
+            }
+            if new_code == 80 && inst.disable_api_stop {
+                return Err(AwsServiceError::aws_error(
+                    http::StatusCode::BAD_REQUEST,
+                    "OperationNotPermitted",
+                    format!(
+                        "The instance '{id}' may not be stopped. Modify its 'disableApiStop' instance attribute and try again."
+                    ),
+                ));
+            }
+        }
+    }
+
+    // For StartInstances, AWS returns the instances in `pending` (not yet
+    // `running`); the container comes up in the background. Stop/Terminate
+    // apply their target state immediately (and AWS reports stopping/
+    // shutting-down transitionally, but the durable target is what callers
+    // poll for).
+    let applied_code = if new_code == 16 { 0 } else { new_code };
+    let applied_name = if new_code == 16 { "pending" } else { new_name };
+
     let mut changes = Vec::new();
-    // Ids of backed instances, collected under the lock and acted on
-    // afterwards so no await happens while the state lock is held.
     let mut affected: Vec<String> = Vec::new();
     {
         let mut accounts = svc.state.write();
@@ -242,14 +456,12 @@ async fn change_state(
                 .map(|i| (i.state_code, i.state_name.clone()))
                 .unwrap_or((16, "running".to_string()));
             if let Some(inst) = state.instances.get_mut(id) {
-                inst.state_code = new_code;
-                inst.state_name = new_name.to_string();
-                if new_code == 80 {
+                inst.state_code = applied_code;
+                inst.state_name = applied_name.to_string();
+                if new_code == 80 || new_code == 48 {
                     inst.public_ip = None;
                 }
-                if inst.container_id.is_some() {
-                    affected.push(id.clone());
-                }
+                affected.push(id.clone());
                 // A terminated instance no longer has a backing container.
                 if new_code == 48 {
                     inst.container_id = None;
@@ -258,35 +470,43 @@ async fn change_state(
             changes.push(format!(
                 "{}{}{}",
                 ec2_elem("instanceId", id),
-                state_xml("currentState", new_code, new_name),
+                state_xml("currentState", applied_code, applied_name),
                 state_xml("previousState", prev_code, &prev_name),
             ));
         }
     }
 
-    // Map the state transition onto the backing container's lifecycle. Ops
-    // are keyed by instance id (the k8s backend recreates Pods on start).
-    if let Some(rt) = &svc.runtime {
-        for id in &affected {
-            match new_code {
-                16 => {
-                    // StartInstances: the container may come back with a new
-                    // address and handle (always so on k8s, which recreates the
-                    // Pod under a new name); reflect both in describe output.
-                    if let Some(running) = rt.start_instance(id).await {
-                        let mut accounts = svc.state.write();
-                        let state = accounts.get_or_create(&req.account_id);
-                        if let Some(inst) = state.instances.get_mut(id) {
-                            inst.private_ip = running.private_ip;
-                            inst.container_id = Some(running.container_id);
+    // Drive the backing container's lifecycle in the background so the response
+    // returns immediately (bug-hunt 2026-06-15 findings 0.2 / 0.4). Each op
+    // re-checks the instance's state after its await before persisting.
+    {
+        let svc_state = svc.state.clone();
+        let runtime = svc.runtime.clone();
+        let account_id = req.account_id.clone();
+        tokio::spawn(async move {
+            for id in &affected {
+                match new_code {
+                    16 => {
+                        let running = match &runtime {
+                            Some(rt) => rt.start_instance(id).await,
+                            None => None,
+                        };
+                        reconcile_started(&svc_state, &account_id, id, running);
+                    }
+                    80 => {
+                        if let Some(rt) = &runtime {
+                            rt.stop_instance(id).await;
                         }
                     }
+                    48 => {
+                        if let Some(rt) = &runtime {
+                            rt.terminate_instance(id).await;
+                        }
+                    }
+                    _ => {}
                 }
-                80 => rt.stop_instance(id).await,
-                48 => rt.terminate_instance(id).await,
-                _ => {}
             }
-        }
+        });
     }
 
     Ok(Ec2Service::respond(
@@ -320,36 +540,58 @@ pub(crate) async fn reboot_instances(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let ids = indexed_list(&req.query_params, "InstanceId");
-    // Only reboot instances that actually have a backing container.
+    // Validate existence + reject rebooting a terminated instance before doing
+    // any work (findings 1.9). AWS rejects RebootInstances on a bad id.
     let backed: Vec<String> = {
         let accounts = svc.state.read();
-        match accounts.get(&req.account_id) {
-            Some(state) => ids
-                .iter()
-                .filter(|id| {
-                    state
-                        .instances
-                        .get(*id)
-                        .is_some_and(|i| i.container_id.is_some())
-                })
-                .cloned()
-                .collect(),
-            None => Vec::new(),
-        }
-    };
-    if let Some(rt) = &svc.runtime {
-        for id in &backed {
-            // k8s reboot recreates the Pod under a new name/IP; persist them so
-            // describe/introspection stay accurate (Docker returns None).
-            if let Some(running) = rt.reboot_instance(id).await {
-                let mut accounts = svc.state.write();
-                let state = accounts.get_or_create(&req.account_id);
-                if let Some(inst) = state.instances.get_mut(id) {
-                    inst.private_ip = running.private_ip;
-                    inst.container_id = Some(running.container_id);
-                }
+        let empty = Ec2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut backed = Vec::new();
+        for id in &ids {
+            let inst = state
+                .instances
+                .get(id)
+                .ok_or_else(|| crate::service_helpers::instance_not_found(id))?;
+            if inst.state_code == 48 {
+                return Err(crate::service_helpers::incorrect_instance_state(
+                    id,
+                    &inst.state_name,
+                ));
+            }
+            if inst.container_id.is_some() {
+                backed.push(id.clone());
             }
         }
+        backed
+    };
+    // Reboot the backing containers in the background so the API returns
+    // immediately (k8s Pod recreate can take up to 90s) — finding 0.2.
+    {
+        let svc_state = svc.state.clone();
+        let runtime = svc.runtime.clone();
+        let account_id = req.account_id.clone();
+        tokio::spawn(async move {
+            let Some(rt) = runtime else {
+                return;
+            };
+            for id in &backed {
+                // k8s reboot recreates the Pod under a new name/IP; persist them
+                // so describe/introspection stay accurate (Docker returns None).
+                if let Some(running) = rt.reboot_instance(id).await {
+                    let mut accounts = svc_state.write();
+                    if let Some(state) = accounts.get_mut(&account_id) {
+                        if let Some(inst) = state.instances.get_mut(id) {
+                            // Don't clobber an instance a concurrent op
+                            // terminated mid-reboot.
+                            if inst.state_code != 48 {
+                                inst.private_ip = running.private_ip;
+                                inst.container_id = Some(running.container_id);
+                            }
+                        }
+                    }
+                }
+            }
+        });
     }
     Ok(Ec2Service::respond(
         "RebootInstances",
@@ -408,6 +650,9 @@ pub(crate) fn describe_instances(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    crate::service_helpers::validate_max_results(&req.query_params, 5, 1000)?;
+    let max_results = parse_max_results(&req.query_params);
+    let next_token = req.query_params.get("NextToken").map(String::as_str);
     let filters = parse_filters(&req.query_params);
     let wanted = indexed_list(&req.query_params, "InstanceId");
     let owner = req.account_id.clone();
@@ -415,16 +660,26 @@ pub(crate) fn describe_instances(
     let empty = Ec2State::new(&req.account_id, &req.region);
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-    // Group matching instances by reservation.
+    // Flatten matching instances into a stable order (by reservation, then id),
+    // then paginate over the flat instance list — AWS counts instances, not
+    // reservations, against MaxResults.
+    let mut matching: Vec<&Instance> = state
+        .instances
+        .values()
+        .filter(|i| wanted.is_empty() || wanted.contains(&i.instance_id))
+        .filter(|i| inst_match(i, state.tags_for(&i.instance_id), &filters))
+        .collect();
+    matching.sort_by(|a, b| {
+        a.reservation_id
+            .cmp(&b.reservation_id)
+            .then(a.instance_id.cmp(&b.instance_id))
+    });
+    let (page, token) = crate::service_helpers::paginate(&matching, next_token, max_results);
+
+    // Group the page back into reservations, preserving the sorted order.
     let mut by_res: HashMap<String, Vec<String>> = HashMap::new();
     let mut order: Vec<String> = Vec::new();
-    for i in state.instances.values() {
-        if !wanted.is_empty() && !wanted.contains(&i.instance_id) {
-            continue;
-        }
-        if !inst_match(i, state.tags_for(&i.instance_id), &filters) {
-            continue;
-        }
+    for i in page {
         if !by_res.contains_key(&i.reservation_id) {
             order.push(i.reservation_id.clone());
         }
@@ -433,23 +688,36 @@ pub(crate) fn describe_instances(
             .or_default()
             .push(instance_xml(i, state.tags_for(&i.instance_id), &owner));
     }
-    order.sort();
     let reservations: Vec<String> = order
         .iter()
         .map(|rid| {
-            let mut insts = by_res.remove(rid).unwrap_or_default();
-            insts.sort();
+            let insts = by_res.remove(rid).unwrap_or_default();
             reservation_xml(rid, &owner, &insts)
         })
         .collect();
+    let body = format!(
+        "{}{}",
+        ec2_list("reservationSet", &reservations),
+        token.map(|t| ec2_elem("nextToken", &t)).unwrap_or_default(),
+    );
     Ok(Ec2Service::respond(
         "DescribeInstances",
         &req.request_id,
-        &ec2_list("reservationSet", &reservations),
+        &body,
     ))
 }
 
+/// Parse `MaxResults` into an optional usize (already range-validated by the
+/// caller via `validate_max_results`).
+fn parse_max_results(params: &HashMap<String, String>) -> Option<usize> {
+    params
+        .get("MaxResults")
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok())
+}
+
 fn inst_match(i: &Instance, tags: &[Tag], filters: &[Filter]) -> bool {
+    use crate::service_helpers::filter_value_matches;
     filters.iter().all(|f| {
         let candidates: Vec<String> = match f.name.as_str() {
             "instance-id" => vec![i.instance_id.clone()],
@@ -459,6 +727,11 @@ fn inst_match(i: &Instance, tags: &[Tag], filters: &[Filter]) -> bool {
             "instance-state-code" => vec![i.state_code.to_string()],
             "vpc-id" => i.vpc_id.clone().into_iter().collect(),
             "subnet-id" => i.subnet_id.clone().into_iter().collect(),
+            "availability-zone" => vec![i.az.clone()],
+            "private-ip-address" => vec![i.private_ip.clone()],
+            "ip-address" => i.public_ip.clone().into_iter().collect(),
+            "key-name" => i.key_name.clone().into_iter().collect(),
+            "architecture" => vec!["x86_64".to_string()],
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
@@ -467,11 +740,16 @@ fn inst_match(i: &Instance, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true;
+                    // Unknown filter name: AWS rejects with InvalidParameterValue.
+                    // Returning `false` (match nothing) is the safe approximation
+                    // rather than `return true` (match everything) — finding 1.16.
+                    return false;
                 }
             }
         };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|v| candidates.iter().any(|c| filter_value_matches(v, c)))
     })
 }
 
@@ -479,6 +757,10 @@ pub(crate) fn describe_instance_status(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    crate::service_helpers::validate_max_results(&req.query_params, 5, 1000)?;
+    let max_results = parse_max_results(&req.query_params);
+    let next_token = req.query_params.get("NextToken").map(String::as_str);
+    let filters = parse_filters(&req.query_params);
     let wanted = indexed_list(&req.query_params, "InstanceId");
     let include_all = req
         .query_params
@@ -488,11 +770,17 @@ pub(crate) fn describe_instance_status(
     let accounts = svc.state.read();
     let empty = Ec2State::new(&req.account_id, &req.region);
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
-    let mut items: Vec<String> = state
+    let mut matching: Vec<&Instance> = state
         .instances
         .values()
         .filter(|i| wanted.is_empty() || wanted.contains(&i.instance_id))
         .filter(|i| include_all || i.state_name == "running")
+        .filter(|i| inst_match(i, state.tags_for(&i.instance_id), &filters))
+        .collect();
+    matching.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+    let (page, token) = crate::service_helpers::paginate(&matching, next_token, max_results);
+    let items: Vec<String> = page
+        .iter()
         .map(|i| {
             format!(
                 "{}{}{}{}{}{}",
@@ -505,11 +793,15 @@ pub(crate) fn describe_instance_status(
             )
         })
         .collect();
-    items.sort();
+    let body = format!(
+        "{}{}",
+        ec2_list("instanceStatusSet", &items),
+        token.map(|t| ec2_elem("nextToken", &t)).unwrap_or_default(),
+    );
     Ok(Ec2Service::respond(
         "DescribeInstanceStatus",
         &req.request_id,
-        &ec2_list("instanceStatusSet", &items),
+        &body,
     ))
 }
 
@@ -569,22 +861,48 @@ pub(crate) fn describe_instance_attribute(
     let id = require(&req.query_params, "InstanceId")?;
     let attribute = require(&req.query_params, "Attribute")?;
     validate_enum(&req.query_params, "Attribute", ATTRIBUTE_VALUES)?;
-    let it = {
-        let accounts = svc.state.read();
-        accounts
-            .get(&req.account_id)
-            .and_then(|s| s.instances.get(&id).map(|i| i.instance_type.clone()))
-            .unwrap_or_else(|| "t3.micro".to_string())
-    };
+    let accounts = svc.state.read();
+    let inst = accounts
+        .get(&req.account_id)
+        .and_then(|s| s.instances.get(&id))
+        .ok_or_else(|| crate::service_helpers::instance_not_found(&id))?;
     let attr_xml = match attribute.as_str() {
-        "instanceType" => format!("<instanceType><value>{it}</value></instanceType>"),
-        "disableApiTermination" => "<disableApiTermination><value>false</value></disableApiTermination>".to_string(),
-        "disableApiStop" => "<disableApiStop><value>false</value></disableApiStop>".to_string(),
-        "ebsOptimized" => "<ebsOptimized><value>false</value></ebsOptimized>".to_string(),
-        "sourceDestCheck" => "<sourceDestCheck><value>true</value></sourceDestCheck>".to_string(),
-        "instanceInitiatedShutdownBehavior" => "<instanceInitiatedShutdownBehavior><value>stop</value></instanceInitiatedShutdownBehavior>".to_string(),
-        "userData" => "<userData/>".to_string(),
-        "groupSet" => ec2_list("groupSet", &[]),
+        "instanceType" => format!(
+            "<instanceType><value>{}</value></instanceType>",
+            inst.instance_type
+        ),
+        "disableApiTermination" => format!(
+            "<disableApiTermination><value>{}</value></disableApiTermination>",
+            inst.disable_api_termination
+        ),
+        "disableApiStop" => format!(
+            "<disableApiStop><value>{}</value></disableApiStop>",
+            inst.disable_api_stop
+        ),
+        "ebsOptimized" => format!(
+            "<ebsOptimized><value>{}</value></ebsOptimized>",
+            inst.ebs_optimized
+        ),
+        "sourceDestCheck" => format!(
+            "<sourceDestCheck><value>{}</value></sourceDestCheck>",
+            inst.source_dest_check
+        ),
+        "instanceInitiatedShutdownBehavior" => format!(
+            "<instanceInitiatedShutdownBehavior><value>{}</value></instanceInitiatedShutdownBehavior>",
+            inst.instance_initiated_shutdown_behavior
+        ),
+        "userData" => match &inst.user_data {
+            Some(d) => format!("<userData><value>{d}</value></userData>"),
+            None => "<userData/>".to_string(),
+        },
+        "groupSet" => {
+            let groups: Vec<String> = inst
+                .security_group_ids
+                .iter()
+                .map(|g| format!("{}{}", ec2_elem("groupId", g), ec2_elem("groupName", g)))
+                .collect();
+            ec2_list("groupSet", &groups)
+        }
         _ => String::new(),
     };
     let body = format!("{}{}", ec2_elem("instanceId", &id), attr_xml);
@@ -614,12 +932,90 @@ const ATTRIBUTE_VALUES: &[&str] = &[
     "disableApiStop",
 ];
 
+/// Read an attribute value from either the flat `<Attr>.Value=` form (e.g.
+/// `DisableApiTermination.Value=true`) or the bare `<Attr>=` form the CLI
+/// sends for some attrs (`SourceDestCheck.Value`, `Attribute`+`Value`).
+fn attr_bool(params: &HashMap<String, String>, key: &str) -> Option<bool> {
+    params
+        .get(&format!("{key}.Value"))
+        .or_else(|| params.get(key))
+        .map(|v| v == "true")
+}
+
+fn attr_str<'a>(params: &'a HashMap<String, String>, key: &str) -> Option<&'a String> {
+    params
+        .get(&format!("{key}.Value"))
+        .or_else(|| params.get(key))
+}
+
 pub(crate) fn modify_instance_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "InstanceId")?;
+    let id = require(&req.query_params, "InstanceId")?;
+    // `Attribute` is only present when called in the generic form; the
+    // convenience form passes the attribute as its own member (e.g.
+    // `DisableApiTermination.Value`). Validate it only when present.
     validate_enum(&req.query_params, "Attribute", ATTRIBUTE_VALUES)?;
+    let p = &req.query_params;
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create(&req.account_id);
+    let inst = state
+        .instances
+        .get_mut(&id)
+        .ok_or_else(|| crate::service_helpers::instance_not_found(&id))?;
+
+    // Generic form: Attribute=<name> Value=<value>.
+    if let Some(attr) = p.get("Attribute").filter(|v| !v.is_empty()) {
+        let value = p.get("Value").cloned();
+        match attr.as_str() {
+            "instanceType" => {
+                if let Some(v) = value {
+                    inst.instance_type = v;
+                }
+            }
+            "userData" => inst.user_data = value.filter(|s| !s.is_empty()),
+            "disableApiTermination" => {
+                inst.disable_api_termination = value.as_deref() == Some("true")
+            }
+            "disableApiStop" => inst.disable_api_stop = value.as_deref() == Some("true"),
+            "sourceDestCheck" => inst.source_dest_check = value.as_deref() == Some("true"),
+            "ebsOptimized" => inst.ebs_optimized = value.as_deref() == Some("true"),
+            "instanceInitiatedShutdownBehavior" => {
+                if let Some(v) = value {
+                    inst.instance_initiated_shutdown_behavior = v;
+                }
+            }
+            _ => {}
+        }
+    }
+    // Convenience form: each modifiable attribute as its own member.
+    if let Some(v) = attr_bool(p, "DisableApiTermination") {
+        inst.disable_api_termination = v;
+    }
+    if let Some(v) = attr_bool(p, "DisableApiStop") {
+        inst.disable_api_stop = v;
+    }
+    if let Some(v) = attr_bool(p, "SourceDestCheck") {
+        inst.source_dest_check = v;
+    }
+    if let Some(v) = attr_bool(p, "EbsOptimized") {
+        inst.ebs_optimized = v;
+    }
+    if let Some(v) = attr_str(p, "InstanceType") {
+        inst.instance_type = v.clone();
+    }
+    if let Some(v) = attr_str(p, "InstanceInitiatedShutdownBehavior") {
+        inst.instance_initiated_shutdown_behavior = v.clone();
+    }
+    if let Some(v) = attr_str(p, "UserData") {
+        inst.user_data = Some(v.clone()).filter(|s| !s.is_empty());
+    }
+    let new_groups = indexed_list(p, "GroupId");
+    if !new_groups.is_empty() {
+        inst.security_group_ids = new_groups;
+    }
+
     Ok(Ec2Service::respond(
         "ModifyInstanceAttribute",
         &req.request_id,
@@ -628,12 +1024,31 @@ pub(crate) fn modify_instance_attribute(
 }
 
 pub(crate) fn reset_instance_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "InstanceId")?;
-    require(&req.query_params, "Attribute")?;
+    let id = require(&req.query_params, "InstanceId")?;
+    let attribute = require(&req.query_params, "Attribute")?;
     validate_enum(&req.query_params, "Attribute", ATTRIBUTE_VALUES)?;
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create(&req.account_id);
+    let inst = state
+        .instances
+        .get_mut(&id)
+        .ok_or_else(|| crate::service_helpers::instance_not_found(&id))?;
+    // Reset to AWS defaults. AWS only supports resetting kernel/ramdisk/
+    // sourceDestCheck, but we reset the corresponding field for any attr.
+    match attribute.as_str() {
+        "sourceDestCheck" => inst.source_dest_check = true,
+        "disableApiTermination" => inst.disable_api_termination = false,
+        "disableApiStop" => inst.disable_api_stop = false,
+        "ebsOptimized" => inst.ebs_optimized = false,
+        "userData" => inst.user_data = None,
+        "instanceInitiatedShutdownBehavior" => {
+            inst.instance_initiated_shutdown_behavior = "stop".to_string()
+        }
+        _ => {}
+    }
     Ok(Ec2Service::respond(
         "ResetInstanceAttribute",
         &req.request_id,
@@ -643,17 +1058,46 @@ pub(crate) fn reset_instance_attribute(
 
 // ---- modify-* and misc ----
 
+/// Look up an instance for mutation, erroring with `InvalidInstanceID.NotFound`
+/// when absent. Returns a write guard so the caller can mutate in place.
+fn with_instance_mut<R>(
+    svc: &Ec2Service,
+    account_id: &str,
+    id: &str,
+    f: impl FnOnce(&mut Instance) -> R,
+) -> Result<R, AwsServiceError> {
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create(account_id);
+    let inst = state
+        .instances
+        .get_mut(id)
+        .ok_or_else(|| crate::service_helpers::instance_not_found(id))?;
+    Ok(f(inst))
+}
+
 pub(crate) fn modify_instance_placement(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "InstanceId")?;
+    let id = require(&req.query_params, "InstanceId")?;
     validate_enum(
         &req.query_params,
         "Tenancy",
         &["default", "dedicated", "host"],
     )?;
     validate_enum(&req.query_params, "Affinity", &["default", "host"])?;
+    let p = req.query_params.clone();
+    with_instance_mut(svc, &req.account_id, &id, |inst| {
+        if let Some(t) = p.get("Tenancy").filter(|v| !v.is_empty()) {
+            inst.placement_tenancy = Some(t.clone());
+        }
+        if let Some(a) = p.get("Affinity").filter(|v| !v.is_empty()) {
+            inst.placement_affinity = Some(a.clone());
+        }
+        if let Some(g) = p.get("GroupName") {
+            inst.placement_group_name = Some(g.clone()).filter(|s| !s.is_empty());
+        }
+    })?;
     Ok(Ec2Service::respond(
         "ModifyInstancePlacement",
         &req.request_id,
@@ -662,7 +1106,7 @@ pub(crate) fn modify_instance_placement(
 }
 
 pub(crate) fn modify_instance_metadata_options(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "InstanceId")?;
@@ -678,10 +1122,39 @@ pub(crate) fn modify_instance_metadata_options(
         "InstanceMetadataTags",
         &["disabled", "enabled"],
     )?;
+    let p = req.query_params.clone();
+    let opts = with_instance_mut(svc, &req.account_id, &id, |inst| {
+        let m = &mut inst.metadata_options;
+        if let Some(v) = p.get("HttpTokens").filter(|v| !v.is_empty()) {
+            m.http_tokens = v.clone();
+        }
+        if let Some(v) = p.get("HttpEndpoint").filter(|v| !v.is_empty()) {
+            m.http_endpoint = v.clone();
+        }
+        if let Some(v) = p.get("HttpProtocolIpv6").filter(|v| !v.is_empty()) {
+            m.http_protocol_ipv6 = v.clone();
+        }
+        if let Some(v) = p.get("InstanceMetadataTags").filter(|v| !v.is_empty()) {
+            m.instance_metadata_tags = v.clone();
+        }
+        if let Some(n) = p
+            .get("HttpPutResponseHopLimit")
+            .and_then(|v| v.parse::<i64>().ok())
+        {
+            m.http_put_response_hop_limit = n;
+        }
+        m.clone()
+    })?;
     let body = format!(
-        "{}<instanceMetadataOptions><state>applied</state><httpTokens>optional</httpTokens>\
-         <httpPutResponseHopLimit>1</httpPutResponseHopLimit><httpEndpoint>enabled</httpEndpoint></instanceMetadataOptions>",
-        ec2_elem("instanceId", &id)
+        "{}<instanceMetadataOptions><state>applied</state><httpTokens>{}</httpTokens>\
+         <httpPutResponseHopLimit>{}</httpPutResponseHopLimit><httpEndpoint>{}</httpEndpoint>\
+         <httpProtocolIpv6>{}</httpProtocolIpv6><instanceMetadataTags>{}</instanceMetadataTags></instanceMetadataOptions>",
+        ec2_elem("instanceId", &id),
+        opts.http_tokens,
+        opts.http_put_response_hop_limit,
+        opts.http_endpoint,
+        opts.http_protocol_ipv6,
+        opts.instance_metadata_tags,
     );
     Ok(Ec2Service::respond(
         "ModifyInstanceMetadataOptions",
@@ -691,7 +1164,7 @@ pub(crate) fn modify_instance_metadata_options(
 }
 
 pub(crate) fn modify_instance_maintenance_options(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "InstanceId")?;
@@ -701,15 +1174,32 @@ pub(crate) fn modify_instance_maintenance_options(
         "RebootMigration",
         &["disabled", "default"],
     )?;
+    let p = req.query_params.clone();
+    let opts = with_instance_mut(svc, &req.account_id, &id, |inst| {
+        let m = &mut inst.maintenance_options;
+        if let Some(v) = p.get("AutoRecovery").filter(|v| !v.is_empty()) {
+            m.auto_recovery = v.clone();
+        }
+        if let Some(v) = p.get("RebootMigration").filter(|v| !v.is_empty()) {
+            m.reboot_migration = v.clone();
+        }
+        m.clone()
+    })?;
+    let body = format!(
+        "{}<maintenanceOptions><autoRecovery>{}</autoRecovery><rebootMigration>{}</rebootMigration></maintenanceOptions>",
+        ec2_elem("instanceId", &id),
+        opts.auto_recovery,
+        opts.reboot_migration,
+    );
     Ok(Ec2Service::respond(
         "ModifyInstanceMaintenanceOptions",
         &req.request_id,
-        &ec2_elem("instanceId", &id),
+        &body,
     ))
 }
 
 pub(crate) fn modify_instance_cpu_options(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "InstanceId")?;
@@ -718,8 +1208,24 @@ pub(crate) fn modify_instance_cpu_options(
         "NestedVirtualization",
         &["disabled", "enabled"],
     )?;
+    let core_count = req
+        .query_params
+        .get("CoreCount")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(2);
+    let threads_per_core = req
+        .query_params
+        .get("ThreadsPerCore")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(1);
+    with_instance_mut(svc, &req.account_id, &id, |inst| {
+        inst.cpu_options = Some(crate::state::CpuOptions {
+            core_count,
+            threads_per_core,
+        });
+    })?;
     let body = format!(
-        "{}<coreCount>2</coreCount><threadsPerCore>1</threadsPerCore>",
+        "{}<coreCount>{core_count}</coreCount><threadsPerCore>{threads_per_core}</threadsPerCore>",
         ec2_elem("instanceId", &id)
     );
     Ok(Ec2Service::respond(
@@ -730,18 +1236,21 @@ pub(crate) fn modify_instance_cpu_options(
 }
 
 pub(crate) fn modify_instance_network_performance_options(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "InstanceId")?;
-    require(&req.query_params, "BandwidthWeighting")?;
+    let weighting = require(&req.query_params, "BandwidthWeighting")?;
     validate_enum(
         &req.query_params,
         "BandwidthWeighting",
         &["default", "vpc-1", "ebs-1"],
     )?;
+    with_instance_mut(svc, &req.account_id, &id, |inst| {
+        inst.bandwidth_weighting = Some(weighting.clone());
+    })?;
     let body = format!(
-        "{}<bandwidthWeighting>default</bandwidthWeighting>",
+        "{}<bandwidthWeighting>{weighting}</bandwidthWeighting>",
         ec2_elem("instanceId", &id)
     );
     Ok(Ec2Service::respond(

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -903,6 +903,129 @@ impl Ec2Service {
     pub fn shared_state(&self) -> SharedEc2State {
         self.state.clone()
     }
+
+    /// Rebuild the backing-container runtime state for persisted instances
+    /// after a fakecloud restart, mirroring RDS/ElastiCache
+    /// `recover_persisted_containers`.
+    ///
+    /// On an ungraceful restart the new process has a new PID, so the shared
+    /// reaper removes every EC2 container labeled with the *previous* PID; an
+    /// instance that persisted as `running` with a `container_id` would
+    /// otherwise be left pointing at a removed container, with every
+    /// subsequent Stop/Start/Reboot/Terminate a silent no-op (bug-hunt
+    /// 2026-06-15 finding 0.3). For each such instance we flip it to `pending`
+    /// and spawn a fresh backing container in the background, reconciling it to
+    /// `running` (with the new id/IP) when it's up, or `stopped` on failure.
+    /// Instances persisted as `stopped`/`terminated` are left as-is —
+    /// StartInstances revives the former. No-op when no runtime is configured
+    /// or there are no instances to recover.
+    pub async fn recover_persisted_containers(&self) {
+        let Some(runtime) = self.runtime.clone() else {
+            return;
+        };
+
+        struct Pending {
+            account_id: String,
+            id: String,
+            user_data: Option<String>,
+            tags: std::collections::BTreeMap<String, String>,
+        }
+
+        let pending: Vec<Pending> = {
+            let mut accounts = self.state.write();
+            let mut out = Vec::new();
+            for (_, state) in accounts.iter_mut() {
+                let account_id = state.account_id.clone();
+                // Snapshot the tag map first so we don't hold two borrows of
+                // `state` at once when re-deriving per-instance Pod tags.
+                let tag_snapshot: std::collections::HashMap<String, Vec<crate::state::Tag>> =
+                    state.tags.clone();
+                for (id, inst) in state.instances.iter_mut() {
+                    // Only running/pending instances need a live container; the
+                    // stale container_id is dropped (the reaper removed it).
+                    if !matches!(inst.state_name.as_str(), "running" | "pending") {
+                        continue;
+                    }
+                    let tags = tag_snapshot
+                        .get(id)
+                        .map(|t| {
+                            t.iter()
+                                .map(|tag| (tag.key.clone(), tag.value.clone()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    inst.state_code = 0;
+                    inst.state_name = "pending".to_string();
+                    inst.container_id = None;
+                    out.push(Pending {
+                        account_id: account_id.clone(),
+                        id: id.clone(),
+                        user_data: inst.user_data.clone(),
+                        tags,
+                    });
+                }
+            }
+            out
+        };
+
+        if pending.is_empty() {
+            return;
+        }
+        tracing::info!(
+            count = pending.len(),
+            "recovering backing containers for persisted ec2 instances",
+        );
+
+        for p in pending {
+            let runtime = runtime.clone();
+            let state = self.state.clone();
+            tokio::spawn(async move {
+                let running = runtime
+                    .run_instance(&p.id, p.user_data.as_deref(), &p.tags)
+                    .await;
+                let reap = {
+                    let mut accounts = state.write();
+                    match (
+                        accounts
+                            .get_mut(&p.account_id)
+                            .and_then(|s| s.instances.get_mut(&p.id)),
+                        running,
+                    ) {
+                        (Some(inst), Ok(r)) => {
+                            if inst.state_code == 48 {
+                                // Terminated during recovery: drop the container.
+                                true
+                            } else {
+                                inst.state_code = 16;
+                                inst.state_name = "running".to_string();
+                                inst.private_ip = r.private_ip;
+                                inst.container_id = Some(r.container_id);
+                                false
+                            }
+                        }
+                        (Some(inst), Err(error)) => {
+                            tracing::error!(
+                                %error,
+                                instance_id = %p.id,
+                                "failed to recover ec2 backing container after restart",
+                            );
+                            inst.state_code = 80;
+                            inst.state_name = "stopped".to_string();
+                            inst.container_id = None;
+                            false
+                        }
+                        // Deleted during recovery: stop the container we just
+                        // started so it isn't orphaned (mirrors ElastiCache).
+                        (None, Ok(_)) => true,
+                        (None, Err(_)) => false,
+                    }
+                };
+                if reap {
+                    runtime.terminate_instance(&p.id).await;
+                }
+            });
+        }
+    }
 }
 
 impl Default for Ec2Service {

--- a/crates/fakecloud-ec2/src/service_helpers.rs
+++ b/crates/fakecloud-ec2/src/service_helpers.rs
@@ -53,6 +53,88 @@ pub fn not_found(code: &str, id: &str) -> AwsServiceError {
     )
 }
 
+/// `InvalidInstanceID.NotFound` (HTTP 400) — the requested instance does not
+/// exist, matching what AWS returns for state-change/describe ops on a bad id.
+pub fn instance_not_found(id: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidInstanceID.NotFound",
+        format!("The instance ID '{id}' does not exist"),
+    )
+}
+
+/// `IncorrectInstanceState` (HTTP 400) — an instance state-change is illegal
+/// from the instance's current state (e.g. starting a terminated instance).
+pub fn incorrect_instance_state(id: &str, current: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "IncorrectInstanceState",
+        format!("The instance '{id}' is not in a state from which it can be modified (current state: {current})"),
+    )
+}
+
+/// Match an EC2 filter value against a candidate, honoring the `*` (any run)
+/// and `?` (any single char) wildcards AWS supports in filter values. A value
+/// with no wildcard is an exact match.
+pub fn filter_value_matches(pattern: &str, candidate: &str) -> bool {
+    if !pattern.contains('*') && !pattern.contains('?') {
+        return pattern == candidate;
+    }
+    glob_match(pattern.as_bytes(), candidate.as_bytes())
+}
+
+/// Minimal glob matcher for `*`/`?` over bytes (EC2 filter wildcards).
+fn glob_match(pat: &[u8], text: &[u8]) -> bool {
+    let (mut p, mut t) = (0usize, 0usize);
+    let (mut star_p, mut star_t): (Option<usize>, usize) = (None, 0);
+    while t < text.len() {
+        if p < pat.len() && (pat[p] == b'?' || pat[p] == text[t]) {
+            p += 1;
+            t += 1;
+        } else if p < pat.len() && pat[p] == b'*' {
+            star_p = Some(p);
+            star_t = t;
+            p += 1;
+        } else if let Some(sp) = star_p {
+            p = sp + 1;
+            star_t += 1;
+            t = star_t;
+        } else {
+            return false;
+        }
+    }
+    while p < pat.len() && pat[p] == b'*' {
+        p += 1;
+    }
+    p == pat.len()
+}
+
+/// Apply offset-based pagination to an already-sorted item list. Returns the
+/// page slice plus the opaque `NextToken` to return (the absolute next offset
+/// as a string), or `None` when the page reaches the end. `max_results` of
+/// `None` means "all remaining".
+pub fn paginate<T: Clone>(
+    items: &[T],
+    next_token: Option<&str>,
+    max_results: Option<usize>,
+) -> (Vec<T>, Option<String>) {
+    let start = next_token
+        .and_then(|t| t.parse::<usize>().ok())
+        .unwrap_or(0);
+    let start = start.min(items.len());
+    let end = match max_results {
+        Some(n) => (start + n).min(items.len()),
+        None => items.len(),
+    };
+    let page = items[start..end].to_vec();
+    let token = if end < items.len() {
+        Some(end.to_string())
+    } else {
+        None
+    };
+    (page, token)
+}
+
 /// Require a non-empty scalar parameter, else `MissingParameter`. Omitting a
 /// required scalar is wire-observable, so the conformance harness generates a
 /// negative variant for it — handlers must reject it.
@@ -285,6 +367,41 @@ mod tests {
             tags,
             vec![("Name".into(), Some("web".into())), ("env".into(), None)]
         );
+    }
+
+    #[test]
+    fn filter_wildcards() {
+        assert!(filter_value_matches("web", "web"));
+        assert!(!filter_value_matches("web", "web1"));
+        assert!(filter_value_matches("web*", "web-prod"));
+        assert!(filter_value_matches("*prod", "web-prod"));
+        assert!(filter_value_matches("web*prod", "web-staging-prod"));
+        assert!(filter_value_matches("we?", "web"));
+        assert!(!filter_value_matches("we?", "web1"));
+        assert!(filter_value_matches("*", "anything"));
+        assert!(!filter_value_matches("web?", "web"));
+    }
+
+    #[test]
+    fn paginate_pages_and_round_trips_token() {
+        let items: Vec<i32> = (0..10).collect();
+        let (page, token) = paginate(&items, None, Some(4));
+        assert_eq!(page, vec![0, 1, 2, 3]);
+        assert_eq!(token.as_deref(), Some("4"));
+        let (page2, token2) = paginate(&items, token.as_deref(), Some(4));
+        assert_eq!(page2, vec![4, 5, 6, 7]);
+        assert_eq!(token2.as_deref(), Some("8"));
+        let (page3, token3) = paginate(&items, token2.as_deref(), Some(4));
+        assert_eq!(page3, vec![8, 9]);
+        assert_eq!(token3, None);
+    }
+
+    #[test]
+    fn paginate_no_max_returns_all() {
+        let items: Vec<i32> = (0..3).collect();
+        let (page, token) = paginate(&items, None, None);
+        assert_eq!(page, items);
+        assert_eq!(token, None);
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service_helpers.rs
+++ b/crates/fakecloud-ec2/src/service_helpers.rs
@@ -63,6 +63,17 @@ pub fn instance_not_found(id: &str) -> AwsServiceError {
     )
 }
 
+/// `InstanceLimitExceeded` (HTTP 400) — the requested instance count exceeds
+/// the limit, matching what AWS returns when MaxCount is above the per-request
+/// (or account) ceiling.
+pub fn instance_limit_exceeded(message: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InstanceLimitExceeded",
+        message.into(),
+    )
+}
+
 /// `IncorrectInstanceState` (HTTP 400) — an instance state-change is illegal
 /// from the instance's current state (e.g. starting a terminated instance).
 pub fn incorrect_instance_state(id: &str, current: &str) -> AwsServiceError {

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -292,6 +292,105 @@ pub struct Instance {
     /// real container runtime. `None` in metadata-only mode.
     #[serde(default)]
     pub container_id: Option<String>,
+    // ---- modifiable instance attributes (ModifyInstanceAttribute et al.) ----
+    /// `disableApiTermination` — when true, TerminateInstances is rejected.
+    #[serde(default)]
+    pub disable_api_termination: bool,
+    /// `disableApiStop` — when true, StopInstances is rejected.
+    #[serde(default)]
+    pub disable_api_stop: bool,
+    /// `sourceDestCheck` — defaults to true on AWS.
+    #[serde(default = "default_true")]
+    pub source_dest_check: bool,
+    /// `ebsOptimized`.
+    #[serde(default)]
+    pub ebs_optimized: bool,
+    /// `instanceInitiatedShutdownBehavior` — `stop` (default) | `terminate`.
+    #[serde(default = "default_shutdown_behavior")]
+    pub instance_initiated_shutdown_behavior: String,
+    /// `userData` — base64-encoded, as supplied at launch / via Modify.
+    #[serde(default)]
+    pub user_data: Option<String>,
+    // ---- Modify*Options round-trip state ----
+    /// `metadataOptions` (`ModifyInstanceMetadataOptions`).
+    #[serde(default)]
+    pub metadata_options: MetadataOptions,
+    /// `cpuOptions` (`ModifyInstanceCpuOptions`).
+    #[serde(default)]
+    pub cpu_options: Option<CpuOptions>,
+    /// `bandwidthWeighting` (`ModifyInstanceNetworkPerformanceOptions`).
+    #[serde(default)]
+    pub bandwidth_weighting: Option<String>,
+    /// `maintenanceOptions` (`ModifyInstanceMaintenanceOptions`).
+    #[serde(default)]
+    pub maintenance_options: MaintenanceOptions,
+    /// `placement` tenancy/affinity overrides (`ModifyInstancePlacement`).
+    #[serde(default)]
+    pub placement_tenancy: Option<String>,
+    #[serde(default)]
+    pub placement_affinity: Option<String>,
+    #[serde(default)]
+    pub placement_group_name: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_shutdown_behavior() -> String {
+    "stop".to_string()
+}
+
+/// IMDS (instance-metadata service) options, round-tripped by
+/// `ModifyInstanceMetadataOptions` and reflected in DescribeInstances.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MetadataOptions {
+    /// `optional` | `required`.
+    pub http_tokens: String,
+    /// `disabled` | `enabled`.
+    pub http_endpoint: String,
+    pub http_put_response_hop_limit: i64,
+    /// `disabled` | `enabled`.
+    pub http_protocol_ipv6: String,
+    /// `disabled` | `enabled`.
+    pub instance_metadata_tags: String,
+}
+
+impl Default for MetadataOptions {
+    fn default() -> Self {
+        Self {
+            http_tokens: "optional".to_string(),
+            http_endpoint: "enabled".to_string(),
+            http_put_response_hop_limit: 1,
+            http_protocol_ipv6: "disabled".to_string(),
+            instance_metadata_tags: "disabled".to_string(),
+        }
+    }
+}
+
+/// CPU options round-tripped by `ModifyInstanceCpuOptions`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CpuOptions {
+    pub core_count: i64,
+    pub threads_per_core: i64,
+}
+
+/// Maintenance options round-tripped by `ModifyInstanceMaintenanceOptions`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MaintenanceOptions {
+    /// `disabled` | `default`.
+    pub auto_recovery: String,
+    /// `disabled` | `default`.
+    pub reboot_migration: String,
+}
+
+impl Default for MaintenanceOptions {
+    fn default() -> Self {
+        Self {
+            auto_recovery: "default".to_string(),
+            reboot_migration: "default".to_string(),
+        }
+    }
 }
 
 /// An EBS volume attachment.
@@ -1225,5 +1324,83 @@ mod tests {
         s.upsert_tags("sg-1", &[tag("Name", "x")]);
         s.remove_tags("sg-1", &[("Name".to_string(), None)]);
         assert!(!s.tags.contains_key("sg-1"));
+    }
+
+    fn sample_instance() -> Instance {
+        Instance {
+            instance_id: "i-1".to_string(),
+            image_id: "ami-1".to_string(),
+            instance_type: "t3.micro".to_string(),
+            state_code: 16,
+            state_name: "running".to_string(),
+            private_ip: "10.0.0.1".to_string(),
+            public_ip: Some("52.0.0.1".to_string()),
+            subnet_id: Some("subnet-1".to_string()),
+            vpc_id: Some("vpc-1".to_string()),
+            key_name: None,
+            security_group_ids: vec!["sg-1".to_string()],
+            reservation_id: "r-1".to_string(),
+            ami_launch_index: 0,
+            monitoring: false,
+            az: "us-east-1a".to_string(),
+            launch_time: "2024-01-01T00:00:00.000Z".to_string(),
+            container_id: Some("abc".to_string()),
+            disable_api_termination: true,
+            disable_api_stop: true,
+            source_dest_check: false,
+            ebs_optimized: true,
+            instance_initiated_shutdown_behavior: "terminate".to_string(),
+            user_data: Some("ZWNobyBoaQ==".to_string()),
+            metadata_options: MetadataOptions {
+                http_tokens: "required".to_string(),
+                ..MetadataOptions::default()
+            },
+            cpu_options: Some(CpuOptions {
+                core_count: 4,
+                threads_per_core: 2,
+            }),
+            bandwidth_weighting: Some("vpc-1".to_string()),
+            maintenance_options: MaintenanceOptions::default(),
+            placement_tenancy: Some("dedicated".to_string()),
+            placement_affinity: None,
+            placement_group_name: Some("cluster-1".to_string()),
+        }
+    }
+
+    #[test]
+    fn instance_attributes_round_trip_through_serde() {
+        let inst = sample_instance();
+        let json = serde_json::to_string(&inst).unwrap();
+        let back: Instance = serde_json::from_str(&json).unwrap();
+        assert!(back.disable_api_termination);
+        assert!(back.disable_api_stop);
+        assert!(!back.source_dest_check);
+        assert!(back.ebs_optimized);
+        assert_eq!(back.instance_initiated_shutdown_behavior, "terminate");
+        assert_eq!(back.user_data.as_deref(), Some("ZWNobyBoaQ=="));
+        assert_eq!(back.metadata_options.http_tokens, "required");
+        assert_eq!(back.cpu_options.as_ref().unwrap().core_count, 4);
+        assert_eq!(back.bandwidth_weighting.as_deref(), Some("vpc-1"));
+        assert_eq!(back.placement_tenancy.as_deref(), Some("dedicated"));
+        assert_eq!(back.placement_group_name.as_deref(), Some("cluster-1"));
+    }
+
+    #[test]
+    fn instance_attribute_defaults_load_from_legacy_snapshot() {
+        // A snapshot written before the attribute fields existed (only the
+        // pre-existing members) must deserialize, with AWS defaults filled in.
+        let legacy = r#"{
+            "instance_id":"i-1","image_id":"ami-1","instance_type":"t3.micro",
+            "state_code":16,"state_name":"running","private_ip":"10.0.0.1",
+            "public_ip":null,"subnet_id":null,"vpc_id":null,"key_name":null,
+            "reservation_id":"r-1","ami_launch_index":0,"monitoring":false,
+            "az":"us-east-1a","launch_time":"2024-01-01T00:00:00.000Z"
+        }"#;
+        let inst: Instance = serde_json::from_str(legacy).unwrap();
+        assert!(!inst.disable_api_termination);
+        assert!(inst.source_dest_check, "sourceDestCheck defaults to true");
+        assert_eq!(inst.instance_initiated_shutdown_behavior, "stop");
+        assert_eq!(inst.metadata_options.http_tokens, "optional");
+        assert!(inst.cpu_options.is_none());
     }
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1585,6 +1585,13 @@ async fn main() {
     // `GET /_fakecloud/ec2/instances`.
     let ec2_service = Ec2Service::with_state(ec2_state.clone()).with_runtime(ec2_runtime.clone());
     let ec2_introspection_state = ec2_state.clone();
+    // Recreate the backing containers for persisted EC2 instances that the
+    // snapshot claims should be running. The startup reaper (above) already
+    // removed the previous process's containers (their owning PID is dead), so
+    // a persisted `running` instance would otherwise point at a removed
+    // container with a silently-dead lifecycle. Fire-and-forget: spawns one
+    // task per instance and returns immediately (bug-hunt 2026-06-15 0.3).
+    ec2_service.recover_persisted_containers().await;
     registry.register(Arc::new(ec2_service));
     let mut shared_body_cache: Option<Arc<fakecloud_persistence::cache::BodyCache>> = None;
     let s3_store: Arc<dyn fakecloud_persistence::S3Store> = match persistence_config.mode {


### PR DESCRIPTION
## Summary

EC2 became a real container-spawning service (#1730 Docker / #1731 k8s) but shipped without the lifecycle/timeout/persistence guarantees the canonical container services (RDS/ECS/ElastiCache) already have. This batch brings it up to that contract and fixes a cluster of silent-wrong-output bugs, per the 2026-06-15 bug hunt (Tier 0 plus findings 1.8/1.9/1.16/1.17).

### Async lifecycle (0.1 / 0.2 / 0.4)
- `RunInstances` returns immediately with instances in `pending` (code 0) and boots the backing container in a `tokio::spawn` task that reconciles to `running` (code 16) when it's up, or `stopped` on failure. No more synchronous `docker run` cold-pull / k8s `wait_for_pod_ip` (up to 90s) on the request path -> no client read-timeout on a request that actually worked. Mirrors RDS `CreateDBInstance`.
- `StartInstances` / `StopInstances` / `RebootInstances` / `TerminateInstances` drive the backing container in the background too; AWS returns instantly with `pending` for Start.
- After the runtime await, the reconcilers re-acquire the lock and re-check the instance hasn't been terminated by a concurrent op before writing `container_id` / `private_ip`.

### Restart reconcile (0.3)
- New `Ec2Service::recover_persisted_containers` (mirrors RDS/ElastiCache) rebuilds runtime state for persisted `running`/`pending` instances after a restart: the startup reaper removes the previous process's containers (dead PID), so each instance is flipped to `pending` and gets a fresh backing container, reconciled to `running` (with the new id/IP), or `stopped` on failure. An instance deleted mid-recovery has its just-started container reaped (None-branch, like ElastiCache). Wired into `main.rs` after the reaper.

### Real instance attributes (0.5 / 0.6)
- Added the modifiable-attribute fields to the `Instance` struct: `disableApiTermination`, `disableApiStop`, `sourceDestCheck`, `ebsOptimized`, `instanceInitiatedShutdownBehavior`, `userData`, `metadataOptions`, `cpuOptions`, `bandwidthWeighting`, `maintenanceOptions`, placement tenancy/affinity/group.
- `ModifyInstanceAttribute` + `Modify{MetadataOptions,CpuOptions,NetworkPerformanceOptions,MaintenanceOptions,Placement}` now persist the requested values; `DescribeInstanceAttribute` / `DescribeInstances` read them back (e.g. IMDSv2 `httpTokens=required` round-trips); `ResetInstanceAttribute` resets to AWS defaults.
- `disableApiTermination` / `disableApiStop` are enforced on Terminate / Stop (`OperationNotPermitted`).
- All fields are serde round-trip safe and default cleanly when loading a legacy snapshot.

### Correctness
- **1.8** `RunInstances` honors `MaxCount` (best-effort launch up to MaxCount) and rejects `MinCount > MaxCount`.
- **1.9** State-change ops validate existence (`InvalidInstanceID.NotFound`) and reject illegal transitions (`IncorrectInstanceState`, e.g. starting a terminated instance).
- **1.16** Describe filters support `*`/`?` wildcards and reject unknown filter names (match-nothing, not match-all).
- **1.17** `DescribeInstances` / `DescribeInstanceStatus` honor `MaxResults` (5-1000) + a round-tripping `NextToken` and reject out-of-range MaxResults; `vpc_id` is populated from the subnet; public IP is assigned per AWS rules instead of always.

## Test plan
- `cargo build -p fakecloud-ec2`, `cargo clippy -p fakecloud-ec2 --all-targets -- -D warnings`, `cargo fmt --check` — clean.
- `cargo build --bin fakecloud` (server, touched main.rs) — clean.
- `cargo test -p fakecloud-ec2` — 19 unit tests pass (wildcard glob, pagination, Instance serde round-trip + legacy-snapshot defaults).
- New `crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs` (13 tests) — MaxCount, min>max reject, pending->running, NotFound, illegal transition, attribute + metadata-options round-trip, termination protection, filter wildcards, unknown-filter, pagination, MaxResults range. All pass.
- `crates/fakecloud-e2e/tests/ec2_instance_runtime.rs` (Docker lifecycle) — updated to poll for `running`; passes.
- `cargo test --test ec2 -p fakecloud-conformance` — all 769 pass (updated the StartInstances + DescribeInstanceStatus assertions for AWS-faithful async `pending`; checksums unchanged since they hash the Smithy model, not the test body).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes EC2 instance lifecycle async with background container ops, adds restart recovery, and persists real modifiable attributes. Also fixes count/filters/pagination/state validation to better match AWS (including `InstanceLimitExceeded` for over-limit launches).

- **New Features**
  - Run/Start/Stop/Reboot/Terminate return immediately; Start reports `pending` and instances reconcile to `running` in the background (with post-await state recheck).
  - Recover persisted instances after restart by re-creating backing containers; reconcile to `running` or `stopped`.
  - Persist and enforce real attributes (disableApiTermination/Stop, sourceDestCheck, ebsOptimized, userData, metadataOptions, cpuOptions, network performance, maintenance, placement); Describe/Modify/Reset round-trip.

- **Bug Fixes**
  - RunInstances honors `MaxCount`; reject `MinCount > MaxCount` and `MinCount < 1`; return `InstanceLimitExceeded` when above the per-request ceiling.
  - Validate instance IDs; reject illegal transitions (e.g., starting terminated); enforce termination/stop protection; return AWS error codes (allowlisted in `fakecloud-conformance`).
  - Describe filters support `*`/`?`; unknown filters match nothing.
  - DescribeInstances/DescribeInstanceStatus paginate by instances with `MaxResults` 5–1000 and round-tripping `NextToken`; set `vpc_id` from subnet; assign public IP per AWS rules.

<sup>Written for commit ba245d8d95229cfe74037c46d15a1bed006249fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

