### PR TITLE
fix(secretsmanager): persist scheduled rotations through the snapshot

### DIFF
--- a/crates/fakecloud-secretsmanager/src/rotation.rs
+++ b/crates/fakecloud-secretsmanager/src/rotation.rs
@@ -14,9 +14,16 @@ use crate::state::{SecretVersion, SharedSecretsManagerState};
 /// invokes the rotation Lambda through all four steps.
 ///
 /// Returns the list of secret names that were rotated.
+///
+/// `snapshot_store`, when present, is written through after any rotation so the
+/// new AWSCURRENT version survives a restart. A scheduled rotation mutates
+/// secret state directly here, outside the normal action-dispatch path that is
+/// otherwise the only thing that snapshots -- without this the secret reverts to
+/// its pre-rotation value after a restart (bug-audit 2026-06-20, 0.A3).
 pub async fn check_and_rotate(
     state: &SharedSecretsManagerState,
     delivery_bus: Option<&Arc<DeliveryBus>>,
+    snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>>,
 ) -> Vec<String> {
     let now = Utc::now();
     let mut rotated = Vec::new();
@@ -164,6 +171,14 @@ pub async fn check_and_rotate(
         }
     }
 
+    // Write the rotated state through to disk. The snapshot file is written
+    // atomically (temp + rename), so a fresh local lock is sufficient to guard
+    // the in-memory clone for this one persist.
+    if !rotated.is_empty() {
+        let lock = tokio::sync::Mutex::new(());
+        crate::service::save_secretsmanager_snapshot(state, snapshot_store, &lock).await;
+    }
+
     rotated
 }
 
