### PR TITLE
fix(ec2,docker): ship nft in the image + document SG-enforcement enable path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,14 @@ RUN apt-get update \
 FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates nftables \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+# `nft` (nftables) backs EC2 security-group / NACL packet enforcement when the
+# operator opts in with FAKECLOUD_EC2_SG_ENFORCEMENT=1 and grants CAP_NET_ADMIN
+# (cap_add: NET_ADMIN). Without the binary in the image the feature could never
+# activate and silently degraded to metadata-only even with the capability —
+# the same "documented feature, missing binary" shape as issue #1539 Bug 4.
 # The docker CLI is required for Lambda / RDS / ElastiCache / ECS
 # container orchestration when running fakecloud-in-Docker with the host
 # socket bind-mounted (the documented setup at

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,16 @@ services:
       FAKECLOUD_REGION: "us-east-1"
       FAKECLOUD_ACCOUNT_ID: "123456789012"
       FAKECLOUD_LOG: "info"
+      # Opt in to EC2 security-group / NACL packet enforcement (nftables).
+      # Off by default — uncomment together with the cap_add below. Needs
+      # CAP_NET_ADMIN + the `nft` binary (shipped in the image) on a native-
+      # Linux Docker daemon; degrades to metadata-only otherwise.
+      # FAKECLOUD_EC2_SG_ENFORCEMENT: "1"
+    # Required for EC2 security-group enforcement (FAKECLOUD_EC2_SG_ENFORCEMENT).
+    # Uncomment to let fakecloud install nftables rules on its per-subnet
+    # bridges. Leave commented for the default metadata-only behavior.
+    # cap_add:
+    #   - NET_ADMIN
     # The slim image ships no curl/wget — use the binary's own healthcheck
     # subcommand, which probes 127.0.0.1:<port>/_fakecloud/health.
     healthcheck:

--- a/website/content/docs/services/ec2.md
+++ b/website/content/docs/services/ec2.md
@@ -37,7 +37,15 @@ VPC/subnet/security-group/NACL metadata isn't just stored — fakecloud gives in
 
 - **Default VPC** — every account+region ships a default VPC (`172.31.0.0/16`) with an internet gateway, a main route table, one default subnet per AZ, a `default` security group, and a default NACL, exactly like AWS. `RunInstances` with no `SubnetId` lands in the default subnet and attaches the `default` security group.
 - **L3 isolation (Docker/Podman)** — each subnet gets its own daemon network (`fakecloud-subnet-<id>`); instances in the same subnet share a bridge and can talk, while instances in different VPCs/subnets land on different bridges and **cannot route to each other**. Private subnets (no `0.0.0.0/0 → igw` route) back onto `--internal` networks with no NAT to the host.
-- **Security-group + NACL enforcement (Docker/Podman)** — when enabled, security-group and NACL rules are translated into an **nftables** ruleset applied on the host, so SG rules actually block/allow traffic. This needs `CAP_NET_ADMIN` + `nft`, so it is **opt-in** via `FAKECLOUD_EC2_SG_ENFORCEMENT=1` and **degrades gracefully**: without the capability (CI, Docker Desktop, rootless podman) the rules are tracked but not enforced, with a one-time startup warning — L3 isolation still holds.
+- **Security-group + NACL enforcement (Docker/Podman)** — when enabled, security-group and NACL rules are translated into an **nftables** ruleset applied on the host, so SG rules actually block/allow traffic. This needs `CAP_NET_ADMIN` + `nft`, so it is **opt-in** via `FAKECLOUD_EC2_SG_ENFORCEMENT=1` and **degrades gracefully**: without the capability (CI, Docker Desktop, rootless podman) the rules are tracked but not enforced, with a one-time startup warning — L3 isolation still holds. The published image ships `nft`; you only need to grant the capability and set the env var. With `docker run`:
+
+  ```sh
+  docker run -e FAKECLOUD_EC2_SG_ENFORCEMENT=1 --cap-add=NET_ADMIN \
+    -p 4566:4566 -v /var/run/docker.sock:/var/run/docker.sock \
+    ghcr.io/faiscadev/fakecloud:latest
+  ```
+
+  or in `docker-compose.yml`, uncomment the `cap_add: [NET_ADMIN]` and `FAKECLOUD_EC2_SG_ENFORCEMENT` lines in the shipped compose. Confirm it took effect via `GET /_fakecloud/ec2/instance-networks` — `securityGroupEnforcement` reads `nftables` and `enforcementActive` is `true` when active.
 - **Kubernetes** — on the k8s backend, isolation is expressed as **NetworkPolicy** objects (one per instance, derived from its security groups) and enforced by the cluster CNI. fakecloud detects the CNI (Calico/Cilium enforce; kindnet does not) and warns when NetworkPolicy won't be enforced, but always creates the policies.
 - **Compose interop** — to let your own containers reach an instance by its private IP, attach them to the instance's subnet network: `docker network connect fakecloud-subnet-<id> <your-container>` (find `<id>` via `/_fakecloud/ec2/instance-networks`). Cross-VPC traffic stays isolated by design.
 


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-18 finding **0.1** (Tier 0) + **D.1**. EC2 security-group/NACL enforcement (#1745 phase 3) shells out to `nft`, but the published slim image installed only `ca-certificates` — so an operator who set `FAKECLOUD_EC2_SG_ENFORCEMENT=1` *and* granted `CAP_NET_ADMIN` still got a silent degrade to metadata-only because the binary wasn't present. Same "documented feature, missing binary" shape as #1539 Bug 4.

- **Dockerfile**: install `nftables` in the final stage so `nft` exists in the published image.
- **docker-compose.yml**: add commented `cap_add: [NET_ADMIN]` + `FAKECLOUD_EC2_SG_ENFORCEMENT` lines — the enable path is now one uncomment away (off by default, no behavior change).
- **ec2.md**: runnable `docker run --cap-add=NET_ADMIN` example + how to confirm via `/_fakecloud/ec2/instance-networks`.

## Test plan

- `scripts/check-doc-counts.sh` clean. No Rust changes. The docker-publish CI builds the image with `nftables` installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship `nftables` in the published image so EC2 security-group/NACL enforcement works when enabled; it previously degraded to metadata-only because `nft` was missing. Add a clear enable path in `docker-compose.yml` and docs (commented `FAKECLOUD_EC2_SG_ENFORCEMENT` and `cap_add: [NET_ADMIN]`, plus a `docker run` example); defaults remain unchanged.

<sup>Written for commit 20399d0cdafda47d927370bc73ec7c5485f4eec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

