### PR TITLE
refactor(core,sns,s3,ses,cognito,route53): harden access-point routing + shrink pub surface

### DIFF
--- a/crates/fakecloud-cognito/src/webauthn.rs
+++ b/crates/fakecloud-cognito/src/webauthn.rs
@@ -63,7 +63,7 @@ fn cbor_map_get<'a>(map: &'a [(CborValue, CborValue)], key: &str) -> Option<&'a 
 
 /// Parse a base64url-encoded WebAuthn `attestationObject` and return the
 /// "packed" attestation pieces. Rejects every other `fmt`.
-pub fn parse_packed_attestation(
+pub(crate) fn parse_packed_attestation(
     attestation_object_b64: &str,
 ) -> Result<PackedAttestation, AttestationError> {
     let raw = b64url_decode(attestation_object_b64)?;

--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -362,12 +362,17 @@ fn parse_aws_prefix(prefix: &str) -> Option<RoutingHost> {
                 bucket: None,
             });
         }
-        let bucket = labels[..labels.len() - 2].join(".");
-        return Some(RoutingHost {
-            service: "s3".to_string(),
-            region: labels[labels.len() - 1].to_string(),
-            bucket: Some(bucket),
-        });
+        // Virtual-hosted form needs at least {alias}.{region}.s3-accesspoint, i.e.
+        // 3+ labels. A bare "s3-accesspoint" host (1 label) must not reach the
+        // `len() - 2` slice, which would underflow and panic.
+        if labels.len() >= 3 {
+            let bucket = labels[..labels.len() - 2].join(".");
+            return Some(RoutingHost {
+                service: "s3".to_string(),
+                region: labels[labels.len() - 1].to_string(),
+                bucket: Some(bucket),
+            });
+        }
     }
 
     // `s3-control.<region>` or `{account-id}.s3-control.<region>` — S3
@@ -1079,6 +1084,14 @@ mod tests {
         assert!(parse_routing_host("foo.bar.baz.localhost.localstack.cloud").is_none());
         assert!(parse_routing_host(".amazonaws.com").is_none());
         assert!(parse_routing_host("amazonaws.com").is_none());
+    }
+
+    #[test]
+    fn parse_routing_host_bare_s3_accesspoint_does_not_panic() {
+        // A single-label "s3-accesspoint" host has < 2 labels, so the
+        // virtual-hosted `len() - 2` slice would underflow and panic without
+        // the length guard. It must be rejected, not crash the router.
+        assert!(parse_routing_host("s3-accesspoint").is_none());
     }
 
     #[test]

