### PR TITLE
fix(stepfunctions): persist execution terminal status + abort interrupted on restart

### DIFF
--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2564,6 +2564,17 @@ async fn main() {
                     "failed to read stepfunctions persistence snapshot: {err}"
                 )),
             }
+            // Executions that were RUNNING when the server stopped have no
+            // interpreter driving them anymore; abort them so they don't report
+            // RUNNING forever (bug-audit 2026-06-20, 0.A2).
+            let aborted =
+                fakecloud_stepfunctions::reconcile_interrupted_executions(&stepfunctions_state);
+            if aborted > 0 {
+                tracing::info!(
+                    aborted,
+                    "aborted stepfunctions executions interrupted by restart"
+                );
+            }
             Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
         } else {
             None

--- a/crates/fakecloud-stepfunctions/src/lib.rs
+++ b/crates/fakecloud-stepfunctions/src/lib.rs
@@ -6,7 +6,10 @@ pub mod io_processing;
 pub(crate) mod service;
 pub(crate) mod state;
 
-pub use service::{start_execution_from_delivery, SharedServiceRegistry, StepFunctionsService};
+pub use service::{
+    reconcile_interrupted_executions, start_execution_from_delivery, SharedServiceRegistry,
+    StepFunctionsService,
+};
 pub use state::{
     Activity, AliasRoute, Execution, SharedStepFunctionsState, StateMachine, StateMachineAlias,
     StateMachineStatus, StateMachineType, StateMachineVersion, StepFunctionsSnapshot,

--- a/crates/fakecloud-stepfunctions/src/service/executions.rs
+++ b/crates/fakecloud-stepfunctions/src/service/executions.rs
@@ -86,9 +86,19 @@ impl StepFunctionsService {
         let delivery = self.delivery.clone();
         let dynamodb_state = self.dynamodb_state.clone();
         let registry = self.registry.clone();
+        // The interpreter flips the execution to its terminal status
+        // (Succeeded/Failed/TimedOut) directly in shared state, outside the
+        // action-dispatch path that snapshots -- so the post-StartExecution
+        // save below only ever captured the RUNNING execution. Without writing
+        // through when the interpreter finishes, a completed execution reported
+        // stale RUNNING (with no output/history) after a restart, and an
+        // in-flight one came back RUNNING forever with no driver to advance it
+        // (bug-audit 2026-06-20, 0.A2).
+        let snapshot_store = self.snapshot_store.clone();
+        let snapshot_lock = self.snapshot_lock.clone();
         tokio::spawn(async move {
             interpreter::execute_state_machine(
-                shared_state,
+                shared_state.clone(),
                 exec_arn_clone,
                 definition,
                 input_clone,
@@ -98,6 +108,7 @@ impl StepFunctionsService {
                 logging_config,
             )
             .await;
+            super::save_stepfunctions_snapshot(&shared_state, snapshot_store, &snapshot_lock).await;
         });
 
         Ok(AwsResponse::ok_json(json!({

--- a/crates/fakecloud-stepfunctions/src/service/mod.rs
+++ b/crates/fakecloud-stepfunctions/src/service/mod.rs
@@ -183,6 +183,43 @@ pub async fn save_stepfunctions_snapshot(
     }
 }
 
+/// Abort executions that were RUNNING (or PENDING_REDRIVE) when the server
+/// stopped, called once after a persistence snapshot is loaded on startup.
+///
+/// The in-memory interpreter that was driving each one is gone after a restart,
+/// so the execution can never advance. Real Step Functions resumes from durable
+/// interpreter state; fakecloud can't, so leaving them RUNNING would strand them
+/// forever (DescribeExecution would report RUNNING with no way to ever finish).
+/// Aborting with a terminal stop date + error/cause is the honest outcome
+/// (bug-audit 2026-06-20, 0.A2). Returns the number reconciled.
+pub fn reconcile_interrupted_executions(state: &SharedStepFunctionsState) -> usize {
+    let now = Utc::now();
+    let mut count = 0;
+    let mut accounts = state.write();
+    let account_ids: Vec<String> = accounts.iter().map(|(id, _)| id.to_string()).collect();
+    for account_id in account_ids {
+        let Some(s) = accounts.get_mut(&account_id) else {
+            continue;
+        };
+        for exec in s.executions.values_mut() {
+            if matches!(
+                exec.status,
+                ExecutionStatus::Running | ExecutionStatus::PendingRedrive
+            ) {
+                exec.status = ExecutionStatus::Aborted;
+                exec.stop_date = Some(now);
+                exec.error = Some("Fakecloud.Restart".to_string());
+                exec.cause = Some(
+                    "Execution was interrupted by a fakecloud restart and cannot be resumed"
+                        .to_string(),
+                );
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
 fn is_mutating_action(action: &str) -> bool {
     matches!(
         action,
@@ -1704,6 +1741,58 @@ mod tests {
             .snapshot_hook()
             .expect("hook present when a store is set");
         hook().await;
+    }
+
+    fn make_execution(arn: &str, status: ExecutionStatus) -> Execution {
+        Execution {
+            execution_arn: arn.to_string(),
+            state_machine_arn: "arn:aws:states:us-east-1:123456789012:stateMachine:sm".to_string(),
+            state_machine_name: "sm".to_string(),
+            name: arn.to_string(),
+            status,
+            input: None,
+            output: None,
+            start_date: Utc::now(),
+            stop_date: None,
+            error: None,
+            cause: None,
+            history_events: vec![],
+            parent_execution_arn: None,
+            is_sync: false,
+            billed_duration_ms: None,
+            billed_memory_mb: None,
+        }
+    }
+
+    #[test]
+    fn reconcile_aborts_running_executions_on_restart() {
+        // After a restart a RUNNING execution has no interpreter driving it, so
+        // it must be aborted rather than left RUNNING forever (0.A2). A
+        // completed execution is untouched.
+        let state = make_state();
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_or_create("123456789012");
+            s.executions.insert(
+                "running".into(),
+                make_execution("running", ExecutionStatus::Running),
+            );
+            s.executions.insert(
+                "done".into(),
+                make_execution("done", ExecutionStatus::Succeeded),
+            );
+        }
+
+        let n = reconcile_interrupted_executions(&state);
+        assert_eq!(n, 1, "only the RUNNING execution is reconciled");
+
+        let accounts = state.read();
+        let s = accounts.get("123456789012").unwrap();
+        let running = &s.executions["running"];
+        assert_eq!(running.status, ExecutionStatus::Aborted);
+        assert!(running.stop_date.is_some());
+        assert_eq!(running.error.as_deref(), Some("Fakecloud.Restart"));
+        assert_eq!(s.executions["done"].status, ExecutionStatus::Succeeded);
     }
 }
 


### PR DESCRIPTION
## Summary

`StartExecution` spawns a background interpreter task that flips the execution to its terminal status (Succeeded/Failed/TimedOut) **directly in shared state**, outside the action-dispatch path that snapshots. The post-`StartExecution` save only captured the RUNNING execution, so in persistent mode:

- a completed execution reported stale `RUNNING` (with no output/history) after a restart, and
- an in-flight execution came back `RUNNING` forever with no interpreter to advance it — stuck permanently.

Two-part fix:

1. **Persist on completion** — the spawned task writes the snapshot through once `execute_state_machine` finishes, so the terminal status, output, and history are durable. (The sync `StartSyncExecution` path already persists via `handle`, since the interpreter runs inline.)
2. **Reconcile on restart** — `reconcile_interrupted_executions` runs after the snapshot loads and aborts any execution still marked `RUNNING`/`PENDING_REDRIVE`. Its interpreter is gone and it can never advance; real Step Functions resumes from durable interpreter state, fakecloud can't, so aborting (terminal stop date + `Fakecloud.Restart` error/cause) is the honest outcome instead of stranding it forever.

Found by the 2026-06-20 bug-hunt audit (finding 0.A2, #1766 side-channel-persistence class).

## Test plan

- `reconcile_aborts_running_executions_on_restart` — asserts a RUNNING execution is aborted with a stop date + `Fakecloud.Restart` error, and a completed one is untouched.
- All 187 stepfunctions unit tests pass.
- `cargo clippy -p fakecloud-stepfunctions -p fakecloud --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Step Functions execution terminal status on completion and abort executions left RUNNING after a restart to prevent stale or stuck executions. This fixes cases where executions showed RUNNING with no output/history or never progressed after a restart.

- **Bug Fixes**
  - Persist snapshot when the `StartExecution` interpreter finishes so terminal status, output, and history are saved.
  - On startup, reconcile and abort executions still `RUNNING`/`PENDING_REDRIVE` with a stop date and `Fakecloud.Restart` error.
  - Expose `reconcile_interrupted_executions` from `fakecloud-stepfunctions` and invoke it in `fakecloud-server` after loading the snapshot.
  - Add unit test `reconcile_aborts_running_executions_on_restart`; existing stepfunctions tests remain green.

<sup>Written for commit 51b3ca743bc490e896b883eab03e5fac53de811b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

