### PR TITLE
chore(release): bump workspace to v0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4320,7 +4320,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -112,175 +112,175 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.19.1"
+version = "0.20.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/crates/fakecloud-rds/src/runtime/mod.rs
+++ b/crates/fakecloud-rds/src/runtime/mod.rs
@@ -1201,6 +1201,15 @@ impl RdsRuntime {
 pub(crate) fn bridge_image_tag(image: &str, major_version: &str) -> String {
     let registry = std::env::var("FAKECLOUD_POSTGRES_REGISTRY")
         .unwrap_or_else(|_| DEFAULT_POSTGRES_REGISTRY.to_string());
+    bridge_image_tag_with_registry(&registry, image, major_version)
+}
+
+/// Pure tag builder split out from [`bridge_image_tag`] so callers (and
+/// tests) can supply the registry explicitly. Keeping the env read in the
+/// thin wrapper means the formatting logic is testable without mutating the
+/// process-global `FAKECLOUD_POSTGRES_REGISTRY`, which `cargo test`'s parallel
+/// workers would otherwise race over.
+fn bridge_image_tag_with_registry(registry: &str, image: &str, major_version: &str) -> String {
     let registry = registry.trim_end_matches('/');
     format!(
         "{}/{}:{}-{}",
@@ -1215,58 +1224,56 @@ pub(crate) fn bridge_image_tag(image: &str, major_version: &str) -> String {
 mod tests {
     use super::*;
 
-    /// Single test (rather than three) so the cases run sequentially —
-    /// `bridge_image_tag` reads a process-global env var and parallel
-    /// `cargo test` workers would race over it otherwise.
+    /// Exercises the pure tag builder with explicit registries so the cases
+    /// never touch the process-global `FAKECLOUD_POSTGRES_REGISTRY`. Parallel
+    /// `cargo test` workers used to race over that env var, which surfaced as
+    /// an override silently resolving to the default registry.
     #[test]
     fn bridge_image_tag_resolves_registry_overrides() {
-        let prev = std::env::var("FAKECLOUD_POSTGRES_REGISTRY").ok();
-
-        std::env::remove_var("FAKECLOUD_POSTGRES_REGISTRY");
+        // Default registry (matches the env-less `bridge_image_tag` path).
         assert_eq!(
-            bridge_image_tag("fakecloud-postgres", "16"),
+            bridge_image_tag_with_registry(DEFAULT_POSTGRES_REGISTRY, "fakecloud-postgres", "16"),
             format!(
                 "ghcr.io/faiscadev/fakecloud-postgres:16-{}",
                 env!("CARGO_PKG_VERSION")
             )
         );
         assert_eq!(
-            bridge_image_tag("fakecloud-mysql", "8.0"),
+            bridge_image_tag_with_registry(DEFAULT_POSTGRES_REGISTRY, "fakecloud-mysql", "8.0"),
             format!(
                 "ghcr.io/faiscadev/fakecloud-mysql:8.0-{}",
                 env!("CARGO_PKG_VERSION")
             )
         );
         assert_eq!(
-            bridge_image_tag("fakecloud-mariadb", "10.11"),
+            bridge_image_tag_with_registry(DEFAULT_POSTGRES_REGISTRY, "fakecloud-mariadb", "10.11"),
             format!(
                 "ghcr.io/faiscadev/fakecloud-mariadb:10.11-{}",
                 env!("CARGO_PKG_VERSION")
             )
         );
 
-        std::env::set_var("FAKECLOUD_POSTGRES_REGISTRY", "registry.example.com/team");
+        // Custom registry override.
         assert_eq!(
-            bridge_image_tag("fakecloud-postgres", "15"),
+            bridge_image_tag_with_registry("registry.example.com/team", "fakecloud-postgres", "15"),
             format!(
                 "registry.example.com/team/fakecloud-postgres:15-{}",
                 env!("CARGO_PKG_VERSION")
             )
         );
 
-        std::env::set_var("FAKECLOUD_POSTGRES_REGISTRY", "registry.example.com/team/");
+        // Trailing slash on the override is trimmed.
         assert_eq!(
-            bridge_image_tag("fakecloud-postgres", "13"),
+            bridge_image_tag_with_registry(
+                "registry.example.com/team/",
+                "fakecloud-postgres",
+                "13"
+            ),
             format!(
                 "registry.example.com/team/fakecloud-postgres:13-{}",
                 env!("CARGO_PKG_VERSION")
             )
         );
-
-        match prev {
-            Some(v) => std::env::set_var("FAKECLOUD_POSTGRES_REGISTRY", v),
-            None => std::env::remove_var("FAKECLOUD_POSTGRES_REGISTRY"),
-        }
     }
 
     fn running_stub(container_id: &str) -> RunningDbContainer {

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.19.1")
+    testImplementation("dev.fakecloud:fakecloud:0.20.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.19.1</version>
+    <version>0.20.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.19.1"
+version = "0.20.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.19.1"
+version = "0.20.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release v0.20.0 (minor). Highlights since v0.19.1:

- feat(ec2): real VPC network isolation + security-group/NACL packet filtering (#1745, phases 1-5): default VPC topology on boot, per-subnet Docker/Podman networks for L3 isolation, opt-in nftables SG/NACL enforcement, k8s NetworkPolicy enforcement.
- feat(ec2): `GET /_fakecloud/ec2/instance-networks` introspection endpoint + method in all six SDKs.
- fix(ec2): async lifecycle, restart reconcile, real instance attributes, count/filter/pagination correctness (#1747).
- fix(cloudformation): persist provisioned resources across restart (#1767).
- Numerous bug-hunt fixes across dynamodb, s3, sqs, sns, kms, kinesis, ecs, rds, ecr, stepfunctions, eventbridge, iam, cognito, wafv2, apigateway, elasticache.

Bumps `[workspace.package]` + all `fakecloud-*` dep pins, Cargo.lock, and the TS/Python/Java SDK versions.

## Test plan

- CI green (workspace build, clippy, fmt, tests).
- Tag push triggers the publish workflow after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.20.0: bumps the Rust workspace and SDKs for publish. Adds EC2 VPC network isolation and a new instance-network introspection endpoint, and fixes an RDS test flake by removing an env-var race in image tag building.

- **New Features**
  - EC2: real VPC L3 isolation; per‑subnet networks; optional nftables SG/NACL; k8s NetworkPolicy.
  - EC2: `GET /_fakecloud/ec2/instance-networks` endpoint + SDK method.

- **Dependencies**
  - Bump Rust workspace (`fakecloud`, all `fakecloud-*`) to `0.20.0`; update `Cargo.lock`.
  - Bump SDKs to `0.20.0` in `sdks/java`, `sdks/python`, `sdks/typescript`.

<sup>Written for commit be93a0aa39589a1c5c2207f44b6448e7d40affbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

