### PR TITLE
fix(scheduler): persist ticker state mutations across restart

### DIFF
--- a/crates/fakecloud-scheduler/src/ticker.rs
+++ b/crates/fakecloud-scheduler/src/ticker.rs
@@ -12,14 +12,24 @@ use std::time::Duration;
 use chrono::{DateTime, Datelike, Timelike, Utc};
 
 use fakecloud_core::delivery::DeliveryBus;
+use fakecloud_persistence::SnapshotStore;
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::delivery::{deliver_target, route_to_dlq};
 use crate::expr::{self, Expr};
+use crate::service::save_scheduler_snapshot;
 use crate::state::{ScheduleKey, SharedSchedulerState};
 
 pub struct Ticker {
     state: SharedSchedulerState,
     delivery: Arc<DeliveryBus>,
+    /// Persist hook. The ticker mutates schedule state directly (sets
+    /// `last_fired`, deletes one-shot `at(...)` runs on completion) outside the
+    /// service's action-dispatch path that is otherwise the only thing that
+    /// snapshots -- so without writing through here a fired one-shot reappears,
+    /// and rate-rule timing resets, after a restart (bug-audit 2026-06-20, 0.A5).
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 /// Bookkeeping for an in-flight retry: how many delivery attempts the
@@ -44,7 +54,19 @@ struct PendingFire {
 
 impl Ticker {
     pub fn new(state: SharedSchedulerState, delivery: Arc<DeliveryBus>) -> Self {
-        Self { state, delivery }
+        Self {
+            state,
+            delivery,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    /// Wire the snapshot store so each tick that mutates schedule state is
+    /// written through to disk (see the `snapshot_store` field).
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
     }
 
     pub async fn run(self) {
@@ -58,16 +80,41 @@ impl Ticker {
         let mut retries: HashMap<(String, ScheduleKey), RetryState> = HashMap::new();
         loop {
             interval.tick().await;
-            self.tick(&mut cron_last_minute, &mut pending_fires, &mut retries);
+            self.tick_and_persist(&mut cron_last_minute, &mut pending_fires, &mut retries)
+                .await;
         }
     }
 
-    fn tick(
+    /// Run one tick and, if it changed persisted schedule state, write the
+    /// snapshot through. `last_fired` updates and one-shot `at(...)` deletions
+    /// are otherwise only in memory and lost on restart. Only persists on a
+    /// mutating tick, to avoid a snapshot every idle second.
+    async fn tick_and_persist(
         &self,
         cron_last_minute: &mut HashMap<(String, ScheduleKey), CronFireStamp>,
         pending_fires: &mut HashMap<(String, ScheduleKey), PendingFire>,
         retries: &mut HashMap<(String, ScheduleKey), RetryState>,
     ) {
+        let mutated = self.tick(cron_last_minute, pending_fires, retries);
+        if mutated {
+            save_scheduler_snapshot(
+                &self.state,
+                self.snapshot_store.clone(),
+                &self.snapshot_lock,
+            )
+            .await;
+        }
+    }
+
+    /// Run one firing pass. Returns `true` if it mutated persisted schedule
+    /// state (set `last_fired` on a fired schedule or deleted a completed
+    /// one-shot), so the caller knows to write the snapshot through.
+    fn tick(
+        &self,
+        cron_last_minute: &mut HashMap<(String, ScheduleKey), CronFireStamp>,
+        pending_fires: &mut HashMap<(String, ScheduleKey), PendingFire>,
+        retries: &mut HashMap<(String, ScheduleKey), RetryState>,
+    ) -> bool {
         let now = Utc::now();
         // Phase 1: collect due schedules while holding a short write lock.
         let mut due: Vec<(String, ScheduleKey)> = Vec::new();
@@ -246,6 +293,10 @@ impl Ticker {
                 }
             }
         }
+
+        // Any schedule that fired had its `last_fired` advanced (and a
+        // completed one-shot was deleted), so persisted state changed.
+        !due.is_empty()
     }
 }
 
@@ -874,6 +925,67 @@ mod tests {
         assert!(
             retries.is_empty(),
             "retry state must be cleared after success"
+        );
+    }
+
+    /// A SnapshotStore that records the last bytes saved (the real
+    /// MemorySnapshotStore is a no-op), so a test can assert the ticker wrote
+    /// through.
+    #[derive(Default)]
+    struct RecordingSnap {
+        bytes: std::sync::Mutex<Option<Vec<u8>>>,
+    }
+    impl fakecloud_persistence::SnapshotStore for RecordingSnap {
+        fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+            Ok(self.bytes.lock().unwrap().clone())
+        }
+        fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+            *self.bytes.lock().unwrap() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn fired_schedule_is_written_through() {
+        // A fired schedule advances last_fired in memory; without write-through
+        // it (and a self-deleted one-shot) is lost on restart (0.A5). A tick
+        // that fires must persist; an idle tick must not.
+        let state = make_state();
+        seed_schedule(
+            &state,
+            "r",
+            "rate(1 minute)",
+            "arn:aws:sqs:us-east-1:111122223333:q",
+        );
+        let store = Arc::new(RecordingSnap::default());
+        let ticker = Ticker::new(state.clone(), Arc::new(DeliveryBus::new()))
+            .with_snapshot_store(store.clone());
+        let mut cron = HashMap::new();
+        let mut pending = HashMap::new();
+        let mut retries = HashMap::new();
+
+        // First tick: rate schedule is due -> fires -> writes through.
+        ticker
+            .tick_and_persist(&mut cron, &mut pending, &mut retries)
+            .await;
+        assert!(
+            fakecloud_persistence::SnapshotStore::load(store.as_ref())
+                .unwrap()
+                .is_some(),
+            "a fired schedule must be written through to the snapshot"
+        );
+
+        // Reset the recorder; a second tick in the same minute isn't due again,
+        // so it must NOT snapshot (avoid a write every idle second).
+        *store.bytes.lock().unwrap() = None;
+        ticker
+            .tick_and_persist(&mut cron, &mut pending, &mut retries)
+            .await;
+        assert!(
+            fakecloud_persistence::SnapshotStore::load(store.as_ref())
+                .unwrap()
+                .is_none(),
+            "an idle tick must not snapshot"
         );
     }
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2821,6 +2821,11 @@ async fn main() {
         } else {
             None
         };
+    // Clone the snapshot store for the background ticker, which mutates
+    // schedule state (last_fired, one-shot deletion) outside the service's
+    // action-dispatch path and so must write through itself (bug-audit
+    // 2026-06-20, 0.A5).
+    let scheduler_ticker_snapshot_store = scheduler_snapshot_store.clone();
     let mut scheduler_service = SchedulerService::new(scheduler_state.clone());
     if let Some(store) = scheduler_snapshot_store {
         scheduler_service = scheduler_service.with_snapshot_store(store);
@@ -2927,8 +2932,11 @@ async fn main() {
     let delivery_for_scheduler_fire = delivery_for_scheduler.clone();
     let default_account_for_scheduler_fire = cli.account_id.clone();
     let default_region_for_scheduler_fire = cli.region.clone();
-    let scheduler_ticker =
+    let mut scheduler_ticker =
         fakecloud_scheduler::ticker::Ticker::new(scheduler_state.clone(), delivery_for_scheduler);
+    if let Some(store) = scheduler_ticker_snapshot_store {
+        scheduler_ticker = scheduler_ticker.with_snapshot_store(store);
+    }
     tokio::spawn(scheduler_ticker.run());
     // Spawn background tasks
     let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state.clone());


### PR DESCRIPTION
## Summary

The EventBridge Scheduler background ticker advances `last_fired` on every fire and deletes one-shot `at(...)` schedules on `ActionAfterCompletion=DELETE`, but it held no snapshot store and never persisted. Only the service's action-dispatch path triggers a snapshot, so in persistent mode:

- a fired-and-self-deleted one-shot reappeared after a restart (and could fire a second time), and
- rate-rule timing recomputed from scratch, firing once extra immediately on restart.

Fix: wire the snapshot store into the `Ticker`. `tick` now reports whether it changed persisted state, and the run loop writes the snapshot through only on a mutating tick (no write on idle seconds).

Found by the 2026-06-20 bug-hunt audit (finding 0.A5, #1766 side-channel-persistence class).

## Test plan

- `fired_schedule_is_written_through` — a tick that fires a rate schedule writes through to a recording snapshot store; a second idle tick in the same minute does not. Fails on the pre-fix code (nothing persisted).
- All 89 scheduler unit tests pass.
- `cargo clippy -p fakecloud-scheduler -p fakecloud --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted scheduler ticker state so fired one-shots stay deleted and rate schedules don’t double-fire after restart. Snapshots are written only on mutating ticks to avoid idle writes.

- **Bug Fixes**
  - `fakecloud-scheduler`: `Ticker` accepts a `SnapshotStore` via `with_snapshot_store`; new `tick_and_persist` writes snapshots only when `tick` mutates state (updates `last_fired`, deletes one-shots).
  - `fakecloud-server`: Wires the scheduler snapshot store into the background `Ticker`.
  - Adds `fired_schedule_is_written_through` test to verify persistence on fire and no snapshot on idle.

<sup>Written for commit 974f1e8956c196d32843cb01630d0d3e14a896cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

