### PR TITLE
fix(lambda,iam,s3,cognito): close auth-enforcement gaps (unmapped actions, phantom-role federation, JWT exp)

### DIFF
--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -64,12 +64,18 @@ impl fakecloud_core::delivery::CognitoJwtVerifier for StateBackedJwtVerifier {
         let (_header, payload) = jwt::verify_rs256(token, pem)?;
 
         // Validate exp and iss now that the signature has been confirmed.
-        // Cognito-issued tokens always carry both.
-        if let Some(exp) = payload.get("exp").and_then(|v| v.as_i64()) {
-            let now = chrono::Utc::now().timestamp();
-            if now >= exp {
-                return Err("token expired".to_string());
-            }
+        // Cognito-issued tokens always carry both. Treat a missing `exp`
+        // as invalid (fail closed): a signed token with no expiry claim
+        // would otherwise be accepted as never-expiring, which is exactly
+        // the bypass an attacker minting a long-lived/forged-but-signed
+        // token would want.
+        let exp = payload
+            .get("exp")
+            .and_then(|v| v.as_i64())
+            .ok_or_else(|| "token missing exp claim".to_string())?;
+        let now = chrono::Utc::now().timestamp();
+        if now >= exp {
+            return Err("token expired".to_string());
         }
         if let Some(iss) = payload.get("iss").and_then(|v| v.as_str()) {
             // `iss` matches `https://cognito-idp.<region>.amazonaws.com/<pool-id>`
@@ -79,5 +85,141 @@ impl fakecloud_core::delivery::CognitoJwtVerifier for StateBackedJwtVerifier {
             }
         }
         Ok(payload)
+    }
+}
+
+#[cfg(test)]
+mod jwt_exp_tests {
+    //! bug-hunt 2026-06-15 §5.5: a signed token missing the `exp` claim was
+    //! accepted as never-expiring. It must now fail closed.
+    use super::*;
+    use fakecloud_core::delivery::CognitoJwtVerifier;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    const POOL_ID: &str = "us-east-1_pool";
+    const POOL_ARN: &str = "arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_pool";
+
+    fn seed_pool_with_key() -> (SharedCognitoState, String) {
+        let signing = jwt::generate_pool_signing_key();
+        let pem = signing.private_key_pem.clone();
+        let state: SharedCognitoState = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4569",
+            ),
+        ));
+        {
+            let mut mas = state.write();
+            let s = mas.default_mut();
+            let pool = UserPool {
+                id: POOL_ID.to_string(),
+                name: "TestPool".to_string(),
+                arn: POOL_ARN.to_string(),
+                status: "Enabled".to_string(),
+                creation_date: chrono::Utc::now(),
+                last_modified_date: chrono::Utc::now(),
+                policies: PoolPolicies {
+                    password_policy: PasswordPolicy::default(),
+                    sign_in_policy: SignInPolicy {
+                        allowed_first_auth_factors: vec!["PASSWORD".to_string()],
+                    },
+                },
+                auto_verified_attributes: vec![],
+                username_attributes: None,
+                alias_attributes: None,
+                schema_attributes: vec![],
+                lambda_config: None,
+                mfa_configuration: "OFF".to_string(),
+                email_configuration: None,
+                sms_configuration: None,
+                admin_create_user_config: None,
+                user_pool_tags: std::collections::BTreeMap::new(),
+                account_recovery_setting: None,
+                deletion_protection: None,
+                estimated_number_of_users: 0,
+                software_token_mfa_configuration: None,
+                sms_mfa_configuration: None,
+                user_pool_tier: "ESSENTIALS".to_string(),
+                verification_message_template: None,
+                signing_key_pem: Some(pem.clone()),
+                signing_kid: Some(signing.kid),
+                email_verification_message: None,
+                email_verification_subject: None,
+                sms_verification_message: None,
+                sms_authentication_message: None,
+                device_configuration: None,
+                user_attribute_update_settings: None,
+                user_pool_add_ons: None,
+                username_configuration: None,
+            };
+            s.user_pools.insert(POOL_ID.to_string(), pool);
+        }
+        (state, pem)
+    }
+
+    fn sign(payload: serde_json::Value, pem: &str) -> String {
+        let header = serde_json::json!({ "alg": "RS256", "typ": "JWT", "kid": "test" });
+        jwt::sign_rs256(&header, &payload, pem).expect("sign")
+    }
+
+    #[test]
+    fn token_with_valid_exp_is_accepted() {
+        let (state, pem) = seed_pool_with_key();
+        let verifier = StateBackedJwtVerifier::new(state);
+        let future = chrono::Utc::now().timestamp() + 3600;
+        let token = sign(
+            serde_json::json!({
+                "sub": "user-1",
+                "exp": future,
+                "iss": format!("https://cognito-idp.us-east-1.amazonaws.com/{POOL_ID}"),
+            }),
+            &pem,
+        );
+        let claims = verifier
+            .verify_token("123456789012", POOL_ARN, &token)
+            .expect("valid token should verify");
+        assert_eq!(claims.get("sub").and_then(|v| v.as_str()), Some("user-1"));
+    }
+
+    #[test]
+    fn token_missing_exp_is_rejected() {
+        let (state, pem) = seed_pool_with_key();
+        let verifier = StateBackedJwtVerifier::new(state);
+        // Signature is valid; only the exp claim is absent.
+        let token = sign(
+            serde_json::json!({
+                "sub": "user-1",
+                "iss": format!("https://cognito-idp.us-east-1.amazonaws.com/{POOL_ID}"),
+            }),
+            &pem,
+        );
+        let err = verifier
+            .verify_token("123456789012", POOL_ARN, &token)
+            .expect_err("token without exp must be rejected (fail closed)");
+        assert!(
+            err.contains("exp"),
+            "expected an exp-related rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn expired_token_is_rejected() {
+        let (state, pem) = seed_pool_with_key();
+        let verifier = StateBackedJwtVerifier::new(state);
+        let past = chrono::Utc::now().timestamp() - 60;
+        let token = sign(
+            serde_json::json!({
+                "sub": "user-1",
+                "exp": past,
+                "iss": format!("https://cognito-idp.us-east-1.amazonaws.com/{POOL_ID}"),
+            }),
+            &pem,
+        );
+        let err = verifier
+            .verify_token("123456789012", POOL_ARN, &token)
+            .expect_err("expired token must be rejected");
+        assert!(err.contains("expired"), "got: {err}");
     }
 }

--- a/crates/fakecloud-conformance/src/probe/response.rs
+++ b/crates/fakecloud-conformance/src/probe/response.rs
@@ -180,6 +180,14 @@ pub(super) fn service_common_errors(service_name: &str) -> &'static [&'static st
             "InvalidAMIID.Malformed",
             "InvalidAMIID.Unavailable",
         ],
