### PR TITLE
fix(lambda): signal function errors + 404 unknown aliases on Invoke

### DIFF
--- a/crates/fakecloud-lambda/src/service/invoke.rs
+++ b/crates/fakecloud-lambda/src/service/invoke.rs
@@ -11,6 +11,30 @@ impl LambdaService {
         invocation_type: InvocationType,
         qualifier: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
+        // An unknown alias must 404 like GetFunction does, not silently fall
+        // through to $LATEST. resolve_qualifier_to_version returns None for both
+        // "$LATEST" and a non-existent alias, conflating "run live" with "not
+        // found" -- so a typo'd alias quietly invoked prod $LATEST. Reject an
+        // alias qualifier that doesn't exist here (bug-audit 2026-06-20, 1.9).
+        // Numeric versions keep the existing lenient fallback (a missing version
+        // snapshot is legacy state, handled below).
+        if let Some(q) = qualifier {
+            if q != "$LATEST" && !q.chars().all(|c| c.is_ascii_digit()) {
+                let accounts = self.state.read();
+                let empty = LambdaState::new(account_id, "");
+                let state = accounts.get(account_id).unwrap_or(&empty);
+                if !state.aliases.contains_key(&format!("{function_name}:{q}")) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "ResourceNotFoundException",
+                        format!(
+                            "Function not found: arn:aws:lambda:{}:{}:function:{function_name}:{q}",
+                            state.region, state.account_id
+                        ),
+                    ));
+                }
+            }
+        }
         // Resolve qualifier (alias / numeric version / $LATEST) to a
         // concrete version string. Aliases with a
         // `RoutingConfig.AdditionalVersionWeights` map do a weighted
@@ -236,11 +260,25 @@ impl LambdaService {
                 InvocationType::RequestResponse | InvocationType::DryRun => {
                     match runtime.invoke(&func, payload, &layer_zips).await {
                         Ok(response_bytes) => {
+                            // A handler that throws still returns HTTP 200 with
+                            // the error payload in the body; AWS signals it with
+                            // the `X-Amz-Function-Error` header (surfaced as
+                            // `FunctionError` by the SDKs). Without it, boto3/JS
+                            // callers treat a failed invocation as success. The
+                            // async Event branch already detects this envelope;
+                            // mirror it here (bug-audit 2026-06-20, 1.8).
+                            let is_function_error = is_function_error_payload(&response_bytes);
                             let mut resp = AwsResponse::json(StatusCode::OK, response_bytes);
                             if let Ok(v) = http::header::HeaderValue::from_str(&executed_version) {
                                 resp.headers.insert(
                                     http::header::HeaderName::from_static("x-amz-executed-version"),
                                     v,
+                                );
+                            }
+                            if is_function_error {
+                                resp.headers.insert(
+                                    http::header::HeaderName::from_static("x-amz-function-error"),
+                                    http::header::HeaderValue::from_static("Unhandled"),
                                 );
                             }
                             Ok(resp)
@@ -347,5 +385,41 @@ impl LambdaService {
             }
         }
         None
+    }
+}
+
+/// True when a synchronous invoke's response body is a Lambda function-error
+/// envelope (`{"errorMessage": ..., "errorType": ...}`). The runtime returns
+/// HTTP 200 with this body when the handler throws; the caller sets
+/// `X-Amz-Function-Error` so SDKs surface it as `FunctionError`
+/// (bug-audit 2026-06-20, 1.8).
+pub(crate) fn is_function_error_payload(bytes: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(bytes)
+        .ok()
+        .as_ref()
+        .and_then(|v| v.as_object())
+        .map(|m| m.contains_key("errorMessage") || m.contains_key("errorType"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod invoke_error_tests {
+    use super::is_function_error_payload;
+
+    #[test]
+    fn detects_function_error_envelope() {
+        assert!(is_function_error_payload(
+            br#"{"errorMessage":"boom","errorType":"Error"}"#
+        ));
+        assert!(is_function_error_payload(
+            br#"{"errorType":"Runtime.Error"}"#
+        ));
+    }
+
+    #[test]
+    fn plain_result_is_not_a_function_error() {
+        assert!(!is_function_error_payload(br#"{"statusCode":200}"#));
+        assert!(!is_function_error_payload(br#""just a string""#));
+        assert!(!is_function_error_payload(b"not json"));
     }
 }

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -3227,3 +3227,25 @@ async fn snapshot_hook_fires_with_store() {
     // Must not panic; exercises the closure and `save_lambda_snapshot`.
     hook().await;
 }
+
+#[tokio::test]
+async fn invoke_unknown_alias_returns_not_found() {
+    // A typo'd or nonexistent alias must 404 like GetFunction does, not silently
+    // fall through to $LATEST and run prod code (bug-audit 2026-06-20, 1.9).
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "afn").await;
+
+    let result = svc
+        .invoke(
+            "afn",
+            b"{}",
+            "123456789012",
+            InvocationType::RequestResponse,
+            Some("no-such-alias"),
+        )
+        .await;
+    match result {
+        Err(e) => assert_eq!(e.code(), "ResourceNotFoundException"),
+        Ok(_) => panic!("expected ResourceNotFoundException for an unknown alias"),
+    }
+}


### PR DESCRIPTION
## Summary

Two synchronous-`Invoke` correctness gaps (no error, wrong behavior):

1. **Missing `X-Amz-Function-Error` (1.8).** A handler that throws returns HTTP 200 with an error envelope (`{"errorMessage","errorType"}`) in the body, but the `RequestResponse` branch never set the `X-Amz-Function-Error` header. boto3/JS callers read `FunctionError` from that header, so they treated a **failed invocation as success**. The async `Event` branch already detects this envelope; this mirrors it on the sync path.

2. **Unknown alias silently runs `$LATEST` (1.9).** `resolve_qualifier_to_version` returns `None` for both `$LATEST` and a non-existent alias, conflating "run live" with "not found" — so a typo'd alias invoked prod `$LATEST`. `GetFunction` 404s on the same input. Now an alias qualifier that doesn't exist returns `ResourceNotFoundException`. Numeric versions keep the existing lenient fallback (a missing version snapshot is legacy state).

Found by the 2026-06-20 bug-hunt audit (findings 1.8, 1.9).

## Test plan

- `detects_function_error_envelope` / `plain_result_is_not_a_function_error` — unit-test the envelope detection that drives the header.
- `invoke_unknown_alias_returns_not_found` — invoking with an unknown alias returns `ResourceNotFoundException` (before the fix it fell through to `$LATEST`).
- `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Lambda Invoke correctness: sets `X-Amz-Function-Error` on handler errors and returns 404 for unknown alias qualifiers, matching AWS. This stops SDKs from treating failures as success and prevents silent `$LATEST` runs on alias typos.

- **Bug Fixes**
  - Sync `RequestResponse` now detects error envelopes and adds `X-Amz-Function-Error: Unhandled`.
  - Unknown alias qualifiers return `ResourceNotFoundException`; numeric versions keep the existing fallback.
  - Tests added for error-envelope detection and unknown-alias 404.

<sup>Written for commit ff1cf7cf2a824fdd3b543c3de7c0fc8ec3874351. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

