### PR TITLE
fix: Tier-1 medium/low API divergences across 10 services (bug-hunt 2026-06-15 batch 7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3377,6 +3377,7 @@ dependencies = [
  "fakecloud-core",
  "fakecloud-iam",
  "fakecloud-persistence",
+ "hmac 0.12.1",
  "http 1.4.0",
  "parking_lot",
  "rand 0.8.5",

--- a/crates/fakecloud-apigateway/src/helpers.rs
+++ b/crates/fakecloud-apigateway/src/helpers.rs
@@ -44,6 +44,49 @@ pub(crate) fn strip_nulls_deep(value: Value) -> Value {
     }
 }
 
+/// The SDK-type descriptors API Gateway exposes via GetSdkTypes, shared
+/// with GetSdkType so a single id lookup returns a real descriptor.
+pub(crate) fn sdk_types() -> Vec<Value> {
+    vec![
+        serde_json::json!({
+            "id": "android",
+            "friendlyName": "Android",
+            "description": "Android SDK with a Java client",
+            "configurationProperties": []
+        }),
+        serde_json::json!({
+            "id": "javascript",
+            "friendlyName": "JavaScript",
+            "description": "JavaScript SDK",
+            "configurationProperties": []
+        }),
+        serde_json::json!({
+            "id": "ios-objectivec",
+            "friendlyName": "iOS (Objective-C)",
+            "description": "iOS SDK in Objective-C",
+            "configurationProperties": []
+        }),
+        serde_json::json!({
+            "id": "ios-swift",
+            "friendlyName": "iOS (Swift)",
+            "description": "iOS SDK in Swift",
+            "configurationProperties": []
+        }),
+        serde_json::json!({
+            "id": "java",
+            "friendlyName": "Java",
+            "description": "Java SDK",
+            "configurationProperties": []
+        }),
+        serde_json::json!({
+            "id": "ruby",
+            "friendlyName": "Ruby",
+            "description": "Ruby SDK",
+            "configurationProperties": []
+        }),
+    ]
+}
+
 pub(crate) fn ok_no_content() -> Result<AwsResponse, AwsServiceError> {
     Ok(AwsResponse {
         status: StatusCode::ACCEPTED,

--- a/crates/fakecloud-apigateway/src/service_extras.rs
+++ b/crates/fakecloud-apigateway/src/service_extras.rs
@@ -416,6 +416,20 @@ impl ApiGatewayService {
         })
     }
 
+    /// GetSdkType: return the descriptor for a known SDK type id instead
+    /// of a literal "Stub" friendlyName.
+    pub(super) fn get_sdk_type(
+        &self,
+        params: &BTreeMap<String, String>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = params.get("id").cloned().unwrap_or_default();
+        sdk_types()
+            .into_iter()
+            .find(|t| t["id"].as_str() == Some(id.as_str()))
+            .map(ok)
+            .unwrap_or_else(|| Err(not_found("SDK type not found")))
+    }
+
     pub(super) fn tag_resource(
         &self,
         req: &AwsRequest,

--- a/crates/fakecloud-apigateway/src/service_rest_api_resources.rs
+++ b/crates/fakecloud-apigateway/src/service_rest_api_resources.rs
@@ -97,7 +97,7 @@ impl ApiGatewayService {
             "GetUsagePlanKeys" => self.get_usage_plan_keys(req, &params),
             "DeleteUsagePlanKey" => self.delete_usage_plan_key(req, &params),
             "GetUsage" => self.get_usage(req, &params),
-            "UpdateUsage" => ok(json!({})),
+            "UpdateUsage" => self.update_usage(req, &params),
             "CreateVpcLink" => self.create_vpc_link(req),
             "GetVpcLink" => self.get_vpc_link(req, &params),
             "GetVpcLinks" => self.get_vpc_links(req),
@@ -141,19 +141,8 @@ impl ApiGatewayService {
             "UpdateGatewayResponse" => self.update_gateway_response(req, &params),
             "GetExport" => self.get_export(req, &params),
             "GetSdk" => self.get_sdk(req, &params),
-            "GetSdkType" => ok(
-                json!({"id": params.get("id"), "friendlyName": "Stub", "configurationProperties": []}),
-            ),
-            "GetSdkTypes" => ok(json!({
-                "item": [
-                    {"id": "java", "friendlyName": "Java"},
-                    {"id": "javascript", "friendlyName": "JavaScript"},
-                    {"id": "android", "friendlyName": "Android"},
-                    {"id": "objectivec", "friendlyName": "Objective-C"},
-                    {"id": "swift", "friendlyName": "Swift"},
-                    {"id": "ruby", "friendlyName": "Ruby"},
-                ]
-            })),
+            "GetSdkType" => self.get_sdk_type(&params),
+            "GetSdkTypes" => ok(json!({ "item": sdk_types() })),
             "TagResource" => self.tag_resource(req, &params),
             "UntagResource" => self.untag_resource(req, &params),
             "GetTags" => self.get_tags(req, &params),

--- a/crates/fakecloud-apigateway/src/service_usage_plans.rs
+++ b/crates/fakecloud-apigateway/src/service_usage_plans.rs
@@ -202,18 +202,200 @@ impl ApiGatewayService {
 
     pub(super) fn get_usage(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         params: &BTreeMap<String, String>,
     ) -> Result<AwsResponse, AwsServiceError> {
-        // Real usage tracking would tie into request counters; fakecloud
-        // returns the empty-but-valid AWS response shape so callers
-        // that ask for usage at least see a well-formed reply.
         let plan_id = params.get("usagePlanId").cloned().unwrap_or_default();
+        let accounts = self.state.read();
+        let empty = crate::state::ApiGatewayState::new(&request_account(req), &req.region);
+        let state = accounts.get(&request_account(req)).unwrap_or(&empty);
+
+        let plan = state
+            .usage_plans
+            .get(&plan_id)
+            .ok_or_else(|| not_found("Usage plan not found"))?;
+        let quota_limit = quota_limit_for(plan);
+
+        // Build `values: { keyId: [[used, remaining]] }` for each key on
+        // the plan, falling back to the full quota when a key hasn't been
+        // metered yet.
+        let mut values = serde_json::Map::new();
+        if let Some(keys) = state.usage_plan_keys.get(&plan_id) {
+            for key_id in keys.keys() {
+                let remaining = state
+                    .usage_remaining
+                    .get(&plan_id)
+                    .and_then(|m| m.get(key_id))
+                    .copied()
+                    .unwrap_or(quota_limit);
+                let used = (quota_limit - remaining).max(0);
+                values.insert(key_id.clone(), json!([[used, remaining]]));
+            }
+        }
+
         ok(json!({
             "usagePlanId": plan_id,
-            "startDate": "1970-01-01",
-            "endDate": chrono::Utc::now().format("%Y-%m-%d").to_string(),
-            "values": serde_json::Value::Object(serde_json::Map::new()),
+            "startDate": params.get("startDate").cloned().unwrap_or_else(|| "1970-01-01".to_string()),
+            "endDate": params
+                .get("endDate")
+                .cloned()
+                .unwrap_or_else(|| chrono::Utc::now().format("%Y-%m-%d").to_string()),
+            "values": serde_json::Value::Object(values),
         }))
+    }
+
+    /// UpdateUsage applies the supplied JSON-patch operations to the
+    /// per-key remaining quota. AWS uses `op=replace` with
+    /// `path=/<keyId>` and `value=<remaining>`.
+    pub(super) fn update_usage(
+        &self,
+        req: &AwsRequest,
+        params: &BTreeMap<String, String>,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let plan_id = params.get("usagePlanId").cloned().unwrap_or_default();
+        let body = req.json_body();
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request_account(req));
+        if !state.usage_plans.contains_key(&plan_id) {
+            return Err(not_found("Usage plan not found"));
+        }
+
+        if let Some(ops) = body["patchOperations"].as_array() {
+            let entry = state.usage_remaining.entry(plan_id.clone()).or_default();
+            for op in ops {
+                let path = op["path"].as_str().unwrap_or_default();
+                let key_id = path.trim_start_matches('/');
+                if key_id.is_empty() {
+                    continue;
+                }
+                // value may arrive as a number or a numeric string.
+                let value = op["value"]
+                    .as_i64()
+                    .or_else(|| op["value"].as_str().and_then(|s| s.parse::<i64>().ok()));
+                if let Some(v) = value {
+                    entry.insert(key_id.to_string(), v);
+                }
+            }
+        }
+
+        // Echo the resulting usage view back (same shape as GetUsage).
+        drop(accounts);
+        self.get_usage(req, params)
+    }
+}
+
+/// Resolve a usage plan's quota limit, defaulting to a large value when
+/// the plan has no quota configured.
+fn quota_limit_for(plan: &crate::state::UsagePlan) -> i64 {
+    plan.quota
+        .as_ref()
+        .and_then(|q| q["limit"].as_i64())
+        .unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod usage_tests {
+    use super::*;
+    use crate::service::ApiGatewayService;
+    use bytes::Bytes;
+    use http::{HeaderMap, Method};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn svc() -> ApiGatewayService {
+        let state = Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
+        ApiGatewayService::new(state)
+    }
+
+    fn req(body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "apigateway".to_string(),
+            action: String::new(),
+            method: Method::POST,
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            path_segments: vec![],
+            query_params: HashMap::new(),
+            headers: HeaderMap::new(),
+            body: Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            request_id: "rid".to_string(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    /// 1.24: UpdateUsage applies the patch and GetUsage reflects the
+    /// resulting remaining quota; no longer canned.
+    #[test]
+    fn usage_update_and_get_round_trip() {
+        let s = svc();
+        // Create a plan with a quota limit of 1000.
+        let resp = s
+            .create_usage_plan(&req(
+                json!({"name": "p", "quota": {"limit": 1000, "period": "DAY"}}),
+            ))
+            .unwrap();
+        let pb: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let plan_id = pb["id"].as_str().unwrap().to_string();
+
+        // Attach a key directly to the plan's key map.
+        {
+            let mut accts = s.state.write();
+            let st = accts.get_or_create("123456789012");
+            st.usage_plan_keys
+                .entry(plan_id.clone())
+                .or_default()
+                .insert("key-1".to_string(), json!({"id": "key-1"}));
+        }
+
+        let params: BTreeMap<String, String> =
+            BTreeMap::from([("usagePlanId".to_string(), plan_id.clone())]);
+
+        // Initially remaining == limit.
+        let resp = s.get_usage(&req(json!({})), &params).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["values"]["key-1"][0][1].as_i64(), Some(1000));
+        assert_eq!(body["values"]["key-1"][0][0].as_i64(), Some(0));
+
+        // UpdateUsage sets remaining to 250.
+        let upd_body = json!({"patchOperations": [
+            {"op": "replace", "path": "/key-1", "value": 250}
+        ]});
+        let resp = s.update_usage(&req(upd_body), &params).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["values"]["key-1"][0][1].as_i64(), Some(250));
+        // used = limit - remaining
+        assert_eq!(body["values"]["key-1"][0][0].as_i64(), Some(750));
+
+        // GetUsage continues to reflect the persisted value.
+        let resp = s.get_usage(&req(json!({})), &params).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["values"]["key-1"][0][1].as_i64(), Some(250));
+    }
+
+    /// 1.28: GetSdkType returns a real descriptor for a known id rather
+    /// than the literal "Stub".
+    #[test]
+    fn get_sdk_type_returns_real_descriptor() {
+        let s = svc();
+        let params: BTreeMap<String, String> =
+            BTreeMap::from([("id".to_string(), "java".to_string())]);
+        let resp = s.get_sdk_type(&params).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["id"].as_str(), Some("java"));
+        assert_eq!(body["friendlyName"].as_str(), Some("Java"));
+        assert_ne!(body["friendlyName"].as_str(), Some("Stub"));
+
+        // Unknown id -> NotFound.
+        let params: BTreeMap<String, String> =
+            BTreeMap::from([("id".to_string(), "cobol".to_string())]);
+        assert!(s.get_sdk_type(&params).is_err());
     }
 }

--- a/crates/fakecloud-apigateway/src/state.rs
+++ b/crates/fakecloud-apigateway/src/state.rs
@@ -85,6 +85,11 @@ pub struct ApiGatewayState {
     /// Usage plan keys keyed by `usagePlanId` -> `apiKeyId`.
     #[serde(default)]
     pub usage_plan_keys: BTreeMap<String, BTreeMap<String, serde_json::Value>>,
+    /// Per-(usagePlanId, apiKeyId) remaining quota, as observed/adjusted
+    /// via GetUsage / UpdateUsage. Absent until a key is metered; falls
+    /// back to the plan's quota limit.
+    #[serde(default)]
+    pub usage_remaining: BTreeMap<String, BTreeMap<String, i64>>,
     /// VPC links keyed by id.
     #[serde(default)]
     pub vpc_links: BTreeMap<String, serde_json::Value>,
@@ -162,6 +167,7 @@ impl ApiGatewayState {
             api_keys: BTreeMap::new(),
             usage_plans: BTreeMap::new(),
             usage_plan_keys: BTreeMap::new(),
+            usage_remaining: BTreeMap::new(),
             vpc_links: BTreeMap::new(),
             domain_names: BTreeMap::new(),
             domain_name_access_associations: BTreeMap::new(),
@@ -192,6 +198,7 @@ impl ApiGatewayState {
         self.api_keys.clear();
         self.usage_plans.clear();
         self.usage_plan_keys.clear();
+        self.usage_remaining.clear();
         self.vpc_links.clear();
         self.domain_names.clear();
         self.domain_name_access_associations.clear();

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sqs.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sqs.rs
@@ -67,6 +67,7 @@ impl ResourceProvisioner {
             next_sequence_number: 0,
             permission_labels: Vec::new(),
             receipt_handle_map: std::collections::BTreeMap::new(),
+            receive_attempt_cache: std::collections::BTreeMap::new(),
         };
 
         state

--- a/crates/fakecloud-cognito/Cargo.toml
+++ b/crates/fakecloud-cognito/Cargo.toml
@@ -24,6 +24,7 @@ bytes = { workspace = true }
 rand = { workspace = true }
 rsa = { workspace = true }
 sha2 = { workspace = true }
+hmac = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 ciborium = "0.2"

--- a/crates/fakecloud-cognito/src/service/auth/initiate.rs
+++ b/crates/fakecloud-cognito/src/service/auth/initiate.rs
@@ -136,6 +136,34 @@ impl CognitoService {
         }
     }
 
+    /// Look up the app client's secret and, if it has one, require a
+    /// valid `SECRET_HASH` on the request. `secret_hash` is the value from
+    /// AuthParameters / the request body (may be absent).
+    pub(super) fn require_secret_hash(
+        &self,
+        client_id: &str,
+        username: &str,
+        secret_hash: Option<&Value>,
+    ) -> Result<(), AwsServiceError> {
+        let client_secret = {
+            let accounts = self.state.read();
+            let mut found = None;
+            for (_, account) in accounts.iter() {
+                if let Some(client) = account.user_pool_clients.get(client_id) {
+                    found = client.client_secret.clone();
+                    break;
+                }
+            }
+            found
+        };
+        crate::service::validate_secret_hash(
+            client_secret.as_deref(),
+            secret_hash.and_then(|v| v.as_str()),
+            username,
+            client_id,
+        )
+    }
+
     pub(super) async fn initiate_user_password_auth(
         &self,
         body: &Value,
@@ -184,6 +212,10 @@ impl CognitoService {
                     "PASSWORD is required in AuthParameters",
                 )
             })?;
+
+        // When the app client has a secret, the request must present a
+        // valid SECRET_HASH (matches the OAuth /token enforcement).
+        self.require_secret_hash(client_id, username, auth_params.get("SECRET_HASH"))?;
 
         // CompromisedCredentialsRiskConfiguration: when the pool has a
         // risk config with `EventAction = BLOCK` for sign-in events and
@@ -486,6 +518,9 @@ impl CognitoService {
                     "USERNAME is required in AuthParameters",
                 )
             })?;
+
+        // SECRET_HASH enforcement for clients with a secret.
+        self.require_secret_hash(client_id, username, auth_params.get("SECRET_HASH"))?;
 
         let (user_attrs, region, account_id) = {
             let accounts = self.state.read();

--- a/crates/fakecloud-cognito/src/service/auth/signup.rs
+++ b/crates/fakecloud-cognito/src/service/auth/signup.rs
@@ -33,6 +33,15 @@ impl CognitoService {
             })?;
             let pool_id = client.user_pool_id.clone();
 
+            // When the app client has a secret, SignUp must present a valid
+            // SECRET_HASH (matches the OAuth /token + InitiateAuth checks).
+            crate::service::validate_secret_hash(
+                client.client_secret.as_deref(),
+                body["SecretHash"].as_str(),
+                username,
+                client_id,
+            )?;
+
             // Validate password against pool policy
             let pool = state.user_pools.get(&pool_id).ok_or_else(|| {
                 AwsServiceError::aws_error(

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -731,6 +731,54 @@ fn generate_client_secret() -> String {
     encoded.chars().take(51).collect()
 }
 
+/// Compute the Cognito SECRET_HASH for an app client that has a secret:
+/// `base64(HMAC-SHA256(username + client_id, client_secret))`.
+pub(crate) fn compute_secret_hash(username: &str, client_id: &str, client_secret: &str) -> String {
+    use base64::Engine;
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    let mut mac = Hmac::<Sha256>::new_from_slice(client_secret.as_bytes())
+        .expect("HMAC accepts keys of any size");
+    mac.update(username.as_bytes());
+    mac.update(client_id.as_bytes());
+    base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
+}
+
+/// Validate a request's `SECRET_HASH` for a client that has a secret.
+/// Returns the AWS error when the hash is missing or wrong; a no-op when
+/// the client has no secret (mirrors the OAuth `/token` enforcement but
+/// for the JSON InitiateAuth / SignUp / Confirm* surface). AWS uses
+/// InvalidParameterException when the hash is absent and
+/// NotAuthorizedException when it's present but wrong.
+pub(crate) fn validate_secret_hash(
+    client_secret: Option<&str>,
+    supplied_secret_hash: Option<&str>,
+    username: &str,
+    client_id: &str,
+) -> Result<(), AwsServiceError> {
+    let Some(secret) = client_secret else {
+        return Ok(());
+    };
+    let Some(supplied) = supplied_secret_hash else {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterException",
+            format!(
+                "Client {client_id} is configured with secret but SECRET_HASH was not received"
+            ),
+        ));
+    };
+    let expected = compute_secret_hash(username, client_id, secret);
+    if supplied != expected {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "NotAuthorizedException",
+            "Unable to verify secret hash for client ".to_string() + client_id,
+        ));
+    }
+    Ok(())
+}
+
 fn parse_token_validity_units(val: &Value) -> Option<TokenValidityUnits> {
     if !val.is_object() {
         return None;

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -2139,6 +2139,148 @@ fn auth_events_recorded_on_sign_up() {
     assert!(st.auth_events[0].success);
 }
 
+/// 1.27: SignUp + InitiateAuth must enforce SECRET_HASH for app clients
+/// that have a secret.
+#[test]
+fn secret_hash_enforced_for_clients_with_secret() {
+    let (svc, pool_id) = setup_svc_with_pool();
+
+    // Client WITH a secret + USER_PASSWORD_AUTH.
+    let body = serde_json::to_string(&json!({
+        "UserPoolId": pool_id,
+        "ClientName": "sec",
+        "GenerateSecret": true,
+        "ExplicitAuthFlows": ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+    }))
+    .unwrap();
+    let resp = svc
+        .create_user_pool_client(&make_req("CreateUserPoolClient", &body))
+        .unwrap();
+    let rb: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let client_id = rb["UserPoolClient"]["ClientId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let client_secret = rb["UserPoolClient"]["ClientSecret"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // SignUp WITHOUT SecretHash -> InvalidParameterException.
+    let su = json!({"ClientId": client_id, "Username": "u1", "Password": "P@ssw0rd!"});
+    let err = block_on(svc.sign_up(&make_req("SignUp", &su.to_string())))
+        .err()
+        .expect("missing secret hash rejected");
+    assert_eq!(err.code(), "InvalidParameterException");
+
+    // SignUp WITH the wrong SecretHash -> NotAuthorizedException.
+    let su = json!({
+        "ClientId": client_id, "Username": "u1", "Password": "P@ssw0rd!",
+        "SecretHash": "definitely-wrong",
+    });
+    let err = block_on(svc.sign_up(&make_req("SignUp", &su.to_string())))
+        .err()
+        .expect("wrong secret hash rejected");
+    assert_eq!(err.code(), "NotAuthorizedException");
+
+    // SignUp WITH the correct SecretHash -> success.
+    let correct = crate::service::compute_secret_hash("u1", &client_id, &client_secret);
+    let su = json!({
+        "ClientId": client_id, "Username": "u1", "Password": "P@ssw0rd!",
+        "SecretHash": correct,
+    });
+    block_on(svc.sign_up(&make_req("SignUp", &su.to_string()))).unwrap();
+
+    // Set a permanent password so InitiateAuth can authenticate.
+    svc.admin_set_user_password(&make_req(
+        "AdminSetUserPassword",
+        &json!({"UserPoolId": pool_id, "Username": "u1", "Password": "P@ssw0rd!", "Permanent": true})
+            .to_string(),
+    ))
+    .unwrap();
+
+    // InitiateAuth WITHOUT SECRET_HASH -> rejected.
+    let ia = json!({
+        "ClientId": client_id,
+        "AuthFlow": "USER_PASSWORD_AUTH",
+        "AuthParameters": {"USERNAME": "u1", "PASSWORD": "P@ssw0rd!"},
+    });
+    let err = block_on(svc.initiate_auth(&make_req("InitiateAuth", &ia.to_string())))
+        .err()
+        .expect("InitiateAuth without SECRET_HASH rejected");
+    assert_eq!(err.code(), "InvalidParameterException");
+
+    // InitiateAuth WITH correct SECRET_HASH -> success.
+    let ia = json!({
+        "ClientId": client_id,
+        "AuthFlow": "USER_PASSWORD_AUTH",
+        "AuthParameters": {
+            "USERNAME": "u1", "PASSWORD": "P@ssw0rd!",
+            "SECRET_HASH": crate::service::compute_secret_hash("u1", &client_id, &client_secret),
+        },
+    });
+    block_on(svc.initiate_auth(&make_req("InitiateAuth", &ia.to_string()))).unwrap();
+}
+
+/// 1.27: a client WITHOUT a secret must not require SECRET_HASH.
+#[test]
+fn secret_hash_not_required_for_clients_without_secret() {
+    let (svc, pool_id) = setup_svc_with_pool();
+    let body = json!({
+        "UserPoolId": pool_id, "ClientName": "nosec",
+        "ExplicitAuthFlows": ["ALLOW_USER_PASSWORD_AUTH"]
+    });
+    let resp = svc
+        .create_user_pool_client(&make_req("CreateUserPoolClient", &body.to_string()))
+        .unwrap();
+    let rb: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let client_id = rb["UserPoolClient"]["ClientId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let su = json!({"ClientId": client_id, "Username": "u2", "Password": "P@ssw0rd!"});
+    block_on(svc.sign_up(&make_req("SignUp", &su.to_string()))).unwrap();
+}
+
+/// 1.28: ListUsers must honor AttributesToGet, restricting each user's
+/// Attributes array to the requested names.
+#[test]
+fn list_users_honors_attributes_to_get() {
+    let (svc, pool_id) = setup_svc_with_pool();
+    block_on(
+        svc.admin_create_user(&make_req(
+            "AdminCreateUser",
+            &json!({
+                "UserPoolId": pool_id,
+                "Username": "lu1",
+                "UserAttributes": [
+                    {"Name": "email", "Value": "a@b.com"},
+                    {"Name": "phone_number", "Value": "+15551112222"},
+                ],
+            })
+            .to_string(),
+        )),
+    )
+    .unwrap();
+
+    let resp = svc
+        .list_users(&make_req(
+            "ListUsers",
+            &json!({"UserPoolId": pool_id, "AttributesToGet": ["email"]}).to_string(),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let attrs = body["Users"][0]["Attributes"].as_array().unwrap();
+    let names: Vec<&str> = attrs.iter().filter_map(|a| a["Name"].as_str()).collect();
+    assert!(names.contains(&"email"));
+    assert!(
+        !names.contains(&"phone_number"),
+        "AttributesToGet must drop unrequested attrs"
+    );
+    assert!(!names.contains(&"sub"));
+}
+
 #[test]
 fn auth_events_recorded_on_sign_in_and_failure() {
     let state = std::sync::Arc::new(parking_lot::RwLock::new(

--- a/crates/fakecloud-cognito/src/service/users.rs
+++ b/crates/fakecloud-cognito/src/service/users.rs
@@ -568,11 +568,37 @@ impl CognitoService {
             0
         };
 
+        // Optional AttributesToGet projection: restrict each user's
+        // Attributes array to the requested names (AWS returns only those).
+        let attributes_to_get: Option<Vec<String>> =
+            body["AttributesToGet"].as_array().map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            });
+
         let page: Vec<Value> = users
             .iter()
             .skip(start_idx)
             .take(limit)
-            .map(|u| user_to_json(u))
+            .map(|u| {
+                let mut json = user_to_json(u);
+                if let Some(ref wanted) = attributes_to_get {
+                    if let Some(attrs) = json["Attributes"].as_array() {
+                        let filtered: Vec<Value> = attrs
+                            .iter()
+                            .filter(|a| {
+                                a["Name"]
+                                    .as_str()
+                                    .is_some_and(|n| wanted.iter().any(|w| w == n))
+                            })
+                            .cloned()
+                            .collect();
+                        json["Attributes"] = json!(filtered);
+                    }
+                }
+                json
+            })
             .collect();
 
         let has_more = start_idx + limit < users.len();

--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -23,7 +23,7 @@ use super::{
     apply_update_expression, build_consumed_capacity, evaluate_condition, execute_partiql_in_state,
     extract_key, get_table, get_table_mut, parse_expression_attribute_names,
     parse_expression_attribute_values, require_str_with_code, return_consumed_mode,
-    return_icm_mode, DynamoDbService,
+    return_icm_mode, validate_key_attributes_in_key, validate_key_in_item, DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -49,6 +49,24 @@ impl DynamoDbService {
             })?
             .clone();
 
+        // AWS limits a single BatchGetItem to 100 keys across all
+        // tables; over that it returns a ValidationException rather than
+        // silently processing the whole oversized batch.
+        let total_keys: usize = request_items
+            .values()
+            .filter_map(|p| p["Keys"].as_array().map(|k| k.len()))
+            .sum();
+        if total_keys > 100 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "Too many items requested for the BatchGetItem call: {total_keys} \
+                     (max 100)"
+                ),
+            ));
+        }
+
         let accounts = self.state.read();
         let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
@@ -69,8 +87,15 @@ impl DynamoDbService {
             for key_val in keys {
                 let key: HashMap<String, AttributeValue> =
                     serde_json::from_value(key_val.clone()).unwrap_or_default();
+                // Reject malformed/under-specified keys the same way
+                // GetItem does instead of coercing to `{}`.
+                validate_key_attributes_in_key(table, &key)?;
                 if let Some(idx) = table.find_item_index(&key) {
-                    items.push(json!(table.items[idx]));
+                    // Honor the per-table ProjectionExpression /
+                    // AttributesToGet so callers only get the attributes
+                    // they asked for (GetItem already does this).
+                    let projected = super::project_item(&table.items[idx], params);
+                    items.push(json!(projected));
                 }
             }
             let key_count = keys.len().max(1) as f64;
@@ -125,10 +150,85 @@ impl DynamoDbService {
             })?
             .clone();
 
+        // AWS caps a single BatchWriteItem at 25 write requests across
+        // all tables; over that it returns a ValidationException rather
+        // than processing the oversized batch.
+        let total_requests: usize = request_items
+            .values()
+            .filter_map(|r| r.as_array().map(|a| a.len()))
+            .sum();
+        if total_requests > 25 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "Too many items requested for the BatchWriteItem call: {total_requests} \
+                     (max 25)"
+                ),
+            ));
+        }
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
         let mut consumed_capacity: Vec<Value> = Vec::new();
         let mut item_collection_metrics: HashMap<String, Vec<Value>> = HashMap::new();
