### PR TITLE
fix(ec2): re-apply SG firewall after restart-recovery and reboot

### DIFF
--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -688,6 +688,13 @@ pub(crate) async fn reboot_instances(
                     }
                 }
             }
+            // A reboot can change the instance's IP (k8s Pod recreate), which
+            // leaves a stale /32 in every peer's security-group rules until an
+            // unrelated reconcile fires. Re-apply the firewall now (#1745;
+            // bug-hunt 2026-06-18 finding 4.2). No-op when enforcement is off.
+            if rt.network_isolation_enforced() {
+                super::firewall_model::reconcile(&svc_state, &rt).await;
+            }
         });
     }
     Ok(Ec2Service::respond(

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -1016,10 +1016,11 @@ impl Ec2Service {
             "recovering backing containers for persisted ec2 instances",
         );
 
+        let mut handles = Vec::new();
         for p in pending {
             let runtime = runtime.clone();
             let state = self.state.clone();
-            tokio::spawn(async move {
+            handles.push(tokio::spawn(async move {
                 let running = runtime
                     .run_instance(&p.id, p.user_data.as_deref(), &p.tags, p.network.as_ref())
                     .await;
@@ -1062,6 +1063,26 @@ impl Ec2Service {
                 };
                 if reap {
                     runtime.terminate_instance(&p.id).await;
+                }
+            }));
+        }
+
+        // Once every instance is back up, (re)apply the security-group
+        // firewall. The startup reaper cleared the previous process's nft
+        // table / NetworkPolicies, and the per-instance recovery tasks above
+        // don't reconcile — without this, recovered instances would run
+        // unfiltered until some unrelated later op happened to trigger a
+        // reconcile (#1745; bug-hunt 2026-06-18 finding 4.1). No-op when
+        // enforcement is disabled.
+        {
+            let runtime = runtime.clone();
+            let state = self.state.clone();
+            tokio::spawn(async move {
+                for h in handles {
+                    let _ = h.await;
+                }
+                if runtime.network_isolation_enforced() {
+                    firewall_model::reconcile(&state, &runtime).await;
                 }
             });
         }


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-18 findings **4.1**, **4.2**. The SG nftables/NetworkPolicy reconcile is event-triggered, but two lifecycle paths didn't fire it:

- **4.1 (MED)** — `recover_persisted_containers` rebuilds containers after a restart but never reconciled. The startup reaper had cleared the previous process's nft table / NetworkPolicies, so with enforcement enabled the recovered instances ran **unfiltered** until some unrelated later op triggered a reconcile. A coordinator task now awaits all per-instance recovery tasks and fires one reconcile once they're up.
- **4.2 (LOW/MED)** — `RebootInstances` can change an instance's IP (k8s Pod recreate), leaving a stale `/32` in peers' SG rules. The reboot bg task now reconciles after the recreate loop.

Both gated on `network_isolation_enforced()` (no-op when enforcement is off — the default).

## Test plan

- `cargo test -p fakecloud-ec2`, clippy, fmt clean. Enforcement-path behavior (nft/NetworkPolicy actually applied) needs `CAP_NET_ADMIN`/a CNI and isn't CI-testable — same as the #1745 phase-3/4 enforcement code; the reconcile model itself is unit-tested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-applies SG firewall rules after restart recovery and instance reboot so instances don’t run unfiltered or with stale peer IPs when network isolation is enforced.

- **Bug Fixes**
  - After process restart, recovered instances now trigger one SG reconcile once all containers are back up.
  - After `RebootInstances`, we reconcile to refresh SG rules if instance IPs changed.
  - Both paths are gated by `network_isolation_enforced()` (no-op when disabled).

<sup>Written for commit b5f3f381c00bfb51cc6c479803d155b3d95bb753. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

