### PR TITLE
fix(cloudformation): persist provisioned services on ExecuteChangeSet

### DIFF
--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -1697,6 +1697,22 @@ impl AwsService for CloudFormationService {
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
             self.save_snapshot().await;
         }
+        // ExecuteChangeSet provisions resources by mutating each service's
+        // shared state directly but -- unlike CreateStack/UpdateStack/DeleteStack
+        // -- never triggered the per-service snapshot hook, so the provisioned
+        // resources were never written through to disk (#1766 class). `cdk
+        // deploy`, `aws cloudformation deploy`, and SAM all provision via
+        // CreateChangeSet + ExecuteChangeSet (not CreateStack), so without this
+        // their resources reported CREATE_COMPLETE yet vanished on restart.
+        // save_snapshot above only persists CloudFormation's own stack metadata;
+        // flush every snapshot-backed service the changeset could have touched.
+        if action == "ExecuteChangeSet"
+            && matches!(result.as_ref(), Ok(resp) if resp.status.is_success())
+        {
+            for hook in self.snapshot_hooks.values() {
+                hook().await;
+            }
+        }
         result
     }
 
@@ -3131,6 +3147,52 @@ mod tests {
         );
         let loaded = fakecloud_persistence::S3Store::load(store.as_ref()).unwrap();
         assert!(loaded.buckets.contains_key("cfn-bucket"));
+    }
+
+    #[tokio::test]
+    async fn cfn_execute_change_set_persists_touched_services() {
+        // The changeset path -- CreateChangeSet + ExecuteChangeSet -- is how
+        // `cdk deploy`, `aws cloudformation deploy`, and SAM provision. It must
+        // write provisioned services through to disk the same way CreateStack
+        // does, or the resources report CREATE_COMPLETE yet vanish on restart
+        // (bug-audit 2026-06-20, 0.A1 / #1766 class).
+        let tmp = tempfile::tempdir().unwrap();
+        let store = disk_s3_store(&tmp);
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut hooks: BTreeMap<&'static str, fakecloud_persistence::SnapshotHook> =
+            BTreeMap::new();
+        hooks.insert("sqs", counting_hook(counter.clone()));
+        let svc = make_service()
+            .with_s3_store(store.clone())
+            .with_snapshot_hooks(hooks);
+
+        let mut create = HashMap::new();
+        create.insert("StackName".to_string(), "cs-stack".to_string());
+        create.insert("ChangeSetName".to_string(), "cs1".to_string());
+        create.insert("ChangeSetType".to_string(), "CREATE".to_string());
+        create.insert(
+            "TemplateBody".to_string(),
+            r#"{"Resources":{"Q":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"cs-q"}}}}"#
+                .to_string(),
+        );
+        svc.handle(make_request("CreateChangeSet", create))
+            .await
+            .unwrap();
+        // CreateChangeSet doesn't provision -- it must not persist a service yet.
+        let before = counter.load(Ordering::SeqCst);
+
+        let mut exec = HashMap::new();
+        exec.insert("StackName".to_string(), "cs-stack".to_string());
+        exec.insert("ChangeSetName".to_string(), "cs1".to_string());
+        svc.handle(make_request("ExecuteChangeSet", exec))
+            .await
+            .unwrap();
+
+        assert!(
+            counter.load(Ordering::SeqCst) > before,
+            "ExecuteChangeSet must fire the sqs snapshot hook so the provisioned \
+             queue survives a restart"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`ExecuteChangeSet` provisions resources by mutating each service's shared state directly (same as `CreateStack`/`UpdateStack`/`DeleteStack`), but unlike those paths it never fired the per-service snapshot hook. The provisioned resources were written to the in-memory map only and lost on restart.

This is the **default provisioning path** for `cdk deploy`, `aws cloudformation deploy`, and SAM — all of which provision via `CreateChangeSet` + `ExecuteChangeSet`, not `CreateStack`. So a stack created with any of those tools reported `CREATE_COMPLETE`, yet its physical resources (queues, functions, secrets, ...) vanished after a fakecloud restart in persistent mode.

`save_snapshot` already runs for `ExecuteChangeSet`, but it only persists CloudFormation's own stack metadata — not the underlying services. The fix flushes every snapshot-backed service the changeset could have touched after a successful `ExecuteChangeSet`, mirroring the `CreateStack` write-through.

This closes the changeset-path gap left by #1767 (which fixed only `CreateStack`/`UpdateStack`/`DeleteStack`).

Found by the 2026-06-20 bug-hunt audit (finding 0.A1, #1766 class).

## Test plan

- `cfn_execute_change_set_persists_touched_services` — drives `CreateChangeSet` (asserts no service persist yet) then `ExecuteChangeSet`, and asserts the provisioned SQS queue's snapshot hook fires. Fails on the pre-fix code (hook count stays 0).
- Existing `cfn_create/update/delete_persists_*` write-through tests still pass.
- `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist resources provisioned via CloudFormation `ExecuteChangeSet` by firing per-service snapshot hooks after a successful run. Fixes resources disappearing on restart; impacts the default deploy path used by CDK, `aws cloudformation deploy`, and SAM.

- **Bug Fixes**
  - Flush all snapshot-backed services after a successful `ExecuteChangeSet`, mirroring `CreateStack`/`UpdateStack`/`DeleteStack` write-through.
  - Added `cfn_execute_change_set_persists_touched_services` test to assert the SQS snapshot hook fires only on `ExecuteChangeSet`.

<sup>Written for commit 329e4cf9d268fccccf12f6d2011cb9f21dd253d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