+
+        // Validate every request before mutating any state so a
+        // malformed/keyless item or a duplicate key in the batch fails
+        // the whole call (AWS rejects these up-front, not after partial
+        // application).
+        for (table_name, requests) in &request_items {
+            let table = state.tables.get(table_name.as_str()).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Requested resource not found: Table: {table_name} not found"),
+                )
+            })?;
+            let reqs = requests.as_array().ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Request list must be an array",
+                )
+            })?;
+            let mut seen_keys: Vec<HashMap<String, AttributeValue>> = Vec::new();
+            for request in reqs {
+                let key = if let Some(put_req) = request.get("PutRequest") {
+                    let item: HashMap<String, AttributeValue> =
+                        serde_json::from_value(put_req["Item"].clone()).map_err(|_| {
+                            AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "ValidationException",
+                                "PutRequest.Item is not a valid item",
+                            )
+                        })?;
+                    validate_key_in_item(table, &item)?;
+                    extract_key(table, &item)
+                } else if let Some(del_req) = request.get("DeleteRequest") {
+                    let key: HashMap<String, AttributeValue> =
+                        serde_json::from_value(del_req["Key"].clone()).map_err(|_| {
+                            AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "ValidationException",
+                                "DeleteRequest.Key is not a valid key",
+                            )
+                        })?;
+                    validate_key_attributes_in_key(table, &key)?;
+                    key
+                } else {
+                    continue;
+                };
+                if seen_keys.contains(&key) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationException",
+                        "Provided list of item keys contains duplicates",
+                    ));
+                }
+                seen_keys.push(key);
+            }
+        }
 
         for (table_name, requests) in &request_items {
             let table = state.tables.get_mut(table_name.as_str()).ok_or_else(|| {
@@ -760,11 +860,13 @@ impl DynamoDbService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
-        // ExecuteStatement's Smithy `errors:` list lacks ValidationException.
-        // Surface missing-statement and malformed-PartiQL failures as
-        // ResourceNotFoundException, which is declared and semantically the
-        // closest fit ("no resource matches that query").
-        let statement = require_str_with_code(&body, "Statement", "ResourceNotFoundException")?;
+        // A genuinely missing table is the only PartiQL failure AWS maps
+        // to ResourceNotFoundException; the shared engine already returns
+        // that code via `get_table`. Malformed-PartiQL and key/type
+        // errors must stay ValidationException with the correct `__type`,
+        // so we do NOT blanket-remap them. A missing `Statement` field is
+        // itself a ValidationException.
+        let statement = require_str_with_code(&body, "Statement", "ValidationException")?;
         let parameters = body["Parameters"].as_array().cloned().unwrap_or_default();
 
         // Hold the write lock only long enough to mutate state and
@@ -777,8 +879,7 @@ impl DynamoDbService {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&req.account_id);
             let region = state.region.clone();
-            let outcome = execute_partiql_in_state(state, statement, &parameters)
-                .map_err(remap_execute_statement_error)?;
+            let outcome = execute_partiql_in_state(state, statement, &parameters)?;
             let response = outcome.response.clone();
 
             let kinesis_info = if let (Some(table_name), Some(event_name)) =
@@ -1136,29 +1237,6 @@ impl DynamoDbService {
     }
 }
 
-/// Rewrite a `ValidationException` from the shared PartiQL engine into a
-/// `ResourceNotFoundException` so the strict-mode conformance probe accepts
-/// the response on ExecuteStatement (which doesn't declare ValidationException
-/// in its Smithy `errors:` list).
-fn remap_execute_statement_error(err: AwsServiceError) -> AwsServiceError {
-    match err {
-        AwsServiceError::AwsError {
-            status,
-            code,
-            message,
-            extra_fields,
-            headers,
-        } if code == "ValidationException" => AwsServiceError::AwsError {
-            status,
-            code: "ResourceNotFoundException".to_string(),
-            message,
-            extra_fields,
-            headers,
-        },
-        other => other,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1241,6 +1319,177 @@ mod tests {
             on_demand_throughput: None,
         };
         s.tables.insert(name.to_string(), table);
+    }
+
+    /// 1.11/1.12: BatchGetItem must honor the per-table
+    /// ProjectionExpression / AttributesToGet instead of returning the
+    /// whole stored item.
+    #[tokio::test]
+    async fn batch_get_item_honors_projection_and_legacy_attributes_to_get() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+        svc.batch_write_item(&req_for(
+            "BatchWriteItem",
+            json!({"RequestItems": {"Widgets": [
+                {"PutRequest": {"Item": {"pk": {"S": "a"}, "x": {"S": "1"}, "y": {"S": "2"}}}},
+            ]}}),
+        ))
+        .unwrap();
+
+        // ProjectionExpression
+        let resp = svc
+            .batch_get_item(&req_for(
+                "BatchGetItem",
+                json!({"RequestItems": {"Widgets": {
+                    "Keys": [{"pk": {"S": "a"}}],
+                    "ProjectionExpression": "x",
+                }}}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let item = &body["Responses"]["Widgets"][0];
+        assert!(item.get("x").is_some());
+        assert!(item.get("y").is_none(), "projection must drop y");
+        assert!(item.get("pk").is_none(), "projection only returns x");
+
+        // Legacy AttributesToGet
+        let resp = svc
+            .batch_get_item(&req_for(
+                "BatchGetItem",
+                json!({"RequestItems": {"Widgets": {
+                    "Keys": [{"pk": {"S": "a"}}],
+                    "AttributesToGet": ["pk", "y"],
+                }}}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let item = &body["Responses"]["Widgets"][0];
+        assert!(item.get("pk").is_some());
+        assert!(item.get("y").is_some());
+        assert!(item.get("x").is_none(), "AttributesToGet must drop x");
+    }
+
+    /// 1.14: BatchGetItem must reject >100 keys.
+    #[tokio::test]
+    async fn batch_get_item_rejects_over_100_keys() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+        let keys: Vec<Value> = (0..101)
+            .map(|i| json!({"pk": {"S": i.to_string()}}))
+            .collect();
+        let err = svc
+            .batch_get_item(&req_for(
+                "BatchGetItem",
+                json!({"RequestItems": {"Widgets": {"Keys": keys}}}),
+            ))
+            .err()
+            .expect("over-100 batch rejected");
+        assert!(format!("{err:?}").contains("ValidationException"));
+    }
+
+    /// 1.14: BatchWriteItem must reject >25 requests.
+    #[tokio::test]
+    async fn batch_write_item_rejects_over_25_requests() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+        let reqs: Vec<Value> = (0..26)
+            .map(|i| json!({"PutRequest": {"Item": {"pk": {"S": i.to_string()}}}}))
+            .collect();
+        let err = svc
+            .batch_write_item(&req_for(
+                "BatchWriteItem",
+                json!({"RequestItems": {"Widgets": reqs}}),
+            ))
+            .err()
+            .expect("over-25 batch rejected");
+        assert!(format!("{err:?}").contains("ValidationException"));
+    }
+
+    /// 1.14: BatchWriteItem must reject duplicate keys within one batch.
+    #[tokio::test]
+    async fn batch_write_item_rejects_duplicate_keys() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+        let err = svc
+            .batch_write_item(&req_for(
+                "BatchWriteItem",
+                json!({"RequestItems": {"Widgets": [
+                    {"PutRequest": {"Item": {"pk": {"S": "a"}}}},
+                    {"DeleteRequest": {"Key": {"pk": {"S": "a"}}}},
+                ]}}),
+            ))
+            .err()
+            .expect("duplicate key rejected");
+        assert!(format!("{err:?}").contains("duplicates"));
+    }
+
+    /// 1.14: BatchWriteItem must reject keyless items instead of coercing
+    /// them to `{}` and writing them.
+    #[tokio::test]
+    async fn batch_write_item_rejects_keyless_item() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+        let err = svc
+            .batch_write_item(&req_for(
+                "BatchWriteItem",
+                json!({"RequestItems": {"Widgets": [
+                    {"PutRequest": {"Item": {"notthekey": {"S": "x"}}}},
+                ]}}),
+            ))
+            .err()
+            .expect("keyless item rejected");
+        assert!(format!("{err:?}").contains("Missing the key pk"));
+        // Nothing should have been written.
+        let accts = state.read();
+        let table = accts
+            .get("123456789012")
+            .unwrap()
+            .tables
+            .get("Widgets")
+            .unwrap();
+        assert_eq!(table.items.len(), 0);
+    }
+
+    /// 1.26: ExecuteStatement must keep a genuine PartiQL
+    /// ValidationException as ValidationException (not remap to
+    /// ResourceNotFoundException) while still mapping a missing table to
+    /// ResourceNotFoundException.
+    #[tokio::test]
+    async fn execute_statement_preserves_validation_vs_not_found() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+
+        // Malformed PartiQL -> ValidationException.
+        let err = svc
+            .execute_statement(&req_for(
+                "ExecuteStatement",
+                json!({"Statement": "BOGUS NOT A REAL PARTIQL STATEMENT"}),
+            ))
+            .err()
+            .expect("malformed partiql");
+        assert!(
+            format!("{err:?}").contains("ValidationException"),
+            "malformed PartiQL must stay ValidationException, got {err:?}"
+        );
+
+        // Missing table -> ResourceNotFoundException.
+        let err = svc
+            .execute_statement(&req_for(
+                "ExecuteStatement",
+                json!({"Statement": "SELECT * FROM \"Nope\""}),
+            ))
+            .err()
+            .expect("missing table");
+        assert!(
+            format!("{err:?}").contains("ResourceNotFoundException"),
+            "missing table must be ResourceNotFoundException, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/fakecloud-dynamodb/src/service/global_tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/global_tables.rs
@@ -34,6 +34,7 @@ impl DynamoDbService {
                     replica_status: "ACTIVE".to_string(),
                     read_capacity_auto_scaling: None,
                     write_capacity_auto_scaling: None,
+                    read_capacity_units: None,
                 })
             })
             .collect::<Vec<_>>();
@@ -61,6 +62,8 @@ impl DynamoDbService {
             global_table_status: "ACTIVE".to_string(),
             creation_date: now,
             replication_group: replication_group.clone(),
+            billing_mode: "PROVISIONED".to_string(),
+            provisioned_write_capacity_units: None,
         };
 
         state
@@ -133,23 +136,7 @@ impl DynamoDbService {
             )
         })?;
 
