### PR TITLE
fix(lambda,ecs): authorize podman sibling host for local ECR pulls

### DIFF
--- a/crates/fakecloud-core/src/container_net.rs
+++ b/crates/fakecloud-core/src/container_net.rs
@@ -179,6 +179,30 @@ pub fn resolve_sibling_host(host_alias: &str, env_value: Option<String>) -> Stri
     }
 }
 
+/// Hostnames fakecloud's bundled ECR/OCI registry can be addressed by from a
+/// sibling container, each at `server_port`.
+///
+/// A container-spawning service rewrites the image pull URI to the runtime's
+/// sibling host -- `host.docker.internal` under Docker, `host.containers.internal`
+/// under podman -- or leaves it `127.0.0.1` when fakecloud runs on the host. The
+/// registry enforces auth, and the Docker/Podman CLI only attaches the
+/// `Authorization` header for hosts present in `config.json`, so the isolated
+/// pull config must list *every* alias or the pull gets a 401. The map
+/// previously omitted the podman alias, so image-based Lambda/ECS pulls failed
+/// under podman-in-a-container (bug-audit 2026-06-20, 0.B2). Authorize all of
+/// them with the same credential; centralized here so the two builders can't
+/// drift again.
+pub fn registry_auth_hosts(server_port: u16) -> Vec<String> {
+    [
+        "127.0.0.1",
+        "host.docker.internal",
+        "host.containers.internal",
+    ]
+    .iter()
+    .map(|host| format!("{host}:{server_port}"))
+    .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -187,6 +211,19 @@ mod tests {
     fn is_podman_binary_matches_bare_name() {
         assert!(is_podman_binary("podman"));
         assert!(is_podman_binary("podman-remote"));
+    }
+
+    #[test]
+    fn registry_auth_hosts_includes_podman_alias() {
+        // The podman sibling alias (host.containers.internal) must be authorized
+        // or image-based Lambda/ECS pulls 401 under podman-in-a-container (0.B2).
+        let hosts = registry_auth_hosts(4566);
+        assert!(hosts.contains(&"127.0.0.1:4566".to_string()));
+        assert!(hosts.contains(&"host.docker.internal:4566".to_string()));
+        assert!(
+            hosts.contains(&"host.containers.internal:4566".to_string()),
+            "podman sibling alias must be authorized: {hosts:?}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ecs/src/runtime/mod.rs
+++ b/crates/fakecloud-ecs/src/runtime/mod.rs
@@ -1530,19 +1530,21 @@ fn snapshot_task(state: &SharedEcsState, account_id: &str, task_id: &str) -> Opt
 /// Build an isolated docker config directory with Basic auth for
 /// fakecloud ECR. Lets `docker pull/push/tag` work against the local OCI
 /// v2 registry without requiring the user to run
-/// `aws ecr get-login-password | docker login` first. Authorizes both
-/// `127.0.0.1` (fakecloud on the host) and `host.docker.internal`
-/// (fakecloud in a container, pull URIs rewritten to the sibling host —
-/// issue #1539, bug 0.8).
+/// `aws ecr get-login-password | docker login` first. Authorizes every host
+/// fakecloud's ECR can be addressed by -- `127.0.0.1` (fakecloud on the host),
+/// `host.docker.internal` (Docker) and `host.containers.internal` (podman) when
+/// fakecloud runs in a container and pull URIs are rewritten to the sibling
+/// host. Centralized in container_net so Lambda and ECS can't drift (bug-audit
+/// 2026-06-20, 0.B2).
 fn build_local_registry_docker_config(server_port: u16) -> Option<TempDir> {
     let dir = TempDir::new().ok()?;
     let auth = base64::engine::general_purpose::STANDARD.encode("AWS:fakecloud-ecs-runtime");
-    let config = serde_json::json!({
-        "auths": {
-            format!("127.0.0.1:{server_port}"): { "auth": auth },
-            format!("host.docker.internal:{server_port}"): { "auth": auth },
-        }
-    });
+    let auths: serde_json::Map<String, serde_json::Value> =
+        fakecloud_core::container_net::registry_auth_hosts(server_port)
+            .into_iter()
+            .map(|host| (host, serde_json::json!({ "auth": auth })))
+            .collect();
+    let config = serde_json::json!({ "auths": auths });
     std::fs::write(dir.path().join("config.json"), config.to_string()).ok()?;
     Some(dir)
 }

--- a/crates/fakecloud-lambda/src/runtime/docker.rs
+++ b/crates/fakecloud-lambda/src/runtime/docker.rs
@@ -589,16 +589,17 @@ pub fn extract_zip(zip_bytes: &[u8], dest: &Path) -> Result<(), RuntimeError> {
 fn build_local_registry_docker_config(server_port: u16) -> Option<TempDir> {
     let dir = TempDir::new().ok()?;
     let auth = base64::engine::general_purpose::STANDARD.encode("AWS:fakecloud-lambda-runtime");
-    // Authorize both hostnames fakecloud's ECR can be addressed by:
-    // `127.0.0.1` on the host, and `host.docker.internal` when fakecloud
-    // runs in a container and the pull URI is rewritten to the sibling
-    // host (issue #1539, bug 0.8).
-    let config = serde_json::json!({
-        "auths": {
-            format!("127.0.0.1:{server_port}"): { "auth": auth },
-            format!("host.docker.internal:{server_port}"): { "auth": auth },
-        }
-    });
+    // Authorize every hostname fakecloud's ECR can be addressed by:
+    // `127.0.0.1` on the host, `host.docker.internal` (Docker) and
+    // `host.containers.internal` (podman) when fakecloud runs in a container and
+    // the pull URI is rewritten to the sibling host. Centralized in
+    // container_net so Lambda and ECS can't drift (bug-audit 2026-06-20, 0.B2).
+    let auths: serde_json::Map<String, serde_json::Value> =
+        fakecloud_core::container_net::registry_auth_hosts(server_port)
+            .into_iter()
+            .map(|host| (host, serde_json::json!({ "auth": auth })))
+            .collect();
+    let config = serde_json::json!({ "auths": auths });
     std::fs::write(dir.path().join("config.json"), config.to_string()).ok()?;
     Some(dir)
 }


### PR DESCRIPTION
## Summary

Image-based Lambda functions and ECS tasks pull from fakecloud's bundled ECR over an isolated `DOCKER_CONFIG` whose `auths` map only listed `127.0.0.1` and `host.docker.internal`. But when fakecloud runs **in a container under podman**, the pull URI is rewritten to the podman sibling alias `host.containers.internal` (which `resolve_sibling_host` already does correctly). The Docker/Podman CLI only attaches the `Authorization` header for hosts present in `config.json`, so the pull reached fakecloud's auth-enforcing OCI registry with **no credentials and got a 401** — the canonical "publish image + bind socket" setup, but under podman (the #1539-Bug-4 scenario, for podman).

Fix: centralize the authorized host list in `container_net::registry_auth_hosts` (`127.0.0.1` + both the docker and podman sibling aliases) and use it from both the Lambda and ECS config builders, so the two duplicated builders can't drift apart again.

Found by the 2026-06-20 bug-hunt audit (finding 0.B2).

## Test plan

- `registry_auth_hosts_includes_podman_alias` — asserts the authorized host set includes `host.containers.internal` (plus `127.0.0.1` and `host.docker.internal`).
- `cargo clippy -p fakecloud-core -p fakecloud-lambda -p fakecloud-ecs --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 401s on image pulls when running under podman by authorizing `host.containers.internal`, and centralizes the allowed ECR host list used by Lambda and ECS.

- **Bug Fixes**
  - Add `host.containers.internal` alongside `127.0.0.1` and `host.docker.internal` to the isolated `DOCKER_CONFIG` for local ECR pulls.
  - Centralize the list via `fakecloud-core`’s `container_net::registry_auth_hosts(server_port)` and use it in both `fakecloud-lambda` and `fakecloud-ecs` to avoid drift.

<sup>Written for commit b03525d370cddc7037abefe757bbe937c1a1d071. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

