### PR TITLE
feat(ec2): seed default VPC topology on boot (#1745 phase 1)

### DIFF
--- a/crates/fakecloud-conformance/tests/ec2.rs
+++ b/crates/fakecloud-conformance/tests/ec2.rs
@@ -3913,13 +3913,16 @@ async fn ec2_delete_network_acl() {
         .send()
         .await
         .unwrap();
-    assert!(c
+    // The deleted NACL is gone. (The account's default NACL still exists, like
+    // AWS — so assert the specific id is absent rather than an empty list.)
+    assert!(!c
         .describe_network_acls()
         .send()
         .await
         .unwrap()
         .network_acls()
-        .is_empty());
+        .iter()
+        .any(|n| n.network_acl_id() == Some(id.as_str())));
 }
 
 #[test_action("ec2", "CreateNetworkAclEntry", checksum = "084c817c")]

--- a/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
+++ b/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
@@ -490,7 +490,9 @@ async fn default_vpc_and_subnets_exist_on_boot() {
         "expected >=3 default subnets, got {}",
         defaults.len()
     );
-    assert!(defaults.iter().all(|sn| sn.vpc_id() == Some(vpc_id.as_str())));
+    assert!(defaults
+        .iter()
+        .all(|sn| sn.vpc_id() == Some(vpc_id.as_str())));
     assert!(defaults
         .iter()
         .all(|sn| sn.map_public_ip_on_launch() == Some(true)));
@@ -519,7 +521,9 @@ async fn run_instances_without_subnet_lands_in_default_vpc() {
     let inst = &resp.instances()[0];
     let vpc_id = inst.vpc_id().expect("instance should resolve a vpc-id");
     assert!(vpc_id.starts_with("vpc-"), "got {vpc_id}");
-    let subnet_id = inst.subnet_id().expect("instance should resolve a subnet-id");
+    let subnet_id = inst
+        .subnet_id()
+        .expect("instance should resolve a subnet-id");
     assert!(subnet_id.starts_with("subnet-"), "got {subnet_id}");
 
     // The resolved VPC is the default VPC.

--- a/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
+++ b/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
@@ -460,3 +460,82 @@ async fn describe_instances_rejects_out_of_range_max_results() {
         "expected InvalidParameterValue, got {msg}"
     );
 }
+
+// ---- Phase 1: default VPC topology (issue #1745) ----
+
+#[tokio::test]
+async fn default_vpc_and_subnets_exist_on_boot() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+
+    // Every account+region ships a default VPC, like AWS.
+    let vpcs = c.describe_vpcs().send().await.unwrap();
+    let default_vpc = vpcs
+        .vpcs()
+        .iter()
+        .find(|v| v.is_default() == Some(true))
+        .expect("a default VPC should exist on boot");
+    assert_eq!(default_vpc.cidr_block(), Some("172.31.0.0/16"));
+    let vpc_id = default_vpc.vpc_id().unwrap().to_string();
+
+    // Default subnets, one per AZ, all default-for-az.
+    let subnets = c.describe_subnets().send().await.unwrap();
+    let defaults: Vec<_> = subnets
+        .subnets()
+        .iter()
+        .filter(|sn| sn.default_for_az() == Some(true))
+        .collect();
+    assert!(
+        defaults.len() >= 3,
+        "expected >=3 default subnets, got {}",
+        defaults.len()
+    );
+    assert!(defaults.iter().all(|sn| sn.vpc_id() == Some(vpc_id.as_str())));
+    assert!(defaults
+        .iter()
+        .all(|sn| sn.map_public_ip_on_launch() == Some(true)));
+
+    // A `default` security group exists in the default VPC.
+    let sgs = c.describe_security_groups().send().await.unwrap();
+    assert!(sgs
+        .security_groups()
+        .iter()
+        .any(|g| g.group_name() == Some("default") && g.vpc_id() == Some(vpc_id.as_str())));
+}
+
+#[tokio::test]
+async fn run_instances_without_subnet_lands_in_default_vpc() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+
+    let resp = c
+        .run_instances()
+        .image_id("ami-12345678")
+        .min_count(1)
+        .max_count(1)
+        .send()
+        .await
+        .unwrap();
+    let inst = &resp.instances()[0];
+    let vpc_id = inst.vpc_id().expect("instance should resolve a vpc-id");
+    assert!(vpc_id.starts_with("vpc-"), "got {vpc_id}");
+    let subnet_id = inst.subnet_id().expect("instance should resolve a subnet-id");
+    assert!(subnet_id.starts_with("subnet-"), "got {subnet_id}");
+
+    // The resolved VPC is the default VPC.
+    let vpcs = c.describe_vpcs().vpc_ids(vpc_id).send().await.unwrap();
+    assert_eq!(vpcs.vpcs()[0].is_default(), Some(true));
+
+    // The instance picked up the VPC's default security group.
+    let described = c
+        .describe_instances()
+        .instance_ids(inst.instance_id().unwrap())
+        .send()
+        .await
+        .unwrap();
+    let groups = described.reservations()[0].instances()[0].security_groups();
+    assert!(
+        groups.iter().any(|g| g.group_name() == Some("default")),
+        "instance should attach the default security group"
+    );
+}