-        let replica_settings: Vec<Value> = gt
-            .replication_group
-            .iter()
-            .map(|r| {
-                json!({
-                    "RegionName": r.region_name,
-                    "ReplicaStatus": r.replica_status,
-                    "ReplicaProvisionedReadCapacityUnits": 0,
-                    "ReplicaProvisionedWriteCapacityUnits": 0
-                })
-            })
-            .collect();
-
-        Self::ok_json(json!({
-            "GlobalTableName": gt.global_table_name,
-            "ReplicaSettings": replica_settings
-        }))
+        Self::ok_json(global_table_settings_response(gt))
     }
 
     pub(super) fn list_global_tables(
@@ -219,6 +206,7 @@ impl DynamoDbService {
                             replica_status: "ACTIVE".to_string(),
                             read_capacity_auto_scaling: None,
                             write_capacity_auto_scaling: None,
+                            read_capacity_units: None,
                         });
                     }
                 }
@@ -263,33 +251,219 @@ impl DynamoDbService {
             i64::MAX,
         )?;
 
-        let accounts = self.state.read();
-        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
-        let gt = state.global_tables.get(global_table_name).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "GlobalTableNotFoundException",
-                format!("Global table not found: {global_table_name}"),
-            )
-        })?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let gt = state
+            .global_tables
+            .get_mut(global_table_name)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "GlobalTableNotFoundException",
+                    format!("Global table not found: {global_table_name}"),
+                )
+            })?;
 
-        let replica_settings: Vec<Value> = gt
-            .replication_group
-            .iter()
-            .map(|r| {
-                json!({
-                    "RegionName": r.region_name,
-                    "ReplicaStatus": r.replica_status,
-                    "ReplicaProvisionedReadCapacityUnits": 0,
-                    "ReplicaProvisionedWriteCapacityUnits": 0
-                })
+        // Persist the billing mode + global provisioned write capacity so
+        // they round-trip through DescribeGlobalTableSettings instead of
+        // being validated and dropped.
+        if let Some(mode) = body["GlobalTableBillingMode"].as_str() {
+            gt.billing_mode = mode.to_string();
+        }
+        if let Some(wcu) = body["GlobalTableProvisionedWriteCapacityUnits"].as_i64() {
+            gt.provisioned_write_capacity_units = Some(wcu);
+        }
+        if gt.billing_mode == "PAY_PER_REQUEST" {
+            // On-demand tables have no provisioned capacity.
+            gt.provisioned_write_capacity_units = None;
+        }
+
+        // Apply per-replica read-capacity updates from ReplicaSettingsUpdate.
+        if let Some(updates) = body["ReplicaSettingsUpdate"].as_array() {
+            for upd in updates {
+                let Some(region) = upd["RegionName"].as_str() else {
+                    continue;
+                };
+                let rcu = upd["ReplicaProvisionedReadCapacityUnits"].as_i64();
+                if let Some(replica) = gt
+                    .replication_group
+                    .iter_mut()
+                    .find(|r| r.region_name == region)
+                {
+                    if let Some(rcu) = rcu {
+                        replica.read_capacity_units = Some(rcu);
+                    }
+                }
+            }
+        }
+
+        let gt = &state.global_tables[global_table_name];
+        Self::ok_json(global_table_settings_response(gt))
+    }
+}
+
+/// Build the GlobalTableSettings response shape shared by
+/// `UpdateGlobalTableSettings` and `DescribeGlobalTableSettings`,
+/// reflecting the persisted billing mode and per-replica capacity.
+fn global_table_settings_response(gt: &GlobalTableDescription) -> Value {
+    let write_cu = gt.provisioned_write_capacity_units.unwrap_or(0);
+    let replica_settings: Vec<Value> = gt
+        .replication_group
+        .iter()
+        .map(|r| {
+            json!({
+                "RegionName": r.region_name,
+                "ReplicaStatus": r.replica_status,
+                "ReplicaBillingModeSummary": {
+                    "BillingMode": gt.billing_mode,
+                },
+                "ReplicaProvisionedReadCapacityUnits": r.read_capacity_units.unwrap_or(0),
+                "ReplicaProvisionedWriteCapacityUnits": write_cu,
             })
-            .collect();
+        })
+        .collect();
+    json!({
+        "GlobalTableName": gt.global_table_name,
+        "ReplicaSettings": replica_settings,
+    })
+}
 
