### PR TITLE
fix(kinesis): return null NextShardIterator for a closed, drained shard

### DIFF
--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -533,12 +533,23 @@ impl KinesisService {
             })
             .collect();
 
-        let millis_behind_latest = if end_index < shard.records.len() {
-            1
+        // Capture the shard fields before the borrow ends so the mutable
+        // `insert_iterator` call below can run.
+        let total_records = shard.records.len();
+        let shard_closed = !shard.is_open;
+
+        let millis_behind_latest = if end_index < total_records { 1 } else { 0 };
+
+        // A shard closed by SplitShard/MergeShards and then fully read returns a
+        // null NextShardIterator, signalling the consumer to move on to the
+        // child shard(s). Returning a live iterator forever (the old behaviour)
+        // makes KCL-style consumers loop on the parent shard and never advance
+        // past the split/merge (bug-audit 2026-06-20, 1.7).
+        let next_iterator = if shard_closed && end_index >= total_records {
+            Value::Null
         } else {
-            0
+            json!(state.insert_iterator(&lease.stream_name, &lease.shard_id, end_index))
         };
-        let next_iterator = state.insert_iterator(&lease.stream_name, &lease.shard_id, end_index);
 
         Ok(AwsResponse::ok_json(json!({
             "MillisBehindLatest": millis_behind_latest,

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -531,6 +531,61 @@ fn get_shard_iterator_and_records_happy_path() {
 }
 
 #[test]
+fn get_records_returns_null_iterator_for_closed_drained_shard() {
+    // After SplitShard/MergeShards closes a shard and the consumer has read it
+    // to the end, GetRecords must return NextShardIterator: null so the consumer
+    // advances to the child shard(s). Returning a live iterator forever traps
+    // KCL-style consumers on the parent (bug-audit 2026-06-20, 1.7).
+    let (svc, state) = make_service();
+    create_stream_action(&svc, "orders", 1);
+    svc.put_record(&request(
+        "PutRecord",
+        json!({
+            "StreamName": "orders",
+            "Data": base64::engine::general_purpose::STANDARD.encode(b"hi"),
+            "PartitionKey": "k1",
+        }),
+    ))
+    .unwrap();
+
+    // Close the shard, as SplitShard/MergeShards would.
+    let shard_id = {
+        let mut g = state.write();
+        let stream = g.default_mut().streams.get_mut("orders").unwrap();
+        stream.shards[0].is_open = false;
+        stream.shards[0].shard_id.clone()
+    };
+
+    let iter = json_response(
+        svc.get_shard_iterator(&request(
+            "GetShardIterator",
+            json!({
+                "StreamName": "orders",
+                "ShardId": shard_id,
+                "ShardIteratorType": "TRIM_HORIZON",
+            }),
+        ))
+        .unwrap(),
+    )["ShardIterator"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // The single record is drained in this call; the shard is closed and fully
+    // read, so NextShardIterator must be null.
+    let body = json_response(
+        svc.get_records(&request("GetRecords", json!({ "ShardIterator": iter })))
+            .unwrap(),
+    );
+    assert_eq!(body["Records"].as_array().unwrap().len(), 1);
+    assert!(
+        body["NextShardIterator"].is_null(),
+        "closed drained shard must return null NextShardIterator, got {:?}",
+        body["NextShardIterator"]
+    );
+}
+
+#[test]
 fn get_records_requires_shard_iterator() {
     let (svc, _) = make_service();
     assert_code_kinesis(


### PR DESCRIPTION
## Summary

`GetRecords` unconditionally minted a fresh `NextShardIterator` regardless of whether the shard was still open. After `SplitShard`/`MergeShards` closes a parent shard, a consumer that reads it to the end never received the `NextShardIterator: null` that signals "move on to the child shard(s)" — so KCL-style consumers looped on the parent shard forever and never advanced past the split/merge.

Fix: return `null` when the shard is closed (`is_open == false`) **and** the read reached the end of its records; otherwise keep minting a live iterator (including for a closed shard that still has buffered records left to drain).

Found by the 2026-06-20 bug-hunt audit (finding 1.7).

## Test plan

- `get_records_returns_null_iterator_for_closed_drained_shard` — closes a shard, drains its one record, and asserts `NextShardIterator` is null.
- `get_shard_iterator_and_records_happy_path` (existing) still returns a string iterator for an open shard.
- `cargo clippy -p fakecloud-kinesis --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GetRecords` in `fakecloud-kinesis` to return `NextShardIterator: null` when a shard is closed and drained, so consumers move to child shards. Prevents KCL-style consumers from looping on the parent after `SplitShard`/`MergeShards`; closed shards with remaining records still return a live iterator.

<sup>Written for commit 241ec2629329ee01de4da974bc11e639b43e3f3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