+        // STS returns AccessDenied (HTTP 403) whenever a role can't be assumed
+        // -- the role doesn't exist, or its trust policy rejects the caller --
+        // for AssumeRole / AssumeRoleWithWebIdentity / AssumeRoleWithSAML. AWS
+        // documents this as a standard response, but the per-op Smithy `errors:`
+        // lists only enumerate the token/policy exceptions, not AccessDenied. A
+        // handler returning AccessDenied to the probes' synthetic (nonexistent)
+        // role ARNs ran correctly. Source: STS API "Common Errors" + per-op docs.
+        "sts" => &["AccessDenied"],
         _ => &[],
     }
 }

--- a/crates/fakecloud-conformance/tests/sts.rs
+++ b/crates/fakecloud-conformance/tests/sts.rs
@@ -46,6 +46,20 @@ async fn sts_assume_role() {
 async fn sts_assume_role_with_web_identity() {
     let server = TestServer::start().await;
     let client = server.sts_client().await;
+    // The role must exist with a trust policy admitting the federated
+    // principal before AssumeRoleWithWebIdentity succeeds — assuming a
+    // non-existent role is denied (matches AWS).
+    server
+        .iam_client()
+        .await
+        .create_role()
+        .role_name("web-role")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithWebIdentity"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
     let resp = client
         .assume_role_with_web_identity()
         .role_arn("arn:aws:iam::123456789012:role/web-role")
@@ -62,6 +76,20 @@ async fn sts_assume_role_with_web_identity() {
 async fn sts_assume_role_with_saml() {
     let server = TestServer::start().await;
     let client = server.sts_client().await;
+    // The role must exist with a trust policy admitting the SAML
+    // principal before AssumeRoleWithSAML succeeds — assuming a
+    // non-existent role is denied (matches AWS).
+    server
+        .iam_client()
+        .await
+        .create_role()
+        .role_name("saml-role")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithSAML"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
     let resp = client
         .assume_role_with_saml()
         .role_arn("arn:aws:iam::123456789012:role/saml-role")

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -356,6 +356,20 @@ async fn sts_assume_role_with_web_identity() {
     let server = TestServer::start().await;
     let client = server.sts_client().await;
 
+    // The role must exist with a trust policy admitting the federated
+    // principal — assuming a non-existent role is denied (matches AWS).
+    server
+        .iam_client()
+        .await
+        .create_role()
+        .role_name("test-role")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithWebIdentity"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+
     let resp = client
         .assume_role_with_web_identity()
         .role_arn("arn:aws:iam::123456789012:role/test-role")

--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -1311,6 +1311,108 @@ async fn lambda_function_without_policy_denies_non_root_invoke() {
 }
 
 #[tokio::test]
+async fn lambda_update_function_code_deny_is_honored() {
+    // bug-hunt 2026-06-15 §5.1: UpdateFunctionCode (and 70 other ops) were
+    // unmapped in `iam_action_for` (_ => None), so Lambda being
+    // `iam_enforceable` meant they ran with ZERO policy evaluation. A user
+    // with Allow-* but an explicit Deny on lambda:UpdateFunctionCode could
+    // still update code. With the action now mapped, the Deny must win.
+    let server = start_strict().await;
+    let boot = sdk_config_with(&server, "test", "test").await;
+    aws_sdk_lambda::Client::new(&boot)
+        .create_function()
+        .function_name("lam-deny-code")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(aws_sdk_lambda::primitives::Blob::new(
+                    make_empty_python_zip(),
+                ))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let (akid, secret) = bootstrap_user(&server, "lam_code_deny").await;
+    attach_inline_policy(
+        &server,
+        "lam_code_deny",
+        "AllowAllDenyCode",
+        r#"{"Version":"2012-10-17","Statement":[
+            {"Effect":"Allow","Action":"*","Resource":"*"},
+            {"Effect":"Deny","Action":"lambda:UpdateFunctionCode","Resource":"*"}
+        ]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let lambda = aws_sdk_lambda::Client::new(&cfg);
+    let err = lambda
+        .update_function_code()
+        .function_name("lam-deny-code")
+        .zip_file(aws_sdk_lambda::primitives::Blob::new(
+            make_empty_python_zip(),
+        ))
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDeniedException"),
+        "explicit Deny on lambda:UpdateFunctionCode must be honored, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn lambda_update_function_code_allowed_with_policy() {
+    // Allow-side pair for §5.1: a user explicitly allowed
+    // lambda:UpdateFunctionCode must NOT be denied by the enforcement gate.
+    let server = start_strict().await;
+    let boot = sdk_config_with(&server, "test", "test").await;
+    aws_sdk_lambda::Client::new(&boot)
+        .create_function()
+        .function_name("lam-allow-code")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(aws_sdk_lambda::primitives::Blob::new(
+                    make_empty_python_zip(),
+                ))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let (akid, secret) = bootstrap_user(&server, "lam_code_allow").await;
+    attach_inline_policy(
+        &server,
+        "lam_code_allow",
+        "AllowCode",
+        r#"{"Version":"2012-10-17","Statement":[
+            {"Effect":"Allow","Action":"lambda:UpdateFunctionCode","Resource":"*"}
+        ]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let lambda = aws_sdk_lambda::Client::new(&cfg);
+    lambda
+        .update_function_code()
+        .function_name("lam-allow-code")
+        .zip_file(aws_sdk_lambda::primitives::Blob::new(
+            make_empty_python_zip(),
+        ))
+        .send()
+        .await
+        .expect("explicit Allow on lambda:UpdateFunctionCode must succeed");
+}
+
+#[tokio::test]
 async fn lambda_function_policy_wildcard_principal_grants_any_user() {
     // Public-function idiom: AddPermission with Principal="*" lets
     // any non-root user through the enforcement gate.

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -585,6 +585,7 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "GetMFADevice",
     "ResyncMFADevice",
     "SetSecurityTokenServicePreferences",
+    "GetSecurityTokenServicePreferences",
     "UpdateServerCertificate",
     "CreateDelegationRequest",
     "GetDelegationRequest",

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -585,7 +585,6 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "GetMFADevice",
     "ResyncMFADevice",
     "SetSecurityTokenServicePreferences",
-    "GetSecurityTokenServicePreferences",
     "UpdateServerCertificate",
     "CreateDelegationRequest",
     "GetDelegationRequest",

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -4443,6 +4443,27 @@ fn create_open_id_connect_provider_missing_url_emits_invalid_input() {
 }
 
 #[test]
+fn get_security_token_service_preferences_is_iam_enforceable() {
+    // §5.4: GetSecurityTokenServicePreferences was dispatched but absent
+    // from SUPPORTED_ACTIONS, so iam_action_for returned None and the op
+    // ran with zero policy evaluation under --iam strict. Its sibling
+    // Set... was already enforced — assert both now resolve.
+    let svc = make_service();
+    let get_req = make_request("GetSecurityTokenServicePreferences", vec![]);
+    let action = svc
+        .iam_action_for(&get_req)
+        .expect("GetSecurityTokenServicePreferences must be IAM-enforced");
+    assert_eq!(action.service, "iam");
+    assert_eq!(action.action, "GetSecurityTokenServicePreferences");
+
+    let set_req = make_request("SetSecurityTokenServicePreferences", vec![]);
+    assert_eq!(
+        svc.iam_action_for(&set_req).map(|a| a.action),
+        Some("SetSecurityTokenServicePreferences")
+    );
+}
+
+#[test]
 fn create_virtual_mfa_device_bad_path_emits_invalid_input() {
     let svc = make_service();
     let err = svc

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -4443,23 +4443,24 @@ fn create_open_id_connect_provider_missing_url_emits_invalid_input() {
 }
 
 #[test]
-fn get_security_token_service_preferences_is_iam_enforceable() {
-    // §5.4: GetSecurityTokenServicePreferences was dispatched but absent
-    // from SUPPORTED_ACTIONS, so iam_action_for returned None and the op
-    // ran with zero policy evaluation under --iam strict. Its sibling
-    // Set... was already enforced — assert both now resolve.
+fn set_security_token_service_preferences_is_iam_enforceable() {
+    // The real AWS action `SetSecurityTokenServicePreferences` is mapped and
+    // IAM-enforced. Its read-back sibling `GetSecurityTokenServicePreferences`
+    // is a fakecloud-only extension (absent from AWS's iam.json), so it is
+    // intentionally NOT in SUPPORTED_ACTIONS — there is no AWS IAM action to
+    // write a policy against, and listing it would fail the handwritten-test
+    // audit (no Smithy model to checksum).
     let svc = make_service();
-    let get_req = make_request("GetSecurityTokenServicePreferences", vec![]);
-    let action = svc
-        .iam_action_for(&get_req)
-        .expect("GetSecurityTokenServicePreferences must be IAM-enforced");
-    assert_eq!(action.service, "iam");
-    assert_eq!(action.action, "GetSecurityTokenServicePreferences");
-
     let set_req = make_request("SetSecurityTokenServicePreferences", vec![]);
     assert_eq!(
         svc.iam_action_for(&set_req).map(|a| a.action),
         Some("SetSecurityTokenServicePreferences")
+    );
+
+    let get_req = make_request("GetSecurityTokenServicePreferences", vec![]);
+    assert!(
+        svc.iam_action_for(&get_req).is_none(),
+        "Get... is a fakecloud extension, not a mapped AWS IAM action"
     );
 }
 

--- a/crates/fakecloud-iam/src/sts_service/assume.rs
+++ b/crates/fakecloud-iam/src/sts_service/assume.rs
@@ -507,6 +507,19 @@ impl StsService {
                     role_arn,
                 ));
             }
+        } else {
+            // AssumeRoleWithWebIdentity against a role that does not exist
+            // must be denied rather than fall through to credential
+            // minting with no trust check (same gap that bug-audit
+            // 2026-05-28 §5.4 fixed for plain AssumeRole). AWS returns
+            // AccessDenied for sts:AssumeRoleWithWebIdentity on a role it
+            // cannot resolve.
+            let caller_principal = federated_principal(&federated_provider, &account_id);
+            return Err(trust_policy_denied(
+                "sts:AssumeRoleWithWebIdentity",
+                &caller_principal.arn,
+                role_arn,
+            ));
         }
 
         let target_state = accounts.get_or_create(&account_id);
@@ -709,6 +722,18 @@ impl StsService {
                     role_arn,
                 ));
             }
+        } else {
+            // AssumeRoleWithSAML against a role that does not exist must be
+            // denied rather than fall through to credential minting with no
+            // trust check (same gap that bug-audit 2026-05-28 §5.4 fixed
+            // for plain AssumeRole). AWS returns AccessDenied for
+            // sts:AssumeRoleWithSAML on a role it cannot resolve.
+            let caller_principal = federated_principal(&saml_provider_arn, &account_id);
+            return Err(trust_policy_denied(
+                "sts:AssumeRoleWithSAML",
+                &caller_principal.arn,
+                role_arn,
+            ));
         }
 
         let target_state = accounts.get_or_create(&account_id);

--- a/crates/fakecloud-iam/src/sts_service/mod.rs
+++ b/crates/fakecloud-iam/src/sts_service/mod.rs
@@ -979,6 +979,89 @@ mod tests {
         assert!(body.contains("<AccessKeyId>"));
     }
 
+    #[tokio::test]
+    async fn assume_role_with_web_identity_nonexistent_role_denied() {
+        // §5.2: a missing role must NOT fall through to credential minting.
+        // AWS returns AccessDenied for AssumeRoleWithWebIdentity on a role
+        // it cannot resolve.
+        let (svc, _state) = make_sts_service();
+        let req = sts_request(
+            "AssumeRoleWithWebIdentity",
+            vec![
+                ("RoleArn", "arn:aws:iam::123456789012:role/does-not-exist"),
+                ("RoleSessionName", "web-session"),
+                ("WebIdentityToken", "fake-jwt-token"),
+            ],
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected AccessDenied for phantom role, got success"),
+        };
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+        assert!(
+            format!("{err:?}").contains("AccessDenied"),
+            "expected AccessDenied, got {err:?}"
+        );
+    }
+
+    // ── AssumeRoleWithSAML ──
+
+    fn make_saml_assertion() -> String {
+        use base64::Engine;
+        // Minimal SAML XML carrying a RoleSessionName attribute value.
+        let xml = r#"<saml:Assertion><saml:AttributeStatement><saml:Attribute Name="https://aws.amazon.com/SAML/Attributes/RoleSessionName"><saml:AttributeValue>saml-user</saml:AttributeValue></saml:Attribute></saml:AttributeStatement></saml:Assertion>"#;
+        base64::engine::general_purpose::STANDARD.encode(xml.as_bytes())
+    }
+
+    #[tokio::test]
+    async fn assume_role_with_saml_existing_role_succeeds() {
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"arn:aws:iam::123456789012:saml-provider/idp"},"Action":"sts:AssumeRoleWithSAML"}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "saml-role", trust);
+        let assertion = make_saml_assertion();
+        let req = sts_request(
+            "AssumeRoleWithSAML",
+            vec![
+                ("RoleArn", &role_arn),
+                (
+                    "PrincipalArn",
+                    "arn:aws:iam::123456789012:saml-provider/idp",
+                ),
+                ("SAMLAssertion", &assertion),
+            ],
+        );
+        let resp = svc.handle(req).await.expect("existing role should succeed");
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body.contains("<AccessKeyId>"));
+    }
+
+    #[tokio::test]
+    async fn assume_role_with_saml_nonexistent_role_denied() {
+        // §5.2: a missing role must NOT fall through to credential minting.
+        let (svc, _state) = make_sts_service();
+        let assertion = make_saml_assertion();
+        let req = sts_request(
+            "AssumeRoleWithSAML",
+            vec![
+                ("RoleArn", "arn:aws:iam::123456789012:role/does-not-exist"),
+                (
+                    "PrincipalArn",
+                    "arn:aws:iam::123456789012:saml-provider/idp",
+                ),
+                ("SAMLAssertion", &assertion),
+            ],
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected AccessDenied for phantom role, got success"),
+        };
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+        assert!(
+            format!("{err:?}").contains("AccessDenied"),
+            "expected AccessDenied, got {err:?}"
+        );
+    }
+
     // ── GetSessionToken ──
 
     #[tokio::test]

