### PR TITLE
ci(e2e): load br_netfilter at job level to de-flake SG enforcement test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -212,6 +212,18 @@ jobs:
       - name: Install nftables
         run: sudo apt-get update && sudo apt-get install -y nftables
 
+      # Same-subnet instances share one Linux bridge, so their traffic is L2-switched
+      # and only traverses the nft `forward` chain when bridge netfilter is active.
+      # The runtime tries to enable this in-process, but loading the module + setting
+      # the sysctl deterministically at the host level *before* any container network
+      # is created removes the race that intermittently let the "deny" packet through.
+      - name: Enable bridge netfilter
+        run: |
+          sudo modprobe br_netfilter
+          echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
+          echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables
+          echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-arptables
+
       - name: Pre-pull the instance base image
         run: docker pull alpine:3
 


### PR DESCRIPTION
## Summary

The privileged `ec2_sg_enforcement_real` test has been intermittently failing the **deny** assertion (packet not dropped) on PRs unrelated to EC2 - including the post-v0.20.0 audit PRs.

Root cause: same-subnet instances share one Linux bridge, so their traffic is L2-switched and only traverses the nft `forward` chain when **bridge netfilter** is active. The runtime enables it in-process during reconcile, but that races the container-network setup on loaded runners - the default-deny rule was present (the test's `wait_for_deny_rule` guard passed) yet the packet still got through.

Fix: load `br_netfilter` and set the `bridge-nf-call-{ip,ip6,arp}tables` sysctls deterministically at the job level, before any container network is created. This removes the race so bridged forward traffic reliably hits fakecloud's `forward` chain (priority -5, ahead of docker's).

## Test plan

- This PR's own `EC2 SG enforcement (privileged)` job exercises the fix end-to-end (real deny -> allow packet transition).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the EC2 SG enforcement (privileged) e2e test by enabling bridge netfilter at the job level, before any container network exists. Loads `br_netfilter` and sets `bridge-nf-call-{ip,ip6,arp}tables` sysctls so bridged traffic hits the nft `forward` chain and the deny assertion stops flaking.

<sup>Written for commit b84a415d9d8c82cf79756d6f36c8db5ee6a380d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

