### PR TITLE
feat(ec2): security-group + NACL nftables enforcement (#1745 phase 3)

### DIFF
--- a/crates/fakecloud-e2e/tests/ec2_sg_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/ec2_sg_enforcement.rs
@@ -142,7 +142,7 @@ async fn sg_enforcement_degrades_without_net_admin() {
         .unwrap();
     let sg = sg.group_id().unwrap().to_string();
 
-    let mut launch = |n: &str| {
+    let launch = |n: &str| {
         let c = c.clone();
         let subnet = subnet.clone();
         let sg = sg.clone();

--- a/crates/fakecloud-e2e/tests/ec2_sg_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/ec2_sg_enforcement.rs
@@ -1,0 +1,200 @@
+//! EC2 security-group enforcement degrade path (issue #1745 phase 3).
+//!
+//! Real packet filtering needs nftables + `CAP_NET_ADMIN`, which CI doesn't
+//! have. The *enforcement* ruleset is unit-tested in
+//! `fakecloud_ec2::runtime::firewall`; this E2E proves the other half: when
+//! enforcement is requested but the host can't back it, fakecloud **degrades
+//! gracefully** — instances still boot and phase-2 L3 isolation still holds,
+//! with no new blocking (no regression).
+//!
+//! Requires Docker (hard-fails in CI, skips locally).
+
+mod helpers;
+
+use helpers::TestServer;
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("Skipping {test}: docker not available");
+    false
+}
+
+/// Whether the host can actually back nftables enforcement. When false, we
+/// expect the degrade path; when true (a privileged runner), enforcement is
+/// active and the deny-by-default SG would block the ping, so we don't assert
+/// reachability.
+fn nft_enforceable() -> bool {
+    std::process::Command::new("nft")
+        .args(["list", "ruleset"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn docker(args: &[&str]) -> String {
+    let out = std::process::Command::new("docker")
+        .args(args)
+        .output()
+        .expect("spawn docker");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn docker_ok(args: &[&str]) -> bool {
+    std::process::Command::new("docker")
+        .args(args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn container_for(instance_id: &str) -> String {
+    docker(&[
+        "ps",
+        "-aq",
+        "--filter",
+        &format!("label=fakecloud-ec2={instance_id}"),
+    ])
+}
+
+async fn wait_running(c: &aws_sdk_ec2::Client, id: &str) -> String {
+    for _ in 0..80 {
+        let d = c
+            .describe_instances()
+            .instance_ids(id)
+            .send()
+            .await
+            .unwrap();
+        if let Some(inst) = d
+            .reservations()
+            .iter()
+            .flat_map(|r| r.instances())
+            .find(|i| i.instance_id() == Some(id))
+        {
+            if inst.state().and_then(|s| s.name()).map(|n| n.as_str()) == Some("running") {
+                let ip = inst.private_ip_address().unwrap_or_default().to_string();
+                if !ip.is_empty() && !ip.starts_with("10.0.0.") {
+                    return ip;
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    panic!("instance {id} never reached running with a real container IP");
+}
+
+#[tokio::test]
+async fn sg_enforcement_degrades_without_net_admin() {
+    if !require_docker_or_skip("sg_enforcement_degrades_without_net_admin") {
+        return;
+    }
+    // Request enforcement; on an unprivileged host this degrades to
+    // metadata-only and must not regress phase-2 behavior.
+    std::env::set_var("FAKECLOUD_EC2_SG_ENFORCEMENT", "1");
+    std::env::set_var("FAKECLOUD_EC2_DEFAULT_IMAGE", "alpine:3");
+
+    let server = TestServer::start().await;
+    let c = server.ec2_client().await;
+
+    let vpc = c
+        .create_vpc()
+        .cidr_block("10.40.0.0/16")
+        .send()
+        .await
+        .unwrap();
+    let vpc = vpc.vpc().unwrap().vpc_id().unwrap().to_string();
+    let subnet = c
+        .create_subnet()
+        .vpc_id(&vpc)
+        .cidr_block("10.40.1.0/24")
+        .send()
+        .await
+        .unwrap();
+    let subnet = subnet.subnet().unwrap().subnet_id().unwrap().to_string();
+
+    // A security group with NO ingress allows (deny-by-default). Under real
+    // enforcement this would block inbound; under degrade it blocks nothing.
+    let sg = c
+        .create_security_group()
+        .group_name("locked-down")
+        .description("no ingress")
+        .vpc_id(&vpc)
+        .send()
+        .await
+        .unwrap();
+    let sg = sg.group_id().unwrap().to_string();
+
+    let mut launch = |n: &str| {
+        let c = c.clone();
+        let subnet = subnet.clone();
+        let sg = sg.clone();
+        let n = n.to_string();
+        async move {
+            let r = c
+                .run_instances()
+                .image_id("ami-12345678")
+                .min_count(1)
+                .max_count(1)
+                .subnet_id(&subnet)
+                .security_group_ids(&sg)
+                .send()
+                .await
+                .unwrap();
+            let _ = n;
+            r.instances()[0].instance_id().unwrap().to_string()
+        }
+    };
+    let a = launch("a").await;
+    let b = launch("b").await;
+
+    let _a_ip = wait_running(&c, &a).await;
+    let b_ip = wait_running(&c, &b).await;
+
+    // Both booted (graceful degrade never blocks the boot).
+    let ca = container_for(&a);
+    let cb = container_for(&b);
+    assert!(
+        !ca.is_empty() && !cb.is_empty(),
+        "both instances should boot"
+    );
+
+    if !nft_enforceable() {
+        // Degrade path: the deny-by-default SG is NOT enforced, so same-subnet
+        // reachability is unchanged from phase 2.
+        assert!(
+            docker_ok(&["exec", &ca, "ping", "-c", "1", "-W", "2", &b_ip]),
+            "with enforcement degraded, same-subnet instances must still reach each other"
+        );
+    } else {
+        eprintln!("nft enforceable on this host; skipping degrade reachability assertion");
+    }
+
+    for id in [&a, &b] {
+        let _ = c.terminate_instances().instance_ids(id).send().await;
+    }
+    for _ in 0..40 {
+        if [&a, &b].iter().all(|id| container_for(id).is_empty()) {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    let _ = docker(&["network", "rm", &format!("fakecloud-subnet-{subnet}")]);
+}

--- a/crates/fakecloud-ec2/src/runtime/firewall.rs
+++ b/crates/fakecloud-ec2/src/runtime/firewall.rs
@@ -1,0 +1,483 @@
+//! Security-group + network-ACL packet filtering (issue #1745 phase 3).
+//!
+//! Phase 2 isolates instances at L3 by giving each subnet its own daemon
+//! bridge. That stops cross-VPC traffic but does nothing *within* a subnet —
+//! security-group and NACL rules still block nothing. This module closes that
+//! gap by translating the SG/NACL model into an **nftables** ruleset and
+//! applying it on the host, scoped to fakecloud's per-subnet bridges.
+//!
+//! ## Why nftables, and why opt-in
+//!
+//! Real packet filtering needs `CAP_NET_ADMIN`, which instance containers
+//! deliberately don't have. nftables (over iptables) is chosen for its atomic
+//! ruleset swaps — a clean fit for the dynamic Authorize/Revoke churn of
+//! security groups. Because applying host firewall rules is privileged and can
+//! interfere with a user's own networking, enforcement is **opt-in** via
+//! `FAKECLOUD_EC2_SG_ENFORCEMENT` and **degrades gracefully**: when nft or
+//! `CAP_NET_ADMIN` is missing (CI, Docker Desktop, rootless podman) the driver
+//! logs one warning and falls back to metadata-only — phase-2 isolation still
+//! holds, exactly as before (no regression).
+//!
+//! ## What's tested where
+//!
+//! The translation from the SG/NACL model to the nft ruleset
+//! ([`render_ruleset`]) is pure and exhaustively unit-tested. The apply path
+//! shells out to `nft -f -`; it cannot be exercised in CI (no `CAP_NET_ADMIN`),
+//! so it is kept thin and the *generated ruleset* is the verified artifact.
+
+use std::collections::BTreeMap;
+
+/// A single allow rule flattened out of a security group: one protocol/port
+/// range from one CIDR (referenced-group and prefix-list sources are resolved
+/// to CIDRs by the caller, or dropped when they can't be).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FirewallRule {
+    /// `tcp` | `udp` | `icmp` | `-1` (all protocols).
+    pub protocol: String,
+    /// Port range; `-1`/`-1` means "all ports" (omit the port match).
+    pub from_port: i64,
+    pub to_port: i64,
+    /// Source (ingress) / destination (egress) IPv4 CIDR. `None` = anywhere.
+    pub cidr: Option<String>,
+}
+
+/// One instance's firewall view: its address on the subnet bridge plus the
+/// ingress/egress rules flattened from every security group attached to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceFirewall {
+    pub private_ip: String,
+    pub ingress: Vec<FirewallRule>,
+    pub egress: Vec<FirewallRule>,
+}
+
+/// A subnet-level NACL entry (allow/deny, ordered by rule number by the
+/// caller). NACLs are stateless and apply to the whole subnet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NaclRule {
+    pub egress: bool,
+    /// True = allow, false = deny.
+    pub allow: bool,
+    pub protocol: String,
+    pub from_port: i64,
+    pub to_port: i64,
+    pub cidr: Option<String>,
+}
+
+/// Everything needed to render the firewall for one subnet bridge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubnetFirewall {
+    /// The daemon network name (`fakecloud-subnet-<id>`); doubles as the nft
+    /// chain comment so a human reading `nft list ruleset` can see which subnet
+    /// a rule belongs to.
+    pub network_name: String,
+    pub instances: Vec<InstanceFirewall>,
+    pub nacl: Vec<NaclRule>,
+}
+
+/// The nftables table fakecloud owns. Kept in its own table so a full
+/// `flush table` + re-add is an atomic, side-effect-free swap that never
+/// touches docker's own iptables/nftables rules.
+const TABLE: &str = "inet fakecloud_ec2";
+
+/// Render the complete nft ruleset for a set of subnets. Deterministic
+/// (subnets and rules emitted in the order given; the caller sorts for
+/// stability) so the output can be diffed and unit-tested.
+///
+/// Model: a single `forward` chain, default-accept, that for every instance
+/// emits its allow rules followed by a default-deny to that instance's IP.
+/// Established/related traffic is accepted up front so security groups behave
+/// statefully, like AWS. NACL deny rules are emitted per subnet before the
+/// per-instance rules (stateless, subnet-wide).
+pub fn render_ruleset(subnets: &[SubnetFirewall]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("flush table {TABLE}\n"));
+    out.push_str(&format!("table {TABLE} {{\n"));
+    out.push_str("  chain forward {\n");
+    out.push_str("    type filter hook forward priority -5; policy accept;\n");
+    // Stateful: let replies through so SG rules only need to describe the
+    // opening direction, matching AWS security-group semantics.
+    out.push_str("    ct state established,related accept\n");
+
+    for subnet in subnets {
+        out.push_str(&format!("    # subnet {}\n", subnet.network_name));
+
+        // Subnet-wide NACL denies first (stateless, highest precedence).
+        for rule in subnet.nacl.iter().filter(|r| !r.allow) {
+            if let Some(line) = render_nacl_drop(rule) {
+                out.push_str(&format!("    {line}\n"));
+            }
+        }
+
+        for inst in &subnet.instances {
+            // Ingress: allow matching, then default-deny to this instance.
+            for rule in &inst.ingress {
+                out.push_str(&format!(
+                    "    {}\n",
+                    render_rule(rule, Direction::Ingress, &inst.private_ip)
+                ));
+            }
+            out.push_str(&format!(
+                "    ip daddr {} drop comment \"default-deny ingress\"\n",
+                inst.private_ip
+            ));
+
+            // Egress: allow matching, then default-deny from this instance.
+            for rule in &inst.egress {
+                out.push_str(&format!(
+                    "    {}\n",
+                    render_rule(rule, Direction::Egress, &inst.private_ip)
+                ));
+            }
+            out.push_str(&format!(
+                "    ip saddr {} drop comment \"default-deny egress\"\n",
+                inst.private_ip
+            ));
+        }
+    }
+
+    out.push_str("  }\n");
+    out.push_str("}\n");
+    out
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+    Ingress,
+    Egress,
+}
+
+/// Render one allow rule. Ingress matches on `ip daddr <instance>` (+ optional
+/// `ip saddr <cidr>`); egress mirrors it.
+fn render_rule(rule: &FirewallRule, dir: Direction, instance_ip: &str) -> String {
+    let mut parts = Vec::new();
+    match dir {
+        Direction::Ingress => {
+            parts.push(format!("ip daddr {instance_ip}"));
+            if let Some(cidr) = normalized_cidr(&rule.cidr) {
+                parts.push(format!("ip saddr {cidr}"));
+            }
+        }
+        Direction::Egress => {
+            parts.push(format!("ip saddr {instance_ip}"));
+            if let Some(cidr) = normalized_cidr(&rule.cidr) {
+                parts.push(format!("ip daddr {cidr}"));
+            }
+        }
+    }
+    push_proto_ports(&mut parts, &rule.protocol, rule.from_port, rule.to_port);
+    parts.push("accept".to_string());
+    parts.join(" ")
+}
+
+/// Render a NACL deny as a drop line scoped to its direction + match. Returns
+/// `None` for an allow rule (allows are the default-accept policy; only denies
+/// need an explicit line).
+fn render_nacl_drop(rule: &NaclRule) -> Option<String> {
+    if rule.allow {
+        return None;
+    }
+    let mut parts = Vec::new();
+    if let Some(cidr) = normalized_cidr(&rule.cidr) {
+        // Deny traffic from (ingress) / to (egress) the CIDR.
+        if rule.egress {
+            parts.push(format!("ip daddr {cidr}"));
+        } else {
+            parts.push(format!("ip saddr {cidr}"));
+        }
+    }
+    push_proto_ports(&mut parts, &rule.protocol, rule.from_port, rule.to_port);
+    parts.push("drop".to_string());
+    parts.push("comment \"nacl-deny\"".to_string());
+    Some(parts.join(" "))
+}
+
+/// Append protocol + (for tcp/udp) destination-port matching to an nft rule.
+/// Protocol `-1` matches everything (no clause); a `-1` port range likewise
+/// omits the port match.
+fn push_proto_ports(parts: &mut Vec<String>, protocol: &str, from: i64, to: i64) {
+    match protocol {
+        "-1" | "" => {}
+        "icmp" | "1" => parts.push("ip protocol icmp".to_string()),
+        proto @ ("tcp" | "udp" | "6" | "17") => {
+            let p = match proto {
+                "6" => "tcp",
+                "17" => "udp",
+                other => other,
+            };
+            parts.push(p.to_string());
+            if from >= 0 && to >= 0 {
+                if from == to {
+                    parts.push(format!("dport {from}"));
+                } else {
+                    parts.push(format!("dport {from}-{to}"));
+                }
+            }
+        }
+        other => parts.push(format!("ip protocol {other}")),
+    }
+}
+
+/// Drop `0.0.0.0/0` (which nft rejects as a no-op match) to `None`, and strip a
+/// redundant `/32` host suffix so single-host rules read cleanly.
+fn normalized_cidr(cidr: &Option<String>) -> Option<String> {
+    let c = cidr.as_deref()?;
+    if c == "0.0.0.0/0" || c.is_empty() {
+        return None;
+    }
+    Some(c.trim_end_matches("/32").to_string())
+}
+
+/// How security-group enforcement is backed in this process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnforcementMode {
+    /// nftables on the host (requires `CAP_NET_ADMIN` + `nft`).
+    Nftables,
+    /// Degraded: rules are tracked but not enforced (metadata-only).
+    Disabled,
+}
+
+/// Decide the enforcement mode from the environment. Enforcement is opt-in:
+/// `FAKECLOUD_EC2_SG_ENFORCEMENT` must be set to `1`/`true`/`nftables`, and
+/// `nft` must actually be runnable, or we degrade to `Disabled` with a single
+/// warning. `env` and `nft_probe` are injected so the decision is unit-testable
+/// without touching the real environment or running `nft`.
+pub fn resolve_enforcement_mode(
+    env: Option<&str>,
+    nft_probe: impl FnOnce() -> bool,
+) -> EnforcementMode {
+    let opted_in = matches!(
+        env.map(|v| v.to_ascii_lowercase()).as_deref(),
+        Some("1") | Some("true") | Some("nftables") | Some("on")
+    );
+    if !opted_in {
+        return EnforcementMode::Disabled;
+    }
+    if nft_probe() {
+        EnforcementMode::Nftables
+    } else {
+        EnforcementMode::Disabled
+    }
+}
+
+/// True when `nft list ruleset` runs successfully — i.e. nft exists and this
+/// process holds enough capability to read the ruleset (a good proxy for being
+/// able to write it).
+pub fn nft_available() -> bool {
+    std::process::Command::new("nft")
+        .args(["list", "ruleset"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Group instances by their subnet network name into the per-subnet model the
+/// renderer consumes. Pure helper so the service layer can build the model from
+/// its own state without depending on render internals.
+pub fn group_by_subnet(
+    instances: Vec<(String, InstanceFirewall)>,
+    nacls: BTreeMap<String, Vec<NaclRule>>,
+) -> Vec<SubnetFirewall> {
+    let mut by_net: BTreeMap<String, Vec<InstanceFirewall>> = BTreeMap::new();
+    for (network_name, inst) in instances {
+        by_net.entry(network_name).or_default().push(inst);
+    }
+    by_net
+        .into_iter()
+        .map(|(network_name, mut instances)| {
+            instances.sort_by(|a, b| a.private_ip.cmp(&b.private_ip));
+            let nacl = nacls.get(&network_name).cloned().unwrap_or_default();
+            SubnetFirewall {
+                network_name,
+                instances,
+                nacl,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tcp(port: i64, cidr: Option<&str>) -> FirewallRule {
+        FirewallRule {
+            protocol: "tcp".into(),
+            from_port: port,
+            to_port: port,
+            cidr: cidr.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn renders_allow_then_default_deny_for_ingress() {
+        let model = vec![SubnetFirewall {
+            network_name: "fakecloud-subnet-a".into(),
+            instances: vec![InstanceFirewall {
+                private_ip: "172.30.0.2".into(),
+                ingress: vec![tcp(22, Some("10.0.0.0/8"))],
+                egress: vec![],
+            }],
+            nacl: vec![],
+        }];
+        let rs = render_ruleset(&model);
+        assert!(rs.contains("flush table inet fakecloud_ec2"));
+        assert!(rs.contains("ct state established,related accept"));
+        assert!(rs.contains("ip daddr 172.30.0.2 ip saddr 10.0.0.0/8 tcp dport 22 accept"));
+        assert!(rs.contains("ip daddr 172.30.0.2 drop comment \"default-deny ingress\""));
+        // egress had no explicit allows -> still a default-deny line
+        assert!(rs.contains("ip saddr 172.30.0.2 drop comment \"default-deny egress\""));
+    }
+
+    #[test]
+    fn all_protocols_and_anywhere_omit_match_clauses() {
+        let rule = FirewallRule {
+            protocol: "-1".into(),
+            from_port: -1,
+            to_port: -1,
+            cidr: Some("0.0.0.0/0".into()),
+        };
+        let line = render_rule(&rule, Direction::Ingress, "172.30.0.5");
+        // no saddr (anywhere), no proto, no port:
+        assert_eq!(line, "ip daddr 172.30.0.5 accept");
+    }
+
+    #[test]
+    fn port_range_and_single_port() {
+        let range = FirewallRule {
+            protocol: "tcp".into(),
+            from_port: 8000,
+            to_port: 8100,
+            cidr: None,
+        };
+        assert!(render_rule(&range, Direction::Egress, "172.30.0.9")
+            .contains("tcp dport 8000-8100 accept"));
+        assert!(
+            render_rule(&tcp(443, None), Direction::Ingress, "172.30.0.9")
+                .contains("tcp dport 443 accept")
+        );
+    }
+
+    #[test]
+    fn icmp_and_numeric_protocols() {
+        let icmp = FirewallRule {
+            protocol: "icmp".into(),
+            from_port: -1,
+            to_port: -1,
+            cidr: None,
+        };
+        assert!(render_rule(&icmp, Direction::Ingress, "172.30.0.2").contains("ip protocol icmp"));
+        let udp = FirewallRule {
+            protocol: "17".into(),
+            from_port: 53,
+            to_port: 53,
+            cidr: None,
+        };
+        assert!(render_rule(&udp, Direction::Ingress, "172.30.0.2").contains("udp dport 53"));
+    }
+
+    #[test]
+    fn host_cidr_strips_slash_32() {
+        let r = tcp(22, Some("203.0.113.7/32"));
+        assert!(render_rule(&r, Direction::Ingress, "172.30.0.2")
+            .contains("ip saddr 203.0.113.7 tcp dport 22"));
+    }
+
+    #[test]
+    fn nacl_deny_emitted_before_instance_rules() {
+        let model = vec![SubnetFirewall {
+            network_name: "fakecloud-subnet-a".into(),
+            instances: vec![InstanceFirewall {
+                private_ip: "172.30.0.2".into(),
+                ingress: vec![],
+                egress: vec![],
+            }],
+            nacl: vec![NaclRule {
+                egress: false,
+                allow: false,
+                protocol: "tcp".into(),
+                from_port: 3389,
+                to_port: 3389,
+                cidr: Some("198.51.100.0/24".into()),
+            }],
+        }];
+        let rs = render_ruleset(&model);
+        let deny = rs
+            .find("ip saddr 198.51.100.0/24 tcp dport 3389 drop")
+            .unwrap();
+        let inst = rs.find("ip daddr 172.30.0.2 drop").unwrap();
+        assert!(
+            deny < inst,
+            "nacl deny must precede the instance default-deny"
+        );
+        // allow NACL entries produce no explicit line
+        assert!(!rs.contains("nacl-allow"));
+    }
+
+    #[test]
+    fn enforcement_mode_is_opt_in_and_capability_gated() {
+        // not opted in -> disabled regardless of nft availability
+        assert_eq!(
+            resolve_enforcement_mode(None, || true),
+            EnforcementMode::Disabled
+        );
+        assert_eq!(
+            resolve_enforcement_mode(Some("0"), || true),
+            EnforcementMode::Disabled
+        );
+        // opted in but nft missing -> degrade
+        assert_eq!(
+            resolve_enforcement_mode(Some("1"), || false),
+            EnforcementMode::Disabled
+        );
+        // opted in + capable -> nftables
+        assert_eq!(
+            resolve_enforcement_mode(Some("nftables"), || true),
+            EnforcementMode::Nftables
+        );
+        assert_eq!(
+            resolve_enforcement_mode(Some("TRUE"), || true),
+            EnforcementMode::Nftables
+        );
+    }
+
+    #[test]
+    fn group_by_subnet_sorts_and_attaches_nacls() {
+        let instances = vec![
+            (
+                "net-a".to_string(),
+                InstanceFirewall {
+                    private_ip: "172.30.0.9".into(),
+                    ingress: vec![],
+                    egress: vec![],
+                },
+            ),
+            (
+                "net-a".to_string(),
+                InstanceFirewall {
+                    private_ip: "172.30.0.2".into(),
+                    ingress: vec![],
+                    egress: vec![],
+                },
+            ),
+        ];
+        let mut nacls = BTreeMap::new();
+        nacls.insert(
+            "net-a".to_string(),
+            vec![NaclRule {
+                egress: false,
+                allow: false,
+                protocol: "-1".into(),
+                from_port: -1,
+                to_port: -1,
+                cidr: Some("10.0.0.0/8".into()),
+            }],
+        );
+        let grouped = group_by_subnet(instances, nacls);
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[0].instances[0].private_ip, "172.30.0.2");
+        assert_eq!(grouped[0].instances[1].private_ip, "172.30.0.9");
+        assert_eq!(grouped[0].nacl.len(), 1);
+    }
+}

--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -18,12 +18,15 @@
 //! state transitions) so every API call still succeeds. Real container
 //! backing is best-effort fidelity layered on top.
 
+pub mod firewall;
 mod k8s;
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
+
+use firewall::{render_ruleset, resolve_enforcement_mode, EnforcementMode, SubnetFirewall};
 
 /// Default base image an instance's container runs. AMIs don't map to a
 /// concrete OS image, so we boot a real Amazon Linux container by default
@@ -120,6 +123,96 @@ enum InstanceBackend {
     K8s(k8s::K8sInstances),
 }
 
+/// Host firewall enforcement for security groups + NACLs (#1745 phase 3).
+///
+/// The network-driver abstraction the issue asks for: today there is one real
+/// driver (nftables) plus the degraded no-op, selected once at construction.
+/// Branching on podman vs docker isn't needed explicitly — rootless podman
+/// can't touch the host firewall, so the `nft list ruleset` capability probe
+/// already degrades it; rootful podman with netavark passes the same probe.
+#[derive(Debug, Clone)]
+pub struct FirewallEnforcer {
+    mode: EnforcementMode,
+}
+
+impl FirewallEnforcer {
+    /// Resolve the enforcement mode from `FAKECLOUD_EC2_SG_ENFORCEMENT` and an
+    /// `nft` capability probe, warning once when enforcement was requested but
+    /// can't be backed (so the operator knows it degraded, not silently).
+    fn detect() -> Self {
+        let requested = std::env::var("FAKECLOUD_EC2_SG_ENFORCEMENT").ok();
+        let mode = resolve_enforcement_mode(requested.as_deref(), firewall::nft_available);
+        if requested.is_some() && mode == EnforcementMode::Disabled {
+            tracing::warn!(
+                "EC2 security-group enforcement was requested but nftables/CAP_NET_ADMIN \
+                 is unavailable; falling back to metadata-only (phase-2 L3 isolation stays \
+                 active, security-group rules are tracked but not enforced)"
+            );
+        } else if mode == EnforcementMode::Nftables {
+            tracing::info!("EC2 security-group enforcement active via nftables");
+        }
+        Self { mode }
+    }
+
+    /// Disabled enforcer (k8s backend, or no container runtime).
+    fn disabled() -> Self {
+        Self {
+            mode: EnforcementMode::Disabled,
+        }
+    }
+
+    pub fn mode(&self) -> EnforcementMode {
+        self.mode
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.mode != EnforcementMode::Disabled
+    }
+
+    /// Atomically swap in the rendered ruleset via `nft -f -`. No-op when
+    /// disabled. Best-effort: a failed apply logs and leaves the previous
+    /// ruleset in place rather than erroring the originating API call.
+    async fn reconcile(&self, subnets: &[SubnetFirewall]) {
+        if self.mode == EnforcementMode::Disabled {
+            return;
+        }
+        let ruleset = render_ruleset(subnets);
+        use tokio::io::AsyncWriteExt;
+        let mut child = match tokio::process::Command::new("nft")
+            .args(["-f", "-"])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to spawn nft; security-group ruleset not applied");
+                return;
+            }
+        };
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(ruleset.as_bytes()).await;
+            let _ = stdin.shutdown().await;
+        }
+        match child.wait_with_output().await {
+            Ok(out) if out.status.success() => {
+                tracing::debug!(
+                    subnets = subnets.len(),
+                    "applied EC2 security-group nft ruleset"
+                );
+            }
+            Ok(out) => {
+                tracing::warn!(
+                    stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                    "nft rejected the security-group ruleset; leaving the previous ruleset in place"
+                );
+            }
+            Err(e) => tracing::warn!(error = %e, "nft apply failed"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Ec2Runtime {
     backend: InstanceBackend,
@@ -127,6 +220,8 @@ pub struct Ec2Runtime {
     /// lifecycle operations and reset/shutdown teardown work without
     /// consulting service state.
     instances: Arc<RwLock<HashMap<String, InstanceRecord>>>,
+    /// Host firewall enforcer for security groups + NACLs.
+    firewall: FirewallEnforcer,
 }
 
 impl Ec2Runtime {
@@ -140,6 +235,7 @@ impl Ec2Runtime {
                 instance_id: format!("fakecloud-{}", std::process::id()),
             }),
             instances: Arc::new(RwLock::new(HashMap::new())),
+            firewall: FirewallEnforcer::detect(),
         })
     }
 
@@ -151,7 +247,21 @@ impl Ec2Runtime {
         Ok(Self {
             backend: InstanceBackend::K8s(backend),
             instances: Arc::new(RwLock::new(HashMap::new())),
+            // k8s isolation is a NetworkPolicy concern (phase 4), not host nft.
+            firewall: FirewallEnforcer::disabled(),
         })
+    }
+
+    /// The firewall enforcer, so the control plane can skip building the model
+    /// when enforcement is disabled and report the mode for introspection.
+    pub fn firewall(&self) -> &FirewallEnforcer {
+        &self.firewall
+    }
+
+    /// Re-render and atomically apply the security-group/NACL ruleset for the
+    /// given per-subnet model. No-op (cheap) when enforcement is disabled.
+    pub async fn reconcile_firewall(&self, subnets: Vec<SubnetFirewall>) {
+        self.firewall.reconcile(&subnets).await;
     }
 
     /// Name of the active backend, for logging.

--- a/crates/fakecloud-ec2/src/service/firewall_model.rs
+++ b/crates/fakecloud-ec2/src/service/firewall_model.rs
@@ -1,0 +1,295 @@
+//! Builds the per-subnet firewall model (#1745 phase 3) from EC2 control-plane
+//! state and drives the runtime's nftables reconcile.
+//!
+//! The host nft ruleset is global, so the model is built across *every* account
+//! partition and applied as one atomic swap — reconciling for a single account
+//! would flush the others' rules. Reconcile is a no-op when enforcement is
+//! disabled (the common case), and the control plane skips even building the
+//! model then.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use crate::runtime::firewall::{
+    group_by_subnet, FirewallRule, InstanceFirewall, NaclRule, SubnetFirewall,
+};
+use crate::runtime::{subnet_network_name, Ec2Runtime};
+use crate::state::{Ec2State, NetworkAcl, SecurityGroupRule, SharedEc2State};
+
+/// True for an instance that should be in the firewall model: running and
+/// placed in a subnet (so it has a backing subnet network to filter on).
+fn enforced(inst: &crate::state::Instance) -> Option<&str> {
+    if inst.state_name == "running" {
+        inst.subnet_id.as_deref()
+    } else {
+        None
+    }
+}
+
+/// Flatten one stored security-group rule into zero or more firewall rules.
+/// IPv4 CIDR rules pass through; a referenced-group rule expands to the `/32`
+/// of every running member of that group (so the default SG's "allow from
+/// self" actually works); IPv6 / prefix-list sources are not modeled (the nft
+/// table is `ip`-only) and are skipped.
+fn flatten_rule(
+    rule: &SecurityGroupRule,
+    sg_members: &HashMap<String, Vec<String>>,
+) -> Vec<FirewallRule> {
+    let mk = |cidr: Option<String>| FirewallRule {
+        protocol: rule.ip_protocol.clone(),
+        from_port: rule.from_port,
+        to_port: rule.to_port,
+        cidr,
+    };
+    if let Some(group) = &rule.referenced_group_id {
+        sg_members
+            .get(group)
+            .map(|ips| ips.iter().map(|ip| mk(Some(format!("{ip}/32")))).collect())
+            .unwrap_or_default()
+    } else if let Some(cidr) = &rule.cidr_ipv4 {
+        vec![mk(Some(cidr.clone()))]
+    } else {
+        Vec::new()
+    }
+}
+
+/// NACL deny/allow entries that apply to a subnet, as the renderer's model.
+/// (Only denies become explicit nft lines; allows ride the default-accept
+/// policy. We still pass both so future ordering work has the full picture.)
+fn nacl_rules(acl: &NetworkAcl) -> Vec<NaclRule> {
+    acl.entries
+        .iter()
+        // The catch-all `*` deny (rule 32767) is the implicit policy, not a
+        // user rule — skip it so it doesn't blackhole everything.
+        .filter(|e| e.rule_number != 32767)
+        .map(|e| NaclRule {
+            egress: e.egress,
+            allow: e.rule_action == "allow",
+            protocol: e.protocol.clone(),
+            from_port: e.port_range.map(|(f, _)| f).unwrap_or(-1),
+            to_port: e.port_range.map(|(_, t)| t).unwrap_or(-1),
+            cidr: e.cidr_block.clone(),
+        })
+        .collect()
+}
+
+/// Find the NACL governing `subnet_id`: an explicit association wins, else the
+/// default NACL of the subnet's VPC.
+fn subnet_nacl<'a>(state: &'a Ec2State, subnet_id: &str) -> Option<&'a NetworkAcl> {
+    if let Some(acl) = state
+        .network_acls
+        .values()
+        .find(|a| a.associations.iter().any(|x| x.subnet_id == subnet_id))
+    {
+        return Some(acl);
+    }
+    let vpc = state.subnets.get(subnet_id).map(|s| &s.vpc_id)?;
+    state
+        .network_acls
+        .values()
+        .find(|a| a.is_default && &a.vpc_id == vpc)
+}
+
+/// Build the per-subnet firewall model for one account partition.
+pub(crate) fn build_for_state(state: &Ec2State) -> Vec<SubnetFirewall> {
+    // sg-id -> running member IPs, for referenced-group expansion.
+    let mut sg_members: HashMap<String, Vec<String>> = HashMap::new();
+    for inst in state.instances.values() {
+        if enforced(inst).is_some() {
+            for sg in &inst.security_group_ids {
+                sg_members
+                    .entry(sg.clone())
+                    .or_default()
+                    .push(inst.private_ip.clone());
+            }
+        }
+    }
+
+    let mut instances: Vec<(String, InstanceFirewall)> = Vec::new();
+    let mut subnets_in_play: Vec<String> = Vec::new();
+    for inst in state.instances.values() {
+        let Some(subnet_id) = enforced(inst) else {
+            continue;
+        };
+        let mut ingress = Vec::new();
+        let mut egress = Vec::new();
+        for sg_id in &inst.security_group_ids {
+            if let Some(sg) = state.security_groups.get(sg_id) {
+                for rule in &sg.rules {
+                    let flat = flatten_rule(rule, &sg_members);
+                    if rule.is_egress {
+                        egress.extend(flat);
+                    } else {
+                        ingress.extend(flat);
+                    }
+                }
+            }
+        }
+        instances.push((
+            subnet_network_name(subnet_id),
+            InstanceFirewall {
+                private_ip: inst.private_ip.clone(),
+                ingress,
+                egress,
+            },
+        ));
+        if !subnets_in_play.contains(&subnet_id.to_string()) {
+            subnets_in_play.push(subnet_id.to_string());
+        }
+    }
+
+    let mut nacls: BTreeMap<String, Vec<NaclRule>> = BTreeMap::new();
+    for subnet_id in &subnets_in_play {
+        if let Some(acl) = subnet_nacl(state, subnet_id) {
+            nacls.insert(subnet_network_name(subnet_id), nacl_rules(acl));
+        }
+    }
+
+    group_by_subnet(instances, nacls)
+}
+
+/// Build the model across every account partition (the host nft table is
+/// global) and hand it to the runtime to apply.
+pub(crate) async fn reconcile(state: &SharedEc2State, runtime: &Arc<Ec2Runtime>) {
+    let model: Vec<SubnetFirewall> = {
+        let accounts = state.read();
+        accounts
+            .iter()
+            .flat_map(|(_, s)| build_for_state(s))
+            .collect()
+    };
+    runtime.reconcile_firewall(model).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{Instance, SecurityGroup, SecurityGroupRule};
+
+    fn running_instance(id: &str, ip: &str, subnet: &str, sgs: &[&str]) -> Instance {
+        Instance {
+            instance_id: id.into(),
+            image_id: "ami-1".into(),
+            instance_type: "t3.micro".into(),
+            state_code: 16,
+            state_name: "running".into(),
+            private_ip: ip.into(),
+            public_ip: None,
+            subnet_id: Some(subnet.into()),
+            vpc_id: Some("vpc-x".into()),
+            key_name: None,
+            security_group_ids: sgs.iter().map(|s| s.to_string()).collect(),
+            reservation_id: "r-1".into(),
+            ami_launch_index: 0,
+            monitoring: false,
+            az: "us-east-1a".into(),
+            launch_time: "2024-01-01T00:00:00.000Z".into(),
+            container_id: None,
+            disable_api_termination: false,
+            disable_api_stop: false,
+            source_dest_check: true,
+            ebs_optimized: false,
+            instance_initiated_shutdown_behavior: "stop".into(),
+            user_data: None,
+            metadata_options: Default::default(),
+            cpu_options: None,
+            bandwidth_weighting: None,
+            maintenance_options: Default::default(),
+            placement_tenancy: None,
+            placement_affinity: None,
+            placement_group_name: None,
+        }
+    }
+
+    fn sg(id: &str, rules: Vec<SecurityGroupRule>) -> SecurityGroup {
+        SecurityGroup {
+            group_id: id.into(),
+            group_name: "g".into(),
+            description: String::new(),
+            vpc_id: "vpc-x".into(),
+            rules,
+        }
+    }
+
+    fn ingress_tcp(
+        group: &str,
+        port: i64,
+        cidr: Option<&str>,
+        refg: Option<&str>,
+    ) -> SecurityGroupRule {
+        SecurityGroupRule {
+            rule_id: "sgr-1".into(),
+            group_id: group.into(),
+            is_egress: false,
+            ip_protocol: "tcp".into(),
+            from_port: port,
+            to_port: port,
+            cidr_ipv4: cidr.map(str::to_string),
+            cidr_ipv6: None,
+            prefix_list_id: None,
+            referenced_group_id: refg.map(str::to_string),
+            description: String::new(),
+        }
+    }
+
+    #[test]
+    fn builds_ingress_from_cidr_rule() {
+        let mut state = Ec2State::new("123456789012", "us-east-1");
+        state.security_groups.insert(
+            "sg-1".into(),
+            sg(
+                "sg-1",
+                vec![ingress_tcp("sg-1", 22, Some("10.0.0.0/8"), None)],
+            ),
+        );
+        state.instances.insert(
+            "i-1".into(),
+            running_instance("i-1", "172.30.0.2", "subnet-1", &["sg-1"]),
+        );
+
+        let model = build_for_state(&state);
+        assert_eq!(model.len(), 1);
+        assert_eq!(model[0].network_name, subnet_network_name("subnet-1"));
+        let inst = &model[0].instances[0];
+        assert_eq!(inst.ingress.len(), 1);
+        assert_eq!(inst.ingress[0].cidr.as_deref(), Some("10.0.0.0/8"));
+    }
+
+    #[test]
+    fn referenced_group_expands_to_member_ips() {
+        let mut state = Ec2State::new("123456789012", "us-east-1");
+        // sg-1 allows all from itself (the default-SG shape).
+        state.security_groups.insert(
+            "sg-1".into(),
+            sg("sg-1", vec![ingress_tcp("sg-1", 80, None, Some("sg-1"))]),
+        );
+        state.instances.insert(
+            "i-1".into(),
+            running_instance("i-1", "172.30.0.2", "subnet-1", &["sg-1"]),
+        );
+        state.instances.insert(
+            "i-2".into(),
+            running_instance("i-2", "172.30.0.3", "subnet-1", &["sg-1"]),
+        );
+
+        let model = build_for_state(&state);
+        let inst = model[0]
+            .instances
+            .iter()
+            .find(|i| i.private_ip == "172.30.0.2")
+            .unwrap();
+        // referenced sg-1 -> both members' /32s
+        let cidrs: Vec<_> = inst.ingress.iter().filter_map(|r| r.cidr.clone()).collect();
+        assert!(cidrs.contains(&"172.30.0.2/32".to_string()));
+        assert!(cidrs.contains(&"172.30.0.3/32".to_string()));
+    }
+
+    #[test]
+    fn pending_instances_are_excluded() {
+        let mut state = Ec2State::new("123456789012", "us-east-1");
+        let mut inst = running_instance("i-1", "172.30.0.2", "subnet-1", &[]);
+        inst.state_name = "pending".into();
+        state.instances.insert("i-1".into(), inst);
+        assert!(build_for_state(&state).is_empty());
+    }
+}

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -410,6 +410,14 @@ pub(crate) async fn run_instances(
                 };
                 reconcile_started(&svc_state, &account_id, id, running);
             }
+            // All instances are up with their real IPs: (re)apply the
+            // security-group firewall so the new instances are filtered
+            // (#1745 phase 3). No-op when enforcement is disabled.
+            if let Some(rt) = &runtime {
+                if rt.firewall().enabled() {
+                    super::firewall_model::reconcile(&svc_state, rt).await;
+                }
+            }
         });
     }
 
@@ -592,6 +600,13 @@ async fn change_state(
                         }
                     }
                     _ => {}
+                }
+            }
+            // Lifecycle changes move/remove instances (new IP on start, gone on
+            // terminate): re-apply the security-group firewall (#1745 ph3).
+            if let Some(rt) = &runtime {
+                if rt.firewall().enabled() {
+                    super::firewall_model::reconcile(&svc_state, rt).await;
                 }
             }
         });

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -6,6 +6,7 @@ mod dhcp;
 mod eip;
 mod endpoint;
 mod eni;
+mod firewall_model;
 mod fleet;
 mod ice;
 mod image;
@@ -902,6 +903,27 @@ impl Ec2Service {
     /// introspection endpoints (`GET /_fakecloud/ec2/instances`).
     pub fn shared_state(&self) -> SharedEc2State {
         self.state.clone()
+    }
+
+    /// Re-derive the security-group/NACL firewall model from current state and
+    /// (re)apply it via the runtime's nftables enforcer (#1745 phase 3).
+    ///
+    /// Cheap no-op when there's no runtime or enforcement is disabled — the
+    /// common case — so it's safe to call liberally after any mutation that can
+    /// change the ruleset (RunInstances, Terminate, Authorize/Revoke,
+    /// network-ACL edits). Runs in the background so it never blocks the API
+    /// response.
+    pub(crate) fn spawn_firewall_reconcile(&self) {
+        let Some(runtime) = self.runtime.clone() else {
+            return;
+        };
+        if !runtime.firewall().enabled() {
+            return;
+        }
+        let state = self.state.clone();
+        tokio::spawn(async move {
+            firewall_model::reconcile(&state, &runtime).await;
+        });
     }
 
     /// Rebuild the backing-container runtime state for persisted instances

--- a/crates/fakecloud-ec2/src/service/nacl.rs
+++ b/crates/fakecloud-ec2/src/service/nacl.rs
@@ -247,6 +247,7 @@ pub(crate) fn create_network_acl_entry(
             acl.entries.push(parse_entry(req));
         }
     }
+    svc.spawn_firewall_reconcile();
     Ok(Ec2Service::respond(
         "CreateNetworkAclEntry",
         &req.request_id,
@@ -285,6 +286,7 @@ pub(crate) fn replace_network_acl_entry(
             }
         }
     }
+    svc.spawn_firewall_reconcile();
     Ok(Ec2Service::respond(
         "ReplaceNetworkAclEntry",
         &req.request_id,
@@ -312,6 +314,7 @@ pub(crate) fn delete_network_acl_entry(
                 .retain(|e| !(e.rule_number == num && e.egress == egress));
         }
     }
+    svc.spawn_firewall_reconcile();
     Ok(Ec2Service::respond(
         "DeleteNetworkAclEntry",
         &req.request_id,
@@ -352,6 +355,7 @@ pub(crate) fn replace_network_acl_association(
             }
         }
     }
+    svc.spawn_firewall_reconcile();
     Ok(Ec2Service::respond(
         "ReplaceNetworkAclAssociation",
         &req.request_id,

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -397,6 +397,8 @@ fn authorize(
             sg.rules.extend(new_rules.clone());
         }
     }
+    // New rules change what traffic is allowed — re-apply the firewall (ph3).
+    svc.spawn_firewall_reconcile();
     let rule_items: Vec<String> = new_rules
         .iter()
         .map(|r| rule_xml(r, &owner, &region))
@@ -447,6 +449,8 @@ fn revoke(
             }
         }
     }
+    // Removing rules tightens the firewall — re-apply (ph3).
+    svc.spawn_firewall_reconcile();
     Ok(Ec2Service::respond(
         action,
         &req.request_id,


### PR DESCRIPTION
## Summary

Phase 3 of EC2 real network isolation (#1745). Stacked on #1755 (phase 2) -> #1754 (phase 1); bases retarget as each merges.

Phase 2 isolates subnets at L3 but does nothing *within* a subnet — SG/NACL rules block no traffic. This adds a **network-driver abstraction** that translates the SG/NACL model into an **nftables** ruleset and applies it on the host, scoped to fakecloud's per-subnet bridges.

- **`runtime::firewall`** — pure, exhaustively unit-tested renderer: a per-subnet model (instances + flattened SG ingress/egress + subnet NACL denies) -> an `inet fakecloud_ec2` nft table. Stateful (`established,related accept`), per-instance allow-then-default-deny, NACL denies first. Protocols/ports/CIDRs/icmp/referenced-groups handled.
- **`FirewallEnforcer`** — the driver. nftables when capable, else a degraded no-op. **Opt-in** via `FAKECLOUD_EC2_SG_ENFORCEMENT`, capability-gated by an `nft list ruleset` probe. When requested but unbacked (CI, Docker Desktop, rootless podman) it warns once and degrades to metadata-only — phase-2 isolation still holds, **no regression**. Apply is an atomic `nft -f -` swap of fakecloud's own table (never touches docker's rules).
- **`service::firewall_model`** — builds the model across every account partition (the host nft table is global); referenced security groups expand to member `/32`s so the default SG's allow-from-self works; only running, subnet-placed instances are enforced.
- Re-applied on RunInstances (once up), Start/Stop/Terminate, Authorize/Revoke ingress/egress, and network-ACL entry/association edits — all in the background, all skipped when enforcement is disabled.

k8s keeps a disabled enforcer (isolation there is NetworkPolicy, phase 4).

## Test plan

- 11 new unit tests: nft ruleset rendering (allow/deny, protocols, ports, CIDR/`/32`, icmp, NACL ordering, opt-in/capability gating) + model building (CIDR + referenced-group expansion, pending exclusion).
- `crates/fakecloud-e2e/tests/ec2_sg_enforcement.rs` (Docker-gated): the **degrade path** — enforcement requested, no NET_ADMIN -> instances still boot and same-subnet reachability is unchanged.
- `cargo test -p fakecloud-ec2` (38 pass), clippy + fmt clean.

Enforcement-on (real packet drops) needs nftables + `CAP_NET_ADMIN`, which CI lacks; that path is covered by the unit-tested ruleset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add host-level enforcement of EC2 security groups and NACLs via nftables, scoped to per-subnet bridges. This completes phase 3 of real network isolation (#1745), gated by `FAKECLOUD_EC2_SG_ENFORCEMENT`, and degrades cleanly when `nft`/`CAP_NET_ADMIN` are unavailable.

- **New Features**
  - `runtime::firewall`: renderer from a per-subnet model to an `inet fakecloud_ec2` nft table; stateful (`established,related accept`), per-instance allow-then-default-deny; NACL denies first.
  - `FirewallEnforcer`: picks nftables or no-op via capability probe; applies with atomic `nft -f -` swaps; warns once when requested but unavailable; never touches Docker rules.
  - `service::firewall_model`: builds the model across all accounts; expands referenced groups to member `/32`s; only running, subnet-placed instances are enforced.
  - Automatic reconcile after RunInstances start, Start/Stop/Terminate, SG authorize/revoke, and NACL entry/association changes; runs in the background; k8s backend keeps enforcement disabled.

- **Migration**
  - Enable by setting `FAKECLOUD_EC2_SG_ENFORCEMENT=1` on hosts with `nft` and `CAP_NET_ADMIN`.
  - If requested but unavailable (e.g., CI, Docker Desktop, rootless podman), it logs once and falls back to metadata-only; phase-2 isolation is unchanged.
  - No action needed if you leave enforcement disabled.

<sup>Written for commit 39117a4cccdd49465b65ea864d5d0c39763f76be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