-        Self::ok_json(json!({
-            "GlobalTableName": gt.global_table_name,
-            "ReplicaSettings": replica_settings
-        }))
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::DynamoDbService;
+    use crate::state::SharedDynamoDbState;
+    use bytes::Bytes;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn req_for(action: &str, body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "dynamodb".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: "123456789012".into(),
+            request_id: "r".into(),
+            headers: HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn make_state() -> SharedDynamoDbState {
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ))
+    }
+
+    /// 1.15: UpdateGlobalTableSettings must persist the billing mode and
+    /// provisioned write capacity and reflect them in
+    /// DescribeGlobalTableSettings (it previously validated then dropped
+    /// the update behind a read lock).
+    #[tokio::test]
+    async fn update_global_table_settings_persists_and_round_trips() {
+        let state = make_state();
+        let svc = DynamoDbService::new(state);
+
+        svc.create_global_table(&req_for(
+            "CreateGlobalTable",
+            json!({
+                "GlobalTableName": "Widgets",
+                "ReplicationGroup": [{"RegionName": "us-east-1"}, {"RegionName": "eu-west-1"}],
+            }),
+        ))
+        .unwrap();
+
+        let resp = svc
+            .update_global_table_settings(&req_for(
+                "UpdateGlobalTableSettings",
+                json!({
+                    "GlobalTableName": "Widgets",
+                    "GlobalTableBillingMode": "PROVISIONED",
+                    "GlobalTableProvisionedWriteCapacityUnits": 50,
+                    "ReplicaSettingsUpdate": [
+                        {"RegionName": "us-east-1", "ReplicaProvisionedReadCapacityUnits": 17},
+                    ],
+                }),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let settings = body["ReplicaSettings"].as_array().unwrap();
+        let us = settings
+            .iter()
+            .find(|r| r["RegionName"] == "us-east-1")
+            .unwrap();
+        assert_eq!(
+            us["ReplicaProvisionedWriteCapacityUnits"].as_i64(),
+            Some(50)
+        );
+        assert_eq!(us["ReplicaProvisionedReadCapacityUnits"].as_i64(), Some(17));
+        assert_eq!(
+            us["ReplicaBillingModeSummary"]["BillingMode"],
+            "PROVISIONED"
+        );
+
+        // Describe must reflect the persisted update, not zeros.
+        let desc = svc
+            .describe_global_table_settings(&req_for(
+                "DescribeGlobalTableSettings",
+                json!({"GlobalTableName": "Widgets"}),
+            ))
+            .unwrap();
+        let dbody: Value = serde_json::from_slice(desc.body.expect_bytes()).unwrap();
+        let dsettings = dbody["ReplicaSettings"].as_array().unwrap();
+        let dus = dsettings
+            .iter()
+            .find(|r| r["RegionName"] == "us-east-1")
+            .unwrap();
+        assert_eq!(
+            dus["ReplicaProvisionedWriteCapacityUnits"].as_i64(),
+            Some(50)
+        );
+        assert_eq!(
+            dus["ReplicaProvisionedReadCapacityUnits"].as_i64(),
+            Some(17)
+        );
+    }
+
+    /// PAY_PER_REQUEST clears provisioned write capacity.
+    #[tokio::test]
+    async fn update_global_table_settings_pay_per_request_clears_write_capacity() {
+        let state = make_state();
+        let svc = DynamoDbService::new(state);
+        svc.create_global_table(&req_for(
+            "CreateGlobalTable",
+            json!({
+                "GlobalTableName": "Widgets",
+                "ReplicationGroup": [{"RegionName": "us-east-1"}],
+            }),
+        ))
+        .unwrap();
+        let resp = svc
+            .update_global_table_settings(&req_for(
+                "UpdateGlobalTableSettings",
+                json!({
+                    "GlobalTableName": "Widgets",
+                    "GlobalTableBillingMode": "PAY_PER_REQUEST",
+                }),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let us = body["ReplicaSettings"][0].clone();
+        assert_eq!(us["ReplicaProvisionedWriteCapacityUnits"].as_i64(), Some(0));
+        assert_eq!(
+            us["ReplicaBillingModeSummary"]["BillingMode"],
+            "PAY_PER_REQUEST"
+        );
     }
 }

--- a/crates/fakecloud-dynamodb/src/service/helpers/paths.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/paths.rs
@@ -42,27 +42,64 @@ pub(crate) fn project_item(
     match projection {
         Some(proj) if !proj.is_empty() => {
             let expr_attr_names = parse_expression_attribute_names(body);
-            let mut result = HashMap::new();
-            for raw in proj.split(',') {
-                let raw = raw.trim();
-                // Single-segment: treat as literal top-level attribute even if
-                // the alias resolves to a name containing `.` (e.g. `#sw` ->
-                // `Safety.Warning`).
-                if !raw.contains('.') && !raw.contains('[') {
-                    let key = resolve_attr_name(raw, &expr_attr_names);
-                    if let Some(v) = item.get(&key) {
-                        result.insert(key, v.clone());
-                    }
-                } else {
-                    let segs = resolve_projection_path_segments(raw, &expr_attr_names);
-                    if let Some(v) = resolve_nested_path_segments(item, &segs) {
-                        insert_nested_value_segments(&mut result, &segs, v);
-                    }
-                }
-            }
-            result
+            project_with_expression(item, proj, &expr_attr_names)
         }
-        _ => item.clone(),
+        _ => {
+            // Honor the deprecated `AttributesToGet` parameter the same
+            // way real DynamoDB still does: it is a flat list of
+            // (possibly document-path) attribute names with no `#alias`
+            // substitution. Falls back to the whole item when neither
+            // projection form is present.
+            match body["AttributesToGet"].as_array() {
+                Some(attrs) if !attrs.is_empty() => {
+                    let names = HashMap::new();
+                    let mut result = HashMap::new();
+                    for raw in attrs.iter().filter_map(|v| v.as_str()) {
+                        project_single_path_into(&mut result, item, raw, &names);
+                    }
+                    result
+                }
+                _ => item.clone(),
+            }
+        }
+    }
+}
+
+/// Project an item using a comma-separated `ProjectionExpression`,
+/// resolving `#alias` references via `expr_attr_names`.
+pub(crate) fn project_with_expression(
+    item: &HashMap<String, AttributeValue>,
+    proj: &str,
+    expr_attr_names: &HashMap<String, String>,
+) -> HashMap<String, AttributeValue> {
+    let mut result = HashMap::new();
+    for raw in proj.split(',') {
+        project_single_path_into(&mut result, item, raw.trim(), expr_attr_names);
+    }
+    result
+}
+
+/// Resolve a single projection path against `item` and merge the result
+/// into `result`. Shared by ProjectionExpression and AttributesToGet.
+fn project_single_path_into(
+    result: &mut HashMap<String, AttributeValue>,
+    item: &HashMap<String, AttributeValue>,
+    raw: &str,
+    expr_attr_names: &HashMap<String, String>,
+) {
+    // Single-segment: treat as literal top-level attribute even if the
+    // alias resolves to a name containing `.` (e.g. `#sw` ->
+    // `Safety.Warning`).
+    if !raw.contains('.') && !raw.contains('[') {
+        let key = resolve_attr_name(raw, expr_attr_names);
+        if let Some(v) = item.get(&key) {
+            result.insert(key, v.clone());
+        }
+    } else {
+        let segs = resolve_projection_path_segments(raw, expr_attr_names);
+        if let Some(v) = resolve_nested_path_segments(item, &segs) {
+            insert_nested_value_segments(result, &segs, v);
+        }
     }
 }
 

--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -64,8 +64,9 @@ impl DynamoDbService {
             &mut expr_attr_values,
         )?;
         let scan_forward = body["ScanIndexForward"].as_bool().unwrap_or(true);
-        let limit = body["Limit"].as_i64().map(|l| l as usize);
+        let limit = validate_limit(&body)?;
         let index_name = body["IndexName"].as_str();
+        let count_only = resolve_select(&body, index_name.is_some())?;
         let exclusive_start_key: Option<HashMap<String, AttributeValue>> =
             parse_key_map(&body["ExclusiveStartKey"]);
 
@@ -257,8 +258,6 @@ impl DynamoDbService {
             Vec::new()
         };
 
-        let select = body["Select"].as_str();
-        let count_only = matches!(select, Some("COUNT"));
         let items: Vec<Value> = if count_only {
             Vec::new()
         } else {
@@ -351,9 +350,10 @@ impl DynamoDbService {
             &mut expr_attr_names,
             &mut expr_attr_values,
         )?;
-        let limit = body["Limit"].as_i64().map(|l| l as usize);
+        let limit = validate_limit(&body)?;
         let exclusive_start_key: Option<HashMap<String, AttributeValue>> =
             parse_key_map(&body["ExclusiveStartKey"]);
+        let count_only = resolve_select(&body, body["IndexName"].as_str().is_some())?;
 
         // IndexName: when present, items still come from the base
         // table (fakecloud doesn't keep separate per-index storage)
@@ -490,8 +490,6 @@ impl DynamoDbService {
             Vec::new()
         };
 
-        let select = body["Select"].as_str();
-        let count_only = matches!(select, Some("COUNT"));
         let items: Vec<Value> = if count_only {
             Vec::new()
         } else {
@@ -600,6 +598,87 @@ fn resolve_legacy_or_expression(
             legacy, role, names, values,
         )?)),
         (None, None) => Ok(None),
+    }
+}
+
+/// Validate the `Limit` parameter shared by Query and Scan. AWS rejects
+/// any non-positive limit with a ValidationException rather than casting
+/// `-1` to `usize::MAX` or returning an empty page (which spins
+/// paginators). Returns the validated limit as `Option<usize>`.
+fn validate_limit(body: &Value) -> Result<Option<usize>, AwsServiceError> {
+    match body["Limit"].as_i64() {
+        Some(l) if l < 1 => Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "Limit must be >= 1",
+        )),
+        Some(l) => Ok(Some(l as usize)),
+        None => Ok(None),
+    }
+}
+
+/// Validate the `Select` parameter for a Query/Scan and decide whether
+/// the operation returns only a count. `is_index_query` is true when an
+/// IndexName is present (only then is ALL_PROJECTED_ATTRIBUTES legal).
+///
+/// AWS rules enforced here:
+/// - `Select` must be one of the four documented enum values.
+/// - `SPECIFIC_ATTRIBUTES` requires a ProjectionExpression or
+///   AttributesToGet, and conversely any projection forces
+///   SPECIFIC_ATTRIBUTES (any other explicit Select is rejected).
+/// - `ALL_PROJECTED_ATTRIBUTES` is only valid on an index query.
+fn resolve_select(body: &Value, is_index_query: bool) -> Result<bool, AwsServiceError> {
+    let select = body["Select"].as_str();
+    let has_projection = body["ProjectionExpression"]
+        .as_str()
+        .is_some_and(|p| !p.is_empty())
+        || body["AttributesToGet"]
+            .as_array()
+            .is_some_and(|a| !a.is_empty());
+
+    if let Some(sel) = select {
+        if !matches!(
+            sel,
+            "ALL_ATTRIBUTES" | "ALL_PROJECTED_ATTRIBUTES" | "SPECIFIC_ATTRIBUTES" | "COUNT"
+        ) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "1 validation error detected: Value '{sel}' at 'select' failed to satisfy \
+                     constraint: Member must satisfy enum value set: \
+                     [SPECIFIC_ATTRIBUTES, COUNT, ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES]"
+                ),
+            ));
+        }
+        if sel == "ALL_PROJECTED_ATTRIBUTES" && !is_index_query {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Select type ALL_PROJECTED_ATTRIBUTES is not supported for queries on the table; \
+                 it is only supported on index queries",
+            ));
+        }
+        if sel == "SPECIFIC_ATTRIBUTES" && !has_projection {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Select type SPECIFIC_ATTRIBUTES requires a ProjectionExpression or AttributesToGet",
+            ));
+        }
+        if has_projection && sel != "SPECIFIC_ATTRIBUTES" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "Cannot use both Select and ProjectionExpression/AttributesToGet unless \
+                     Select is SPECIFIC_ATTRIBUTES (got {sel})"
+                ),
+            ));
+        }
+        Ok(sel == "COUNT")
+    } else {
+        Ok(false)
     }
 }
 
@@ -777,6 +856,156 @@ mod tests {
             body["LastEvaluatedKey"].is_object(),
             "LastEvaluatedKey must point at the last examined item, not the last surviving"
         );
+    }
+
+    /// 1.25: Scan must reject Limit <= 0 with ValidationException rather
+    /// than casting -1 to usize::MAX or returning an empty page with a
+    /// LastEvaluatedKey.
+    #[tokio::test]
+    async fn scan_rejects_non_positive_limit() {
+        let state = make_state();
+        seed_table(&state, "T", vec![item("a"), item("b")]);
+        let svc = DynamoDbService::new(state);
+        for bad in [-1, 0] {
+            let err = svc
+                .scan(&req_for("Scan", json!({"TableName": "T", "Limit": bad})))
+                .err()
+                .unwrap_or_else(|| panic!("Limit={bad} must be rejected"));
+            assert!(format!("{err:?}").contains("ValidationException"));
+        }
+    }
+
+    /// 1.25: Query must reject Limit <= 0 too.
+    #[tokio::test]
+    async fn query_rejects_non_positive_limit() {
+        let state = make_state();
+        seed_table(&state, "T", vec![item("a")]);
+        let svc = DynamoDbService::new(state);
+        let err = svc
+            .query(&req_for(
+                "Query",
+                json!({
+                    "TableName": "T",
+                    "Limit": 0,
+                    "KeyConditionExpression": "pk = :v",
+                    "ExpressionAttributeValues": {":v": {"S": "a"}},
+                }),
+            ))
+            .err()
+            .expect("Limit=0 rejected");
+        assert!(format!("{err:?}").contains("ValidationException"));
+    }
+
+    /// 1.13: Scan Select=SPECIFIC_ATTRIBUTES with a ProjectionExpression
+    /// projects to the requested attributes; Select=COUNT counts only.
+    #[tokio::test]
+    async fn scan_select_specific_attributes_projects() {
+        let state = make_state();
+        seed_table(&state, "T", vec![item_with("a", "color", "red")]);
+        let svc = DynamoDbService::new(state);
+        let resp = svc
+            .scan(&req_for(
+                "Scan",
+                json!({
+                    "TableName": "T",
+                    "Select": "SPECIFIC_ATTRIBUTES",
+                    "ProjectionExpression": "color",
+                }),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let item0 = &body["Items"][0];
+        assert!(item0.get("color").is_some());
+        assert!(item0.get("pk").is_none());
+    }
+
+    /// 1.13: Scan Select=ALL_ATTRIBUTES returns full items.
+    #[tokio::test]
+    async fn scan_select_all_attributes_returns_full_item() {
+        let state = make_state();
+        seed_table(&state, "T", vec![item_with("a", "color", "red")]);
+        let svc = DynamoDbService::new(state);
+        let resp = svc
+            .scan(&req_for(
+                "Scan",
+                json!({"TableName": "T", "Select": "ALL_ATTRIBUTES"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let item0 = &body["Items"][0];
+        assert!(item0.get("pk").is_some());
+        assert!(item0.get("color").is_some());
+    }
+
+    /// 1.13: Invalid Select values and incompatible combinations are
+    /// rejected with ValidationException.
+    #[tokio::test]
+    async fn scan_rejects_invalid_and_incompatible_select() {
+        let state = make_state();
+        seed_table(&state, "T", vec![item("a")]);
+        let svc = DynamoDbService::new(state);
+
+        // garbage enum value
+        let err = svc
+            .scan(&req_for(
+                "Scan",
+                json!({"TableName": "T", "Select": "NONSENSE"}),
+            ))
+            .err()
+            .expect("invalid Select rejected");
+        assert!(format!("{err:?}").contains("ValidationException"));
+
+        // SPECIFIC_ATTRIBUTES with no projection
+        let err = svc
+            .scan(&req_for(
+                "Scan",
+                json!({"TableName": "T", "Select": "SPECIFIC_ATTRIBUTES"}),
+            ))
+            .err()
+            .expect("SPECIFIC_ATTRIBUTES needs projection");
+        assert!(format!("{err:?}").contains("ValidationException"));
+
+        // ALL_PROJECTED_ATTRIBUTES on a non-index (table) scan
+        let err = svc
+            .scan(&req_for(
+                "Scan",
+                json!({"TableName": "T", "Select": "ALL_PROJECTED_ATTRIBUTES"}),
+            ))
+            .err()
+            .expect("ALL_PROJECTED needs an index");
+        assert!(format!("{err:?}").contains("ValidationException"));
+
+        // ProjectionExpression with Select=ALL_ATTRIBUTES is incompatible
+        let err = svc
+            .scan(&req_for(
+                "Scan",
+                json!({
+                    "TableName": "T",
+                    "Select": "ALL_ATTRIBUTES",
+                    "ProjectionExpression": "pk",
+                }),
+            ))
+            .err()
+            .expect("projection forces SPECIFIC_ATTRIBUTES");
+        assert!(format!("{err:?}").contains("ValidationException"));
+    }
+
+    /// 1.12: Scan honors the legacy AttributesToGet parameter.
+    #[tokio::test]
+    async fn scan_honors_legacy_attributes_to_get() {
+        let state = make_state();
+        seed_table(&state, "T", vec![item_with("a", "color", "red")]);
+        let svc = DynamoDbService::new(state);
+        let resp = svc
+            .scan(&req_for(
+                "Scan",
+                json!({"TableName": "T", "AttributesToGet": ["color"]}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let item0 = &body["Items"][0];
+        assert!(item0.get("color").is_some());
+        assert!(item0.get("pk").is_none());
     }
 
     #[tokio::test]

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -3706,9 +3706,9 @@ fn partiql_insert_rejects_missing_partition_key() {
         Ok(_) => panic!("expected INSERT without pk to fail"),
     };
     let dbg = format!("{err:?}");
-    // ExecuteStatement doesn't declare ValidationException; we remap to
-    // ResourceNotFoundException to stay Smithy-compliant.
-    assert!(dbg.contains("ResourceNotFoundException"), "got {dbg}");
+    // A key/validation error on an existing table is a ValidationException,
+    // not a ResourceNotFoundException (only a missing table maps to NotFound).
+    assert!(dbg.contains("ValidationException"), "got {dbg}");
     assert!(dbg.contains("Missing the key pk"), "got {dbg}");
 }
 
@@ -3728,7 +3728,7 @@ fn partiql_insert_rejects_wrong_key_type() {
         Ok(_) => panic!("expected INSERT with wrong-type pk to fail"),
     };
     let dbg = format!("{err:?}");
-    assert!(dbg.contains("ResourceNotFoundException"), "got {dbg}");
+    assert!(dbg.contains("ValidationException"), "got {dbg}");
     assert!(dbg.contains("Type mismatch for key pk"), "got {dbg}");
 }
 
@@ -3945,7 +3945,7 @@ fn partiql_insert_rejects_missing_sort_key() {
         .err()
         .expect("missing sort key");
     let dbg = format!("{err:?}");
-    assert!(dbg.contains("ResourceNotFoundException"), "got {dbg}");
+    assert!(dbg.contains("ValidationException"), "got {dbg}");
     assert!(dbg.contains("Missing the key sk"), "got {dbg}");
 }
 

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -230,6 +230,19 @@ pub struct GlobalTableDescription {
     pub global_table_status: String,
     pub creation_date: DateTime<Utc>,
     pub replication_group: Vec<ReplicaDescription>,
+    /// Billing mode applied across all replicas via
+    /// `UpdateGlobalTableSettings` (`PROVISIONED` / `PAY_PER_REQUEST`).
+    /// Defaults to PROVISIONED to match real DynamoDB global-table v1.
+    #[serde(default = "default_global_billing_mode")]
+    pub billing_mode: String,
+    /// Global provisioned write capacity applied across all replicas via
+    /// `UpdateGlobalTableSettings`. `None` under PAY_PER_REQUEST.
+    #[serde(default)]
+    pub provisioned_write_capacity_units: Option<i64>,
+}
+
+fn default_global_billing_mode() -> String {
+    "PROVISIONED".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -244,6 +257,10 @@ pub struct ReplicaDescription {
     /// Per-replica provisioned-write-capacity autoscaling settings.
     #[serde(default)]
     pub write_capacity_auto_scaling: Option<serde_json::Value>,
+    /// Per-replica provisioned read capacity supplied via
+    /// `UpdateGlobalTableSettings` ReplicaSettingsUpdate.
+    #[serde(default)]
+    pub read_capacity_units: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
+++ b/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
@@ -190,11 +190,10 @@ async fn ddb_partiql_insert_missing_sort_key_validation() {
         .await
         .expect_err("insert without sort key must fail");
     let msg = format!("{:?}", err.into_service_error());
-    // PartiQL INSERT with a missing required key surfaces as
-    // ResourceNotFoundException after #1359 — DynamoDB's Smithy errors
-    // list for ExecuteStatement doesn't declare ValidationException, so
-    // fakecloud now emits the declared shape instead.
-    assert!(msg.contains("ResourceNotFoundException"), "got {msg}");
+    // PartiQL INSERT with a missing required key is a ValidationException,
+    // matching AWS — the prior remap to ResourceNotFoundException returned the
+    // wrong __type to clients and is no longer applied.
+    assert!(msg.contains("ValidationException"), "got {msg}");
     assert!(msg.contains("Missing the key sk"), "got {msg}");
 }
 

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -4919,10 +4919,10 @@ async fn dynamodb_partiql_insert_rejects_missing_partition_key() {
         .expect_err("insert without partition key must be rejected");
     let svc_err = err.into_service_error();
     let msg = format!("{svc_err:?}");
-    // ExecuteStatement doesn't declare ValidationException in its Smithy
-    // errors list; we remap to ResourceNotFoundException so the strict-mode
-    // conformance probe accepts the response.
-    assert!(msg.contains("ResourceNotFoundException"), "got {msg}");
+    // PartiQL INSERT with a missing required key is a ValidationException,
+    // matching AWS — the prior remap to ResourceNotFoundException returned the
+    // wrong __type to clients and is no longer applied.
+    assert!(msg.contains("ValidationException"), "got {msg}");
     assert!(msg.contains("Missing the key pk"), "got {msg}");
 }
 
@@ -4962,7 +4962,7 @@ async fn dynamodb_partiql_insert_rejects_wrong_key_type() {
         .expect_err("insert with wrong-type pk must be rejected");
     let svc_err = err.into_service_error();
     let msg = format!("{svc_err:?}");
-    assert!(msg.contains("ResourceNotFoundException"), "got {msg}");
+    assert!(msg.contains("ValidationException"), "got {msg}");
     assert!(msg.contains("Type mismatch for key pk"), "got {msg}");
 }
 

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -1302,7 +1302,25 @@ pub(crate) fn global_replication_group_xml(
         String::new()
     };
     let global_node_groups_xml = if group.cluster_enabled {
-        "<GlobalNodeGroups><GlobalNodeGroup><GlobalNodeGroupId>0001</GlobalNodeGroupId><Slots>0-16383</Slots></GlobalNodeGroup></GlobalNodeGroups>".to_string()
+        let count = group.num_node_groups.max(1);
+        // Partition the 16384-slot keyspace evenly across the node groups
+        // so the rendered slot ranges reflect the actual shard count.
+        let total_slots = 16384i32;
+        let mut members = String::new();
+        let mut next_slot = 0i32;
+        for i in 0..count {
+            let remaining = count - i;
+            let chunk = (total_slots - next_slot) / remaining;
+            let end = next_slot + chunk - 1;
+            members.push_str(&format!(
+                "<GlobalNodeGroup><GlobalNodeGroupId>{:04}</GlobalNodeGroupId><Slots>{}-{}</Slots></GlobalNodeGroup>",
+                i + 1,
+                next_slot,
+                end
+            ));
+            next_slot = end + 1;
+        }
+        format!("<GlobalNodeGroups>{members}</GlobalNodeGroups>")
     } else {
         String::new()
     };

--- a/crates/fakecloud-elasticache/src/service/misc.rs
+++ b/crates/fakecloud-elasticache/src/service/misc.rs
@@ -525,16 +525,71 @@ impl ElastiCacheService {
         action: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let id = required_query_param(request, "GlobalReplicationGroupId")?;
-        let accounts = self.state.read();
-        let empty = ElastiCacheState::new(&request.account_id, &request.region);
-        let state = accounts.get(&request.account_id).unwrap_or(&empty);
-        let group = state.global_replication_groups.get(&id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "GlobalReplicationGroupNotFoundFault",
-                format!("GlobalReplicationGroup {id} not found."),
-            )
-        })?;
+        // NodeGroupCount is the target shard count for Increase/Decrease;
+        // Rebalance keeps the count and only re-partitions slots.
+        let requested_count = optional_query_param(request, "NodeGroupCount")
+            .as_deref()
+            .and_then(|v| v.parse::<i32>().ok());
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let group = state
+            .global_replication_groups
+            .get_mut(&id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "GlobalReplicationGroupNotFoundFault",
+                    format!("GlobalReplicationGroup {id} not found."),
+                )
+            })?;
+
+        match action {
+            "IncreaseNodeGroupsInGlobalReplicationGroup" => {
+                let target = requested_count.ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValueException",
+                        "NodeGroupCount is required",
+                    )
+                })?;
+                if target <= group.num_node_groups {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValueException",
+                        format!(
+                            "NodeGroupCount ({target}) must be greater than the current count ({})",
+                            group.num_node_groups
+                        ),
+                    ));
+                }
+                group.num_node_groups = target;
+            }
+            "DecreaseNodeGroupsInGlobalReplicationGroup" => {
+                let target = requested_count.ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValueException",
+                        "NodeGroupCount is required",
+                    )
+                })?;
+                if target < 1 || target >= group.num_node_groups {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValueException",
+                        format!(
+                            "NodeGroupCount ({target}) must be >= 1 and less than the current count ({})",
+                            group.num_node_groups
+                        ),
+                    ));
+                }
+                group.num_node_groups = target;
+            }
+            // RebalanceSlotsInGlobalReplicationGroup: keep the shard count,
+            // the slot re-partition is reflected by the xml builder.
+            _ => {}
+        }
+
         let xml = global_replication_group_xml(group, true);
         Ok(AwsResponse::xml(
             StatusCode::OK,

--- a/crates/fakecloud-elasticache/src/service/replication.rs
+++ b/crates/fakecloud-elasticache/src/service/replication.rs
@@ -403,11 +403,12 @@ impl ElastiCacheService {
                 automatic_failover: primary_group.automatic_failover_enabled,
                 status: "associated".to_string(),
             }],
-            cluster_enabled: false,
+            cluster_enabled: primary_group.cluster_enabled,
             arn: format!(
                 "arn:aws:elasticache:{}:{}:globalreplicationgroup:{}",
                 region, account_id, global_replication_group_id
             ),
+            num_node_groups: primary_group.num_node_groups.max(1),
         };
 
         let xml = global_replication_group_xml(&group, true);

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -1250,10 +1250,11 @@ fn service_with_global_replication_group(
                     automatic_failover: false,
                     status: "associated".to_string(),
                 }],
