### PR TITLE
fix(s3,sqs): close three reachable request-path panics (DoS)

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -1639,6 +1639,85 @@ async fn s3_complete_multipart_wrong_etag_returns_error() {
     );
 }
 
+/// Regression: UploadPartCopy with a malformed/out-of-bounds copy-source-range (start>end,
+/// or any range over a 0-byte source) used to underflow `len()-1` / slice past the buffer and
+/// panic the request thread. It must return InvalidArgument and leave the server responsive.
+#[tokio::test]
+async fn s3_upload_part_copy_bad_range_returns_error_not_panic() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("upc-range-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // A small source object and an empty source object.
+    client
+        .put_object()
+        .bucket("upc-range-bucket")
+        .key("src-small.txt")
+        .body(ByteStream::from_static(b"hello"))
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_object()
+        .bucket("upc-range-bucket")
+        .key("src-empty.txt")
+        .body(ByteStream::from_static(b""))
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("upc-range-bucket")
+        .key("dst.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    // start > end against a non-empty source.
+    let inverted = client
+        .upload_part_copy()
+        .bucket("upc-range-bucket")
+        .key("dst.bin")
+        .upload_id(&upload_id)
+        .part_number(1)
+        .copy_source("upc-range-bucket/src-small.txt")
+        .copy_source_range("bytes=100-0")
+        .send()
+        .await;
+    assert!(inverted.is_err(), "inverted range must error, not panic");
+
+    // Any range over a 0-byte source (previously underflowed len()-1).
+    let empty_src = client
+        .upload_part_copy()
+        .bucket("upc-range-bucket")
+        .key("dst.bin")
+        .upload_id(&upload_id)
+        .part_number(1)
+        .copy_source("upc-range-bucket/src-empty.txt")
+        .copy_source_range("bytes=0-0")
+        .send()
+        .await;
+    assert!(empty_src.is_err(), "range over empty source must error");
+
+    // The server survived both: a normal request still succeeds.
+    let head = client
+        .head_object()
+        .bucket("upc-range-bucket")
+        .key("src-small.txt")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(head.content_length(), Some(5));
+}
+
 /// Regression: AbortMultipartUpload with wrong key returns NoSuchUpload error.
 #[tokio::test]
 async fn s3_abort_multipart_wrong_key_returns_error() {

--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -660,6 +660,81 @@ async fn sqs_change_message_visibility_batch() {
     assert_eq!(recv_resp2.messages().len(), 3);
 }
 
+/// Regression: an out-of-range VisibilityTimeout in a batch entry used to overflow
+/// `now + Duration::seconds(..)` and panic the request thread (dropped connection).
+/// It must instead land in `failed` with InvalidParameterValue, like the single-op path,
+/// while valid entries in the same batch still succeed.
+#[tokio::test]
+async fn sqs_change_message_visibility_batch_rejects_out_of_range() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+
+    let resp = client
+        .create_queue()
+        .queue_name("cmvb-range-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = resp.queue_url().unwrap().to_string();
+
+    for i in 0..2 {
+        client
+            .send_message()
+            .queue_url(&queue_url)
+            .message_body(format!("range-msg-{i}"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let recv_resp = client
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(10)
+        .send()
+        .await
+        .unwrap();
+    let messages = recv_resp.messages();
+    assert_eq!(messages.len(), 2);
+
+    // One valid entry (timeout 10) and one wildly out-of-range entry that previously
+    // overflowed the timestamp arithmetic.
+    let entries = vec![
+        ChangeMessageVisibilityBatchRequestEntry::builder()
+            .id("ok")
+            .receipt_handle(messages[0].receipt_handle().unwrap())
+            .visibility_timeout(10)
+            .build()
+            .unwrap(),
+        ChangeMessageVisibilityBatchRequestEntry::builder()
+            .id("overflow")
+            .receipt_handle(messages[1].receipt_handle().unwrap())
+            // > 43200 (12h max). Out-of-range values are what overflow the timestamp
+            // arithmetic when sent as a raw i64; the typed SDK caps at i32, but any value
+            // past the limit must still be soft-rejected before that arithmetic runs.
+            .visibility_timeout(50_000)
+            .build()
+            .unwrap(),
+    ];
+
+    // The request must complete (no panic / dropped connection).
+    let batch_resp = client
+        .change_message_visibility_batch()
+        .queue_url(&queue_url)
+        .set_entries(Some(entries))
+        .send()
+        .await
+        .unwrap();
+
+    let successful = batch_resp.successful();
+    let failed = batch_resp.failed();
+    assert_eq!(successful.len(), 1);
+    assert_eq!(successful[0].id(), "ok");
+    assert_eq!(failed.len(), 1);
+    assert_eq!(failed[0].id(), "overflow");
+    assert_eq!(failed[0].code(), "InvalidParameterValue");
+}
+
 /// Fair Queues: when multiple message groups exist on a standard queue,
 /// messages from groups with fewer in-flight messages are prioritized.
 #[tokio::test]

--- a/crates/fakecloud-s3/src/select.rs
+++ b/crates/fakecloud-s3/src/select.rs
@@ -164,9 +164,25 @@ pub fn parse_sql(sql: &str) -> Result<Query, &'static str> {
     })
 }
 
+/// Case-insensitive search for an ASCII keyword that returns a byte offset into
+/// `s` itself (at a char boundary). Searching a `to_uppercase()` copy is unsafe
+/// because uppercasing can change byte length (e.g. `ﬀ` -> `FF`), so an offset
+/// from the uppercased string can land off a char boundary in the original and
+/// panic when used to slice it.
+fn find_ascii_keyword_ci(s: &str, kw: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let kw = kw.as_bytes();
+    if kw.len() > bytes.len() {
+        return None;
+    }
+    // A char-boundary match of an all-ASCII needle guarantees the matched bytes
+    // are ASCII, so `pos + kw.len()` is also a valid char boundary.
+    (0..=bytes.len() - kw.len())
+        .find(|&i| s.is_char_boundary(i) && bytes[i..i + kw.len()].eq_ignore_ascii_case(kw))
+}
+
 fn parse_where(s: &str) -> Result<WhereClause, &'static str> {
-    let upper = s.to_uppercase();
-    if let Some(pos) = upper.find(" LIKE ") {
+    if let Some(pos) = find_ascii_keyword_ci(s, " LIKE ") {
         let col = s[..pos].trim().to_string();
         let pattern = s[pos + 6..].trim();
         let pat = strip_quotes(pattern).unwrap_or(pattern).to_string();
@@ -409,6 +425,30 @@ mod tests {
     #[test]
     fn parse_where_like() {
         let q = parse_sql("SELECT * FROM s3object WHERE name LIKE 'a%'").unwrap();
+        assert!(
+            matches!(q.where_clause, Some(WhereClause::Like(ref col, ref pat)) if col == "name" && pat == "a%")
+        );
+    }
+
+    #[test]
+    fn parse_where_like_multibyte_column_does_not_panic() {
+        // `ﬀ` (U+FB00) uppercases to the two-byte "FF", so a byte offset taken from a
+        // `to_uppercase()` copy would land off a char boundary in the original string and
+        // panic when slicing. The case-insensitive keyword search must operate on the
+        // original bytes so this parses cleanly instead of crashing the request thread.
+        let q = parse_sql("SELECT * FROM s3object WHERE ﬀ LIKE 'x%'").unwrap();
+        match q.where_clause {
+            Some(WhereClause::Like(ref col, ref pat)) => {
+                assert_eq!(col, "ﬀ");
+                assert_eq!(pat, "x%");
+            }
+            other => panic!("expected LIKE clause, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_where_like_is_case_insensitive() {
+        let q = parse_sql("SELECT * FROM s3object WHERE name like 'a%'").unwrap();
         assert!(
             matches!(q.where_clause, Some(WhereClause::Like(ref col, ref pat)) if col == "name" && pat == "a%")
         );

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -361,11 +361,32 @@ impl S3Service {
         let src_bytes = state.read_body(&src_body_ref).map_err(super::io_to_aws)?;
         let src_data = if let Some(range_str) = copy_range {
             let range_part = range_str.strip_prefix("bytes=").unwrap_or(range_str);
+            let invalid_range = || {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidArgument",
+                    format!(
+                        "The x-amz-copy-source-range value \"{range_str}\" is not valid for \
+                         the source object of size {}.",
+                        src_bytes.len()
+                    ),
+                )
+            };
             if let Some((start_str, end_str)) = range_part.split_once('-') {
-                let start: usize = start_str.parse().unwrap_or(0);
-                let end: usize = end_str.parse().unwrap_or(src_bytes.len() - 1);
-                let end = std::cmp::min(end + 1, src_bytes.len());
-                src_bytes.slice(start..end)
+                // A copy-source-range over an empty object has no valid offsets, and a
+                // malformed/out-of-bounds range must be rejected rather than slicing past
+                // the buffer (which would panic the request thread).
+                let last = src_bytes.len().checked_sub(1).ok_or_else(invalid_range)?;
+                let start: usize = start_str.trim().parse().map_err(|_| invalid_range())?;
+                let end: usize = if end_str.trim().is_empty() {
+                    last
+                } else {
+                    end_str.trim().parse().map_err(|_| invalid_range())?
+                };
+                if start > end || end > last {
+                    return Err(invalid_range());
+                }
+                src_bytes.slice(start..end + 1)
             } else {
                 src_bytes.clone()
             }

--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -965,6 +965,21 @@ impl SqsService {
                     continue;
                 }
             };
+            // AWS limits VisibilityTimeout to 0..=43200 seconds (12 h). Out-of-range values
+            // are a per-entry InvalidParameterValue, mirroring the single-op path; without
+            // this guard a huge value overflows `now + Duration::seconds(..)` and panics the
+            // request thread.
+            if !(0..=43200).contains(&visibility_timeout) {
+                failed.push(json!({
+                    "Id": id,
+                    "SenderFault": true,
+                    "Code": "InvalidParameterValue",
+                    "Message": format!(
+                        "VisibilityTimeout {visibility_timeout} is invalid. Reason: Must be between 0 and 43200 seconds."
+                    ),
+                }));
+                continue;
+            }
 
             let message_id = find_message_id_for_receipt(queue, receipt_handle);
 


### PR DESCRIPTION
## Summary

Fixes three production request-path panics found by the 2026-06-18 code-quality audit. Each is reachable from malformed-but-accepted input and drops the client connection (DoS):

1. **S3 `UploadPartCopy`** (`s3/service/multipart.rs`) - a `x-amz-copy-source-range` with `start > end`, or any range over a 0-byte source object, underflowed `len()-1` and sliced past the buffer. Now range-validated -> `InvalidArgument`. Brings it to parity with the guards the GetObject range path already has.
2. **SQS `ChangeMessageVisibilityBatch`** (`sqs/service/messages.rs`) - an out-of-range `VisibilityTimeout` overflowed `now + Duration::seconds(..)`. The single-op `ChangeMessageVisibility` already rejects values outside `0..=43200`; the batch loop did not. Now emits a per-entry `InvalidParameterValue` failure (valid entries in the same batch still succeed).
3. **S3 `SelectObjectContent` `WHERE ... LIKE`** (`s3/select.rs`) - the `LIKE` offset came from a `to_uppercase()` copy whose byte length can differ from the original (e.g. `U+FB00` -> `FF`), so slicing the original could panic on a non-char-boundary. Replaced with a case-insensitive ASCII-keyword search over the original bytes.

## Test plan

- `cargo test -p fakecloud-s3 --lib select::tests::parse_where` - multibyte-column LIKE no longer panics + case-insensitive LIKE.
- `cargo test -p fakecloud-e2e --test s3 s3_upload_part_copy_bad_range_returns_error_not_panic` - inverted range + empty-source copy both error, server stays responsive.
- `cargo test -p fakecloud-e2e --test sqs sqs_change_message_visibility_batch_rejects_out_of_range` - out-of-range entry soft-fails with `InvalidParameterValue`, valid entry in same batch succeeds.
- `cargo clippy -p fakecloud-s3 -p fakecloud-sqs -p fakecloud-e2e --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three request-path panics in S3 and SQS that could drop client connections. Adds strict validation and safe parsing so malformed input returns errors instead of crashing.

- **Bug Fixes**
  - S3 UploadPartCopy: validate `x-amz-copy-source-range`; reject `start > end`, `end` past last byte, and any range on empty sources with `InvalidArgument` (parity with GetObject).
  - SQS ChangeMessageVisibilityBatch: enforce `VisibilityTimeout` in `0..=43200`; out-of-range entries return `InvalidParameterValue` while valid entries succeed.
  - S3 SelectObjectContent WHERE ... LIKE: replace `to_uppercase()` offset logic with an ASCII case-insensitive keyword search on original bytes at char boundaries to avoid char-boundary panics; LIKE stays case-insensitive.

<sup>Written for commit 077f6bce910155006bce9564f944525cc0653c62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

