### PR TITLE
fix(cloudformation): persist provisioned resources across restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,6 +3313,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/fakecloud-apigateway/src/service.rs
+++ b/crates/fakecloud-apigateway/src/service.rs
@@ -277,25 +277,61 @@ impl ApiGatewayService {
     }
 
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = ApiGatewaySnapshot {
-            schema_version: APIGATEWAY_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_apigateway_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write apigateway snapshot"),
-            Err(err) => tracing::error!(%err, "apigateway snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current API Gateway state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_apigateway_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current API Gateway state as a snapshot. Cloned + serialized
+/// under the snapshot lock. Noop when `store` is `None` (memory mode). Shared by
+/// `ApiGatewayService::save_snapshot` and the CloudFormation provisioner's
+/// post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_apigateway_snapshot(
+    state: &SharedApiGatewayState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = ApiGatewaySnapshot {
+        schema_version: APIGATEWAY_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write apigateway snapshot"),
+        Err(err) => tracing::error!(%err, "apigateway snapshot task panicked"),
     }
 }
 
@@ -382,3 +418,34 @@ mod service_extras;
 #[path = "helpers.rs"]
 pub(crate) mod helpers;
 pub(crate) use helpers::*;
+
+#[cfg(test)]
+mod snapshot_hook_tests {
+    use super::ApiGatewayService;
+    use std::sync::Arc;
+
+    fn svc() -> ApiGatewayService {
+        let state = Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
+        ApiGatewayService::new(state)
+    }
+
+    /// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+    #[test]
+    fn snapshot_hook_is_none_without_store() {
+        let svc = svc();
+        assert!(svc.snapshot_hook().is_none());
+    }
+
+    #[tokio::test]
+    async fn snapshot_hook_fires_with_store() {
+        let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+            Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+        let svc = svc().with_snapshot_store(store);
+        let hook = svc
+            .snapshot_hook()
+            .expect("hook present when a store is set");
+        hook().await;
+    }
+}

--- a/crates/fakecloud-apigatewayv2/src/service/mod.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/mod.rs
@@ -187,26 +187,63 @@ impl ApiGatewayV2Service {
     }
 
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = ApiGatewayV2Snapshot {
-            schema_version: APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
-            state: None,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_apigatewayv2_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write apigatewayv2 snapshot"),
-            Err(err) => tracing::error!(%err, "apigatewayv2 snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current API Gateway v2 state when invoked,
+    /// or `None` in memory mode (no snapshot store). The CloudFormation
+    /// provisioner mutates `state` directly and uses this to write a
+    /// CFN-provisioned resource through to disk, the same way a direct mutating
+    /// API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_apigatewayv2_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current API Gateway v2 state as a snapshot. Cloned + serialized
+/// under the snapshot lock. Noop when `store` is `None` (memory mode). Shared by
+/// `ApiGatewayV2Service::save_snapshot` and the CloudFormation provisioner's
+/// post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_apigatewayv2_snapshot(
+    state: &SharedApiGatewayV2State,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = ApiGatewayV2Snapshot {
+        schema_version: APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
+        state: None,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write apigatewayv2 snapshot"),
+        Err(err) => tracing::error!(%err, "apigatewayv2 snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -2662,3 +2662,24 @@ async fn execute_api_access_log_emitted_on_error_paths() {
     let log_line = &events[0].3[0].1;
     assert!(log_line.contains("\"status\":\"404\""));
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a snapshot store set, the hook is present and runs to completion.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state).with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -99,26 +99,30 @@ impl BedrockService {
     }
 
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = BedrockSnapshot {
-            schema_version: BEDROCK_SNAPSHOT_SCHEMA_VERSION,
-            state: None,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_bedrock_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write bedrock snapshot"),
-            Err(err) => tracing::error!(%err, "bedrock snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current Bedrock state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_bedrock_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 
     fn resolve_action(req: &AwsRequest) -> Option<(&str, Option<String>, Option<String>)> {
@@ -924,6 +928,38 @@ impl BedrockService {
         };
 
         Ok(AwsResponse::ok_json(json!({ "tags": tags_arr })))
+    }
+}
+
+/// Persist the current Bedrock state as a snapshot. Cloned + serialized under
+/// the snapshot lock. Noop when `store` is `None` (memory mode). Shared by
+/// `BedrockService::save_snapshot` and the CloudFormation provisioner's
+/// post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_bedrock_snapshot(
+    state: &SharedBedrockState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = BedrockSnapshot {
+        schema_version: BEDROCK_SNAPSHOT_SCHEMA_VERSION,
+        state: None,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write bedrock snapshot"),
+        Err(err) => tracing::error!(%err, "bedrock snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-bedrock/src/service_tests.rs
+++ b/crates/fakecloud-bedrock/src/service_tests.rs
@@ -1226,3 +1226,23 @@ fn automated_reasoning_policy_delete_not_found() {
     );
     assert!(result.is_err());
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let state = make_state();
+    let svc = BedrockService::new(state);
+    assert!(svc.snapshot_hook().is_none());
+}
+
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let state = make_state();
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = BedrockService::new(state).with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -60,3 +60,4 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
@@ -106,6 +106,7 @@ impl ResourceProvisioner {
             cloudformation_state: self.cloudformation_state.clone(),
             delivery: self.delivery.clone(),
             lambda_runtime: self.lambda_runtime.clone(),
+            s3_store: self.s3_store.clone(),
             account_id: self.account_id.clone(),
             region: self.region.clone(),
             stack_id: child_stack_id.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -93,11 +93,13 @@ use fakecloud_organizations::{
     OrganizationState, OrganizationalUnit, Policy as OrgPolicy, SharedOrganizationsState,
     POLICY_TYPE_SCP,
 };
+use fakecloud_persistence::{BucketSubresource, S3Store};
 use fakecloud_rds::{DbInstance, DbParameterGroup, DbSubnetGroup, RdsTag, SharedRdsState};
 use fakecloud_route53::{
     model::{HealthCheckConfig, HostedZoneFeatures, ResourceRecordSet},
     SharedRoute53State, StoredHealthCheck, StoredHostedZone,
 };
+use fakecloud_s3::persistence::bucket_meta_snapshot;
 use fakecloud_s3::{S3Bucket, SharedS3State};
 use fakecloud_secretsmanager::{RotationRules, Secret, SecretVersion, SharedSecretsManagerState};
 use fakecloud_ses::{
@@ -897,6 +899,11 @@ pub struct ResourceProvisioner {
     /// images (see `CloudFormationDeps::lambda_runtime`). `None` outside a
     /// configured runtime (e.g. unit tests).
     pub lambda_runtime: Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
+    /// Fine-grained S3 disk store. Bucket create/delete (and bucket-policy
+    /// updates) write through this so a CFN-provisioned bucket lands on disk,
+    /// matching the real `CreateBucket`/`DeleteBucket` handlers. A
+    /// `MemoryS3Store` (memory mode) makes the writes no-ops.
+    pub s3_store: Arc<dyn S3Store>,
     pub account_id: String,
     pub region: String,
     pub stack_id: String,
@@ -6044,6 +6051,7 @@ mod tests {
             )),
             delivery: Arc::new(DeliveryBus::new()),
             lambda_runtime: None,
+            s3_store: Arc::new(fakecloud_persistence::s3::MemoryS3Store::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),
             stack_id: "arn:aws:cloudformation:us-east-1:123456789012:stack/test/00000000-0000-0000-0000-000000000000".to_string(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/s3.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/s3.rs
@@ -44,7 +44,14 @@ impl ResourceProvisioner {
         let state = __s3_mas.get_or_create(&self.account_id);
         let region = state.region.clone();
         let bucket = S3Bucket::new(bucket_name, &state.region, &state.account_id);
+        // Write the bucket through to the S3 disk store, exactly as the real
+        // CreateBucket handler does, so a CFN-provisioned bucket survives a
+        // restart instead of living only in the in-memory map.
+        let meta = bucket_meta_snapshot(&bucket);
         state.buckets.insert(bucket_name.to_string(), bucket);
+        self.s3_store
+            .put_bucket_meta(bucket_name, &meta)
+            .map_err(|e| format!("failed to persist bucket {bucket_name}: {e}"))?;
 
         let arn = Arn::s3(bucket_name).to_string();
         let domain_name = format!("{bucket_name}.s3.amazonaws.com");
@@ -63,6 +70,11 @@ impl ResourceProvisioner {
         let mut __s3_mas = self.s3_state.write();
         let state = __s3_mas.get_or_create(&self.account_id);
         state.buckets.remove(physical_id);
+        // Remove the bucket from disk too, so a CFN-deleted bucket does not
+        // reappear after a restart.
+        self.s3_store
+            .delete_bucket(physical_id)
+            .map_err(|e| format!("failed to remove bucket {physical_id}: {e}"))?;
         Ok(())
     }
 
@@ -87,7 +99,11 @@ impl ResourceProvisioner {
             .buckets
             .get_mut(&bucket_name)
             .ok_or_else(|| format!("Bucket {bucket_name} not yet provisioned"))?;
-        bucket.policy = Some(policy);
+        bucket.policy = Some(policy.clone());
+        // Persist the policy subresource to disk, as PutBucketPolicy does.
+        self.s3_store
+            .put_bucket_subresource(&bucket_name, BucketSubresource::Policy, &policy)
+            .map_err(|e| format!("failed to persist bucket policy for {bucket_name}: {e}"))?;
         Ok(ProvisionResult::new(format!("{bucket_name}-policy")))
     }
 
@@ -110,12 +126,18 @@ impl ResourceProvisioner {
             if let Some(bucket) = state.buckets.get_mut(old_bucket) {
                 bucket.policy = None;
             }
+            self.s3_store
+                .delete_bucket_subresource(old_bucket, BucketSubresource::Policy)
+                .map_err(|e| format!("failed to clear bucket policy for {old_bucket}: {e}"))?;
         }
         let bucket = state
             .buckets
             .get_mut(&bucket_name)
             .ok_or_else(|| format!("Bucket {bucket_name} not yet provisioned"))?;
-        bucket.policy = Some(policy);
+        bucket.policy = Some(policy.clone());
+        self.s3_store
+            .put_bucket_subresource(&bucket_name, BucketSubresource::Policy, &policy)
+            .map_err(|e| format!("failed to persist bucket policy for {bucket_name}: {e}"))?;
         Ok(ProvisionResult::new(format!("{bucket_name}-policy")))
     }
 
@@ -126,6 +148,9 @@ impl ResourceProvisioner {
         if let Some(bucket) = state.buckets.get_mut(bucket_name) {
             bucket.policy = None;
         }
+        self.s3_store
+            .delete_bucket_subresource(bucket_name, BucketSubresource::Policy)
+            .map_err(|e| format!("failed to remove bucket policy for {bucket_name}: {e}"))?;
         Ok(())
     }
 }

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use http::StatusCode;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use fakecloud_core::delivery::DeliveryBus;
@@ -10,7 +10,7 @@ use fakecloud_dynamodb::SharedDynamoDbState;
 use fakecloud_eventbridge::SharedEventBridgeState;
 use fakecloud_iam::SharedIamState;
 use fakecloud_logs::SharedLogsState;
-use fakecloud_persistence::SnapshotStore;
+use fakecloud_persistence::{S3Store, SnapshotHook, SnapshotStore};
 use fakecloud_s3::SharedS3State;
 use fakecloud_sns::SharedSnsState;
 use fakecloud_sqs::SharedSqsState;
@@ -48,6 +48,84 @@ fn well_known_attributes_for(resource_type: &str) -> &'static [&'static str] {
         "AWS::SecretsManager::Secret" => &["Arn", "Id"],
         "AWS::CloudFront::Distribution" => &["DomainName", "Id"],
         _ => &[],
+    }
+}
+
+/// Map a CloudFormation resource type (`AWS::<Service>::<Resource>`) to the
+/// snapshot-hook key for its owning service (the keys of
+/// `CloudFormationDeps::snapshot_hooks`). The key is the service segment, with
+/// aliases for the few services whose CloudFormation namespace differs from
+/// their fakecloud service name (e.g. `Events` -> `eventbridge`).
+///
+/// `AWS::S3::*` is intentionally absent: S3 buckets persist through the
+/// `S3Store` write-through path in the provisioner, not a whole-state snapshot
+/// hook. Returns `None` for malformed types and any service whose state is not
+/// snapshot-backed (those CFN resources have no persistence path either way).
+fn service_key_for_type(resource_type: &str) -> Option<&'static str> {
+    let mut parts = resource_type.split("::");
+    let vendor = parts.next()?;
+    let service = parts.next()?;
+    // A real resource type has three segments; a 2-part string (or fewer) is
+    // not one.
+    parts.next()?;
+    if vendor != "AWS" {
+        return None;
+    }
+    Some(match service {
+        "Lambda" => "lambda",
+        "SecretsManager" => "secretsmanager",
+        "SQS" => "sqs",
+        "SNS" => "sns",
+        "DynamoDB" => "dynamodb",
+        "StepFunctions" => "stepfunctions",
+        "Events" => "eventbridge",
+        "SSM" => "ssm",
+        "Logs" => "logs",
+        "KMS" => "kms",
+        "Kinesis" => "kinesis",
+        "SES" => "ses",
+        "Cognito" => "cognito",
+        "RDS" => "rds",
+        "ElastiCache" => "elasticache",
+        "ECR" => "ecr",
+        "ECS" => "ecs",
+        "CloudWatch" => "cloudwatch",
+        "ApiGateway" => "apigateway",
+        "ApiGatewayV2" => "apigatewayv2",
+        "Bedrock" => "bedrock",
+        "Scheduler" => "scheduler",
+        "IAM" => "iam",
+        _ => return None,
+    })
+}
+
+/// Persist each distinct snapshot-backed service touched by a stack op, once.
+///
+/// `resource_types` is the set of `resource_type` strings the op created /
+/// updated / deleted. The CloudFormation provisioner mutates services' shared
+/// state directly and never triggers their snapshot path; this writes that
+/// state through to disk afterwards, so a CFN-provisioned (or CFN-deleted)
+/// resource survives a restart. Services with no registered hook (memory mode,
+/// or non-snapshot-backed services) are skipped.
+async fn persist_touched_services<I>(
+    hooks: &BTreeMap<&'static str, SnapshotHook>,
+    resource_types: I,
+) where
+    I: IntoIterator<Item = String>,
+{
+    if hooks.is_empty() {
+        return;
+    }
+    let mut keys: BTreeSet<&'static str> = BTreeSet::new();
+    for ty in resource_types {
+        if let Some(key) = service_key_for_type(&ty) {
+            keys.insert(key);
+        }
+    }
+    for key in keys {
+        if let Some(hook) = hooks.get(key) {
+            hook().await;
+        }
     }
 }
 
@@ -211,6 +289,19 @@ pub struct CloudFormationService {
     pub(crate) deps: CloudFormationDeps,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
+    /// Fine-grained S3 disk store. CFN bucket create/delete writes through this
+    /// (the same path the real `CreateBucket`/`DeleteBucket` use) instead of
+    /// only mutating the in-memory map, so a CFN-provisioned bucket survives a
+    /// restart. Defaults to a `MemoryS3Store` (no-op); the server wires the
+    /// real store via `with_s3_store` once it has been built.
+    s3_store: Arc<dyn S3Store>,
+    /// Whole-state snapshot persist hooks keyed by service name (see
+    /// `service_key_for_type`). After a stack op the handler invokes the hook
+    /// for each touched service so a CFN-provisioned (or CFN-deleted) resource
+    /// is written through to disk, the same persistence a direct mutating API
+    /// call would trigger. Empty by default (memory mode, or no services
+    /// wired); the server populates it via `with_snapshot_hooks`.
+    snapshot_hooks: BTreeMap<&'static str, SnapshotHook>,
 }
 
 /// Everything the async CreateStack provisioning task needs to provision
@@ -221,6 +312,7 @@ struct CreateStackContext {
     delivery: Arc<DeliveryBus>,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
+    snapshot_hooks: BTreeMap<&'static str, SnapshotHook>,
     provisioner: ResourceProvisioner,
     account_id: String,
     stack_name: String,
@@ -239,11 +331,27 @@ impl CloudFormationService {
             deps,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
+            s3_store: Arc::new(fakecloud_persistence::s3::MemoryS3Store::new()),
+            snapshot_hooks: BTreeMap::new(),
         }
     }
 
     pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
         self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Wire the fine-grained S3 disk store so CFN-provisioned buckets are
+    /// written through to disk (see `ResourceProvisioner::s3_store`).
+    pub fn with_s3_store(mut self, store: Arc<dyn S3Store>) -> Self {
+        self.s3_store = store;
+        self
+    }
+
+    /// Register the per-service snapshot persist hooks (keyed by service name)
+    /// used to persist every snapshot-backed service a stack op touches.
+    pub fn with_snapshot_hooks(mut self, hooks: BTreeMap<&'static str, SnapshotHook>) -> Self {
+        self.snapshot_hooks = hooks;
         self
     }
 
@@ -312,6 +420,7 @@ impl CloudFormationService {
             cloudformation_state: self.state.clone(),
             delivery: self.deps.delivery.clone(),
             lambda_runtime: self.deps.lambda_runtime.clone(),
+            s3_store: self.s3_store.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
             stack_id: stack_id.to_string(),
@@ -749,6 +858,7 @@ impl CloudFormationService {
             delivery: self.deps.delivery.clone(),
             snapshot_store: self.snapshot_store.clone(),
             snapshot_lock: self.snapshot_lock.clone(),
+            snapshot_hooks: self.snapshot_hooks.clone(),
             provisioner: self.provisioner(&stack_id, &req.account_id, &req.region),
             account_id: req.account_id.clone(),
             stack_name: stack_name.clone(),
@@ -819,6 +929,7 @@ impl CloudFormationService {
             delivery,
             snapshot_store,
             snapshot_lock,
+            snapshot_hooks,
             provisioner,
             account_id,
             stack_name,
@@ -925,6 +1036,15 @@ impl CloudFormationService {
         );
 
         save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+        // Persist every snapshot-backed service the stack provisioned, so a
+        // CFN-created resource (e.g. a Lambda function or Secret whose service
+        // is not otherwise re-mutated) is written to disk and survives a
+        // restart -- not just the CloudFormation stack metadata above.
+        persist_touched_services(
+            &snapshot_hooks,
+            resources.iter().map(|r| r.resource_type.clone()),
+        )
+        .await;
     }
 
     /// Roll a stack into CREATE_FAILED, record the lifecycle event, and
@@ -963,7 +1083,7 @@ impl CloudFormationService {
         );
     }
 
-    fn delete_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    async fn delete_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let stack_name = Self::get_param(req, "StackName").ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -972,96 +1092,111 @@ impl CloudFormationService {
             )
         })?;
 
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-
-        // Find stack by name or stack ID
-        let stack = state.stacks.values_mut().find(|s| {
-            (s.name == stack_name || s.stack_id == stack_name) && s.status != "DELETE_COMPLETE"
-        });
-
-        if let Some(stack) = stack {
-            let stack_id = stack.stack_id.clone();
-            let stack_name_for_notif = stack.name.clone();
-            let notification_arns = stack.notification_arns.clone();
-            let resources: Vec<_> = stack.resources.clone();
-
-            // Block delete if any of this stack's exports are still
-            // imported by another live stack. Mirrors real CFN.
-            let owned_exports: Vec<String> = state
-                .exports
-                .iter()
-                .filter(|(_, e)| e.exporting_stack_name == stack_name_for_notif)
-                .map(|(k, _)| k.clone())
-                .collect();
-            for export in &owned_exports {
-                if let Some(consumers) = state.imports.get(export) {
-                    let consumers: Vec<&String> = consumers
-                        .iter()
-                        .filter(|c| **c != stack_name_for_notif)
-                        .collect();
-                    if !consumers.is_empty() {
-                        let names: Vec<&str> = consumers.iter().map(|s| s.as_str()).collect();
-                        // DeleteStack declares only `TokenAlreadyExistsException`,
-                        // which is the closest declared shape for "this delete
-                        // can't proceed". Strict conformance rarely hits this
-                        // pre-flight (probe state is fresh per run); the unit
-                        // test asserting the legacy message still passes since
-                        // both error codes carry the same body text.
-                        return Err(AwsServiceError::aws_error(
-                            StatusCode::BAD_REQUEST,
-                            "TokenAlreadyExistsException",
-                            format!(
-                                "Export {export} cannot be deleted as it is in use by {}",
-                                names.join(", ")
-                            ),
-                        ));
-                    }
-                }
-            }
-
-            // Build the provisioner while we still have the stack_id
-            // Drop the write lock temporarily so the provisioner can read state
-            drop(accounts);
-            let provisioner = self.provisioner(&stack_id, &req.account_id, &req.region);
-
-            // Delete resources in reverse order
-            for resource in resources.iter().rev() {
-                let _ = provisioner.delete_resource(resource);
-            }
-
-            // Re-acquire the write lock to update stack status
+        // Resource types deleted by this op, captured so we can persist the
+        // owning services after every state guard has been released (the
+        // `.await` must not straddle a non-Send `RwLockWriteGuard`). The guard
+        // work is wrapped in a block so the lock is dropped on every path -
+        // including the stack-not-found path - before the await below.
+        let mut deleted_types: Vec<String> = Vec::new();
+        {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&req.account_id);
-            if let Some(stack) = state.stacks.values_mut().find(|s| s.stack_id == stack_id) {
-                stack.status = "DELETE_COMPLETE".to_string();
-                stack.resources.clear();
-                stack.outputs.clear();
-            }
-            // Drop this stack's exports + import-consumer entries.
-            let stale_exports: Vec<String> = state
-                .exports
-                .iter()
-                .filter(|(_, e)| e.exporting_stack_name == stack_name_for_notif)
-                .map(|(k, _)| k.clone())
-                .collect();
-            for k in stale_exports {
-                state.exports.remove(&k);
-            }
-            for entries in state.imports.values_mut() {
-                entries.retain(|s| s != &stack_name_for_notif);
-            }
-            state.imports.retain(|_, v| !v.is_empty());
-            drop(accounts);
 
-            Self::send_stack_notification(
-                &self.deps.delivery,
-                &notification_arns,
-                &stack_name_for_notif,
-                &stack_id,
-                "DELETE_COMPLETE",
-            );
+            // Find stack by name or stack ID
+            let stack = state.stacks.values_mut().find(|s| {
+                (s.name == stack_name || s.stack_id == stack_name) && s.status != "DELETE_COMPLETE"
+            });
+
+            if let Some(stack) = stack {
+                let stack_id = stack.stack_id.clone();
+                let stack_name_for_notif = stack.name.clone();
+                let notification_arns = stack.notification_arns.clone();
+                let resources: Vec<_> = stack.resources.clone();
+
+                // Block delete if any of this stack's exports are still
+                // imported by another live stack. Mirrors real CFN.
+                let owned_exports: Vec<String> = state
+                    .exports
+                    .iter()
+                    .filter(|(_, e)| e.exporting_stack_name == stack_name_for_notif)
+                    .map(|(k, _)| k.clone())
+                    .collect();
+                for export in &owned_exports {
+                    if let Some(consumers) = state.imports.get(export) {
+                        let consumers: Vec<&String> = consumers
+                            .iter()
+                            .filter(|c| **c != stack_name_for_notif)
+                            .collect();
+                        if !consumers.is_empty() {
+                            let names: Vec<&str> = consumers.iter().map(|s| s.as_str()).collect();
+                            // DeleteStack declares only `TokenAlreadyExistsException`,
+                            // which is the closest declared shape for "this delete
+                            // can't proceed". Strict conformance rarely hits this
+                            // pre-flight (probe state is fresh per run); the unit
+                            // test asserting the legacy message still passes since
+                            // both error codes carry the same body text.
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "TokenAlreadyExistsException",
+                                format!(
+                                    "Export {export} cannot be deleted as it is in use by {}",
+                                    names.join(", ")
+                                ),
+                            ));
+                        }
+                    }
+                }
+
+                // Build the provisioner while we still have the stack_id
+                // Drop the write lock temporarily so the provisioner can read state
+                drop(accounts);
+                let provisioner = self.provisioner(&stack_id, &req.account_id, &req.region);
+
+                // Delete resources in reverse order
+                for resource in resources.iter().rev() {
+                    let _ = provisioner.delete_resource(resource);
+                }
+
+                // Re-acquire the write lock to update stack status
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(&req.account_id);
+                if let Some(stack) = state.stacks.values_mut().find(|s| s.stack_id == stack_id) {
+                    stack.status = "DELETE_COMPLETE".to_string();
+                    stack.resources.clear();
+                    stack.outputs.clear();
+                }
+                // Drop this stack's exports + import-consumer entries.
+                let stale_exports: Vec<String> = state
+                    .exports
+                    .iter()
+                    .filter(|(_, e)| e.exporting_stack_name == stack_name_for_notif)
+                    .map(|(k, _)| k.clone())
+                    .collect();
+                for k in stale_exports {
+                    state.exports.remove(&k);
+                }
+                for entries in state.imports.values_mut() {
+                    entries.retain(|s| s != &stack_name_for_notif);
+                }
+                state.imports.retain(|_, v| !v.is_empty());
+                drop(accounts);
+
+                Self::send_stack_notification(
+                    &self.deps.delivery,
+                    &notification_arns,
+                    &stack_name_for_notif,
+                    &stack_id,
+                    "DELETE_COMPLETE",
+                );
+
+                deleted_types = resources.iter().map(|r| r.resource_type.clone()).collect();
+            }
         }
+
+        // Persist every snapshot-backed service whose resource was deleted, so
+        // a CFN-deleted resource does not reappear after a restart. Done here,
+        // outside any state-guard scope, so the future stays `Send`.
+        persist_touched_services(&self.snapshot_hooks, deleted_types).await;
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -1190,7 +1325,7 @@ impl CloudFormationService {
         ))
     }
 
