### PR TITLE
docs(sdk): EC2 introspection section in SDK references (#1745 follow-up)

### DIFF
--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -208,6 +208,13 @@ FakeCloud fc = new FakeCloud("http://localhost:4566"); // explicit base URL
 | `getServerlessCaches()`   | List ElastiCache serverless caches   |
 | `getElastiCacheAcls()`    | List ElastiCache (Valkey/Redis) ACLs |
 
+### `fc.ec2()`
+
+| Method                  | Description                                                                                                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getInstances()`        | List EC2 instances with control-plane + runtime metadata                                                                                                    |
+| `getInstanceNetworks()` | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
+
 ### `fc.ecr()`
 
 | Method                                    | Description                                  |

--- a/sdks/php/README.md
+++ b/sdks/php/README.md
@@ -88,6 +88,13 @@ $fc = new FakeCloud('http://localhost:4566'); // explicit base URL
 | `getServerlessCaches()`   | List ElastiCache serverless caches  |
 | `getElastiCacheAcls()`    | List ElastiCache user ACLs          |
 
+### `$fc->ec2()`
+
+| Method                  | Description                                                                                                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getInstances()`        | List EC2 instances with control-plane + runtime metadata                                                                                                    |
+| `getInstanceNetworks()` | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
+
 ### `$fc->ecr()`
 
 | Method                              | Description                          |

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -124,6 +124,13 @@ Pass `base_url` (default `http://localhost:4566`).
 | `get_images(repository_name=None)` | List images, optionally filtered by repo |
 | `get_pull_through_rules()` | List pull-through cache rules |
 
+### `fc.ec2`
+
+| Method | Description |
+|---|---|
+| `get_instances()` | List EC2 instances with control-plane + runtime metadata |
+| `get_instance_networks()` | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
+
 ### `fc.ecs`
 
 | Method | Description |

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -139,6 +139,13 @@ Top-level client. Defaults to `http://localhost:4566`.
 | ----------- | ---------------------- |
 | `tickTtl()` | Tick the TTL processor |
 
+### `fc.ec2`
+
+| Method                  | Description                                                                                                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getInstances()`        | List EC2 instances with control-plane + runtime metadata                                                                                                    |
+| `getInstanceNetworks()` | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
+
 ### `fc.ecr`
 
 | Method                  | Description                                         |

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -141,9 +141,9 @@ Top-level client. Defaults to `http://localhost:4566`.
 
 ### `fc.ec2`
 
-| Method                  | Description                                                                                                                                                  |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `getInstances()`        | List EC2 instances with control-plane + runtime metadata                                                                                                    |
+| Method                  | Description                                                                                                                                                             |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getInstances()`        | List EC2 instances with control-plane + runtime metadata                                                                                                                |
 | `getInstanceNetworks()` | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
 
 ### `fc.ecr`

--- a/website/content/docs/sdks/go.md
+++ b/website/content/docs/sdks/go.md
@@ -129,6 +129,13 @@ Sub-clients are accessed via methods: `fc.SES()`, `fc.SNS()`, `fc.Lambda()`, etc
 |--------|-------------|
 | `GetNamedQueries(ctx)` | List saved named queries |
 
+## `fc.EC2()`
+
+| Method | Description |
+|--------|-------------|
+| `GetInstances(ctx)` | List EC2 instances with control-plane + runtime metadata |
+| `GetInstanceNetworks(ctx)` | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
+
 ## `fc.ECR()`
 
 | Method | Description |

--- a/website/content/docs/sdks/java.md
+++ b/website/content/docs/sdks/java.md
@@ -73,6 +73,13 @@ FakeCloud fc2 = new FakeCloud("http://localhost:5000"); // explicit base URL
 | `getServerlessCaches()`   | List ElastiCache serverless caches  |
 | `getElastiCacheAcls()`    | List ElastiCache (Valkey/Redis) ACLs |
 
+## `fc.ec2()`
+
+| Method                  | Description                                                                                                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getInstances()`        | List EC2 instances with control-plane + runtime metadata                                                                                                    |
+| `getInstanceNetworks()` | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
+
 ## `fc.ecr()`
 
 | Method                                  | Description                                                  |

--- a/website/content/docs/sdks/php.md
+++ b/website/content/docs/sdks/php.md
@@ -59,6 +59,13 @@ $fc = new FakeCloud('http://localhost:5000');   // explicit base URL
 | `getServerlessCaches()`  | List ElastiCache serverless caches  |
 | `getElastiCacheAcls()`   | List ElastiCache user ACLs          |
 
+## `$fc->ec2()`
+
+| Method                  | Description                                                                                                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getInstances()`        | List EC2 instances with control-plane + runtime metadata                                                                                                    |
+| `getInstanceNetworks()` | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
+
 ## `$fc->ecr()`
 
 | Method                              | Description                           |

--- a/website/content/docs/sdks/python.md
+++ b/website/content/docs/sdks/python.md
@@ -99,6 +99,13 @@ emails = fc.ses.get_emails()
 | `get_images(repository_name=None)`| List images, optionally filtered by repo     |
 | `get_pull_through_rules()`        | List pull-through cache rules                |
 
+## `fc.ec2`
+
+| Method                      | Description                                                                                                                                                  |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_instances()`           | List EC2 instances with control-plane + runtime metadata                                                                                                    |
+| `get_instance_networks()`   | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
+
 ## `fc.ecs`
 
 | Method                                          | Description                                                |

--- a/website/content/docs/sdks/rust.md
+++ b/website/content/docs/sdks/rust.md
@@ -113,6 +113,13 @@ Every sub-client is constructed lazily via an accessor (`fc.lambda()`, `fc.sqs()
 | ------------------ | ------------------------------------------ |
 | `tick_ttl().await` | Tick the DynamoDB TTL processor            |
 
+## `fc.ec2()`
+
+| Method                              | Description                                                                                                                                                  |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_instances().await`             | List EC2 instances with control-plane + runtime metadata                                                                                                    |
+| `get_instance_networks().await`     | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
+
 ## `fc.ecr()`
 
 | Method                              | Description                                |

--- a/website/content/docs/sdks/typescript.md
+++ b/website/content/docs/sdks/typescript.md
@@ -112,6 +112,13 @@ const fc = new FakeCloud("http://localhost:5000");
 | ----------- | ---------------------- |
 | `tickTtl()` | Tick the TTL processor |
 
+## `fc.ec2`
+
+| Method                  | Description                                                                                                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getInstances()`        | List EC2 instances with control-plane + runtime metadata                                                                                                    |
+| `getInstanceNetworks()` | Inspect each instance's backing network (Docker/Podman network or k8s NetworkPolicy), container IP, isolation backend, and whether security-group enforcement is active |
+
 ## `fc.ecr`
 
 | Method                  | Description                                                       |


### PR DESCRIPTION
Markdown-only follow-up to #1758. The phase-5 PR documented the new `/_fakecloud/ec2/instance-networks` endpoint in the main introspection reference and `ec2.md`, but the per-SDK reference tables (4 SDK READMEs + 6 SDK doc pages) were edited in the wrong working tree and missed that merge. This adds the EC2 section (`getInstances` + `getInstanceNetworks`, per-language naming) to each.

Docs only; no code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add EC2 introspection to all SDK references, documenting how to list instances and inspect their networks across languages. This makes the `getInstances` and `getInstanceNetworks` APIs discoverable in 4 SDK READMEs and 6 website pages, and formats the TypeScript README EC2 section for consistency.

<sup>Written for commit cdb74c5d053a8b6b9eacbbaa73a560b5c3416958. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

