### PR TITLE
fix(cognito): validate AdminCreateUser TemporaryPassword against pool policy

### DIFF
--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -7493,3 +7493,46 @@ fn oauth_token_maps_survive_snapshot_roundtrip() {
         "issued authorization code must persist"
     );
 }
+
+#[test]
+fn admin_create_user_validates_temporary_password_against_policy() {
+    // A supplied TemporaryPassword must satisfy the pool's password policy,
+    // exactly like SignUp/AdminSetUserPassword; the old code stored it
+    // unchecked, bypassing the policy for admin-provisioned users
+    // (bug-audit 2026-06-20, 1.12).
+    let state = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4569",
+        ),
+    ));
+    let svc = CognitoService::new(state);
+    let resp = block_on(svc.create_user_pool(&make_req(
+        "CreateUserPool",
+        r#"{"PoolName":"p","Policies":{"PasswordPolicy":{"MinimumLength":8,"RequireUppercase":true}}}"#,
+    )))
+    .unwrap();
+    let pool_id = serde_json::from_slice::<Value>(resp.body.expect_bytes()).unwrap()["UserPool"]
+        ["Id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Weak temporary password -> rejected.
+    let weak = make_req(
+        "AdminCreateUser",
+        &format!(r#"{{"UserPoolId":"{pool_id}","Username":"u1","TemporaryPassword":"short"}}"#),
+    );
+    match block_on(svc.admin_create_user(&weak)) {
+        Err(e) => assert_eq!(e.code(), "InvalidPasswordException"),
+        Ok(_) => panic!("a weak TemporaryPassword must be rejected"),
+    }
+
+    // Policy-conforming temporary password -> accepted.
+    let strong = make_req(
+        "AdminCreateUser",
+        &format!(r#"{{"UserPoolId":"{pool_id}","Username":"u2","TemporaryPassword":"Strong123"}}"#),
+    );
+    block_on(svc.admin_create_user(&strong)).unwrap();
+}

--- a/crates/fakecloud-cognito/src/service/users.rs
+++ b/crates/fakecloud-cognito/src/service/users.rs
@@ -55,6 +55,20 @@ impl CognitoService {
             // Validate pool exists
             ensure_user_pool_exists(state, pool_id)?;
 
+            // A supplied TemporaryPassword must satisfy the pool's password
+            // policy, like SignUp and AdminSetUserPassword do. The old code
+            // stored it unchecked, bypassing the policy for admin-provisioned
+            // users (bug-audit 2026-06-20, 1.12).
+            if let Some(temp_pw) = body["TemporaryPassword"].as_str() {
+                let policy = state
+                    .user_pools
+                    .get(pool_id)
+                    .map(|p| p.policies.password_policy.clone());
+                if let Some(policy) = policy {
+                    validate_password(temp_pw, &policy)?;
+                }
+            }
+
             // Check username doesn't already exist
             let pool_users = state.users.entry(pool_id.to_string()).or_default();
             if pool_users.contains_key(username) {


### PR DESCRIPTION
## Summary

`SignUp` and `AdminSetUserPassword` run `validate_password` against the pool's password policy, but `AdminCreateUser` stored the supplied `TemporaryPassword` **unchecked**. A pool requiring e.g. `MinimumLength=8` + uppercase accepted `AdminCreateUser(TemporaryPassword="weak")`, bypassing the policy for admin-provisioned users — AWS returns `InvalidPasswordException`.

Fix: validate a supplied `TemporaryPassword` against the pool's password policy before creating the user. Omitting it stays valid (Cognito generates one).

Found by the 2026-06-20 bug-hunt audit (finding 1.12).

## Test plan

- `admin_create_user_validates_temporary_password_against_policy` — a pool with `MinimumLength=8`/`RequireUppercase` rejects a weak `TemporaryPassword` with `InvalidPasswordException` and accepts a conforming one.
- `cargo clippy -p fakecloud-cognito --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `AdminCreateUser` `TemporaryPassword` against the user pool password policy to prevent bypassing requirements and match AWS behavior (returns `InvalidPasswordException` on weak passwords).

- **Bug Fixes**
  - Enforce password policy when a `TemporaryPassword` is provided; omission still allowed (Cognito generates one).
  - Added test to reject weak passwords and accept compliant ones in `fakecloud-cognito`.

<sup>Written for commit bd3a28522006f72802e42e62118b000c43278e3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