--- a/crates/fakecloud-route53/src/dnssec.rs
+++ b/crates/fakecloud-route53/src/dnssec.rs
@@ -222,7 +222,7 @@ pub fn rrsig_signed_data(header: &RrsigHeader<'_>, rrset_canonical: &[u8]) -> Ve
 
 /// Sign `data` with the PKCS#8-PEM private key. Returns the raw 64-byte
 /// `r || s` ECDSA-P256 signature ready for the RRSIG `Signature` field.
-pub fn sign_with_pkcs8_pem(private_key_pem: &str, data: &[u8]) -> Vec<u8> {
+pub(crate) fn sign_with_pkcs8_pem(private_key_pem: &str, data: &[u8]) -> Vec<u8> {
     let signing_key =
         SigningKey::from_pkcs8_pem(private_key_pem).expect("valid pkcs8 pem from derive_keypair");
     let signature: Signature = signing_key.sign(data);

--- a/crates/fakecloud-s3/src/logging.rs
+++ b/crates/fakecloud-s3/src/logging.rs
@@ -18,7 +18,7 @@ pub struct LoggingConfig {
 
 /// Parse a `<BucketLoggingStatus>` XML body into a `LoggingConfig`, if logging
 /// is enabled (i.e. the `<LoggingEnabled>` element is present).
-pub fn parse_logging_config(xml: &str) -> Option<LoggingConfig> {
+pub(crate) fn parse_logging_config(xml: &str) -> Option<LoggingConfig> {
     let le_start = xml.find("<LoggingEnabled>")?;
     let le_end = xml.find("</LoggingEnabled>")?;
     let le_body = &xml[le_start + 16..le_end];

--- a/crates/fakecloud-s3/src/select.rs
+++ b/crates/fakecloud-s3/src/select.rs
@@ -112,7 +112,7 @@ pub struct Query {
 
 /// Parse a minimal SELECT statement. Errors are static strings for
 /// simplicity — callers map them to AWS error codes.
-pub fn parse_sql(sql: &str) -> Result<Query, &'static str> {
+pub(crate) fn parse_sql(sql: &str) -> Result<Query, &'static str> {
     let sql = sql.trim();
     let upper = sql.to_uppercase();
 
@@ -211,7 +211,7 @@ fn strip_quotes(s: &str) -> Option<&str> {
 
 // ── CSV parser ──────────────────────────────────────────────────────
 
-pub fn parse_csv(
+pub(crate) fn parse_csv(
     input: &[u8],
     has_header: bool,
     field_delimiter: char,
@@ -238,7 +238,7 @@ pub fn parse_csv(
 
 // ── JSON parser (newline-delimited) ─────────────────────────────────
 
-pub fn parse_json_lines(input: &[u8]) -> (Option<Vec<String>>, Vec<Vec<String>>) {
+pub(crate) fn parse_json_lines(input: &[u8]) -> (Option<Vec<String>>, Vec<Vec<String>>) {
     let text = String::from_utf8_lossy(input);
     let mut headers: Option<Vec<String>> = None;
     let mut rows = Vec::new();

--- a/crates/fakecloud-ses/src/smtp_relay.rs
+++ b/crates/fakecloud-ses/src/smtp_relay.rs
@@ -13,7 +13,7 @@ use std::net::TcpStream;
 use std::time::Duration;
 
 /// Parse `smtp://host:port` (or `host:port`) into `(host, port)`.
-pub fn parse_relay_url(url: &str) -> Option<(String, u16)> {
+pub(crate) fn parse_relay_url(url: &str) -> Option<(String, u16)> {
     let s = url.trim().strip_prefix("smtp://").unwrap_or(url);
     let (host, port) = s.rsplit_once(':')?;
     let port: u16 = port.parse().ok()?;

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -86,6 +86,12 @@ pub fn handle_v1_action(
     }
 }
 
+/// SES-flavored required-parameter check. Intentionally diverges from
+/// `fakecloud_core::query::required_param`: it returns a borrowed `&str` and
+/// emits SES's `ValidationError` / "Value for parameter X is required" wording
+/// (the AWS-correct response for the SES query protocol), where core emits
+/// `MissingParameter` / "The request must contain the parameter X." Do not
+/// "consolidate" this into the core helper - it would break SES error parity.
 pub(crate) fn required_param<'a>(
     params: &'a HashMap<String, String>,
     key: &str,

--- a/crates/fakecloud-sns/src/signing.rs
+++ b/crates/fakecloud-sns/src/signing.rs
@@ -78,7 +78,7 @@ pub fn sign(canonical: &str) -> String {
 ///
 /// Order is alphabetical by key, with each `Key\nValue\n` pair appended.
 /// `Subject` is included only when present.
-pub fn canonical_notification(
+pub(crate) fn canonical_notification(
     message: &str,
     message_id: &str,
     subject: Option<&str>,


### PR DESCRIPTION
## Summary

Cleanup batch from the 2026-06-18 code-quality audit:

- **`core/protocol.rs` hardening** - a bare single-label `s3-accesspoint` Host reached the virtual-hosted `labels[..len-2]` slice and would underflow/panic. Now guarded with `len() >= 3`; the bare host is rejected. Unit test added.
- **Shrink published API surface** - demote internal parser/crypto helpers with zero cross-crate (and zero external-test) consumers from `pub` to `pub(crate)`: `parse_relay_url`, `parse_logging_config`, `parse_sql`/`parse_csv`/`parse_json_lines`, `parse_packed_attestation`, `canonical_notification`, `sign_with_pkcs8_pem`. `canonical_rrset_bytes` stays `pub` (used by external integration tests).
- **`ses required_param` doc** - notes the intentional `ValidationError`-wording divergence from `core::query::required_param` so it isn't mistakenly consolidated.

## Decision note

Demoting `sns::canonical_subscription_confirmation` revealed it has **no internal caller** - it's a built-but-unwired signing primitive for `SubscriptionConfirmation`/`UnsubscribeConfirmation` messages (the HTTP confirmation-delivery path that would sign with it isn't implemented). Kept it `pub` rather than deleting the intended primitive; wiring confirmation-message delivery is a separate feature, surfaced here for follow-up.

## Test plan

- `cargo clippy` on all six crates `--all-targets -D warnings` clean.
- `cargo test --lib` on core/s3/sns/ses/route53/cognito - all pass (1404 tests).
- New `parse_routing_host_bare_s3_accesspoint_does_not_panic` unit test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened S3 access-point host parsing to prevent a panic on malformed hosts, and reduced the public API surface by scoping internal helpers to `pub(crate)`. Safer routing and a smaller API with no feature changes.

- **Bug Fixes**
  - Reject bare `s3-accesspoint` host in `fakecloud-core` routing; added a length guard and a unit test.

- **Refactors**
  - Demoted internal helpers to `pub(crate)`: `ses::parse_relay_url`, `s3::parse_logging_config`, `s3::parse_sql`, `s3::parse_csv`, `s3::parse_json_lines`, `cognito::parse_packed_attestation`, `sns::canonical_notification`, `route53::sign_with_pkcs8_pem`.
  - Kept `route53::canonical_rrset_bytes` and `sns::canonical_subscription_confirmation` public. Documented `ses::required_param` to preserve SES-specific `ValidationError` wording.

<sup>Written for commit 2529966033642958fe9d54d7031c181e9a9749c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

