### PR TITLE
fix(ec2): default-VPC region coherence + CreateDefault idempotency + delete protection

### DIFF
--- a/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
+++ b/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
@@ -543,3 +543,101 @@ async fn run_instances_without_subnet_lands_in_default_vpc() {
         "instance should attach the default security group"
     );
 }
+
+// ---- Default-VPC coherence (bug-hunt 2026-06-18: 1.1, 1.2, 1.3 + delete-protection) ----
+
+#[tokio::test]
+async fn create_default_vpc_is_idempotent() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    // The account already ships a seeded default VPC; CreateDefaultVpc must
+    // return THAT one, never mint a second isDefault=true VPC.
+    let a = c.create_default_vpc().send().await.unwrap();
+    let b = c.create_default_vpc().send().await.unwrap();
+    assert_eq!(a.vpc().unwrap().vpc_id(), b.vpc().unwrap().vpc_id());
+    let vpcs = c.describe_vpcs().send().await.unwrap();
+    let defaults = vpcs
+        .vpcs()
+        .iter()
+        .filter(|v| v.is_default() == Some(true))
+        .count();
+    assert_eq!(defaults, 1, "exactly one default VPC must exist");
+}
+
+#[tokio::test]
+async fn create_default_subnet_attaches_to_real_default_vpc() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let default_vpc = c
+        .describe_vpcs()
+        .send()
+        .await
+        .unwrap()
+        .vpcs()
+        .iter()
+        .find(|v| v.is_default() == Some(true))
+        .and_then(|v| v.vpc_id())
+        .unwrap()
+        .to_string();
+    let r = c
+        .create_default_subnet()
+        .availability_zone("us-east-1a")
+        .send()
+        .await
+        .unwrap();
+    let subnet = r.subnet().unwrap();
+    // Must be in the real default VPC, not the bogus literal "vpc-default".
+    assert_eq!(subnet.vpc_id(), Some(default_vpc.as_str()));
+    assert_ne!(subnet.vpc_id(), Some("vpc-default"));
+}
+
+#[tokio::test]
+async fn default_security_group_cannot_be_deleted() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let default_sg = c
+        .describe_security_groups()
+        .send()
+        .await
+        .unwrap()
+        .security_groups()
+        .iter()
+        .find(|g| g.group_name() == Some("default"))
+        .and_then(|g| g.group_id())
+        .unwrap()
+        .to_string();
+    let err = c
+        .delete_security_group()
+        .group_id(&default_sg)
+        .send()
+        .await
+        .expect_err("deleting the default SG must be rejected");
+    assert!(format!("{err:?}").contains("CannotDelete"), "got {err:?}");
+}
+
+#[tokio::test]
+async fn default_network_acl_cannot_be_deleted() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let default_acl = c
+        .describe_network_acls()
+        .send()
+        .await
+        .unwrap()
+        .network_acls()
+        .iter()
+        .find(|a| a.is_default() == Some(true))
+        .and_then(|a| a.network_acl_id())
+        .unwrap()
+        .to_string();
+    let err = c
+        .delete_network_acl()
+        .network_acl_id(&default_acl)
+        .send()
+        .await
+        .expect_err("deleting the default NACL must be rejected");
+    assert!(
+        format!("{err:?}").contains("CannotDeleteDefaultNetworkAcl"),
+        "got {err:?}"
+    );
+}

--- a/crates/fakecloud-ec2/src/defaults.rs
+++ b/crates/fakecloud-ec2/src/defaults.rs
@@ -10,10 +10,10 @@
 //!
 //! fakecloud builds the same fixtures the first time an account's EC2 state is
 //! constructed ([`Ec2State::new`](crate::state::Ec2State::new)). The resource
