### PR TITLE
feat(ec2): k8s NetworkPolicy enforcement for security groups (#1745 phase 4)

### DIFF
--- a/crates/fakecloud-ec2/src/runtime/firewall.rs
+++ b/crates/fakecloud-ec2/src/runtime/firewall.rs
@@ -50,6 +50,19 @@ pub struct InstanceFirewall {
     pub egress: Vec<FirewallRule>,
 }
 
+/// One running instance's flattened firewall view, keyed by both its id (for
+/// the k8s NetworkPolicy `podSelector`) and its IP (for nft). The shared
+/// intermediate the service layer produces from EC2 state; the nft model
+/// builder and the k8s NetworkPolicy builder both consume it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceRules {
+    pub instance_id: String,
+    pub subnet_id: String,
+    pub private_ip: String,
+    pub ingress: Vec<FirewallRule>,
+    pub egress: Vec<FirewallRule>,
+}
+
 /// A subnet-level NACL entry (allow/deny, ordered by rule number by the
 /// caller). NACLs are stateless and apply to the whole subnet.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/fakecloud-ec2/src/runtime/k8s.rs
+++ b/crates/fakecloud-ec2/src/runtime/k8s.rs
@@ -21,6 +21,8 @@ use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
 use fakecloud_k8s::{labels, names, K8sClient, K8sEnv, K8sPodConfig};
 
+use super::firewall::InstanceRules;
+use super::netpolicy::{self, CniDriver};
 use super::{boot_command, BackendInitError, RunningInstance, RuntimeError};
 
 /// Which `fakecloud-service` label instance Pods carry.
@@ -44,6 +46,10 @@ pub(super) struct K8sInstances {
     /// `Terminating`; a fresh name avoids a name collision with it (the old
     /// Pod terminates on its own).
     spawn_seq: Arc<AtomicU64>,
+    /// The detected cluster CNI, deciding whether NetworkPolicy is enforced
+    /// (#1745 phase 4). Policies are always created; this only governs the
+    /// degrade warning.
+    cni: CniDriver,
 }
 
 impl std::fmt::Debug for K8sInstances {
@@ -66,12 +72,46 @@ impl K8sInstances {
             "K8s EC2 backend initialized"
         );
         let pod_config = K8sPodConfig::resolved_base("FAKECLOUD_EC2_K8S")?;
+        // Detect the CNI so we can warn when NetworkPolicy won't be enforced.
+        let cni = CniDriver::from_components(client.kube_system_pod_names().await);
+        if cni.enforces() {
+            tracing::info!(?cni, "k8s CNI enforces NetworkPolicy; EC2 security groups will be applied as NetworkPolicies");
+        } else {
+            tracing::warn!(
+                "k8s CNI does not appear to enforce NetworkPolicy (detected: {cni:?}); EC2 \
+                 security-group NetworkPolicies will be created but may not be enforced by the \
+                 cluster -- install a NetworkPolicy-enforcing CNI (e.g. Calico) for real isolation"
+            );
+        }
         Ok(Self {
             client,
             pull_secret: env.pull_secret,
             pod_config,
             spawn_seq: Arc::new(AtomicU64::new(0)),
+            cni,
         })
+    }
+
+    /// (Re)apply one NetworkPolicy per running instance and prune policies for
+    /// instances that no longer exist. Always creates the policies; whether
+    /// they're enforced is up to the cluster CNI (warned about at startup).
+    pub(super) async fn reconcile_network_policies(&self, rules: &[InstanceRules]) {
+        let namespace = self.client.namespace().to_string();
+        let owner = self.client.instance_id().to_string();
+        let policies = netpolicy::build_policies(rules, &namespace, &owner);
+        let keep: std::collections::HashSet<String> = policies
+            .iter()
+            .filter_map(|p| p.metadata.name.clone())
+            .collect();
+        for policy in &policies {
+            self.client.apply_network_policy(policy).await;
+        }
+        self.client.prune_network_policies(&keep).await;
+        tracing::debug!(
+            count = policies.len(),
+            enforced = self.cni.enforces(),
+            "applied EC2 NetworkPolicies"
+        );
     }
 
     /// Spawn (or recreate) the Pod backing an instance. Each spawn gets a

