### PR TITLE
fix(dynamodb): validate key attribute types in the classic item API

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/helpers/keys.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/keys.rs
@@ -91,6 +91,10 @@ pub(crate) fn validate_key_in_item(
             ));
         }
     }
+    check_key_type(table, item, hash_key)?;
+    if let Some(range_key) = table.range_key_name() {
+        check_key_type(table, item, range_key)?;
+    }
     Ok(())
 }
 
@@ -117,6 +121,48 @@ pub(crate) fn validate_key_attributes_in_key(
                 format!("Missing the key {range_key} in the item"),
             ));
         }
+    }
+    check_key_type(table, key, hash_key)?;
+    if let Some(range_key) = table.range_key_name() {
+        check_key_type(table, key, range_key)?;
+    }
+    Ok(())
+}
+
+/// Verify a key attribute present in `attrs` carries the scalar type declared
+/// in the table's AttributeDefinitions. AWS rejects a wrong-typed key with
+/// ValidationException; without this a `pk: S` table silently stored
+/// `{"pk":{"N":"1"}}`, after which a correctly-typed GetItem couldn't find the
+/// row -- the data appeared to vanish (bug-audit 2026-06-20, 1.13). The
+/// PartiQL path already enforced this; the classic item API didn't.
+fn check_key_type(
+    table: &DynamoTable,
+    attrs: &HashMap<String, AttributeValue>,
+    name: &str,
+) -> Result<(), AwsServiceError> {
+    let Some(val) = attrs.get(name) else {
+        return Ok(());
+    };
+    let Some(expected) = table
+        .attribute_definitions
+        .iter()
+        .find(|d| d.attribute_name == name)
+        .map(|d| d.attribute_type.as_str())
+    else {
+        return Ok(());
+    };
+    let actual = val
+        .as_object()
+        .and_then(|o| o.keys().next().map(|k| k.as_str()));
+    if actual != Some(expected) {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            format!(
+                "One or more parameter values were invalid: Type mismatch for key {name} expected: {expected} actual: {}",
+                actual.unwrap_or("NULL"),
+            ),
+        ));
     }
     Ok(())
 }

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -163,6 +163,7 @@ impl DynamoDbService {
             let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
             let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
             let table = get_table(&state.tables, table_name)?;
+            validate_key_attributes_in_key(table, &key)?;
             let needs_insights = table.contributor_insights_status == "ENABLED";
 
             let mut result = match table.find_item_index(&key) {

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -5025,3 +5025,51 @@ async fn snapshot_hook_fires_with_store() {
         .expect("hook present when a store is set");
     hook().await;
 }
+
+#[test]
+fn put_item_rejects_wrong_key_attribute_type() {
+    // The `pk` key is declared S; PutItem with `pk: {N: ...}` must be a
+    // ValidationException, not a silent store of a malformed key that a
+    // correctly-typed GetItem can never find (bug-audit 2026-06-20, 1.13).
+    let svc = make_service();
+    create_test_table(&svc);
+
+    let bad = make_request(
+        "PutItem",
+        json!({
+            "TableName": "test-table",
+            "Item": { "pk": { "N": "1" } }
+        }),
+    );
+    match svc.put_item(&bad) {
+        Err(e) => assert_eq!(e.code(), "ValidationException"),
+        Ok(_) => panic!("a wrong-typed key must be rejected"),
+    }
+
+    // The correctly-typed key still works.
+    let good = make_request(
+        "PutItem",
+        json!({
+            "TableName": "test-table",
+            "Item": { "pk": { "S": "ok" } }
+        }),
+    );
+    svc.put_item(&good).unwrap();
+}
+
+#[test]
+fn get_item_rejects_wrong_key_attribute_type() {
+    let svc = make_service();
+    create_test_table(&svc);
+    let bad = make_request(
+        "GetItem",
+        json!({
+            "TableName": "test-table",
+            "Key": { "pk": { "N": "1" } }
+        }),
+    );
+    match svc.get_item(&bad) {
+        Err(e) => assert_eq!(e.code(), "ValidationException"),
+        Ok(_) => panic!("a wrong-typed key must be rejected on GetItem"),
+    }
+}


### PR DESCRIPTION
## Summary

Key validation only checked that the hash/range key was **present**, never that its `AttributeValue` type matched the `AttributeDefinitions`. A table with `pk: S` accepted `PutItem {"pk":{"N":"1"}}` and stored a malformed key; a later correctly-typed `GetItem` couldn't find the row, so the data appeared to vanish. The PartiQL path already enforced this; the classic item API didn't.

Fix: type-check the key attributes against `AttributeDefinitions` (S/N/B) in `validate_key_in_item` (PutItem) and `validate_key_attributes_in_key` (GetItem/UpdateItem/DeleteItem/batch), rejecting a mismatch with `ValidationException` like AWS. (GetItem now also runs the key validator.)

Found by the 2026-06-20 bug-hunt audit (finding 1.13).

## Test plan

- `put_item_rejects_wrong_key_attribute_type` — `pk:{N}` on an `S` table → `ValidationException`; `pk:{S}` still works.
- `get_item_rejects_wrong_key_attribute_type` — same on GetItem.
- Full DynamoDB suite: 310 passed.
- `cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate DynamoDB key attribute types (S/N/B) in the classic item API to match table AttributeDefinitions. Wrong-typed keys now return `ValidationException`, preventing malformed writes and “vanishing item” cases, and aligning behavior with AWS and our PartiQL path.

- **Bug Fixes**
  - Type-check hash/range keys against AttributeDefinitions for all classic item ops via `check_key_type` in `validate_key_in_item` and `validate_key_attributes_in_key`.
  - Run key validation on `GetItem`; add tests to assert `ValidationException` for mismatched types and cover the prior “vanishing item” bug.

<sup>Written for commit 416ab635743cfe65f00a057e77a9a5947c589595. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