-//! ids are **deterministic** functions of the account id, region, and a role
-//! string, so the throwaway empty states that the read paths synthesize as a
-//! "not found" fallback report the *same* ids as the persisted account state —
-//! two `DescribeVpcs` calls before any write agree on the default VPC id.
+//! ids are **deterministic** functions of the account id and a role string
+//! (region-independent — see [`deterministic_id`]), so the throwaway empty
+//! states that the read paths synthesize as a "not found" fallback report the
+//! *same* ids as the persisted account state regardless of the caller's region.
 //!
 //! Per-VPC packet isolation (issue #1745 phase 2+) keys off this topology: a
 //! subnet whose route table has a `0.0.0.0/0 -> igw-…` route is public and gets
@@ -32,12 +32,19 @@ const DEFAULT_VPC_CIDR: &str = "172.31.0.0/16";
 /// test exercises (and keeps the deterministic CIDR layout simple).
 const DEFAULT_AZ_SUFFIXES: [&str; 3] = ["a", "b", "c"];
 
-/// Deterministic EC2 resource id: `<prefix>-<17 hex>` derived from the
-/// account, region, and a per-resource `role`. Stable across processes and
-/// across the throwaway empty states the read paths build, so the default
-/// VPC's ids never flap between calls.
-pub(crate) fn deterministic_id(prefix: &str, account: &str, region: &str, role: &str) -> String {
-    let seed = format!("{account}/{region}/{role}");
+/// Deterministic EC2 resource id: `<prefix>-<17 hex>` derived from the account
+/// and a per-resource `role`. Deliberately **region-independent**: a
+/// `MultiAccountState` partitions by account and pins a single region per
+/// server, but read handlers build a throwaway `Ec2State::new(account,
+/// req.region)` for accounts that don't exist yet — where `req.region` is the
+/// caller's SigV4 scope, not the server's region. Seeding the id on the region
+/// made those throwaway-derived ids disagree with the persisted account's ids
+/// whenever the client region differed from the server's, so a no-subnet launch
+/// stamped the instance with a subnet/VPC id that didn't exist in its own
+/// account (bug-hunt 2026-06-18 finding 1.1). Dropping region from the seed
+/// makes both paths agree; the AZ/CIDR cosmetics below still use the region.
+pub(crate) fn deterministic_id(prefix: &str, account: &str, role: &str) -> String {
+    let seed = format!("{account}/{role}");
     let h1 = fnv1a64(seed.as_bytes());
     let h2 = fnv1a64(format!("{seed}/salt").as_bytes());
     // 16 hex from the first hash + 1 nibble from the second = the 17 hex chars
@@ -72,15 +79,15 @@ fn az_id_prefix(region: &str) -> String {
     }
 }
 
-/// The default VPC id for an account+region (also exposed so request handlers
-/// can resolve the implicit default without re-deriving the seed by hand).
-pub(crate) fn default_vpc_id(account: &str, region: &str) -> String {
-    deterministic_id("vpc", account, region, "default-vpc")
+/// The default VPC id for an account (also exposed so request handlers can
+/// resolve the implicit default without re-deriving the seed by hand).
+pub(crate) fn default_vpc_id(account: &str) -> String {
+    deterministic_id("vpc", account, "default-vpc")
 }
 
-/// The default security-group id for an account+region.
-pub(crate) fn default_security_group_id(account: &str, region: &str) -> String {
-    deterministic_id("sg", account, region, "default-sg")
+/// The default security-group id for an account.
+pub(crate) fn default_security_group_id(account: &str) -> String {
+    deterministic_id("sg", account, "default-sg")
 }
 
 /// Populate `state` with the default VPC topology. Called once at state
@@ -94,11 +101,11 @@ pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
         state.region.clone()
     };
 
-    let vpc_id = default_vpc_id(&account, &region);
-    let igw_id = deterministic_id("igw", &account, &region, "default-igw");
-    let rtb_id = deterministic_id("rtb", &account, &region, "default-rtb");
-    let acl_id = deterministic_id("acl", &account, &region, "default-acl");
-    let sg_id = default_security_group_id(&account, &region);
+    let vpc_id = default_vpc_id(&account);
+    let igw_id = deterministic_id("igw", &account, "default-igw");
+    let rtb_id = deterministic_id("rtb", &account, "default-rtb");
+    let acl_id = deterministic_id("acl", &account, "default-acl");
+    let sg_id = default_security_group_id(&account);
 
     // --- default VPC ---
     state.vpcs.insert(
@@ -129,12 +136,7 @@ pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
     let az_prefix = az_id_prefix(&region);
     let mut subnet_ids = Vec::new();
     for (idx, suffix) in DEFAULT_AZ_SUFFIXES.iter().enumerate() {
-        let subnet_id = deterministic_id(
-            "subnet",
-            &account,
-            &region,
-            &format!("default-subnet-{suffix}"),
-        );
+        let subnet_id = deterministic_id("subnet", &account, &format!("default-subnet-{suffix}"));
         let az = format!("{region}{suffix}");
         state.subnets.insert(
             subnet_id.clone(),
@@ -161,7 +163,7 @@ pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
 
     // --- main route table: local + default route at the IGW (public) ---
     let mut associations = vec![RouteTableAssociation {
-        association_id: deterministic_id("rtbassoc", &account, &region, "default-rtb-main"),
+        association_id: deterministic_id("rtbassoc", &account, "default-rtb-main"),
         route_table_id: rtb_id.clone(),
         subnet_id: None,
         gateway_id: None,
@@ -169,12 +171,7 @@ pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
     }];
     for sid in &subnet_ids {
         associations.push(RouteTableAssociation {
-            association_id: deterministic_id(
-                "rtbassoc",
-                &account,
-                &region,
-                &format!("default-rtb-{sid}"),
-            ),
+            association_id: deterministic_id("rtbassoc", &account, &format!("default-rtb-{sid}")),
             route_table_id: rtb_id.clone(),
             subnet_id: Some(sid.clone()),
             gateway_id: None,
@@ -212,7 +209,7 @@ pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
             vpc_id: vpc_id.clone(),
             rules: vec![
                 SecurityGroupRule {
-                    rule_id: deterministic_id("sgr", &account, &region, "default-sg-ingress"),
+                    rule_id: deterministic_id("sgr", &account, "default-sg-ingress"),
                     group_id: sg_id.clone(),
                     is_egress: false,
                     ip_protocol: "-1".to_string(),
@@ -225,7 +222,7 @@ pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
                     description: String::new(),
                 },
                 SecurityGroupRule {
-                    rule_id: deterministic_id("sgr", &account, &region, "default-sg-egress"),
+                    rule_id: deterministic_id("sgr", &account, "default-sg-egress"),
                     group_id: sg_id.clone(),
                     is_egress: true,
                     ip_protocol: "-1".to_string(),
@@ -245,12 +242,7 @@ pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
     let nacl_associations = subnet_ids
         .iter()
         .map(|sid| NetworkAclAssoc {
-            association_id: deterministic_id(
-                "aclassoc",
-                &account,
-                &region,
-                &format!("default-acl-{sid}"),
-            ),
+            association_id: deterministic_id("aclassoc", &account, &format!("default-acl-{sid}")),
             subnet_id: sid.clone(),
         })
         .collect();
@@ -340,8 +332,8 @@ mod tests {
 
     #[test]
     fn deterministic_id_is_stable_and_shaped() {
-        let a = deterministic_id("vpc", "123456789012", "us-east-1", "default-vpc");
-        let b = deterministic_id("vpc", "123456789012", "us-east-1", "default-vpc");
+        let a = deterministic_id("vpc", "123456789012", "default-vpc");
+        let b = deterministic_id("vpc", "123456789012", "default-vpc");
         assert_eq!(a, b);
         assert!(a.starts_with("vpc-"));
         // 17 hex chars after the prefix, matching EC2 long-ids.
@@ -351,19 +343,21 @@ mod tests {
     }
 
     #[test]
-    fn deterministic_id_varies_by_account_region_role() {
-        let base = deterministic_id("vpc", "111111111111", "us-east-1", "default-vpc");
-        assert_ne!(
-            base,
-            deterministic_id("vpc", "222222222222", "us-east-1", "default-vpc")
-        );
-        assert_ne!(
-            base,
-            deterministic_id("vpc", "111111111111", "eu-west-1", "default-vpc")
-        );
-        assert_ne!(
-            base,
-            deterministic_id("vpc", "111111111111", "us-east-1", "default-igw")
+    fn deterministic_id_varies_by_account_and_role() {
+        let base = deterministic_id("vpc", "111111111111", "default-vpc");
+        assert_ne!(base, deterministic_id("vpc", "222222222222", "default-vpc"));
+        assert_ne!(base, deterministic_id("vpc", "111111111111", "default-igw"));
+    }
+
+    #[test]
+    fn deterministic_id_is_region_independent() {
+        // The id seed deliberately excludes region so read-path (req.region)
+        // and persisted (server region) states agree (finding 1.1). Region is
+        // not a parameter anymore — this documents the contract by asserting
+        // default_vpc_id depends only on the account.
+        assert_eq!(
+            default_vpc_id("111111111111"),
+            deterministic_id("vpc", "111111111111", "default-vpc")
         );
     }
 
@@ -416,6 +410,23 @@ mod tests {
         let a_vpc: Vec<_> = a.vpcs.keys().collect();
         let b_vpc: Vec<_> = b.vpcs.keys().collect();
         assert_eq!(a_vpc, b_vpc);
-        assert_eq!(a_vpc[0], &default_vpc_id("123456789012", "us-east-1"));
+        assert_eq!(a_vpc[0], &default_vpc_id("123456789012"));
+    }
+
+    #[test]
+    fn default_vpc_id_agrees_across_regions() {
+        // The crux of finding 1.1: a read-path empty built with the caller's
+        // region must derive the SAME default VPC id as the persisted account
+        // state built with the server's region.
+        let read_path = Ec2State::new("123456789012", "eu-west-1");
+        let persisted = Ec2State::new("123456789012", "us-east-1");
+        let read_vpc = read_path.vpcs.keys().next().unwrap();
+        let persisted_vpc = persisted.vpcs.keys().next().unwrap();
+        assert_eq!(read_vpc, persisted_vpc);
+        // subnets too (so a no-subnet launch resolves a subnet that exists in
+        // the persisted account regardless of the caller's region).
+        let read_subnets: std::collections::BTreeSet<_> = read_path.subnets.keys().collect();
+        let persisted_subnets: std::collections::BTreeSet<_> = persisted.subnets.keys().collect();
+        assert_eq!(read_subnets, persisted_subnets);
     }
 }

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -272,7 +272,7 @@ pub(crate) async fn run_instances(
         if sg_ids.is_empty() {
             let vpc = resolved_vpc
                 .clone()
-                .unwrap_or_else(|| crate::defaults::default_vpc_id(&req.account_id, &req.region));
+                .unwrap_or_else(|| crate::defaults::default_vpc_id(&req.account_id));
             if let Some(sg) = state
                 .security_groups
                 .values()
@@ -302,13 +302,7 @@ pub(crate) async fn run_instances(
                 .unwrap_or((None, false)),
             // No subnet (and no default subnet found): still a default-VPC
             // launch, which assigns public IPs by default.
-            None => (
-                Some(crate::defaults::default_vpc_id(
-                    &req.account_id,
-                    &req.region,
-                )),
-                true,
-            ),
+            None => (Some(crate::defaults::default_vpc_id(&req.account_id)), true),
         };
         (vpc, auto_public, instance_network)
     };

--- a/crates/fakecloud-ec2/src/service/nacl.rs
+++ b/crates/fakecloud-ec2/src/service/nacl.rs
@@ -127,6 +127,15 @@ pub(crate) fn delete_network_acl(
     let id = require(&req.query_params, "NetworkAclId")?;
     let mut accounts = svc.state.write();
     let state = accounts.get_or_create(&req.account_id);
+    // The default NACL of a VPC cannot be deleted — AWS returns
+    // `CannotDeleteDefaultNetworkAcl` (delete-protection finding).
+    if state.network_acls.get(&id).is_some_and(|a| a.is_default) {
+        return Err(AwsServiceError::aws_error(
+            http::StatusCode::BAD_REQUEST,
+            "CannotDeleteDefaultNetworkAcl",
+            format!("The network acl '{id}' is the default network acl and cannot be deleted"),
+        ));
+    }
     state.network_acls.remove(&id);
     state.tags.remove(&id);
     Ok(Ec2Service::respond(

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -300,6 +300,31 @@ pub(crate) fn delete_security_group(
 ) -> Result<AwsResponse, AwsServiceError> {
     let mut accounts = svc.state.write();
     let state = accounts.get_or_create(&req.account_id);
+    // The VPC's `default` security group cannot be deleted — AWS returns
+    // `CannotDelete`. Without this guard, deleting it left a VPC with no
+    // default group, so a later no-SecurityGroupId RunInstances launched with
+    // an empty group list (impossible on AWS) (bug-hunt 2026-06-18 finding,
+    // delete-protection). Resolve the target group(s) and reject the default.
+    let targets: Vec<&crate::state::SecurityGroup> =
+        if let Some(id) = req.query_params.get("GroupId") {
+            state.security_groups.get(id).into_iter().collect()
+        } else if let Some(name) = req.query_params.get("GroupName") {
+            state
+                .security_groups
+                .values()
+                .filter(|g| &g.group_name == name)
+                .collect()
+        } else {
+            Vec::new()
+        };
+    if targets.iter().any(|g| g.group_name == "default") {
+        return Err(AwsServiceError::aws_error(
+            http::StatusCode::BAD_REQUEST,
+            "CannotDelete",
+            "the default security group cannot be deleted",
+        ));
+    }
+
     if let Some(id) = req.query_params.get("GroupId") {
         state.security_groups.remove(id);
         state.tags.remove(id);

--- a/crates/fakecloud-ec2/src/service/subnet.rs
+++ b/crates/fakecloud-ec2/src/service/subnet.rs
@@ -123,19 +123,34 @@ pub(crate) fn create_default_subnet(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let az = default_az(req);
-    let subnet = build_subnet(
-        "vpc-default".to_string(),
-        "172.31.0.0/20".to_string(),
-        &az,
-        true,
-    );
-    let id = subnet.subnet_id.clone();
     let owner = req.account_id.clone();
     let region = req.region.clone();
     let body = {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        state.subnets.insert(id.clone(), subnet.clone());
+        // Attach to the account's real default VPC, not the literal
+        // `vpc-default` (which matches no VPC and orphaned the subnet —
+        // bug-hunt 2026-06-18 finding 1.2). If a default subnet already exists
+        // for this AZ (the bootstrap seeds one per AZ), return it instead of
+        // minting a duplicate, matching CreateDefaultSubnet's idempotency.
+        let default_vpc = state
+            .vpcs
+            .values()
+            .find(|v| v.is_default)
+            .map(|v| v.vpc_id.clone())
+            .unwrap_or_else(|| crate::defaults::default_vpc_id(&req.account_id));
+        let subnet = if let Some(existing) = state
+            .subnets
+            .values()
+            .find(|s| s.vpc_id == default_vpc && s.default_for_az && s.availability_zone == az)
+            .cloned()
+        {
+            existing
+        } else {
+            let s = build_subnet(default_vpc, "172.31.0.0/20".to_string(), &az, true);
+            state.subnets.insert(s.subnet_id.clone(), s.clone());
+            s
+        };
         format!(
             "<subnet>{}</subnet>",
             subnet_xml(&subnet, &[], &owner, &region)

--- a/crates/fakecloud-ec2/src/service/vpc.rs
+++ b/crates/fakecloud-ec2/src/service/vpc.rs
@@ -107,14 +107,28 @@ pub(crate) fn create_default_vpc(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let vpc = build_vpc("172.31.0.0/16".to_string(), "default".to_string(), true);
-    let vpc_id = vpc.vpc_id.clone();
+    // Every account already ships a seeded default VPC (bootstrapped at state
+    // construction), so CreateDefaultVpc must return THAT one, not mint a
+    // second `isDefault=true` VPC — a state impossible on AWS, which returns
+    // `DefaultVpcAlreadyExists` when one exists (bug-hunt 2026-06-18 finding
+    // 1.3). We surface the existing default rather than the error so callers
+    // that defensively call CreateDefaultVpc keep working.
     let owner = req.account_id.clone();
     let body = {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        let tags = state.tags_for(&vpc_id).to_vec();
-        state.vpcs.insert(vpc_id.clone(), vpc.clone());
+        let vpc = state
+            .vpcs
+            .values()
+            .find(|v| v.is_default)
+            .cloned()
+            // No default VPC somehow (e.g. it was deleted): re-create one.
+            .unwrap_or_else(|| {
+                let v = build_vpc("172.31.0.0/16".to_string(), "default".to_string(), true);
+                state.vpcs.insert(v.vpc_id.clone(), v.clone());
+                v
+            });
+        let tags = state.tags_for(&vpc.vpc_id).to_vec();
         format!("<vpc>{}</vpc>", vpc_xml(&vpc, &tags, &owner))
     };
     Ok(Ec2Service::respond(


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-18 findings **1.1**, **1.2**, **1.3**, + delete-protection.

- **1.1 (HIGH)** — default-resource ids were seeded on `(account, region, role)`, but read handlers build a throwaway `Ec2State::new(account, req.region)` for accounts that don't exist yet, where `req.region` is the caller's SigV4 scope, not the server's region. When they differed (server `us-east-1`, client `eu-west-1`), a no-subnet `RunInstances` stamped the instance with subnet/VPC ids absent from its own persisted account. Fix: `deterministic_id` is now **region-independent** (fakecloud pins one region per server), so read-path and persisted ids always agree.
- **1.3 (MED)** — `CreateDefaultVpc` now returns the seeded default VPC instead of minting a second `isDefault=true` VPC.
- **1.2 (HIGH)** — `CreateDefaultSubnet` now attaches to the account's real default VPC (was the literal `vpc-default`, which matched no VPC and orphaned the subnet) and returns the existing per-AZ default subnet when one exists.
- **delete-protection** — `DeleteSecurityGroup` on the `default` group → `CannotDelete`; `DeleteNetworkAcl` on a default NACL → `CannotDeleteDefaultNetworkAcl` (matches AWS). Prevents a VPC ending up with no default SG.

## Test plan

- `cargo test -p fakecloud-ec2` — unit tests for region-independent ids (incl. read-vs-persist agreement across regions).
- `cargo test -p fakecloud-e2e --test ec2_instance_control_plane` — idempotent CreateDefaultVpc, CreateDefaultSubnet attaches to the real default VPC, default SG/NACL delete rejection (20/20).
- `cargo test -p fakecloud-conformance --test ec2` — **769/769**.
- clippy + fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EC2 default network behavior: default resource IDs are now region-independent, CreateDefaultVpc/Subnet are idempotent and attach correctly, and default SG/NACL delete protection matches AWS. This prevents mismatched IDs on cross-region reads and avoids orphaned subnets or missing default groups.

- **Bug Fixes**
  - Made `deterministic_id` region-independent so read paths and persisted state agree; no-subnet RunInstances now lands in the real default VPC/subnet.
  - CreateDefaultVpc returns the existing seeded default VPC (recreates if missing) instead of creating a second default VPC.
  - CreateDefaultSubnet attaches to the account’s actual default VPC and returns the existing per-AZ default subnet when present.
  - Block deletion of the default security group (`CannotDelete`) and default NACL (`CannotDeleteDefaultNetworkAcl`) to prevent invalid states.

<sup>Written for commit cf23a7447fba8558576acbfd7105aa9ab38749b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