-    fn update_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    async fn update_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let mut input = UpdateStackInput::from_params(req)?;
 
         // Get stack_id before write lock for the provisioner
@@ -1288,135 +1423,156 @@ impl CloudFormationService {
 
         let provisioner = self.provisioner(&found_stack_id, &req.account_id, &req.region);
 
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        // UpdateStack declares only `InsufficientCapabilitiesException` and
-        // `TokenAlreadyExistsException` — neither describes a missing stack.
-        // Real AWS returns `ValidationError` for this case, but that wire
-        // code isn't declared on UpdateStack. The conformance probe's
-        // Success variants supply placeholder `StackName` values that point
-        // at no real stack, so degrade to a synthetic-success response
-        // (echoing a generated StackId) rather than emit an undeclared
-        // error. Real callers always create the stack first.
-        let stack_exists = state.stacks.values().any(|s| {
-            (s.name == input.stack_name || s.stack_id == input.stack_name)
-                && s.status != "DELETE_COMPLETE"
-        });
-        if !stack_exists {
-            let stack_id = if found_stack_id.is_empty() {
-                format!(
-                    "arn:aws:cloudformation:{}:{}:stack/{}/{}",
-                    req.region,
-                    req.account_id,
-                    input.stack_name,
-                    uuid::Uuid::new_v4()
+        // All `RwLockWriteGuard` work happens inside this block so the (non-Send)
+        // guard is released before the persist `.await` below, keeping the
+        // handler future `Send`. The block yields everything the post-lock tail
+        // needs, including the resource types touched by the update.
+        let (touched_types, stack_id, stack_name_for_notif, notification_arns, resources_snapshot) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            // UpdateStack declares only `InsufficientCapabilitiesException` and
+            // `TokenAlreadyExistsException` -- neither describes a missing stack.
+            // Real AWS returns `ValidationError` for this case, but that wire
+            // code isn't declared on UpdateStack. The conformance probe's
+            // Success variants supply placeholder `StackName` values that point
+            // at no real stack, so degrade to a synthetic-success response
+            // (echoing a generated StackId) rather than emit an undeclared
+            // error. Real callers always create the stack first.
+            let stack_exists = state.stacks.values().any(|s| {
+                (s.name == input.stack_name || s.stack_id == input.stack_name)
+                    && s.status != "DELETE_COMPLETE"
+            });
+            if !stack_exists {
+                let stack_id = if found_stack_id.is_empty() {
+                    format!(
+                        "arn:aws:cloudformation:{}:{}:stack/{}/{}",
+                        req.region,
+                        req.account_id,
+                        input.stack_name,
+                        uuid::Uuid::new_v4()
+                    )
+                } else {
+                    found_stack_id.clone()
+                };
+                return Ok(AwsResponse::xml(
+                    StatusCode::OK,
+                    xml_responses::update_stack_response(&stack_id, &req.request_id),
+                ));
+            }
+            let (update_result, stack_id, stack_name_owned, resources_snapshot, notification_arns) = {
+                let stack = state
+                    .stacks
+                    .values_mut()
+                    .find(|s| {
+                        (s.name == input.stack_name || s.stack_id == input.stack_name)
+                            && s.status != "DELETE_COMPLETE"
+                    })
+                    .expect("stack existence checked above");
+
+                stack.status = "UPDATE_IN_PROGRESS".to_string();
+                let update_result = apply_resource_updates(
+                    stack,
+                    &parsed.resources,
+                    &input.template_body,
+                    &input.parameters,
+                    &provisioner,
+                );
+
+                let stack_id = stack.stack_id.clone();
+                let stack_name_owned = stack.name.clone();
+                stack.template = input.template_body.clone();
+                stack.status = if update_result.is_err() {
+                    "UPDATE_ROLLBACK_COMPLETE".to_string()
+                } else {
+                    "UPDATE_COMPLETE".to_string()
+                };
+                stack.parameters = input.parameters.clone();
+                if !input.tags.is_empty() {
+                    stack.tags = input.tags;
+                }
+                stack.updated_at = Some(Utc::now());
+                stack.description = parsed.description;
+                if !input.notification_arns.is_empty() {
+                    stack.notification_arns = input.notification_arns.clone();
+                }
+                if update_result.is_ok() {
+                    stack.outputs.clear();
+                }
+                (
+                    update_result,
+                    stack_id,
+                    stack_name_owned,
+                    stack.resources.clone(),
+                    stack.notification_arns.clone(),
                 )
-            } else {
-                found_stack_id.clone()
             };
-            return Ok(AwsResponse::xml(
-                StatusCode::OK,
-                xml_responses::update_stack_response(&stack_id, &req.request_id),
-            ));
-        }
-        let (update_result, stack_id, stack_name_owned, resources_snapshot, notification_arns) = {
-            let stack = state
-                .stacks
-                .values_mut()
-                .find(|s| {
-                    (s.name == input.stack_name || s.stack_id == input.stack_name)
-                        && s.status != "DELETE_COMPLETE"
-                })
-                .expect("stack existence checked above");
 
-            stack.status = "UPDATE_IN_PROGRESS".to_string();
-            let update_result = apply_resource_updates(
-                stack,
-                &parsed.resources,
-                &input.template_body,
-                &input.parameters,
-                &provisioner,
+            // Emit lifecycle events (now that the &mut Stack borrow is dropped).
+            record_stack_status_event(
+                state,
+                &stack_id,
+                &stack_name_owned,
+                "AWS::CloudFormation::Stack",
+                "UPDATE_IN_PROGRESS",
             );
-
-            let stack_id = stack.stack_id.clone();
-            let stack_name_owned = stack.name.clone();
-            stack.template = input.template_body.clone();
-            stack.status = if update_result.is_err() {
-                "UPDATE_ROLLBACK_COMPLETE".to_string()
-            } else {
-                "UPDATE_COMPLETE".to_string()
+            let update_result = match update_result {
+                Ok(changes) => {
+                    // Capture every service touched by the update (created,
+                    // updated, or deleted resources) so we can persist them once
+                    // the stack reaches UPDATE_COMPLETE.
+                    let touched_types: Vec<String> =
+                        changes.iter().map(|c| c.resource_type.clone()).collect();
+                    record_stack_events(state, &stack_id, &stack_name_owned, &changes);
+                    record_stack_status_event(
+                        state,
+                        &stack_id,
+                        &stack_name_owned,
+                        "AWS::CloudFormation::Stack",
+                        "UPDATE_COMPLETE",
+                    );
+                    Ok(touched_types)
+                }
+                Err(e) => {
+                    record_stack_status_event(
+                        state,
+                        &stack_id,
+                        &stack_name_owned,
+                        "AWS::CloudFormation::Stack",
+                        "UPDATE_ROLLBACK_COMPLETE",
+                    );
+                    Err(e)
+                }
             };
-            stack.parameters = input.parameters.clone();
-            if !input.tags.is_empty() {
-                stack.tags = input.tags;
-            }
-            stack.updated_at = Some(Utc::now());
-            stack.description = parsed.description;
-            if !input.notification_arns.is_empty() {
-                stack.notification_arns = input.notification_arns.clone();
-            }
-            if update_result.is_ok() {
-                stack.outputs.clear();
-            }
+            let stack_name_for_notif = stack_name_owned.clone();
+
+            let touched_types = match update_result {
+                Ok(types) => types,
+                Err(error_msg) => {
+                    drop(accounts);
+                    Self::send_stack_notification(
+                        &self.deps.delivery,
+                        &notification_arns,
+                        &stack_name_for_notif,
+                        &stack_id,
+                        "UPDATE_FAILED",
+                    );
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InsufficientCapabilitiesException",
+                        error_msg,
+                    ));
+                }
+            };
+
+            drop(accounts);
             (
-                update_result,
+                touched_types,
                 stack_id,
-                stack_name_owned,
-                stack.resources.clone(),
-                stack.notification_arns.clone(),
+                stack_name_for_notif,
+                notification_arns,
+                resources_snapshot,
             )
         };
-
-        // Emit lifecycle events (now that the &mut Stack borrow is dropped).
-        record_stack_status_event(
-            state,
-            &stack_id,
-            &stack_name_owned,
-            "AWS::CloudFormation::Stack",
-            "UPDATE_IN_PROGRESS",
-        );
-        let update_result = match update_result {
-            Ok(changes) => {
-                record_stack_events(state, &stack_id, &stack_name_owned, &changes);
-                record_stack_status_event(
-                    state,
-                    &stack_id,
-                    &stack_name_owned,
-                    "AWS::CloudFormation::Stack",
-                    "UPDATE_COMPLETE",
-                );
-                Ok(())
-            }
-            Err(e) => {
-                record_stack_status_event(
-                    state,
-                    &stack_id,
-                    &stack_name_owned,
-                    "AWS::CloudFormation::Stack",
-                    "UPDATE_ROLLBACK_COMPLETE",
-                );
-                Err(e)
-            }
-        };
-        let stack_name_for_notif = stack_name_owned.clone();
-
-        if let Err(error_msg) = update_result {
-            drop(accounts);
-            Self::send_stack_notification(
-                &self.deps.delivery,
-                &notification_arns,
-                &stack_name_for_notif,
-                &stack_id,
-                "UPDATE_FAILED",
-            );
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InsufficientCapabilitiesException",
-                error_msg,
-            ));
-        }
-
-        drop(accounts);
 
         let outputs = Self::resolve_template_outputs(
             &input.template_body,
@@ -1451,6 +1607,10 @@ impl CloudFormationService {
             &stack_id,
             "UPDATE_COMPLETE",
         );
+
+        // Persist every snapshot-backed service the update touched, so created
+        // or deleted resources are reflected on disk after a restart.
+        persist_touched_services(&self.snapshot_hooks, touched_types).await;
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -1525,12 +1685,12 @@ impl AwsService for CloudFormationService {
         );
         let result = match action {
             "CreateStack" => self.create_stack(&req).await,
-            "DeleteStack" => self.delete_stack(&req),
+            "DeleteStack" => self.delete_stack(&req).await,
             "DescribeStacks" => self.describe_stacks(&req),
             "ListStacks" => self.list_stacks(&req),
             "ListStackResources" => self.list_stack_resources(&req),
             "DescribeStackResources" => self.describe_stack_resources(&req),
-            "UpdateStack" => self.update_stack(&req),
+            "UpdateStack" => self.update_stack(&req).await,
             "GetTemplate" => self.get_template(&req),
             _ => self.handle_extra_action(&req),
         };
@@ -2248,7 +2408,7 @@ mod tests {
             r#"{"Resources":{"MyQueue":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"q1"}},"BadSub":{"Type":"AWS::SNS::Subscription","Properties":{"TopicArn":"arn:aws:sns:us-east-1:123456789012:nope","Protocol":"sqs","Endpoint":"arn:aws:sqs:us-east-1:123456789012:q1"}}}}"#.to_string(),
         );
         let req = make_request("UpdateStack", update_params);
-        let result = svc.update_stack(&req);
+        let result = svc.update_stack(&req).await;
 
         // Should return an error
         assert!(result.is_err());
@@ -2452,13 +2612,13 @@ mod tests {
             .expect("bad-body create succeeds");
     }
 
-    #[test]
-    fn delete_stack_unknown_is_noop() {
+    #[tokio::test]
+    async fn delete_stack_unknown_is_noop() {
         let svc = make_service();
         let mut params = HashMap::new();
         params.insert("StackName".to_string(), "ghost".to_string());
         let req = make_request("DeleteStack", params);
-        assert!(svc.delete_stack(&req).is_ok());
+        assert!(svc.delete_stack(&req).await.is_ok());
     }
 
     #[test]
@@ -2552,17 +2712,17 @@ mod tests {
         svc.get_template(&req).expect("unknown is empty");
     }
 
-    #[test]
-    fn update_stack_missing_name_errors() {
+    #[tokio::test]
+    async fn update_stack_missing_name_errors() {
         let svc = make_service();
         let mut params = HashMap::new();
         params.insert("TemplateBody".to_string(), "{}".to_string());
         let req = make_request("UpdateStack", params);
-        assert!(svc.update_stack(&req).is_err());
+        assert!(svc.update_stack(&req).await.is_err());
     }
 
-    #[test]
-    fn update_stack_unknown_stack_returns_synthetic_id() {
+    #[tokio::test]
+    async fn update_stack_unknown_stack_returns_synthetic_id() {
         // UpdateStack declares only `InsufficientCapabilitiesException`
         // and `TokenAlreadyExistsException`, neither of which fits
         // "stack does not exist". Synthetic conformance inputs target
@@ -2577,7 +2737,10 @@ mod tests {
             r#"{"Resources":{}}"#.to_string(),
         );
         let req = make_request("UpdateStack", params);
-        let resp = svc.update_stack(&req).expect("ghost update is synthetic");
+        let resp = svc
+            .update_stack(&req)
+            .await
+            .expect("ghost update is synthetic");
         let b = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(b.contains("UpdateStackResult"));
     }
@@ -2782,7 +2945,7 @@ mod tests {
         // Producer delete must fail while consumer still imports.
         let mut p = HashMap::new();
         p.insert("StackName".to_string(), "producer".to_string());
-        match svc.delete_stack(&make_request("DeleteStack", p)) {
+        match svc.delete_stack(&make_request("DeleteStack", p)).await {
             Ok(_) => panic!("delete must fail while imports exist"),
             Err(e) => {
                 let msg = format!("{e:?}");
@@ -2794,17 +2957,289 @@ mod tests {
         let mut p = HashMap::new();
         p.insert("StackName".to_string(), "consumer".to_string());
         svc.delete_stack(&make_request("DeleteStack", p))
+            .await
             .expect("consumer delete");
 
         // Now producer delete succeeds.
         let mut p = HashMap::new();
         p.insert("StackName".to_string(), "producer".to_string());
         svc.delete_stack(&make_request("DeleteStack", p))
+            .await
             .expect("producer delete after consumer gone");
 
         let accounts = svc.state.read();
         let state = accounts.get("123456789012").unwrap();
         assert!(state.exports.is_empty(), "exports cleared after delete");
         assert!(state.imports.is_empty(), "imports cleared after delete");
+    }
+
+    // ---- CFN provisioner persistence (issue: CFN resources lost on restart) ----
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A snapshot hook that counts how many times it fires, standing in for a
+    /// real service's whole-state persist.
+    fn counting_hook(counter: Arc<AtomicUsize>) -> fakecloud_persistence::SnapshotHook {
+        Arc::new(move || {
+            let counter = counter.clone();
+            Box::pin(async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+            })
+        })
+    }
+
+    fn disk_s3_store(tmp: &tempfile::TempDir) -> Arc<fakecloud_persistence::s3::DiskS3Store> {
+        let cache = Arc::new(fakecloud_persistence::cache::BodyCache::new(1024 * 1024));
+        Arc::new(fakecloud_persistence::s3::DiskS3Store::new(
+            tmp.path().to_path_buf(),
+            cache,
+        ))
+    }
+
+    // A stack touching SQS + SNS (snapshot-backed) and an S3 bucket (S3Store
+    // write-through). Lambda is registered as a hook below but NOT in the
+    // template, so it must not fire -- proving per-service selectivity.
+    const PERSIST_TEMPLATE: &str = r#"{"Resources":{
+        "Q":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"cfn-q"}},
+        "T":{"Type":"AWS::SNS::Topic","Properties":{"TopicName":"cfn-t"}},
+        "B":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-bucket"}}
+    }}"#;
+
+    fn create_req(stack: &str) -> AwsRequest {
+        let mut p = HashMap::new();
+        p.insert("StackName".to_string(), stack.to_string());
+        p.insert("TemplateBody".to_string(), PERSIST_TEMPLATE.to_string());
+        make_request("CreateStack", p)
+    }
+
+    #[tokio::test]
+    async fn cfn_create_persists_touched_services_and_writes_bucket_to_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = disk_s3_store(&tmp);
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut hooks: BTreeMap<&'static str, fakecloud_persistence::SnapshotHook> =
+            BTreeMap::new();
+        hooks.insert("sqs", counting_hook(counter.clone()));
+        hooks.insert("sns", counting_hook(counter.clone()));
+        // Registered but not in the template -> must not fire.
+        hooks.insert("lambda", counting_hook(counter.clone()));
+        let svc = make_service()
+            .with_s3_store(store.clone())
+            .with_snapshot_hooks(hooks);
+
+        svc.create_stack(&create_req("probe")).await.unwrap();
+
+        // sqs + sns fired once each; lambda untouched.
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+        // The bucket was written through to the S3 store, not just the in-memory map.
+        let loaded = fakecloud_persistence::S3Store::load(store.as_ref()).unwrap();
+        assert!(
+            loaded.buckets.contains_key("cfn-bucket"),
+            "CFN bucket should be persisted to the S3 store"
+        );
+    }
+
+    #[tokio::test]
+    async fn cfn_delete_persists_touched_services_and_removes_bucket_from_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = disk_s3_store(&tmp);
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut hooks: BTreeMap<&'static str, fakecloud_persistence::SnapshotHook> =
+            BTreeMap::new();
+        hooks.insert("sqs", counting_hook(counter.clone()));
+        hooks.insert("sns", counting_hook(counter.clone()));
+        let svc = make_service()
+            .with_s3_store(store.clone())
+            .with_snapshot_hooks(hooks);
+
+        svc.create_stack(&create_req("probe")).await.unwrap();
+        assert_eq!(counter.load(Ordering::SeqCst), 2, "create fired sqs + sns");
+
+        let mut p = HashMap::new();
+        p.insert("StackName".to_string(), "probe".to_string());
+        svc.delete_stack(&make_request("DeleteStack", p))
+            .await
+            .unwrap();
+
+        // Delete fired the touched services again (sqs + sns).
+        assert_eq!(counter.load(Ordering::SeqCst), 4, "delete fired sqs + sns");
+        // And the CFN-deleted bucket is gone from the store, so it does not
+        // reappear after a restart.
+        let loaded = fakecloud_persistence::S3Store::load(store.as_ref()).unwrap();
+        assert!(
+            !loaded.buckets.contains_key("cfn-bucket"),
+            "CFN-deleted bucket should be removed from the S3 store"
+        );
+    }
+
+    #[tokio::test]
+    async fn cfn_persist_skips_services_without_a_registered_hook() {
+        // Only "sqs" has a hook; the stack also touches SNS and S3. The missing
+        // hooks must be silently skipped (no panic), and "sqs" fires once.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = disk_s3_store(&tmp);
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut hooks: BTreeMap<&'static str, fakecloud_persistence::SnapshotHook> =
+            BTreeMap::new();
+        hooks.insert("sqs", counting_hook(counter.clone()));
+        let svc = make_service()
+            .with_s3_store(store.clone())
+            .with_snapshot_hooks(hooks);
+
+        svc.create_stack(&create_req("probe")).await.unwrap();
+        assert_eq!(counter.load(Ordering::SeqCst), 1, "only sqs has a hook");
+    }
+
+    #[tokio::test]
+    async fn cfn_update_persists_touched_services() {
+        // Create with just SQS, then update to a template that adds SNS + a
+        // bucket; the update must persist the services it touches.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = disk_s3_store(&tmp);
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut hooks: BTreeMap<&'static str, fakecloud_persistence::SnapshotHook> =
+            BTreeMap::new();
+        hooks.insert("sqs", counting_hook(counter.clone()));
+        hooks.insert("sns", counting_hook(counter.clone()));
+        let svc = make_service()
+            .with_s3_store(store.clone())
+            .with_snapshot_hooks(hooks);
+
+        let mut create = HashMap::new();
+        create.insert("StackName".to_string(), "upd".to_string());
+        create.insert(
+            "TemplateBody".to_string(),
+            r#"{"Resources":{"Q":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"u-q"}}}}"#
+                .to_string(),
+        );
+        svc.create_stack(&make_request("CreateStack", create))
+            .await
+            .unwrap();
+        let after_create = counter.load(Ordering::SeqCst);
+
+        let mut update = HashMap::new();
+        update.insert("StackName".to_string(), "upd".to_string());
+        update.insert("TemplateBody".to_string(), PERSIST_TEMPLATE.to_string());
+        svc.update_stack(&make_request("UpdateStack", update))
+            .await
+            .unwrap();
+
+        // The update touched at least SNS (added); the hook count must grow.
+        assert!(
+            counter.load(Ordering::SeqCst) > after_create,
+            "update should persist the services it touched"
+        );
+        let loaded = fakecloud_persistence::S3Store::load(store.as_ref()).unwrap();
+        assert!(loaded.buckets.contains_key("cfn-bucket"));
+    }
+
+    #[test]
+    fn service_key_for_type_maps_services_and_aliases() {
+        // Direct service segments.
+        assert_eq!(
+            service_key_for_type("AWS::Lambda::Function"),
+            Some("lambda")
+        );
+        assert_eq!(
+            service_key_for_type("AWS::SecretsManager::Secret"),
+            Some("secretsmanager")
+        );
+        assert_eq!(service_key_for_type("AWS::SQS::Queue"), Some("sqs"));
+        assert_eq!(service_key_for_type("AWS::IAM::Role"), Some("iam"));
+        assert_eq!(
+            service_key_for_type("AWS::StepFunctions::StateMachine"),
+            Some("stepfunctions")
+        );
+        // Namespace aliases that differ from the fakecloud service name.
+        assert_eq!(
+            service_key_for_type("AWS::Events::Rule"),
+            Some("eventbridge")
+        );
+        assert_eq!(service_key_for_type("AWS::Logs::LogGroup"), Some("logs"));
+        // S3 has no snapshot hook (it persists via the S3Store write-through).
+        assert_eq!(service_key_for_type("AWS::S3::Bucket"), None);
+        // Non-snapshot-backed services.
+        assert_eq!(
+            service_key_for_type("AWS::CertificateManager::Certificate"),
+            None
+        );
+        // Malformed / non-AWS types.
+        assert_eq!(service_key_for_type("AWS::Lambda"), None);
+        assert_eq!(service_key_for_type("Custom::Thing::Resource"), None);
+        assert_eq!(service_key_for_type("AWS"), None);
+        assert_eq!(service_key_for_type(""), None);
+    }
+
+    #[tokio::test]
+    async fn persist_touched_services_noop_with_empty_hooks() {
+        // No registered hooks -> nothing to do, must not panic.
+        let hooks: BTreeMap<&'static str, fakecloud_persistence::SnapshotHook> = BTreeMap::new();
+        persist_touched_services(&hooks, vec!["AWS::SQS::Queue".to_string()]).await;
+    }
+
+    #[tokio::test]
+    async fn cfn_bucket_policy_write_through_create_update_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = disk_s3_store(&tmp);
+        let svc = make_service().with_s3_store(store.clone());
+
+        // Create a bucket + bucket policy.
+        let mut create = HashMap::new();
+        create.insert("StackName".to_string(), "pol".to_string());
+        create.insert(
+            "TemplateBody".to_string(),
+            r#"{"Resources":{
+                "B":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"pol-bucket"}},
+                "BP":{"Type":"AWS::S3::BucketPolicy","Properties":{"Bucket":"pol-bucket","PolicyDocument":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*","Principal":"*"}]}}}
+            }}"#
+            .to_string(),
+        );
+        svc.create_stack(&make_request("CreateStack", create))
+            .await
+            .unwrap();
+        let loaded = fakecloud_persistence::S3Store::load(store.as_ref()).unwrap();
+        let policy = loaded.buckets["pol-bucket"]
+            .subresources
+            .get("policy.toml")
+            .cloned()
+            .expect("bucket policy persisted on create");
+        assert!(policy.contains("s3:GetObject"));
+
+        // Update the policy document; the update must write through.
+        let mut update = HashMap::new();
+        update.insert("StackName".to_string(), "pol".to_string());
+        update.insert(
+            "TemplateBody".to_string(),
+            r#"{"Resources":{
+                "B":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"pol-bucket"}},
+                "BP":{"Type":"AWS::S3::BucketPolicy","Properties":{"Bucket":"pol-bucket","PolicyDocument":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:PutObject","Resource":"*","Principal":"*"}]}}}
+            }}"#
+            .to_string(),
+        );
+        svc.update_stack(&make_request("UpdateStack", update))
+            .await
+            .unwrap();
+        let loaded = fakecloud_persistence::S3Store::load(store.as_ref()).unwrap();
+        let policy = loaded.buckets["pol-bucket"]
+            .subresources
+            .get("policy.toml")
+            .cloned()
+            .expect("bucket policy still persisted after update");
+        assert!(
+            policy.contains("s3:PutObject"),
+            "updated policy should be written through"
+        );
+
+        // Delete the stack; the bucket (and its policy) must be removed from disk.
+        let mut del = HashMap::new();
+        del.insert("StackName".to_string(), "pol".to_string());
+        svc.delete_stack(&make_request("DeleteStack", del))
+            .await
+            .unwrap();
+        let loaded = fakecloud_persistence::S3Store::load(store.as_ref()).unwrap();
+        assert!(
+            !loaded.buckets.contains_key("pol-bucket"),
+            "CFN-deleted bucket and policy should be gone from the store"
+        );
     }
 }

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -142,25 +142,62 @@ impl CloudWatchService {
     /// the snapshot lock so concurrent mutators can't race a stale-last
     /// write.
     pub(crate) async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = CloudWatchSnapshot {
-            schema_version: CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
-            accounts: self.state.read().clone_for_snapshot(),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_cloudwatch_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write cloudwatch snapshot"),
-            Err(err) => tracing::error!(%err, "cloudwatch snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current CloudWatch state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_cloudwatch_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current CloudWatch state as a snapshot. Cloned + serialized
+/// under the snapshot lock so concurrent mutators can't race a stale-last
+/// write. Noop when `store` is `None` (memory mode). Shared by
+/// `CloudWatchService::save_snapshot` and the CloudFormation provisioner's
+/// post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_cloudwatch_snapshot(
+    state: &SharedCloudWatchState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &Mutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = CloudWatchSnapshot {
+        schema_version: CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
+        accounts: state.read().clone_for_snapshot(),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write cloudwatch snapshot"),
+        Err(err) => tracing::error!(%err, "cloudwatch snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-cloudwatch/src/tests.rs
+++ b/crates/fakecloud-cloudwatch/src/tests.rs
@@ -433,3 +433,21 @@ async fn introspection_collapses_metric_series() {
     assert_eq!(latest.value, Some(5.0));
     assert_eq!(latest.unit.as_deref(), Some("Count"));
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = service();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = service().with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -253,26 +253,62 @@ impl CognitoService {
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = CognitoSnapshot {
-            schema_version: COGNITO_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
-            state: None,
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_cognito_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write cognito snapshot"),
-            Err(err) => tracing::error!(%err, "cognito snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current Cognito state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_cognito_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current Cognito state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `CognitoService::save_snapshot` and the
+/// CloudFormation provisioner's post-provision persist hook so both route
+/// through the same serialize-and-write path.
+pub async fn save_cognito_snapshot(
+    state: &SharedCognitoState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = CognitoSnapshot {
+        schema_version: COGNITO_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+        state: None,
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write cognito snapshot"),
+        Err(err) => tracing::error!(%err, "cognito snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -7393,3 +7393,25 @@ fn user_pool_replica_error_paths() {
         .unwrap();
     assert!(format!("{err:?}").contains("ResourceNotFound"));
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let (svc, _state) = make_svc();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating Cognito
+/// state directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let (_svc, state) = make_svc();
+    let store: std::sync::Arc<dyn fakecloud_persistence::SnapshotStore> =
+        std::sync::Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = CognitoService::new(state).with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -159,26 +159,31 @@ impl DynamoDbService {
     /// serialization + the blocking file write are offloaded to the
     /// blocking pool to keep Tokio workers responsive.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = DynamoDbSnapshot {
-            schema_version: DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
-            state: None,
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_dynamodb_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write dynamodb snapshot"),
-            Err(err) => tracing::error!(%err, "dynamodb snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current DynamoDB state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation
+    /// provisioner mutates `state` directly and uses this to write a
+    /// CFN-provisioned table through to disk, the same way a direct mutating
+    /// API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_dynamodb_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 
     fn kinesis_target(table: &DynamoTable) -> Option<KinesisDeliveryTarget> {
@@ -269,6 +274,38 @@ impl DynamoDbService {
 
     fn ok_json(body: Value) -> Result<AwsResponse, AwsServiceError> {
         Ok(AwsResponse::ok_json(body))
+    }
+}
+
+/// Persist the current DynamoDB state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `DynamoDbService::save_snapshot` and the
+/// CloudFormation provisioner's post-provision persist hook so both route
+/// through the same serialize-and-write path.
+pub async fn save_dynamodb_snapshot(
+    state: &SharedDynamoDbState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &tokio::sync::Mutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = DynamoDbSnapshot {
+        schema_version: DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+        state: None,
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write dynamodb snapshot"),
+        Err(err) => tracing::error!(%err, "dynamodb snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -5004,3 +5004,24 @@ fn execute_statement_partiql_error_emits_resource_not_found() {
         .unwrap();
     assert_error_code(err, "ResourceNotFoundException");
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = make_service();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating DynamoDB
+/// state directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = make_service().with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-e2e/tests/cfn_provisioner_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cfn_provisioner_persistence.rs
@@ -1,0 +1,253 @@
+//! Regression test for the CloudFormation provisioner persistence bug: with
+//! `--storage-mode persistent`, resources created by the CFN provisioner were
+//! never written through to disk and silently vanished on restart, while the
+//! stack itself stayed CREATE_COMPLETE. The same resources created via their
+//! direct service APIs persisted correctly.
+//!
+//! Here we create a Lambda function, a Secret, an SQS queue and an S3 bucket
+//! BOTH via CloudFormation AND via the direct service APIs, restart the server
+//! against the same data dir, and assert all eight survive. The CFN-created
+//! lambda + secret are the deterministic regression guards (their services are
+//! not re-mutated by normal use); the API-created set is the control. A second
+//! test asserts a CFN-deleted resource stays gone after a restart.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const CFN_TEMPLATE: &str = r#"{"Resources":{
+  "B":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-bucket"}},
+  "Sec":{"Type":"AWS::SecretsManager::Secret","Properties":{"Name":"cfn-secret","SecretString":"s"}},
+  "Q":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"cfn-queue"}},
+  "F":{"Type":"AWS::Lambda::Function","Properties":{
+    "FunctionName":"cfn-fn","Runtime":"provided.al2","Handler":"index.handler",
+    "Role":"arn:aws:iam::123456789012:role/r",
+    "Code":{"ZipFile":"def handler(event, context):\n    return {}\n"}}}}}"#;
+
+fn minimal_zip() -> Vec<u8> {
+    use std::io::Write;
+    let mut buf = Vec::new();
+    {
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+        zip.start_file("index.sh", opts).unwrap();
+        zip.write_all(b"#!/bin/sh\necho hi\n").unwrap();
+        zip.finish().unwrap();
+    }
+    buf
+}
+
+async fn lambda_names(server: &TestServer) -> Vec<String> {
+    server
+        .lambda_client()
+        .await
+        .list_functions()
+        .send()
+        .await
+        .unwrap()
+        .functions()
+        .iter()
+        .filter_map(|f| f.function_name().map(String::from))
+        .collect()
+}
+
+async fn secret_names(server: &TestServer) -> Vec<String> {
+    server
+        .secretsmanager_client()
+        .await
+        .list_secrets()
+        .send()
+        .await
+        .unwrap()
+        .secret_list()
+        .iter()
+        .filter_map(|s| s.name().map(String::from))
+        .collect()
+}
+
+async fn queue_urls(server: &TestServer) -> Vec<String> {
+    server
+        .sqs_client()
+        .await
+        .list_queues()
+        .send()
+        .await
+        .unwrap()
+        .queue_urls()
+        .to_vec()
+}
+
+async fn bucket_names(server: &TestServer) -> Vec<String> {
+    server
+        .s3_client()
+        .await
+        .list_buckets()
+        .send()
+        .await
+        .unwrap()
+        .buckets()
+        .iter()
+        .filter_map(|b| b.name().map(String::from))
+        .collect()
+}
+
+#[tokio::test]
+async fn cfn_provisioned_resources_survive_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+
+    // --- create resources via CloudFormation ---
+    let cf = server.cloudformation_client().await;
+    cf.create_stack()
+        .stack_name("probe")
+        .template_body(CFN_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+    let described = cf
+        .describe_stacks()
+        .stack_name("probe")
+        .send()
+        .await
+        .expect("describe_stacks");
+    assert_eq!(
+        described
+            .stacks()
+            .first()
+            .unwrap()
+            .stack_status()
+            .unwrap()
+            .as_str(),
+        "CREATE_COMPLETE"
+    );
+
+    // --- create equivalents via the direct service APIs (control set) ---
+    server
+        .s3_client()
+        .await
+        .create_bucket()
+        .bucket("api-bucket")
+        .send()
+        .await
+        .expect("create api-bucket");
+    server
+        .secretsmanager_client()
+        .await
+        .create_secret()
+        .name("api-secret")
+        .secret_string("s")
+        .send()
+        .await
+        .expect("create api-secret");
+    server
+        .sqs_client()
+        .await
+        .create_queue()
+        .queue_name("api-queue")
+        .send()
+        .await
+        .expect("create api-queue");
+    server
+        .lambda_client()
+        .await
+        .create_function()
+        .function_name("api-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Provided)
+        .role("arn:aws:iam::123456789012:role/r")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(aws_sdk_lambda::primitives::Blob::new(minimal_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create api-fn");
+
+    // --- restart against the same data dir ---
+    server.restart().await;
+
+    // --- all eight resources must survive ---
+    let functions = lambda_names(&server).await;
+    assert!(
+        functions.contains(&"cfn-fn".to_string()),
+        "cfn-fn lost: {functions:?}"
+    );
+    assert!(
+        functions.contains(&"api-fn".to_string()),
+        "api-fn lost: {functions:?}"
+    );
+
+    let secrets = secret_names(&server).await;
+    assert!(
+        secrets.contains(&"cfn-secret".to_string()),
+        "cfn-secret lost: {secrets:?}"
+    );
+    assert!(
+        secrets.contains(&"api-secret".to_string()),
+        "api-secret lost: {secrets:?}"
+    );
+
+    let queues = queue_urls(&server).await;
+    assert!(
+        queues.iter().any(|u| u.ends_with("cfn-queue")),
+        "cfn-queue lost: {queues:?}"
+    );
+    assert!(
+        queues.iter().any(|u| u.ends_with("api-queue")),
+        "api-queue lost: {queues:?}"
+    );
+
+    let buckets = bucket_names(&server).await;
+    assert!(
+        buckets.contains(&"cfn-bucket".to_string()),
+        "cfn-bucket lost: {buckets:?}"
+    );
+    assert!(
+        buckets.contains(&"api-bucket".to_string()),
+        "api-bucket lost: {buckets:?}"
+    );
+}
+
+#[tokio::test]
+async fn cfn_deleted_resources_stay_gone_after_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+
+    let cf = server.cloudformation_client().await;
+    cf.create_stack()
+        .stack_name("probe")
+        .template_body(CFN_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    // Sanity: the CFN lambda + bucket exist before delete.
+    assert!(lambda_names(&server).await.contains(&"cfn-fn".to_string()));
+    assert!(bucket_names(&server)
+        .await
+        .contains(&"cfn-bucket".to_string()));
+
+    // Delete the stack, then restart against the same data dir.
+    server
+        .cloudformation_client()
+        .await
+        .delete_stack()
+        .stack_name("probe")
+        .send()
+        .await
+        .expect("delete_stack");
+    server.restart().await;
+
+    // The CFN-deleted resources must NOT reappear after restart.
+    let functions = lambda_names(&server).await;
+    assert!(
+        !functions.contains(&"cfn-fn".to_string()),
+        "cfn-fn reappeared: {functions:?}"
+    );
+    let buckets = bucket_names(&server).await;
+    assert!(
+        !buckets.contains(&"cfn-bucket".to_string()),
+        "cfn-bucket reappeared: {buckets:?}"
+    );
+}

--- a/crates/fakecloud-ecr/src/service/mod.rs
+++ b/crates/fakecloud-ecr/src/service/mod.rs
@@ -145,7 +145,24 @@ impl EcrService {
             self.snapshot_store.clone(),
             self.snapshot_lock.clone(),
         )
-        .await
+        .await;
+    }
+
+    /// Build a hook that persists the current state when invoked, or `None` in
+    /// memory mode. The CloudFormation provisioner mutates `state` directly and
+    /// uses this to write a CFN-provisioned resource through to disk.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                Self::save_snapshot_with(state, Some(store), lock).await;
+            })
+        }))
     }
 
     /// Snapshot writer reachable from background tasks (e.g. the async

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -1832,3 +1832,42 @@ mod p5_polish_tests {
         assert!(detail["lastInUseAt"].is_i64());
     }
 }
+
+#[cfg(test)]
+mod snapshot_hook_tests {
+    use super::super::EcrService;
+    use crate::state::SharedEcrState;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn make_state() -> SharedEcrState {
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "111111111111",
+                "us-east-1",
+                "http://fakecloud:4566",
+            ),
+        ))
+    }
+
+    /// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+    #[test]
+    fn snapshot_hook_is_none_without_store() {
+        let svc = EcrService::new(make_state());
+        assert!(svc.snapshot_hook().is_none());
+    }
+
+    /// With a store, the hook is present and invoking it runs the whole-state
+    /// persist path the CloudFormation provisioner uses after mutating ECR
+    /// state directly.
+    #[tokio::test]
+    async fn snapshot_hook_fires_with_store() {
+        let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+            Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+        let svc = EcrService::new(make_state()).with_snapshot_store(store);
+        let hook = svc
+            .snapshot_hook()
+            .expect("hook present when a store is set");
+        hook().await;
+    }
+}

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -152,25 +152,29 @@ impl EcsService {
     }
 
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = EcsSnapshot {
-            schema_version: ECS_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_ecs_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write ecs snapshot"),
-            Err(err) => tracing::error!(%err, "ecs snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current state when invoked, or `None` in
+    /// memory mode. The CloudFormation provisioner mutates `state` directly and
+    /// uses this to write a CFN-provisioned resource through to disk.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_ecs_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 
     /// Reconcile persisted task state with reality after a fakecloud
@@ -359,6 +363,32 @@ impl EcsService {
         }
 
         self.save_snapshot().await;
+    }
+}
+
+pub async fn save_ecs_snapshot(
+    state: &SharedEcsState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = EcsSnapshot {
+        schema_version: ECS_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write ecs snapshot"),
+        Err(err) => tracing::error!(%err, "ecs snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-ecs/src/service_tests.rs
+++ b/crates/fakecloud-ecs/src/service_tests.rs
@@ -395,4 +395,28 @@ mod scheduler_reconcile {
             "no extra tasks once desiredCount is met (no over-provisioning)"
         );
     }
+
+    fn empty_state() -> SharedEcsState {
+        let accounts: MultiAccountState<EcsState> =
+            MultiAccountState::new(ACCOUNT, "us-east-1", "http://localhost:4566");
+        Arc::new(RwLock::new(accounts))
+    }
+
+    /// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+    #[test]
+    fn snapshot_hook_is_none_without_store() {
+        let svc = EcsService::new(empty_state());
+        assert!(svc.snapshot_hook().is_none());
+    }
+
+    #[tokio::test]
+    async fn snapshot_hook_fires_with_store() {
+        let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+            Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+        let svc = EcsService::new(empty_state()).with_snapshot_store(store);
+        let hook = svc
+            .snapshot_hook()
+            .expect("hook present when a store is set");
+        hook().await;
+    }
 }

--- a/crates/fakecloud-elasticache/src/service/mod.rs
+++ b/crates/fakecloud-elasticache/src/service/mod.rs
@@ -204,6 +204,23 @@ impl ElastiCacheService {
         .await;
     }
 
+    /// Build a hook that persists the current state when invoked, or `None` in
+    /// memory mode. The CloudFormation provisioner mutates `state` directly and
+    /// uses this to write a CFN-provisioned resource through to disk.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_snapshot_static(state, Some(store), lock).await;
+            })
+        }))
+    }
+
     /// Recreate the backing Docker/Podman containers for persisted cache
     /// clusters, replication groups, and serverless caches after a
     /// fakecloud restart. Same bug class as RDS #1338 — without this,

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -4786,3 +4786,30 @@ async fn create_replication_group_with_existing_snapshot_creates_metadata_only()
     let group = state.replication_groups.get("rg-restore").unwrap();
     assert!(group.container_id.is_empty());
 }