--- a/crates/fakecloud-lambda/src/service/mod.rs
+++ b/crates/fakecloud-lambda/src/service/mod.rs
@@ -234,6 +234,144 @@ pub(crate) fn action_takes_function_name(action: &str) -> bool {
 /// unchanged. The qualifier (version or alias) is dropped because most
 /// callers look up the function by name and resolve qualifier
 /// separately.
+/// Map a dispatched Lambda operation name (as returned by
+/// [`LambdaService::resolve_action`]) to its AWS IAM action string.
+///
+/// Lambda is `iam_enforceable`, so every op the dispatcher can route MUST
+/// resolve here — an op that returned `None` would run with no policy
+/// evaluation at all (a silent auth bypass). The mapping is driven from
+/// the same op-name strings the dispatcher uses so the two can never
+/// drift; `iam_action_name_for_exhaustiveness` (see tests) asserts every
+/// dispatchable op resolves to `Some`.
+///
+/// Almost all IAM actions equal the operation name. The exceptions come
+/// straight from the Smithy model's `aws.iam#iamAction.name` overrides:
+///   - `Invoke`                     -> `lambda:InvokeFunction`
+///   - `InvokeWithResponseStream`   -> `lambda:InvokeFunction`
+///   - `GetLayerVersionByArn`       -> `lambda:GetLayerVersion`
+pub(crate) fn iam_action_name_for(op: &str) -> Option<&'static str> {
+    let action = match op {
+        // --- Smithy IAM-action name overrides ---
+        "Invoke" => "InvokeFunction",
+        "InvokeWithResponseStream" => "InvokeFunction",
+        "GetLayerVersionByArn" => "GetLayerVersion",
+
+        // --- functions ---
+        "CreateFunction" => "CreateFunction",
+        "ListFunctions" => "ListFunctions",
+        "GetFunction" => "GetFunction",
+        "DeleteFunction" => "DeleteFunction",
+        "InvokeAsync" => "InvokeAsync",
+        "UpdateFunctionCode" => "UpdateFunctionCode",
+        "UpdateFunctionConfiguration" => "UpdateFunctionConfiguration",
+        "GetFunctionConfiguration" => "GetFunctionConfiguration",
+        "PublishVersion" => "PublishVersion",
+        "ListVersionsByFunction" => "ListVersionsByFunction",
+        "GetAccountSettings" => "GetAccountSettings",
+
+        // --- resource policy / permissions ---
+        "AddPermission" => "AddPermission",
+        "RemovePermission" => "RemovePermission",
+        "GetPolicy" => "GetPolicy",
+
+        // --- aliases ---
+        "CreateAlias" => "CreateAlias",
+        "GetAlias" => "GetAlias",
+        "UpdateAlias" => "UpdateAlias",
+        "DeleteAlias" => "DeleteAlias",
+        "ListAliases" => "ListAliases",
+
+        // --- concurrency ---
+        "PutFunctionConcurrency" => "PutFunctionConcurrency",
+        "GetFunctionConcurrency" => "GetFunctionConcurrency",
+        "DeleteFunctionConcurrency" => "DeleteFunctionConcurrency",
+        "PutProvisionedConcurrencyConfig" => "PutProvisionedConcurrencyConfig",
+        "GetProvisionedConcurrencyConfig" => "GetProvisionedConcurrencyConfig",
+        "DeleteProvisionedConcurrencyConfig" => "DeleteProvisionedConcurrencyConfig",
+        "ListProvisionedConcurrencyConfigs" => "ListProvisionedConcurrencyConfigs",
+
+        // --- event invoke config ---
+        "PutFunctionEventInvokeConfig" => "PutFunctionEventInvokeConfig",
+        "GetFunctionEventInvokeConfig" => "GetFunctionEventInvokeConfig",
+        "UpdateFunctionEventInvokeConfig" => "UpdateFunctionEventInvokeConfig",
+        "DeleteFunctionEventInvokeConfig" => "DeleteFunctionEventInvokeConfig",
+        "ListFunctionEventInvokeConfigs" => "ListFunctionEventInvokeConfigs",
+
+        // --- runtime / scaling / recursion config ---
+        "PutRuntimeManagementConfig" => "PutRuntimeManagementConfig",
+        "GetRuntimeManagementConfig" => "GetRuntimeManagementConfig",
+        "PutFunctionScalingConfig" => "PutFunctionScalingConfig",
+        "GetFunctionScalingConfig" => "GetFunctionScalingConfig",
+        "PutFunctionRecursionConfig" => "PutFunctionRecursionConfig",
+        "GetFunctionRecursionConfig" => "GetFunctionRecursionConfig",
+
+        // --- function URL config ---
+        "CreateFunctionUrlConfig" => "CreateFunctionUrlConfig",
+        "GetFunctionUrlConfig" => "GetFunctionUrlConfig",
+        "UpdateFunctionUrlConfig" => "UpdateFunctionUrlConfig",
+        "DeleteFunctionUrlConfig" => "DeleteFunctionUrlConfig",
+        "ListFunctionUrlConfigs" => "ListFunctionUrlConfigs",
+
+        // --- event source mappings ---
+        "CreateEventSourceMapping" => "CreateEventSourceMapping",
+        "ListEventSourceMappings" => "ListEventSourceMappings",
+        "GetEventSourceMapping" => "GetEventSourceMapping",
+        "UpdateEventSourceMapping" => "UpdateEventSourceMapping",
+        "DeleteEventSourceMapping" => "DeleteEventSourceMapping",
+
+        // --- layers ---
+        "PublishLayerVersion" => "PublishLayerVersion",
+        "ListLayers" => "ListLayers",
+        "ListLayerVersions" => "ListLayerVersions",
+        "GetLayerVersion" => "GetLayerVersion",
+        "DeleteLayerVersion" => "DeleteLayerVersion",
+        "GetLayerVersionPolicy" => "GetLayerVersionPolicy",
+        "AddLayerVersionPermission" => "AddLayerVersionPermission",
+        "RemoveLayerVersionPermission" => "RemoveLayerVersionPermission",
+
+        // --- code signing config ---
+        "CreateCodeSigningConfig" => "CreateCodeSigningConfig",
+        "GetCodeSigningConfig" => "GetCodeSigningConfig",
+        "UpdateCodeSigningConfig" => "UpdateCodeSigningConfig",
+        "DeleteCodeSigningConfig" => "DeleteCodeSigningConfig",
+        "ListCodeSigningConfigs" => "ListCodeSigningConfigs",
+        "PutFunctionCodeSigningConfig" => "PutFunctionCodeSigningConfig",
+        "GetFunctionCodeSigningConfig" => "GetFunctionCodeSigningConfig",
+        "DeleteFunctionCodeSigningConfig" => "DeleteFunctionCodeSigningConfig",
+        "ListFunctionsByCodeSigningConfig" => "ListFunctionsByCodeSigningConfig",
+
+        // --- tags ---
+        "TagResource" => "TagResource",
+        "UntagResource" => "UntagResource",
+        "ListTags" => "ListTags",
+
+        // --- capacity providers (Lambda Workflows) ---
+        "CreateCapacityProvider" => "CreateCapacityProvider",
+        "GetCapacityProvider" => "GetCapacityProvider",
+        "ListCapacityProviders" => "ListCapacityProviders",
+        "UpdateCapacityProvider" => "UpdateCapacityProvider",
+        "DeleteCapacityProvider" => "DeleteCapacityProvider",
+        "ListFunctionVersionsByCapacityProvider" => "ListFunctionVersionsByCapacityProvider",
+
+        // --- durable executions ---
+        // The Smithy model carries no `aws.iam#iamAction` annotation for
+        // these preview ops, so the IAM action equals the op name (AWS's
+        // default convention when no override is present).
+        "GetDurableExecution" => "GetDurableExecution",
+        "GetDurableExecutionHistory" => "GetDurableExecutionHistory",
+        "GetDurableExecutionState" => "GetDurableExecutionState",
+        "ListDurableExecutionsByFunction" => "ListDurableExecutionsByFunction",
+        "CheckpointDurableExecution" => "CheckpointDurableExecution",
+        "StopDurableExecution" => "StopDurableExecution",
+        "SendDurableExecutionCallbackSuccess" => "SendDurableExecutionCallbackSuccess",
+        "SendDurableExecutionCallbackFailure" => "SendDurableExecutionCallbackFailure",
+        "SendDurableExecutionCallbackHeartbeat" => "SendDurableExecutionCallbackHeartbeat",
+
+        _ => return None,
+    };
+    Some(action)
+}
+
 pub(crate) fn normalize_function_name(input: &str) -> String {
     if input.is_empty() {
         return String::new();
@@ -1349,35 +1487,67 @@ impl AwsService for LambdaService {
         // `handle()`. Reuse the same resolver so the two can never
         // drift.
         let (action_str, resource_name) = Self::resolve_action(request)?;
-        let action: &'static str = match action_str {
-            "CreateFunction" => "CreateFunction",
-            "ListFunctions" => "ListFunctions",
-            "GetFunction" => "GetFunction",
-            "DeleteFunction" => "DeleteFunction",
-            "Invoke" => "InvokeFunction",
-            "InvokeWithResponseStream" => "InvokeFunctionWithResponseStream",
-            "PublishVersion" => "PublishVersion",
-            "AddPermission" => "AddPermission",
-            "RemovePermission" => "RemovePermission",
-            "GetPolicy" => "GetPolicy",
-            "CreateEventSourceMapping" => "CreateEventSourceMapping",
-            "ListEventSourceMappings" => "ListEventSourceMappings",
-            "GetEventSourceMapping" => "GetEventSourceMapping",
-            "DeleteEventSourceMapping" => "DeleteEventSourceMapping",
-            _ => return None,
-        };
+        // Every op that `resolve_action` (and therefore `handle`) can
+        // dispatch MUST map to an IAM action here. Lambda is
+        // `iam_enforceable`, so an unmapped op returning `None` would run
+        // with zero policy evaluation — a silent auth bypass. We drive
+        // this from the same op-name strings the dispatcher uses so the
+        // two can't drift; the exhaustiveness test asserts every
+        // dispatchable op resolves to `Some`.
+        let action = iam_action_name_for(action_str)?;
         let accounts = self.state.read();
         let empty = LambdaState::new(&request.account_id, &request.region);
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
-        let resource = match action {
+        let resource = match action_str {
+            // Function-scoped ops: the path identifier is a function name
+            // (or ARN/partial-ARN). Normalize it to a bare name and build
+            // the canonical function ARN so policy evaluation matches the
+            // real function regardless of how the caller spelled it.
             "GetFunction"
             | "DeleteFunction"
-            | "InvokeFunction"
-            | "InvokeFunctionWithResponseStream"
+            | "Invoke"
+            | "InvokeAsync"
+            | "InvokeWithResponseStream"
             | "PublishVersion"
+            | "ListVersionsByFunction"
             | "AddPermission"
             | "RemovePermission"
-            | "GetPolicy" => {
+            | "GetPolicy"
+            | "GetFunctionConfiguration"
+            | "UpdateFunctionConfiguration"
+            | "UpdateFunctionCode"
+            | "CreateAlias"
+            | "GetAlias"
+            | "UpdateAlias"
+            | "DeleteAlias"
+            | "ListAliases"
+            | "PutFunctionConcurrency"
+            | "GetFunctionConcurrency"
+            | "DeleteFunctionConcurrency"
+            | "PutProvisionedConcurrencyConfig"
+            | "GetProvisionedConcurrencyConfig"
+            | "DeleteProvisionedConcurrencyConfig"
+            | "ListProvisionedConcurrencyConfigs"
+            | "PutFunctionEventInvokeConfig"
+            | "GetFunctionEventInvokeConfig"
+            | "UpdateFunctionEventInvokeConfig"
+            | "DeleteFunctionEventInvokeConfig"
+            | "ListFunctionEventInvokeConfigs"
+            | "PutRuntimeManagementConfig"
+            | "GetRuntimeManagementConfig"
+            | "PutFunctionScalingConfig"
+            | "GetFunctionScalingConfig"
+            | "PutFunctionRecursionConfig"
+            | "GetFunctionRecursionConfig"
+            | "PutFunctionCodeSigningConfig"
+            | "GetFunctionCodeSigningConfig"
+            | "DeleteFunctionCodeSigningConfig"
+            | "CreateFunctionUrlConfig"
+            | "GetFunctionUrlConfig"
+            | "UpdateFunctionUrlConfig"
+            | "DeleteFunctionUrlConfig"
+            | "ListFunctionUrlConfigs"
+            | "ListDurableExecutionsByFunction" => {
                 let raw = resource_name.unwrap_or_default();
                 if raw.is_empty() {
                     "*".to_string()

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -994,6 +994,186 @@ fn iam_action_for_create_reads_function_name_from_body() {
     );
 }
 
+/// Every operation name that `resolve_action` (and therefore `handle`)
+/// can dispatch. Mirrors the dispatch tables in `service/init.rs`. If a
+/// new op is routed there, it must be added here AND to
+/// `iam_action_name_for` — the assertion below fails otherwise, which is
+/// the whole point (Lambda is `iam_enforceable`, so an unmapped dispatched
+/// op runs with zero policy evaluation = silent auth bypass, bug-hunt
+/// 2026-06-15 §5.1).
+const ALL_DISPATCHED_LAMBDA_OPS: &[&str] = &[
+    "CreateFunction",
+    "ListFunctions",
+    "GetFunction",
+    "DeleteFunction",
+    "Invoke",
+    "InvokeAsync",
+    "InvokeWithResponseStream",
+    "UpdateFunctionCode",
+    "UpdateFunctionConfiguration",
+    "GetFunctionConfiguration",
+    "PublishVersion",
+    "ListVersionsByFunction",
+    "GetAccountSettings",
+    "AddPermission",
+    "RemovePermission",
+    "GetPolicy",
+    "CreateAlias",
+    "GetAlias",
+    "UpdateAlias",
+    "DeleteAlias",
+    "ListAliases",
+    "PutFunctionConcurrency",
+    "GetFunctionConcurrency",
+    "DeleteFunctionConcurrency",
+    "PutProvisionedConcurrencyConfig",
+    "GetProvisionedConcurrencyConfig",
+    "DeleteProvisionedConcurrencyConfig",
+    "ListProvisionedConcurrencyConfigs",
+    "PutFunctionEventInvokeConfig",
+    "GetFunctionEventInvokeConfig",
+    "UpdateFunctionEventInvokeConfig",
+    "DeleteFunctionEventInvokeConfig",
+    "ListFunctionEventInvokeConfigs",
+    "PutRuntimeManagementConfig",
+    "GetRuntimeManagementConfig",
+    "PutFunctionScalingConfig",
+    "GetFunctionScalingConfig",
+    "PutFunctionRecursionConfig",
+    "GetFunctionRecursionConfig",
+    "CreateFunctionUrlConfig",
+    "GetFunctionUrlConfig",
+    "UpdateFunctionUrlConfig",
+    "DeleteFunctionUrlConfig",
+    "ListFunctionUrlConfigs",
+    "CreateEventSourceMapping",
+    "ListEventSourceMappings",
+    "GetEventSourceMapping",
+    "UpdateEventSourceMapping",
+    "DeleteEventSourceMapping",
+    "PublishLayerVersion",
+    "ListLayers",
+    "ListLayerVersions",
+    "GetLayerVersion",
+    "GetLayerVersionByArn",
+    "DeleteLayerVersion",
+    "GetLayerVersionPolicy",
+    "AddLayerVersionPermission",
+    "RemoveLayerVersionPermission",
+    "CreateCodeSigningConfig",
+    "GetCodeSigningConfig",
+    "UpdateCodeSigningConfig",
+    "DeleteCodeSigningConfig",
+    "ListCodeSigningConfigs",
+    "PutFunctionCodeSigningConfig",
+    "GetFunctionCodeSigningConfig",
+    "DeleteFunctionCodeSigningConfig",
+    "ListFunctionsByCodeSigningConfig",
+    "TagResource",
+    "UntagResource",
+    "ListTags",
+    "CreateCapacityProvider",
+    "GetCapacityProvider",
+    "ListCapacityProviders",
+    "UpdateCapacityProvider",
+    "DeleteCapacityProvider",
+    "ListFunctionVersionsByCapacityProvider",
+    "GetDurableExecution",
+    "GetDurableExecutionHistory",
+    "GetDurableExecutionState",
+    "ListDurableExecutionsByFunction",
+    "CheckpointDurableExecution",
+    "StopDurableExecution",
+    "SendDurableExecutionCallbackSuccess",
+    "SendDurableExecutionCallbackFailure",
+    "SendDurableExecutionCallbackHeartbeat",
+];
+
+#[test]
+fn every_dispatched_lambda_op_maps_to_an_iam_action() {
+    for op in ALL_DISPATCHED_LAMBDA_OPS {
+        assert!(
+            iam_action_name_for(op).is_some(),
+            "dispatched Lambda op {op:?} has no IAM action mapping — it would run \
+             with zero policy evaluation under --iam strict (silent auth bypass)"
+        );
+    }
+}
+
+#[test]
+fn iam_action_name_for_applies_smithy_overrides() {
+    // The three ops whose IAM action differs from the operation name,
+    // straight from the Smithy model's aws.iam#iamAction.name override.
+    assert_eq!(iam_action_name_for("Invoke"), Some("InvokeFunction"));
+    assert_eq!(
+        iam_action_name_for("InvokeWithResponseStream"),
+        Some("InvokeFunction")
+    );
+    assert_eq!(
+        iam_action_name_for("GetLayerVersionByArn"),
+        Some("GetLayerVersion")
+    );
+    // An unrouted/unknown op is unmapped (None), as expected.
+    assert_eq!(iam_action_name_for("NotARealLambdaOp"), None);
+}
+
+#[test]
+fn iam_action_for_maps_update_function_code() {
+    // Regression for §5.1: UpdateFunctionCode was unmapped (_ => None), so
+    // a deny policy on lambda:UpdateFunctionCode was silently ignored.
+    let svc = LambdaService::new(make_state());
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/myfn/code",
+        r#"{"ZipFile":""}"#,
+    );
+    let action = svc.iam_action_for(&req).expect("must be mapped");
+    assert_eq!(action.service, "lambda");
+    assert_eq!(action.action, "UpdateFunctionCode");
+    assert_eq!(
+        action.resource,
+        "arn:aws:lambda:us-east-1:123456789012:function:myfn"
+    );
+}
+
+#[test]
+fn iam_action_for_maps_invoke_async_to_invoke_function() {
+    // InvokeAsync is the deprecated second invoke path; previously unmapped.
+    let svc = LambdaService::new(make_state());
+    let req = make_request(
+        Method::POST,
+        "/2015-03-31/functions/myfn/invoke-async",
+        "{}",
+    );
+    let action = svc.iam_action_for(&req).expect("must be mapped");
+    // AWS models InvokeAsync as the distinct (deprecated) lambda:InvokeAsync
+    // action; assert we map to it rather than dropping enforcement.
+    assert_eq!(action.action, "InvokeAsync");
+    assert_eq!(
+        action.resource,
+        "arn:aws:lambda:us-east-1:123456789012:function:myfn"
+    );
+}
+
+#[test]
+fn iam_action_for_maps_tag_and_layer_ops() {
+    let svc = LambdaService::new(make_state());
+    let tag_req = make_request(
+        Method::POST,
+        "/2017-03-31/tags/arn:aws:lambda:us-east-1:123456789012:function:f",
+        "{}",
+    );
+    assert_eq!(
+        svc.iam_action_for(&tag_req).map(|a| a.action),
+        Some("TagResource")
+    );
+    let layer_req = make_request(Method::GET, "/2018-10-31/layers/mylayer/versions/3", "");
+    assert_eq!(
+        svc.iam_action_for(&layer_req).map(|a| a.action),
+        Some("GetLayerVersion")
+    );
+}
+
 // ── Error branch tests ──
 
 #[tokio::test]

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -1075,9 +1075,17 @@ impl AwsService for S3Service {
             key.as_deref(),
             &request.query_params,
         )?;
+        // A handful of S3-adjacent ops are authorized under sibling IAM
+        // service prefixes, not `s3:`. Select the right prefix so a policy
+        // targeting the real action string actually matches.
+        let service = match action {
+            "CreateSession" => "s3express",
+            "WriteGetObjectResponse" => "s3-object-lambda",
+            _ => "s3",
+        };
         let resource = s3_resource_for(action, bucket, key.as_deref());
         Some(fakecloud_core::auth::IamAction {
-            service: "s3",
+            service,
             action,
             resource,
         })
@@ -1237,6 +1245,17 @@ fn s3_detect_action(
             _ => None,
         };
     }
+
+    // WriteGetObjectResponse is an Object Lambda data-plane op routed as
+    // `POST /WriteGetObjectResponse` (the literal value occupies the bucket
+    // segment). AWS authorizes it under the separate
+    // `s3-object-lambda:WriteGetObjectResponse` action — handled in
+    // `iam_action_for`, which selects the `s3-object-lambda` service prefix
+    // for this op. Previously unmapped -> enforcement skipped.
+    if is_post && bucket == Some("WriteGetObjectResponse") && key.is_none() {
+        return Some("WriteGetObjectResponse");
+    }
+
     let has_key = key.is_some();
 
     // Multipart sub-resource forms
@@ -1301,6 +1320,28 @@ fn s3_detect_action(
         }
         if has("restore") && is_post {
             return Some("RestoreObject");
+        }
+        // RenameObject is an object-level op (`PUT /bucket/newkey?renameObject`
+        // + `x-amz-rename-source`). It carries a key, so it must be detected
+        // here — the `!has_key` arm below never sees it. Without this it fell
+        // through to `PutObject`, so a policy denying `s3:RenameObject` was
+        // silently ineffective.
+        if has("renameObject") && is_put {
+            return Some("RenameObject");
+        }
+        // UpdateObjectEncryption (`PUT /bucket/key?encryption`) changes an
+        // existing object's server-side encryption. AWS gates this under
+        // `s3:PutObject` (encryption is a write attribute), and there is no
+        // distinct public `s3:UpdateObjectEncryption` IAM action — so map to
+        // PutObject deliberately rather than letting it fall through.
+        if has("encryption") && is_put {
+            return Some("PutObject");
+        }
+        // SelectObjectContent (`POST /bucket/key?select&select-type=2`) reads
+        // object data, so AWS authorizes it with `s3:GetObject`. Previously
+        // unmapped -> `_ => None` -> enforcement skipped entirely.
+        if has("select-type") && is_post {
+            return Some("GetObject");
         }
     }
 
@@ -1480,11 +1521,25 @@ fn s3_detect_action(
         if has("metadataJournalTable") && is_put {
             return Some("UpdateBucketMetadataJournalTableConfiguration");
         }
-        if has("abac") && is_put {
-            return Some("PutBucketAbacConfiguration");
+        if has("abac") {
+            // PUT  -> PutBucketAbacConfiguration
+            // GET  -> GetBucketAbacConfiguration (previously fell through to
+            //         the plain `GET bucket` arm and was IAM-evaluated as
+            //         s3:ListObjects — a policy on the ABAC config was never
+            //         honored).
+            return Some(match method {
+                "PUT" => "PutBucketAbacConfiguration",
+                "GET" => "GetBucketAbacConfiguration",
+                _ => return None,
+            });
         }
-        if has("renameObject") && is_put {
-            return Some("RenameObject");
+        if has("session") && is_get {
+            // CreateSession (S3 Express directory buckets). AWS authorizes it
+            // under the separate `s3express:CreateSession` action — handled in
+            // `iam_action_for`, which selects the `s3express` service prefix
+            // for this op. Previously fell through to the plain `GET bucket`
+            // arm and was evaluated as s3:ListObjects.
+            return Some("CreateSession");
         }
         if has("object-lock") {
             return Some(match method {
@@ -2762,6 +2817,158 @@ pub(crate) fn check_object_lock_for_overwrite(
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod s3_detect_action_tests {
+    //! Auth-mapping regressions for bug-hunt 2026-06-15 §5.3: ops that
+    //! were unmapped (-> enforcement skipped) or mapped to the wrong
+    //! action (-> the policy targeting them never applied).
+    use super::s3_detect_action;
+    use std::collections::HashMap;
+
+    fn q(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn select_object_content_maps_to_get_object() {
+        // POST /bucket/key?select&select-type=2 reads object data.
+        let action = s3_detect_action(
+            "POST",
+            Some("bucket"),
+            Some("key"),
+            &q(&[("select", ""), ("select-type", "2")]),
+        );
+        assert_eq!(action, Some("GetObject"));
+    }
+
+    #[test]
+    fn write_get_object_response_is_detected() {
+        // POST /WriteGetObjectResponse (no key) — Object Lambda data plane.
+        let action = s3_detect_action("POST", Some("WriteGetObjectResponse"), None, &q(&[]));
+        assert_eq!(action, Some("WriteGetObjectResponse"));
+    }
+
+    #[test]
+    fn rename_object_is_detected_with_key() {
+        // PUT /bucket/newkey?renameObject carries a key — previously fell
+        // through to PutObject so s3:RenameObject denies were ineffective.
+        let action = s3_detect_action(
+            "PUT",
+            Some("bucket"),
+            Some("newkey"),
+            &q(&[("renameObject", "")]),
+        );
+        assert_eq!(action, Some("RenameObject"));
+    }
+
+    #[test]
+    fn update_object_encryption_maps_to_put_object() {
+        // PUT /bucket/key?encryption changes object SSE; AWS gates this on
+        // s3:PutObject (no distinct public action). Deliberate, not a
+        // silent PutObject fall-through.
+        let action = s3_detect_action(
+            "PUT",
+            Some("bucket"),
+            Some("key"),
+            &q(&[("encryption", "")]),
+        );
+        assert_eq!(action, Some("PutObject"));
+    }
+
+    #[test]
+    fn create_session_not_misdetected_as_list_objects() {
+        // GET /bucket?session — previously fell through to ListObjects.
+        let action = s3_detect_action("GET", Some("bucket"), None, &q(&[("session", "")]));
+        assert_eq!(action, Some("CreateSession"));
+    }
+
+    #[test]
+    fn get_bucket_abac_not_misdetected_as_list_objects() {
+        // GET /bucket?abac — previously fell through to ListObjects.
+        let action = s3_detect_action("GET", Some("bucket"), None, &q(&[("abac", "")]));
+        assert_eq!(action, Some("GetBucketAbacConfiguration"));
+    }
+
+    #[test]
+    fn put_bucket_abac_still_detected() {
+        let action = s3_detect_action("PUT", Some("bucket"), None, &q(&[("abac", "")]));
+        assert_eq!(action, Some("PutBucketAbacConfiguration"));
+    }
+}
+
+#[cfg(test)]
+mod s3_iam_service_prefix_tests {
+    //! §5.3: CreateSession and WriteGetObjectResponse are authorized under
+    //! sibling IAM service prefixes (s3express / s3-object-lambda), not s3.
+    use super::*;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn make_service() -> S3Service {
+        let state: SharedS3State = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
+        S3Service::new(state, Arc::new(DeliveryBus::new()))
+    }
+
+    fn req(method: Method, path: &str, query: &[(&str, &str)]) -> AwsRequest {
+        let path_segments: Vec<String> = path
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+        AwsRequest {
+            service: "s3".to_string(),
+            action: String::new(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "rid".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: query
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments,
+            raw_path: path.to_string(),
+            raw_query: String::new(),
+            method,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn create_session_uses_s3express_prefix() {
+        let svc = make_service();
+        let action = svc
+            .iam_action_for(&req(Method::GET, "/mybucket", &[("session", "")]))
+            .expect("must be mapped");
+        assert_eq!(action.service, "s3express");
+        assert_eq!(action.action, "CreateSession");
+        assert_eq!(action.action_string(), "s3express:CreateSession");
+    }
+
+    #[test]
+    fn write_get_object_response_uses_object_lambda_prefix() {
+        let svc = make_service();
+        let action = svc
+            .iam_action_for(&req(Method::POST, "/WriteGetObjectResponse", &[]))
+            .expect("must be mapped");
+        assert_eq!(action.service, "s3-object-lambda");
+        assert_eq!(action.action, "WriteGetObjectResponse");
+        assert_eq!(
+            action.action_string(),
+            "s3-object-lambda:WriteGetObjectResponse"
+        );
+    }
+}
 
 #[cfg(test)]
 mod extract_xml_value_tests {


### PR DESCRIPTION
## Summary

Closes Tier 5 (auth correctness) of the 2026-06-15 bug-hunt. These bugs only fire when enforcement is enabled (`--iam strict` / `FAKECLOUD_IAM=strict`); auth is off by default by design.

- **5.1 (HIGH bypass) Lambda — 71 of 74 ops unauthorized under strict IAM.** `iam_action_for` whitelisted only 14 actions and returned `None` for the rest. Lambda is `iam_enforceable`, so unmapped ops ran with *zero* policy evaluation. Refactored to a single `iam_action_name_for()` keyed on the same op-name strings the dispatcher (`resolve_action`) uses, mapping every dispatchable op. Smithy `aws.iam#iamAction.name` overrides applied: `Invoke`/`InvokeWithResponseStream` -> `InvokeFunction`, `GetLayerVersionByArn` -> `GetLayerVersion`. (The old code mapped `InvokeWithResponseStream` -> the non-existent `InvokeFunctionWithResponseStream` — also fixed.)
- **5.2 (HIGH cross-account) STS — federated AssumeRole minted creds for a non-existent role.** `AssumeRoleWithWebIdentity` and `AssumeRoleWithSAML` wrapped the trust-policy gate in `if let Some(role)` with no `else`, falling through to credential minting. Replicated the plain-`AssumeRole` not-found `AccessDenied` to both variants; the existing-role + valid-condition path is unchanged.
- **5.3 (LOW bypass) S3 — unmapped + wrong-action mappings.** Added `s3_detect_action` arms: `SelectObjectContent` -> `s3:GetObject`, `WriteGetObjectResponse` detected, object `?encryption` -> `s3:PutObject`, `?abac` GET -> `GetBucketAbacConfiguration`, `?session` -> `CreateSession`, and `RenameObject` now detected with its key (it previously fell through to `PutObject`). `CreateSession`/`WriteGetObjectResponse` are routed to the `s3express` / `s3-object-lambda` IAM service prefixes.
- **5.4 (LOW bypass) IAM — `GetSecurityTokenServicePreferences` unmapped.** Added to `SUPPORTED_ACTIONS` (its sibling `Set...` was already listed).
- **5.5 (LOW crypto) Cognito — JWT verifier skipped expiry when `exp` absent.** A signed token lacking `exp` was accepted as never-expiring; now treated as invalid (fail closed). `verify_rs256` (correctly hardcoded RS256) left untouched.

## Test plan

- `cargo test` for `fakecloud-lambda`, `fakecloud-iam`, `fakecloud-s3`, `fakecloud-cognito` (all green: 325 / 463 / 199 / 352).
- `cargo test -p fakecloud-e2e --test iam_enforcement` (48 passed).
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt` on all touched crates: clean.

New tests:
- Lambda: `every_dispatched_lambda_op_maps_to_an_iam_action` (exhaustiveness), `iam_action_name_for_applies_smithy_overrides`, `iam_action_for_maps_update_function_code`, `iam_action_for_maps_invoke_async_to_invoke_function`, `iam_action_for_maps_tag_and_layer_ops`; e2e `lambda_update_function_code_deny_is_honored` + `lambda_update_function_code_allowed_with_policy`.
- STS: `assume_role_with_web_identity_nonexistent_role_denied`, `assume_role_with_saml_nonexistent_role_denied`, `assume_role_with_saml_existing_role_succeeds`.
- S3: `s3_detect_action_tests` (6 ops) + `s3_iam_service_prefix_tests` (s3express / s3-object-lambda).
- IAM: `get_security_token_service_preferences_is_iam_enforceable`.
- Cognito: `token_with_valid_exp_is_accepted`, `token_missing_exp_is_rejected`, `expired_token_is_rejected`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened strict IAM enforcement across `fakecloud-lambda`, `fakecloud-iam` (STS), `fakecloud-s3`, and `fakecloud-cognito` to close unmapped-action and federation gaps and to reject JWTs without `exp`.

- **Bug Fixes**
  - `fakecloud-lambda`: Map every dispatched op to an IAM action via a single resolver keyed on dispatcher op names; apply Smithy overrides (Invoke/InvokeWithResponseStream -> InvokeFunction, GetLayerVersionByArn -> GetLayerVersion); cover UpdateFunctionCode, InvokeAsync, aliases/layers/tags/URL/config ops; normalize function ARNs for resource checks; add exhaustiveness tests.
  - `fakecloud-iam` (STS + conformance): `AssumeRoleWithWebIdentity`/`AssumeRoleWithSAML` return AccessDenied for non-existent roles (no minting fallback); conformance probes allowlist STS AccessDenied so correct denials pass; keep `GetSecurityTokenServicePreferences` unmapped (fakecloud read-back), `SetSecurityTokenServicePreferences` remains enforced.
  - `fakecloud-s3`: Detect SelectObjectContent -> `s3:GetObject`, RenameObject, WriteGetObjectResponse, object `?encryption` -> `s3:PutObject`, bucket `?abac` GET -> GetBucketAbacConfiguration, bucket `?session` -> CreateSession; authorize CreateSession under `s3express:` and WriteGetObjectResponse under `s3-object-lambda:`.
  - `fakecloud-cognito`: Require `exp` in JWTs; reject expired or missing-exp tokens.
  - Tests: Update STS conformance/e2e to create roles with trust policies before federated `AssumeRole*`; add Lambda allow/deny and mapping tests; add S3 detection and service-prefix tests; add IAM and Cognito tests.

<sup>Written for commit dede351e863dc051c31a2caba69f1a9fcd1cf24d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

