### PR TITLE
fix(kinesis,sns,kms,iam,s3,eventbridge): correct silent-wrong-output divergences from AWS

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
@@ -45,6 +45,7 @@ impl ResourceProvisioner {
             created_at: Utc::now(),
             subscriptions_deleted: 0,
             fifo_sequence: 0,
+            dedup_cache: BTreeMap::new(),
         };
 
         state.topics.insert(topic_arn.clone(), topic);

--- a/crates/fakecloud-eventbridge/src/service_partner_sources.rs
+++ b/crates/fakecloud-eventbridge/src/service_partner_sources.rs
@@ -313,18 +313,145 @@ impl EventBridgeService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_required("Entries", &body["Entries"])?;
-        let entries = body["Entries"]
+        let entries_array = body["Entries"]
             .as_array()
             .ok_or_else(|| missing("Entries"))?;
+        if entries_array.is_empty() || entries_array.len() > 10 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Value at 'Entries' failed to satisfy constraint: \
+                 Member must have length between 1 and 10",
+            ));
+        }
+        let entries = entries_array.clone();
 
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let mut result_entries = Vec::new();
-        for _entry in entries {
+        let mut events_to_deliver = Vec::new();
+        let mut failed_count = 0;
+
+        for entry in &entries {
+            // For partner events the bus is the partner source name: AWS
+            // routes the event to the partner event bus that mirrors the
+            // source. Validate Source/DetailType/Detail like PutEvents.
+            let source = entry["Source"].as_str().unwrap_or("").to_string();
+            let detail_type = entry["DetailType"].as_str().unwrap_or("").to_string();
+            let detail = entry["Detail"].as_str().unwrap_or("").to_string();
+
+            if let Err(error) = validate_put_events_entry(&source, &detail_type, &detail) {
+                failed_count += 1;
+                result_entries.push(error);
+                continue;
+            }
+
             let event_id = uuid::Uuid::new_v4().to_string();
+            // The partner event bus is named after the source. If the
+            // receiving account has not created that bus yet, the event is
+            // accepted (returns an EventId) but not routed -- matching AWS.
+            let event_bus_name = source.clone();
+            let time = parse_put_events_time(&entry["Time"]);
+            let resources: Vec<String> = entry["Resources"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let event = PutEvent {
+                event_id: event_id.clone(),
+                source: source.clone(),
+                detail_type: detail_type.clone(),
+                detail: detail.clone(),
+                event_bus_name: event_bus_name.clone(),
+                time,
+                resources: resources.clone(),
+            };
+
+            archive_matching_event(
+                state,
+                &event,
+                &event_bus_name,
+                &source,
+                &detail_type,
+                &detail,
+                &req.account_id,
+                &req.region,
+                &resources,
+            );
+
+            state.events.push(event);
+
+            // Route to rules attached to the partner event bus.
+            let matching_targets: Vec<EventTarget> = state
+                .rules
+                .values()
+                .filter(|r| {
+                    r.event_bus_name == event_bus_name
+                        && r.state == "ENABLED"
+                        && matches_pattern(
+                            r.event_pattern.as_deref(),
+                            &source,
+                            &detail_type,
+                            &detail,
+                            &req.account_id,
+                            &req.region,
+                            &resources,
+                        )
+                })
+                .flat_map(|r| r.targets.clone())
+                .collect();
+
+            if !matching_targets.is_empty() {
+                events_to_deliver.push((
+                    event_id.clone(),
+                    source,
+                    detail_type,
+                    detail,
+                    time,
+                    resources,
+                    matching_targets,
+                ));
+            }
+
             result_entries.push(json!({ "EventId": event_id }));
         }
 
+        drop(accounts);
+
+        for (event_id, source, detail_type, detail, time, resources, targets) in events_to_deliver {
+            let detail_value: Value = serde_json::from_str(&detail).unwrap_or(json!({}));
+            let event_json = json!({
+                "version": "0",
+                "id": event_id,
+                "source": source,
+                "account": req.account_id,
+                "detail-type": detail_type,
+                "detail": detail_value,
+                "time": time.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+                "region": req.region,
+                "resources": resources,
+            });
+
+            let ctx = EventDispatchContext {
+                state: &self.state,
+                delivery: &self.delivery,
+                lambda_state: self.lambda_state.as_ref(),
+                logs_state: self.logs_state.as_ref(),
+                container_runtime: &self.container_runtime,
+                account_id: &req.account_id,
+                region: &req.region,
+            };
+            for target in targets {
+                dispatch_event_target(&ctx, &target, &event_json, &event_id, &detail_type);
+            }
+        }
+
         Ok(AwsResponse::ok_json(json!({
-            "FailedEntryCount": 0,
+            "FailedEntryCount": failed_count,
             "Entries": result_entries,
         })))
     }

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -1165,6 +1165,91 @@ fn put_partner_events() {
     assert!(body["Entries"][0]["EventId"].as_str().is_some());
 }
 
+#[test]
+fn put_partner_events_validates_and_records_failed_entries() {
+    let svc = make_service();
+    // Missing DetailType + a valid entry -> one failure, one success.
+    let req = make_request(
+        "PutPartnerEvents",
+        json!({
+            "Entries": [
+                { "Source": "aws.partner/x/y", "Detail": "{}" },
+                { "Source": "aws.partner/x/y", "DetailType": "T", "Detail": "{}" }
+            ]
+        }),
+    );
+    let resp = svc.put_partner_events(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["FailedEntryCount"], 1);
+    assert!(body["Entries"][0]["ErrorCode"].as_str().is_some());
+    assert!(body["Entries"][1]["EventId"].as_str().is_some());
+}
+
+#[test]
+fn put_partner_events_routes_to_partner_bus_rule_target() {
+    let (svc, messages) = make_service_with_sqs_recorder();
+    let source = "aws.partner/example.com/test-source";
+    let queue_arn = "arn:aws:sqs:us-east-1:123456789012:partner-queue";
+
+    // 1. Create the partner event source.
+    svc.create_partner_event_source(&make_request(
+        "CreatePartnerEventSource",
+        json!({ "Name": source, "Account": "123456789012" }),
+    ))
+    .unwrap();
+
+    // 2. The receiving account creates the partner event bus (name == source).
+    svc.create_event_bus(&make_request(
+        "CreateEventBus",
+        json!({ "Name": source, "EventSourceName": source }),
+    ))
+    .unwrap();
+
+    // 3. Rule on the partner bus matching the source, with an SQS target.
+    svc.put_rule(&make_request(
+        "PutRule",
+        json!({
+            "Name": "partner-rule",
+            "EventBusName": source,
+            "EventPattern": format!(r#"{{"source": ["{source}"]}}"#),
+            "State": "ENABLED"
+        }),
+    ))
+    .unwrap();
+    svc.put_targets(&make_request(
+        "PutTargets",
+        json!({
+            "Rule": "partner-rule",
+            "EventBusName": source,
+            "Targets": [{ "Id": "t1", "Arn": queue_arn }]
+        }),
+    ))
+    .unwrap();
+
+    // 4. PutPartnerEvents with Source == the partner bus name.
+    let resp = svc
+        .put_partner_events(&make_request(
+            "PutPartnerEvents",
+            json!({
+                "Entries": [{
+                    "Source": source,
+                    "DetailType": "OrderCreated",
+                    "Detail": "{\"orderId\":\"42\"}"
+                }]
+            }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["FailedEntryCount"], 0);
+
+    // 5. The event must have been routed to the rule's SQS target.
+    let delivered = messages.lock();
+    assert_eq!(delivered.len(), 1, "partner event should reach the target");
+    assert_eq!(delivered[0].0, queue_arn);
+    assert!(delivered[0].1.contains("OrderCreated"));
+    assert!(delivered[0].1.contains("42"));
+}
+
 // ---- Archive + Replay delivery tests ----
 
 /// Helper: create a service with a mock SQS delivery that records messages.

--- a/crates/fakecloud-iam/src/iam_service/groups.rs
+++ b/crates/fakecloud-iam/src/iam_service/groups.rs
@@ -156,7 +156,8 @@ impl IamService {
     }
 
     pub(super) fn list_groups(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let _ = validate_list_pagination(req)?;
+        let max_items = validate_list_pagination(req)? as usize;
+        let marker = req.query_params.get("Marker").cloned();
         let accounts = self.state.read();
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -165,8 +166,32 @@ impl IamService {
         if let Some(prefix) = &path_prefix {
             groups.retain(|g| g.path.starts_with(prefix));
         }
+        groups.sort_by(|a, b| a.group_name.cmp(&b.group_name));
 
-        let members: String = groups
+        // Marker-based pagination: resume after the marked item.
+        let start_idx = marker
+            .as_ref()
+            .and_then(|m| {
+                groups
+                    .iter()
+                    .position(|g| g.group_name == *m)
+                    .map(|p| p + 1)
+            })
+            .unwrap_or(0);
+        let page = groups.get(start_idx..).unwrap_or(&[]);
+        let is_truncated = page.len() > max_items;
+        let page = if is_truncated {
+            &page[..max_items]
+        } else {
+            page
+        };
+        let next_marker = if is_truncated {
+            page.last().map(|g| g.group_name.clone())
+        } else {
+            None
+        };
+
+        let members: String = page
             .iter()
             .map(|g| {
                 format!(
@@ -177,11 +202,16 @@ impl IamService {
             .collect::<Vec<_>>()
             .join("\n");
 
+        let marker_section = match next_marker {
+            Some(m) => format!("\n    <Marker>{m}</Marker>"),
+            None => String::new(),
+        };
+
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListGroupsResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListGroupsResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
     <Groups>
 {members}
     </Groups>

--- a/crates/fakecloud-iam/src/iam_service/policies.rs
+++ b/crates/fakecloud-iam/src/iam_service/policies.rs
@@ -179,6 +179,13 @@ impl IamService {
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let path_prefix = req.query_params.get("PathPrefix").cloned();
         let scope = PolicyScope::from_query(req.query_params.get("Scope").map(|s| s.as_str()));
+        let max_items: usize = req
+            .query_params
+            .get("MaxItems")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(100);
+        let marker = req.query_params.get("Marker").cloned();
+
         let mut policies: Vec<IamPolicy> = state.policies.values().cloned().collect();
         if let Some(prefix) = path_prefix {
             policies.retain(|p| p.path.starts_with(&prefix));
@@ -188,7 +195,33 @@ impl IamService {
             // explicit ``Scope=AWS`` filter returns an empty list.
             policies.clear();
         }
-        let xml = xml_responses::list_policies_response(&policies, &req.request_id);
+        policies.sort_by(|a, b| a.policy_name.cmp(&b.policy_name));
+
+        // Marker-based pagination: resume after the marked item (by ARN, the
+        // stable cursor AWS uses for ListPolicies).
+        let start_idx = marker
+            .as_ref()
+            .and_then(|m| policies.iter().position(|p| p.arn == *m).map(|p| p + 1))
+            .unwrap_or(0);
+        let page = policies.get(start_idx..).unwrap_or(&[]);
+        let is_truncated = page.len() > max_items;
+        let page = if is_truncated {
+            &page[..max_items]
+        } else {
+            page
+        };
+        let next_marker = if is_truncated {
+            page.last().map(|p| p.arn.clone())
+        } else {
+            None
+        };
+
+        let xml = xml_responses::list_policies_response(
+            page,
+            is_truncated,
+            next_marker.as_deref(),
+            &req.request_id,
+        );
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -1722,6 +1722,141 @@ fn list_users_basic() {
     assert!(body.contains("<UserName>u2</UserName>"));
 }
 
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+fn extract_marker(body: &str) -> Option<String> {
+    let start = body.find("<Marker>")? + "<Marker>".len();
+    let end = body[start..].find("</Marker>")? + start;
+    Some(body[start..end].to_string())
+}
+
+#[test]
+fn list_users_paginates_via_marker() {
+    let svc = make_service();
+    for i in 0..5 {
+        svc.create_user(&make_request(
+            "CreateUser",
+            vec![("UserName", &format!("user-{i:02}"))],
+        ))
+        .unwrap();
+    }
+
+    // Page 1: MaxItems=2 -> 2 users, IsTruncated true, a Marker.
+    let body1 = String::from_utf8_lossy(
+        svc.list_users(&make_request("ListUsers", vec![("MaxItems", "2")]))
+            .unwrap()
+            .body
+            .expect_bytes(),
+    )
+    .to_string();
+    assert_eq!(count_occurrences(&body1, "<member>"), 2);
+    assert!(body1.contains("<IsTruncated>true</IsTruncated>"));
+    let marker = extract_marker(&body1).expect("Marker on page 1");
+
+    // Page 2: feed the Marker back -> next 2 users.
+    let body2 = String::from_utf8_lossy(
+        svc.list_users(&make_request(
+            "ListUsers",
+            vec![("MaxItems", "2"), ("Marker", &marker)],
+        ))
+        .unwrap()
+        .body
+        .expect_bytes(),
+    )
+    .to_string();
+    assert_eq!(count_occurrences(&body2, "<member>"), 2);
+    assert!(body2.contains("<IsTruncated>true</IsTruncated>"));
+    let marker = extract_marker(&body2).expect("Marker on page 2");
+
+    // Page 3: last user, not truncated, no Marker.
+    let body3 = String::from_utf8_lossy(
+        svc.list_users(&make_request(
+            "ListUsers",
+            vec![("MaxItems", "2"), ("Marker", &marker)],
+        ))
+        .unwrap()
+        .body
+        .expect_bytes(),
+    )
+    .to_string();
+    assert_eq!(count_occurrences(&body3, "<member>"), 1);
+    assert!(body3.contains("<IsTruncated>false</IsTruncated>"));
+    assert!(extract_marker(&body3).is_none());
+}
+
+#[test]
+fn list_groups_paginates_via_marker() {
+    let svc = make_service();
+    for i in 0..3 {
+        svc.create_group(&make_request(
+            "CreateGroup",
+            vec![("GroupName", &format!("grp-{i}"))],
+        ))
+        .unwrap();
+    }
+    let body1 = String::from_utf8_lossy(
+        svc.list_groups(&make_request("ListGroups", vec![("MaxItems", "2")]))
+            .unwrap()
+            .body
+            .expect_bytes(),
+    )
+    .to_string();
+    assert_eq!(count_occurrences(&body1, "<member>"), 2);
+    assert!(body1.contains("<IsTruncated>true</IsTruncated>"));
+    let marker = extract_marker(&body1).expect("Marker");
+
+    let body2 = String::from_utf8_lossy(
+        svc.list_groups(&make_request(
+            "ListGroups",
+            vec![("MaxItems", "2"), ("Marker", &marker)],
+        ))
+        .unwrap()
+        .body
+        .expect_bytes(),
+    )
+    .to_string();
+    assert_eq!(count_occurrences(&body2, "<member>"), 1);
+    assert!(body2.contains("<IsTruncated>false</IsTruncated>"));
+}
+
+#[test]
+fn list_policies_paginates_via_marker() {
+    let svc = make_service();
+    let doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}"#;
+    for i in 0..3 {
+        svc.create_policy(&make_request(
+            "CreatePolicy",
+            vec![("PolicyName", &format!("pol-{i}")), ("PolicyDocument", doc)],
+        ))
+        .unwrap();
+    }
+    let body1 = String::from_utf8_lossy(
+        svc.list_policies(&make_request("ListPolicies", vec![("MaxItems", "2")]))
+            .unwrap()
+            .body
+            .expect_bytes(),
+    )
+    .to_string();
+    assert_eq!(count_occurrences(&body1, "<member>"), 2);
+    assert!(body1.contains("<IsTruncated>true</IsTruncated>"));
+    let marker = extract_marker(&body1).expect("Marker");
+
+    let body2 = String::from_utf8_lossy(
+        svc.list_policies(&make_request(
+            "ListPolicies",
+            vec![("MaxItems", "2"), ("Marker", &marker)],
+        ))
+        .unwrap()
+        .body
+        .expect_bytes(),
+    )
+    .to_string();
+    assert_eq!(count_occurrences(&body2, "<member>"), 1);
+    assert!(body2.contains("<IsTruncated>false</IsTruncated>"));
+}
+
 #[test]
 fn create_user_with_path_and_tags() {
     let svc = make_service();

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -298,11 +298,43 @@ impl IamService {
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let path_prefix = req.query_params.get("PathPrefix").cloned();
+        let max_items: usize = req
+            .query_params
+            .get("MaxItems")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(100);
+        let marker = req.query_params.get("Marker").cloned();
+
         let mut users: Vec<IamUser> = state.users.values().cloned().collect();
         if let Some(prefix) = path_prefix {
             users.retain(|u| u.path.starts_with(&prefix));
         }
-        let xml = xml_responses::list_users_response(&users, &req.request_id);
+        users.sort_by(|a, b| a.user_name.cmp(&b.user_name));
+
+        // Marker-based pagination: resume after the marked item.
+        let start_idx = marker
+            .as_ref()
+            .and_then(|m| users.iter().position(|u| u.user_name == *m).map(|p| p + 1))
+            .unwrap_or(0);
+        let page = users.get(start_idx..).unwrap_or(&[]);
+        let is_truncated = page.len() > max_items;
+        let page = if is_truncated {
+            &page[..max_items]
+        } else {
+            page
+        };
+        let next_marker = if is_truncated {
+            page.last().map(|u| u.user_name.clone())
+        } else {
+            None
+        };
+
+        let xml = xml_responses::list_users_response(
+            page,
+            is_truncated,
+            next_marker.as_deref(),
+            &req.request_id,
+        );
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -145,7 +145,12 @@ pub fn get_user_response(user: &IamUser, request_id: &str) -> String {
     )
 }
 
-pub fn list_users_response(users: &[IamUser], request_id: &str) -> String {
+pub fn list_users_response(
+    users: &[IamUser],
+    is_truncated: bool,
+    marker: Option<&str>,
+    request_id: &str,
+) -> String {
     let members: String = users
         .iter()
         .map(|u| {
@@ -168,11 +173,17 @@ pub fn list_users_response(users: &[IamUser], request_id: &str) -> String {
         .collect::<Vec<_>>()
         .join("\n");
 
+    let marker_section = if let Some(m) = marker {
+        format!("\n    <Marker>{}</Marker>", xml_escape(m))
+    } else {
+        String::new()
+    };
+
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListUsersResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListUsersResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
     <Users>
 {members}
     </Users>
@@ -430,7 +441,12 @@ pub fn create_policy_response(policy: &IamPolicy, request_id: &str) -> String {
     )
 }
 
-pub fn list_policies_response(policies: &[IamPolicy], request_id: &str) -> String {
+pub fn list_policies_response(
+    policies: &[IamPolicy],
+    is_truncated: bool,
+    marker: Option<&str>,
+    request_id: &str,
+) -> String {
     let members: String = policies
         .iter()
         .map(|p| {
@@ -458,11 +474,17 @@ pub fn list_policies_response(policies: &[IamPolicy], request_id: &str) -> Strin
         .collect::<Vec<_>>()
         .join("\n");
 
+    let marker_section = if let Some(m) = marker {
+        format!("\n    <Marker>{}</Marker>", xml_escape(m))
+    } else {
+        String::new()
+    };
+
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListPoliciesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListPoliciesResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
     <Policies>
 {members}
     </Policies>

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -525,7 +525,8 @@ impl KinesisService {
         let partition_key = require_partition_key(&body)?;
         let data = decode_record_data(&body["Data"])?;
         let encryption_type = stream.encryption_type.clone();
-        let shard = select_shard_mut(stream, partition_key);
+        let explicit_hash_key = body["ExplicitHashKey"].as_str();
+        let shard = select_shard_mut(stream, partition_key, explicit_hash_key)?;
         let sequence_number = append_record(shard, partition_key, data);
         let shard_id = shard.shard_id.clone();
 
@@ -1353,12 +1354,20 @@ impl KinesisService {
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let stream = state.lookup_stream(&body)?;
 
-        let exclusive_start = body["ExclusiveStartShardId"].as_str();
+        // Resume position: a NextToken (opaque cursor) takes precedence over
+        // ExclusiveStartShardId. AWS forbids mixing NextToken with the other
+        // filter params; at minimum we decode it back into the shard id to
+        // resume from the right place so SDK paginators advance.
+        let exclusive_start: Option<String> = match body["NextToken"].as_str() {
+            Some(token) => Some(decode_list_shards_token(token)?),
+            None => body["ExclusiveStartShardId"].as_str().map(str::to_string),
+        };
+
         let mut shards: Vec<Value> = stream
             .shards
             .iter()
             .filter(|s| {
-                if let Some(start_id) = exclusive_start {
+                if let Some(start_id) = exclusive_start.as_deref() {
                     s.shard_id.as_str() > start_id
                 } else {
                     true
@@ -1373,8 +1382,8 @@ impl KinesisService {
 
         let mut resp = json!({ "Shards": shards });
         if has_more {
-            if let Some(last) = shards.last() {
-                resp["NextToken"] = last["ShardId"].clone();
+            if let Some(last_id) = shards.last().and_then(|s| s["ShardId"].as_str()) {
+                resp["NextToken"] = json!(encode_list_shards_token(last_id));
             }
         }
 

--- a/crates/fakecloud-kinesis/src/service_helpers.rs
+++ b/crates/fakecloud-kinesis/src/service_helpers.rs
@@ -184,30 +184,56 @@ pub(crate) fn decode_record_data(value: &Value) -> Result<Vec<u8>, AwsServiceErr
         .map_err(|_| invalid_argument("Data must be valid base64"))
 }
 
+/// Compute the 128-bit hash key for a partition key exactly as AWS does:
+/// the big-endian unsigned integer value of `MD5(partitionKey)`.
+pub(crate) fn partition_key_hash(partition_key: &str) -> u128 {
+    let digest = Md5::digest(partition_key.as_bytes());
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    u128::from_be_bytes(bytes)
+}
+
+/// Resolve the routing hash for a record. When `ExplicitHashKey` is supplied
+/// it overrides the partition-key hash (AWS allows a base-10 string in
+/// `[0, 2^128-1]`); otherwise we hash the partition key with MD5.
+pub(crate) fn routing_hash(
+    partition_key: &str,
+    explicit_hash_key: Option<&str>,
+) -> Result<u128, AwsServiceError> {
+    if let Some(raw) = explicit_hash_key.filter(|value| !value.is_empty()) {
+        return raw
+            .parse::<u128>()
+            .map_err(|_| invalid_argument("ExplicitHashKey must be a valid 128-bit integer"));
+    }
+    Ok(partition_key_hash(partition_key))
+}
+
+/// Locate the open shard whose `[StartingHashKey, EndingHashKey]` range
+/// contains `hash`. Falls back to the last open shard (or the last shard
+/// overall when none are open) so a routing hash can never fail to land.
+pub(crate) fn select_shard_index_for_hash(stream: &KinesisStream, hash: u128) -> usize {
+    let mut fallback: Option<usize> = None;
+    for (idx, shard) in stream.shards.iter().enumerate() {
+        if !shard.is_open {
+            continue;
+        }
+        fallback = Some(idx);
+        let (start, end) = shard_hash_range(shard);
+        if hash >= start && hash <= end {
+            return idx;
+        }
+    }
+    fallback.unwrap_or_else(|| stream.shards.len().saturating_sub(1))
+}
+
 pub(crate) fn select_shard_mut<'a>(
     stream: &'a mut KinesisStream,
     partition_key: &str,
-) -> &'a mut KinesisShard {
-    let open_indices: Vec<usize> = stream
-        .shards
-        .iter()
-        .enumerate()
-        .filter(|(_, s)| s.is_open)
-        .map(|(i, _)| i)
-        .collect();
-    if open_indices.is_empty() {
-        let idx = partition_key_to_shard_index(partition_key, stream.shards.len());
-        return &mut stream.shards[idx];
-    }
-    let idx = partition_key_to_shard_index(partition_key, open_indices.len());
-    &mut stream.shards[open_indices[idx]]
-}
-
-pub(crate) fn partition_key_to_shard_index(partition_key: &str, shard_count: usize) -> usize {
-    let digest = Md5::digest(partition_key.as_bytes());
-    let mut bytes = [0u8; 8];
-    bytes.copy_from_slice(&digest[..8]);
-    (u64::from_be_bytes(bytes) as usize) % shard_count
+    explicit_hash_key: Option<&str>,
+) -> Result<&'a mut KinesisShard, AwsServiceError> {
+    let hash = routing_hash(partition_key, explicit_hash_key)?;
+    let idx = select_shard_index_for_hash(stream, hash);
+    Ok(&mut stream.shards[idx])
 }
 
 pub(crate) fn append_record(
@@ -240,7 +266,9 @@ pub(crate) fn put_records_entry(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "PartitionKey is required".to_string())?;
     let data = decode_record_data(&entry["Data"]).map_err(|error| error.message())?;
-    let shard = select_shard_mut(stream, partition_key);
+    let explicit_hash_key = entry["ExplicitHashKey"].as_str();
+    let shard = select_shard_mut(stream, partition_key, explicit_hash_key)
+        .map_err(|error| error.message())?;
     let sequence_number = append_record(shard, partition_key, data);
     Ok((shard.shard_id.clone(), sequence_number))
 }
@@ -304,6 +332,30 @@ pub(crate) fn find_record_index_by_sequence_number(
         .iter()
         .position(|record| record.sequence_number == sequence_number)
         .ok_or_else(|| invalid_argument("StartingSequenceNumber is invalid"))
+}
+
+/// Encode a `ListShards` continuation token. AWS returns an opaque base64
+/// cursor; we wrap the last-returned shard id so that a paginator feeding the
+/// token back resumes immediately after it.
+pub(crate) fn encode_list_shards_token(last_shard_id: &str) -> String {
+    let payload = json!({ "ExclusiveStartShardId": last_shard_id });
+    base64::engine::general_purpose::STANDARD.encode(payload.to_string().as_bytes())
+}
+
+/// Decode a `ListShards` continuation token back into the exclusive-start
+/// shard id. Rejects malformed tokens with `InvalidArgumentException`, the
+/// same shape AWS uses for an expired/garbage `NextToken`.
+pub(crate) fn decode_list_shards_token(token: &str) -> Result<String, AwsServiceError> {
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(token)
+        .map_err(|_| invalid_argument("Invalid NextToken"))?;
+    let parsed: Value =
+        serde_json::from_slice(&raw).map_err(|_| invalid_argument("Invalid NextToken"))?;
+    parsed["ExclusiveStartShardId"]
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| invalid_argument("Invalid NextToken"))
 }
 
 pub(crate) fn validate_stream_id(body: &Value) -> Result<(), AwsServiceError> {

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -27,6 +27,27 @@ fn request(action: &str, body: Value) -> AwsRequest {
     }
 }
 
+fn test_stream(name: &str) -> KinesisStream {
+    KinesisStream {
+        stream_name: name.to_string(),
+        stream_arn: format!("arn:aws:kinesis:us-east-1:123456789012:stream/{name}"),
+        stream_status: "ACTIVE".to_string(),
+        stream_creation_timestamp: Utc::now(),
+        retention_period_hours: 24,
+        stream_mode: "PROVISIONED".to_string(),
+        encryption_type: "NONE".to_string(),
+        key_id: None,
+        shard_count: 0,
+        open_shard_count: 0,
+        tags: Default::default(),
+        shards: Vec::new(),
+        next_shard_index: 0,
+        enhanced_metrics: Vec::new(),
+        warm_throughput_mibps: None,
+        max_record_size_kib: None,
+    }
+}
+
 fn test_shard() -> KinesisShard {
     KinesisShard {
         shard_id: "shardId-000000000000".to_string(),
@@ -125,12 +146,64 @@ fn update_retention_period_validates_direction() {
 
 #[test]
 fn partition_keys_route_deterministically() {
-    let shard_a = partition_key_to_shard_index("customer-1", 4);
-    let shard_b = partition_key_to_shard_index("customer-1", 4);
-    let shard_c = partition_key_to_shard_index("customer-2", 4);
+    // The same partition key always yields the same 128-bit hash.
+    let hash_a = partition_key_hash("customer-1");
+    let hash_b = partition_key_hash("customer-1");
+    assert_eq!(hash_a, hash_b);
+}
 
-    assert_eq!(shard_a, shard_b);
-    assert!(shard_c < 4);
+#[test]
+fn partition_key_routes_into_containing_hash_range() {
+    // Build a 4-shard stream and verify every partition key lands in the
+    // open shard whose [start, end] range contains MD5(partitionKey).
+    let shards = build_stream_shards(4);
+    let stream = KinesisStream {
+        shards,
+        ..test_stream("orders")
+    };
+    for key in ["customer-1", "customer-2", "alpha", "beta", "gamma", "zeta"] {
+        let hash = partition_key_hash(key);
+        let idx = select_shard_index_for_hash(&stream, hash);
+        let (start, end) = shard_hash_range(&stream.shards[idx]);
+        assert!(
+            hash >= start && hash <= end,
+            "key {key} hash {hash} not in shard {idx} range [{start}, {end}]"
+        );
+        assert!(stream.shards[idx].is_open);
+    }
+}
+
+#[test]
+fn explicit_hash_key_overrides_partition_key() {
+    let shards = build_stream_shards(4);
+    let mut stream = KinesisStream {
+        shards,
+        ..test_stream("orders")
+    };
+    // ExplicitHashKey points at the very top of the keyspace -> last shard.
+    let top = MAX_HASH_KEY.to_string();
+    let shard = select_shard_mut(&mut stream, "ignored-partition-key", Some(&top)).unwrap();
+    assert_eq!(shard.shard_id, "shardId-000000000003");
+
+    // ExplicitHashKey of 0 -> first shard regardless of partition key.
+    let shard = select_shard_mut(&mut stream, "ignored-partition-key", Some("0")).unwrap();
+    assert_eq!(shard.shard_id, "shardId-000000000000");
+}
+
+#[test]
+fn routing_skips_closed_shards() {
+    let mut shards = build_stream_shards(2);
+    // Close the first shard; everything must route to the open one.
+    shards[0].is_open = false;
+    let mut stream = KinesisStream {
+        shards,
+        ..test_stream("orders")
+    };
+    // A hash that falls in the (now closed) first shard's range still routes
+    // to an open shard.
+    let shard = select_shard_mut(&mut stream, "x", Some("0")).unwrap();
+    assert!(shard.is_open);
+    assert_eq!(shard.shard_id, "shardId-000000000001");
 }
 
 #[test]
@@ -1284,6 +1357,161 @@ fn list_shards_unknown_stream_errors() {
     let (svc, _) = make_service();
     let req = request("ListShards", json!({"StreamName": "ghost"}));
     assert!(svc.list_shards(&req).is_err());
+}
+
+#[test]
+fn list_shards_next_token_paginates_through_all_shards() {
+    let (svc, _) = make_service();
+    svc.create_stream(&request(
+        "CreateStream",
+        json!({ "StreamName": "paged", "ShardCount": 5 }),
+    ))
+    .unwrap();
+
+    // Page 1: MaxResults=2 -> 2 shards + a NextToken.
+    let resp = svc
+        .list_shards(&request(
+            "ListShards",
+            json!({ "StreamName": "paged", "MaxResults": 2 }),
+        ))
+        .unwrap();
+    let v = json_response(resp);
+    let page1: Vec<String> = v["Shards"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["ShardId"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(page1.len(), 2);
+    let token = v["NextToken"].as_str().expect("NextToken on page 1");
+
+    // Page 2: feed the token back -> next 2 distinct shards.
+    let resp = svc
+        .list_shards(&request(
+            "ListShards",
+            json!({ "StreamName": "paged", "MaxResults": 2, "NextToken": token }),
+        ))
+        .unwrap();
+    let v = json_response(resp);
+    let page2: Vec<String> = v["Shards"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["ShardId"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(page2.len(), 2);
+    let token = v["NextToken"].as_str().expect("NextToken on page 2");
+    // Pages must advance, not loop on page 1 (the bug).
+    assert!(page2.iter().all(|s| !page1.contains(s)), "pages overlap");
+
+    // Page 3: final shard, no NextToken.
+    let resp = svc
+        .list_shards(&request(
+            "ListShards",
+            json!({ "StreamName": "paged", "MaxResults": 2, "NextToken": token }),
+        ))
+        .unwrap();
+    let v = json_response(resp);
+    let page3: Vec<String> = v["Shards"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["ShardId"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(page3.len(), 1);
+    assert!(v.get("NextToken").is_none() || v["NextToken"].is_null());
+
+    // All 5 shards seen exactly once across the three pages.
+    let mut all: Vec<String> = page1;
+    all.extend(page2);
+    all.extend(page3);
+    all.sort();
+    all.dedup();
+    assert_eq!(all.len(), 5);
+}
+
+#[test]
+fn list_shards_rejects_garbage_next_token() {
+    let (svc, _) = make_service();
+    svc.create_stream(&request(
+        "CreateStream",
+        json!({ "StreamName": "paged", "ShardCount": 2 }),
+    ))
+    .unwrap();
+    let err = svc
+        .list_shards(&request(
+            "ListShards",
+            json!({ "StreamName": "paged", "NextToken": "not-a-real-token" }),
+        ))
+        .err()
+        .expect("garbage NextToken should fail");
+    assert_eq!(err.code(), "InvalidArgumentException");
+}
+
+#[test]
+fn put_record_routes_into_shard_whose_range_contains_the_hash() {
+    let (svc, state) = make_service();
+    svc.create_stream(&request(
+        "CreateStream",
+        json!({ "StreamName": "routed", "ShardCount": 4 }),
+    ))
+    .unwrap();
+
+    for key in ["alpha", "beta", "gamma", "delta", "omega"] {
+        let resp = svc
+            .put_record(&request(
+                "PutRecord",
+                json!({
+                    "StreamName": "routed",
+                    "PartitionKey": key,
+                    "Data": base64::engine::general_purpose::STANDARD.encode(b"x"),
+                }),
+            ))
+            .unwrap();
+        let v = json_response(resp);
+        let shard_id = v["ShardId"].as_str().unwrap();
+
+        // Verify the chosen shard's hash range actually contains MD5(key).
+        let hash = partition_key_hash(key);
+        let accts = state.read();
+        let st = accts.default_ref();
+        let stream = st.streams.get("routed").unwrap();
+        let shard = stream
+            .shards
+            .iter()
+            .find(|s| s.shard_id == shard_id)
+            .unwrap();
+        let (start, end) = shard_hash_range(shard);
+        assert!(
+            hash >= start && hash <= end,
+            "key {key} hash {hash} routed to shard {shard_id} range [{start},{end}]"
+        );
+    }
+}
+
+#[test]
+fn put_record_explicit_hash_key_overrides_partition_key() {
+    let (svc, _state) = make_service();
+    svc.create_stream(&request(
+        "CreateStream",
+        json!({ "StreamName": "ehk", "ShardCount": 4 }),
+    ))
+    .unwrap();
+
+    // ExplicitHashKey=0 must land in the first shard regardless of key.
+    let resp = svc
+        .put_record(&request(
+            "PutRecord",
+            json!({
+                "StreamName": "ehk",
+                "PartitionKey": "any-key",
+                "ExplicitHashKey": "0",
+                "Data": base64::engine::general_purpose::STANDARD.encode(b"x"),
+            }),
+        ))
+        .unwrap();
+    let v = json_response(resp);
+    assert_eq!(v["ShardId"].as_str().unwrap(), "shardId-000000000000");
 }
 
 #[test]

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -100,6 +100,36 @@ impl KmsService {
         let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
         let decoded = decode_ciphertext_envelope(state, ciphertext_b64, &ec_aad)?;
 
+        // When the caller supplies KeyId for a symmetric decrypt, AWS
+        // validates it identifies the same CMK that produced the blob and
+        // returns IncorrectKeyException otherwise (1.5). For symmetric keys
+        // KeyId is optional (AWS recovers it from the blob), but if present
+        // it must match. We resolve the caller KeyId (raw id / key ARN /
+        // alias / alias ARN) to its key ARN and compare against the
+        // producing key's ARN.
+        if let Some(caller_key_id) = body["KeyId"].as_str().filter(|s| !s.is_empty()) {
+            let resolved = Self::resolve_key_id_with_state(state, caller_key_id)
+                .and_then(|id| state.keys.get(&id))
+                .map(|k| k.arn.clone());
+            match resolved {
+                Some(arn) if arn == decoded.source_arn => {}
+                Some(_) => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "IncorrectKeyException",
+                        "The key ID in the request does not identify a CMK that can perform this operation.",
+                    ));
+                }
+                None => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "NotFoundException",
+                        format!("Key '{caller_key_id}' does not exist"),
+                    ));
+                }
+            }
+        }
+
         // Gate Decrypt on the source key's lifecycle state. AWS rejects
         // Decrypt against a key in any state other than `Enabled`.
         if let Some(key_id_only) = decoded.source_arn.rsplit('/').next() {

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -2809,3 +2809,82 @@ fn re_encrypt_rejects_mismatched_source_encryption_context() {
         .expect("source EC mismatch must abort ReEncrypt");
     assert!(format!("{err:?}").contains("InvalidCiphertextException"));
 }
+
+#[test]
+fn decrypt_with_correct_key_id_succeeds() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+
+    let plaintext = base64::engine::general_purpose::STANDARD.encode(b"top-secret");
+    let enc = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({ "KeyId": key_id, "Plaintext": plaintext }),
+        ))
+        .unwrap();
+    let enc_body: Value = serde_json::from_slice(enc.body.expect_bytes()).unwrap();
+    let ciphertext = enc_body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    // Passing the SAME KeyId that produced the blob must succeed.
+    let dec = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({ "CiphertextBlob": ciphertext, "KeyId": key_id }),
+        ))
+        .unwrap();
+    let dec_body: Value = serde_json::from_slice(dec.body.expect_bytes()).unwrap();
+    assert_eq!(dec_body["Plaintext"].as_str().unwrap(), plaintext);
+}
+
+#[test]
+fn decrypt_with_wrong_key_id_returns_incorrect_key_exception() {
+    let svc = make_service();
+    let producing_key = create_key(&svc);
+    let other_key = create_key(&svc);
+
+    let plaintext = base64::engine::general_purpose::STANDARD.encode(b"top-secret");
+    let enc = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({ "KeyId": producing_key, "Plaintext": plaintext }),
+        ))
+        .unwrap();
+    let enc_body: Value = serde_json::from_slice(enc.body.expect_bytes()).unwrap();
+    let ciphertext = enc_body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    // Supplying a DIFFERENT KeyId must be rejected, not silently decrypted.
+    let err = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({ "CiphertextBlob": ciphertext, "KeyId": other_key }),
+        ))
+        .err()
+        .expect("wrong KeyId must be rejected");
+    assert_eq!(err.code(), "IncorrectKeyException");
+}
+
+#[test]
+fn decrypt_without_key_id_still_succeeds() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+
+    let plaintext = base64::engine::general_purpose::STANDARD.encode(b"hi");
+    let enc = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({ "KeyId": key_id, "Plaintext": plaintext }),
+        ))
+        .unwrap();
+    let enc_body: Value = serde_json::from_slice(enc.body.expect_bytes()).unwrap();
+    let ciphertext = enc_body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    // KeyId is optional for symmetric decrypt; omitting it works.
+    let dec = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({ "CiphertextBlob": ciphertext }),
+        ))
+        .unwrap();
+    let dec_body: Value = serde_json::from_slice(dec.body.expect_bytes()).unwrap();
+    assert_eq!(dec_body["Plaintext"].as_str().unwrap(), plaintext);
+}

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2076,6 +2076,18 @@ pub(crate) fn compute_checksum(algorithm: &str, data: &[u8]) -> String {
             let crc = crc32fast::hash(data);
             BASE64.encode(crc.to_be_bytes())
         }
+        // CRC32C and CRC64NVME use the same crates as the streaming path so
+        // CopyObject / CompleteMultipartUpload produce identical results to
+        // a streaming PutObject (1.7).
+        "CRC32C" => {
+            let crc = crc32c::crc32c(data);
+            BASE64.encode(crc.to_be_bytes())
+        }
+        "CRC64NVME" => {
+            let mut hasher = crc64fast_nvme::Digest::new();
+            hasher.write(data);
+            BASE64.encode(hasher.sum64().to_be_bytes())
+        }
         "SHA1" => {
             use sha1::Digest as _;
             let hash = sha1::Sha1::digest(data);
@@ -2744,4 +2756,51 @@ mod extract_xml_value_tests {
     fn open_without_close_is_none() {
         assert_eq!(extract_xml_value("<Key>value", "Key"), None);
     }
+}
+
+#[cfg(test)]
+mod compute_checksum_tests {
+    use super::{compute_checksum, compute_checksum_streaming};
+
+    // bug-audit 2026-06-15, 1.7: CopyObject / CompleteMultipartUpload routed
+    // through the non-streaming compute_checksum, whose `_ =>` arm returned an
+    // empty string for CRC32C / CRC64NVME -> GetObjectAttributes reported an
+    // empty checksum and integrity checks silently broke.
+    #[test]
+    fn crc32c_is_non_empty_and_matches_known_vector() {
+        // CRC32C of "123456789" is 0xE3069283; base64 of those 4 BE bytes.
+        let out = compute_checksum("CRC32C", b"123456789");
+        assert!(!out.is_empty());
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&out)
+            .unwrap();
+        assert_eq!(bytes, 0xE306_9283u32.to_be_bytes());
+    }
+
+    #[test]
+    fn crc64nvme_is_non_empty() {
+        let out = compute_checksum("CRC64NVME", b"hello world");
+        assert!(!out.is_empty());
+        // 8 BE bytes of a u64.
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&out)
+            .unwrap();
+        assert_eq!(bytes.len(), 8);
+    }
+
+    #[tokio::test]
+    async fn non_streaming_matches_streaming_for_all_algorithms() {
+        let data = b"the quick brown fox jumps over the lazy dog".repeat(100);
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(tmp.path(), &data).await.unwrap();
+
+        for algo in ["CRC32", "CRC32C", "CRC64NVME", "SHA1", "SHA256"] {
+            let direct = compute_checksum(algo, &data);
+            let streamed = compute_checksum_streaming(algo, tmp.path()).await.unwrap();
+            assert!(!direct.is_empty(), "{algo} direct empty");
+            assert_eq!(direct, streamed, "{algo} direct != streaming");
+        }
+    }
+
+    use base64::Engine as _;
 }

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -79,8 +79,8 @@ impl SnsDeliveryImpl {
             topic_arn,
             subject,
             endpoint: &endpoint,
-            sqs_message: message,
             default_message: message,
+            structure: None,
             envelope_attrs: &envelope_attrs,
             message_attributes: &empty_attrs,
             message_group_id,
@@ -139,6 +139,7 @@ mod tests {
             created_at: Utc::now(),
             subscriptions_deleted: 0,
             fifo_sequence: 0,
+            dedup_cache: std::collections::BTreeMap::new(),
         };
         (topic, arn)
     }

--- a/crates/fakecloud-sns/src/helpers.rs
+++ b/crates/fakecloud-sns/src/helpers.rs
@@ -134,6 +134,21 @@ pub(crate) fn validate_message_structure_json(message: &str) -> Result<(), AwsSe
     Ok(())
 }
 
+/// Lowercase hex SHA-256 of the input, used for SNS FIFO
+/// content-based deduplication (1.4).
+pub(crate) fn sns_sha256_hex(input: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
 pub(crate) fn not_found(entity: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::NOT_FOUND,
@@ -459,6 +474,7 @@ pub(crate) fn collect_topic_subscribers(
         .map(|s| crate::service::HttpSubscriber {
             endpoint: s.endpoint.clone(),
             subscription_arn: s.subscription_arn.clone(),
+            protocol: s.protocol.clone(),
             delivery_policy: s.attributes.get("DeliveryPolicy").cloned(),
             redrive_policy: s.attributes.get("RedrivePolicy").cloned(),
         })
@@ -477,7 +493,7 @@ pub(crate) fn collect_topic_subscribers(
         .values()
         .filter(|s| s.protocol == "email" || s.protocol == "email-json")
         .filter(confirmed_for_topic)
-        .map(|s| s.endpoint.clone())
+        .map(|s| (s.endpoint.clone(), s.protocol.clone()))
         .collect();
 
     let sms = state

--- a/crates/fakecloud-sns/src/resource_policy.rs
+++ b/crates/fakecloud-sns/src/resource_policy.rs
@@ -109,6 +109,7 @@ mod tests {
                 created_at: Utc::now(),
                 subscriptions_deleted: 0,
                 fifo_sequence: 0,
+                dedup_cache: std::collections::BTreeMap::new(),
             },
         );
         state

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -588,6 +588,7 @@ impl SnsService {
                 created_at: Utc::now(),
                 subscriptions_deleted: 0,
                 fifo_sequence: 0,
+                dedup_cache: std::collections::BTreeMap::new(),
             };
             state.topics.insert(topic_arn.clone(), topic);
         }
@@ -1727,7 +1728,8 @@ pub(crate) struct TopicSubscribers {
     pub(crate) http: Vec<HttpSubscriber>,
     /// (function_arn, subscription_arn)
     pub(crate) lambda: Vec<(String, String)>,
-    pub(crate) email: Vec<String>,
+    /// (email_address, protocol) where protocol is `email` or `email-json`
+    pub(crate) email: Vec<(String, String)>,
     pub(crate) sms: Vec<String>,
 }
 
@@ -1737,6 +1739,9 @@ pub(crate) struct TopicSubscribers {
 pub(crate) struct HttpSubscriber {
     pub(crate) endpoint: String,
     pub(crate) subscription_arn: String,
+    /// `http` or `https` — used to resolve the per-protocol body when
+    /// `MessageStructure=json`.
+    pub(crate) protocol: String,
     pub(crate) delivery_policy: Option<String>,
     pub(crate) redrive_policy: Option<String>,
 }
@@ -1751,12 +1756,36 @@ pub(crate) struct TopicFanoutContext<'a> {
     pub(crate) topic_arn: &'a str,
     pub(crate) subject: Option<&'a str>,
     pub(crate) endpoint: &'a str,
-    pub(crate) sqs_message: &'a str,
     pub(crate) default_message: &'a str,
+    /// When `MessageStructure=json`, the parsed protocol->body map. Each
+    /// fan-out helper resolves its own protocol key from this (falling back
+    /// to the `default` key) so every subscriber gets a protocol-specific
+    /// body, not just SQS. `None` for a plain (non-json) message.
+    pub(crate) structure: Option<&'a Value>,
     pub(crate) envelope_attrs: &'a serde_json::Map<String, Value>,
     pub(crate) message_attributes: &'a BTreeMap<String, MessageAttribute>,
     pub(crate) message_group_id: Option<&'a str>,
     pub(crate) message_dedup_id: Option<&'a str>,
+}
+
+impl TopicFanoutContext<'_> {
+    /// Resolve the body for a specific subscriber protocol when
+    /// `MessageStructure=json`. AWS picks the protocol-specific key
+    /// (`http`/`https`/`lambda`/`email`/`email-json`/`sms`/`application`/
+    /// `sqs`/`firehose`) and falls back to the required `default` key when
+    /// the protocol key is absent. With no JSON structure the resolved body
+    /// is just `default_message`.
+    pub(crate) fn body_for_protocol(&self, protocol: &str) -> String {
+        match self.structure {
+            Some(structure) => structure
+                .get(protocol)
+                .or_else(|| structure.get("default"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(self.default_message)
+                .to_string(),
+            None => self.default_message.to_string(),
+        }
+    }
 }
 
 /// Known match type keys for filter policy objects.

--- a/crates/fakecloud-sns/src/service_publish.rs
+++ b/crates/fakecloud-sns/src/service_publish.rs
@@ -144,6 +144,52 @@ impl SnsService {
 
         self.record_topic_kms_usage(&req.account_id, &topic_arn, kms_key_id.as_deref(), &message)?;
 
+        // FIFO dedup (1.4). Resolve the effective dedup id: the explicit
+        // MessageDeduplicationId, or the SHA-256 of the message body when
+        // ContentBasedDeduplication is enabled. A duplicate within the
+        // 5-minute window is suppressed (not fanned out) and replays the
+        // ORIGINAL MessageId/SequenceNumber. Mirrors SQS FIFO dedup.
+        let effective_dedup_id: Option<String> = if is_fifo {
+            message_dedup_id.clone().or_else(|| {
+                if content_dedup {
+                    Some(sns_sha256_hex(&message))
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        };
+
+        if let Some(ref dedup_id) = effective_dedup_id {
+            let now = Utc::now();
+            if let Some(topic) = state.topics.get_mut(&topic_arn) {
+                topic.dedup_cache.retain(|_, e| e.expiry > now);
+                if let Some(entry) = topic.dedup_cache.get(dedup_id) {
+                    let sequence_xml = entry
+                        .sequence_number
+                        .as_deref()
+                        .map(|s| format!("\n    <SequenceNumber>{s}</SequenceNumber>"))
+                        .unwrap_or_default();
+                    let original_id = entry.message_id.clone();
+                    return Ok(xml_resp(
+                        &format!(
+                            r#"<PublishResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <PublishResult>
+    <MessageId>{original_id}</MessageId>{sequence_xml}
+  </PublishResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</PublishResponse>"#,
+                            req.request_id
+                        ),
+                        &req.request_id,
+                    ));
+                }
+            }
+        }
+
         // Mint a strictly-increasing FIFO SequenceNumber (1.6). None for standard topics.
         let sequence_number = if is_fifo {
             state.topics.get_mut(&topic_arn).map(|t| {
@@ -166,6 +212,21 @@ impl SnsService {
             timestamp: Utc::now(),
         });
 
+        // Record this publish in the FIFO dedup cache so a duplicate within
+        // the 5-minute window replays it (1.4).
+        if let Some(ref dedup_id) = effective_dedup_id {
+            if let Some(topic) = state.topics.get_mut(&topic_arn) {
+                topic.dedup_cache.insert(
+                    dedup_id.clone(),
+                    crate::state::SnsDedupEntry {
+                        message_id: msg_id.clone(),
+                        sequence_number: sequence_number.clone(),
+                        expiry: Utc::now() + chrono::Duration::minutes(5),
+                    },
+                );
+            }
+        }
+
         // Resolve the actual message per protocol for MessageStructure=json
         let parsed_structure: Option<Value> = if message_structure.as_deref() == Some("json") {
             Some(serde_json::from_str(&message).map_err(|_| {
@@ -184,18 +245,8 @@ impl SnsService {
         let endpoint = state.endpoint.clone();
         drop(accounts);
 
-        // Determine actual message content per protocol
-        let sqs_message = if let Some(ref structure) = parsed_structure {
-            structure
-                .get("sqs")
-                .or_else(|| structure.get("default"))
-                .and_then(|v| v.as_str())
-                .unwrap_or(&message)
-                .to_string()
-        } else {
-            message.clone()
-        };
-
+        // Determine the fallback ("default" key) body; each fan-out helper
+        // resolves its own protocol-specific body from `parsed_structure`.
         let default_message = if let Some(ref structure) = parsed_structure {
             structure
                 .get("default")
@@ -213,8 +264,8 @@ impl SnsService {
             topic_arn: &topic_arn,
             subject: subject.as_deref(),
             endpoint: &endpoint,
-            sqs_message: &sqs_message,
             default_message: &default_message,
+            structure: parsed_structure.as_ref(),
             envelope_attrs: &envelope_attrs,
             message_attributes: &message_attributes,
             message_group_id: message_group_id.as_deref(),
@@ -654,6 +705,7 @@ pub(crate) fn deliver_to_sqs_subscribers(
     subs: &[(String, bool)],
     ctx: &TopicFanoutContext<'_>,
 ) {
+    let sqs_message = ctx.body_for_protocol("sqs");
     for (queue_arn, raw) in subs {
         if *raw {
             let mut sqs_msg_attrs = HashMap::new();
@@ -670,7 +722,7 @@ pub(crate) fn deliver_to_sqs_subscribers(
             }
             delivery.send_to_sqs_with_attrs(
                 queue_arn,
-                ctx.sqs_message,
+                &sqs_message,
                 &sqs_msg_attrs,
                 ctx.message_group_id,
                 ctx.message_dedup_id,
@@ -680,7 +732,7 @@ pub(crate) fn deliver_to_sqs_subscribers(
                 ctx.msg_id,
                 ctx.topic_arn,
                 &ctx.subject.map(|s| s.to_string()),
-                ctx.sqs_message,
+                &sqs_message,
                 ctx.envelope_attrs,
                 ctx.endpoint,
             );
@@ -704,11 +756,12 @@ pub(crate) fn deliver_to_http_subscribers(
     ctx: &TopicFanoutContext<'_>,
 ) {
     for sub in subs {
+        let protocol_body = ctx.body_for_protocol(&sub.protocol);
         let body = build_sns_envelope(
             ctx.msg_id,
             ctx.topic_arn,
             &ctx.subject.map(|s| s.to_string()),
-            ctx.default_message,
+            &protocol_body,
             ctx.envelope_attrs,
             ctx.endpoint,
         );
@@ -765,6 +818,7 @@ pub(crate) fn deliver_to_lambda_subscribers(
     }
     let now = Utc::now();
     let subject_owned = ctx.subject.map(|s| s.to_string());
+    let lambda_message = ctx.body_for_protocol("lambda");
 
     let lambda_payloads: Vec<(String, String)> = subs
         .iter()
@@ -773,7 +827,7 @@ pub(crate) fn deliver_to_lambda_subscribers(
                 message_id: ctx.msg_id,
                 topic_arn: ctx.topic_arn,
                 subscription_arn,
-                message: ctx.default_message,
+                message: &lambda_message,
                 subject: ctx.subject,
                 message_attributes: ctx.envelope_attrs,
                 timestamp: &now,
@@ -792,7 +846,7 @@ pub(crate) fn deliver_to_lambda_subscribers(
                 .lambda_invocations
                 .push(crate::state::LambdaInvocation {
                     function_arn: function_arn.clone(),
-                    message: ctx.default_message.to_string(),
+                    message: lambda_message.clone(),
                     subject: subject_owned.clone(),
                     timestamp: now,
                 });
@@ -830,7 +884,7 @@ pub(crate) fn deliver_to_lambda_subscribers(
 
 pub(crate) fn deliver_to_email_subscribers(
     state: &SharedSnsState,
-    subs: &[String],
+    subs: &[(String, String)],
     ctx: &TopicFanoutContext<'_>,
 ) {
     if subs.is_empty() {
@@ -839,12 +893,22 @@ pub(crate) fn deliver_to_email_subscribers(
     let now = Utc::now();
     let subject_owned = ctx.subject.map(|s| s.to_string());
     let topic_arn = ctx.topic_arn.to_string();
-    let body = ctx.default_message.to_string();
+    // Resolve the body per protocol so `email` and `email-json` subscribers
+    // can each receive their own MessageStructure=json variant.
+    let email_body = ctx.body_for_protocol("email");
+    let email_json_body = ctx.body_for_protocol("email-json");
+    let body_for = |protocol: &str| -> String {
+        if protocol == "email-json" {
+            email_json_body.clone()
+        } else {
+            email_body.clone()
+        }
+    };
     let acct = ctx.topic_arn.split(':').nth(4).unwrap_or("");
     {
         let mut accounts = state.write();
         let state = accounts.get_or_create(acct);
-        for email_address in subs {
+        for (email_address, protocol) in subs {
             tracing::info!(
                 email = %email_address,
                 topic_arn = %topic_arn,
@@ -852,7 +916,7 @@ pub(crate) fn deliver_to_email_subscribers(
             );
             state.sent_emails.push(crate::state::SentEmail {
                 email_address: email_address.clone(),
-                message: body.clone(),
+                message: body_for(protocol),
                 subject: subject_owned.clone(),
                 topic_arn: topic_arn.clone(),
                 timestamp: now,
@@ -869,15 +933,16 @@ pub(crate) fn deliver_to_email_subscribers(
             .clone()
             .unwrap_or_else(|| format!("AWS Notification - {topic_arn}"));
         let from = format!("no-reply@sns.{}.amazonaws.com", default_region(&topic_arn));
-        for email_address in subs {
+        for (email_address, protocol) in subs {
             let to = [email_address.clone()];
+            let relay_body = body_for(protocol);
             let mail = fakecloud_ses::smtp_relay::OutboundMail {
                 from: &from,
                 to: &to,
                 cc: &[],
                 bcc: &[],
                 subject: Some(&subject),
-                text_body: Some(&body),
+                text_body: Some(&relay_body),
                 html_body: None,
             };
             if let Err(err) = fakecloud_ses::smtp_relay::relay(&relay_url, &mail) {
@@ -909,6 +974,7 @@ pub(crate) fn deliver_to_sms_subscribers(
     if subs.is_empty() {
         return;
     }
+    let sms_message = ctx.body_for_protocol("sms");
     let acct = ctx.topic_arn.split(':').nth(4).unwrap_or("");
     let mut accounts = state.write();
     let state = accounts.get_or_create(acct);
@@ -920,7 +986,7 @@ pub(crate) fn deliver_to_sms_subscribers(
         );
         state
             .sms_messages
-            .push((phone_number.clone(), ctx.default_message.to_string()));
+            .push((phone_number.clone(), sms_message.clone()));
     }
 }
 

--- a/crates/fakecloud-sns/src/service_tests.rs
+++ b/crates/fakecloud-sns/src/service_tests.rs
@@ -154,6 +154,7 @@ fn add_permission_with_invalid_policy_returns_error_not_panic() {
                 created_at: Utc::now(),
                 subscriptions_deleted: 0,
                 fifo_sequence: 0,
+                dedup_cache: std::collections::BTreeMap::new(),
             },
         );
     }
@@ -246,6 +247,187 @@ fn assert_ok(result: &Result<AwsResponse, AwsServiceError>) {
 
 fn response_body(result: &Result<AwsResponse, AwsServiceError>) -> String {
     String::from_utf8(result.as_ref().unwrap().body.expect_bytes().to_vec()).unwrap()
+}
+
+fn message_id_from(body: &str) -> String {
+    let start = body.find("<MessageId>").unwrap() + "<MessageId>".len();
+    let end = body[start..].find("</MessageId>").unwrap() + start;
+    body[start..end].to_string()
+}
+
+#[test]
+fn json_structure_delivers_per_protocol_body_to_each_subscriber() {
+    let (svc, state) = make_sns();
+    let topic_arn = "arn:aws:sns:us-east-1:123456789012:proto";
+    assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "proto")])));
+
+    for (proto, endpoint) in [
+        ("email", "plain@example.com"),
+        ("email-json", "json@example.com"),
+        ("sms", "+15551234567"),
+    ] {
+        assert_ok(&svc.subscribe(&sns_request(
+            "Subscribe",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Protocol", proto),
+                ("Endpoint", endpoint),
+            ],
+        )));
+    }
+
+    let structured = r#"{"default":"DEFAULT-BODY","email":"EMAIL-BODY","email-json":"EMAILJSON-BODY","sms":"SMS-BODY"}"#;
+    assert_ok(&svc.publish(&sns_request(
+        "Publish",
+        vec![
+            ("TopicArn", topic_arn),
+            ("Message", structured),
+            ("MessageStructure", "json"),
+        ],
+    )));
+
+    let guard = state.read();
+    let s = guard.default_ref();
+    let plain = s
+        .sent_emails
+        .iter()
+        .find(|e| e.email_address == "plain@example.com")
+        .unwrap();
+    assert_eq!(plain.message, "EMAIL-BODY");
+    let json_sub = s
+        .sent_emails
+        .iter()
+        .find(|e| e.email_address == "json@example.com")
+        .unwrap();
+    assert_eq!(json_sub.message, "EMAILJSON-BODY");
+    let sms = s
+        .sms_messages
+        .iter()
+        .find(|(num, _)| num == "+15551234567")
+        .unwrap();
+    assert_eq!(sms.1, "SMS-BODY");
+}
+
+#[test]
+fn json_structure_falls_back_to_default_when_protocol_key_absent() {
+    let (svc, state) = make_sns();
+    let topic_arn = "arn:aws:sns:us-east-1:123456789012:fallback";
+    assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "fallback")])));
+    assert_ok(&svc.subscribe(&sns_request(
+        "Subscribe",
+        vec![
+            ("TopicArn", topic_arn),
+            ("Protocol", "email"),
+            ("Endpoint", "fb@example.com"),
+        ],
+    )));
+
+    let structured = r#"{"default":"ONLY-DEFAULT","sms":"SMS-ONLY"}"#;
+    assert_ok(&svc.publish(&sns_request(
+        "Publish",
+        vec![
+            ("TopicArn", topic_arn),
+            ("Message", structured),
+            ("MessageStructure", "json"),
+        ],
+    )));
+
+    let guard = state.read();
+    let s = guard.default_ref();
+    let email = s
+        .sent_emails
+        .iter()
+        .find(|e| e.email_address == "fb@example.com")
+        .unwrap();
+    assert_eq!(email.message, "ONLY-DEFAULT");
+}
+
+#[test]
+fn fifo_publish_deduplicates_within_window() {
+    let (svc, state) = make_sns();
+    let topic_arn = "arn:aws:sns:us-east-1:123456789012:dedup.fifo";
+    assert_ok(&svc.create_topic(&sns_request(
+        "CreateTopic",
+        vec![
+            ("Name", "dedup.fifo"),
+            ("Attributes.entry.1.key", "FifoTopic"),
+            ("Attributes.entry.1.value", "true"),
+        ],
+    )));
+
+    let publish = || {
+        svc.publish(&sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Message", "hello"),
+                ("MessageGroupId", "g1"),
+                ("MessageDeduplicationId", "dup-1"),
+            ],
+        ))
+    };
+
+    let first = publish();
+    assert_ok(&first);
+    let id1 = message_id_from(&response_body(&first));
+
+    let second = publish();
+    assert_ok(&second);
+    let id2 = message_id_from(&response_body(&second));
+
+    assert_eq!(
+        id1, id2,
+        "duplicate publish should replay original MessageId"
+    );
+
+    let guard = state.read();
+    let s = guard.default_ref();
+    let count = s
+        .published
+        .iter()
+        .filter(|m| m.topic_arn == topic_arn)
+        .count();
+    assert_eq!(count, 1, "duplicate should not be re-published");
+}
+
+#[test]
+fn fifo_content_based_dedup_suppresses_identical_body() {
+    let (svc, state) = make_sns();
+    let topic_arn = "arn:aws:sns:us-east-1:123456789012:cbd.fifo";
+    assert_ok(&svc.create_topic(&sns_request(
+        "CreateTopic",
+        vec![
+            ("Name", "cbd.fifo"),
+            ("Attributes.entry.1.key", "FifoTopic"),
+            ("Attributes.entry.1.value", "true"),
+            ("Attributes.entry.2.key", "ContentBasedDeduplication"),
+            ("Attributes.entry.2.value", "true"),
+        ],
+    )));
+
+    let publish = || {
+        svc.publish(&sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Message", "same-body"),
+                ("MessageGroupId", "g1"),
+            ],
+        ))
+    };
+
+    let id1 = message_id_from(&response_body(&publish()));
+    let id2 = message_id_from(&response_body(&publish()));
+    assert_eq!(id1, id2);
+
+    let guard = state.read();
+    let s = guard.default_ref();
+    let count = s
+        .published
+        .iter()
+        .filter(|m| m.topic_arn == topic_arn)
+        .count();
+    assert_eq!(count, 1);
 }
 
 // --- Subscribe / Unsubscribe / ListSubscriptions / ListSubscriptionsByTopic ---

--- a/crates/fakecloud-sns/src/state.rs
+++ b/crates/fakecloud-sns/src/state.rs
@@ -3,6 +3,17 @@ use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+/// One FIFO dedup-cache entry for an SNS topic: the original (non-duplicate)
+/// publish result, kept until `expiry`. A duplicate within the 5-minute
+/// window replays this MessageId/SequenceNumber instead of fanning out
+/// again, mirroring the SQS FIFO dedup behaviour (bug-audit 2026-06-15, 1.4).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SnsDedupEntry {
+    pub message_id: String,
+    pub sequence_number: Option<String>,
+    pub expiry: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SnsTopic {
     pub topic_arn: String,
@@ -23,6 +34,12 @@ pub struct SnsTopic {
     /// to a FIFO topic; non-FIFO topics emit none. (bug-audit 2026-05-28, 1.6)
     #[serde(default)]
     pub fifo_sequence: u64,
+    /// FIFO dedup cache: dedup_id -> the original publish result + expiry, so
+    /// a duplicate within the 5-minute window replays the ORIGINAL
+    /// MessageId/SequenceNumber without re-fanning-out or advancing the
+    /// counter (bug-audit 2026-06-15, 1.4).
+    #[serde(default)]
+    pub dedup_cache: BTreeMap<String, SnsDedupEntry>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Summary

Batch 4 of the 2026-06-15 bug-hunt: eight Tier-1 silent-wrong-output bugs across Kinesis/SNS/KMS/IAM/S3/EventBridge where the service returned success but the wrong data, so callers never saw an error. Each is fixed to match AWS exactly.

- **Kinesis ListShards NextToken (1.1)** -- the token was set to the last ShardId but never consumed on resume (only `ExclusiveStartShardId` was read), so SDK paginators looped on page 1 forever. NextToken is now a real opaque base64 cursor that resumes after the right shard; garbage tokens return `InvalidArgumentException`.
- **Kinesis PutRecord(s) shard routing (1.2)** -- routing used the first 8 bytes of MD5(partitionKey) mod open_shard_count, so KCL-style consumers read the wrong shard. Now computes the full 128-bit MD5 and routes into the OPEN shard whose `[StartingHashKey, EndingHashKey]` contains it; honors `ExplicitHashKey` override. Stays correct after split/merge.
- **SNS MessageStructure=json (1.3)** -- only the `sqs` key was resolved; HTTP/HTTPS/Lambda/email/email-json/SMS subscribers all got the `default` body. Each subscriber now gets its protocol-specific body, falling back to the required `default` key.
- **SNS FIFO dedup (1.4)** -- FIFO topics never deduplicated. Added a per-topic 5-minute dedup cache keyed on `MessageDeduplicationId` (or SHA-256 content hash when `ContentBasedDeduplication=true`); a duplicate within the window is suppressed (not fanned out) and replays the ORIGINAL MessageId/SequenceNumber. Mirrors SQS FIFO.
- **KMS Decrypt KeyId (1.5)** -- a caller-supplied KeyId was ignored for symmetric ciphertext, so a wrong KeyId still succeeded. Now validated against the producing CMK -> `IncorrectKeyException` on mismatch (KeyId stays optional; encryption-context enforcement unchanged).
- **IAM ListUsers/ListPolicies/ListGroups pagination (1.6)** -- all three hardcoded `IsTruncated=false` and returned everything at once. Now implement real Marker/MaxItems pagination (default 100, cap 1000) with correct IsTruncated/Marker, matching the existing ListRoles/ListAccessKeys behavior.
- **S3 CopyObject & CompleteMultipartUpload checksums (1.7)** -- the non-streaming `compute_checksum` returned an empty string for CRC32C/CRC64NVME (the modern SDK default), so `GetObjectAttributes` reported empty. Implemented both using the same crates as the streaming path so results match.
- **EventBridge PutPartnerEvents (1.10)** -- the handler ignored entry contents entirely (`for _entry in entries`), so partner-bus rules never fired. Now validates each entry, routes matching events to the partner event bus (named after the source), evaluates rules, dispatches targets, and returns correct per-entry EventId / FailedEntryCount, mirroring PutEvents.

## Test plan

All added as unit tests in the respective crates; full touched-crate suites pass, `cargo clippy --all-targets -- -D warnings` is clean, `cargo fmt` applied.

- Kinesis: ListShards NextToken round-trips through all shards (no page-1 loop) + rejects garbage token; PutRecord routes into the shard whose hash range contains MD5(key); ExplicitHashKey overrides the partition key; routing skips closed shards.
- SNS: json structure delivers a distinct per-protocol body to email/email-json/sms subscribers + falls back to default when a protocol key is absent; FIFO publish with explicit dedup id and with content-based dedup both replay the original MessageId and do not re-publish.
- KMS: correct KeyId decrypts; wrong KeyId -> IncorrectKeyException; omitted KeyId still decrypts.
- IAM: ListUsers/ListGroups/ListPolicies paginate via Marker (create > MaxItems, walk pages, IsTruncated flips correctly).
- S3: CRC32C matches a known vector and is non-empty; CRC64NVME non-empty; non-streaming compute_checksum matches compute_checksum_streaming for all five algorithms.
- EventBridge: PutPartnerEvents validates entries (failed-entry accounting) and routes a partner event to a rule's SQS target on the partner event bus.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes eight silent-wrong-output bugs across Kinesis, SNS, KMS, IAM, S3, and EventBridge. Behavior now matches AWS so paginators, routing, dedup, checksums, and partner events work as expected.

- **Bug Fixes**
  - Kinesis ListShards: NextToken is now an opaque base64 cursor that resumes from the right shard; it takes precedence over ExclusiveStartShardId and rejects invalid tokens; SDK paginators advance.
  - Kinesis PutRecord(s): route by the full 128‑bit MD5(partitionKey) to the OPEN shard whose hash range contains it; honor ExplicitHashKey; stable across split/merge.
  - SNS MessageStructure=json: deliver protocol-specific bodies for http/https/lambda/email/email-json/sms/sqs, with fallback to default.
  - SNS FIFO: 5‑minute per‑topic dedup keyed by MessageDeduplicationId (or SHA‑256 when ContentBasedDeduplication=true); duplicates are suppressed; original MessageId/SequenceNumber are replayed.
  - KMS Decrypt: if KeyId is supplied, validate it matches the producing CMK; return IncorrectKeyException on mismatch; still optional.
  - IAM ListUsers/ListPolicies/ListGroups: real Marker/MaxItems pagination with correct IsTruncated and Marker.
  - S3 CopyObject/CompleteMultipartUpload: add CRC32C and CRC64NVME to non‑streaming checksums; matches streaming; GetObjectAttributes no longer empty.
  - EventBridge PutPartnerEvents: validate entries (1–10), route to the partner bus by Source, evaluate rules, dispatch targets, and return per‑entry EventId with accurate FailedEntryCount.

<sup>Written for commit 5c40e972d7accb65d4c8dd7048a01d6e791e655c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

