### PR TITLE
feat(ec2): per-subnet docker networks for L3 isolation (#1745 phase 2)

### DIFF
--- a/crates/fakecloud-e2e/tests/ec2_network_isolation.rs
+++ b/crates/fakecloud-e2e/tests/ec2_network_isolation.rs
@@ -1,0 +1,246 @@
+//! EC2 per-subnet network isolation E2E (issue #1745 phase 2). Proves that
+//! `RunInstances` attaches each backing container to a per-subnet daemon
+//! network so:
+//!   - instances in the *same* subnet share a bridge and can reach each other,
+//!   - instances in *different* VPCs/subnets land on different bridges and
+//!     cannot route to each other,
+//!   - a private subnet (no internet gateway) backs onto an `--internal`
+//!     network while a public/default subnet does not.
+//!
+//! Requires Docker (hard-fails in CI, skips locally), like the runtime E2E.
+
+mod helpers;
+
+use helpers::TestServer;
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("Skipping {test}: docker not available");
+    false
+}
+
+/// Run `docker <args>` and return trimmed stdout (empty on failure).
+fn docker(args: &[&str]) -> String {
+    let out = std::process::Command::new("docker")
+        .args(args)
+        .output()
+        .expect("spawn docker");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Run `docker <args>` and return whether it exited 0 (for `exec ping`).
+fn docker_ok(args: &[&str]) -> bool {
+    std::process::Command::new("docker")
+        .args(args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// The container id backing an instance, via the `fakecloud-ec2=<id>` label.
+fn container_for(instance_id: &str) -> String {
+    docker(&[
+        "ps",
+        "-aq",
+        "--filter",
+        &format!("label=fakecloud-ec2={instance_id}"),
+    ])
+}
+
+/// The set of daemon networks a container is attached to.
+fn networks_of(container_id: &str) -> Vec<String> {
+    docker(&[
+        "inspect",
+        "-f",
+        "{{range $k, $v := .NetworkSettings.Networks}}{{$k}} {{end}}",
+        container_id,
+    ])
+    .split_whitespace()
+    .map(str::to_string)
+    .collect()
+}
+
+async fn run_in_subnet(c: &aws_sdk_ec2::Client, subnet_id: Option<&str>) -> String {
+    let mut req = c
+        .run_instances()
+        .image_id("ami-12345678")
+        .min_count(1)
+        .max_count(1);
+    if let Some(s) = subnet_id {
+        req = req.subnet_id(s);
+    }
+    let resp = req.send().await.unwrap();
+    resp.instances()[0].instance_id().unwrap().to_string()
+}
+
+/// Poll DescribeInstances until `id` is `running`; return its real private IP.
+async fn wait_running(c: &aws_sdk_ec2::Client, id: &str) -> String {
+    for _ in 0..80 {
+        let d = c
+            .describe_instances()
+            .instance_ids(id)
+            .send()
+            .await
+            .unwrap();
+        if let Some(inst) = d
+            .reservations()
+            .iter()
+            .flat_map(|r| r.instances())
+            .find(|i| i.instance_id() == Some(id))
+        {
+            if inst.state().and_then(|s| s.name()).map(|n| n.as_str()) == Some("running") {
+                let ip = inst.private_ip_address().unwrap_or_default().to_string();
+                if !ip.is_empty() && !ip.starts_with("10.0.0.") {
+                    return ip;
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    panic!("instance {id} never reached running with a real container IP");
+}
+
+#[tokio::test]
+async fn instances_isolate_by_subnet_network() {
+    if !require_docker_or_skip("instances_isolate_by_subnet_network") {
+        return;
+    }
+    std::env::set_var("FAKECLOUD_EC2_DEFAULT_IMAGE", "alpine:3");
+
+    let server = TestServer::start().await;
+    let c = server.ec2_client().await;
+
+    // Two VPCs, each with one (private, no-IGW) subnet.
+    let vpc_a = c
+        .create_vpc()
+        .cidr_block("10.10.0.0/16")
+        .send()
+        .await
+        .unwrap();
+    let vpc_a = vpc_a.vpc().unwrap().vpc_id().unwrap().to_string();
+    let subnet_a = c
+        .create_subnet()
+        .vpc_id(&vpc_a)
+        .cidr_block("10.10.1.0/24")
+        .send()
+        .await
+        .unwrap();
+    let subnet_a = subnet_a.subnet().unwrap().subnet_id().unwrap().to_string();
+
+    let vpc_b = c
+        .create_vpc()
+        .cidr_block("10.20.0.0/16")
+        .send()
+        .await
+        .unwrap();
+    let vpc_b = vpc_b.vpc().unwrap().vpc_id().unwrap().to_string();
+    let subnet_b = c
+        .create_subnet()
+        .vpc_id(&vpc_b)
+        .cidr_block("10.20.1.0/24")
+        .send()
+        .await
+        .unwrap();
+    let subnet_b = subnet_b.subnet().unwrap().subnet_id().unwrap().to_string();
+
+    // a1 + a2 in subnet A; b1 in subnet B; c1 with no subnet (default subnet).
+    let a1 = run_in_subnet(&c, Some(&subnet_a)).await;
+    let a2 = run_in_subnet(&c, Some(&subnet_a)).await;
+    let b1 = run_in_subnet(&c, Some(&subnet_b)).await;
+    let c1 = run_in_subnet(&c, None).await;
+
+    let a1_ip = wait_running(&c, &a1).await;
+    let a2_ip = wait_running(&c, &a2).await;
+    let b1_ip = wait_running(&c, &b1).await;
+    let _c1_ip = wait_running(&c, &c1).await;
+
+    let net_a = format!("fakecloud-subnet-{subnet_a}");
+    let net_b = format!("fakecloud-subnet-{subnet_b}");
+    let (ca1, ca2, cb1, cc1) = (
+        container_for(&a1),
+        container_for(&a2),
+        container_for(&b1),
+        container_for(&c1),
+    );
+
+    // Same-subnet instances share the subnet's network.
+    assert!(
+        networks_of(&ca1).contains(&net_a),
+        "a1 should be on {net_a}, got {:?}",
+        networks_of(&ca1)
+    );
+    assert!(
+        networks_of(&ca2).contains(&net_a),
+        "a2 should be on {net_a}"
+    );
+    // Different-VPC instance is on a different network.
+    assert!(
+        networks_of(&cb1).contains(&net_b),
+        "b1 should be on {net_b}"
+    );
+    assert!(
+        !networks_of(&cb1).contains(&net_a),
+        "b1 must not share subnet A's network"
+    );
+
+    // Connectivity: a1 -> a2 (same subnet) works; a1 -> b1 (cross VPC) fails.
+    assert!(
+        docker_ok(&["exec", &ca1, "ping", "-c", "1", "-W", "2", &a2_ip]),
+        "same-subnet instances should reach each other"
+    );
+    assert!(
+        !docker_ok(&["exec", &ca1, "ping", "-c", "1", "-W", "2", &b1_ip]),
+        "instances in different VPCs must not reach each other"
+    );
+
+    // The no-IGW subnet network is `--internal`; the default subnet (public,
+    // has a 0.0.0.0/0 -> igw route) is not.
+    assert_eq!(
+        docker(&["network", "inspect", "-f", "{{.Internal}}", &net_a]),
+        "true",
+        "private (no-IGW) subnet should back onto an internal network"
+    );
+    let default_net = networks_of(&cc1)
+        .into_iter()
+        .find(|n| n.starts_with("fakecloud-subnet-"))
+        .expect("default-subnet instance should be on a subnet network");
+    assert_eq!(
+        docker(&["network", "inspect", "-f", "{{.Internal}}", &default_net]),
+        "false",
+        "public/default subnet should not be internal"
+    );
+
+    // Cleanup: terminate instances, then remove the subnet networks.
+    for id in [&a1, &a2, &b1, &c1] {
+        let _ = c.terminate_instances().instance_ids(id).send().await;
+    }
+    for _ in 0..40 {
+        if [&a1, &a2, &b1, &c1]
+            .iter()
+            .all(|id| container_for(id).is_empty())
+        {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    for net in [&net_a, &net_b, &default_net] {
+        let _ = docker(&["network", "rm", net]);
+    }
+}

--- a/crates/fakecloud-e2e/tests/ec2_network_isolation.rs
+++ b/crates/fakecloud-e2e/tests/ec2_network_isolation.rs
@@ -166,7 +166,8 @@ async fn instances_isolate_by_subnet_network() {
     let b1 = run_in_subnet(&c, Some(&subnet_b)).await;
     let c1 = run_in_subnet(&c, None).await;
 
-    let a1_ip = wait_running(&c, &a1).await;
+    // a1 must be up before we exec into it; its own IP isn't needed.
+    wait_running(&c, &a1).await;
     let a2_ip = wait_running(&c, &a2).await;
     let b1_ip = wait_running(&c, &b1).await;
     let _c1_ip = wait_running(&c, &c1).await;

--- a/crates/fakecloud-ec2/src/runtime/k8s.rs
+++ b/crates/fakecloud-ec2/src/runtime/k8s.rs
@@ -124,6 +124,9 @@ impl K8sInstances {
         Ok(RunningInstance {
             container_id: pod_name,
             private_ip: pod_ip,
+            // k8s pods share a flat network; per-subnet isolation is a
+            // NetworkPolicy concern (#1745 phase 4), not a daemon network.
+            network: None,
         })
     }
 

--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -62,6 +62,32 @@ pub struct RunningInstance {
     /// The instance's private IP — the container's address on the daemon
     /// network (Docker) or the Pod IP (k8s).
     pub private_ip: String,
+    /// Name of the backing daemon network the container was attached to
+    /// (`fakecloud-subnet-<id>`), or `None` when it ran on the default bridge
+    /// (no network spec, or creation failed and we fell back). Surfaced for
+    /// introspection (#1745 phase 5).
+    pub network: Option<String>,
+}
+
+/// The L3 placement of an instance's backing container: which subnet it lands
+/// in and whether that subnet is private.
+///
+/// Per-subnet networks give the isolation #1745 wants for free: two instances
+/// in the same subnet share a bridge and can talk; instances in different
+/// subnets / VPCs land on different bridges and cannot route to each other.
+#[derive(Debug, Clone)]
+pub struct InstanceNetwork {
+    /// The EC2 subnet id the instance launched into.
+    pub subnet_id: String,
+    /// True when the subnet has no `0.0.0.0/0 -> igw` route (private): the
+    /// backing network is created `--internal` (no NAT to host/internet).
+    pub internal: bool,
+}
+
+/// The daemon network name backing an EC2 subnet. Stable per subnet so every
+/// instance in the subnet attaches to the same bridge.
+pub fn subnet_network_name(subnet_id: &str) -> String {
+    format!("fakecloud-subnet-{subnet_id}")
 }
 
 /// What the runtime remembers per instance so it can drive the backing
@@ -80,6 +106,11 @@ struct InstanceRecord {
     /// survive a k8s `Start`/`Reboot` recreate, so they're stored here
     /// rather than re-read from the control plane.
     tags: BTreeMap<String, String>,
+    /// The instance's subnet placement, captured at `RunInstances` so a k8s
+    /// `Start`/`Reboot` recreate re-applies the same network and phase-5
+    /// introspection can report the backing network. `None` in metadata-only
+    /// network mode.
+    network: Option<InstanceNetwork>,
 }
 
 /// The selected backing-container backend.
@@ -139,10 +170,17 @@ impl Ec2Runtime {
         instance_id: &str,
         user_data: Option<&str>,
         tags: &BTreeMap<String, String>,
+        network: Option<&InstanceNetwork>,
     ) -> Result<RunningInstance, RuntimeError> {
         let image = default_image();
         let running = match &self.backend {
-            InstanceBackend::Docker(d) => d.run_instance(instance_id, &image, user_data).await?,
+            // Docker attaches the container to the subnet's per-VPC bridge for
+            // L3 isolation. k8s pods share a flat network; isolation there is a
+            // NetworkPolicy concern handled separately (#1745 phase 4).
+            InstanceBackend::Docker(d) => {
+                d.run_instance(instance_id, &image, user_data, network)
+                    .await?
+            }
             InstanceBackend::K8s(k) => k.spawn_pod(instance_id, &image, user_data, tags).await?,
         };
         self.instances.write().insert(
@@ -152,6 +190,7 @@ impl Ec2Runtime {
                 image,
                 user_data: user_data.map(str::to_string),
                 tags: tags.clone(),
+                network: network.cloned(),
             },
         );
         Ok(running)
@@ -178,11 +217,16 @@ impl Ec2Runtime {
         let record = self.instances.read().get(instance_id)?.clone();
         match &self.backend {
             InstanceBackend::Docker(d) => {
-                // Same container; only the IP may change.
+                // Same container; only the IP may change. The subnet network the
+                // container was created on persists across stop/start.
                 let private_ip = d.start(&record.handle).await?;
                 Some(RunningInstance {
                     container_id: record.handle,
                     private_ip,
+                    network: record
+                        .network
+                        .as_ref()
+                        .map(|n| subnet_network_name(&n.subnet_id)),
                 })
             }
             InstanceBackend::K8s(k) => {
@@ -324,7 +368,16 @@ impl DockerInstances {
         instance_id: &str,
         image: &str,
         user_data: Option<&str>,
+        network: Option<&InstanceNetwork>,
     ) -> Result<RunningInstance, RuntimeError> {
+        // Ensure the subnet's bridge exists and attach to it for L3 isolation.
+        // Network creation is best-effort: on failure we fall back to the
+        // default bridge so the instance still boots (no regression vs today).
+        let attached_network = match network {
+            Some(net) => self.ensure_subnet_network(net).await,
+            None => None,
+        };
+
         let mut args: Vec<String> = vec![
             "run".to_string(),
             "-d".to_string(),
@@ -332,8 +385,12 @@ impl DockerInstances {
             format!("fakecloud-ec2={instance_id}"),
             "--label".to_string(),
             format!("fakecloud-instance={}", self.instance_id),
-            image.to_string(),
         ];
+        if let Some(name) = &attached_network {
+            args.push("--network".to_string());
+            args.push(name.clone());
+        }
+        args.push(image.to_string());
         args.extend(boot_command(user_data));
 
         let output = tokio::process::Command::new(&self.cli)
@@ -357,7 +414,61 @@ impl DockerInstances {
         Ok(RunningInstance {
             container_id,
             private_ip,
+            network: attached_network,
         })
+    }
+
+    /// Create (idempotently) the daemon network backing a subnet and return its
+    /// name, or `None` if creation failed (caller falls back to the default
+    /// bridge). The network carries the shared `fakecloud-instance` ownership
+    /// label so the startup reaper prunes it after an ungraceful restart, plus
+    /// a `fakecloud-subnet=<id>` label for introspection. Private subnets get
+    /// an `--internal` network (no NAT to the host/internet).
+    async fn ensure_subnet_network(&self, net: &InstanceNetwork) -> Option<String> {
+        let name = subnet_network_name(&net.subnet_id);
+        let mut args = vec!["network".to_string(), "create".to_string()];
+        if net.internal {
+            args.push("--internal".to_string());
+        }
+        args.push("--label".to_string());
+        args.push(format!("fakecloud-subnet={}", net.subnet_id));
+        args.push("--label".to_string());
+        args.push(format!("fakecloud-instance={}", self.instance_id));
+        args.push(name.clone());
+
+        let output = tokio::process::Command::new(&self.cli)
+            .args(&args)
+            .output()
+            .await;
+        match output {
+            // Created fresh.
+            Ok(out) if out.status.success() => Some(name),
+            // Already exists (another instance in the same subnet created it):
+            // a benign race — the network is there, so attach to it.
+            Ok(out) => {
+                let err = String::from_utf8_lossy(&out.stderr);
+                if err.contains("already exists") || err.contains("exists") {
+                    Some(name)
+                } else {
+                    tracing::warn!(
+                        subnet = %net.subnet_id,
+                        network = %name,
+                        error = %err.trim(),
+                        "subnet network creation failed; falling back to default bridge"
+                    );
+                    None
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    subnet = %net.subnet_id,
+                    network = %name,
+                    error = %e,
+                    "subnet network creation failed; falling back to default bridge"
+                );
+                None
+            }
+        }
     }
 
     /// Read the container's private IP from `inspect`. Returns `None` if the

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -244,7 +244,7 @@ pub(crate) async fn run_instances(
         .get("NetworkInterface.1.AssociatePublicIpAddress")
         .or_else(|| req.query_params.get("AssociatePublicIpAddress"))
         .map(|v| v == "true");
-    let (vpc_id, subnet_auto_public) = {
+    let (vpc_id, subnet_auto_public, instance_network) = {
         let accounts = svc.state.read();
         let empty = Ec2State::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -281,7 +281,15 @@ pub(crate) async fn run_instances(
                 sg_ids = vec![sg.group_id.clone()];
             }
         }
-        match subnet_id.as_ref() {
+        // The backing per-subnet network for phase-2 L3 isolation. A subnet
+        // with no `0.0.0.0/0 -> igw` route is private -> `internal` network.
+        let instance_network = subnet_id
+            .as_ref()
+            .map(|sid| crate::runtime::InstanceNetwork {
+                subnet_id: sid.clone(),
+                internal: !crate::defaults::subnet_is_public(state, sid),
+            });
+        let (vpc, auto_public) = match subnet_id.as_ref() {
             Some(sid) => state
                 .subnets
                 .get(sid)
@@ -301,7 +309,8 @@ pub(crate) async fn run_instances(
                 )),
                 true,
             ),
-        }
+        };
+        (vpc, auto_public, instance_network)
     };
     let assign_public = assoc_public.unwrap_or(subnet_auto_public);
 
@@ -377,11 +386,17 @@ pub(crate) async fn run_instances(
         let runtime = svc.runtime.clone();
         let account_id = req.account_id.clone();
         let ids = ids.clone();
+        let instance_network = instance_network.clone();
         tokio::spawn(async move {
             for id in &ids {
                 let running = if let Some(rt) = &runtime {
                     match rt
-                        .run_instance(id, user_data.as_deref(), &instance_tags)
+                        .run_instance(
+                            id,
+                            user_data.as_deref(),
+                            &instance_tags,
+                            instance_network.as_ref(),
+                        )
                         .await
                     {
                         Ok(r) => Some(r),

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -929,6 +929,7 @@ impl Ec2Service {
             id: String,
             user_data: Option<String>,
             tags: std::collections::BTreeMap<String, String>,
+            network: Option<crate::runtime::InstanceNetwork>,
         }
 
         let pending: Vec<Pending> = {
@@ -940,6 +941,15 @@ impl Ec2Service {
                 // `state` at once when re-deriving per-instance Pod tags.
                 let tag_snapshot: std::collections::HashMap<String, Vec<crate::state::Tag>> =
                     state.tags.clone();
+                // Which subnets are public (have an IGW default route), computed
+                // before the mutable instance loop so we can re-derive each
+                // recovered instance's `internal` flag without a second borrow.
+                let public_subnets: std::collections::HashSet<String> = state
+                    .subnets
+                    .keys()
+                    .filter(|sid| crate::defaults::subnet_is_public(state, sid))
+                    .cloned()
+                    .collect();
                 for (id, inst) in state.instances.iter_mut() {
                     // Only running/pending instances need a live container; the
                     // stale container_id is dropped (the reaper removed it).
@@ -954,6 +964,13 @@ impl Ec2Service {
                                 .collect()
                         })
                         .unwrap_or_default();
+                    let network =
+                        inst.subnet_id
+                            .clone()
+                            .map(|sid| crate::runtime::InstanceNetwork {
+                                internal: !public_subnets.contains(&sid),
+                                subnet_id: sid,
+                            });
                     inst.state_code = 0;
                     inst.state_name = "pending".to_string();
                     inst.container_id = None;
@@ -962,6 +979,7 @@ impl Ec2Service {
                         id: id.clone(),
                         user_data: inst.user_data.clone(),
                         tags,
+                        network,
                     });
                 }
             }
@@ -981,7 +999,7 @@ impl Ec2Service {
             let state = self.state.clone();
             tokio::spawn(async move {
                 let running = runtime
-                    .run_instance(&p.id, p.user_data.as_deref(), &p.tags)
+                    .run_instance(&p.id, p.user_data.as_deref(), &p.tags, p.network.as_ref())
                     .await;
                 let reap = {
                     let mut accounts = state.write();

--- a/crates/fakecloud-ec2/tests/k8s_integration.rs
+++ b/crates/fakecloud-ec2/tests/k8s_integration.rs
@@ -157,12 +157,14 @@ async fn instance_lifecycle_boots_pod_runs_user_data_and_recreates_on_start() {
     let api = pods_api(&c);
     let instance_id = "i-0k8slifecycle";
 
-    // RunInstances boots a Pod and runs user-data at boot.
+    // RunInstances boots a Pod and runs user-data at boot. (k8s ignores the
+    // per-subnet network spec — isolation there is a NetworkPolicy concern.)
     let running = rt
         .run_instance(
             instance_id,
             Some(USER_DATA_B64),
             &std::collections::BTreeMap::new(),
+            None,
         )
         .await
         .expect("run_instance");


### PR DESCRIPTION
## Summary

Phase 2 of EC2 real network isolation (#1745). Stacked on #1754 (phase 1) — base will retarget to `main` once that merges.

Backing containers all shared the default Docker bridge, so instances in different VPCs could reach each other and there was no L3 segmentation. This attaches each instance's container to a **per-subnet daemon network**:

- `RunInstances` computes an `InstanceNetwork { subnet_id, internal }` from the resolved subnet (`internal` = the subnet has no `0.0.0.0/0 -> igw` route) and passes it to the runtime.
- The Docker backend ensures `fakecloud-subnet-<id>` exists (idempotent; `--internal` for private subnets), labels it `fakecloud-subnet=<id>` + the shared `fakecloud-instance` ownership label so the startup reaper prunes it, and attaches with `--network`.
- **Same-subnet** instances share a bridge and can talk; **different VPCs/subnets** get different bridges and cannot route to each other.
- Best-effort: if network creation fails the instance still boots on the default bridge (no regression vs metadata-only).
- k8s pods keep their flat network (isolation there is a NetworkPolicy concern, phase 4). Subnet placement is recorded so persisted instances recover onto the same network, and phase-5 introspection can report it.

## Test plan

- `crates/fakecloud-e2e/tests/ec2_network_isolation.rs` (Docker-gated, hard-fails in CI): same-subnet reachability, cross-VPC isolation (ping passes/fails accordingly), private subnet -> `--internal` network, public/default subnet -> not internal.
- `cargo test -p fakecloud-ec2`, `cargo clippy -p fakecloud-ec2 --all-targets -- -D warnings`, `cargo fmt --all --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-subnet Docker networks for EC2 instances to enforce L3 isolation across VPCs/subnets. Phase 2 of #1745; persists subnet placement so restarts keep the same network; k8s remains flat.

- **New Features**
  - `RunInstances` derives `InstanceNetwork { subnet_id, internal }` (private if no `0.0.0.0/0 -> igw`) and passes it to the runtime.
  - Docker ensures `fakecloud-subnet-<id>` exists (idempotent), labels it `fakecloud-subnet=<id>` and `fakecloud-instance=<daemon>`, attaches with `--network`; uses `--internal` for private subnets. Falls back to the default bridge if creation fails.
  - Runtime stores subnet placement and returns it in `RunningInstance.network`; restarts re-attach to the same network. k8s returns `network: None`.
  - New Docker-gated E2E test verifies same-subnet reachability, cross-VPC isolation, and `--internal` on private vs public/default subnets.

- **Bug Fixes**
  - Updated the k8s integration test to the new 4-arg `run_instance` signature.
  - Dropped an unused binding in the E2E test to satisfy `clippy -D warnings`.

<sup>Written for commit 800114f57e75e0aa8d28ae8cdabfe9a030038d66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

