### PR TITLE
test(eventbridge,ssm): assert real behavior; drop stale dead_code allow

### DIFF
--- a/crates/fakecloud-e2e/tests/eventbridge.rs
+++ b/crates/fakecloud-e2e/tests/eventbridge.rs
@@ -602,8 +602,13 @@ async fn eb_delete_nonexistent_event_bus() {
     let server = TestServer::start().await;
     let client = server.eventbridge_client().await;
 
-    // Deleting a non-existent bus may return error or succeed silently
-    let _ = client.delete_event_bus().name("no-such-bus").send().await;
+    // DeleteEventBus is idempotent in AWS: deleting a bus that doesn't exist
+    // succeeds (200) rather than erroring.
+    let result = client.delete_event_bus().name("no-such-bus").send().await;
+    assert!(
+        result.is_ok(),
+        "DeleteEventBus on a missing bus should succeed idempotently, got: {result:?}"
+    );
 }
 
 // ---- EventBridge Multiple Targets ----

--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -852,17 +852,31 @@ async fn ssm_association_batch_and_start() {
         .unwrap();
     assert_eq!(batch_resp.successful().len(), 2);
 
-    // StartAssociationsOnce
+    // StartAssociationsOnce against a real association id succeeds...
     let assoc_id = batch_resp.successful()[0]
         .association_id()
         .unwrap()
         .to_string();
-    let _ = client
+    client
         .start_associations_once()
         .association_ids(&assoc_id)
         .send()
         .await
         .unwrap();
+
+    // ...and leaves the association intact and resolvable.
+    let described = client
+        .describe_association()
+        .association_id(&assoc_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described
+            .association_description()
+            .and_then(|d| d.association_id()),
+        Some(assoc_id.as_str())
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-ec2/src/defaults.rs
+++ b/crates/fakecloud-ec2/src/defaults.rs
@@ -294,9 +294,8 @@ fn deny_all_entry(egress: bool) -> NetworkAclEntry {
 /// without such a route is private and (phase 2) backs onto an `internal`
 /// network. Subnets default to their VPC's main route table when not
 /// explicitly associated.
-// Consumed by phase-2 per-subnet networking (chooses `internal` vs routable
-// backing networks) and exercised by the tests below.
-#[allow(dead_code)]
+// Drives per-subnet networking (chooses `internal` vs routable backing
+// networks) from `service/mod.rs` and `instance.rs`.
 pub(crate) fn subnet_is_public(state: &Ec2State, subnet_id: &str) -> bool {
     let Some(subnet) = state.subnets.get(subnet_id) else {
         return false;


### PR DESCRIPTION
## Summary

Three small cleanups from the 2026-06-18 code-quality audit:

1. **`eb_delete_nonexistent_event_bus`** discarded the `DeleteEventBus` result with a "may error or succeed" comment, so it could never fail. The impl is idempotent (deleting a missing non-default bus returns 200, matching AWS) - now asserts `is_ok()`.
2. **`ssm_association_batch_and_start`** discarded the `StartAssociationsOnce` response; half the named subject was unverified. Now asserts the call succeeds and the association is still resolvable via `DescribeAssociation`.
3. **`ec2 defaults::subnet_is_public`** carried `#[allow(dead_code)]` with a comment claiming it was only test-exercised, but it is called from `service/mod.rs` and `instance.rs`. Removed the (misleading) suppression; clippy `-D warnings` confirms it's live.

## Test plan

- `cargo test -p fakecloud-e2e --test eventbridge eb_delete_nonexistent_event_bus` passes.
- `cargo test -p fakecloud-e2e --test ssm ssm_association_batch_and_start` passes.
- `cargo clippy -p fakecloud-ec2 -- -D warnings` clean (no dead_code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened EventBridge and SSM e2e tests to assert real AWS behavior and prevent false positives. Removed a stale `dead_code` allow in `fakecloud-ec2` after confirming the function is used.

- **Bug Fixes**
  - `fakecloud-e2e`: EventBridge test now asserts `DeleteEventBus` on a missing bus succeeds (AWS idempotency).
  - `fakecloud-e2e`: SSM test now checks `StartAssociationsOnce` succeeds and the association is still returned by `DescribeAssociation`.

- **Refactors**
  - `fakecloud-ec2`: Removed `#[allow(dead_code)]` from `subnet_is_public` and updated the comment to reflect real call sites.

<sup>Written for commit 04cdd24065277c88ae7b04ee5b643a8b6e6093f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