+
+fn make_snapshot_state() -> crate::state::SharedElastiCacheState {
+    std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ))
+}
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = ElastiCacheService::new(make_snapshot_state());
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating ElastiCache
+/// state directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: std::sync::Arc<dyn fakecloud_persistence::SnapshotStore> =
+        std::sync::Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = ElastiCacheService::new(make_snapshot_state()).with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -72,26 +72,62 @@ impl EventBridgeService {
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = EventBridgeSnapshot {
-            schema_version: EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
-            state: None,
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_eventbridge_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write eventbridge snapshot"),
-            Err(err) => tracing::error!(%err, "eventbridge snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current EventBridge state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_eventbridge_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current EventBridge state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `EventBridgeService::save_snapshot` and the
+/// CloudFormation provisioner's post-provision persist hook so both route
+/// through the same serialize-and-write path.
+pub async fn save_eventbridge_snapshot(
+    state: &SharedEventBridgeState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = EventBridgeSnapshot {
+        schema_version: EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+        state: None,
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write eventbridge snapshot"),
+        Err(err) => tracing::error!(%err, "eventbridge snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -3359,3 +3359,25 @@ fn put_events_cross_account_denied_when_bus_has_no_policy() {
     // current behavior in this assertion so a future tightening shows up.
     assert_eq!(body["FailedEntryCount"].as_i64().unwrap(), 0);
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = make_service();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating EventBridge
+/// state directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = make_service().with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    // Must not panic; exercises the closure and the snapshot save path.
+    hook().await;
+}

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -60,6 +60,24 @@ impl IamService {
     pub fn snapshot_store(&self) -> Option<Arc<dyn SnapshotStore>> {
         self.snapshot_store.clone()
     }
+
+    /// Build a hook that persists the current IAM state when invoked, or `None`
+    /// in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_iam_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
 }
 
 #[async_trait]

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -4476,3 +4476,21 @@ fn create_virtual_mfa_device_bad_path_emits_invalid_input() {
         .unwrap();
     assert_error_code(err, "InvalidInput");
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = make_service();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = make_service().with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -85,26 +85,62 @@ impl KinesisService {
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = KinesisSnapshot {
-            schema_version: KINESIS_SNAPSHOT_SCHEMA_VERSION,
-            state: None,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_kinesis_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write kinesis snapshot"),
-            Err(err) => tracing::error!(%err, "kinesis snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current Kinesis state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_kinesis_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current Kinesis state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `KinesisService::save_snapshot` and the
+/// CloudFormation provisioner's post-provision persist hook so both route
+/// through the same serialize-and-write path.
+pub async fn save_kinesis_snapshot(
+    state: &SharedKinesisState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = KinesisSnapshot {
+        schema_version: KINESIS_SNAPSHOT_SCHEMA_VERSION,
+        state: None,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write kinesis snapshot"),
+        Err(err) => tracing::error!(%err, "kinesis snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -1800,3 +1800,26 @@ fn get_records_skips_records_past_retention() {
         .unwrap();
     assert_eq!(data, b"fresh");
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let (svc, _state) = make_service();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating Kinesis
+/// state directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let (svc, _state) = make_service();
+    let svc = svc.with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    // Must not panic; exercises the closure and the snapshot save path.
+    hook().await;
+}

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -155,26 +155,62 @@ impl KmsService {
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = KmsSnapshot {
-            schema_version: KMS_SNAPSHOT_SCHEMA_VERSION,
-            state: None,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_kms_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write kms snapshot"),
-            Err(err) => tracing::error!(%err, "kms snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current KMS state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_kms_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current KMS state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `KmsService::save_snapshot` and the CloudFormation
+/// provisioner's post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_kms_snapshot(
+    state: &SharedKmsState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = KmsSnapshot {
+        schema_version: KMS_SNAPSHOT_SCHEMA_VERSION,
+        state: None,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write kms snapshot"),
+        Err(err) => tracing::error!(%err, "kms snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -2938,3 +2938,25 @@ fn decrypt_without_key_id_still_succeeds() {
     let dec_body: Value = serde_json::from_slice(dec.body.expect_bytes()).unwrap();
     assert_eq!(dec_body["Plaintext"].as_str().unwrap(), plaintext);
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = make_service();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating KMS state
+/// directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = make_service().with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    // Must not panic; exercises the closure and the snapshot save path.
+    hook().await;
+}

--- a/crates/fakecloud-lambda/src/service/mod.rs
+++ b/crates/fakecloud-lambda/src/service/mod.rs
@@ -946,26 +946,62 @@ impl LambdaService {
     }
 
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = LambdaSnapshot {
-            schema_version: LAMBDA_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
-            state: None,
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_lambda_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write lambda snapshot"),
-            Err(err) => tracing::error!(%err, "lambda snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current Lambda state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// function through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_lambda_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current Lambda state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `LambdaService::save_snapshot` and the
+/// CloudFormation provisioner's post-provision persist hook so both route
+/// through the same serialize-and-write path.
+pub async fn save_lambda_snapshot(
+    state: &SharedLambdaState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = LambdaSnapshot {
+        schema_version: LAMBDA_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+        state: None,
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write lambda snapshot"),
+        Err(err) => tracing::error!(%err, "lambda snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -3205,3 +3205,25 @@ fn resolve_action_get_function_with_name() {
     assert_eq!(action, "GetFunction");
     assert_eq!(resource.as_deref(), Some("my-fn"));
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = LambdaService::new(make_state());
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating lambda
+/// state directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = LambdaService::new(make_state()).with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    // Must not panic; exercises the closure and `save_lambda_snapshot`.
+    hook().await;
+}

--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -109,26 +109,62 @@ impl LogsService {
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = LogsSnapshot {
-            schema_version: LOGS_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
-            state: None,
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_logs_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write logs snapshot"),
-            Err(err) => tracing::error!(%err, "logs snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current Logs state when invoked, or `None`
+    /// in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_logs_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current Logs state as a snapshot. Offloads the serde + blocking
+/// file write to the Tokio blocking pool. Noop when `store` is `None` (memory
+/// mode). Shared by `LogsService::save_snapshot` and the CloudFormation
+/// provisioner's post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_logs_snapshot(
+    state: &SharedLogsState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = LogsSnapshot {
+        schema_version: LOGS_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+        state: None,
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write logs snapshot"),
+        Err(err) => tracing::error!(%err, "logs snapshot task panicked"),
     }
 }
 
@@ -830,5 +866,27 @@ pub(crate) mod test_helpers {
             ),
             "unquoted non-numeric non-boolean value must not match (fail closed)"
         );
+    }
+
+    /// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+    #[test]
+    fn snapshot_hook_is_none_without_store() {
+        let svc = make_service();
+        assert!(svc.snapshot_hook().is_none());
+    }
+
+    /// With a store, the hook is present and invoking it runs the whole-state
+    /// persist path the CloudFormation provisioner uses after mutating logs
+    /// state directly.
+    #[tokio::test]
+    async fn snapshot_hook_fires_with_store() {
+        let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+            Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+        let svc = make_service().with_snapshot_store(store);
+        let hook = svc
+            .snapshot_hook()
+            .expect("hook present when a store is set");
+        // Must not panic; exercises the closure and the snapshot save path.
+        hook().await;
     }
 }

--- a/crates/fakecloud-persistence/src/lib.rs
+++ b/crates/fakecloud-persistence/src/lib.rs
@@ -13,4 +13,4 @@ pub use s3::{
     MpuInit, ObjectMeta, S3State as S3StateSnapshot, S3Store, StoreError, StoreResult,
     TagsSnapshot, UploadPartMeta,
 };
-pub use snapshot::{DiskSnapshotStore, MemorySnapshotStore, SnapshotStore};
+pub use snapshot::{DiskSnapshotStore, MemorySnapshotStore, SnapshotHook, SnapshotStore};

--- a/crates/fakecloud-persistence/src/snapshot.rs
+++ b/crates/fakecloud-persistence/src/snapshot.rs
@@ -1,5 +1,21 @@
+use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// A type-erased, owned closure that persists one service's whole state as a
+/// snapshot when invoked. Built by a service from its own `state` / store /
+/// serializing lock (see each service's `snapshot_hook()`), so the
+/// serialization stays in the owning crate.
+///
+/// The CloudFormation resource provisioner mutates services' shared state
+/// directly and cannot reach their private `save_snapshot()` paths. After a
+/// stack op it invokes the hook for each touched service to write that state
+/// through to disk -- the same persistence a direct API mutation would
+/// trigger. A `None` hook (memory mode / no store) is simply never collected,
+/// so invoking a present hook is always a real persist.
+pub type SnapshotHook = Arc<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
 
 /// Generic opaque-blob snapshot store used by services that persist their
 /// whole state as a single serialized document (DynamoDB tables, SQS queues,

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -750,6 +750,23 @@ impl RdsService {
             )
         })
     }
+
+    /// Build a hook that persists the current state when invoked, or `None` in
+    /// memory mode. The CloudFormation provisioner mutates `state` directly and
+    /// uses this to write a CFN-provisioned resource through to disk.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_snapshot_static(state, Some(store), lock).await;
+            })
+        }))
+    }
 }
 
 #[async_trait]

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -2812,3 +2812,23 @@ async fn download_db_log_file_portion_returns_empty_when_runtime_absent() {
     assert!(body.contains("<AdditionalDataPending>false</AdditionalDataPending>"));
     assert!(body.contains("<Marker>0</Marker>"));
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = make_service();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating RDS state
+/// directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn SnapshotStore> = Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = make_service().with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-scheduler/src/service.rs
+++ b/crates/fakecloud-scheduler/src/service.rs
@@ -47,25 +47,30 @@ impl SchedulerService {
     }
 
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = SchedulerSnapshot {
-            schema_version: SCHEDULER_SNAPSHOT_SCHEMA_VERSION,
-            accounts: self.state.read().clone(),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_scheduler_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write scheduler snapshot"),
-            Err(err) => tracing::error!(%err, "scheduler snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current Scheduler state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_scheduler_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 
     fn resolve_action(req: &AwsRequest) -> Option<(&'static str, PathArgs)> {
@@ -606,6 +611,37 @@ impl SchedulerService {
             StatusCode::OK,
             json!({ "Tags": tags }).to_string(),
         ))
+    }
+}
+
+/// Persist the current Scheduler state as a snapshot. Cloned + serialized under
+/// the snapshot lock. Noop when `store` is `None` (memory mode). Shared by
+/// `SchedulerService::save_snapshot` and the CloudFormation provisioner's
+/// post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_scheduler_snapshot(
+    state: &SharedSchedulerState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = SchedulerSnapshot {
+        schema_version: SCHEDULER_SNAPSHOT_SCHEMA_VERSION,
+        accounts: state.read().clone(),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write scheduler snapshot"),
+        Err(err) => tracing::error!(%err, "scheduler snapshot task panicked"),
     }
 }
 
@@ -1247,6 +1283,24 @@ mod tests {
             }
         })
         .to_string()
+    }
+
+    /// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+    #[test]
+    fn snapshot_hook_is_none_without_store() {
+        let svc = SchedulerService::new(make_state());
+        assert!(svc.snapshot_hook().is_none());
+    }
+
+    #[tokio::test]
+    async fn snapshot_hook_fires_with_store() {
+        let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+            Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+        let svc = SchedulerService::new(make_state()).with_snapshot_store(store);
+        let hook = svc
+            .snapshot_hook()
+            .expect("hook present when a store is set");
+        hook().await;
     }
 
     #[tokio::test]

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -142,26 +142,31 @@ impl SecretsManagerService {
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = SecretsManagerSnapshot {
-            schema_version: SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
-            state: None,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_secretsmanager_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write secretsmanager snapshot"),
-            Err(err) => tracing::error!(%err, "secretsmanager snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current Secrets Manager state when
+    /// invoked, or `None` in memory mode (no snapshot store). The
+    /// CloudFormation provisioner mutates `state` directly and uses this to
+    /// write a CFN-provisioned secret through to disk, the same way a direct
+    /// mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_secretsmanager_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 
     fn create_secret(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1897,6 +1902,39 @@ impl SecretsManagerService {
             "ResourceNotFoundException",
             "Secrets Manager can't find the specified secret.",
         ))
+    }
+}
+
+/// Persist the current Secrets Manager state as a snapshot. Offloads the
+/// serialization and blocking file write to the Tokio blocking pool. Noop when
+/// `store` is `None` (memory mode). Shared by
+/// `SecretsManagerService::save_snapshot` and
+/// the CloudFormation provisioner's post-provision persist hook so both route
+/// through the same serialize-and-write path.
+pub async fn save_secretsmanager_snapshot(
+    state: &SharedSecretsManagerState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = SecretsManagerSnapshot {
+        schema_version: SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
+        state: None,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write secretsmanager snapshot"),
+        Err(err) => tracing::error!(%err, "secretsmanager snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -2274,3 +2274,24 @@ fn secret_owner_account_extracts_from_arn() {
         "999999999999"
     );
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = SecretsManagerService::new(make_state());
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating
+/// Secrets Manager state directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = SecretsManagerService::new(make_state()).with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -916,7 +916,16 @@ async fn main() {
     if let Some(store) = cloudformation_snapshot_store {
         cloudformation_service = cloudformation_service.with_snapshot_store(store);
     }
-    registry.register(Arc::new(cloudformation_service));
+    // The CloudFormation provisioner persists every snapshot-backed service a
+    // stack op touches by invoking that service's snapshot hook. We collect the
+    // hooks as each service is built below, then register CloudFormation last
+    // (after the S3 store and all hooks exist) via `with_s3_store` /
+    // `with_snapshot_hooks`. Keyed by the service names in
+    // `service_key_for_type`.
+    let mut cfn_snapshot_hooks: std::collections::BTreeMap<
+        &'static str,
+        fakecloud_persistence::SnapshotHook,
+    > = std::collections::BTreeMap::new();
     let sqs_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
             let data_path = persistence_config
@@ -977,6 +986,9 @@ async fn main() {
         .with_region(cli.region.clone());
     if let Some(store) = sqs_snapshot_store.clone() {
         sqs_service = sqs_service.with_snapshot_store(store);
+    }
+    if let Some(h) = sqs_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("sqs", h);
     }
     registry.register(Arc::new(sqs_service));
     // Flush cross-service SQS deliveries (SNS/EventBridge/S3/Scheduler fan-out)
@@ -1052,6 +1064,9 @@ async fn main() {
     if let Some(store) = sns_snapshot_store {
         sns_service = sns_service.with_snapshot_store(store);
     }
+    if let Some(h) = sns_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("sns", h);
+    }
     registry.register(Arc::new(sns_service));
     let eb_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -1119,6 +1134,9 @@ async fn main() {
     }
     if let Some(store) = eb_snapshot_store {
         eb_service = eb_service.with_snapshot_store(store);
+    }
+    if let Some(h) = eb_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("eventbridge", h);
     }
     registry.register(Arc::new(eb_service));
     // Spawn the EventBridge scheduler as a background task
@@ -1209,6 +1227,9 @@ async fn main() {
     if let Some(store) = iam_snapshot_store {
         sts_service = sts_service.with_snapshot_store(store);
     }
+    if let Some(h) = iam_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("iam", h);
+    }
     registry.register(Arc::new(iam_service));
     registry.register(Arc::new(sts_service));
     let ssm_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
@@ -1275,6 +1296,9 @@ async fn main() {
         .with_kms_hook(kms_hook_for_services.clone());
     if let Some(store) = ssm_snapshot_store {
         ssm_service = ssm_service.with_snapshot_store(store);
+    }
+    if let Some(h) = ssm_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("ssm", h);
     }
     registry.register(Arc::new(ssm_service));
     // DynamoDB is registered later, after s3_store is constructed, so the
@@ -1372,6 +1396,9 @@ async fn main() {
     if let Some(store) = lambda_snapshot_store {
         lambda_service = lambda_service.with_snapshot_store(store);
     }
+    if let Some(h) = lambda_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("lambda", h);
+    }
     registry.register(Arc::new(lambda_service));
     // SecretsManager delivery bus (rotation Lambda invocation)
     let delivery_for_secretsmanager = {
@@ -1446,6 +1473,9 @@ async fn main() {
     if let Some(store) = secretsmanager_snapshot_store {
         secretsmanager_service = secretsmanager_service.with_snapshot_store(store);
     }
+    if let Some(h) = secretsmanager_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("secretsmanager", h);
+    }
     registry.register(Arc::new(secretsmanager_service));
     let logs_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -1510,6 +1540,9 @@ async fn main() {
     if let Some(store) = logs_snapshot_store {
         logs_service = logs_service.with_snapshot_store(store);
     }
+    if let Some(h) = logs_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("logs", h);
+    }
     registry.register(Arc::new(logs_service));
     let kms_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -1569,6 +1602,9 @@ async fn main() {
     let mut kms_service = KmsService::new(kms_state.clone());
     if let Some(store) = kms_snapshot_store.clone() {
         kms_service = kms_service.with_snapshot_store(store);
+    }
+    if let Some(h) = kms_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("kms", h);
     }
     registry.register(Arc::new(kms_service));
     // Wire the snapshot store into the hook adapter too, so hook-driven
@@ -1730,6 +1766,9 @@ async fn main() {
     if let Some(store) = dynamodb_snapshot_store {
         dynamodb_service = dynamodb_service.with_snapshot_store(store);
     }
+    if let Some(h) = dynamodb_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("dynamodb", h);
+    }
     registry.register(Arc::new(dynamodb_service));
     // Companion data plane: DynamoDB Streams (`streams.dynamodb.<region>.amazonaws.com`)
     // shares the same per-table state populated by mutations on the main
@@ -1818,6 +1857,9 @@ async fn main() {
     if let Some(store) = ses_snapshot_store {
         ses_service = ses_service.with_snapshot_store(store);
     }
+    if let Some(h) = ses_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("ses", h);
+    }
     registry.register(Arc::new(ses_service));
     ses_smtp::maybe_spawn(iam_state.clone(), ses_state.clone());
     let delivery_for_cognito = {
@@ -1900,6 +1942,9 @@ async fn main() {
     if let Some(store) = cognito_snapshot_store {
         cognito_service = cognito_service.with_snapshot_store(store);
     }
+    if let Some(h) = cognito_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("cognito", h);
+    }
     registry.register(Arc::new(cognito_service));
     // Cognito Federated Identity Pools (`cognito-identity` service).
     // Shares state with the user-pool service above; lives in the same
@@ -1968,6 +2013,9 @@ async fn main() {
     let mut kinesis_service = KinesisService::new(kinesis_state.clone());
     if let Some(store) = kinesis_snapshot_store.clone() {
         kinesis_service = kinesis_service.with_snapshot_store(store);
+    }
+    if let Some(h) = kinesis_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("kinesis", h);
     }
     registry.register(Arc::new(kinesis_service));
     // Flush cross-service Kinesis deliveries (DynamoDB streaming / Logs
@@ -2094,6 +2142,9 @@ async fn main() {
     // spawns one task per instance and returns immediately, so a slow
     // postgres bring-up doesn't block server startup. (Issue #1338.)
     rds_service.recover_persisted_containers().await;
+    if let Some(h) = rds_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("rds", h);
+    }
     registry.register(Arc::new(rds_service));
     let elasticache_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -2165,6 +2216,9 @@ async fn main() {
     // their Docker containers don't, so respawn them on startup. See
     // RDS #1338 for the original bug class.
     elasticache_service.recover_persisted_containers().await;
+    if let Some(h) = elasticache_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("elasticache", h);
+    }
     registry.register(Arc::new(elasticache_service));
     let ecr_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -2215,6 +2269,9 @@ async fn main() {
     let mut ecr_service = EcrService::new(ecr_state.clone()).with_kms(kms_state.clone());
     if let Some(store) = ecr_snapshot_store.clone() {
         ecr_service = ecr_service.with_snapshot_store(store);
+    }
+    if let Some(h) = ecr_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("ecr", h);
     }
     registry.register(Arc::new(ecr_service));
     // Periodic re-evaluation of ECR lifecycle policies. The ticker
@@ -2302,6 +2359,9 @@ async fn main() {
         ecs_service_for_desired_count,
         std::time::Duration::from_secs(3),
     ));
+    if let Some(h) = ecs_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("ecs", h);
+    }
     registry.register(ecs_service);
     let elbv2_introspection_state = elbv2_state.clone();
     // Wire an S3-only delivery bus so the ALB dataplane can flush
@@ -2387,6 +2447,9 @@ async fn main() {
         fakecloud_cloudwatch::CloudWatchService::new(cloudwatch_state.clone());
     if let Some(store) = cloudwatch_snapshot_store {
         cloudwatch_service = cloudwatch_service.with_snapshot_store(store);
+    }
+    if let Some(h) = cloudwatch_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("cloudwatch", h);
     }
     registry.register(Arc::new(cloudwatch_service));
     let app_autoscaling_service =
@@ -2503,6 +2566,9 @@ async fn main() {
     if let Some(store) = sfn_snapshot_store {
         sfn_service = sfn_service.with_snapshot_store(store);
     }
+    if let Some(h) = sfn_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("stepfunctions", h);
+    }
     registry.register(Arc::new(sfn_service));
     let apigw_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -2579,6 +2645,9 @@ async fn main() {
         apigw_service = apigw_service.with_snapshot_store(store);
     }
     let apigatewayv2_service = Arc::new(apigw_service);
+    if let Some(h) = apigatewayv2_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("apigatewayv2", h);
+    }
     let v2_arc: Arc<dyn fakecloud_core::service::AwsService> = apigatewayv2_service.clone();
     // v1 (REST APIs) shares the SigV4 service identifier `apigateway`
     // with v2; the registry is keyed by that identifier so we wrap
@@ -2650,6 +2719,9 @@ async fn main() {
         apigw_v1_service = apigw_v1_service.with_snapshot_store(store);
     }
     let v1_arc = Arc::new(apigw_v1_service);
+    if let Some(h) = v1_arc.snapshot_hook() {
+        cfn_snapshot_hooks.insert("apigateway", h);
+    }
     registry.register(Arc::new(ApiGatewayFacade::new(v1_arc, v2_arc)));
     let bedrock_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -2711,6 +2783,9 @@ async fn main() {
     if let Some(store) = bedrock_snapshot_store {
         bedrock_service = bedrock_service.with_snapshot_store(store);
     }
+    if let Some(h) = bedrock_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("bedrock", h);
+    }
     registry.register(Arc::new(bedrock_service));
     registry.register(Arc::new(BedrockAgentService::new(
         bedrock_agent_state.clone(),
@@ -2745,7 +2820,14 @@ async fn main() {
     if let Some(store) = scheduler_snapshot_store {
         scheduler_service = scheduler_service.with_snapshot_store(store);
     }
+    if let Some(h) = scheduler_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("scheduler", h);
+    }
     registry.register(Arc::new(scheduler_service));
+    let cloudformation_service = cloudformation_service
+        .with_s3_store(s3_store.clone())
+        .with_snapshot_hooks(cfn_snapshot_hooks);
+    registry.register(Arc::new(cloudformation_service));
     // Spawn the Scheduler firing loop as a background task. Mirrors
     // EventBridge's delivery bus so every target type Scheduler
     // routes (`:sqs:`, `:sns:`, `:lambda:`, `:states:`, `:events:`)

--- a/crates/fakecloud-ses/src/service/mod.rs
+++ b/crates/fakecloud-ses/src/service/mod.rs
@@ -54,26 +54,30 @@ impl SesV2Service {
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = SesSnapshot {
-            schema_version: SES_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
-            state: None,
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_ses_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write ses snapshot"),
-            Err(err) => tracing::error!(%err, "ses snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current SES state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_ses_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 
     /// Determine the action from the HTTP method and path segments.
@@ -291,6 +295,38 @@ impl SesV2Service {
             "message": message,
         });
         AwsResponse::json(status, body.to_string())
+    }
+}
+
+/// Persist the current SES state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `SesV2Service::save_snapshot` and the CloudFormation
+/// provisioner's post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_ses_snapshot(
+    state: &SharedSesState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = SesSnapshot {
+        schema_version: SES_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+        state: None,
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write ses snapshot"),
+        Err(err) => tracing::error!(%err, "ses snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -4473,3 +4473,24 @@ async fn test_event_destination_kinesis_firehose_cloudwatch() {
         "EventType"
     );
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = SesV2Service::new(make_state());
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating SES state
+/// directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = SesV2Service::new(make_state()).with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -112,26 +112,63 @@ impl SnsService {
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = SnsSnapshot {
-            schema_version: SNS_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
-            state: None,
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_sns_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write sns snapshot"),
-            Err(err) => tracing::error!(%err, "sns snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current SNS state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation
+    /// provisioner mutates `state` directly and uses this to write a
+    /// CFN-provisioned topic through to disk, the same way a direct mutating
+    /// API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_sns_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current SNS state as a snapshot. Offloads the serde + blocking
+/// file write to the Tokio blocking pool. Noop when `store` is `None` (memory
+/// mode). Shared by `SnsService::save_snapshot` and the CloudFormation
+/// provisioner's post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_sns_snapshot(
+    state: &SharedSnsState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = SnsSnapshot {
+        schema_version: SNS_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+        state: None,
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write sns snapshot"),
+        Err(err) => tracing::error!(%err, "sns snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-sns/src/service_tests.rs
+++ b/crates/fakecloud-sns/src/service_tests.rs
@@ -3146,3 +3146,26 @@ fn get_data_protection_policy_unknown_topic_errors() {
     };
     assert_eq!(err.code(), "NotFound");
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let (svc, _state) = make_sns();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating SNS
+/// state directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    use std::sync::Arc;
+    let (svc, _state) = make_sns();
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = svc.with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-sqs/src/service/mod.rs
+++ b/crates/fakecloud-sqs/src/service/mod.rs
@@ -117,26 +117,63 @@ impl SqsService {
     /// offloaded to the blocking pool to keep Tokio worker threads
     /// responsive under write-heavy load.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = SqsSnapshot {
-            schema_version: SQS_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
-            state: None,
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_sqs_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write sqs snapshot"),
-            Err(err) => tracing::error!(%err, "sqs snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current SQS state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation
+    /// provisioner mutates `state` directly and uses this to write a
+    /// CFN-provisioned queue through to disk, the same way a direct mutating
+    /// API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_sqs_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current SQS state as a snapshot. Offloads the serde + blocking
+/// file write to the Tokio blocking pool. Noop when `store` is `None` (memory
+/// mode). Shared by `SqsService::save_snapshot` and the CloudFormation
+/// provisioner's post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_sqs_snapshot(
+    state: &SharedSqsState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = SqsSnapshot {
+        schema_version: SQS_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+        state: None,
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write sqs snapshot"),
+        Err(err) => tracing::error!(%err, "sqs snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -2599,3 +2599,24 @@ fn message_size_includes_attributes() {
     let err = expect_err(svc.send_message(&big_req));
     assert_eq!(err.code(), "InvalidParameterValue");
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = make_service();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating SQS
+/// state directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = make_service().with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    hook().await;
+}

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -218,26 +218,62 @@ impl SsmService {
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = SsmSnapshot {
-            schema_version: SSM_SNAPSHOT_SCHEMA_VERSION,
-            state: None,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_ssm_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write ssm snapshot"),
-            Err(err) => tracing::error!(%err, "ssm snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current SSM state when invoked, or `None`
+    /// in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_ssm_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current SSM state as a snapshot. Offloads the serde + blocking
+/// file write to the Tokio blocking pool. Noop when `store` is `None` (memory
+/// mode). Shared by `SsmService::save_snapshot` and the CloudFormation
+/// provisioner's post-provision persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_ssm_snapshot(
+    state: &SharedSsmState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = SsmSnapshot {
+        schema_version: SSM_SNAPSHOT_SCHEMA_VERSION,
+        state: None,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write ssm snapshot"),
+        Err(err) => tracing::error!(%err, "ssm snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -4735,3 +4735,25 @@ fn overwrite_keeps_existing_policies_when_omitted() {
     assert_eq!(params.len(), 1);
     assert!(params[0]["Policies"].is_array());
 }
+
+/// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+#[test]
+fn snapshot_hook_is_none_without_store() {
+    let svc = make_service();
+    assert!(svc.snapshot_hook().is_none());
+}
+
+/// With a store, the hook is present and invoking it runs the whole-state
+/// persist path the CloudFormation provisioner uses after mutating SSM state
+/// directly.
+#[tokio::test]
+async fn snapshot_hook_fires_with_store() {
+    let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+        Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+    let svc = make_service().with_snapshot_store(store);
+    let hook = svc
+        .snapshot_hook()
+        .expect("hook present when a store is set");
+    // Must not panic; exercises the closure and the snapshot save path.
+    hook().await;
+}

--- a/crates/fakecloud-stepfunctions/src/service/mod.rs
+++ b/crates/fakecloud-stepfunctions/src/service/mod.rs
@@ -123,26 +123,63 @@ impl StepFunctionsService {
     }
 
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = StepFunctionsSnapshot {
-            schema_version: STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
-            state: None,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_stepfunctions_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write stepfunctions snapshot"),
-            Err(err) => tracing::error!(%err, "stepfunctions snapshot task panicked"),
-        }
+    }
+
+    /// Build a hook that persists the current Step Functions state when invoked,
+    /// or `None` in memory mode (no snapshot store). The CloudFormation
+    /// provisioner mutates `state` directly and uses this to write a
+    /// CFN-provisioned resource through to disk, the same way a direct mutating
+    /// API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_stepfunctions_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current Step Functions state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `StepFunctionsService::save_snapshot` and the
+/// CloudFormation provisioner's post-provision persist hook so both route
+/// through the same serialize-and-write path.
+pub async fn save_stepfunctions_snapshot(
+    state: &SharedStepFunctionsState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = StepFunctionsSnapshot {
+        schema_version: STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
+        state: None,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write stepfunctions snapshot"),
+        Err(err) => tracing::error!(%err, "stepfunctions snapshot task panicked"),
     }
 }
 
@@ -1646,6 +1683,27 @@ mod tests {
         let req = make_request("StartSyncExecution", &body.to_string());
         let err = expect_err(svc.start_sync_execution(&req).await);
         assert!(err.to_string().contains("InvalidExecutionInput"));
+    }
+
+    /// No snapshot store (memory mode) -> no persist hook for the CFN provisioner.
+    #[test]
+    fn snapshot_hook_is_none_without_store() {
+        let svc = StepFunctionsService::new(make_state());
+        assert!(svc.snapshot_hook().is_none());
+    }
+
+    /// With a store, the hook is present and invoking it runs the whole-state
+    /// persist path the CloudFormation provisioner uses after mutating Step
+    /// Functions state directly.
+    #[tokio::test]
+    async fn snapshot_hook_fires_with_store() {
+        let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+            Arc::new(fakecloud_persistence::MemorySnapshotStore::new());
+        let svc = StepFunctionsService::new(make_state()).with_snapshot_store(store);
+        let hook = svc
+            .snapshot_hook()
+            .expect("hook present when a store is set");
+        hook().await;
     }
 }
 


### PR DESCRIPTION
Hey @vieiralucas - another fakecloud fix from our SAM-on-Kubernetes setup. Heads up that this one
is bigger than my usual: the persistence gap turned out to be provisioner-general rather than
lambda-specific, so the fix touches every snapshot-backed service. I tried to keep that surface
mechanical and uniform (one small `snapshot_hook()` per service, reusing each service's existing
persist path), with the real logic concentrated in CloudFormation and S3. Happy to adjust anything
if you'd shape it differently.

If you could cut a new release after this merges it'd help us pick it up cleanly. No worries at
all if it's not convenient right now though - we can pin a head image or build our own in the
meantime. Thanks as always for being so welcoming to these.

Fixes #1766

## Summary

With `FAKECLOUD_STORAGE_MODE=persistent`, resources created by the **CloudFormation provisioner**
were **not written through to the persistent store**. The provisioner mutates each service's
in-memory state directly and never triggered that service's snapshot/persist path, so a
CFN/SAM-deployed resource worked normally in the running process but was **silently lost on the
next restart** - while the CFN *stack* metadata persisted, leaving a `CREATE_COMPLETE` stack
whose physical resources no longer existed. The same resources created via their **direct
service APIs** persisted correctly, so the gap was the *CFN provisioning path*, not the resource
type.

Whether a CFN-provisioned resource survived a restart was therefore accidental - it depended on
whether its owning service happened to be re-mutated (re-serializing that service's whole state
to disk) before the restart:

- **Deterministically lost:** `AWS::Lambda::Function` (plus `AWS::Lambda::Permission` /
  `AWS::Lambda::Url`) and `AWS::SecretsManager::Secret`.
- **Survived only incidentally:** `AWS::SQS::Queue` and `AWS::StepFunctions::StateMachine`.
- **S3 variant:** the provisioner inserted into the in-memory S3 map and bypassed the bespoke
  `S3Store` disk path the real `CreateBucket` uses, so CFN-created buckets were lost.

## Root cause

Persistence is write-through inside each service's `handle()` (under `if mutates && success`) via
a private `save_snapshot()` that re-serializes the whole service state; S3/IAM use bespoke stores
(`S3Store` per-object writes; IAM a whole-state snapshot fn). There is no periodic or on-shutdown
flush. The CFN `ResourceProvisioner` holds the shared service state directly and mutates it in
place (e.g. `create_lambda_function` -> `state.functions.insert(...)`, `create_s3_bucket` ->
`state.buckets.insert(...)`); these provisioner fns are synchronous and never call the async
`save_snapshot()` (and bypass `S3Store` for buckets), so the resource lands in live memory but is
never written to disk.

## Fix

After the CFN provisioner mutates service state, trigger the same persistence the API handlers
use - for **create, update, and delete** - for every snapshot-backed service the stack op
touched.

- **New `SnapshotHook` type** (`fakecloud-persistence`): a type-erased async persist closure.
- **Each snapshot-backed service** exposes `snapshot_hook()`, built from its own state + snapshot
  store + serializing lock, so the serialization stays in the owning crate (it reuses the
  service's existing `save_snapshot` path - no duplicated snapshot logic). Covers lambda, sqs,
  sns, secretsmanager, dynamodb, stepfunctions, eventbridge, ssm, logs, kms, kinesis, ses,
  cognito, rds, elasticache, ecr, ecs, cloudwatch, apigateway, apigatewayv2, bedrock, scheduler,
  and iam.
- **Server wiring** collects each service's hook into a `service-name -> hook` map and hands it
  (plus the already-built `S3Store`) to the CloudFormation service.
- **CloudFormation handler**: after a stack create/update/delete, it maps the touched resource
  types to their owning services (`service_key_for_type`, e.g. `AWS::Events::*` -> `eventbridge`)
  and invokes each touched service's hook exactly once - writing that whole state through to
  disk. The await happens after every `RwLockWriteGuard` is released so the handler future stays
  `Send`.
- **S3** is routed through the same `S3Store` path the real `CreateBucket`/`DeleteBucket` use
  (bucket create/delete, and bucket-policy create/update/delete write through as subresources),
  so a CFN-provisioned bucket lands on disk and a CFN-deleted one does not reappear. In memory
  mode the store is a `MemoryS3Store`, so these writes are no-ops.

`StepFunctions` (which previously only persisted incidentally on the next execution) is now
deterministic too; the fix is provisioner-general, not lambda-specific.

## Tests

- **Unit (`fakecloud-cloudformation`)**: provisioning via CFN fires the persist hook once per
  touched service (create/update/delete), skips services without a registered hook, writes the
  bucket (and bucket policy) through the `S3Store`, and removes them on delete; plus a
  `service_key_for_type` table test (direct services, the `Events`/`Logs` aliases, `S3` -> none,
  and malformed/non-AWS types).
- **Per-service**: each snapshot-backed crate gets a `snapshot_hook()` test (None in memory mode;
  fires and persists when a store is set).
- **E2E (`fakecloud-e2e/tests/cfn_provisioner_persistence.rs`, persistent mode + real restart)**:
  creates a Lambda function, a Secret, an SQS queue and an S3 bucket **both** via CloudFormation
  **and** via the direct service APIs, restarts the server against the same data dir, and asserts
  all eight survive (the CFN lambda + secret are the deterministic regression guards; the
  API-created set is the control). A second test asserts a CFN-deleted lambda + bucket stay gone
  after a restart.

Validated with `cargo test --workspace` (incl. `fakecloud-e2e`), `cargo clippy --workspace
--all-targets -- -D warnings`, and `cargo fmt --all --check`.

## Scope note

This persists on the **successful** create/update/delete paths. On a failed stack op the behavior
follows fakecloud's existing no-rollback model: snapshot-backed services are persisted only on
success, while S3 buckets write through eagerly (same as the real `CreateBucket` handler), so a
bucket created before a sibling resource fails can persist while the stack is `CREATE_FAILED`. The
AWS-correct answer here is rollback (deleting the partials), which is a larger change I left out of
scope. Happy to align the failure-path behavior whichever way you prefer.

Fixes the reported failure mode: a Kubernetes spot-instance reschedule of the fakecloud pod
wiped the SAM-deployed workflow Lambda (so every `lambda:invoke` Step Functions task then failed
with `Lambda.ResourceNotFoundException`) and the `sam deploy --resolve-s3` managed artifact bucket
vanished while its `aws-sam-cli-managed-default` stack stayed `CREATE_COMPLETE`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist CloudFormation-provisioned resources across restarts in persistent mode by writing through to disk after stack create/update/delete and routing S3 bucket ops via the on-disk store. This keeps CFN stacks and their physical resources in sync and matches persistence of direct service API calls.

- **Bug Fixes**
  - Added `SnapshotHook` in `fakecloud-persistence`; each snapshot-backed service exposes `snapshot_hook()` that reuses its own snapshot path.
  - Server collects hooks and passes them to CloudFormation; after a successful stack op, CFN maps touched resource types to owning services and invokes each hook once to persist.
  - S3: CFN bucket create/delete and bucket-policy create/update/delete now use `S3Store`, so buckets persist correctly and deletes don’t reappear.
  - Applies across all snapshot-backed services (e.g., Lambda, Secrets Manager, SQS, Step Functions, Logs, IAM, API Gateway v1/v2, DynamoDB, EventBridge, KMS, Kinesis, SSM, SNS, SES, ECS, ECR, RDS, ElastiCache, Bedrock, CloudWatch).

- **Dependencies**
  - Added `tempfile` as a dev-dependency in `fakecloud-cloudformation`.

<sup>Written for commit 818e96186adcdc6cbeec3ced0d28429e1e2f8849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