@@ -258,7 +273,7 @@ mod tests {
             .secrets
             .insert("due-secret".to_string(), secret);
 
-        let rotated = check_and_rotate(&state, None).await;
+        let rotated = check_and_rotate(&state, None, None).await;
         assert_eq!(rotated, vec!["due-secret"]);
 
         // Verify a new version was created (simple rotation without Lambda)
@@ -279,7 +294,7 @@ mod tests {
             .secrets
             .insert("not-due".to_string(), secret);
 
-        let rotated = check_and_rotate(&state, None).await;
+        let rotated = check_and_rotate(&state, None, None).await;
         assert!(rotated.is_empty());
     }
 
@@ -293,7 +308,7 @@ mod tests {
             .secrets
             .insert("disabled".to_string(), secret);
 
-        let rotated = check_and_rotate(&state, None).await;
+        let rotated = check_and_rotate(&state, None, None).await;
         assert!(rotated.is_empty());
     }
 
@@ -307,7 +322,7 @@ mod tests {
             .secrets
             .insert("no-rules".to_string(), secret);
 
-        let rotated = check_and_rotate(&state, None).await;
+        let rotated = check_and_rotate(&state, None, None).await;
         assert!(rotated.is_empty());
     }
 
@@ -321,7 +336,7 @@ mod tests {
             .secrets
             .insert("no-last".to_string(), secret);
 
-        let rotated = check_and_rotate(&state, None).await;
+        let rotated = check_and_rotate(&state, None, None).await;
         assert!(rotated.is_empty());
     }
 
@@ -336,7 +351,60 @@ mod tests {
             .secrets
             .insert("deleted".to_string(), secret);
 
-        let rotated = check_and_rotate(&state, None).await;
+        let rotated = check_and_rotate(&state, None, None).await;
         assert!(rotated.is_empty());
+    }
+
+    /// A SnapshotStore that records the last bytes saved, so a test can assert
+    /// the rotation wrote through (the real MemorySnapshotStore is a no-op).
+    #[derive(Default)]
+    struct RecordingStore {
+        bytes: std::sync::Mutex<Option<Vec<u8>>>,
+    }
+    impl fakecloud_persistence::SnapshotStore for RecordingStore {
+        fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+            Ok(self.bytes.lock().unwrap().clone())
+        }
+        fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+            *self.bytes.lock().unwrap() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn rotation_persists_through_snapshot_store() {
+        // A scheduled (no-Lambda) rotation mutates secret state directly. Without
+        // write-through the new AWSCURRENT version is lost on restart and the
+        // secret reverts to its old value (bug-audit 2026-06-20, 0.A3).
+        let state = make_state();
+        let secret = make_secret("due-secret", true, Some(1), Some(2));
+        let original_vid = secret.current_version_id.clone();
+        state
+            .write()
+            .default_mut()
+            .secrets
+            .insert("due-secret".to_string(), secret);
+
+        let store = Arc::new(RecordingStore::default());
+        let rotated = check_and_rotate(
+            &state,
+            None,
+            Some(store.clone() as Arc<dyn fakecloud_persistence::SnapshotStore>),
+        )
+        .await;
+        assert_eq!(rotated, vec!["due-secret"]);
+
+        // The rotated state was written through, so a reload sees the new
+        // AWSCURRENT version, not the pre-rotation one.
+        let bytes = fakecloud_persistence::SnapshotStore::load(store.as_ref())
+            .unwrap()
+            .expect("rotation must persist a snapshot");
+        let snap: crate::SecretsManagerSnapshot = serde_json::from_slice(&bytes).unwrap();
+        let accounts = snap.accounts.expect("multi-account snapshot");
+        let persisted = &accounts.default_ref().secrets["due-secret"];
+        assert_ne!(
+            persisted.current_version_id, original_vid,
+            "persisted snapshot must hold the rotated version"
+        );
     }
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1467,6 +1467,10 @@ async fn main() {
         } else {
             None
         };
+    // Clone the snapshot store for the rotation scheduler's /tick route, which
+    // mutates secret state outside the service's action-dispatch path and so
+    // must write through itself (bug-audit 2026-06-20, 0.A3).
+    let secretsmanager_rotation_snapshot_store = secretsmanager_snapshot_store.clone();
     let mut secretsmanager_service =
         SecretsManagerService::new(secretsmanager_state).with_delivery(delivery_for_secretsmanager);
     secretsmanager_service = secretsmanager_service.with_kms_hook(kms_hook_for_services.clone());
@@ -4658,9 +4662,14 @@ async fn main() {
             axum::routing::post({
                 let ss = secretsmanager_rotation_state;
                 let bus = delivery_for_rotation_scheduler;
+                let store = secretsmanager_rotation_snapshot_store;
                 move || async move {
-                    let rotated =
-                        fakecloud_secretsmanager::rotation::check_and_rotate(&ss, Some(&bus)).await;
+                    let rotated = fakecloud_secretsmanager::rotation::check_and_rotate(
+                        &ss,
+                        Some(&bus),
+                        store.clone(),
+                    )
+                    .await;
                     axum::Json(types::RotationTickResponse {
                         rotated_secrets: rotated,
                     })


### PR DESCRIPTION
## Summary

The rotation scheduler's `/_fakecloud/secretsmanager/rotation-scheduler/tick` route, on the no-Lambda path, performs the full AWSCURRENT -> AWSPREVIOUS swap and inserts the new AWSCURRENT version **entirely in memory**, then returns without persisting. Only the normal action-dispatch path triggers a snapshot, so after a restart in persistent mode the secret reverted to its pre-rotation value and the rotated version was lost.

Fix: thread the snapshot store into `check_and_rotate` and write through once after any rotation. The snapshot file is written atomically (temp + rename), so a local lock around the single persist is sufficient. The `/tick` route now passes the rotation scheduler a clone of the secretsmanager snapshot store.

Found by the 2026-06-20 bug-hunt audit (finding 0.A3, #1766 side-channel-persistence class).

## Test plan

- `rotation_persists_through_snapshot_store` — runs a due no-Lambda rotation with a recording snapshot store, then reloads the persisted snapshot and asserts it holds the rotated AWSCURRENT version (not the pre-rotation one). Fails on the pre-fix code (nothing is persisted).
- Existing rotation unit tests still pass.
- `cargo clippy -p fakecloud-secretsmanager -p fakecloud --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scheduled (no-Lambda) secret rotations now persist to disk, so the new AWSCURRENT version survives restarts. This prevents rotated versions from being lost after the rotation scheduler runs.

- **Bug Fixes**
  - Threaded a snapshot store into `check_and_rotate(state, delivery_bus, snapshot_store)` and write through once after any rotation.
  - The `/_fakecloud/secretsmanager/rotation-scheduler/tick` route in `fakecloud-server` now passes a cloned Secrets Manager snapshot store.
  - Snapshot writes are atomic (temp + rename) and guarded by a local lock.
  - Added test `rotation_persists_through_snapshot_store`; existing rotation tests still pass.

<sup>Written for commit c3b81a1b7b080b1cb89c000842a8ed09daffb220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