-                cluster_enabled: false,
+                cluster_enabled: true,
                 arn: format!(
                     "arn:aws:elasticache:us-east-1:123456789012:globalreplicationgroup:{global_replication_group_id}"
                 ),
+                num_node_groups: 2,
             },
         );
     }
@@ -1314,6 +1315,70 @@ fn describe_global_replication_groups_filters_by_id() {
     );
     assert!(body.contains("<ReplicationGroupId>primary-rg</ReplicationGroupId>"));
     assert!(body.contains("<DescribeGlobalReplicationGroupsResponse"));
+}
+
+/// 1.23: Increase/Decrease node groups in a global replication group must
+/// actually apply the count and reflect it in
+/// DescribeGlobalReplicationGroups (no longer a no-op).
+#[test]
+fn global_node_group_reshard_applies_and_reflects() {
+    let service = service_with_global_replication_group("fc-us-east-1-global-a", "primary-rg");
+
+    let count_node_groups = |service: &ElastiCacheService| -> usize {
+        let resp = service
+            .describe_global_replication_groups(&request(
+                "DescribeGlobalReplicationGroups",
+                &[
+                    ("GlobalReplicationGroupId", "fc-us-east-1-global-a"),
+                    ("ShowMemberInfo", "true"),
+                ],
+            ))
+            .unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        body.matches("<GlobalNodeGroup>").count()
+    };
+
+    // Seed starts at 2 node groups.
+    assert_eq!(count_node_groups(&service), 2);
+
+    // Increase to 4.
+    service
+        .increase_node_groups_in_global_replication_group(&request(
+            "IncreaseNodeGroupsInGlobalReplicationGroup",
+            &[
+                ("GlobalReplicationGroupId", "fc-us-east-1-global-a"),
+                ("NodeGroupCount", "4"),
+                ("ApplyImmediately", "true"),
+            ],
+        ))
+        .unwrap();
+    assert_eq!(count_node_groups(&service), 4, "increase must apply");
+
+    // Decrease to 1.
+    service
+        .decrease_node_groups_in_global_replication_group(&request(
+            "DecreaseNodeGroupsInGlobalReplicationGroup",
+            &[
+                ("GlobalReplicationGroupId", "fc-us-east-1-global-a"),
+                ("NodeGroupCount", "1"),
+                ("ApplyImmediately", "true"),
+            ],
+        ))
+        .unwrap();
+    assert_eq!(count_node_groups(&service), 1, "decrease must apply");
+
+    // Increase to a value not greater than current is rejected.
+    let err = service
+        .increase_node_groups_in_global_replication_group(&request(
+            "IncreaseNodeGroupsInGlobalReplicationGroup",
+            &[
+                ("GlobalReplicationGroupId", "fc-us-east-1-global-a"),
+                ("NodeGroupCount", "1"),
+            ],
+        ))
+        .err()
+        .expect("non-increasing count rejected");
+    assert!(format!("{err:?}").contains("InvalidParameterValueException"));
 }
 
 #[test]

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -357,6 +357,15 @@ pub struct GlobalReplicationGroup {
     pub members: Vec<GlobalReplicationGroupMember>,
     pub cluster_enabled: bool,
     pub arn: String,
+    /// Number of global node groups (shards). Adjusted by the
+    /// Increase/Decrease/RebalanceNodeGroupsInGlobalReplicationGroup ops
+    /// and reflected in DescribeGlobalReplicationGroups. Defaults to 1.
+    #[serde(default = "default_global_node_group_count")]
+    pub num_node_groups: i32,
+}
+
+fn default_global_node_group_count() -> i32 {
+    1
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1372,6 +1381,7 @@ mod tests {
                 cluster_enabled: false,
                 arn: "arn:aws:elasticache:us-east-1:123456789012:globalreplicationgroup:global-rg"
                     .to_string(),
+                num_node_groups: 1,
             },
         );
         assert_eq!(state.global_replication_groups.len(), 1);

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -1528,6 +1528,39 @@ fn update_user_rename() {
     assert!(body.contains("<UserName>new-user</UserName>"));
 }
 
+/// 1.29: UpdateUser rename must preserve the ARN partition (aws-cn here)
+/// rather than hardcoding `arn:aws:`.
+#[test]
+fn update_user_rename_preserves_partition() {
+    let svc = make_service();
+    let mut create = make_request("CreateUser", vec![("UserName", "old-cn")]);
+    create.region = "cn-north-1".to_string();
+    let resp = svc.create_user(&create).unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes());
+    assert!(
+        extract_xml_tag(&body, "Arn").starts_with("arn:aws-cn:iam::"),
+        "create should mint an aws-cn ARN"
+    );
+
+    let mut rename = make_request(
+        "UpdateUser",
+        vec![("UserName", "old-cn"), ("NewUserName", "new-cn")],
+    );
+    rename.region = "cn-north-1".to_string();
+    svc.update_user(&rename).unwrap();
+
+    let mut get = make_request("GetUser", vec![("UserName", "new-cn")]);
+    get.region = "cn-north-1".to_string();
+    let resp = svc.get_user(&get).unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes());
+    let arn = extract_xml_tag(&body, "Arn");
+    assert!(
+        arn.starts_with("arn:aws-cn:iam::"),
+        "rename must keep the aws-cn partition, got {arn}"
+    );
+    assert!(arn.ends_with(":user/new-cn"));
+}
+
 // ---- Account Password Policy Tests ----
 
 #[test]

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -375,8 +375,20 @@ impl IamService {
 
         let actual_new_name = new_user_name.unwrap_or_else(|| user_name.clone());
         user.user_name = actual_new_name.clone();
+        // Preserve the existing ARN's partition (aws / aws-cn / aws-us-gov
+        // / aws-iso*) rather than hardcoding `arn:aws:`, which would flip
+        // the partition on a rename in cn-/us-gov-/iso- regions. Derive it
+        // from the user's current ARN, falling back to the region.
+        let partition = user
+            .arn
+            .split(':')
+            .nth(1)
+            .filter(|p| !p.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| partition_for_region(&req.region).to_string());
         user.arn = format!(
-            "arn:aws:iam::{}:user{}{}",
+            "arn:{}:iam::{}:user{}{}",
+            partition,
             state.account_id,
             if user.path == "/" { "/" } else { &user.path },
             actual_new_name

--- a/crates/fakecloud-kms/src/service_aliases.rs
+++ b/crates/fakecloud-kms/src/service_aliases.rs
@@ -173,6 +173,8 @@ impl KmsService {
         })?;
 
         let key_id_filter = body["KeyId"].as_str();
+        let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
+        let marker = body["Marker"].as_str();
 
         let accounts = self.state.read();
         let empty = KmsState::new(&req.account_id, &req.region);
@@ -182,7 +184,7 @@ impl KmsService {
         let resolved_filter =
             key_id_filter.and_then(|kid| Self::resolve_key_id_with_state(state, kid));
 
-        let aliases: Vec<Value> = state
+        let all_aliases: Vec<Value> = state
             .aliases
             .values()
             .filter(|a| match (&resolved_filter, key_id_filter) {
@@ -199,13 +201,35 @@ impl KmsService {
             })
             .collect();
 
+        // Real Limit/Marker pagination (mirrors ListGrants): the marker
+        // is the AliasName of the last item on the previous page; resume
+        // after it.
+        let start = if let Some(m) = marker {
+            all_aliases
+                .iter()
+                .position(|a| a["AliasName"].as_str() == Some(m))
+                .map(|pos| pos + 1)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        let page = &all_aliases[start..all_aliases.len().min(start + limit)];
+        let truncated = start + limit < all_aliases.len();
+
+        let mut result = json!({
+            "Aliases": page,
+            "Truncated": truncated,
+        });
+        if truncated {
+            if let Some(last) = page.last() {
+                result["NextMarker"] = last["AliasName"].clone();
+            }
+        }
+
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({
-                "Aliases": aliases,
-                "Truncated": false,
-            }))
-            .unwrap(),
+            serde_json::to_string(&result).unwrap(),
         ))
     }
 }

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -1877,6 +1877,56 @@ fn create_alias_rejects_unknown_target() {
     assert_eq!(err.code(), "NotFoundException");
 }
 
