### PR TITLE
fix(cognito): persist Hosted-UI OAuth2 mutations across restart

### DIFF
--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -8,8 +8,8 @@ pub mod webauthn;
 pub use service::{
     ensure_pool_signing_key, handle_oauth2_authorize, handle_oauth2_revoke, handle_oauth2_token,
     handle_oauth2_userinfo, mint_authorization_code, oidc_discovery_document,
-    pool_existence_and_domain, pool_jwks_document, CognitoIdentityService, CognitoService,
-    MintAuthorizationCodeError, MintAuthorizationCodeRequest, OAuth2AuthorizeError,
+    pool_existence_and_domain, pool_jwks_document, save_cognito_snapshot, CognitoIdentityService,
+    CognitoService, MintAuthorizationCodeError, MintAuthorizationCodeRequest, OAuth2AuthorizeError,
     OAuth2AuthorizeOutcome, OAuth2AuthorizeRequest, OAuthRevokeError, OAuthTokenError,
     OAuthTokenResponse, OAuthUserInfoError,
 };

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 
 use crate::state::{
-    default_schema_attributes, AccessTokenData, AuthEvent, ChallengeResult, SessionData,
+    default_schema_attributes, AccessTokenData, AuthEvent, AuthorizationCodeData, ChallengeResult,
+    SessionData,
 };
 use crate::triggers;
 
