### PR TITLE
fix(ecs,rds): close container delete/stop-during-create races and ECS reaper label gap

### DIFF
--- a/crates/fakecloud-ecs/src/runtime/mod.rs
+++ b/crates/fakecloud-ecs/src/runtime/mod.rs
@@ -450,6 +450,22 @@ pub(crate) fn task_should_stop(containers: &[RunningContainer]) -> bool {
     containers.iter().all(|c| c.exit_code.is_some())
 }
 
+/// True if the task's `desired_status` in state is `STOPPED` — i.e. a
+/// StopTask / scale-down / DeleteService raced the launch and asked for this
+/// task to be killed. A missing task (deleted from state mid-launch) also
+/// counts as "stop": there's nothing left to keep running for.
+pub(crate) fn task_desired_stopped(
+    state: &SharedEcsState,
+    account_id: &str,
+    task_id: &str,
+) -> bool {
+    let accounts = state.read();
+    match accounts.get(account_id).and_then(|s| s.tasks.get(task_id)) {
+        Some(task) => task.desired_status == "STOPPED",
+        None => true,
+    }
+}
+
 fn build_container_plans(
     state: &SharedEcsState,
     account_id: &str,
@@ -1212,6 +1228,15 @@ fn parse_port_mapping(value: &serde_json::Value) -> Option<PortMapping> {
     })
 }
 
+/// The `fakecloud-instance=fakecloud-<pid>` ownership label value, matching
+/// exactly how RDS/ElastiCache/Lambda/EC2(Docker) construct it. The shared
+/// startup reaper lists containers carrying this label, parses the owning
+/// PID, and removes any whose owner is no longer alive. Returns the full
+/// `key=value` string ready to follow a `--label` flag.
+pub(crate) fn fakecloud_instance_label() -> String {
+    format!("fakecloud-instance=fakecloud-{}", std::process::id())
+}
+
 /// Build the docker `run` argv for a single container plan. Pure so unit
 /// tests can assert on flag ordering / `--publish` translation without
 /// shelling out. The returned vector is everything *after* the binary
@@ -1235,6 +1260,14 @@ pub(crate) fn build_run_argv(
     argv.push(format!("fakecloud-ecs-task={}", task_id));
     argv.push("--label".into());
     argv.push(format!("fakecloud-ecs-container={}", plan.container_name));
+    // Ownership label shared with RDS/ElastiCache/Lambda/EC2(Docker). The
+    // startup reaper (`fakecloud-server::reaper`) filters strictly on
+    // `label=fakecloud-instance` and parses the owning PID out of the value
+    // (`fakecloud-<pid>`). Without this, ECS task containers (and their
+    // host-port publishes / awsvpc networks) leak unreapably after an
+    // ungraceful restart. See fakecloud_instance_label().
+    argv.push("--label".into());
+    argv.push(fakecloud_instance_label());
     // Inject `--add-host host.docker.internal:<ip>` only for docker;
     // podman provides `host.containers.internal` natively and rejects
     // the host-gateway mapping (issue #1539).
@@ -1873,6 +1906,35 @@ mod tests {
             task.captured_logs.starts_with("[task failed to start]:"),
             "captured_logs missing prefix: {:?}",
             task.captured_logs
+        );
+    }
+
+    /// 4.2 — `task_desired_stopped` is the post-launch gate `run_task_inner`
+    /// uses to detect a StopTask / scale-down / DeleteService that raced the
+    /// launch. RUNNING desired_status -> keep running; STOPPED -> self-stop;
+    /// task removed from state -> treat as stop (nothing to keep alive).
+    #[test]
+    fn task_desired_stopped_detects_stop_during_launch() {
+        let mut accounts: MultiAccountState<EcsState> =
+            MultiAccountState::new("000000000000", "us-east-1", "http://localhost:4566");
+        let acct = accounts.get_or_create("000000000000");
+        acct.tasks.insert("running".into(), make_task("running"));
+        let mut stopping = make_task("stopping");
+        stopping.desired_status = "STOPPED".into();
+        acct.tasks.insert("stopping".into(), stopping);
+        let state: SharedEcsState = Arc::new(RwLock::new(accounts));
+
+        assert!(
+            !task_desired_stopped(&state, "000000000000", "running"),
+            "a RUNNING task must not be treated as stopped",
+        );
+        assert!(
+            task_desired_stopped(&state, "000000000000", "stopping"),
+            "a task whose desired_status is STOPPED must be treated as stopped",
+        );
+        assert!(
+            task_desired_stopped(&state, "000000000000", "deleted-mid-launch"),
+            "a task removed from state mid-launch must be treated as stopped",
         );
     }
 