+/// 1.22: ListAliases must honor Limit/Marker with correct
+/// Truncated/NextMarker instead of hardcoding Truncated:false.
+#[test]
+fn list_aliases_paginates_with_limit_and_marker() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    for i in 0..5 {
+        create_alias(&svc, &format!("alias/cust-{i}"), &key_id);
+    }
+
+    // First page: Limit=2 -> 2 aliases (plus any AWS-managed) and a marker.
+    let resp = svc
+        .list_aliases(&make_request("ListAliases", json!({ "Limit": 2 })))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let page1 = body["Aliases"].as_array().unwrap();
+    assert_eq!(page1.len(), 2, "Limit must cap the page size");
+    assert_eq!(body["Truncated"].as_bool(), Some(true));
+    let marker = body["NextMarker"]
+        .as_str()
+        .expect("NextMarker present")
+        .to_string();
+    assert_eq!(
+        marker,
+        page1.last().unwrap()["AliasName"].as_str().unwrap(),
+        "NextMarker is the last alias on the page"
+    );
+
+    // Second page: resume after the marker, no overlap.
+    let resp = svc
+        .list_aliases(&make_request(
+            "ListAliases",
+            json!({ "Limit": 2, "Marker": marker }),
+        ))
+        .unwrap();
+    let body2: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let page2 = body2["Aliases"].as_array().unwrap();
+    assert!(!page2.is_empty());
+    let p1_names: Vec<&str> = page1
+        .iter()
+        .map(|a| a["AliasName"].as_str().unwrap())
+        .collect();
+    for a in page2 {
+        assert!(
+            !p1_names.contains(&a["AliasName"].as_str().unwrap()),
+            "second page must not repeat the first"
+        );
+    }
+}
+
 #[test]
 fn create_alias_duplicate_errors() {
     let svc = make_service();

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2088,23 +2088,15 @@ pub(crate) fn compute_checksum(algorithm: &str, data: &[u8]) -> String {
 pub(crate) fn compute_checksum_raw(algorithm: &str, data: &[u8]) -> Vec<u8> {
     match algorithm {
         "CRC32" => crc32fast::hash(data).to_be_bytes().to_vec(),
+        // CRC32C and CRC64NVME use the same crates as the streaming path so
+        // CopyObject / CompleteMultipartUpload produce identical results to
+        // a streaming PutObject (1.7); the COMPOSITE multipart checksum
+        // concatenates these raw digests before hashing (1.18).
         "CRC32C" => crc32c::crc32c(data).to_be_bytes().to_vec(),
         "CRC64NVME" => {
             let mut hasher = crc64fast_nvme::Digest::new();
             hasher.write(data);
             hasher.sum64().to_be_bytes().to_vec()
-        }
-        // CRC32C and CRC64NVME use the same crates as the streaming path so
-        // CopyObject / CompleteMultipartUpload produce identical results to
-        // a streaming PutObject (1.7).
-        "CRC32C" => {
-            let crc = crc32c::crc32c(data);
-            BASE64.encode(crc.to_be_bytes())
-        }
-        "CRC64NVME" => {
-            let mut hasher = crc64fast_nvme::Digest::new();
-            hasher.write(data);
-            BASE64.encode(hasher.sum64().to_be_bytes())
         }
         "SHA1" => {
             use sha1::Digest as _;

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2071,10 +2071,28 @@ pub(crate) fn compute_md5(data: &[u8]) -> String {
 }
 
 pub(crate) fn compute_checksum(algorithm: &str, data: &[u8]) -> String {
+    let raw = compute_checksum_raw(algorithm, data);
+    if raw.is_empty() {
+        String::new()
+    } else {
+        BASE64.encode(raw)
+    }
+}
+
+/// Compute the raw (un-base64'd) checksum digest bytes for `data`.
+///
+/// Returns the network-order digest bytes so callers can either base64
+/// them ([`compute_checksum`]) or concatenate them when computing an S3
+/// multipart COMPOSITE checksum (which hashes the concatenation of each
+/// part's raw digest, then base64s the result and appends `-N`).
+pub(crate) fn compute_checksum_raw(algorithm: &str, data: &[u8]) -> Vec<u8> {
     match algorithm {
-        "CRC32" => {
-            let crc = crc32fast::hash(data);
-            BASE64.encode(crc.to_be_bytes())
+        "CRC32" => crc32fast::hash(data).to_be_bytes().to_vec(),
+        "CRC32C" => crc32c::crc32c(data).to_be_bytes().to_vec(),
+        "CRC64NVME" => {
+            let mut hasher = crc64fast_nvme::Digest::new();
+            hasher.write(data);
+            hasher.sum64().to_be_bytes().to_vec()
         }
         // CRC32C and CRC64NVME use the same crates as the streaming path so
         // CopyObject / CompleteMultipartUpload produce identical results to
@@ -2090,16 +2108,41 @@ pub(crate) fn compute_checksum(algorithm: &str, data: &[u8]) -> String {
         }
         "SHA1" => {
             use sha1::Digest as _;
-            let hash = sha1::Sha1::digest(data);
-            BASE64.encode(hash)
+            sha1::Sha1::digest(data).to_vec()
         }
         "SHA256" => {
             use sha2::Digest as _;
-            let hash = sha2::Sha256::digest(data);
-            BASE64.encode(hash)
+            sha2::Sha256::digest(data).to_vec()
         }
-        _ => String::new(),
+        _ => Vec::new(),
     }
+}
+
+/// Compute an S3 multipart COMPOSITE additional checksum from each
+/// part's raw digest bytes (in part-number order). AWS defines this as
+/// `base64(HASH(concat(raw_part_digests)))-N` where HASH is the chosen
+/// algorithm and N is the part count. Returns `None` for an unsupported
+/// algorithm or empty part list.
+pub(crate) fn compute_composite_checksum(
+    algorithm: &str,
+    part_raw_digests: &[Vec<u8>],
+) -> Option<String> {
+    if part_raw_digests.is_empty() {
+        return None;
+    }
+    let mut concat = Vec::new();
+    for d in part_raw_digests {
+        concat.extend_from_slice(d);
+    }
+    let digest = compute_checksum_raw(algorithm, &concat);
+    if digest.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{}-{}",
+        BASE64.encode(digest),
+        part_raw_digests.len()
+    ))
 }
 
 /// Streaming variant of [`compute_checksum`] for spool files. Reads

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -12,9 +12,9 @@ use crate::state::{MultipartUpload, S3Object, UploadPart};
 use md5::{Digest, Md5};
 
 use super::{
-    canned_acl_grants, compute_checksum, compute_md5, extract_user_metadata, no_such_bucket,
-    no_such_key, no_such_upload, parse_complete_multipart_xml, parse_grant_headers,
-    parse_url_encoded_tags, precondition_failed, resolve_object, s3_xml, xml_escape, S3Service,
+    canned_acl_grants, compute_md5, extract_user_metadata, no_such_bucket, no_such_key,
+    no_such_upload, parse_complete_multipart_xml, parse_grant_headers, parse_url_encoded_tags,
+    precondition_failed, resolve_object, s3_xml, xml_escape, S3Service,
 };
 
 /// Build the `CompleteMultipartUploadResult` XML response for an object that
@@ -544,6 +544,10 @@ impl S3Service {
         let mut combined_data = Vec::new();
         let mut md5_digests = Vec::new();
         let mut part_sizes = Vec::new();
+        // Per-part raw additional-checksum digests, collected in
+        // part-number order so we can build the COMPOSITE checksum
+        // (hash-of-part-hashes) AWS returns for multipart objects.
+        let mut part_checksum_digests: Vec<Vec<u8>> = Vec::new();
 
         for (part_num, submitted_etag) in &sorted_parts {
             let part = upload.parts.get(part_num).ok_or_else(|| {
@@ -580,6 +584,9 @@ impl S3Service {
                     "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not have matched the part's etag.",
                 ));
             }
+            if let Some(algo) = upload.checksum_algorithm.as_deref() {
+                part_checksum_digests.push(super::compute_checksum_raw(algo, &part_bytes));
+            }
             combined_data.extend_from_slice(&part_bytes);
             md5_digests.extend_from_slice(&part_md5);
             part_sizes.push((*part_num, part_bytes.len() as u64));
@@ -588,10 +595,13 @@ impl S3Service {
         // Multipart ETag: MD5(concat(part_md5_digests))-N
         let combined_md5 = Md5::digest(&md5_digests);
         let etag = format!("{:x}-{}", combined_md5, sorted_parts.len());
+        // Additional-checksum for a multipart object is COMPOSITE:
+        // base64(HASH(concat(raw part digests)))-N - NOT a checksum over
+        // the whole reassembled object.
         let checksum_value = upload
             .checksum_algorithm
             .as_deref()
-            .map(|algo| compute_checksum(algo, &combined_data));
+            .and_then(|algo| super::compute_composite_checksum(algo, &part_checksum_digests));
         let data = Bytes::from(combined_data);
         let store_body = data.clone();
 

--- a/crates/fakecloud-s3/src/service/objects/delete.rs
+++ b/crates/fakecloud-s3/src/service/objects/delete.rs
@@ -290,6 +290,16 @@ impl S3Service {
             ));
         }
 
+        // AWS caps a single DeleteObjects request at 1000 objects and
+        // rejects anything larger with a 400 MalformedXML.
+        if entries.len() > 1000 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MalformedXML",
+                "The XML you provided was not well-formed or did not validate against our published schema",
+            ));
+        }
+
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);
         let b = state

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -903,6 +903,126 @@ async fn mpu_full_lifecycle_creates_object() {
     assert!(!bucket.multipart_uploads.contains_key(&upload_id));
 }
 
+/// 1.18: a multipart object with an additional checksum must report a
+/// COMPOSITE checksum (`base64(HASH(concat(part raw digests)))-N`), not
+/// a checksum over the whole reassembled object.
+#[tokio::test]
+async fn mpu_complete_uses_composite_additional_checksum() {
+    let svc = make_service();
+    seed_bucket(&svc, "comp");
+
+    // Initiate with a SHA256 additional checksum.
+    let init_req = make_request(Method::POST, "/comp/k", &[("uploads", "")], b"");
+    let mut init_req = init_req;
+    init_req.headers.insert(
+        "x-amz-checksum-algorithm",
+        http::HeaderValue::from_static("SHA256"),
+    );
+    let resp = svc
+        .create_multipart_upload("123456789012", &init_req, "comp", "k")
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    let start = body.find("<UploadId>").unwrap() + "<UploadId>".len();
+    let end = body.find("</UploadId>").unwrap();
+    let upload_id = body[start..end].to_string();
+
+    let part1 = vec![b'a'; 5 * 1024 * 1024];
+    let part2 = b"second-part".to_vec();
+    let mut etags = Vec::new();
+    for (n, data) in [(1u32, &part1), (2u32, &part2)] {
+        let req = make_request(
+            Method::PUT,
+            "/comp/k",
+            &[("partNumber", &n.to_string())],
+            data,
+        );
+        let r = svc
+            .upload_part("123456789012", &req, "comp", "k", &upload_id, n as i64)
+            .await
+            .unwrap();
+        etags.push(r.headers.get("etag").unwrap().to_str().unwrap().to_string());
+    }
+
+    let complete_xml = format!(
+        r#"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>{}</ETag></Part><Part><PartNumber>2</PartNumber><ETag>{}</ETag></Part></CompleteMultipartUpload>"#,
+        etags[0], etags[1],
+    );
+    let complete_req = make_request(
+        Method::POST,
+        "/comp/k",
+        &[("uploadId", &upload_id)],
+        complete_xml.as_bytes(),
+    );
+    svc.complete_multipart_upload("123456789012", &complete_req, "comp", "k", &upload_id)
+        .unwrap();
+
+    let expected = super::compute_composite_checksum(
+        "SHA256",
+        &[
+            super::compute_checksum_raw("SHA256", &part1),
+            super::compute_checksum_raw("SHA256", &part2),
+        ],
+    )
+    .unwrap();
+    assert!(
+        expected.ends_with("-2"),
+        "composite checksum must carry -N suffix"
+    );
+
+    let __mas = svc.state.read();
+    let state = __mas.default_ref();
+    let obj = state.buckets.get("comp").unwrap().objects.get("k").unwrap();
+    assert_eq!(
+        obj.checksum_value.as_deref(),
+        Some(expected.as_str()),
+        "stored checksum must be the COMPOSITE checksum-of-checksums, not a whole-object checksum"
+    );
+
+    // Sanity: it must NOT equal a single checksum over the whole object.
+    let mut whole = part1.clone();
+    whole.extend_from_slice(&part2);
+    let whole_ck = super::compute_checksum("SHA256", &whole);
+    assert_ne!(obj.checksum_value.as_deref(), Some(whole_ck.as_str()));
+}
+
+/// 1.18: composite checksum helper round-trips for every supported
+/// additional-checksum algorithm.
+#[test]
+fn compute_composite_checksum_supports_all_algorithms() {
+    for algo in ["CRC32", "CRC32C", "CRC64NVME", "SHA1", "SHA256"] {
+        let p1 = super::compute_checksum_raw(algo, b"part-one");
+        let p2 = super::compute_checksum_raw(algo, b"part-two");
+        assert!(!p1.is_empty(), "{algo} raw digest");
+        let composite = super::compute_composite_checksum(algo, &[p1, p2]).unwrap();
+        assert!(composite.ends_with("-2"), "{algo} composite suffix");
+    }
+    assert!(super::compute_composite_checksum("SHA256", &[]).is_none());
+    assert!(super::compute_composite_checksum("BOGUS", &[vec![1]]).is_none());
+}
+
+/// 1.19: DeleteObjects must reject >1000 keys with a 400 MalformedXML.
+#[tokio::test]
+async fn delete_objects_rejects_over_1000_keys() {
+    let svc = make_service();
+    seed_bucket(&svc, "bdel-limit");
+
+    let mut xml = String::from("<Delete>");
+    for i in 0..1001 {
+        xml.push_str(&format!("<Object><Key>k{i}.txt</Key></Object>"));
+    }
+    xml.push_str("</Delete>");
+    let req = make_request(
+        Method::POST,
+        "/bdel-limit",
+        &[("delete", "")],
+        xml.as_bytes(),
+    );
+    assert_aws_err(
+        svc.delete_objects("123456789012", &req, "bdel-limit"),
+        "MalformedXML",
+    );
+}
+
 /// bug-hunt 2026-06-13, finding 4.1: CompleteMultipartUpload assembles
 /// parts off-lock from a cloned snapshot. In disk mode a concurrent
 /// UploadPart of the same part number rewrites the fixed `part-NNNNN.bin`

--- a/crates/fakecloud-server/src/sqs_lambda_poller.rs
+++ b/crates/fakecloud-server/src/sqs_lambda_poller.rs
@@ -549,6 +549,7 @@ mod tests {
             next_sequence_number: 0,
             permission_labels: Vec::new(),
             receipt_handle_map: BTreeMap::new(),
+            receive_attempt_cache: BTreeMap::new(),
         };
 
         let mut sqs: MultiAccountState<SqsState> =

--- a/crates/fakecloud-sns/src/service_publish.rs
+++ b/crates/fakecloud-sns/src/service_publish.rs
@@ -309,6 +309,11 @@ impl SnsService {
             .get(&topic_arn)
             .ok_or_else(|| not_found("Topic"))?;
         let is_fifo = topic.is_fifo;
+        let content_dedup = topic
+            .attributes
+            .get("ContentBasedDeduplication")
+            .map(|v| v == "true")
+            .unwrap_or(false);
         let endpoint = state.endpoint.clone();
         drop(_accts);
 
@@ -342,6 +347,16 @@ impl SnsService {
             }
         }
 
+        // Validate: at least one entry. AWS returns EmptyBatchRequest for
+        // a batch with no entries rather than silently succeeding.
+        if entries.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "EmptyBatchRequest",
+                "The batch request doesn't contain any entries.",
+            ));
+        }
+
         // Validate: max 10 entries
         if entries.len() > 10 {
             return Err(AwsServiceError::aws_error(
@@ -368,6 +383,16 @@ impl SnsService {
                 StatusCode::BAD_REQUEST,
                 "InvalidParameter",
                 "Invalid parameter: The MessageGroupId parameter is required for FIFO topics",
+            ));
+        }
+
+        // FIFO without ContentBasedDeduplication: every entry must carry a
+        // MessageDeduplicationId (matches the single Publish validation).
+        if is_fifo && !content_dedup && entries.iter().any(|e| e.4.is_none()) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameter",
+                "Invalid parameter: The topic should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
             ));
         }
 

--- a/crates/fakecloud-sns/src/service_tests.rs
+++ b/crates/fakecloud-sns/src/service_tests.rs
@@ -851,6 +851,71 @@ fn publish_batch_rejects_duplicate_ids() {
     assert!(result.is_err(), "Duplicate batch IDs should error");
 }
 
