### PR TITLE
fix(apigateway): use integrationHttpMethod for AWS (non-proxy) integrations

### DIFF
--- a/crates/fakecloud-apigateway/src/data_plane/integrations.rs
+++ b/crates/fakecloud-apigateway/src/data_plane/integrations.rs
@@ -287,6 +287,7 @@ pub(super) async fn mock_response(
 pub(super) async fn aws_direct_integration(
     req: &AwsRequest,
     uri: &str,
+    integration: &Integration,
     service: &ApiGatewayService,
 ) -> Result<AwsResponse, AwsServiceError> {
     let registry = service.registry().ok_or_else(|| {
@@ -315,6 +316,19 @@ pub(super) async fn aws_direct_integration(
         ))
     })?;
 
+    // For a non-proxy `AWS` integration the backend method is the one
+    // configured on the integration (`integrationHttpMethod`), NOT the
+    // client's front-facing method. On real AWS this is always `POST` for
+    // Lambda invoke integrations, so a `GET /users` resource still reaches
+    // Lambda over `POST`. Falling back to the client's method only when no
+    // integration method is set preserves prior behavior for any caller
+    // that omitted it.
+    let dispatch_method = integration
+        .integration_http_method
+        .as_deref()
+        .and_then(|m| Method::from_bytes(m.to_ascii_uppercase().as_bytes()).ok())
+        .unwrap_or_else(|| req.method.clone());
+
     let mut dispatch_req = AwsRequest {
         service: target_service.to_string(),
         action: req.action.clone(),
@@ -328,7 +342,7 @@ pub(super) async fn aws_direct_integration(
         path_segments: req.path_segments.clone(),
         raw_path: req.raw_path.clone(),
         raw_query: req.raw_query.clone(),
-        method: req.method.clone(),
+        method: dispatch_method,
         is_query_protocol: false,
         access_key_id: req.access_key_id.clone(),
         principal: req.principal.clone(),

--- a/crates/fakecloud-apigateway/src/data_plane/mod.rs
+++ b/crates/fakecloud-apigateway/src/data_plane/mod.rs
@@ -429,7 +429,7 @@ pub async fn handle(
                 .uri
                 .as_deref()
                 .ok_or_else(|| bad_gateway("AWS integration missing uri"))?;
-            aws_direct_integration(req, uri, service).await
+            aws_direct_integration(req, uri, &integration, service).await
         }
         other => Err(bad_gateway(format!(
             "Integration type '{other}' not supported in fakecloud's data plane",
@@ -2334,6 +2334,30 @@ mod tests {
 
     // ── AWS direct integration tests ──
 
+    /// Build an `AWS` (non-proxy) integration with the given
+    /// `integrationHttpMethod` for the direct-integration tests.
+    fn aws_integration(integration_http_method: Option<&str>) -> Integration {
+        Integration {
+            rest_api_id: "api1".to_string(),
+            resource_id: "res1".to_string(),
+            http_method: "GET".to_string(),
+            integration_type: "AWS".to_string(),
+            integration_http_method: integration_http_method.map(|m| m.to_string()),
+            uri: None,
+            credentials: None,
+            request_parameters: BTreeMap::new(),
+            request_templates: BTreeMap::new(),
+            passthrough_behavior: "WHEN_NO_MATCH".to_string(),
+            timeout_in_millis: None,
+            cache_namespace: None,
+            cache_key_parameters: vec![],
+            content_handling: None,
+            connection_type: None,
+            connection_id: None,
+            tls_config: None,
+        }
+    }
+
     struct StubAwsService {
         name: String,
         last_request: parking_lot::Mutex<Option<AwsRequest>>,
@@ -2371,9 +2395,13 @@ mod tests {
         let mut req = make_request(HeaderMap::new());
         req.body = bytes::Bytes::from(r#"{"TableName":"t","Item":{"id":{"S":"1"}}}"#);
 
+        // Front-facing method is GET (make_request default) but the
+        // integration is configured for POST: the backend must receive POST.
+        let integration = aws_integration(Some("POST"));
         let resp = aws_direct_integration(
             &req,
             "arn:aws:apigateway:us-east-1:dynamodb:action/PutItem",
+            &integration,
             &service,
         )
         .await
@@ -2386,6 +2414,49 @@ mod tests {
         assert_eq!(dispatched.service, "dynamodb");
         assert_eq!(dispatched.account_id, TEST_ACCOUNT);
         assert_eq!(dispatched.region, TEST_REGION);
+        // The integration's POST overrides the client's GET.
+        assert_eq!(dispatched.method, Method::POST);
+    }
+
+    #[tokio::test]
+    async fn aws_direct_integration_uses_integration_method_not_client_method() {
+        // Regression for #1776: a `GET` resource with an `AWS` Lambda
+        // integration (`integrationHttpMethod = POST`) must reach the
+        // backend over POST, the way real AWS always calls Lambda invoke.
+        let stub = Arc::new(StubAwsService {
+            name: "lambda".to_string(),
+            last_request: parking_lot::Mutex::new(None),
+        });
+        let mut registry = fakecloud_core::registry::ServiceRegistry::new();
+        registry.register(stub.clone());
+        let registry_arc = Arc::new(registry);
+        let registry_handle = Arc::new(std::sync::OnceLock::new());
+        let _ = registry_handle.set(registry_arc);
+
+        let state = build_state("NONE", None);
+        let service = ApiGatewayService::new(state).with_registry(registry_handle);
+
+        let mut req = make_request(HeaderMap::new());
+        req.method = Method::GET;
+
+        let integration = aws_integration(Some("POST"));
+        let resp = aws_direct_integration(
+            &req,
+            "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:my-fn/invocations",
+            &integration,
+            &service,
+        )
+        .await
+        .expect("dispatch must succeed");
+        assert_eq!(resp.status, StatusCode::OK);
+
+        let locked = stub.last_request.lock();
+        let dispatched = locked.as_ref().expect("stub must have received a request");
+        assert_eq!(dispatched.method, Method::POST);
+        assert_eq!(
+            dispatched.raw_path,
+            "/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:my-fn/invocations"
+        );
     }
 
     #[tokio::test]
@@ -2407,9 +2478,15 @@ mod tests {
         req.method = Method::POST;
         req.body = bytes::Bytes::from("Action=SendMessage&QueueUrl=http://q");
 
-        let resp = aws_direct_integration(&req, "arn:aws:apigateway:us-east-1:sqs:path/", &service)
-            .await
-            .expect("dispatch must succeed");
+        let integration = aws_integration(Some("POST"));
+        let resp = aws_direct_integration(
+            &req,
+            "arn:aws:apigateway:us-east-1:sqs:path/",
+            &integration,
+            &service,
+        )
+        .await
+        .expect("dispatch must succeed");
         assert_eq!(resp.status, StatusCode::OK);
 
         let locked = stub.last_request.lock();


### PR DESCRIPTION
## Summary

Fixes #1776. A REST API method with an `AWS` (non-proxy) integration was forwarding the client's front-facing HTTP method to the backend instead of the integration's configured `integrationHttpMethod`.

On real AWS, `integrationHttpMethod` is always `POST` for Lambda invoke integrations regardless of the front-facing method, because the backend is Lambda's Invoke API which only accepts `POST`. fakecloud reused `req.method`, so any resource method other than `POST` (e.g. a `GET /users` mapped to a Lambda via Terraform's `aws_api_gateway_integration`) failed with:

```
InvalidParameterValueException: Could not route request GET /2015-03-31/functions/.../invocations — missing or invalid identifier
```

`aws_direct_integration` now dispatches using the integration's `integrationHttpMethod`, falling back to the client's method only when it is unset (preserving prior behavior for callers that omit it).

## Test plan

- New regression test `aws_direct_integration_uses_integration_method_not_client_method`: a `GET` resource with `integrationHttpMethod = POST` reaches the backend over `POST` and preserves the Lambda invoke path (with embedded ARN colons).
- Updated `aws_direct_integration_dispatches_action_to_service` to assert the integration's POST overrides the client's GET.
- `cargo test -p fakecloud-apigateway`, `cargo clippy --all-targets -D warnings`, `cargo fmt` all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the integration’s `integrationHttpMethod` for API Gateway `AWS` (non-proxy) integrations to match real AWS behavior. Fixes Lambda and other backends being called with the client’s method (e.g., GET) instead of the configured POST.

- **Bug Fixes**
  - Backend dispatch now uses the integration’s `integrationHttpMethod`, falling back to the client method only when unset.
  - Data plane now passes the `Integration` into `aws_direct_integration`; added a regression test for GET resources invoking Lambda over POST.

<sup>Written for commit b850a89276da2a0e901f09a48742a6e959d9b162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