@@ -2971,5 +3033,73 @@ mod tests {
         assert_eq!(tg_targets.len(), 1);
         assert_eq!(tg_targets[0].0, "172.18.0.2");
         assert_eq!(tg_targets[0].1, Some(80));
+    }
+
+    fn minimal_plan() -> ContainerPlan {
+        ContainerPlan {
+            container_name: "app".into(),
+            image: "alpine".into(),
+            env: Vec::new(),
+            entry_point: Vec::new(),
+            command: Vec::new(),
+            secrets_refs: Vec::new(),
+            essential: true,
+            has_task_role: false,
+            port_mappings: Vec::new(),
+            network_mode: None,
+            depends_on: Vec::new(),
+            health_check: None,
+            volume_mounts: Vec::new(),
+            ulimits: Vec::new(),
+            linux_parameters: None,
+            stop_timeout: None,
+            user: None,
+            working_directory: None,
+            tty: false,
+            interactive: false,
+            readonly_rootfs: false,
+        }
+    }
+
+    /// 4.1 — every ECS task container must carry the shared
+    /// `fakecloud-instance` ownership label so the startup reaper picks it
+    /// up after an ungraceful restart (it filters strictly on that label).
+    #[test]
+    fn build_run_argv_emits_fakecloud_instance_label() {
+        let plan = minimal_plan();
+        let argv = build_run_argv(
+            &plan,
+            &[],
+            "task-1",
+            "host.docker.internal",
+            None,
+            "alpine",
+            true,
+        );
+        let expected = fakecloud_instance_label();
+        assert!(
+            argv.windows(2)
+                .any(|w| w[0] == "--label" && w[1] == expected),
+            "argv must contain `--label {expected}`: {argv:?}",
+        );
+    }
+
+    /// 4.1 — the label value must be exactly the shape the reaper parses:
+    /// `fakecloud-instance=fakecloud-<pid>`. The reaper strips the
+    /// `fakecloud-` prefix off the value and `parse::<u32>()`s the rest, so a
+    /// non-numeric tail (e.g. a task id) would silently never reap.
+    #[test]
+    fn fakecloud_instance_label_matches_reaper_format() {
+        let label = fakecloud_instance_label();
+        let (key, value) = label.split_once('=').expect("label is key=value");
+        assert_eq!(key, "fakecloud-instance");
+        let pid_str = value
+            .strip_prefix("fakecloud-")
+            .expect("value starts with fakecloud-");
+        assert_eq!(
+            pid_str.parse::<u32>().ok(),
+            Some(std::process::id()),
+            "reaper must be able to parse the owning pid out of {label}",
+        );
     }
 }

--- a/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
+++ b/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
@@ -167,6 +167,7 @@ impl EcsRuntime {
                     // Ownership label so the startup reaper can prune the
                     // per-task awsvpc network after an ungraceful restart,
                     // matching the container label.
+                    "--label",
                     &super::fakecloud_instance_label(),
                     &network_name,
                 ])

--- a/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
+++ b/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
@@ -164,6 +164,10 @@ impl EcsRuntime {
                     "bridge",
                     "--label",
                     &format!("fakecloud-ecs-task={}", task_id),
+                    // Ownership label so the startup reaper can prune the
+                    // per-task awsvpc network after an ungraceful restart,
+                    // matching the container label.
+                    &super::fakecloud_instance_label(),
                     &network_name,
                 ])
                 .output()