+/// 1.21: PublishBatch with zero entries must return EmptyBatchRequest.
+#[test]
+fn publish_batch_empty_returns_empty_batch_request() {
+    let (svc, _state) = make_sns();
+    assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "empty-batch")])));
+    let req = sns_request(
+        "PublishBatch",
+        vec![("TopicArn", "arn:aws:sns:us-east-1:123456789012:empty-batch")],
+    );
+    let err = svc.publish_batch(&req).err().expect("empty batch errors");
+    assert!(err.to_string().contains("EmptyBatchRequest"), "got {err}");
+}
+
+/// 1.21: PublishBatch on a FIFO topic without ContentBasedDeduplication
+/// must require MessageDeduplicationId on every entry (matches single
+/// Publish).
+#[test]
+fn publish_batch_fifo_requires_dedup_id() {
+    let (svc, _state) = make_sns();
+    let mut req = sns_request("CreateTopic", vec![("Name", "batch.fifo")]);
+    req.query_params.insert(
+        "Attributes.entry.1.key".to_string(),
+        "FifoTopic".to_string(),
+    );
+    req.query_params
+        .insert("Attributes.entry.1.value".to_string(), "true".to_string());
+    assert_ok(&svc.create_topic(&req));
+
+    let topic_arn = "arn:aws:sns:us-east-1:123456789012:batch.fifo";
+    // MessageGroupId present but no MessageDeduplicationId -> error.
+    let req = sns_request(
+        "PublishBatch",
+        vec![
+            ("TopicArn", topic_arn),
+            ("PublishBatchRequestEntries.member.1.Id", "m1"),
+            ("PublishBatchRequestEntries.member.1.Message", "hi"),
+            ("PublishBatchRequestEntries.member.1.MessageGroupId", "g1"),
+        ],
+    );
+    let err = svc
+        .publish_batch(&req)
+        .err()
+        .expect("FIFO batch without dedup id errors");
+    assert!(
+        err.to_string().contains("ContentBasedDeduplication"),
+        "got {err}"
+    );
+
+    // With a MessageDeduplicationId it succeeds.
+    let req = sns_request(
+        "PublishBatch",
+        vec![
+            ("TopicArn", topic_arn),
+            ("PublishBatchRequestEntries.member.1.Id", "m1"),
+            ("PublishBatchRequestEntries.member.1.Message", "hi"),
+            ("PublishBatchRequestEntries.member.1.MessageGroupId", "g1"),
+            (
+                "PublishBatchRequestEntries.member.1.MessageDeduplicationId",
+                "d1",
+            ),
+        ],
+    );
+    assert_ok(&svc.publish_batch(&req));
+}
+
 // --- SetSubscriptionAttributes / GetSubscriptionAttributes ---
 
 #[test]

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -330,6 +330,7 @@ mod tests {
             next_sequence_number: 0,
             permission_labels: Vec::new(),
             receipt_handle_map: BTreeMap::new(),
+            receive_attempt_cache: BTreeMap::new(),
         }
     }
 

--- a/crates/fakecloud-sqs/src/resource_policy.rs
+++ b/crates/fakecloud-sqs/src/resource_policy.rs
@@ -108,6 +108,7 @@ mod tests {
             next_sequence_number: 0,
             permission_labels: Vec::new(),
             receipt_handle_map: BTreeMap::new(),
+            receive_attempt_cache: BTreeMap::new(),
         };
         state.write().default_mut().queues.insert(queue_url, queue);
         state

--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -364,6 +364,14 @@ impl SqsService {
 
         let visibility_timeout = val_as_i64(&body["VisibilityTimeout"]);
 
+        // FIFO receive de-dup: a retried receive carrying the same
+        // ReceiveRequestAttemptId within the visibility window replays the
+        // exact same batch instead of advancing to the next messages.
+        let receive_request_attempt_id = body["ReceiveRequestAttemptId"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(String::from);
+
         let wait_time_raw = val_as_i64(&body["WaitTimeSeconds"]);
         if let Some(wt) = wait_time_raw {
             if !(0..=20).contains(&wt) {
@@ -414,6 +422,7 @@ impl SqsService {
                 &queue_url,
                 max_messages,
                 visibility_timeout,
+                receive_request_attempt_id.as_deref(),
             )?;
 
             if !result.is_empty() || deadline.is_none() {
@@ -447,6 +456,7 @@ impl SqsService {
         queue_url: &str,
         max_messages: usize,
         req_visibility_timeout: Option<i64>,
+        receive_request_attempt_id: Option<&str>,
     ) -> Result<Vec<SqsMessage>, AwsServiceError> {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(account_id);
@@ -467,6 +477,38 @@ impl SqsService {
 
         let is_fifo = queue.is_fifo;
         let now = Utc::now();
+
+        // FIFO receive de-dup: a retried receive with a known, unexpired
+        // ReceiveRequestAttemptId replays the exact same batch - the
+        // messages are still inflight (still within the visibility
+        // window), so we re-resolve them by message id rather than
+        // pulling the next ones. Expired entries are pruned.
+        if is_fifo {
+            queue.receive_attempt_cache.retain(|_, e| e.expiry > now);
+            if let Some(attempt_id) = receive_request_attempt_id {
+                if let Some(entry) = queue.receive_attempt_cache.get(attempt_id).cloned() {
+                    let mut replayed: Vec<SqsMessage> = Vec::new();
+                    for mid in &entry.message_ids {
+                        if let Some(msg) = queue.inflight.iter().find(|m| &m.message_id == mid) {
+                            replayed.push(msg.clone());
+                        }
+                    }
+                    if !replayed.is_empty() {
+                        // Decrypt bodies for the replayed batch, same as the
+                        // normal path below.
+                        let queue_arn = queue.arn.clone();
+                        let kms_key_id = Self::effective_kms_key_id(&queue.attributes);
+                        if kms_key_id.is_some() && self.kms_hook.is_some() {
+                            for msg in replayed.iter_mut() {
+                                msg.body =
+                                    self.decrypt_message_body(account_id, &queue_arn, &msg.body)?;
+                            }
+                        }
+                        return Ok(replayed);
+                    }
+                }
+            }
+        }
 
         // MessageRetentionPeriod expiry: remove messages older than the retention period
         let retention_seconds: i64 = queue
@@ -686,6 +728,24 @@ impl SqsService {
             }
         }
 
+        // Record the FIFO receive attempt so a retry with the same
+        // ReceiveRequestAttemptId within the visibility window replays
+        // this exact batch. The entry expires when the messages become
+        // visible again.
+        if is_fifo && !received.is_empty() {
+            if let Some(attempt_id) = receive_request_attempt_id {
+                if let Some(queue) = state.queues.get_mut(&resolved_url) {
+                    queue.receive_attempt_cache.insert(
+                        attempt_id.to_string(),
+                        crate::state::ReceiveAttemptEntry {
+                            message_ids: received.iter().map(|m| m.message_id.clone()).collect(),
+                            expiry: now + chrono::Duration::seconds(visibility_timeout),
+                        },
+                    );
+                }
+            }
+        }
+
         Ok(received)
     }
 
@@ -835,6 +895,33 @@ impl SqsService {
                 "AWS.SimpleQueueService.EmptyBatchRequest",
                 "There should be at least one entry in the request.",
             ));
+        }
+
+        // AWS caps a batch at 10 entries; over that it returns
+        // TooManyEntriesInBatchRequest (matches SendMessageBatch).
+        if entries.len() > 10 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
+                format!(
+                    "Maximum number of entries per request are 10. You have sent {}.",
+                    entries.len()
+                ),
+            ));
+        }
+
+        // Reject duplicate batch entry IDs (matches the other batch ops).
+        let mut seen_ids = std::collections::HashSet::new();
+        for entry in &entries {
+            if let Some(id) = entry["Id"].as_str() {
+                if !seen_ids.insert(id.to_string()) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "AWS.SimpleQueueService.BatchEntryIdsNotDistinct",
+                        "Two or more batch entries in the operation have the same Id.",
+                    ));
+                }
+            }
         }
 
         let mut accounts = self.state.write();
@@ -1104,6 +1191,19 @@ impl SqsService {
                 StatusCode::BAD_REQUEST,
                 "AWS.SimpleQueueService.EmptyBatchRequest",
                 "There should be at least one DeleteMessageBatchRequestEntry in the request.",
+            ));
+        }
+
+        // AWS caps a batch at 10 entries; over that it returns
+        // TooManyEntriesInBatchRequest (matches SendMessageBatch).
+        if entries.len() > 10 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
+                format!(
+                    "Maximum number of entries per request are 10. You have sent {}.",
+                    entries.len()
+                ),
             ));
         }
 

--- a/crates/fakecloud-sqs/src/service/queues.rs
+++ b/crates/fakecloud-sqs/src/service/queues.rs
@@ -198,6 +198,7 @@ impl SqsService {
             next_sequence_number: 0,
             permission_labels: Vec::new(),
             receipt_handle_map: BTreeMap::new(),
+            receive_attempt_cache: BTreeMap::new(),
         };
 
         state.name_to_url.insert(queue_name, queue_url.clone());

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -1189,6 +1189,127 @@ fn change_message_visibility_batch_updates_multiple() {
     assert_eq!(body["Successful"].as_array().unwrap().len(), 2);
 }
 
