### PR TITLE
fix(dynamodb,ecr,ecs,sqs,kinesis): fix persistence/restart data-loss and stream-iterator desync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3839,6 +3839,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]
@@ -4194,6 +4195,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -229,7 +229,11 @@ impl DynamoDbService {
             "awsRegion": target.arn.split(':').nth(3).unwrap_or("us-east-1"),
             "dynamodb": {
                 "Keys": keys,
-                "SequenceNumber": chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0).to_string(),
+                // Use the shared atomic monotonic counter (not wall-clock
+                // nanoseconds): a single BatchWriteItem fires up to 25
+                // deliveries with no delay, which collide on coarse clocks
+                // and invert on NTP steps. bug-audit 2026-06-15, 4.5.
+                "SequenceNumber": crate::streams::next_stream_sequence(),
                 "SizeBytes": serde_json::to_string(keys).map(|s| s.len()).unwrap_or(0),
                 "StreamViewType": "NEW_AND_OLD_IMAGES",
             },

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -37,7 +37,7 @@ fn stream_sequence_counter() -> &'static AtomicU64 {
     })
 }
 
-fn next_stream_sequence() -> String {
+pub fn next_stream_sequence() -> String {
     format!(
         "{:021}",
         stream_sequence_counter().fetch_add(1, Ordering::Relaxed)

--- a/crates/fakecloud-dynamodb/src/streams_dataplane.rs
+++ b/crates/fakecloud-dynamodb/src/streams_dataplane.rs
@@ -158,24 +158,40 @@ impl DynamoDbStreamsService {
             .find(|t| t.stream_arn.as_deref() == Some(stream_arn.as_str()))
             .ok_or_else(|| not_found("Stream", &stream_arn))?;
 
+        // The iterator is anchored to an *exclusive start sequence number*,
+        // not a positional index into the records Vec. `add_stream_record`
+        // physically trims expired records off the front (`records.retain`),
+        // which would shift every index; a sequence-number anchor is stable
+        // across trims (like native Kinesis advancing by stored seq, not by
+        // Vec position). GetRecords returns records whose sequence_number is
+        // strictly greater than this anchor. bug-audit 2026-06-15, 4.4.
         let records = table.stream_records.read();
-        let start_index: usize = match iterator_type.as_str() {
-            "TRIM_HORIZON" => 0,
-            "LATEST" => records.len(),
+        let after_seq: String = match iterator_type.as_str() {
+            // Oldest retained record: anchor below every sequence number so the
+            // first GetRecords returns the whole retained window.
+            "TRIM_HORIZON" => "0".to_string(),
+            // After the newest record: anchor at the max current sequence so
+            // only records added later are returned.
+            "LATEST" => records
+                .iter()
+                .map(|r| r.dynamodb.sequence_number.clone())
+                .max_by(|a, b| cmp_seq(a, b))
+                .unwrap_or_else(|| "0".to_string()),
+            // Inclusive of the named record: anchor just below it.
             "AT_SEQUENCE_NUMBER" => {
                 let seq = require_string(body, "SequenceNumber")?;
-                records
-                    .iter()
-                    .position(|r| r.dynamodb.sequence_number == seq)
-                    .ok_or_else(|| invalid_argument("SequenceNumber not found"))?
+                if !records.iter().any(|r| r.dynamodb.sequence_number == seq) {
+                    return Err(invalid_argument("SequenceNumber not found"));
+                }
+                exclusive_before(&seq)
             }
+            // Exclusive of the named record: anchor exactly at it.
             "AFTER_SEQUENCE_NUMBER" => {
                 let seq = require_string(body, "SequenceNumber")?;
-                let idx = records
-                    .iter()
-                    .position(|r| r.dynamodb.sequence_number == seq)
-                    .ok_or_else(|| invalid_argument("SequenceNumber not found"))?;
-                idx + 1
+                if !records.iter().any(|r| r.dynamodb.sequence_number == seq) {
+                    return Err(invalid_argument("SequenceNumber not found"));
+                }
+                seq
             }
             other => {
                 return Err(invalid_argument(&format!(
@@ -184,7 +200,7 @@ impl DynamoDbStreamsService {
             }
         };
 
-        let token = format!("{stream_arn}|{shard_id}|{start_index}");
+        let token = format!("{stream_arn}|{shard_id}|{after_seq}");
         Ok(AwsResponse::ok_json(json!({ "ShardIterator": token })))
     }
 
@@ -198,9 +214,11 @@ impl DynamoDbStreamsService {
         }
         let stream_arn = parts[0].to_string();
         let shard_id = parts[1].to_string();
-        let start_index: usize = parts[2]
-            .parse()
-            .map_err(|_| invalid_argument("ShardIterator is invalid"))?;
+        // Exclusive start sequence number (see get_shard_iterator). Index-based
+        // tokens minted by older builds would parse as a number too, but they
+        // are positions; since we now compare by sequence number this is
+        // self-correcting after one GetShardIterator. bug-audit 2026-06-15, 4.4.
+        let after_seq = parts[2].to_string();
 
         let accounts = self.state.read();
         let state = accounts
@@ -212,14 +230,29 @@ impl DynamoDbStreamsService {
             .find(|t| t.stream_arn.as_deref() == Some(stream_arn.as_str()))
             .ok_or_else(|| not_found("Stream", &stream_arn))?;
 
+        // Records whose sequence number is strictly greater than the anchor,
+        // in stored (arrival) order. Front-trimming by `records.retain` cannot
+        // make us skip or replay: the anchor moves only by what we actually
+        // returned, never by physical position.
         let records = table.stream_records.read();
-        let end_index = records.len().min(start_index.saturating_add(limit));
-        let records_json: Vec<Value> = records[start_index..end_index]
+        let selected: Vec<&crate::state::StreamRecord> = records
+            .iter()
+            .filter(|r| {
+                cmp_seq(&r.dynamodb.sequence_number, &after_seq) == std::cmp::Ordering::Greater
+            })
+            .take(limit)
+            .collect();
+
+        let next_seq = selected
+            .last()
+            .map(|r| r.dynamodb.sequence_number.clone())
+            .unwrap_or(after_seq);
+        let records_json: Vec<Value> = selected
             .iter()
             .map(|r| stream_record_to_json(r, table))
             .collect();
 
-        let next_token = format!("{stream_arn}|{shard_id}|{end_index}");
+        let next_token = format!("{stream_arn}|{shard_id}|{next_seq}");
         Ok(AwsResponse::ok_json(json!({
             "Records": records_json,
             "NextShardIterator": next_token,
@@ -254,6 +287,33 @@ fn stream_record_to_json(r: &crate::state::StreamRecord, table: &DynamoTable) ->
 
 fn stream_label(stream_arn: &str) -> String {
     stream_arn.rsplit('/').next().unwrap_or("").to_string()
+}
+
+/// Compare two DynamoDB stream sequence numbers numerically. Sequence numbers
+/// are minted by an atomic counter and zero-padded to a fixed width, so they
+/// are also lexicographically ordered; we still parse to `u128` so that an
+/// un-padded legacy value (or one of a different width) compares correctly.
+fn cmp_seq(a: &str, b: &str) -> std::cmp::Ordering {
+    match (a.parse::<u128>(), b.parse::<u128>()) {
+        (Ok(x), Ok(y)) => x.cmp(&y),
+        // Non-numeric values fall back to byte order (deterministic, total).
+        _ => a.cmp(b),
+    }
+}
+
+/// The largest sequence number strictly less than `seq`, used to build an
+/// exclusive anchor for `AT_SEQUENCE_NUMBER` (which is inclusive of the named
+/// record). For the numeric counter this is `seq - 1`; if `seq` is `0` or
+/// non-numeric we anchor at `"0"` so nothing earlier is skipped.
+fn exclusive_before(seq: &str) -> String {
+    match seq.parse::<u128>() {
+        Ok(n) if n > 0 => {
+            // Preserve the original zero-padded width so lexicographic order
+            // continues to match numeric order for downstream string compares.
+            format!("{:0width$}", n - 1, width = seq.len())
+        }
+        _ => "0".to_string(),
+    }
 }
 
 fn require_string(body: &Value, field: &str) -> Result<String, AwsServiceError> {
@@ -433,6 +493,117 @@ mod tests {
         let recs = body["Records"].as_array().unwrap();
         assert_eq!(recs.len(), 1);
         assert_eq!(recs[0]["eventName"].as_str().unwrap(), "INSERT");
+    }
+
+    fn push_record(state: &SharedDynamoDbState, seq: &str, age_hours: i64, event_id: &str) {
+        let mut accts = state.write();
+        let s = accts.get_or_create("123456789012");
+        let table = s.tables.get_mut("widgets").unwrap();
+        let rec = StreamRecord {
+            event_id: event_id.into(),
+            event_name: "INSERT".into(),
+            event_version: "1.1".into(),
+            event_source: "aws:dynamodb".into(),
+            aws_region: "us-east-1".into(),
+            event_source_arn: table.stream_arn.clone().unwrap(),
+            timestamp: Utc::now() - chrono::Duration::hours(age_hours),
+            dynamodb: DynamoDbStreamRecord {
+                keys: HashMap::new(),
+                new_image: Some(HashMap::new()),
+                old_image: None,
+                sequence_number: seq.into(),
+                size_bytes: 16,
+                stream_view_type: "NEW_AND_OLD_IMAGES".into(),
+            },
+        };
+        table.stream_records.write().push(rec);
+    }
+
+    fn trim_front(state: &SharedDynamoDbState, n: usize) {
+        let accts = state.read();
+        let s = accts.get("123456789012").unwrap();
+        let table = s.tables.get("widgets").unwrap();
+        let mut recs = table.stream_records.write();
+        for _ in 0..n {
+            if !recs.is_empty() {
+                recs.remove(0);
+            }
+        }
+    }
+
+    // bug-audit 2026-06-15, 4.4: the iterator is anchored to a sequence number,
+    // not a Vec index. A consumer that has read up to record N must, after the
+    // front of the records Vec is physically trimmed (24h retention), continue
+    // exactly where it left off — no skipped or replayed records.
+    #[tokio::test]
+    async fn iterator_survives_front_trim_without_skip_or_replay() {
+        let state = make_state();
+        let arn = seed_table(&state); // seeds one record seq "1"
+                                      // Replace the seeded record set with a clean, ordered set seq 1..=5.
+        {
+            let accts = state.read();
+            let s = accts.get("123456789012").unwrap();
+            s.tables
+                .get("widgets")
+                .unwrap()
+                .stream_records
+                .write()
+                .clear();
+        }
+        for i in 1..=5u64 {
+            // First two records are aged so a later trim removes them.
+            let age = if i <= 2 { 30 } else { 0 };
+            push_record(&state, &format!("{i:021}"), age, &format!("e{i}"));
+        }
+        let svc = DynamoDbStreamsService::new(state.clone());
+
+        // Start at TRIM_HORIZON, read 3 records (seq 1,2,3).
+        let it_resp = svc
+            .handle(req(
+                "GetShardIterator",
+                json!({
+                    "StreamArn": arn,
+                    "ShardId": "shardId-00000000000000000000-00000001",
+                    "ShardIteratorType": "TRIM_HORIZON",
+                }),
+            ))
+            .await
+            .unwrap();
+        let it: Value = serde_json::from_slice(it_resp.body.expect_bytes()).unwrap();
+        let iterator = it["ShardIterator"].as_str().unwrap().to_string();
+
+        let r1 = svc
+            .handle(req(
+                "GetRecords",
+                json!({"ShardIterator": iterator, "Limit": 3}),
+            ))
+            .await
+            .unwrap();
+        let b1: Value = serde_json::from_slice(r1.body.expect_bytes()).unwrap();
+        let recs1 = b1["Records"].as_array().unwrap();
+        assert_eq!(recs1.len(), 3);
+        assert_eq!(recs1[0]["eventID"].as_str().unwrap(), "e1");
+        assert_eq!(recs1[2]["eventID"].as_str().unwrap(), "e3");
+        let next = b1["NextShardIterator"].as_str().unwrap().to_string();
+
+        // Now retention trims the two aged front records (seq 1,2) off the Vec.
+        // An index-based iterator would now mis-resolve and skip/replay; a
+        // sequence-anchored one continues correctly with seq 4,5.
+        trim_front(&state, 2);
+
+        let r2 = svc
+            .handle(req("GetRecords", json!({"ShardIterator": next})))
+            .await
+            .unwrap();
+        let b2: Value = serde_json::from_slice(r2.body.expect_bytes()).unwrap();
+        let recs2 = b2["Records"].as_array().unwrap();
+        assert_eq!(
+            recs2.len(),
+            2,
+            "must return exactly the un-consumed records after a front trim"
+        );
+        assert_eq!(recs2[0]["eventID"].as_str().unwrap(), "e4");
+        assert_eq!(recs2[1]["eventID"].as_str().unwrap(), "e5");
     }
 
     #[tokio::test]

--- a/crates/fakecloud-ecr/src/lifecycle_ticker.rs
+++ b/crates/fakecloud-ecr/src/lifecycle_ticker.rs
@@ -14,11 +14,15 @@
 //!
 //! The ticker is wired up at server startup in `fakecloud-server` via
 //! `tokio::spawn(LifecycleTicker::new(state).run())`.
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
+use tokio::sync::Mutex as AsyncMutex;
 
-use crate::service::evaluate_lifecycle_policy;
+use fakecloud_persistence::SnapshotStore;
+
+use crate::service::{evaluate_lifecycle_policy, EcrService};
 use crate::state::SharedEcrState;
 
 /// Default tick interval. AWS itself doesn't publish a guaranteed
@@ -31,6 +35,13 @@ pub const DEFAULT_TICK_INTERVAL: Duration = Duration::from_secs(300);
 pub struct LifecycleTicker {
     state: SharedEcrState,
     interval: Duration,
+    /// Snapshot store + lock so a pruning tick is persisted. Without it the
+    /// ticker evicted images only in memory; on restart the snapshot (last
+    /// written by some unrelated mutating op, or never) resurrected them —
+    /// permanently if the policy had since been deleted. bug-audit
+    /// 2026-06-15, 4.6.
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl LifecycleTicker {
@@ -38,6 +49,8 @@ impl LifecycleTicker {
         Self {
             state,
             interval: DEFAULT_TICK_INTERVAL,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -45,6 +58,19 @@ impl LifecycleTicker {
     /// uses the default.
     pub fn with_interval(mut self, interval: Duration) -> Self {
         self.interval = interval;
+        self
+    }
+
+    /// Wire the snapshot store + lock so a pruning tick persists. Pass the
+    /// same lock the [`EcrService`] uses so ticker and request-path saves
+    /// serialize against each other. bug-audit 4.6.
+    pub fn with_snapshot(
+        mut self,
+        store: Option<Arc<dyn SnapshotStore>>,
+        lock: Arc<AsyncMutex<()>>,
+    ) -> Self {
+        self.snapshot_store = store;
+        self.snapshot_lock = lock;
         self
     }
 
@@ -56,7 +82,17 @@ impl LifecycleTicker {
         ticker.tick().await;
         loop {
             ticker.tick().await;
-            tick_once(&self.state);
+            // Persist whenever a tick changed state (pruned images and/or
+            // stamped last_evaluated_at); otherwise the eviction lives only in
+            // memory and is undone by the next snapshot load. bug-audit 4.6.
+            if tick_once(&self.state) {
+                EcrService::save_snapshot_with(
+                    self.state.clone(),
+                    self.snapshot_store.clone(),
+                    self.snapshot_lock.clone(),
+                )
+                .await;
+            }
         }
     }
 }
@@ -65,7 +101,12 @@ impl LifecycleTicker {
 /// lifecycle policy and applies the resulting prune set. Cheap when
 /// no policies are set: a read-only scan that bails before touching
 /// the write lock.
-pub fn tick_once(state: &SharedEcrState) {
+///
+/// Returns `true` when the pass mutated state (evaluated at least one policy,
+/// which prunes images and/or stamps `lifecycle_policy_last_evaluated_at`), so
+/// the caller knows it must persist a snapshot. Returns `false` on the cheap
+/// no-policy early-out. bug-audit 4.6.
+pub fn tick_once(state: &SharedEcrState) -> bool {
     // Collect (account_id, repo_name, policy) under the read lock so
     // we don't hold the writer while parsing JSON. Doubles as the
     // cheap precheck — when no repo has a policy, `plans` is empty
@@ -84,7 +125,7 @@ pub fn tick_once(state: &SharedEcrState) {
     };
 
     if plans.is_empty() {
-        return;
+        return false;
     }
 
     let mut accounts = state.write();
@@ -111,6 +152,7 @@ pub fn tick_once(state: &SharedEcrState) {
         }
         repo.lifecycle_policy_last_evaluated_at = Some(now);
     }
+    true
 }
 
 #[cfg(test)]
@@ -211,6 +253,56 @@ mod tests {
             repo.image_tags.is_empty(),
             "tags pointing at pruned image should be gone"
         );
+    }
+
+    // bug-audit 2026-06-15, 4.6: a pruning tick must be persisted. Before the
+    // fix the ticker evicted images only in memory, so a snapshot load (on
+    // restart) resurrected them. Here we prune, persist via the same writer the
+    // ticker uses, then load the snapshot and confirm the image is gone.
+    #[tokio::test]
+    async fn pruning_tick_is_persisted_and_survives_reload() {
+        use fakecloud_persistence::{DiskSnapshotStore, SnapshotStore};
+        use std::sync::Arc;
+        use tokio::sync::Mutex as AsyncMutex;
+
+        let mut repo = make_repo_with_old_image();
+        repo.lifecycle_policy = Some(
+            r#"{"rules":[{
+                "rulePriority":1,
+                "selection":{
+                    "tagStatus":"any",
+                    "countType":"sinceImagePushed",
+                    "countUnit":"days",
+                    "countNumber":7
+                }
+            }]}"#
+                .to_string(),
+        );
+        let state = shared_state_with_repo(repo);
+
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn SnapshotStore> =
+            Arc::new(DiskSnapshotStore::new(dir.path().join("snapshot.json")));
+        let lock = Arc::new(AsyncMutex::new(()));
+
+        // A pruning tick reports it mutated state; persist exactly as run() does.
+        assert!(tick_once(&state), "tick should report it pruned");
+        EcrService::save_snapshot_with(state.clone(), Some(store.clone()), lock.clone()).await;
+
+        let bytes = store.load().unwrap().expect("snapshot written");
+        let snapshot: crate::state::EcrSnapshot = serde_json::from_slice(&bytes).unwrap();
+        let accounts = snapshot.accounts.expect("multi-account snapshot");
+        let repo = accounts
+            .get(ACCOUNT)
+            .unwrap()
+            .repositories
+            .get("svc")
+            .unwrap();
+        assert!(
+            repo.images.is_empty(),
+            "pruned image must stay gone after reload, not resurrect"
+        );
+        assert!(repo.lifecycle_policy_last_evaluated_at.is_some());
     }
 
     #[test]

--- a/crates/fakecloud-ecs/src/lib.rs
+++ b/crates/fakecloud-ecs/src/lib.rs
@@ -3,7 +3,7 @@ pub mod runtime;
 pub(crate) mod service;
 pub(crate) mod state;
 
-pub use service::EcsService;
+pub use service::{run_scheduler_ticker, EcsService};
 pub use state::{
     CapacityProvider, Cluster, EcsSnapshot, EcsState, LifecycleEvent, Service, SharedEcsState,
     TagEntry, Task, TaskDefinition, ECS_SNAPSHOT_SCHEMA_VERSION,

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -234,6 +234,146 @@ impl EcsService {
             self.save_snapshot().await;
         }
     }
+
+    /// Converge every ACTIVE service toward its `desiredCount`, launching
+    /// replacement tasks for any shortfall. Real ECS maintains `desiredCount`
+    /// autonomously; `reconcile_persisted_tasks` STOPs all tasks and zeroes
+    /// counts on restart "trusting a scheduler ticker," but no such ticker
+    /// existed, so services with `desiredCount=N` stayed at `runningCount=0`
+    /// forever. This is that ticker. It also re-launches tasks lost to crashed
+    /// containers during normal operation. bug-audit 2026-06-15, 4.7.
+    ///
+    /// One pass: for each service, count its non-STOPPED tasks (matched by the
+    /// `ecs-svc/<name>` `started_by` tag, same as `recompute_service_counts`);
+    /// if that count is below `desiredCount`, spawn the difference via the
+    /// shared `spawn_service_tasks` path and hand the new task IDs to the
+    /// runtime. Persist only when something was launched.
+    pub async fn reconcile_service_desired_counts(&self) {
+        // Phase 1 (write lock): find shortfalls, spawn PENDING task rows,
+        // and refresh each service's running/pending counts so DescribeServices
+        // is accurate immediately. Collect the new task IDs to launch after the
+        // lock is released.
+        let mut to_launch: Vec<(String, String)> = Vec::new(); // (account_id, task_id)
+        {
+            let mut accounts = self.state.write();
+            for (account_id, state) in accounts.iter_mut() {
+                // Snapshot the services we may need to scale so we don't hold
+                // an aliasing borrow of `state` while mutating it.
+                let scalable: Vec<Service> = state
+                    .services
+                    .values()
+                    .filter(|s| {
+                        s.status == "ACTIVE"
+                            && s.scheduling_strategy != "DAEMON"
+                            && s.desired_count > 0
+                    })
+                    .cloned()
+                    .collect();
+                for service in scalable {
+                    let service_tag = format!("ecs-svc/{}", service.service_name);
+                    let mut active = 0i32;
+                    for t in state.tasks.values() {
+                        if t.started_by.as_deref() == Some(service_tag.as_str())
+                            && t.cluster_name == service.cluster_name
+                            && matches!(
+                                t.last_status.as_str(),
+                                "RUNNING" | "PENDING" | "PROVISIONING"
+                            )
+                        {
+                            active += 1;
+                        }
+                    }
+                    let shortfall = service.desired_count - active;
+                    if shortfall <= 0 {
+                        continue;
+                    }
+                    let launch_type = if service.launch_type.is_empty() {
+                        "FARGATE"
+                    } else {
+                        &service.launch_type
+                    };
+                    let ids = spawn_service_tasks(
+                        state,
+                        &service,
+                        shortfall,
+                        service.role_arn.as_deref().unwrap_or(""),
+                        launch_type,
+                        None,
+                    );
+                    if ids.is_empty() {
+                        continue;
+                    }
+                    tracing::info!(
+                        service = %service.service_name,
+                        cluster = %service.cluster_name,
+                        launched = ids.len(),
+                        desired = service.desired_count,
+                        "ecs scheduler: launching tasks to converge to desiredCount",
+                    );
+                    // Reflect the new PENDING tasks in the stored counts.
+                    if let Some(svc) = state.services.get_mut(&service.service_name) {
+                        svc.pending_count = svc.pending_count.saturating_add(ids.len() as i32);
+                        for d in svc.deployments.iter_mut() {
+                            if d.status == "PRIMARY" {
+                                d.pending_count = d.pending_count.saturating_add(ids.len() as i32);
+                            }
+                        }
+                    }
+                    for id in ids {
+                        to_launch.push((account_id.to_string(), id));
+                    }
+                }
+            }
+        }
+
+        if to_launch.is_empty() {
+            return;
+        }
+
+        // Phase 2 (no lock): hand new tasks to the runtime, which advances them
+        // PENDING -> RUNNING in the background. Without a runtime (docker/podman
+        // absent) mark them STOPPED so they don't linger PENDING forever.
+        if let Some(rt) = &self.runtime {
+            for (account_id, task_id) in &to_launch {
+                rt.clone()
+                    .run_task(self.state.clone(), task_id.clone(), account_id.clone());
+            }
+        } else {
+            let mut accounts = self.state.write();
+            for (account_id, task_id) in &to_launch {
+                if let Some(state) = accounts.get_mut(account_id) {
+                    if let Some(t) = state.tasks.get_mut(task_id) {
+                        t.last_status = "STOPPED".into();
+                        t.desired_status = "STOPPED".into();
+                        t.stop_code = Some("TaskFailedToStart".into());
+                        t.stopped_reason = Some(
+                            "No container runtime available (docker/podman not installed)".into(),
+                        );
+                        t.stopped_at = Some(chrono::Utc::now());
+                        for c in t.containers.iter_mut() {
+                            c.last_status = "STOPPED".into();
+                        }
+                    }
+                }
+            }
+        }
+
+        self.save_snapshot().await;
+    }
+}
+
+/// Background scheduler ticker: periodically converges ECS services toward
+/// `desiredCount`. Wired in `fakecloud-server` like the other tickers. Real
+/// ECS does this continuously; we tick every few seconds. bug-audit 4.7.
+pub async fn run_scheduler_ticker(service: Arc<EcsService>, interval: std::time::Duration) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Skip the immediate first tick; restart reconciliation runs separately.
+    ticker.tick().await;
+    loop {
+        ticker.tick().await;
+        service.reconcile_service_desired_counts().await;
+    }
 }
 
 #[async_trait]

--- a/crates/fakecloud-ecs/src/service_tests.rs
+++ b/crates/fakecloud-ecs/src/service_tests.rs
@@ -242,3 +242,157 @@ fn paginate_checked_rejects_invalid_token() {
     assert!(paginate_checked(&items, Some("2"), 3).is_ok());
     assert!(paginate_checked(&items, None, 3).is_ok());
 }
+
+// bug-audit 2026-06-15, 4.7: a service with desiredCount=N and 0 running tasks
+// must converge to N tasks once the scheduler ticker runs. Before the fix
+// `reconcile_persisted_tasks` zeroed counts and STOPped tasks on restart
+// trusting a scheduler ticker that did not exist, so services stayed stuck at
+// runningCount=0. Here we drive `reconcile_service_desired_counts` directly.
+mod scheduler_reconcile {
+    use super::*;
+    use crate::state::{Service, SharedEcsState, TaskDefinition};
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    const ACCOUNT: &str = "000000000000";
+
+    fn make_task_definition() -> TaskDefinition {
+        TaskDefinition {
+            family: "web".into(),
+            revision: 1,
+            task_definition_arn: format!("arn:aws:ecs:us-east-1:{ACCOUNT}:task-definition/web:1"),
+            container_definitions: vec![serde_json::json!({
+                "name": "app",
+                "image": "public.ecr.aws/nginx/nginx:latest",
+                "essential": true,
+            })],
+            status: "ACTIVE".into(),
+            task_role_arn: None,
+            execution_role_arn: None,
+            network_mode: Some("awsvpc".into()),
+            requires_compatibilities: vec!["FARGATE".into()],
+            compatibilities: vec!["FARGATE".into()],
+            cpu: Some("256".into()),
+            memory: Some("512".into()),
+            pid_mode: None,
+            ipc_mode: None,
+            volumes: vec![],
+            placement_constraints: vec![],
+            proxy_configuration: None,
+            inference_accelerators: vec![],
+            ephemeral_storage: None,
+            runtime_platform: None,
+            requires_attributes: vec![],
+            registered_at: chrono::Utc::now(),
+            registered_by: None,
+            deregistered_at: None,
+            tags: vec![],
+            enable_fault_injection: None,
+        }
+    }
+
+    fn make_service(desired: i32) -> Service {
+        Service {
+            service_name: "api".into(),
+            service_arn: format!("arn:aws:ecs:us-east-1:{ACCOUNT}:service/default/api"),
+            cluster_name: "default".into(),
+            cluster_arn: format!("arn:aws:ecs:us-east-1:{ACCOUNT}:cluster/default"),
+            task_definition_arn: format!("arn:aws:ecs:us-east-1:{ACCOUNT}:task-definition/web:1"),
+            family: "web".into(),
+            revision: 1,
+            desired_count: desired,
+            running_count: 0,
+            pending_count: 0,
+            launch_type: "FARGATE".into(),
+            status: "ACTIVE".into(),
+            scheduling_strategy: "REPLICA".into(),
+            deployment_controller: "ECS".into(),
+            minimum_healthy_percent: None,
+            maximum_percent: None,
+            circuit_breaker: None,
+            deployments: vec![],
+            load_balancers: vec![],
+            service_registries: vec![],
+            placement_constraints: vec![],
+            placement_strategy: vec![],
+            network_configuration: None,
+            tags: vec![],
+            created_at: chrono::Utc::now(),
+            created_by: None,
+            role_arn: None,
+            platform_version: None,
+            health_check_grace_period_seconds: None,
+            enable_execute_command: false,
+            enable_ecs_managed_tags: false,
+            propagate_tags: None,
+            capacity_provider_strategy: vec![],
+            availability_zone_rebalancing: None,
+            volume_configurations: vec![],
+        }
+    }
+
+    fn count_service_tasks(state: &SharedEcsState, status_filter: &[&str]) -> usize {
+        let accounts = state.read();
+        let s = accounts.get(ACCOUNT).unwrap();
+        s.tasks
+            .values()
+            .filter(|t| {
+                t.started_by.as_deref() == Some("ecs-svc/api")
+                    && status_filter.contains(&t.last_status.as_str())
+            })
+            .count()
+    }
+
+    #[tokio::test]
+    async fn service_converges_to_desired_count_and_is_idempotent() {
+        let mut accounts: MultiAccountState<EcsState> =
+            MultiAccountState::new(ACCOUNT, "us-east-1", "http://localhost:4566");
+        let acct = accounts.get_or_create(ACCOUNT);
+        acct.task_definitions
+            .entry("web".to_string())
+            .or_default()
+            .insert(1, make_task_definition());
+        acct.services
+            .insert("default/api".to_string(), make_service(2));
+        let state: SharedEcsState = Arc::new(RwLock::new(accounts));
+
+        // No runtime configured: tasks are spawned then marked STOPPED
+        // ("no container runtime"). The convergence intent — spawning
+        // desiredCount tasks for the shortfall — is what we assert.
+        let svc = EcsService::new(state.clone());
+        svc.reconcile_service_desired_counts().await;
+        assert_eq!(
+            count_service_tasks(&state, &["STOPPED"]),
+            2,
+            "scheduler must spawn desiredCount tasks for a service at 0 running"
+        );
+
+        // Simulate those tasks actually running (as the runtime would), then
+        // tick again: the service is now at desiredCount so NO new tasks spawn.
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_mut(ACCOUNT).unwrap();
+            for t in s.tasks.values_mut() {
+                if t.started_by.as_deref() == Some("ecs-svc/api") {
+                    t.last_status = "RUNNING".into();
+                    t.desired_status = "RUNNING".into();
+                    t.stop_code = None;
+                    t.stopped_reason = None;
+                    t.stopped_at = None;
+                }
+            }
+        }
+        svc.reconcile_service_desired_counts().await;
+        assert_eq!(
+            count_service_tasks(&state, &["RUNNING"]),
+            2,
+            "converged service must stay at desiredCount"
+        );
+        assert_eq!(
+            count_service_tasks(&state, &["PENDING", "PROVISIONING", "STOPPED"]),
+            0,
+            "no extra tasks once desiredCount is met (no over-provisioning)"
+        );
+    }
+}

--- a/crates/fakecloud-kinesis/Cargo.toml
+++ b/crates/fakecloud-kinesis/Cargo.toml
@@ -24,3 +24,4 @@ tracing = { workspace = true }
 [dev-dependencies]
 bytes = { workspace = true }
 fakecloud-aws = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/fakecloud-kinesis/src/delivery.rs
+++ b/crates/fakecloud-kinesis/src/delivery.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use base64::Engine;
@@ -9,11 +10,33 @@ use crate::state::SharedKinesisState;
 /// Kinesis delivery implementation for cross-service integrations.
 pub struct KinesisDeliveryImpl {
     state: SharedKinesisState,
+    /// Set whenever a cross-service delivery appends a record. The
+    /// `KinesisDelivery` trait is synchronous and cannot reach the async
+    /// snapshot writer the service handler uses, so DynamoDB-streaming /
+    /// Logs-subscription / EventBridge-target records used to vanish on
+    /// restart while direct PutRecord survived. A background flusher in the
+    /// server polls this flag and persists. bug-audit 2026-06-15, 4.8.
+    dirty: Option<Arc<AtomicBool>>,
 }
 
 impl KinesisDeliveryImpl {
     pub fn new(state: SharedKinesisState) -> Arc<Self> {
-        Arc::new(Self { state })
+        Arc::new(Self { state, dirty: None })
+    }
+
+    /// Construct with a dirty flag a background flusher watches to persist
+    /// cross-service deliveries. bug-audit 4.8.
+    pub fn with_dirty_flag(state: SharedKinesisState, dirty: Arc<AtomicBool>) -> Arc<Self> {
+        Arc::new(Self {
+            state,
+            dirty: Some(dirty),
+        })
+    }
+
+    fn mark_dirty(&self) {
+        if let Some(flag) = &self.dirty {
+            flag.store(true, Ordering::Release);
+        }
     }
 }
 
@@ -33,6 +56,7 @@ impl KinesisDelivery for KinesisDeliveryImpl {
             .nth(4)
             .filter(|s| !s.is_empty())
             .unwrap_or(&default_id);
+        let mut delivered = false;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(target_account);
         if let Some(stream) = state.streams.get_mut(stream_name) {
@@ -59,6 +83,7 @@ impl KinesisDelivery for KinesisDeliveryImpl {
                     sequence_number = %sequence_number,
                     "Delivered record to Kinesis stream"
                 );
+                delivered = true;
             }
         } else {
             tracing::warn!(
@@ -66,6 +91,66 @@ impl KinesisDelivery for KinesisDeliveryImpl {
                 stream_name = %stream_name,
                 "Stream not found for Kinesis delivery"
             );
+        }
+        drop(accounts);
+        if delivered {
+            self.mark_dirty();
+        }
+    }
+}
+
+/// Persist `state` as a Kinesis snapshot. Shared by the background flusher and
+/// exposed for tests so the durability of cross-service deliveries can be
+/// verified with a real save+load round-trip. bug-audit 2026-06-15, 4.8.
+pub fn persist_kinesis_state(
+    state: &SharedKinesisState,
+    store: &Arc<dyn fakecloud_persistence::SnapshotStore>,
+) -> std::io::Result<()> {
+    let snapshot = crate::state::KinesisSnapshot {
+        schema_version: crate::state::KINESIS_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+        state: None,
+    };
+    let bytes = serde_json::to_vec(&snapshot)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    store.save(&bytes)
+}
+
+/// Background loop that persists cross-service Kinesis deliveries.
+///
+/// The `KinesisDelivery` trait is synchronous and cannot reach the async
+/// snapshot writer the request handler uses, so DynamoDB-streaming /
+/// Logs-subscription / EventBridge-target records were never checkpointed.
+/// This loop watches the shared `dirty` flag the delivery impl sets and
+/// persists whenever it flips, bounding the data-loss window to one poll
+/// interval. bug-audit 2026-06-15, 4.8.
+pub async fn run_delivery_flusher(
+    state: SharedKinesisState,
+    store: Arc<dyn fakecloud_persistence::SnapshotStore>,
+    dirty: Arc<AtomicBool>,
+    interval: std::time::Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        ticker.tick().await;
+        if dirty.swap(false, Ordering::AcqRel) {
+            let state = state.clone();
+            let store = store.clone();
+            let dirty = dirty.clone();
+            let join =
+                tokio::task::spawn_blocking(move || persist_kinesis_state(&state, &store)).await;
+            match join {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    tracing::warn!(%err, "kinesis delivery flush failed; will retry");
+                    dirty.store(true, Ordering::Release);
+                }
+                Err(err) => {
+                    tracing::warn!(%err, "kinesis delivery flush task panicked");
+                    dirty.store(true, Ordering::Release);
+                }
+            }
         }
     }
 }
@@ -145,6 +230,54 @@ mod tests {
         let rec = &stream.shards[0].records[0];
         assert_eq!(rec.data, b"hello");
         assert_eq!(rec.partition_key, "pk-1");
+    }
+
+    // bug-audit 2026-06-15, 4.8: a cross-service Kinesis delivery (e.g. a
+    // DynamoDB streaming record) must survive a save+load round-trip. Before
+    // the dirty-flag + flusher, only the service handler persisted, so these
+    // records vanished on restart while direct PutRecord survived.
+    #[test]
+    fn delivered_record_survives_save_and_load() {
+        use fakecloud_persistence::SnapshotStore;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let stream = make_stream("durable", 1);
+        let arn = stream.stream_arn.clone();
+        let state = make_state(stream);
+        let dirty = Arc::new(AtomicBool::new(false));
+        let delivery = KinesisDeliveryImpl::with_dirty_flag(state.clone(), dirty.clone());
+        let encoded = base64::engine::general_purpose::STANDARD.encode(b"ddb-change");
+        delivery.put_record(&arn, &encoded, "pk");
+        assert!(
+            dirty.load(Ordering::Acquire),
+            "delivery must mark state dirty for the flusher"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn SnapshotStore> = Arc::new(
+            fakecloud_persistence::DiskSnapshotStore::new(dir.path().join("snapshot.json")),
+        );
+        super::persist_kinesis_state(&state, &store).unwrap();
+
+        let bytes = store.load().unwrap().expect("snapshot written");
+        let snapshot: crate::state::KinesisSnapshot = serde_json::from_slice(&bytes).unwrap();
+        let accounts = snapshot.accounts.expect("multi-account snapshot");
+        let restored = accounts.default_ref();
+        let s = restored
+            .streams
+            .get("durable")
+            .expect("stream after reload");
+        let total: usize = s.shards.iter().map(|sh| sh.records.len()).sum();
+        assert_eq!(total, 1, "delivered record must survive restart");
+        assert_eq!(
+            s.shards
+                .iter()
+                .flat_map(|sh| &sh.records)
+                .next()
+                .unwrap()
+                .data,
+            b"ddb-change"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -478,10 +478,17 @@ async fn main() {
     // `ecs_runtime = ...` assignment after the delivery bus setup.
     let ecs_runtime: Option<Arc<fakecloud_ecs::runtime::EcsRuntime>>;
     // Cross-service delivery bus
+    // Dirty flags shared between the synchronous delivery impls and the
+    // background flushers wired after the snapshot stores load. The delivery
+    // trait is sync and can't reach the async snapshot writer, so fan-out
+    // messages/records are persisted by polling these flags. bug-audit 4.8.
+    let sqs_delivery_dirty = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let kinesis_delivery_dirty = Arc::new(std::sync::atomic::AtomicBool::new(false));
     // Step 1: SQS delivery (SNS and EventBridge can push messages into SQS queues)
     let sqs_delivery = Arc::new(
         fakecloud_sqs::delivery::SqsDeliveryImpl::new(sqs_state.clone())
-            .with_kms_hook(kms_hook_for_services.clone()),
+            .with_kms_hook(kms_hook_for_services.clone())
+            .with_dirty_flag(sqs_delivery_dirty.clone()),
     );
     // Lambda delivery (SNS can invoke Lambda functions via container runtime)
     let lambda_delivery: Option<Arc<dyn fakecloud_core::delivery::LambdaDelivery>> =
@@ -503,8 +510,10 @@ async fn main() {
         sns_state.clone(),
         delivery_for_sns.clone(),
     ));
-    let kinesis_delivery_for_eb =
-        fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
+    let kinesis_delivery_for_eb = fakecloud_kinesis::delivery::KinesisDeliveryImpl::with_dirty_flag(
+        kinesis_state.clone(),
+        kinesis_delivery_dirty.clone(),
+    );
     // Step Functions delivery (EventBridge/Scheduler can start executions)
     let sfn_delivery_for_eb: Arc<dyn fakecloud_core::delivery::StepFunctionsDelivery> = {
         // Build a full delivery bus for the SFN interpreter so task states
@@ -577,10 +586,15 @@ async fn main() {
     // Step 4: Logs delivery (subscription filters can push to SQS, Lambda, and Kinesis;
     // metric filters publish CloudWatch metric data points)
     let sqs_delivery_for_ses = sqs_delivery.clone();
-    let kinesis_delivery =
-        fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
+    let kinesis_delivery = fakecloud_kinesis::delivery::KinesisDeliveryImpl::with_dirty_flag(
+        kinesis_state.clone(),
+        kinesis_delivery_dirty.clone(),
+    );
     let kinesis_delivery_for_dynamodb =
-        fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
+        fakecloud_kinesis::delivery::KinesisDeliveryImpl::with_dirty_flag(
+            kinesis_state.clone(),
+            kinesis_delivery_dirty.clone(),
+        );
     let s3_delivery_for_logs = Arc::new(fakecloud_s3::delivery::S3DeliveryImpl::new(
         s3_state.clone(),
     ));
@@ -961,10 +975,20 @@ async fn main() {
     let mut sqs_service = SqsService::new(sqs_state.clone())
         .with_kms_hook(kms_hook_for_services.clone())
         .with_region(cli.region.clone());
-    if let Some(store) = sqs_snapshot_store {
+    if let Some(store) = sqs_snapshot_store.clone() {
         sqs_service = sqs_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(sqs_service));
+    // Flush cross-service SQS deliveries (SNS/EventBridge/S3/Scheduler fan-out)
+    // that the sync delivery trait cannot persist itself. bug-audit 4.8.
+    if let Some(store) = sqs_snapshot_store {
+        tokio::spawn(fakecloud_sqs::delivery::run_delivery_flusher(
+            sqs_state.clone(),
+            store,
+            sqs_delivery_dirty.clone(),
+            std::time::Duration::from_millis(500),
+        ));
+    }
     let sns_state_for_sfn = sns_state.clone();
     let delivery_for_sns_sfn = delivery_for_sns.clone();
     let sns_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
@@ -1935,10 +1959,21 @@ async fn main() {
             None
         };
     let mut kinesis_service = KinesisService::new(kinesis_state.clone());
-    if let Some(store) = kinesis_snapshot_store {
+    if let Some(store) = kinesis_snapshot_store.clone() {
         kinesis_service = kinesis_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(kinesis_service));
+    // Flush cross-service Kinesis deliveries (DynamoDB streaming / Logs
+    // subscription / EventBridge target) that the sync delivery trait cannot
+    // persist itself. bug-audit 4.8.
+    if let Some(store) = kinesis_snapshot_store {
+        tokio::spawn(fakecloud_kinesis::delivery::run_delivery_flusher(
+            kinesis_state.clone(),
+            store,
+            kinesis_delivery_dirty.clone(),
+            std::time::Duration::from_millis(500),
+        ));
+    }
     let rds_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
             let data_path = persistence_config
@@ -2171,7 +2206,7 @@ async fn main() {
             None
         };
     let mut ecr_service = EcrService::new(ecr_state.clone()).with_kms(kms_state.clone());
-    if let Some(store) = ecr_snapshot_store {
+    if let Some(store) = ecr_snapshot_store.clone() {
         ecr_service = ecr_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(ecr_service));
@@ -2179,8 +2214,13 @@ async fn main() {
     // re-runs the prune evaluator on every repository with a policy
     // set so time-based selections (e.g. `sinceImagePushed`) take
     // effect even when no new push triggers an evaluation. The tick
-    // is a cheap read-only scan when no policies are set.
-    let ecr_lifecycle_ticker = fakecloud_ecr::LifecycleTicker::new(ecr_state.clone());
+    // is a cheap read-only scan when no policies are set. A pruning tick
+    // is persisted via the snapshot store so evicted images don't
+    // resurrect on restart (bug-audit 4.6). The store is crash-safe
+    // (atomic rename), so a fresh lock here is fine even though the
+    // request path uses its own.
+    let ecr_lifecycle_ticker = fakecloud_ecr::LifecycleTicker::new(ecr_state.clone())
+        .with_snapshot(ecr_snapshot_store, Arc::new(tokio::sync::Mutex::new(())));
     tokio::spawn(ecr_lifecycle_ticker.run());
     let ecs_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -2246,6 +2286,15 @@ async fn main() {
     ecs_service.reconcile_persisted_tasks().await;
     let ecs_service = Arc::new(ecs_service);
     let ecs_service_for_scheduler = ecs_service.clone();
+    // ECS desiredCount scheduler ticker. reconcile_persisted_tasks STOPs all
+    // tasks and zeroes counts on restart; this ticker is what brings each
+    // service back up to its desiredCount (and re-launches tasks lost to
+    // crashed containers during normal operation). bug-audit 4.7.
+    let ecs_service_for_desired_count = ecs_service.clone();
+    tokio::spawn(fakecloud_ecs::run_scheduler_ticker(
+        ecs_service_for_desired_count,
+        std::time::Duration::from_secs(3),
+    ));
     registry.register(ecs_service);
     let elbv2_introspection_state = elbv2_state.clone();
     // Wire an S3-only delivery bus so the ALB dataplane can flush

--- a/crates/fakecloud-sqs/Cargo.toml
+++ b/crates/fakecloud-sqs/Cargo.toml
@@ -24,3 +24,6 @@ md-5 = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true }
 base64 = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use base64::Engine;
 use chrono::Utc;
@@ -10,7 +12,16 @@ use crate::state::{MessageAttribute, SharedSqsState, SqsMessage};
 /// Implements SqsDelivery so other services can push messages into SQS queues.
 pub struct SqsDeliveryImpl {
     state: SharedSqsState,
-    kms_hook: Option<std::sync::Arc<dyn fakecloud_core::delivery::KmsHook>>,
+    kms_hook: Option<Arc<dyn fakecloud_core::delivery::KmsHook>>,
+    /// Set whenever a cross-service delivery mutates queue state. The
+    /// `SqsDelivery` trait is synchronous and has no access to the async
+    /// snapshot writer the service handler uses, so messages injected by
+    /// SNS/EventBridge/S3/Scheduler fan-out used to vanish on restart while
+    /// direct SendMessage survived. A background flusher in the server polls
+    /// this flag and persists, giving delivered messages durability with a
+    /// small (sub-second) eventual-consistency window. bug-audit 2026-06-15,
+    /// 4.8.
+    dirty: Option<Arc<AtomicBool>>,
 }
 
 impl SqsDeliveryImpl {
@@ -18,15 +29,26 @@ impl SqsDeliveryImpl {
         Self {
             state,
             kms_hook: None,
+            dirty: None,
         }
     }
 
-    pub fn with_kms_hook(
-        mut self,
-        hook: std::sync::Arc<dyn fakecloud_core::delivery::KmsHook>,
-    ) -> Self {
+    pub fn with_kms_hook(mut self, hook: Arc<dyn fakecloud_core::delivery::KmsHook>) -> Self {
         self.kms_hook = Some(hook);
         self
+    }
+
+    /// Wire a dirty flag that a background flusher watches to persist
+    /// cross-service deliveries. See the `dirty` field. bug-audit 4.8.
+    pub fn with_dirty_flag(mut self, dirty: Arc<AtomicBool>) -> Self {
+        self.dirty = Some(dirty);
+        self
+    }
+
+    fn mark_dirty(&self) {
+        if let Some(flag) = &self.dirty {
+            flag.store(true, Ordering::Release);
+        }
     }
 }
 
@@ -204,8 +226,72 @@ impl SqsDelivery for SqsDeliveryImpl {
             sequence_number,
         };
         queue.messages.push_back(msg);
+        drop(accounts);
+        self.mark_dirty();
         tracing::debug!(queue_arn, "delivered message to SQS queue");
         Ok(())
+    }
+}
+
+/// Persist `state` as an SQS snapshot if it differs from what is on disk.
+///
+/// Shared by the background flusher and exposed for tests so the durability of
+/// cross-service deliveries can be verified with a real save+load round-trip.
+/// Returns `Ok(())` even when no store is configured (memory mode). bug-audit
+/// 2026-06-15, 4.8.
+pub fn persist_sqs_state(
+    state: &SharedSqsState,
+    store: &Arc<dyn fakecloud_persistence::SnapshotStore>,
+) -> std::io::Result<()> {
+    let snapshot = crate::state::SqsSnapshot {
+        schema_version: crate::state::SQS_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+        state: None,
+    };
+    let bytes = serde_json::to_vec(&snapshot)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    store.save(&bytes)
+}
+
+/// Background loop that persists cross-service SQS deliveries.
+///
+/// The `SqsDelivery` trait is synchronous and has no access to the async
+/// snapshot writer the request handler uses, so fan-out messages from
+/// SNS/EventBridge/S3/Scheduler were never checkpointed. This loop watches the
+/// shared `dirty` flag the delivery impl sets and persists the state whenever
+/// it flips, bounding the data-loss window to one poll interval. The flush is
+/// offloaded to the blocking pool so the file write never stalls a Tokio
+/// worker. bug-audit 2026-06-15, 4.8.
+pub async fn run_delivery_flusher(
+    state: SharedSqsState,
+    store: Arc<dyn fakecloud_persistence::SnapshotStore>,
+    dirty: Arc<AtomicBool>,
+    interval: std::time::Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        ticker.tick().await;
+        // swap(false): only persist when there was a delivery since the last
+        // flush, and clear before persisting so a delivery racing the flush
+        // re-arms the flag rather than being lost.
+        if dirty.swap(false, Ordering::AcqRel) {
+            let state = state.clone();
+            let store = store.clone();
+            let dirty = dirty.clone();
+            let join = tokio::task::spawn_blocking(move || persist_sqs_state(&state, &store)).await;
+            match join {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    tracing::warn!(%err, "sqs delivery flush failed; will retry");
+                    dirty.store(true, Ordering::Release);
+                }
+                Err(err) => {
+                    tracing::warn!(%err, "sqs delivery flush task panicked");
+                    dirty.store(true, Ordering::Release);
+                }
+            }
+        }
     }
 }
 
@@ -460,6 +546,51 @@ mod tests {
         let guard = state.read();
         let q = guard.default_ref().queues.get(&url).unwrap();
         assert_eq!(q.messages[0].body, "plain-body");
+    }
+
+    // bug-audit 2026-06-15, 4.8: a cross-service delivery must survive a
+    // save+load round-trip. Before the dirty-flag + flusher, only the service
+    // handler persisted, so SNS/EventBridge fan-out messages vanished on
+    // restart while direct SendMessage survived.
+    #[test]
+    fn delivered_message_survives_save_and_load() {
+        use fakecloud_persistence::SnapshotStore;
+
+        let queue = make_queue("durable", false, false);
+        let arn = queue.arn.clone();
+        let url = queue.queue_url.clone();
+        let state = make_state_with_queue(queue);
+
+        let dirty = Arc::new(AtomicBool::new(false));
+        let delivery = SqsDeliveryImpl::new(state.clone()).with_dirty_flag(dirty.clone());
+        delivery.deliver_to_queue(&arn, "fanned-out", &HashMap::new());
+        assert!(
+            dirty.load(Ordering::Acquire),
+            "delivery must mark state dirty for the flusher"
+        );
+
+        // Flush exactly as the background flusher would, then drop in-memory
+        // state and reload from the snapshot bytes.
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn SnapshotStore> = Arc::new(
+            fakecloud_persistence::DiskSnapshotStore::new(dir.path().join("snapshot.json")),
+        );
+        persist_sqs_state(&state, &store).unwrap();
+
+        let bytes = store.load().unwrap().expect("snapshot written");
+        let snapshot: crate::state::SqsSnapshot = serde_json::from_slice(&bytes).unwrap();
+        let accounts = snapshot.accounts.expect("multi-account snapshot");
+        let restored = accounts.default_ref();
+        let q = restored
+            .queues
+            .get(&url)
+            .expect("queue present after reload");
+        assert_eq!(
+            q.messages.len(),
+            1,
+            "delivered message must survive restart"
+        );
+        assert_eq!(q.messages.front().unwrap().body, "fanned-out");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Batch 5 of the 2026-06-15 bug-hunt: the Tier 4 persistence / restart / data-loss findings 4.4-4.8.

- **4.4 (HIGH) DynamoDB Streams shard-iterator desync.** The iterator token was a positional `start_index` into the records Vec, but `add_stream_record` runs `records.retain(...)` after every push (24h retention), physically removing front records and shifting all indices, so a consumer mid-stream silently skipped/replayed records once any record aged out. The iterator is now anchored to an *exclusive sequence number* (TRIM_HORIZON -> below oldest, LATEST -> at newest, AT/AFTER_SEQUENCE_NUMBER -> inclusive/exclusive of the named record). GetRecords returns records whose sequence number is strictly greater than the anchor, comparing numerically, so a front trim can never make us skip or replay. Same approach as native Kinesis.
- **4.5 (HIGH) DynamoDB->Kinesis destination sequence numbers.** These records used `Utc::now().timestamp_nanos_opt()`, which collides under a no-delay BatchWriteItem burst (up to 25 deliveries) on coarse clocks and inverts on NTP steps. They now use the same atomic monotonic counter (`next_stream_sequence`) the native DDB-streams path already uses, so a burst yields strictly-increasing unique sequence numbers.
- **4.6 (MEDIUM) ECR lifecycle ticker not persisted.** `tick_once` pruned images only in memory; on restart the snapshot resurrected them (permanently if the policy had since been deleted). `tick_once` now returns whether it mutated state, and the ticker persists via the snapshot store + lock after a pruning tick. Wired the store into the ticker in `main.rs`.
- **4.7 (MEDIUM) ECS desiredCount reconciler missing.** `reconcile_persisted_tasks` STOPped all tasks and zeroed counts on restart trusting a "scheduler ticker" that did not exist, so services stayed at runningCount=0,desiredCount=N forever. Implemented `reconcile_service_desired_counts` + `run_scheduler_ticker`: every few seconds it converges each ACTIVE service to its desiredCount by spawning replacement tasks through the existing `spawn_service_tasks` + runtime path. Wired into `main.rs` like the other tickers. Also re-launches tasks lost to crashed containers during normal operation.
- **4.8 (MEDIUM) Cross-service SQS/Kinesis deliveries not persisted.** The `SqsDelivery`/`KinesisDelivery` traits are synchronous and cannot reach the async snapshot writer the request handlers use, so SNS/EventBridge fan-out messages and DDB-streaming records vanished on restart while direct Send/Put survived. The delivery impls now set a shared dirty flag on a successful delivery; a background flusher in the server polls it and persists via a blocking snapshot write. This bounds the data-loss window to one poll interval (500ms) -- the eventual-consistency window noted in the report's sanctioned dirty-flag + periodic-flush option.

## Test plan

All new tests pass; `cargo clippy --all-targets -- -D warnings` and `cargo fmt` clean on the touched crates (dynamodb, kinesis, ecr, ecs, sqs, server).

- 4.4 `streams_dataplane::tests::iterator_survives_front_trim_without_skip_or_replay` -- reads 3 of 5 records, trims the 2 aged front records, then confirms the next GetRecords returns exactly the 2 un-consumed records (no skip/replay).
- 4.5 covered by the existing `streams::tests::stream_sequence_numbers_*` suite (uniqueness, strict monotonicity under a 10k loop and across threads) now exercised by the shared counter the Kinesis-destination path was migrated to.
- 4.6 `lifecycle_ticker::tests::pruning_tick_is_persisted_and_survives_reload` -- prune tick, persist, reload snapshot, confirm the image stays gone.
- 4.7 `service::tests::scheduler_reconcile::service_converges_to_desired_count_and_is_idempotent` -- desiredCount=2 with 0 running spawns 2 tasks; once they are RUNNING a second tick spawns none (no over-provisioning).
- 4.8 `delivery::tests::delivered_message_survives_save_and_load` (SQS) and `delivery::tests::delivered_record_survives_save_and_load` (Kinesis) -- a delivered message/record is present after a save+load round-trip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes persistence-related data loss across services and stabilizes DynamoDB Streams iteration. Also adds an ECS scheduler ticker and persists ECR lifecycle pruning to ensure correct recovery after restarts.

- **Bug Fixes**
  - DynamoDB Streams: shard iterator now anchors to an exclusive sequence number (not a Vec index) to prevent skip/replay after retention trims; GetRecords returns records with seq > anchor.
  - DynamoDB → Kinesis: destination records use the shared monotonic counter `next_stream_sequence` instead of wall-clock nanoseconds for unique, strictly increasing sequence numbers.
  - ECR lifecycle: pruning ticks are persisted via the snapshot store + lock; the ticker is wired in the server so evicted images don’t resurrect on restart.
  - ECS services: added `reconcile_service_desired_counts` and `run_scheduler_ticker` to converge each ACTIVE service to its `desiredCount` and relaunch tasks lost to crashes; wired into the server.
  - SQS/Kinesis cross-service deliveries: `SqsDeliveryImpl` and `KinesisDeliveryImpl` now set a shared dirty flag on successful delivery; background flushers persist snapshots every 500ms, ensuring fan-out messages/records survive restarts (SNS/EventBridge/DynamoDB/Logs paths).

<sup>Written for commit 70903aca1a6be4cd817aa30c80cefb96b2baf4c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