@@ -258,6 +262,17 @@ impl EcsRuntime {
         // fails to start (or an upstream gate times out), kill the
         // already-started containers and bail — partial-launch state is
         // harder to reason about than a clean failure.
+        // Register the task in `self.containers` BEFORE the launch loop so a
+        // concurrent StopTask / scale-down / DeleteService that arrives
+        // during the multi-second pull+run window can find the entry and stop
+        // whatever has been launched so far. (`stop_task` is a no-op when the
+        // key is absent — the orphan-on-race bug.) We append each container
+        // id to this entry as it starts, mirroring the k8s backend which
+        // registers the Pod name before `create_pod`.
+        self.containers
+            .write()
+            .entry(task_id.to_string())
+            .or_default();
         let mut started: Vec<RunningContainer> = Vec::with_capacity(resolved_plans.len());
         for (idx, (rp, run_image)) in resolved_plans.iter().zip(run_images.iter()).enumerate() {
             // Wait for every dependsOn[] entry on this container. Upstreams
@@ -309,6 +324,14 @@ impl EcsRuntime {
                 return Err(RuntimeError::ContainerStart(err));
             }
             let container_id = String::from_utf8_lossy(&run_out.stdout).trim().to_string();
+            // Append to the runtime map immediately so a StopTask landing
+            // between this container and the next one in the launch loop can
+            // reach it.
+            self.containers
+                .write()
+                .entry(task_id.to_string())
+                .or_default()
+                .push((rp.plan.container_name.clone(), container_id.clone()));
             started.push(RunningContainer {
                 name: rp.plan.container_name.clone(),
                 container_id,
@@ -319,18 +342,60 @@ impl EcsRuntime {
             });
         }
 
-        // Stash all (name, container_id) pairs so StopTask/stop_all can
-        // reach every container backing this task.
-        {
-            let mut guard = self.containers.write();
-            guard.insert(
-                task_id.to_string(),
-                started
-                    .iter()
-                    .map(|c| (c.name.clone(), c.container_id.clone()))
-                    .collect(),
+        // A StopTask / scale-down / DeleteService that raced the launch may
+        // have flipped this task's desired_status to STOPPED while we were
+        // pulling/running (and may have already issued `docker stop` against
+        // the containers it could see in the runtime map). If so, stop every
+        // container we launched and finalize as a clean stop instead of
+        // marking the task RUNNING with a live workload the user asked to
+        // kill. Mirrors the k8s backend, which observes a 404 from the
+        // StopTask-deleted Pod and finalizes the same way.
+        if task_desired_stopped(state, account_id, task_id) {
+            for rc in &started {
+                let _ = Command::new(&self.cli)
+                    .args(["stop", "--time", "10", &rc.container_id])
+                    .output()
+                    .await;
+                let _ = Command::new(&self.cli)
+                    .args(["rm", "-f", &rc.container_id])
+                    .output()
+                    .await;
+            }
+            if network_created {
+                let _ = Command::new(&self.cli)
+                    .args(["network", "rm", &network_name])
+                    .output()
+                    .await;
+            }
+            self.containers.write().remove(task_id);
+            let stopped: Vec<RunningContainer> = started
+                .iter()
+                .map(|rc| RunningContainer {
+                    exit_code: Some(rc.exit_code.unwrap_or(137)),
+                    ..rc.clone()
+                })
+                .collect();
+            finalize_stopped_multi(
+                state,
+                account_id,
+                task_id,
+                &stopped,
+                137,
+                "",
+                "UserInitiated",
+                Some("Task stopped during launch".into()),
             );
+            self.deregister_lb_targets(state, account_id, task_id);
+            self.emit_state_change(
+                state,
+                account_id,
+                task_id,
+                "STOPPED",
+                Some(("UserInitiated", "Task stopped during launch".into())),
+            );
+            return Ok(());
         }
+
         mark_running_multi(state, account_id, task_id, &started);
         self.register_lb_targets(state, account_id, task_id);
         self.emit_state_change(state, account_id, task_id, "RUNNING", None);
@@ -611,6 +676,10 @@ impl EcsRuntime {
         let cli = self.cli.clone();
         let ids: Vec<String> = started.iter().map(|c| c.container_id.clone()).collect();
         let network = format!("fakecloud-ecs-{task_id}");
+        // Drop the runtime map entry we pre-registered before the launch loop
+        // so a failed launch doesn't leave a stale (now-empty) key that
+        // future StopTask calls would treat as a live task.
+        self.containers.write().remove(task_id);
         tokio::spawn(async move {
             for id in ids {
                 let _ = Command::new(&cli).args(["rm", "-f", &id]).output().await;

--- a/crates/fakecloud-rds/src/runtime/mod.rs
+++ b/crates/fakecloud-rds/src/runtime/mod.rs
@@ -1268,4 +1268,71 @@ mod tests {
             None => std::env::remove_var("FAKECLOUD_POSTGRES_REGISTRY"),
         }
     }
+
+    fn running_stub(container_id: &str) -> RunningDbContainer {
+        RunningDbContainer {
+            container_id: container_id.to_string(),
+            host_port: 54321,
+            endpoint_address: "127.0.0.1".to_string(),
+            endpoint_port: 54321,
+        }
+    }
+
+    /// 4.3 — the create-during-delete race. DeleteDBInstance calls
+    /// `stop_container(id)` while `ensure_postgres` is still mid-flight (the
+    /// container not yet registered), so that stop is a no-op. The create
+    /// task then registers a live container. Reproduce that exact ordering
+    /// and assert the registered container leaks when nothing reaps it —
+    /// i.e. the bug the fix closes by re-running `stop_container` in the
+    /// create task's instance-gone branch.
+    #[tokio::test]
+    async fn stop_container_before_registration_is_a_noop_then_registration_leaks() {
+        let rt = RdsRuntime::new_stub();
+
+        // Delete arrives first: container not registered yet -> no-op.
+        rt.stop_container("db-1").await;
+        assert!(
+            rt.containers.read().is_empty(),
+            "nothing registered yet, stop is a no-op",
+        );
+
+        // ensure_postgres finishes and registers the running container.
+        rt.containers
+            .write()
+            .insert("db-1".to_string(), running_stub("container-abc"));
+
+        // Without the fix the create task's instance-gone branch did nothing,
+        // so the container stays registered (and the real docker container
+        // keeps holding its host port) forever.
+        assert_eq!(
+            rt.containers.read().len(),
+            1,
+            "the registered container leaks with no cleanup branch",
+        );
+    }
+
+    /// 4.3 — the fix: once the create task observes the instance is gone, it
+    /// calls `stop_container(id)`. By then the container IS registered, so
+    /// the stop actually reaps it (the runtime uses `cli=true` so the docker
+    /// rm shells out to a successful no-op binary). The map ends empty: no
+    /// zombie backing container.
+    #[tokio::test]
+    async fn stop_container_after_registration_reaps_orphan_on_delete_during_create() {
+        let rt = RdsRuntime::new_stub();
+
+        // Simulate ensure_postgres having registered the just-started
+        // container right before the create task checks state.
+        rt.containers
+            .write()
+            .insert("db-1".to_string(), running_stub("container-abc"));
+
+        // The instance-gone branch reaps it.
+        rt.stop_container("db-1").await;
+
+        assert!(
+            rt.containers.read().is_empty(),
+            "stop_container must reap the registered orphan: {:?}",
+            rt.containers.read().keys().collect::<Vec<_>>(),
+        );
+    }
 }

--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -289,7 +289,7 @@ impl RdsService {
                             }
                         }
 
-                        {
+                        let instance_present = {
                             let mut accounts = state_handle.write();
                             let state = accounts.get_or_create(&account_id);
                             if let Some(inst) = state.instances.get_mut(&id) {
@@ -298,12 +298,37 @@ impl RdsService {
                                 inst.port = i32::from(running.endpoint_port);
                                 inst.host_port = running.host_port;
                                 inst.container_id = running.container_id;
+                                // Register as cluster member so failover /
+                                // restore paths can find the writer.
+                                if let Some(ref cid) = cluster_id_for_attach {
+                                    attach_cluster_member(state, cid, &id);
+                                }
+                                true
+                            } else {
+                                false
                             }
-                            // Register as cluster member so failover /
-                            // restore paths can find the writer.
-                            if let Some(ref cid) = cluster_id_for_attach {
-                                attach_cluster_member(state, cid, &id);
-                            }
+                        };
+                        // DeleteDBInstance raced this create: it removed the
+                        // instance from state and called stop_container(id)
+                        // while ensure_postgres was still mid-flight (before
+                        // it registered the container), so that stop was a
+                        // no-op. The container the runtime just registered is
+                        // now an orphan holding a host port. Stop and remove
+                        // it here, mirroring ElastiCache's deleted-while-
+                        // creating None branch.
+                        if !instance_present {
+                            tracing::info!(
+                                db_instance_identifier = %id,
+                                "instance deleted during create; reaping orphaned backing container",
+                            );
+                            runtime.stop_container(&id).await;
+                            save_snapshot_static(
+                                state_handle.clone(),
+                                snapshot_store.clone(),
+                                snapshot_lock.clone(),
+                            )
+                            .await;
+                            return;
                         }
                         // Persist the flipped status. Without this the
                         // synchronous CreateDBInstance save captures the

--- a/crates/fakecloud-server/src/reaper.rs
+++ b/crates/fakecloud-server/src/reaper.rs
@@ -1,14 +1,15 @@
 //! Startup reaper for orphaned backing containers.
 //!
 //! fakecloud spawns docker containers for RDS (postgres), ElastiCache (redis),
-//! and Lambda (runtime images) and labels each one with
-//! `fakecloud-instance=fakecloud-<server-pid>`. Normal shutdown runs
-//! `stop_all()` on each runtime, but if the server was killed with SIGKILL
-//! (or crashed, or OOM'd) those containers outlive the process and pile up.
+//! Lambda (runtime images), EC2 and ECS tasks, and labels each one with
+//! `fakecloud-instance=fakecloud-<server-pid>`. ECS awsvpc per-task networks
+//! carry the same label. Normal shutdown runs `stop_all()` on each runtime,
+//! but if the server was killed with SIGKILL (or crashed, or OOM'd) those
+//! containers (and networks) outlive the process and pile up.
 //!
-//! On startup we list every container carrying the `fakecloud-instance`
-//! label, parse the owning PID out of the label value, and remove any
-//! container whose owner is no longer alive. Containers owned by the
+//! On startup we list every container — then every network — carrying the
+//! `fakecloud-instance` label, parse the owning PID out of the label value,
+//! and remove any whose owner is no longer alive. Objects owned by the
 //! currently-running fakecloud process are always skipped.
 
 use std::process::{Command, Stdio};
@@ -24,20 +25,43 @@ pub fn reap_stale_containers() {
         return;
     };
 
-    let output = match Command::new(&cli)
-        .args([
-            "ps",
-            "-a",
-            "--filter",
-            "label=fakecloud-instance",
-            "--format",
-            "{{.ID}} {{.Label \"fakecloud-instance\"}}",
-        ])
-        .stderr(Stdio::null())
-        .output()
-    {
+    let reaped = reap_orphans(&cli, &["ps", "-a"], |id| {
+        vec!["rm".to_string(), "-f".to_string(), id.to_string()]
+    });
+    if reaped > 0 {
+        tracing::info!(count = reaped, "reaped orphaned backing containers");
+    }
+
+    // ECS awsvpc per-task networks carry the same ownership label. The
+    // network driver refuses removal while a container is still attached,
+    // so prune networks *after* containers. `network rm` is a no-op for an
+    // already-gone network, so a partial container reap above doesn't wedge
+    // this pass.
+    let reaped_networks = reap_orphans(&cli, &["network", "ls"], |id| {
+        vec!["network".to_string(), "rm".to_string(), id.to_string()]
+    });
+    if reaped_networks > 0 {
+        tracing::info!(count = reaped_networks, "reaped orphaned backing networks");
+    }
+}
+
+/// List objects carrying the `fakecloud-instance` label via
+/// `<cli> <list_args> --filter label=fakecloud-instance`, then run the
+/// `remove_argv(id)` command for every object whose owning PID is no longer
+/// alive (skipping the current process and live owners). Returns the number
+/// removed. Shared by the container and network reap passes.
+fn reap_orphans(cli: &str, list_args: &[&str], remove_argv: impl Fn(&str) -> Vec<String>) -> usize {
+    let mut args: Vec<&str> = list_args.to_vec();
+    args.extend_from_slice(&[
+        "--filter",
+        "label=fakecloud-instance",
+        "--format",
+        "{{.ID}} {{.Label \"fakecloud-instance\"}}",
+    ]);
+
+    let output = match Command::new(cli).args(&args).stderr(Stdio::null()).output() {
         Ok(o) if o.status.success() => o,
-        _ => return,
+        _ => return 0,
     };
 
     let self_pid = std::process::id();
@@ -57,8 +81,8 @@ pub fn reap_stale_containers() {
         if pid == self_pid || pid_alive(pid) {
             continue;
         }
-        let removed = Command::new(&cli)
-            .args(["rm", "-f", id])
+        let removed = Command::new(cli)
+            .args(remove_argv(id))
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
@@ -69,9 +93,7 @@ pub fn reap_stale_containers() {
         }
     }
 
-    if reaped > 0 {
-        tracing::info!(count = reaped, "reaped orphaned backing containers");
-    }
+    reaped
 }
 
 fn detect_cli() -> Option<String> {


### PR DESCRIPTION
## Summary

Closes the Tier 4 container delete/stop-during-create race family from the 2026-06-15 bug hunt (findings 4.1/4.2/4.3). All three share the root cause flagged in the report: the lifecycle handle is registered only at the end of a multi-second async create, so a concurrent stop/delete no-ops and orphans the backing container. ElastiCache (None-branch cleanup) and the k8s ECS backend (register-before-create) are the correct references.

**4.1 (HIGH) — ECS docker task containers leak forever after a crash (reaper label mismatch).** ECS task containers were labeled only `fakecloud-ecs-task` / `fakecloud-ecs-container`. The shared startup reaper filters strictly on `label=fakecloud-instance` and parses the owning pid out of the value, so ECS containers (plus their published host ports and awsvpc networks) were never reaped after an ungraceful restart. Added the `fakecloud-instance=fakecloud-<pid>` ownership label (exactly matching RDS/ElastiCache/Lambda/EC2) to the ECS `docker run` and to the awsvpc `network create`, and extended the reaper with a second pass that prunes orphaned networks carrying the same label (networks pruned after containers, since the driver refuses removal while a container is still attached).

**4.2 (HIGH) — ECS StopTask/scale-down/DeleteService racing container registration.** `run_task_inner` registered into `self.containers` only after the pull/run, so a stop during the launch window no-op'd and the launched container kept running (a service container = forever); DescribeTasks would show `desiredStatus=STOPPED` over a live workload. Now the task entry is registered before the launch loop and each container id is appended as it starts (so `stop_task` can reach in-flight containers), and after launch the task re-checks `desired_status`: if a stop raced us it stops every launched container and finalizes STOPPED instead of marking RUNNING. Mirrors the k8s backend's register-Pod-before-create ordering.

**4.3 (HIGH) — RDS zombie backing container on Delete-during-Create.** A Delete arriving mid-create called `stop_container(id)` before `ensure_postgres` had registered the container (a no-op); the create task then registered a live container, found the instance gone from state, and had no `else` branch to stop it -> a real postgres/mysql container ran forever holding a host port. Added the instance-gone cleanup branch that calls `stop_container(id)` (now effective, since the container is registered by then), mirroring ElastiCache's deleted-while-creating None branch. Other RDS create paths (replicas, restore) are synchronous and already handle the source/instance-missing case, so they are not affected.

## Test plan

These are races, so the tests exercise the observable logic rather than spinning real containers in CI:

- `fakecloud-ecs` `build_run_argv_emits_fakecloud_instance_label` + `fakecloud_instance_label_matches_reaper_format` — every ECS container carries the ownership label and the value parses back to the owning pid the way the reaper expects (cross-crate format contract).
- `fakecloud-ecs` `task_desired_stopped_detects_stop_during_launch` — the post-launch gate returns RUNNING -> keep, STOPPED -> self-stop, task-removed -> stop.
- `fakecloud-rds` `stop_container_before_registration_is_a_noop_then_registration_leaks` — reproduces the exact delete-then-register ordering and shows the leak the fix closes.
- `fakecloud-rds` `stop_container_after_registration_reaps_orphan_on_delete_during_create` — the fix path: once registered, `stop_container` reaps the orphan (runtime uses `cli=true` so the docker rm is a successful no-op).

`cargo test -p fakecloud-ecs -p fakecloud-rds --lib` and `cargo test -p fakecloud --bins reaper` green; `cargo clippy --all-targets -- -D warnings` clean on all three crates; `cargo fmt --check` clean.

A full end-to-end container test of the reaper network pass is infeasible in CI without docker; it reuses the same proven dead-owner logic as the container pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes container lifecycle races in `fakecloud-ecs` and `fakecloud-rds`, closes the ECS reaper label gap so orphaned ECS containers and networks are cleaned after crashes, and fixes a missing `--label` on awsvpc network create. Stop/Delete during create now reliably stops containers and keeps task/instance state correct.

- **Bug Fixes**
  - ECS: Add `fakecloud-instance=fakecloud-<pid>` to task containers and awsvpc networks; `fakecloud-server` reaper now prunes labeled containers first, then networks. Also fix awsvpc network create to include its own `--label` flag.
  - ECS: Register the task in the runtime map before launching; append container IDs as they start; after launch, if `desiredStatus=STOPPED` or the task is gone, stop all started containers, remove the network, finalize STOPPED, and emit the state change. Remove the pre-registered runtime entry on failed launches.
  - RDS: On Delete-during-Create, if the instance is missing once the container registers, call `stop_container(id)` to reap the orphan (mirrors ElastiCache).
  - Tests: Add unit tests for the ownership label format, stop-during-launch gate, and RDS delete-during-create cleanup.

<sup>Written for commit 2575625e80195141e9c0530f94d0820d1372e3a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