--- a/crates/fakecloud-ec2/src/defaults.rs
+++ b/crates/fakecloud-ec2/src/defaults.rs
@@ -1,0 +1,421 @@
+//! Default-VPC bootstrap.
+//!
+//! Every real AWS account has, per region, a *default VPC* (`172.31.0.0/16`)
+//! with an attached internet gateway, a main route table that sends
+//! `0.0.0.0/0` at the gateway, one default subnet per Availability Zone, a
+//! `default` security group, and a default network ACL. Callers that never
+//! touch the VPC APIs (the common case — `RunInstances` with no `SubnetId`)
+//! still expect their instances to land in that default VPC and come back from
+//! `DescribeInstances` with a real `vpc-…` / `subnet-…`.
+//!
+//! fakecloud builds the same fixtures the first time an account's EC2 state is
+//! constructed ([`Ec2State::new`](crate::state::Ec2State::new)). The resource
+//! ids are **deterministic** functions of the account id, region, and a role
+//! string, so the throwaway empty states that the read paths synthesize as a
+//! "not found" fallback report the *same* ids as the persisted account state —
+//! two `DescribeVpcs` calls before any write agree on the default VPC id.
+//!
+//! Per-VPC packet isolation (issue #1745 phase 2+) keys off this topology: a
+//! subnet whose route table has a `0.0.0.0/0 -> igw-…` route is public and gets
+//! a routable backing network; a subnet without one is private (`internal`).
+
+use crate::state::{
+    Ec2State, InternetGateway, NetworkAcl, NetworkAclAssoc, NetworkAclEntry, Route, RouteTable,
+    RouteTableAssociation, SecurityGroup, SecurityGroupRule, Subnet, Vpc,
+};
+
+/// CIDR of the default VPC, matching AWS.
+const DEFAULT_VPC_CIDR: &str = "172.31.0.0/16";
+
+/// The Availability Zone suffixes that receive a default subnet. AWS creates a
+/// default subnet in every AZ; three covers the cardinality every realistic
+/// test exercises (and keeps the deterministic CIDR layout simple).
+const DEFAULT_AZ_SUFFIXES: [&str; 3] = ["a", "b", "c"];
+
+/// Deterministic EC2 resource id: `<prefix>-<17 hex>` derived from the
+/// account, region, and a per-resource `role`. Stable across processes and
+/// across the throwaway empty states the read paths build, so the default
+/// VPC's ids never flap between calls.
+pub(crate) fn deterministic_id(prefix: &str, account: &str, region: &str, role: &str) -> String {
+    let seed = format!("{account}/{region}/{role}");
+    let h1 = fnv1a64(seed.as_bytes());
+    let h2 = fnv1a64(format!("{seed}/salt").as_bytes());
+    // 16 hex from the first hash + 1 nibble from the second = the 17 hex chars
+    // a modern EC2 long-id carries.
+    format!("{prefix}-{:016x}{:01x}", h1, h2 & 0xf)
+}
+
+/// FNV-1a 64-bit. A tiny, dependency-free, stable hash — we only need
+/// determinism, not cryptographic strength.
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bytes {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// AWS-style AZ-id prefix for a region: `us-east-1 -> use1`. Falls back to the
+/// region with dashes stripped for non-`a-b-N` shapes.
+fn az_id_prefix(region: &str) -> String {
+    let parts: Vec<&str> = region.split('-').collect();
+    if parts.len() == 3 && !parts[1].is_empty() {
+        format!(
+            "{}{}{}",
+            parts[0],
+            parts[1].chars().next().unwrap_or('x'),
+            parts[2]
+        )
+    } else {
+        region.replace('-', "")
+    }
+}
+
+/// The default VPC id for an account+region (also exposed so request handlers
+/// can resolve the implicit default without re-deriving the seed by hand).
+pub(crate) fn default_vpc_id(account: &str, region: &str) -> String {
+    deterministic_id("vpc", account, region, "default-vpc")
+}
+
+/// The default security-group id for an account+region.
+pub(crate) fn default_security_group_id(account: &str, region: &str) -> String {
+    deterministic_id("sg", account, region, "default-sg")
+}
+
+/// Populate `state` with the default VPC topology. Called once at state
+/// construction; idempotent in practice because the deterministic ids collide
+/// on re-entry.
+pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
+    let account = state.account_id.clone();
+    let region = if state.region.is_empty() {
+        "us-east-1".to_string()
+    } else {
+        state.region.clone()
+    };
+
+    let vpc_id = default_vpc_id(&account, &region);
+    let igw_id = deterministic_id("igw", &account, &region, "default-igw");
+    let rtb_id = deterministic_id("rtb", &account, &region, "default-rtb");
+    let acl_id = deterministic_id("acl", &account, &region, "default-acl");
+    let sg_id = default_security_group_id(&account, &region);
+
+    // --- default VPC ---
+    state.vpcs.insert(
+        vpc_id.clone(),
+        Vpc {
+            vpc_id: vpc_id.clone(),
+            cidr_block: DEFAULT_VPC_CIDR.to_string(),
+            state: "available".to_string(),
+            dhcp_options_id: "default".to_string(),
+            instance_tenancy: "default".to_string(),
+            is_default: true,
+            enable_dns_support: true,
+            enable_dns_hostnames: true,
+            cidr_associations: Vec::new(),
+        },
+    );
+
+    // --- internet gateway, attached to the default VPC ---
+    state.internet_gateways.insert(
+        igw_id.clone(),
+        InternetGateway {
+            internet_gateway_id: igw_id.clone(),
+            attachments: vec![(vpc_id.clone(), "available".to_string())],
+        },
+    );
+
+    // --- default subnets, one per AZ ---
+    let az_prefix = az_id_prefix(&region);
+    let mut subnet_ids = Vec::new();
+    for (idx, suffix) in DEFAULT_AZ_SUFFIXES.iter().enumerate() {
+        let subnet_id = deterministic_id(
+            "subnet",
+            &account,
+            &region,
+            &format!("default-subnet-{suffix}"),
+        );
+        let az = format!("{region}{suffix}");
+        state.subnets.insert(
+            subnet_id.clone(),
+            Subnet {
+                subnet_id: subnet_id.clone(),
+                vpc_id: vpc_id.clone(),
+                // /20 blocks carved from 172.31.0.0/16: .0, .16, .32 …
+                cidr_block: format!("172.31.{}.0/20", idx * 16),
+                availability_zone: az,
+                availability_zone_id: format!("{az_prefix}-az{}", idx + 1),
+                state: "available".to_string(),
+                available_ip_address_count: 4091,
+                default_for_az: true,
+                // Default subnets auto-assign public IPs, matching AWS.
+                map_public_ip_on_launch: true,
+                assign_ipv6_address_on_creation: false,
+                map_customer_owned_ip_on_launch: false,
+                enable_dns64: false,
+                private_dns_hostname_type: "ip-name".to_string(),
+            },
+        );
+        subnet_ids.push(subnet_id);
+    }
+
+    // --- main route table: local + default route at the IGW (public) ---
+    let mut associations = vec![RouteTableAssociation {
+        association_id: deterministic_id("rtbassoc", &account, &region, "default-rtb-main"),
+        route_table_id: rtb_id.clone(),
+        subnet_id: None,
+        gateway_id: None,
+        main: true,
+    }];
+    for sid in &subnet_ids {
+        associations.push(RouteTableAssociation {
+            association_id: deterministic_id(
+                "rtbassoc",
+                &account,
+                &region,
+                &format!("default-rtb-{sid}"),
+            ),
+            route_table_id: rtb_id.clone(),
+            subnet_id: Some(sid.clone()),
+            gateway_id: None,
+            main: false,
+        });
+    }
+    state.route_tables.insert(
+        rtb_id.clone(),
+        RouteTable {
+            route_table_id: rtb_id.clone(),
+            vpc_id: vpc_id.clone(),
+            routes: vec![
+                Route {
+                    destination_cidr_block: Some(DEFAULT_VPC_CIDR.to_string()),
+                    gateway_id: Some("local".to_string()),
+                    ..Default::default()
+                },
+                Route {
+                    destination_cidr_block: Some("0.0.0.0/0".to_string()),
+                    gateway_id: Some(igw_id.clone()),
+                    ..Default::default()
+                },
+            ],
+            associations,
+        },
+    );
+
+    // --- default security group: allow all from self, allow all egress ---
+    state.security_groups.insert(
+        sg_id.clone(),
+        SecurityGroup {
+            group_id: sg_id.clone(),
+            group_name: "default".to_string(),
+            description: "default VPC security group".to_string(),
+            vpc_id: vpc_id.clone(),
+            rules: vec![
+                SecurityGroupRule {
+                    rule_id: deterministic_id("sgr", &account, &region, "default-sg-ingress"),
+                    group_id: sg_id.clone(),
+                    is_egress: false,
+                    ip_protocol: "-1".to_string(),
+                    from_port: -1,
+                    to_port: -1,
+                    cidr_ipv4: None,
+                    cidr_ipv6: None,
+                    prefix_list_id: None,
+                    referenced_group_id: Some(sg_id.clone()),
+                    description: String::new(),
+                },
+                SecurityGroupRule {
+                    rule_id: deterministic_id("sgr", &account, &region, "default-sg-egress"),
+                    group_id: sg_id.clone(),
+                    is_egress: true,
+                    ip_protocol: "-1".to_string(),
+                    from_port: -1,
+                    to_port: -1,
+                    cidr_ipv4: Some("0.0.0.0/0".to_string()),
+                    cidr_ipv6: None,
+                    prefix_list_id: None,
+                    referenced_group_id: None,
+                    description: String::new(),
+                },
+            ],
+        },
+    );
+
+    // --- default network ACL: allow-all, associated with every default subnet ---
+    let nacl_associations = subnet_ids
+        .iter()
+        .map(|sid| NetworkAclAssoc {
+            association_id: deterministic_id(
+                "aclassoc",
+                &account,
+                &region,
+                &format!("default-acl-{sid}"),
+            ),
+            subnet_id: sid.clone(),
+        })
+        .collect();
+    state.network_acls.insert(
+        acl_id.clone(),
+        NetworkAcl {
+            network_acl_id: acl_id.clone(),
+            vpc_id: vpc_id.clone(),
+            is_default: true,
+            entries: vec![
+                allow_all_entry(false),
+                deny_all_entry(false),
+                allow_all_entry(true),
+                deny_all_entry(true),
+            ],
+            associations: nacl_associations,
+        },
+    );
+}
+
+fn allow_all_entry(egress: bool) -> NetworkAclEntry {
+    NetworkAclEntry {
+        rule_number: 100,
+        protocol: "-1".to_string(),
+        rule_action: "allow".to_string(),
+        egress,
+        cidr_block: Some("0.0.0.0/0".to_string()),
+        ipv6_cidr_block: None,
+        port_range: None,
+        icmp_type_code: None,
+    }
+}
+
+fn deny_all_entry(egress: bool) -> NetworkAclEntry {
+    NetworkAclEntry {
+        rule_number: 32767,
+        protocol: "-1".to_string(),
+        rule_action: "deny".to_string(),
+        egress,
+        cidr_block: Some("0.0.0.0/0".to_string()),
+        ipv6_cidr_block: None,
+        port_range: None,
+        icmp_type_code: None,
+    }
+}
+
+/// True when `subnet_id` resolves to a subnet whose route table carries a
+/// `0.0.0.0/0` route at an internet gateway — i.e. a *public* subnet. A subnet
+/// without such a route is private and (phase 2) backs onto an `internal`
+/// network. Subnets default to their VPC's main route table when not
+/// explicitly associated.
+// Consumed by phase-2 per-subnet networking (chooses `internal` vs routable
+// backing networks) and exercised by the tests below.
+#[allow(dead_code)]
+pub(crate) fn subnet_is_public(state: &Ec2State, subnet_id: &str) -> bool {
+    let Some(subnet) = state.subnets.get(subnet_id) else {
+        return false;
+    };
+    // An explicit association wins; otherwise fall back to the VPC's main table.
+    let explicit = state.route_tables.values().find(|rt| {
+        rt.associations
+            .iter()
+            .any(|a| a.subnet_id.as_deref() == Some(subnet_id))
+    });
+    let main = state
+        .route_tables
+        .values()
+        .find(|rt| rt.vpc_id == subnet.vpc_id && rt.associations.iter().any(|a| a.main));
+    let rt = explicit.or(main);
+    rt.map(route_table_has_igw_default).unwrap_or(false)
+}
+
+fn route_table_has_igw_default(rt: &RouteTable) -> bool {
+    rt.routes.iter().any(|r| {
+        r.destination_cidr_block.as_deref() == Some("0.0.0.0/0")
+            && r.gateway_id
+                .as_deref()
+                .map(|g| g.starts_with("igw-"))
+                .unwrap_or(false)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Ec2State;
+
+    #[test]
+    fn deterministic_id_is_stable_and_shaped() {
+        let a = deterministic_id("vpc", "123456789012", "us-east-1", "default-vpc");
+        let b = deterministic_id("vpc", "123456789012", "us-east-1", "default-vpc");
+        assert_eq!(a, b);
+        assert!(a.starts_with("vpc-"));
+        // 17 hex chars after the prefix, matching EC2 long-ids.
+        let hex = a.strip_prefix("vpc-").unwrap();
+        assert_eq!(hex.len(), 17);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn deterministic_id_varies_by_account_region_role() {
+        let base = deterministic_id("vpc", "111111111111", "us-east-1", "default-vpc");
+        assert_ne!(
+            base,
+            deterministic_id("vpc", "222222222222", "us-east-1", "default-vpc")
+        );
+        assert_ne!(
+            base,
+            deterministic_id("vpc", "111111111111", "eu-west-1", "default-vpc")
+        );
+        assert_ne!(
+            base,
+            deterministic_id("vpc", "111111111111", "us-east-1", "default-igw")
+        );
+    }
+
+    #[test]
+    fn az_id_prefix_matches_aws_shape() {
+        assert_eq!(az_id_prefix("us-east-1"), "use1");
+        assert_eq!(az_id_prefix("eu-west-2"), "euw2");
+        assert_eq!(az_id_prefix("ap-southeast-1"), "aps1");
+    }
+
+    #[test]
+    fn bootstrap_creates_full_default_topology() {
+        let state = Ec2State::new("123456789012", "us-east-1");
+        // exactly one VPC, marked default
+        assert_eq!(state.vpcs.len(), 1);
+        let vpc = state.vpcs.values().next().unwrap();
+        assert!(vpc.is_default);
+        assert_eq!(vpc.cidr_block, "172.31.0.0/16");
+        // one subnet per AZ suffix, all default_for_az + public
+        assert_eq!(state.subnets.len(), DEFAULT_AZ_SUFFIXES.len());
+        assert!(state.subnets.values().all(|s| s.default_for_az));
+        assert!(state.subnets.values().all(|s| s.map_public_ip_on_launch));
+        // IGW attached to the default VPC
+        assert_eq!(state.internet_gateways.len(), 1);
+        let igw = state.internet_gateways.values().next().unwrap();
+        assert_eq!(igw.attachments[0].0, vpc.vpc_id);
+        // default SG + default NACL
+        let sg = state.security_groups.values().next().unwrap();
+        assert_eq!(sg.group_name, "default");
+        assert!(state.network_acls.values().next().unwrap().is_default);
+    }
+
+    #[test]
+    fn default_subnets_are_public() {
+        let state = Ec2State::new("123456789012", "us-east-1");
+        for sid in state.subnets.keys() {
+            assert!(
+                subnet_is_public(&state, sid),
+                "subnet {sid} should be public"
+            );
+        }
+    }
+
+    #[test]
+    fn ids_match_across_fresh_states() {
+        // The throwaway "empty" states read paths build must agree with the
+        // persisted account state on the default VPC id.
+        let a = Ec2State::new("123456789012", "us-east-1");
+        let b = Ec2State::new("123456789012", "us-east-1");
+        let a_vpc: Vec<_> = a.vpcs.keys().collect();
+        let b_vpc: Vec<_> = b.vpcs.keys().collect();
+        assert_eq!(a_vpc, b_vpc);
+        assert_eq!(a_vpc[0], &default_vpc_id("123456789012", "us-east-1"));
+    }
+}

--- a/crates/fakecloud-ec2/src/lib.rs
+++ b/crates/fakecloud-ec2/src/lib.rs
@@ -7,6 +7,7 @@
 //! tagging subsystem, and the region/AZ/account-attribute describe primitives
 //! that almost every SDK client calls implicitly.
 
+pub mod defaults;
 pub mod runtime;
 pub mod service;
 pub mod service_helpers;

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -32,11 +32,30 @@ fn state_xml(tag: &str, code: i64, name: &str) -> String {
     format!("<{tag}><code>{code}</code><name>{name}</name></{tag}>")
 }
 
-fn instance_xml(i: &Instance, tags: &[Tag], owner: &str) -> String {
+/// Map of `security-group-id -> group-name` for the whole state, so
+/// DescribeInstances can render the real `groupName` (AWS returns the name, not
+/// the id) instead of echoing the id back.
+fn sg_name_map(state: &Ec2State) -> HashMap<String, String> {
+    state
+        .security_groups
+        .values()
+        .map(|g| (g.group_id.clone(), g.group_name.clone()))
+        .collect()
+}
+
+fn instance_xml(
+    i: &Instance,
+    tags: &[Tag],
+    owner: &str,
+    sg_names: &HashMap<String, String>,
+) -> String {
     let groups: Vec<String> = i
         .security_group_ids
         .iter()
-        .map(|g| format!("{}{}", ec2_elem("groupId", g), ec2_elem("groupName", g)))
+        .map(|g| {
+            let name = sg_names.get(g).map(String::as_str).unwrap_or(g.as_str());
+            format!("{}{}", ec2_elem("groupId", g), ec2_elem("groupName", name))
+        })
         .collect();
     let public = i
         .public_ip
@@ -197,8 +216,8 @@ pub(crate) async fn run_instances(
         .cloned()
         .unwrap_or_else(|| "t3.micro".to_string());
     let key_name = req.query_params.get("KeyName").cloned();
-    let subnet_id = req.query_params.get("SubnetId").cloned();
-    let sg_ids = indexed_list(&req.query_params, "SecurityGroupId");
+    let mut subnet_id = req.query_params.get("SubnetId").cloned();
+    let mut sg_ids = indexed_list(&req.query_params, "SecurityGroupId");
     let user_data = req.query_params.get("UserData").cloned();
     let owner = req.account_id.clone();
     let az = format!(
@@ -227,8 +246,43 @@ pub(crate) async fn run_instances(
         .map(|v| v == "true");
     let (vpc_id, subnet_auto_public) = {
         let accounts = svc.state.read();
-        match (accounts.get(&req.account_id), subnet_id.as_ref()) {
-            (Some(state), Some(sid)) => state
+        let empty = Ec2State::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        // No explicit subnet: land in the default VPC's default subnet for the
+        // target AZ (falling back to any default subnet), exactly as AWS does.
+        // This fills `subnet_id`/`vpc_id` so DescribeInstances reports a real
+        // subnet/VPC and phase-2 per-subnet networking has something to key on.
+        if subnet_id.is_none() {
+            if let Some(s) = state
+                .subnets
+                .values()
+                .filter(|s| s.default_for_az)
+                .find(|s| s.availability_zone == az)
+                .or_else(|| state.subnets.values().find(|s| s.default_for_az))
+            {
+                subnet_id = Some(s.subnet_id.clone());
+            }
+        }
+        // When the caller named no security group, AWS attaches the VPC's
+        // `default` group. Resolve it from the subnet's VPC (or the default VPC).
+        let resolved_vpc = subnet_id
+            .as_ref()
+            .and_then(|sid| state.subnets.get(sid))
+            .map(|s| s.vpc_id.clone());
+        if sg_ids.is_empty() {
+            let vpc = resolved_vpc
+                .clone()
+                .unwrap_or_else(|| crate::defaults::default_vpc_id(&req.account_id, &req.region));
+            if let Some(sg) = state
+                .security_groups
+                .values()
+                .find(|g| g.vpc_id == vpc && g.group_name == "default")
+            {
+                sg_ids = vec![sg.group_id.clone()];
+            }
+        }
+        match subnet_id.as_ref() {
+            Some(sid) => state
                 .subnets
                 .get(sid)
                 .map(|s| {
@@ -238,9 +292,15 @@ pub(crate) async fn run_instances(
                     )
                 })
                 .unwrap_or((None, false)),
-            // No subnet specified: treat as a launch into the default VPC,
-            // which assigns public IPs by default.
-            _ => (None, true),
+            // No subnet (and no default subnet found): still a default-VPC
+            // launch, which assigns public IPs by default.
+            None => (
+                Some(crate::defaults::default_vpc_id(
+                    &req.account_id,
+                    &req.region,
+                )),
+                true,
+            ),
         }
     };
     let assign_public = assoc_public.unwrap_or(subnet_auto_public);
@@ -257,6 +317,7 @@ pub(crate) async fn run_instances(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        let sg_names = sg_name_map(state);
         for (idx, id) in ids.iter().enumerate() {
             let inst = Instance {
                 instance_id: id.clone(),
@@ -305,7 +366,7 @@ pub(crate) async fn run_instances(
                 "instance",
             );
             let tags = state.tags_for(id).to_vec();
-            rendered.push(instance_xml(&inst, &tags, &owner));
+            rendered.push(instance_xml(&inst, &tags, &owner, &sg_names));
             state.instances.insert(id.clone(), inst);
         }
     }
@@ -689,6 +750,7 @@ pub(crate) fn describe_instances(
     let (page, token) = crate::service_helpers::paginate(&matching, next_token, max_results);
 
     // Group the page back into reservations, preserving the sorted order.
+    let sg_names = sg_name_map(state);
     let mut by_res: HashMap<String, Vec<String>> = HashMap::new();
     let mut order: Vec<String> = Vec::new();
     for i in page {
@@ -698,7 +760,12 @@ pub(crate) fn describe_instances(
         by_res
             .entry(i.reservation_id.clone())
             .or_default()
-            .push(instance_xml(i, state.tags_for(&i.instance_id), &owner));
+            .push(instance_xml(
+                i,
+                state.tags_for(&i.instance_id),
+                &owner,
+                &sg_names,
+            ));
     }
     let reservations: Vec<String> = order
         .iter()
@@ -874,8 +941,8 @@ pub(crate) fn describe_instance_attribute(
     let attribute = require(&req.query_params, "Attribute")?;
     validate_enum(&req.query_params, "Attribute", ATTRIBUTE_VALUES)?;
     let accounts = svc.state.read();
-    let inst = accounts
-        .get(&req.account_id)
+    let acct_state = accounts.get(&req.account_id);
+    let inst = acct_state
         .and_then(|s| s.instances.get(&id))
         .ok_or_else(|| crate::service_helpers::instance_not_found(&id))?;
     let attr_xml = match attribute.as_str() {
@@ -908,10 +975,14 @@ pub(crate) fn describe_instance_attribute(
             None => "<userData/>".to_string(),
         },
         "groupSet" => {
+            let sg_names = acct_state.map(sg_name_map).unwrap_or_default();
             let groups: Vec<String> = inst
                 .security_group_ids
                 .iter()
-                .map(|g| format!("{}{}", ec2_elem("groupId", g), ec2_elem("groupName", g)))
+                .map(|g| {
+                    let name = sg_names.get(g).map(String::as_str).unwrap_or(g.as_str());
+                    format!("{}{}", ec2_elem("groupId", g), ec2_elem("groupName", name))
+                })
                 .collect();
             ec2_list("groupSet", &groups)
         }

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -1231,11 +1231,18 @@ pub struct Ec2State {
 
 impl Ec2State {
     pub fn new(account_id: &str, region: &str) -> Self {
-        Self {
+        let mut state = Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
             ..Default::default()
-        }
+        };
+        // Seed the default VPC topology (VPC, IGW, subnets, route table,
+        // security group, NACL) the way every AWS account+region ships one, so
+        // callers that never touch the VPC APIs still launch into a real,
+        // isolatable network. Ids are deterministic, so the throwaway empty
+        // states the read paths build report the same ids as this one.
+        crate::defaults::bootstrap_default_network(&mut state);
+        state
     }
 
     /// Replace the tag set for `resource_id` with `tags` merged over any


### PR DESCRIPTION
## Summary

Phase 1 of EC2 real network isolation (#1745). Today EC2 VPC/subnet/SG/NACL are metadata-only and only exist when a caller creates them, so `RunInstances` with no `SubnetId` returns a null `vpc-id` and there is nothing for per-VPC isolation to key on.

This seeds the **default VPC topology** the first time an account's EC2 state is constructed, the way every AWS account+region ships one:

- Default VPC `172.31.0.0/16` (`isDefault=true`) + attached internet gateway
- Main route table: `local` + `0.0.0.0/0 -> igw-…` (this is what marks a subnet *public*)
- One default subnet per AZ (`a`/`b`/`c`), `default-for-az`, `map-public-ip-on-launch`
- Default security group (`default`: allow-from-self ingress + allow-all egress)
- Default network ACL (allow-all), associated with the default subnets

Resource ids are **deterministic** functions of account+region, so the throwaway "empty" states the read paths synthesize report the same ids as the persisted account state (two `DescribeVpcs` before any write agree on the default VPC id).

`RunInstances` now:
- resolves an unspecified subnet to the default subnet for the target AZ,
- always fills `vpc-id`,
- attaches the VPC's `default` security group when none is named.

`DescribeInstances` now renders the real security-group **name** (it was echoing the id as the name).

`defaults::subnet_is_public` exposes the public/private (IGW) distinction that **phase 2** uses to pick routable vs `internal` backing networks.

## Test plan

- `cargo test -p fakecloud-ec2` — unit tests for deterministic ids + full default topology
- `cargo test -p fakecloud-e2e --test ec2_instance_control_plane` — default VPC/subnet/SG visible on boot; no-subnet launch lands in the default VPC with the default SG
- `cargo test -p fakecloud-conformance --test ec2` — 769/769 (updated `ec2_delete_network_acl` to assert the deleted id is absent rather than an empty list, since the default NACL now always exists, matching AWS)
- `cargo clippy -p fakecloud-ec2 --all-targets -- -D warnings` clean

Docs/website/SDK updates for the full networking story land together in the phase-5 PR (introspection endpoint + isolation + compose interop).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds the default VPC topology on EC2 state init with deterministic IDs so no‑subnet launches behave like AWS and per‑VPC isolation has stable anchors. Phase 1 for #1745.

- **New Features**
  - Bootstrap default network: VPC `172.31.0.0/16` with IGW; main route table `0.0.0.0/0 -> igw`; default subnets for AZs `a/b/c` with public IPs; `default` security group; default NACL.
  - Deterministic resource IDs per account+region so read paths and persisted state return the same IDs.
  - `RunInstances`: resolves missing `SubnetId` to the AZ’s default subnet (fallback to any default), always sets `vpc-id`, and auto‑attaches the VPC’s `default` security group when none is provided.
  - `DescribeInstances` renders real security group names; `defaults::subnet_is_public` exposes public/private checks used in #1745 phase 2.

<sup>Written for commit e2fc151c199a7e31da100250223a8f0b60112322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