+/// 1.20: DeleteMessageBatch must reject >10 entries with
+/// TooManyEntriesInBatchRequest, like SendMessageBatch.
+#[test]
+fn delete_message_batch_rejects_over_10_entries() {
+    let svc = make_service();
+    let url = create_queue_url(&svc, "del-too-many");
+    let entries: Vec<Value> = (0..11)
+        .map(|i| json!({"Id": format!("e{i}"), "ReceiptHandle": format!("rh{i}")}))
+        .collect();
+    let err = expect_err(svc.delete_message_batch(&make_request(
+        "DeleteMessageBatch",
+        json!({ "QueueUrl": url, "Entries": entries }),
+    )));
+    assert!(
+        err.to_string().contains("TooManyEntriesInBatchRequest"),
+        "got {err}"
+    );
+}
+
+/// 1.20: ChangeMessageVisibilityBatch must reject >10 entries.
+#[test]
+fn change_message_visibility_batch_rejects_over_10_entries() {
+    let svc = make_service();
+    let url = create_queue_url(&svc, "vis-too-many");
+    let entries: Vec<Value> = (0..11)
+        .map(|i| {
+            json!({"Id": format!("e{i}"), "ReceiptHandle": format!("rh{i}"), "VisibilityTimeout": 30})
+        })
+        .collect();
+    let err = expect_err(svc.change_message_visibility_batch(&make_request(
+        "ChangeMessageVisibilityBatch",
+        json!({ "QueueUrl": url, "Entries": entries }),
+    )));
+    assert!(
+        err.to_string().contains("TooManyEntriesInBatchRequest"),
+        "got {err}"
+    );
+}
+
+/// 1.20: ChangeMessageVisibilityBatch must reject duplicate batch entry
+/// IDs (matches the other batch ops).
+#[test]
+fn change_message_visibility_batch_rejects_duplicate_ids() {
+    let svc = make_service();
+    let url = create_queue_url(&svc, "vis-dup");
+    let entries = vec![
+        json!({"Id": "dup", "ReceiptHandle": "rh1", "VisibilityTimeout": 30}),
+        json!({"Id": "dup", "ReceiptHandle": "rh2", "VisibilityTimeout": 30}),
+    ];
+    let err = expect_err(svc.change_message_visibility_batch(&make_request(
+        "ChangeMessageVisibilityBatch",
+        json!({ "QueueUrl": url, "Entries": entries }),
+    )));
+    assert!(
+        err.to_string().contains("BatchEntryIdsNotDistinct"),
+        "got {err}"
+    );
+}
+
+/// 1.28: FIFO ReceiveMessage replays the same batch when retried with the
+/// same ReceiveRequestAttemptId within the visibility window, instead of
+/// returning the next messages.
+#[test]
+fn fifo_receive_request_attempt_id_replays_same_batch() {
+    let svc = make_service();
+    let url = create_queue_url(&svc, "rraid.fifo");
+    for i in 0..3 {
+        svc.send_message(&make_request(
+            "SendMessage",
+            json!({
+                "QueueUrl": url,
+                "MessageBody": format!("m{i}"),
+                "MessageGroupId": "g1",
+                "MessageDeduplicationId": format!("d{i}"),
+            }),
+        ))
+        .unwrap();
+    }
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let recv = |attempt: &str| -> Vec<Value> {
+        let resp = rt
+            .block_on(svc.receive_message(&make_request(
+                "ReceiveMessage",
+                json!({
+                    "QueueUrl": url,
+                    "MaxNumberOfMessages": 1,
+                    "VisibilityTimeout": 300,
+                    "ReceiveRequestAttemptId": attempt,
+                }),
+            )))
+            .unwrap();
+        body_json(resp)["Messages"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+    };
+
+    let first = recv("attempt-A");
+    assert_eq!(first.len(), 1);
+    let first_id = first[0]["MessageId"].as_str().unwrap().to_string();
+
+    // Same attempt id -> same message replayed (not the next one).
+    let replay = recv("attempt-A");
+    assert_eq!(replay.len(), 1);
+    assert_eq!(replay[0]["MessageId"].as_str().unwrap(), first_id);
+
+    // A different attempt id is blocked by FIFO group locking (the group
+    // still has an inflight message), so it returns nothing - which proves
+    // the replay above was the cache, not just a fresh receive.
+    let other = recv("attempt-B");
+    assert!(
+        other.is_empty(),
+        "FIFO group is locked by the inflight message"
+    );
+}
+
 // ── ListDeadLetterSourceQueues ───────────────────────────────────
 
 #[test]

--- a/crates/fakecloud-sqs/src/simulation.rs
+++ b/crates/fakecloud-sqs/src/simulation.rs
@@ -183,6 +183,7 @@ mod tests {
             next_sequence_number: 0,
             permission_labels: Vec::new(),
             receipt_handle_map: BTreeMap::new(),
+            receive_attempt_cache: BTreeMap::new(),
         };
         s.queues.insert(url.clone(), queue);
         s.name_to_url.insert(name.to_string(), url.clone());

--- a/crates/fakecloud-sqs/src/state.rs
+++ b/crates/fakecloud-sqs/src/state.rs
@@ -75,6 +75,19 @@ pub struct SqsQueue {
     pub permission_labels: Vec<String>,
     /// Tracks message_id -> list of all receipt handles ever issued for that message
     pub receipt_handle_map: BTreeMap<String, Vec<String>>,
+    /// FIFO: ReceiveRequestAttemptId -> the message_ids returned by the
+    /// original receive + an expiry. A retried receive with the same id
+    /// within the visibility window replays the exact same batch instead
+    /// of returning the next messages (AWS FIFO de-dup of receive
+    /// attempts).
+    #[serde(default)]
+    pub receive_attempt_cache: BTreeMap<String, ReceiveAttemptEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReceiveAttemptEntry {
+    pub message_ids: Vec<String>,
+    pub expiry: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/fakecloud-wafv2/src/service/mod.rs
+++ b/crates/fakecloud-wafv2/src/service/mod.rs
@@ -982,4 +982,100 @@ mod managed_rule_set_validation_tests {
         assert!(paginate_checked(&items, Some("2"), 3).is_ok());
         assert!(paginate_checked(&items, None, 3).is_ok());
     }
+
+    fn req_json(action: &str, body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "wafv2".into(),
+            action: action.into(),
+            method: http::Method::POST,
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            path_segments: Vec::new(),
+            query_params: std::collections::HashMap::new(),
+            headers: http::HeaderMap::new(),
+            body: serde_json::to_vec(&body).unwrap().into(),
+            body_stream: parking_lot::Mutex::new(None),
+            account_id: "123456789012".into(),
+            region: "us-east-1".into(),
+            request_id: "r".into(),
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    /// 1.23: PutManagedRuleSetVersions persists, and ListManagedRuleSets /
+    /// ListAvailableManagedRuleGroupVersions return what was published -
+    /// real round-trip, not write-only/empty.
+    #[test]
+    fn managed_rule_set_publishing_round_trips() {
+        let svc = Wafv2Service::default();
+
+        // Before publishing, ListManagedRuleSets is empty.
+        let resp = svc
+            .list_managed_rule_sets(&req_json(
+                "ListManagedRuleSets",
+                json!({"Scope": "REGIONAL"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["ManagedRuleSets"].as_array().unwrap().len(), 0);
+
+        // Publish two versions with a recommended version.
+        svc.put_managed_rule_set_versions(&req_json(
+            "PutManagedRuleSetVersions",
+            json!({
+                "Name": "MyRuleSet",
+                "Id": "abc123",
+                "Scope": "REGIONAL",
+                "LockToken": "tok",
+                "RecommendedVersion": "Version_2.0",
+                "VersionsToPublish": {
+                    "Version_1.0": {"ForecastedLifetime": 30},
+                    "Version_2.0": {"ForecastedLifetime": 30},
+                },
+            }),
+        ))
+        .unwrap();
+
+        // ListManagedRuleSets now returns the set.
+        let resp = svc
+            .list_managed_rule_sets(&req_json(
+                "ListManagedRuleSets",
+                json!({"Scope": "REGIONAL"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let sets = body["ManagedRuleSets"].as_array().unwrap();
+        assert_eq!(sets.len(), 1);
+        assert_eq!(sets[0]["Name"].as_str(), Some("MyRuleSet"));
+
+        // ListAvailableManagedRuleGroupVersions returns the published versions.
+        let resp = svc
+            .list_available_managed_rule_group_versions(&req_json(
+                "ListAvailableManagedRuleGroupVersions",
+                json!({"VendorName": "MyVendor", "Name": "MyRuleSet", "Scope": "REGIONAL"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let versions: Vec<&str> = body["Versions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v["Name"].as_str())
+            .collect();
+        assert!(versions.contains(&"Version_1.0"));
+        assert!(versions.contains(&"Version_2.0"));
+        assert_eq!(body["CurrentDefaultVersion"].as_str(), Some("Version_2.0"));
+
+        // A different scope does not see the REGIONAL set.
+        let resp = svc
+            .list_managed_rule_sets(&req_json(
+                "ListManagedRuleSets",
+                json!({"Scope": "CLOUDFRONT"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["ManagedRuleSets"].as_array().unwrap().len(), 0);
+    }
 }

--- a/crates/fakecloud-wafv2/src/service/rule_groups.rs
+++ b/crates/fakecloud-wafv2/src/service/rule_groups.rs
@@ -385,10 +385,35 @@ impl Wafv2Service {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let _vendor = require_str_len(&body, "VendorName", 1, 128)?;
-        let _name = require_str_len(&body, "Name", 1, 128)?;
-        let _scope = require_scope(&body)?;
+        let name = require_str_len(&body, "Name", 1, 128)?;
+        let scope = require_scope(&body)?;
         validate_opt_limit(&body)?;
         validate_opt_next_marker(&body)?;
+
+        // Return the versions actually published via
+        // PutManagedRuleSetVersions for this (scope, name) if any exist;
+        // otherwise fall back to the documented AWS-vendor sample set.
+        let state = self.state.read();
+        if let Some(set) = state
+            .accounts
+            .get(&req.account_id)
+            .and_then(|a| a.managed_rule_sets.get(&(scope.clone(), name.clone())))
+        {
+            let versions: Vec<Value> = set
+                .published_versions
+                .iter()
+                .map(|v| json!({"Name": v, "LastUpdateTimestamp": set.created_time.timestamp() as f64}))
+                .collect();
+            let current = set
+                .recommended_version
+                .clone()
+                .or_else(|| set.published_versions.last().cloned());
+            return Ok(AwsResponse::ok_json(json!({
+                "Versions": versions,
+                "CurrentDefaultVersion": current,
+            })));
+        }
+
         Ok(AwsResponse::ok_json(json!({
             "Versions": [
                 {"Name": "Version_1.0", "LastUpdateTimestamp": Utc::now().timestamp() as f64},
@@ -403,13 +428,33 @@ impl Wafv2Service {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let _scope = require_scope(&body)?;
+        let scope = require_scope(&body)?;
         validate_opt_limit(&body)?;
         validate_opt_next_marker(&body)?;
-        // fakecloud does not expose vendor-side managed rule set publishing,
-        // so this always returns an empty list (matches accounts without
-        // FirewallManager publishing rights).
-        Ok(AwsResponse::ok_json(json!({ "ManagedRuleSets": [] })))
+
+        // Return the managed rule sets this account has published for the
+        // requested scope (via PutManagedRuleSetVersions).
+        let state = self.state.read();
+        let sets: Vec<Value> = state
+            .accounts
+            .get(&req.account_id)
+            .map(|a| {
+                a.managed_rule_sets
+                    .values()
+                    .filter(|s| s.scope == scope)
+                    .map(|s| {
+                        json!({
+                            "Name": s.name,
+                            "Id": s.id,
+                            "Description": s.description,
+                            "LockToken": s.lock_token,
+                            "LabelNamespace": s.label_namespace,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(AwsResponse::ok_json(json!({ "ManagedRuleSets": sets })))
     }
 
     pub(super) fn put_managed_rule_set_versions(
@@ -423,17 +468,55 @@ impl Wafv2Service {
         fakecloud_core::validation::validate_string_length("Id", &id, 1, 36)?;
         let lock_token = require_str(&body, "LockToken")?;
         fakecloud_core::validation::validate_string_length("LockToken", &lock_token, 1, 36)?;
-        let _scope = require_scope(&body)?;
-        if let Some(recommended_version) = body.get("RecommendedVersion").and_then(Value::as_str) {
-            fakecloud_core::validation::validate_string_length(
-                "RecommendedVersion",
-                recommended_version,
-                1,
-                64,
-            )?;
+        let scope = require_scope(&body)?;
+        let recommended_version = match body.get("RecommendedVersion").and_then(Value::as_str) {
+            Some(v) => {
+                fakecloud_core::validation::validate_string_length("RecommendedVersion", v, 1, 64)?;
+                Some(v.to_string())
+            }
+            None => None,
+        };
+
+        // Collect the version names being published (VersionsToPublish is a
+        // map of version-name -> {AssociatedRuleGroupArn, ForecastedLifetime}).
+        let mut published: Vec<String> = body
+            .get("VersionsToPublish")
+            .and_then(Value::as_object)
+            .map(|m| m.keys().cloned().collect())
+            .unwrap_or_default();
+        published.sort();
+
+        let next_lock_token = synth_uuid();
+        let mut state = self.state.write();
+        let account = account_mut(&mut state, &req.account_id);
+        let key = (scope.clone(), name.clone());
+        let entry =
+            account
+                .managed_rule_sets
+                .entry(key)
+                .or_insert_with(|| crate::state::ManagedRuleSet {
+                    id: id.clone(),
+                    name: name.clone(),
+                    scope: scope.clone(),
+                    description: None,
+                    lock_token: next_lock_token.clone(),
+                    label_namespace: format!("awswaf:managed:{name}"),
+                    recommended_version: None,
+                    published_versions: Vec::new(),
+                    created_time: Utc::now(),
+                });
+        for v in published {
+            if !entry.published_versions.contains(&v) {
+                entry.published_versions.push(v);
+            }
         }
+        if recommended_version.is_some() {
+            entry.recommended_version = recommended_version;
+        }
+        entry.lock_token = next_lock_token.clone();
+
         Ok(AwsResponse::ok_json(json!({
-            "NextLockToken": synth_uuid(),
+            "NextLockToken": next_lock_token,
         })))
     }
 

--- a/crates/fakecloud-wafv2/src/state.rs
+++ b/crates/fakecloud-wafv2/src/state.rs
@@ -41,9 +41,28 @@ pub struct AccountState {
     pub associations: BTreeMap<String, String>,
     /// Tags keyed by ARN.
     pub tags: BTreeMap<String, BTreeMap<String, String>>,
+    /// Vendor-published managed rule sets keyed by (scope, name), set via
+    /// PutManagedRuleSetVersions and read by ListManagedRuleSets /
+    /// ListAvailableManagedRuleGroupVersions.
+    #[serde(default)]
+    pub managed_rule_sets: BTreeMap<ScopedKey, ManagedRuleSet>,
 }
 
 pub type ScopedKey = (String, String);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedRuleSet {
+    pub id: String,
+    pub name: String,
+    pub scope: String,
+    pub description: Option<String>,
+    pub lock_token: String,
+    pub label_namespace: String,
+    pub recommended_version: Option<String>,
+    /// Published version names (e.g. "Version_1.0").
+    pub published_versions: Vec<String>,
+    pub created_time: DateTime<Utc>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebAcl {


### PR DESCRIPTION
## Summary

Batch 7 (final) of the 2026-06-15 bug-hunt. Fixes all Tier-1 MEDIUM/LOW findings (1.11-1.29) so each operation matches AWS behavior. All fixes are real behavior changes (no stubs), each with a focused test.

DynamoDB
- 1.11 BatchGetItem honors per-table ProjectionExpression / AttributesToGet (was returning whole item).
- 1.12 Legacy AttributesToGet honored in GetItem/Query/Scan/BatchGet via the shared projection helper.
- 1.13 Select implements SPECIFIC_ATTRIBUTES / ALL_ATTRIBUTES / ALL_PROJECTED_ATTRIBUTES; invalid or incompatible Select now rejected with ValidationException.
- 1.14 Batch ops enforce the 100-key (BatchGetItem) / 25-request (BatchWriteItem) limits, reject duplicate keys within a batch, and reject keyless/malformed items instead of coercing to {}.
- 1.15 UpdateGlobalTableSettings persists billing mode + provisioned write capacity + per-replica read capacity (added struct fields) and reflects them in DescribeGlobalTableSettings (now uses a write lock).
- 1.25 Query/Scan reject Limit <= 0 with ValidationException.
- 1.26 ExecuteStatement keeps genuine PartiQL ValidationException as ValidationException; only a missing table maps to ResourceNotFoundException.

S3
- 1.18 Multipart additional checksum is now COMPOSITE: base64(HASH(concat(raw part digests)))-N. Added compute_checksum_raw / compute_composite_checksum (raw helpers also cover CRC32C/CRC64NVME).
- 1.19 DeleteObjects rejects >1000 keys with 400 MalformedXML.

SQS
- 1.20 DeleteMessageBatch / ChangeMessageVisibilityBatch reject >10 entries (TooManyEntriesInBatchRequest) and duplicate batch ids (BatchEntryIdsNotDistinct).
- 1.28 FIFO ReceiveRequestAttemptId replays the exact same batch when retried within the visibility window (new per-queue receive_attempt_cache).

SNS
- 1.21 PublishBatch returns EmptyBatchRequest for 0 entries and requires MessageDeduplicationId per entry on FIFO topics without ContentBasedDeduplication.

KMS
- 1.22 ListAliases implements real Limit/Marker pagination with correct Truncated/NextMarker (mirrors ListGrants).

ElastiCache
- 1.23 Increase/Decrease node groups in a global replication group apply the new shard count and reflect it (slot partitioning + GlobalNodeGroups) in DescribeGlobalReplicationGroups; non-increasing/decreasing counts rejected.

WAFv2
- 1.23 PutManagedRuleSetVersions persists published versions; ListManagedRuleSets and ListAvailableManagedRuleGroupVersions return what was published (new managed_rule_sets state, scoped).

API Gateway
- 1.24 UpdateUsage applies the patch to per-key remaining quota; GetUsage returns the tracked used/remaining values (round-trip).
- 1.28 GetSdkType returns a real descriptor for known ids (mirrors GetSdkTypes) instead of literal "Stub".

Cognito
- 1.27 InitiateAuth (USER_PASSWORD_AUTH + CUSTOM_AUTH) and SignUp enforce SECRET_HASH for clients with a secret (HMAC-SHA256 of username+client_id), matching the OAuth /token enforcement.
- 1.28 ListUsers honors AttributesToGet, restricting each user's Attributes to the requested names.

IAM
- 1.29 update_user preserves the existing ARN partition (aws / aws-cn / aws-us-gov / aws-iso*) on rename instead of hardcoding arn:aws:.

## Test plan

Per-finding tests (all green; clippy -D warnings + fmt clean on every touched crate; full workspace builds):

- 1.11/1.12 dynamodb batch.rs: batch_get_item_honors_projection_and_legacy_attributes_to_get; queries.rs: scan_honors_legacy_attributes_to_get
- 1.13 queries.rs: scan_select_specific_attributes_projects, scan_select_all_attributes_returns_full_item, scan_rejects_invalid_and_incompatible_select
- 1.14 batch.rs: batch_get_item_rejects_over_100_keys, batch_write_item_rejects_over_25_requests, batch_write_item_rejects_duplicate_keys, batch_write_item_rejects_keyless_item
- 1.15 global_tables.rs: update_global_table_settings_persists_and_round_trips, update_global_table_settings_pay_per_request_clears_write_capacity
- 1.25 queries.rs: scan_rejects_non_positive_limit, query_rejects_non_positive_limit
- 1.26 batch.rs: execute_statement_preserves_validation_vs_not_found (+ updated 3 stale tests that asserted the old remap)
- 1.18 s3 tests.rs: mpu_complete_uses_composite_additional_checksum, compute_composite_checksum_supports_all_algorithms
- 1.19 s3 tests.rs: delete_objects_rejects_over_1000_keys
- 1.20 sqs service_tests.rs: delete_message_batch_rejects_over_10_entries, change_message_visibility_batch_rejects_over_10_entries, change_message_visibility_batch_rejects_duplicate_ids
- 1.28 sqs service_tests.rs: fifo_receive_request_attempt_id_replays_same_batch
- 1.21 sns service_tests.rs: publish_batch_empty_returns_empty_batch_request, publish_batch_fifo_requires_dedup_id
- 1.22 kms service_tests.rs: list_aliases_paginates_with_limit_and_marker
- 1.23 elasticache service_tests.rs: global_node_group_reshard_applies_and_reflects
- 1.23 wafv2 service/mod.rs: managed_rule_set_publishing_round_trips
- 1.24/1.28 apigateway service_usage_plans.rs: usage_update_and_get_round_trip, get_sdk_type_returns_real_descriptor
- 1.27/1.28 cognito service/tests.rs: secret_hash_enforced_for_clients_with_secret, secret_hash_not_required_for_clients_without_secret, list_users_honors_attributes_to_get
- 1.29 iam tests.rs: update_user_rename_preserves_partition

No public surface (new ops) added, so SDK/docs unchanged; these are behavior corrections to existing operations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Tier‑1 medium/low API divergences across 10 services to match AWS behavior, correcting limits, validation, pagination, and response shapes. No new public APIs; behavior corrections only.

- **Bug Fixes**
  - DynamoDB: BatchGetItem honors per-table ProjectionExpression/AttributesToGet; legacy AttributesToGet supported across GetItem/Query/Scan/BatchGet. Select implements SPECIFIC_ATTRIBUTES/ALL_ATTRIBUTES/ALL_PROJECTED_ATTRIBUTES and rejects invalid combos. Batch ops enforce 100/25 limits and reject duplicate/malformed keys. UpdateGlobalTableSettings persists billing mode and capacity; DescribeGlobalTableSettings reflects it. Query/Scan reject Limit <= 0. ExecuteStatement keeps ValidationException (only missing table maps to ResourceNotFoundException).
  - S3: Multipart additional checksum is COMPOSITE (base64(HASH(concat(raw part digests)))-N). DeleteObjects rejects >1000 keys with MalformedXML.
  - SQS: DeleteMessageBatch/ChangeMessageVisibilityBatch reject >10 entries and duplicate IDs. FIFO ReceiveRequestAttemptId replays the same batch within the visibility window.
  - SNS: PublishBatch returns EmptyBatchRequest for 0 entries. FIFO topics without ContentBasedDeduplication require MessageDeduplicationId per entry.
  - KMS: ListAliases implements real Limit/Marker pagination with Truncated/NextMarker.
  - ElastiCache: Increase/Decrease node groups apply the new shard count and slot partitioning; DescribeGlobalReplicationGroups reflects it; invalid counts rejected.
  - WAFv2: PutManagedRuleSetVersions persists published versions; ListManagedRuleSets/ListAvailableManagedRuleGroupVersions return what was published.
  - API Gateway: UpdateUsage updates per-key remaining quota; GetUsage returns used/remaining. GetSdkType returns real descriptors for known IDs.
  - Cognito: InitiateAuth and SignUp enforce SECRET_HASH for clients with a secret; ListUsers honors AttributesToGet.
  - IAM: UpdateUser rename preserves the existing ARN partition (aws/aws-cn/aws-us-gov/aws-iso*).

- **Dependencies**
  - Added `hmac` for Cognito SECRET_HASH validation.

<sup>Written for commit 3537621b05ef6405f401c628508106aa05246854. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