--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -20,13 +20,16 @@
 
 pub mod firewall;
 mod k8s;
+pub mod netpolicy;
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use firewall::{render_ruleset, resolve_enforcement_mode, EnforcementMode, SubnetFirewall};
+use firewall::{
+    render_ruleset, resolve_enforcement_mode, EnforcementMode, InstanceRules, SubnetFirewall,
+};
 
 /// Default base image an instance's container runs. AMIs don't map to a
 /// concrete OS image, so we boot a real Amazon Linux container by default
@@ -262,6 +265,26 @@ impl Ec2Runtime {
     /// given per-subnet model. No-op (cheap) when enforcement is disabled.
     pub async fn reconcile_firewall(&self, subnets: Vec<SubnetFirewall>) {
         self.firewall.reconcile(&subnets).await;
+    }
+
+    /// Whether this runtime backs network isolation with real enforcement —
+    /// host nftables (Docker, opt-in) or k8s NetworkPolicy. Lets the control
+    /// plane skip building the firewall model entirely when neither applies.
+    pub fn network_isolation_enforced(&self) -> bool {
+        self.firewall.enabled() || self.is_k8s()
+    }
+
+    /// True for the Kubernetes backend (isolation via NetworkPolicy).
+    pub fn is_k8s(&self) -> bool {
+        matches!(self.backend, InstanceBackend::K8s(_))
+    }
+
+    /// Apply one NetworkPolicy per instance for the k8s backend. No-op on the
+    /// Docker backend (which uses nftables instead).
+    pub async fn reconcile_network_policies(&self, rules: Vec<InstanceRules>) {
+        if let InstanceBackend::K8s(k) = &self.backend {
+            k.reconcile_network_policies(&rules).await;
+        }
     }
 
     /// Name of the active backend, for logging.

--- a/crates/fakecloud-ec2/src/runtime/netpolicy.rs
+++ b/crates/fakecloud-ec2/src/runtime/netpolicy.rs
@@ -1,0 +1,317 @@
+//! Kubernetes NetworkPolicy enforcement for EC2 security groups (#1745 ph4).
+//!
+//! The Docker backend filters traffic with host nftables (phase 3). k8s Pods
+//! share a flat L3 network with no bridge to hook, so isolation there is
+//! expressed as **NetworkPolicy** objects (L3/L4 pod/IP selectors) and enforced
+//! by the cluster CNI — *if* the CNI enforces NetworkPolicy at all. Several
+//! common CNIs (notably kind's default `kindnet`) ignore NetworkPolicy, so this
+//! module always creates the (correct) policies and **degrades gracefully**:
+//! it detects the CNI, warns once when enforcement isn't guaranteed, and never
+//! blocks Pod creation on it.
+//!
+//! ## Pluggable CNI
+//!
+//! [`CniDriver`] abstracts "does this cluster enforce NetworkPolicy". Calico is
+//! the first known-enforcing driver; the enum is the extension point for
+//! Cilium/others. Detection is best-effort (presence of the CNI's API group /
+//! components); unknown CNIs degrade to "create but don't assume enforcement".
+//!
+//! The policy *translation* ([`build_policies`]) is pure and unit-tested; the
+//! apply path lives in the k8s client.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::networking::v1::{
+    IPBlock, NetworkPolicy, NetworkPolicyEgressRule, NetworkPolicyIngressRule, NetworkPolicyPeer,
+    NetworkPolicyPort, NetworkPolicySpec,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+
+use fakecloud_k8s::{labels, names};
+
+use super::firewall::{FirewallRule, InstanceRules};
+
+/// The `fakecloud-ec2` pod label whose value is the (DNS-safe) instance id —
+/// the same label the instance Pod carries, so a policy's `podSelector` targets
+/// exactly that instance.
+const INSTANCE_LABEL: &str = "fakecloud-ec2";
+
+/// Name of the NetworkPolicy backing one instance.
+pub fn policy_name(instance_id: &str) -> String {
+    format!("fakecloud-ec2-{}", names::label_safe(instance_id))
+}
+
+/// Build one NetworkPolicy per instance from the shared flattened rules. Each
+/// policy selects its instance Pod and restricts ingress/egress to the CIDRs +
+/// ports its security groups allow. `instance_label` is this fakecloud
+/// process's ownership label, stamped on every policy so the reaper can prune
+/// policies orphaned by a previous process.
+pub fn build_policies(
+    rules: &[InstanceRules],
+    namespace: &str,
+    instance_label: &str,
+) -> Vec<NetworkPolicy> {
+    rules
+        .iter()
+        .map(|r| build_one(r, namespace, instance_label))
+        .collect()
+}
+
+fn build_one(r: &InstanceRules, namespace: &str, instance_label: &str) -> NetworkPolicy {
+    let slug = names::label_safe(&r.instance_id);
+
+    let mut policy_labels = BTreeMap::new();
+    policy_labels.insert(
+        labels::MANAGED_BY.to_string(),
+        labels::MANAGED_BY_VALUE.to_string(),
+    );
+    policy_labels.insert(labels::INSTANCE.to_string(), instance_label.to_string());
+    policy_labels.insert(labels::SERVICE.to_string(), "ec2".to_string());
+
+    let mut selector_labels = BTreeMap::new();
+    selector_labels.insert(INSTANCE_LABEL.to_string(), slug);
+
+    NetworkPolicy {
+        metadata: ObjectMeta {
+            name: Some(policy_name(&r.instance_id)),
+            namespace: Some(namespace.to_string()),
+            labels: Some(policy_labels),
+            ..ObjectMeta::default()
+        },
+        spec: Some(NetworkPolicySpec {
+            pod_selector: LabelSelector {
+                match_labels: Some(selector_labels),
+                ..LabelSelector::default()
+            },
+            policy_types: Some(vec!["Ingress".to_string(), "Egress".to_string()]),
+            ingress: Some(r.ingress.iter().map(ingress_rule).collect()),
+            egress: Some(r.egress.iter().map(egress_rule).collect()),
+        }),
+    }
+}
+
+fn ingress_rule(r: &FirewallRule) -> NetworkPolicyIngressRule {
+    NetworkPolicyIngressRule {
+        from: peers(&r.cidr),
+        ports: ports(r),
+    }
+}
+
+fn egress_rule(r: &FirewallRule) -> NetworkPolicyEgressRule {
+    NetworkPolicyEgressRule {
+        to: peers(&r.cidr),
+        ports: ports(r),
+    }
+}
+
+/// `None` (any source/destination) for `0.0.0.0/0`/absent; otherwise a single
+/// `ipBlock` peer. Pod-to-pod allows (referenced security groups) arrive as the
+/// members' `/32`s, which match as ipBlocks.
+fn peers(cidr: &Option<String>) -> Option<Vec<NetworkPolicyPeer>> {
+    let c = cidr.as_deref()?;
+    if c == "0.0.0.0/0" || c.is_empty() {
+        return None;
+    }
+    Some(vec![NetworkPolicyPeer {
+        ip_block: Some(IPBlock {
+            cidr: c.to_string(),
+            except: None,
+        }),
+        ..NetworkPolicyPeer::default()
+    }])
+}
+
+/// Translate a rule's protocol/ports into NetworkPolicy ports. `None` (all
+/// ports) for all-protocols / portless / ICMP rules — standard NetworkPolicy
+/// only matches TCP/UDP/SCTP, so ICMP can't be narrowed and rides as "all".
+fn ports(r: &FirewallRule) -> Option<Vec<NetworkPolicyPort>> {
+    let proto = match r.protocol.as_str() {
+        "tcp" | "6" => "TCP",
+        "udp" | "17" => "UDP",
+        // all-protocols / icmp / unknown: cannot express as a NetworkPolicy
+        // port -> leave ports unset (all ports of all protocols).
+        _ => return None,
+    };
+    if r.from_port < 0 || r.to_port < 0 {
+        return None;
+    }
+    let mut port = NetworkPolicyPort {
+        protocol: Some(proto.to_string()),
+        port: Some(IntOrString::Int(r.from_port as i32)),
+        end_port: None,
+    };
+    if r.to_port > r.from_port {
+        port.end_port = Some(r.to_port as i32);
+    }
+    Some(vec![port])
+}
+
+/// Container Network Interface plugins fakecloud knows how to reason about for
+/// NetworkPolicy enforcement. The pluggable seam: add a variant + detection to
+/// support a new enforcing CNI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CniDriver {
+    /// Calico — enforces NetworkPolicy.
+    Calico,
+    /// Cilium — enforces NetworkPolicy.
+    Cilium,
+    /// A CNI we couldn't identify, or one known not to enforce NetworkPolicy
+    /// (e.g. kindnet). Policies are still created; enforcement isn't assumed.
+    Unknown,
+}
+
+impl CniDriver {
+    /// Whether this CNI is known to enforce NetworkPolicy.
+    pub fn enforces(self) -> bool {
+        matches!(self, CniDriver::Calico | CniDriver::Cilium)
+    }
+
+    /// Identify the CNI from the set of well-known component/daemonset names
+    /// present in the cluster (typically read from `kube-system`). Pure so the
+    /// detection logic is unit-testable without a cluster.
+    pub fn from_components<I, S>(component_names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut calico = false;
+        let mut cilium = false;
+        for name in component_names {
+            let n = name.as_ref();
+            if n.contains("calico") {
+                calico = true;
+            }
+            if n.contains("cilium") {
+                cilium = true;
+            }
+        }
+        if calico {
+            CniDriver::Calico
+        } else if cilium {
+            CniDriver::Cilium
+        } else {
+            CniDriver::Unknown
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rules(
+        instance: &str,
+        ingress: Vec<FirewallRule>,
+        egress: Vec<FirewallRule>,
+    ) -> InstanceRules {
+        InstanceRules {
+            instance_id: instance.to_string(),
+            subnet_id: "subnet-1".to_string(),
+            private_ip: "172.30.0.2".to_string(),
+            ingress,
+            egress,
+        }
+    }
+
+    fn tcp(port: i64, cidr: Option<&str>) -> FirewallRule {
+        FirewallRule {
+            protocol: "tcp".into(),
+            from_port: port,
+            to_port: port,
+            cidr: cidr.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn policy_selects_instance_and_sets_both_directions() {
+        let r = rules("i-0ABC", vec![tcp(22, Some("10.0.0.0/8"))], vec![]);
+        let p = &build_policies(&[r], "fakecloud", "fakecloud-123")[0];
+        assert_eq!(p.metadata.name.as_deref(), Some("fakecloud-ec2-i-0abc"));
+        let spec = p.spec.as_ref().unwrap();
+        // selects the instance pod by its label-safe id
+        assert_eq!(
+            spec.pod_selector
+                .match_labels
+                .as_ref()
+                .unwrap()
+                .get("fakecloud-ec2")
+                .map(String::as_str),
+            Some("i-0abc")
+        );
+        assert_eq!(
+            spec.policy_types.as_ref().unwrap(),
+            &vec!["Ingress".to_string(), "Egress".to_string()]
+        );
+        // one ingress rule: from 10.0.0.0/8 tcp/22
+        let ing = &spec.ingress.as_ref().unwrap()[0];
+        let peer = &ing.from.as_ref().unwrap()[0];
+        assert_eq!(peer.ip_block.as_ref().unwrap().cidr, "10.0.0.0/8");
+        let port = &ing.ports.as_ref().unwrap()[0];
+        assert_eq!(port.protocol.as_deref(), Some("TCP"));
+        assert_eq!(port.port, Some(IntOrString::Int(22)));
+    }
+
+    #[test]
+    fn anywhere_all_protocols_rule_has_no_peer_or_ports() {
+        let all = FirewallRule {
+            protocol: "-1".into(),
+            from_port: -1,
+            to_port: -1,
+            cidr: Some("0.0.0.0/0".into()),
+        };
+        let r = rules("i-1", vec![all], vec![]);
+        let p = &build_policies(&[r], "fakecloud", "x")[0];
+        let ing = &p.spec.as_ref().unwrap().ingress.as_ref().unwrap()[0];
+        assert!(ing.from.is_none(), "0.0.0.0/0 -> any source");
+        assert!(ing.ports.is_none(), "all protocols -> any port");
+    }
+
+    #[test]
+    fn port_range_uses_end_port() {
+        let range = FirewallRule {
+            protocol: "tcp".into(),
+            from_port: 8000,
+            to_port: 8100,
+            cidr: None,
+        };
+        let r = rules("i-1", vec![range], vec![]);
+        let p = &build_policies(&[r], "fakecloud", "x")[0];
+        let port = &p.spec.as_ref().unwrap().ingress.as_ref().unwrap()[0]
+            .ports
+            .as_ref()
+            .unwrap()[0];
+        assert_eq!(port.port, Some(IntOrString::Int(8000)));
+        assert_eq!(port.end_port, Some(8100));
+    }
+
+    #[test]
+    fn referenced_member_ip_becomes_ipblock() {
+        let r = rules("i-1", vec![tcp(80, Some("172.30.0.3/32"))], vec![]);
+        let p = &build_policies(&[r], "fakecloud", "x")[0];
+        let peer = &p.spec.as_ref().unwrap().ingress.as_ref().unwrap()[0]
+            .from
+            .as_ref()
+            .unwrap()[0];
+        assert_eq!(peer.ip_block.as_ref().unwrap().cidr, "172.30.0.3/32");
+    }
+
+    #[test]
+    fn cni_detection_and_enforcement() {
+        assert_eq!(
+            CniDriver::from_components(["calico-node", "coredns"]),
+            CniDriver::Calico
+        );
+        assert_eq!(
+            CniDriver::from_components(["cilium-abc"]),
+            CniDriver::Cilium
+        );
+        assert_eq!(
+            CniDriver::from_components(["kindnet-xyz", "kube-proxy"]),
+            CniDriver::Unknown
+        );
+        assert!(CniDriver::Calico.enforces());
+        assert!(CniDriver::Cilium.enforces());
+        assert!(!CniDriver::Unknown.enforces());
+    }
+}

--- a/crates/fakecloud-ec2/src/service/firewall_model.rs
+++ b/crates/fakecloud-ec2/src/service/firewall_model.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use crate::runtime::firewall::{
-    group_by_subnet, FirewallRule, InstanceFirewall, NaclRule, SubnetFirewall,
+    group_by_subnet, FirewallRule, InstanceFirewall, InstanceRules, NaclRule, SubnetFirewall,
 };
 use crate::runtime::{subnet_network_name, Ec2Runtime};
 use crate::state::{Ec2State, NetworkAcl, SecurityGroupRule, SharedEc2State};
@@ -90,8 +90,10 @@ fn subnet_nacl<'a>(state: &'a Ec2State, subnet_id: &str) -> Option<&'a NetworkAc
         .find(|a| a.is_default && &a.vpc_id == vpc)
 }
 
-/// Build the per-subnet firewall model for one account partition.
-pub(crate) fn build_for_state(state: &Ec2State) -> Vec<SubnetFirewall> {
+/// Flatten every enforced (running, subnet-placed) instance's security groups
+/// into per-instance ingress/egress rules, expanding referenced groups to
+/// member `/32`s.
+pub(crate) fn instance_rules(state: &Ec2State) -> Vec<InstanceRules> {
     // sg-id -> running member IPs, for referenced-group expansion.
     let mut sg_members: HashMap<String, Vec<String>> = HashMap::new();
     for inst in state.instances.values() {
@@ -105,8 +107,7 @@ pub(crate) fn build_for_state(state: &Ec2State) -> Vec<SubnetFirewall> {
         }
     }
 
-    let mut instances: Vec<(String, InstanceFirewall)> = Vec::new();
-    let mut subnets_in_play: Vec<String> = Vec::new();
+    let mut out = Vec::new();
     for inst in state.instances.values() {
         let Some(subnet_id) = enforced(inst) else {
             continue;
@@ -125,16 +126,32 @@ pub(crate) fn build_for_state(state: &Ec2State) -> Vec<SubnetFirewall> {
                 }
             }
         }
+        out.push(InstanceRules {
+            instance_id: inst.instance_id.clone(),
+            subnet_id: subnet_id.to_string(),
+            private_ip: inst.private_ip.clone(),
+            ingress,
+            egress,
+        });
+    }
+    out
+}
+
+/// Build the per-subnet nftables model for one account partition.
+pub(crate) fn build_for_state(state: &Ec2State) -> Vec<SubnetFirewall> {
+    let mut instances: Vec<(String, InstanceFirewall)> = Vec::new();
+    let mut subnets_in_play: Vec<String> = Vec::new();
+    for r in instance_rules(state) {
         instances.push((
-            subnet_network_name(subnet_id),
+            subnet_network_name(&r.subnet_id),
             InstanceFirewall {
-                private_ip: inst.private_ip.clone(),
-                ingress,
-                egress,
+                private_ip: r.private_ip,
+                ingress: r.ingress,
+                egress: r.egress,
             },
         ));
-        if !subnets_in_play.contains(&subnet_id.to_string()) {
-            subnets_in_play.push(subnet_id.to_string());
+        if !subnets_in_play.contains(&r.subnet_id) {
+            subnets_in_play.push(r.subnet_id);
         }
     }
 
@@ -148,9 +165,22 @@ pub(crate) fn build_for_state(state: &Ec2State) -> Vec<SubnetFirewall> {
     group_by_subnet(instances, nacls)
 }
 
-/// Build the model across every account partition (the host nft table is
-/// global) and hand it to the runtime to apply.
+/// Re-derive the firewall model across every account partition and apply it via
+/// the runtime — nftables for the Docker backend, NetworkPolicies for k8s. The
+/// runtime dispatches on its backend; this only assembles the global model.
 pub(crate) async fn reconcile(state: &SharedEc2State, runtime: &Arc<Ec2Runtime>) {
+    if runtime.is_k8s() {
+        // k8s: one NetworkPolicy per instance, built from the shared flatten.
+        let rules: Vec<InstanceRules> = {
+            let accounts = state.read();
+            accounts
+                .iter()
+                .flat_map(|(_, s)| instance_rules(s))
+                .collect()
+        };
+        runtime.reconcile_network_policies(rules).await;
+        return;
+    }
     let model: Vec<SubnetFirewall> = {
         let accounts = state.read();
         accounts

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -414,7 +414,7 @@ pub(crate) async fn run_instances(
             // security-group firewall so the new instances are filtered
             // (#1745 phase 3). No-op when enforcement is disabled.
             if let Some(rt) = &runtime {
-                if rt.firewall().enabled() {
+                if rt.network_isolation_enforced() {
                     super::firewall_model::reconcile(&svc_state, rt).await;
                 }
             }
@@ -605,7 +605,7 @@ async fn change_state(
             // Lifecycle changes move/remove instances (new IP on start, gone on
             // terminate): re-apply the security-group firewall (#1745 ph3).
             if let Some(rt) = &runtime {
-                if rt.firewall().enabled() {
+                if rt.network_isolation_enforced() {
                     super::firewall_model::reconcile(&svc_state, rt).await;
                 }
             }

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -917,7 +917,7 @@ impl Ec2Service {
         let Some(runtime) = self.runtime.clone() else {
             return;
         };
-        if !runtime.firewall().enabled() {
+        if !runtime.network_isolation_enforced() {
             return;
         }
         let state = self.state.clone();

--- a/crates/fakecloud-ec2/tests/k8s_integration.rs
+++ b/crates/fakecloud-ec2/tests/k8s_integration.rs
@@ -205,3 +205,60 @@ async fn instance_lifecycle_boots_pod_runs_user_data_and_recreates_on_start() {
     let removed = poll_until(120, || pod_absent(&api, &new_pod)).await;
     assert!(removed, "Pod should be gone after TerminateInstances");
 }
+
+#[tokio::test]
+async fn security_groups_become_network_policies() {
+    use fakecloud_ec2::runtime::firewall::{FirewallRule, InstanceRules};
+    use fakecloud_ec2::runtime::netpolicy::policy_name;
+    use k8s_openapi::api::networking::v1::NetworkPolicy;
+
+    require_test_env();
+    ensure_namespace().await;
+    k8s_runtime_env();
+
+    let rt = Ec2Runtime::new_k8s(4566).await.expect("new_k8s");
+    let c = client().await;
+    let np_api: Api<NetworkPolicy> = Api::namespaced(c.client().clone(), TEST_NS);
+
+    let instance_id = "i-0k8snetpol";
+    let rules = vec![InstanceRules {
+        instance_id: instance_id.to_string(),
+        subnet_id: "subnet-k8s".to_string(),
+        private_ip: "10.99.0.2".to_string(),
+        ingress: vec![FirewallRule {
+            protocol: "tcp".into(),
+            from_port: 443,
+            to_port: 443,
+            cidr: Some("10.0.0.0/8".into()),
+        }],
+        egress: vec![],
+    }];
+
+    // Reconcile creates one NetworkPolicy selecting the instance pod, with the
+    // SG's ingress rule. (kindnet doesn't enforce it, but the object must exist
+    // -- a NetworkPolicy-enforcing CNI like Calico would then enforce it.)
+    rt.reconcile_network_policies(rules).await;
+    let name = policy_name(instance_id);
+    let np = np_api.get(&name).await.expect("NetworkPolicy should exist");
+    let spec = np.spec.expect("spec");
+    assert_eq!(
+        spec.pod_selector
+            .match_labels
+            .as_ref()
+            .and_then(|l| l.get("fakecloud-ec2"))
+            .map(String::as_str),
+        Some("i-0k8snetpol")
+    );
+    assert_eq!(spec.ingress.as_ref().map(|i| i.len()), Some(1));
+
+    // Reconciling with no instances prunes the policy.
+    rt.reconcile_network_policies(vec![]).await;
+    let pruned = poll_until(20, || async {
+        np_api.get_opt(&name).await.ok().flatten().is_none()
+    })
+    .await;
+    assert!(
+        pruned,
+        "NetworkPolicy should be pruned when its instance is gone"
+    );
+}

--- a/crates/fakecloud-k8s/src/client.rs
+++ b/crates/fakecloud-k8s/src/client.rs
@@ -10,6 +10,7 @@
 use std::time::{Duration, Instant};
 
 use k8s_openapi::api::core::v1::Pod;
+use k8s_openapi::api::networking::v1::NetworkPolicy;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
 use kube::api::{Api, AttachParams, DeleteParams, ListParams, PostParams};
 use kube::Client;
@@ -376,6 +377,77 @@ impl K8sClient {
             tracing::info!(service, reaped, "k8s reap_stale: removed orphan Pods");
         }
         reaped
+    }
+
+    /// Namespaced NetworkPolicy API handle.
+    pub fn network_policies(&self) -> Api<NetworkPolicy> {
+        Api::namespaced(self.client.clone(), &self.namespace)
+    }
+
+    /// Create or replace a NetworkPolicy (delete-then-create, like
+    /// [`create_pod`](Self::create_pod), so a re-apply with changed rules
+    /// always lands). Best-effort: errors are logged, not propagated, since a
+    /// failed policy apply must never fail the originating EC2 API call.
+    pub async fn apply_network_policy(&self, np: &NetworkPolicy) {
+        let Some(name) = np.metadata.name.clone() else {
+            return;
+        };
+        let api = self.network_policies();
+        let _ = api.delete(&name, &DeleteParams::default()).await;
+        if let Err(e) = api.create(&PostParams::default(), np).await {
+            // A concurrent re-apply may have recreated it; a 409 is benign.
+            if !matches!(&e, kube::Error::Api(a) if a.code == 409) {
+                tracing::warn!(policy = %name, error = %e, "k8s apply NetworkPolicy failed");
+            }
+        }
+    }
+
+    /// Delete every NetworkPolicy owned by this process (managed-by + this
+    /// instance label) whose name is not in `keep`. Prunes policies for
+    /// instances that have since terminated. Best-effort.
+    pub async fn prune_network_policies(&self, keep: &std::collections::HashSet<String>) {
+        let api = self.network_policies();
+        let selector = format!(
+            "{}={},{}={}",
+            labels::MANAGED_BY,
+            labels::MANAGED_BY_VALUE,
+            labels::INSTANCE,
+            self.instance_id,
+        );
+        let lp = ListParams::default().labels(&selector);
+        let list = match api.list(&lp).await {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!(error = %e, "k8s prune NetworkPolicies: list failed");
+                return;
+            }
+        };
+        for np in list.items {
+            if let Some(name) = np.metadata.name {
+                if !keep.contains(&name) {
+                    let _ = api.delete(&name, &DeleteParams::default()).await;
+                }
+            }
+        }
+    }
+
+    /// Best-effort detection of the cluster CNI from `kube-system` Pod names
+    /// (e.g. `calico-node-*`, `cilium-*`, `kindnet-*`). Returns the matched
+    /// component names; the caller maps them to a driver. An empty result
+    /// (list failed or no recognizable CNI) maps to "unknown".
+    pub async fn kube_system_pod_names(&self) -> Vec<String> {
+        let api: Api<Pod> = Api::namespaced(self.client.clone(), "kube-system");
+        match api.list(&ListParams::default()).await {
+            Ok(list) => list
+                .items
+                .into_iter()
+                .filter_map(|p| p.metadata.name)
+                .collect(),
+            Err(e) => {
+                tracing::debug!(error = %e, "k8s CNI detect: list kube-system pods failed");
+                Vec::new()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 4 of EC2 real network isolation (#1745). Stacked on #1756 (phase 3); base retargets as the stack merges.

The Docker backend filters with host nftables (phase 3). k8s Pods share a flat L3 network with no bridge to hook, so isolation there is expressed as **NetworkPolicy** objects, enforced by the cluster CNI.

- **`runtime::netpolicy`** — pure, unit-tested translation of the shared per-instance SG model into one NetworkPolicy per instance: `podSelector` on the instance's `fakecloud-ec2` label; ingress/egress as `ipBlock` peers + TCP/UDP ports; referenced security groups arrive as member `/32`s; all-protocols/ICMP ride as "all ports".
- **`CniDriver`** — pluggable CNI abstraction (**Calico** + Cilium known-enforcing, Unknown otherwise), detected from `kube-system` component names. Calico first, extendable. When the CNI doesn't enforce NetworkPolicy (e.g. kind's `kindnet`), policies are still created and a one-time startup warning is logged — **graceful degrade**, never blocks Pod creation.
- **`fakecloud-k8s` client** — `apply_network_policy` (delete-then-create), `prune_network_policies` (reap policies for terminated instances), `kube_system_pod_names` for CNI detection.
- The phase-3 reconcile path now **dispatches on backend**: nftables for Docker, NetworkPolicies for k8s. The shared SG-flatten (`InstanceRules`) feeds both.

## Test plan

- 5 unit tests: policy translation (selector, ipBlock peers, port ranges, member `/32`, anywhere/all-proto) + CNI detection/enforcement.
- kind integration test `security_groups_become_network_policies` (in the existing `k8s_integration` feature suite, run by the "K8s backend (kind)" job): a reconcile creates the NetworkPolicy with the right selector + ingress rule, and a reconcile with no instances prunes it.
- Also fixes the feature-gated k8s integration test's `run_instance` call to the phase-2 4-arg signature (was only compiled in the kind job).
- `cargo test -p fakecloud-ec2 -p fakecloud-k8s`, clippy, fmt clean.

Real enforcement needs a NetworkPolicy-enforcing CNI; kindnet (CI) doesn't, so the kind test asserts policy *creation* + pruning while the translation correctness is unit-tested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Kubernetes NetworkPolicy support to apply EC2 security groups in the k8s backend, creating one policy per instance with CNI detection and graceful fallback. Docker still uses nftables; the control plane dispatches per backend and prunes stale policies.

- **New Features**
  - Added `runtime::netpolicy`: translate shared `InstanceRules` into one `NetworkPolicy` per instance (selector on `fakecloud-ec2`, `ipBlock` peers, TCP/UDP with `endPort`, SG refs as `/32`, ICMP/all-proto as “all ports”).
  - Introduced `CniDriver` with detection from `kube-system` pods (Calico/Cilium enforce; unknown logs a startup warning). Policies are always created and never block Pod creation.
  - Extended `fakecloud-k8s` client with `apply_network_policy`, `prune_network_policies`, and `kube_system_pod_names`.
  - Reconcile path: Docker → nftables; k8s → NetworkPolicies. Runtime adds `network_isolation_enforced()`, `is_k8s()`, and `reconcile_network_policies()`, and prunes policies for terminated instances. Tests cover translation + CNI detection; kind integration test asserts create/prune; fixed k8s test `run_instance` call signature.

<sup>Written for commit 6579dd3792d88c64c4d119088dbab1cd6c1c52e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

