### PR TITLE
fix(s3): guard inverted-XML slices in lifecycle + replication parsing (DoS)

### DIFF
--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2664,6 +2664,13 @@ pub(crate) fn validate_lifecycle_xml(xml: &str) -> Result<(), AwsServiceError> {
             if has_filter {
                 if let Some(fs) = rule_body.find("<Filter>") {
                     if let Some(fe) = rule_body.find("</Filter>") {
+                        // `find` locates the two tags independently, so a body
+                        // with `</Filter>` before `<Filter>` would slice with
+                        // begin > end and panic (dropping the connection -- a
+                        // reachable DoS). Reject as malformed instead.
+                        if fe < fs + 8 {
+                            return Err(malformed());
+                        }
                         let filter_body = &rule_body[fs + 8..fe];
                         let has_prefix_in_filter = filter_body.contains("<Prefix");
                         let has_tag_in_filter = filter_body.contains("<Tag>");

--- a/crates/fakecloud-s3/src/service/notifications.rs
+++ b/crates/fakecloud-s3/src/service/notifications.rs
@@ -72,10 +72,15 @@ pub(crate) fn normalize_replication_xml(xml: &str) -> String {
             let status =
                 extract_xml_value(rule_body, "Status").unwrap_or_else(|| "Enabled".to_string());
 
-            // Extract Destination block (keep as-is)
+            // Extract Destination block (keep as-is). The open/close tags are
+            // located independently, so a body with the closing tag before the
+            // opening one would slice with begin > end and panic (dropping the
+            // connection -- a reachable DoS). Guard each slice so a malformed
+            // ordering is skipped instead of crashing.
             let destination = rule_body.find("<Destination>").and_then(|ds| {
                 rule_body
                     .find("</Destination>")
+                    .filter(|&de| de >= ds)
                     .map(|de| rule_body[ds..de + 14].to_string())
             });
 
@@ -83,6 +88,7 @@ pub(crate) fn normalize_replication_xml(xml: &str) -> String {
             let filter_block = rule_body.find("<Filter>").and_then(|fs| {
                 rule_body
                     .find("</Filter>")
+                    .filter(|&fe| fe >= fs)
                     .map(|fe| rule_body[fs..fe + 9].to_string())
             });
 
@@ -90,6 +96,7 @@ pub(crate) fn normalize_replication_xml(xml: &str) -> String {
             let dmr_block = rule_body.find("<DeleteMarkerReplication>").and_then(|ds| {
                 rule_body
                     .find("</DeleteMarkerReplication>")
+                    .filter(|&de| de >= ds)
                     .map(|de| rule_body[ds..de + "</DeleteMarkerReplication>".len()].to_string())
             });
 
@@ -956,5 +963,36 @@ mod tests {
         assert_eq!(records[0]["s3"]["object"]["size"], 42);
         assert_eq!(records[0]["s3"]["object"]["eTag"], "etag");
         assert_eq!(records[0]["awsRegion"], "us-east-1");
+    }
+
+    #[test]
+    fn normalize_replication_xml_inverted_tags_does_not_panic() {
+        // A rule whose closing tags precede their opening tags would slice with
+        // begin > end and panic (dropping the connection -- a reachable DoS via
+        // PutBucketReplication). The normalizer must return without crashing
+        // (bug-audit 2026-06-20, 2.2).
+        let inverted_destination = "<ReplicationConfiguration><Rule><Status>Enabled</Status>\
+            </Destination>ZZZZZ<Destination></Rule></ReplicationConfiguration>";
+        let _ = normalize_replication_xml(inverted_destination);
+
+        let inverted_filter = "<ReplicationConfiguration><Rule><Status>Enabled</Status>\
+            </Filter>ZZZZZ<Filter></Rule></ReplicationConfiguration>";
+        let _ = normalize_replication_xml(inverted_filter);
+
+        let inverted_dmr = "<ReplicationConfiguration><Rule><Status>Enabled</Status>\
+            </DeleteMarkerReplication>ZZ<DeleteMarkerReplication></Rule></ReplicationConfiguration>";
+        let _ = normalize_replication_xml(inverted_dmr);
+    }
+
+    #[test]
+    fn validate_lifecycle_xml_inverted_filter_tags_is_malformed_not_panic() {
+        // `</Filter>` before `<Filter>` would slice the filter body with
+        // begin > end and panic (reachable DoS via
+        // PutBucketLifecycleConfiguration). It must be rejected as malformed
+        // instead (bug-audit 2026-06-20, 2.1).
+        let xml = "<LifecycleConfiguration><Rule><Status>Enabled</Status>\
+            </Filter>XXXXXXXX<Filter></Rule></LifecycleConfiguration>";
+        let result = crate::service::validate_lifecycle_xml(xml);
+        assert!(result.is_err(), "inverted <Filter> tags must be malformed");
     }
 }


### PR DESCRIPTION
## Summary

`PutBucketLifecycleConfiguration` and `PutBucketReplication` each locate an XML tag's open and close positions with independent `find()` calls, then slice between them. A request body where the **closing tag precedes the opening one** (e.g. `</Filter>...<Filter>`) produces a `begin > end` byte range and panics the request task — the client sees a dropped connection ("Connection was closed before we received a valid response"), a reachable DoS, not a 500.

Both reproduced standalone (`begin > end` slice panic). This is the #1748 / #1770 class: independent `find()` offsets sliced without an ordering check.

Fix:
- **Lifecycle** (`mod.rs`): reject the inverted `<Filter>`/`</Filter>` body as `MalformedXML`.
- **Replication** (`notifications.rs`): skip the malformed `Destination` / `Filter` / `DeleteMarkerReplication` block (guard with `.filter(|&close| close >= open)`) instead of crashing.

Found by the 2026-06-20 bug-hunt audit (findings 2.1, 2.2).

## Test plan

- `validate_lifecycle_xml_inverted_filter_tags_is_malformed_not_panic` — inverted `<Filter>` tags now return `MalformedXML` instead of panicking.
- `normalize_replication_xml_inverted_tags_does_not_panic` — inverted Destination/Filter/DeleteMarkerReplication bodies return without crashing.
- Both fail (panic) on the pre-fix code.
- `cargo clippy -p fakecloud-s3 --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a panic and dropped-connection DoS in S3 `PutBucketLifecycleConfiguration` and `PutBucketReplication` when XML closing tags appear before their opening tags. We now guard tag slices: lifecycle rejects malformed `<Filter>`, replication skips malformed `Destination`, `Filter`, and `DeleteMarkerReplication` blocks.

- **Bug Fixes**
  - Lifecycle: return `MalformedXML` when `</Filter>` precedes `<Filter>` instead of slicing with invalid bounds.
  - Replication: guard open/close indices and skip malformed `Destination`/`Filter`/`DeleteMarkerReplication` blocks to avoid crashes.

<sup>Written for commit 6f9bbad239e28e9096feb9c6eafd5dadb675be67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

