### PR TITLE
fix(secretsmanager): decrypt SecretString in BatchGetSecretValue

### DIFF
--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -1570,7 +1570,19 @@ impl SecretsManagerService {
                                     "CreatedDate": version.created_at.timestamp_millis() as f64 / 1000.0,
                                 });
                                 if let Some(ref s) = version.secret_string {
-                                    entry["SecretString"] = json!(s);
+                                    // Decrypt the same way GetSecretValue does;
+                                    // pushing the raw stored value leaked
+                                    // ciphertext when a KMS hook + KmsKeyId were
+                                    // configured (bug-audit 2026-06-20, 1.10).
+                                    let plaintext = self
+                                        .maybe_decrypt_secret_string(
+                                            &req.account_id,
+                                            &secret.arn,
+                                            secret.kms_key_id.as_deref(),
+                                            Some(s.as_str()),
+                                        )
+                                        .unwrap_or_else(|| s.clone());
+                                    entry["SecretString"] = json!(plaintext);
                                 }
                                 if let Some(ref b) = version.secret_binary {
                                     entry["SecretBinary"] = json!(base64_encode(b));
@@ -1647,7 +1659,17 @@ impl SecretsManagerService {
                             "CreatedDate": version.created_at.timestamp_millis() as f64 / 1000.0,
                         });
                         if let Some(ref s) = version.secret_string {
-                            entry["SecretString"] = json!(s);
+                            // Decrypt like GetSecretValue; the raw stored value
+                            // is ciphertext under a configured KMS hook (1.10).
+                            let plaintext = self
+                                .maybe_decrypt_secret_string(
+                                    &req.account_id,
+                                    &secret.arn,
+                                    secret.kms_key_id.as_deref(),
+                                    Some(s.as_str()),
+                                )
+                                .unwrap_or_else(|| s.clone());
+                            entry["SecretString"] = json!(plaintext);
                         }
                         if let Some(ref b) = version.secret_binary {
                             entry["SecretBinary"] = json!(base64_encode(b));

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -2295,3 +2295,66 @@ async fn snapshot_hook_fires_with_store() {
         .expect("hook present when a store is set");
     hook().await;
 }
+
+/// A KMS hook that "encrypts" by prefixing `ENC:` and "decrypts" by stripping
+/// it, so a test can prove a read path returns plaintext, not the stored
+/// ciphertext.
+struct PrefixKmsHook;
+impl fakecloud_core::delivery::KmsHook for PrefixKmsHook {
+    fn encrypt(
+        &self,
+        _account_id: &str,
+        _region: &str,
+        _key_id: &str,
+        plaintext: &[u8],
+        _service_principal: &str,
+        _ctx: std::collections::HashMap<String, String>,
+    ) -> Result<String, String> {
+        Ok(format!("ENC:{}", String::from_utf8_lossy(plaintext)))
+    }
+    fn decrypt(
+        &self,
+        _account_id: &str,
+        ciphertext_b64: &str,
+        _service_principal: &str,
+        _ctx: std::collections::HashMap<String, String>,
+    ) -> Result<Vec<u8>, String> {
+        Ok(ciphertext_b64
+            .strip_prefix("ENC:")
+            .unwrap_or(ciphertext_b64)
+            .as_bytes()
+            .to_vec())
+    }
+}
+
+#[tokio::test]
+async fn batch_get_secret_value_returns_plaintext_not_ciphertext() {
+    // GetSecretValue decrypts a KMS-backed secret, but BatchGetSecretValue
+    // pushed the raw stored ciphertext -- so a batch fetch returned an
+    // unusable encrypted blob (bug-audit 2026-06-20, 1.10).
+    let state = make_state();
+    let svc = SecretsManagerService::new(state).with_kms_hook(std::sync::Arc::new(PrefixKmsHook));
+
+    let req = make_request(
+        "CreateSecret",
+        r#"{"Name":"enc-secret","SecretString":"topsecret","KmsKeyId":"alias/test"}"#,
+    );
+    svc.handle(req).await.unwrap();
+
+    // Sanity: single-get decrypts.
+    let req = make_request("GetSecretValue", r#"{"SecretId":"enc-secret"}"#);
+    let single: Value =
+        serde_json::from_slice(svc.handle(req).await.unwrap().body.expect_bytes()).unwrap();
+    assert_eq!(single["SecretString"], "topsecret");
+
+    // The fix: batch must decrypt too.
+    let body = serde_json::json!({ "SecretIdList": ["enc-secret"] });
+    let req = make_request("BatchGetSecretValue", &body.to_string());
+    let batch: Value =
+        serde_json::from_slice(svc.handle(req).await.unwrap().body.expect_bytes()).unwrap();
+    let v = &batch["SecretValues"].as_array().unwrap()[0];
+    assert_eq!(
+        v["SecretString"], "topsecret",
+        "BatchGetSecretValue must return plaintext, not ciphertext"
+    );
+}


### PR DESCRIPTION
## Summary

`GetSecretValue` runs the configured KMS hook to decrypt a secret's stored value, but `BatchGetSecretValue` pushed the **raw stored string** straight into the response. With a KMS hook + `KmsKeyId` configured, single-get returned plaintext while a batch fetch returned the **encrypted blob** — silent wrong data that apps batching secret reads can't use.

Fix: decrypt on both `BatchGetSecretValue` paths (the `SecretIdList` branch and the filter branch), exactly like `GetSecretValue`.

Found by the 2026-06-20 bug-hunt audit (finding 1.10).

## Test plan

- `batch_get_secret_value_returns_plaintext_not_ciphertext` — with a mock KMS hook, creates a secret with `KmsKeyId`, then asserts both `GetSecretValue` and `BatchGetSecretValue` return the decrypted plaintext (before the fix, batch returned the `ENC:`-prefixed ciphertext).
- `cargo clippy -p fakecloud-secretsmanager --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decrypts `SecretString` in `BatchGetSecretValue` so batch reads return plaintext, matching `GetSecretValue`. Fixes incorrect encrypted responses when a KMS hook and `KmsKeyId` are configured.

- **Bug Fixes**
  - Decrypt `SecretString` in both `BatchGetSecretValue` branches (`SecretIdList` and filter), mirroring `GetSecretValue`.
  - Added `batch_get_secret_value_returns_plaintext_not_ciphertext` test to verify plaintext is returned with a mock KMS hook.

<sup>Written for commit db020e237b70eb22a5b704fab706b93611a4054a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