@@ -7414,4 +7415,81 @@ async fn snapshot_hook_fires_with_store() {
         .snapshot_hook()
         .expect("hook present when a store is set");
     hook().await;
+}
+
+/// A SnapshotStore that records the last bytes saved (the real
+/// MemorySnapshotStore is a no-op), so a test can assert a write happened.
+#[derive(Default)]
+struct RecordingStore {
+    bytes: std::sync::Mutex<Option<Vec<u8>>>,
+}
+impl fakecloud_persistence::SnapshotStore for RecordingStore {
+    fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+        Ok(self.bytes.lock().unwrap().clone())
+    }
+    fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+        *self.bytes.lock().unwrap() = Some(bytes.to_vec());
+        Ok(())
+    }
+}
+
+#[test]
+fn oauth_token_maps_survive_snapshot_roundtrip() {
+    // The Hosted-UI OAuth2 routes (/oauth2/token, /authorize, /revoke, and the
+    // code-mint helper) mutate these maps directly; the restart fix writes them
+    // through via save_cognito_snapshot (bug-audit 2026-06-20, 0.A4). Prove the
+    // maps round-trip through the snapshot so a restart restores issued
+    // tokens/codes instead of invalidating them.
+    let (svc, pool_id) = setup_svc_with_pool();
+    {
+        let mut mas = svc.state.write();
+        let acct = mas.default_mut();
+        acct.access_tokens.insert(
+            "access-1".to_string(),
+            AccessTokenData {
+                user_pool_id: pool_id.clone(),
+                username: "alice".to_string(),
+                client_id: "client-1".to_string(),
+                issued_at: Utc::now(),
+            },
+        );
+        acct.authorization_codes.insert(
+            "code-1".to_string(),
+            AuthorizationCodeData {
+                user_pool_id: pool_id.clone(),
+                client_id: "client-1".to_string(),
+                username: "alice".to_string(),
+                redirect_uri: "https://app/callback".to_string(),
+                scopes: vec!["openid".to_string()],
+                code_challenge: None,
+                code_challenge_method: None,
+                nonce: None,
+                issued_at: Utc::now(),
+            },
+        );
+    }
+
+    let store: std::sync::Arc<dyn fakecloud_persistence::SnapshotStore> =
+        std::sync::Arc::new(RecordingStore::default());
+    let lock = tokio::sync::Mutex::new(());
+    block_on(save_cognito_snapshot(
+        &svc.state,
+        Some(store.clone()),
+        &lock,
+    ));
+
+    let bytes = fakecloud_persistence::SnapshotStore::load(store.as_ref())
+        .unwrap()
+        .expect("oauth mutation must be written through");
+    let snap: CognitoSnapshot = serde_json::from_slice(&bytes).unwrap();
+    let accounts = snap.accounts.expect("multi-account snapshot");
+    let acct = accounts.default_ref();
+    assert!(
+        acct.access_tokens.contains_key("access-1"),
+        "issued access token must persist"
+    );
+    assert!(
+        acct.authorization_codes.contains_key("code-1"),
+        "issued authorization code must persist"
+    );
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1942,6 +1942,15 @@ async fn main() {
         } else {
             None
         };
+    // The Cognito Hosted-UI OAuth2 endpoints (/oauth2/token, /oauth2/authorize,
+    // /oauth2/revoke, and the code-mint helper) mutate the token/code maps
+    // directly from their own axum routes, outside the service's action-dispatch
+    // path that snapshots -- so without writing through here, refresh/access
+    // tokens, authorization codes, and revocations were lost on restart
+    // (bug-audit 2026-06-20, 0.A4). Hand the routes a clone of the store and a
+    // shared lock; snapshot files are written atomically.
+    let cognito_oauth2_snapshot_store = cognito_snapshot_store.clone();
+    let cognito_oauth2_snapshot_lock = Arc::new(tokio::sync::Mutex::new(()));
     let mut cognito_service =
         CognitoService::new(cognito_state.clone()).with_delivery(cognito_delivery_ctx);
     if let Some(store) = cognito_snapshot_store {
@@ -4930,10 +4939,14 @@ async fn main() {
             "/oauth2/authorize",
             axum::routing::get({
                 let cs = cognito_authorize_state;
+                let store = cognito_oauth2_snapshot_store.clone();
+                let lock = cognito_oauth2_snapshot_lock.clone();
                 move |axum::extract::Query(q): axum::extract::Query<
                     std::collections::BTreeMap<String, String>,
                 >| {
                     let cs = cs.clone();
+                    let store = store.clone();
+                    let lock = lock.clone();
                     async move {
                         let region = std::env::var("AWS_DEFAULT_REGION")
                             .or_else(|_| std::env::var("AWS_REGION"))
@@ -4991,6 +5004,15 @@ async fn main() {
                         };
                         match fakecloud_cognito::handle_oauth2_authorize(&cs, &req, &region).await {
                             Ok(fakecloud_cognito::OAuth2AuthorizeOutcome::Redirect(url)) => {
+                                // A successful authorize minted an authorization
+                                // code (or implicit-grant token) in state; write
+                                // it through so it survives a restart (0.A4).
+                                fakecloud_cognito::save_cognito_snapshot(
+                                    &cs,
+                                    store.clone(),
+                                    &lock,
+                                )
+                                .await;
                                 let mut headers = axum::http::HeaderMap::new();
                                 if let Ok(loc) = axum::http::HeaderValue::from_str(&url) {
                                     headers.insert(axum::http::header::LOCATION, loc);
@@ -5032,8 +5054,12 @@ async fn main() {
             "/oauth2/token",
             axum::routing::post({
                 let cs = cognito_token_state;
+                let store = cognito_oauth2_snapshot_store.clone();
+                let lock = cognito_oauth2_snapshot_lock.clone();
                 move |headers: axum::http::HeaderMap, body: String| {
                     let cs = cs.clone();
+                    let store = store.clone();
+                    let lock = lock.clone();
                     async move {
                         let params: std::collections::BTreeMap<String, String> =
                             match serde_urlencoded::from_str::<Vec<(String, String)>>(&body) {
@@ -5055,7 +5081,17 @@ async fn main() {
                         )
                         .await
                         {
-                            Ok(resp) => (axum::http::StatusCode::OK, axum::Json(resp.to_json())),
+                            Ok(resp) => {
+                                // A successful grant minted refresh/access tokens
+                                // in state; write them through (0.A4).
+                                fakecloud_cognito::save_cognito_snapshot(
+                                    &cs,
+                                    store.clone(),
+                                    &lock,
+                                )
+                                .await;
+                                (axum::http::StatusCode::OK, axum::Json(resp.to_json()))
+                            }
                             Err(err) => {
                                 let status = axum::http::StatusCode::from_u16(err.status_code())
                                     .unwrap_or(axum::http::StatusCode::BAD_REQUEST);
@@ -5162,8 +5198,12 @@ async fn main() {
             "/oauth2/revoke",
             axum::routing::post({
                 let cs = cognito_revoke_state;
+                let store = cognito_oauth2_snapshot_store.clone();
+                let lock = cognito_oauth2_snapshot_lock.clone();
                 move |body: String| {
                     let cs = cs.clone();
+                    let store = store.clone();
+                    let lock = lock.clone();
                     async move {
                         let params: std::collections::BTreeMap<String, String> =
                             match serde_urlencoded::from_str::<Vec<(String, String)>>(&body) {
@@ -5171,10 +5211,20 @@ async fn main() {
                                 Err(_) => std::collections::BTreeMap::new(),
                             };
                         match fakecloud_cognito::handle_oauth2_revoke(&cs, &params) {
-                            Ok(()) => (
-                                axum::http::StatusCode::OK,
-                                axum::Json(serde_json::Value::Object(serde_json::Map::new())),
-                            ),
+                            Ok(()) => {
+                                // A successful revoke deleted the token from
+                                // state; write that deletion through (0.A4).
+                                fakecloud_cognito::save_cognito_snapshot(
+                                    &cs,
+                                    store.clone(),
+                                    &lock,
+                                )
+                                .await;
+                                (
+                                    axum::http::StatusCode::OK,
+                                    axum::Json(serde_json::Value::Object(serde_json::Map::new())),
+                                )
+                            }
                             Err(err) => {
                                 let (code, status) = match err {
                                     fakecloud_cognito::OAuthRevokeError::InvalidClient => (
@@ -5228,8 +5278,12 @@ async fn main() {
             "/_fakecloud/cognito/authorization-codes",
             axum::routing::post({
                 let cs = cognito_state.clone();
+                let store = cognito_oauth2_snapshot_store.clone();
+                let lock = cognito_oauth2_snapshot_lock.clone();
                 move |axum::Json(body): axum::Json<types::MintAuthorizationCodeRequest>| {
                     let cs = cs.clone();
+                    let store = store.clone();
+                    let lock = lock.clone();
                     async move {
                         let req = fakecloud_cognito::MintAuthorizationCodeRequest {
                             user_pool_id: body.user_pool_id,
@@ -5242,12 +5296,23 @@ async fn main() {
                             nonce: body.nonce,
                         };
                         match fakecloud_cognito::mint_authorization_code(&cs, &req) {
-                            Ok(code) => (
-                                axum::http::StatusCode::OK,
-                                axum::Json(serde_json::json!(
-                                    types::MintAuthorizationCodeResponse { code }
-                                )),
-                            ),
+                            Ok(code) => {
+                                // The minted authorization code lives in state;
+                                // write it through so it survives a restart
+                                // (0.A4).
+                                fakecloud_cognito::save_cognito_snapshot(
+                                    &cs,
+                                    store.clone(),
+                                    &lock,
+                                )
+                                .await;
+                                (
+                                    axum::http::StatusCode::OK,
+                                    axum::Json(serde_json::json!(
+                                        types::MintAuthorizationCodeResponse { code }
+                                    )),
+                                )
+                            }
                             Err(err) => {
                                 let (status, msg) = match err {
                                     fakecloud_cognito::MintAuthorizationCodeError::InvalidClient => (


### PR DESCRIPTION
## Summary

The Cognito Hosted-UI OAuth2 endpoints — `/oauth2/token`, `/oauth2/authorize`, `/oauth2/revoke`, and the `/_fakecloud/cognito/authorization-codes` mint helper — mutate the refresh-token, access-token, and authorization-code maps **directly from their own axum routes**, outside the service's action-dispatch path that snapshots. In persistent mode a restart lost all of them:

- refresh tokens issued via `/oauth2/token` -> `invalid_grant`
- persisted access tokens -> userInfo `invalid_token`
- a token revoked via `/oauth2/revoke` un-revoked (deletion lost)
- minted authorization codes vanished

Fix: write the cognito snapshot through on the success path of each of the four routes. The routes share a clone of the cognito snapshot store and a lock; snapshot files are written atomically.

Found by the 2026-06-20 bug-hunt audit (finding 0.A4, #1766 side-channel-persistence class).

## Test plan

- `oauth_token_maps_survive_snapshot_roundtrip` — inserts an access token + authorization code, saves via a recording snapshot store, reloads the `CognitoSnapshot`, and asserts both maps round-trip. Proves the persistence mechanism the routes now invoke.
- All cognito unit tests pass.
- `cargo clippy -p fakecloud-cognito -p fakecloud --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Cognito Hosted-UI OAuth2 state across restarts by snapshotting after successful authorize/token/revoke/code-mint routes. Fixes lost tokens/codes and prevents revoked tokens from reappearing in persistent mode.

- **Bug Fixes**
  - On success, write a Cognito snapshot in `/oauth2/authorize`, `/oauth2/token`, `/oauth2/revoke`, and `/_fakecloud/cognito/authorization-codes` using a shared snapshot store and lock (atomic writes).
  - Export `save_cognito_snapshot` from `fakecloud-cognito` and pass the store/lock into route handlers in `fakecloud-server`.
  - Add `oauth_token_maps_survive_snapshot_roundtrip` to verify access-token and authorization-code persistence.

<sup>Written for commit e4e63a1eef2c87ee5d6d647423d153b762a4e117. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

