### PR TITLE
fix(route53,cloudfront): route trailing-slash collection paths to List

### DIFF
--- a/crates/fakecloud-cloudfront/src/router.rs
+++ b/crates/fakecloud-cloudfront/src/router.rs
@@ -52,11 +52,11 @@ impl Route {
 pub fn route(method: &Method, path: &str, raw_query: &str) -> Option<Route> {
     let path = path.strip_prefix("/2020-05-31").unwrap_or(path);
     let path = path.trim_start_matches('/');
-    let segs: Vec<&str> = if path.is_empty() {
-        Vec::new()
-    } else {
-        path.split('/').collect()
-    };
+    // Filter out empty segments so a trailing slash (`/distribution/`, which
+    // botocore/AWS CLI < 1.40 and curl emit for a collection root) routes to the
+    // List op, not GetDistribution(id="") -> NoSuchDistribution (the #1645
+    // shape; bug-audit 2026-06-20, 1.1).
+    let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
     let q = QueryFlags::parse(raw_query);
     match (method, segs.as_slice()) {
         // ─── Distributions ──────────────────────────────────────────
@@ -574,6 +574,14 @@ mod tests {
         let r = route(&Method::GET, "/2020-05-31/distribution/EDFDVBD632BHDS5", "").unwrap();
         assert_eq!(r.action, "GetDistribution");
         assert_eq!(r.id.as_deref(), Some("EDFDVBD632BHDS5"));
+    }
+
+    #[test]
+    fn trailing_slash_collection_routes_to_list() {
+        // A trailing slash on the collection root must list, not
+        // GetDistribution(id="") -> NoSuchDistribution (1.1).
+        let r = route(&Method::GET, "/2020-05-31/distribution/", "").unwrap();
+        assert_eq!(r.action, "ListDistributions");
     }
 
     #[test]

--- a/crates/fakecloud-route53/src/router.rs
+++ b/crates/fakecloud-route53/src/router.rs
@@ -44,11 +44,11 @@ pub fn route(method: &Method, path: &str, _raw_query: &str) -> Option<Route> {
         return None;
     }
     let path = path.trim_start_matches('/');
-    let segs: Vec<&str> = if path.is_empty() {
-        Vec::new()
-    } else {
-        path.split('/').collect()
-    };
+    // Filter out empty segments so a trailing slash (`/hostedzone/`, which
+    // botocore/AWS CLI < 1.40 and curl emit for a collection root) routes to the
+    // List op, not GetHostedZone(id="") -> NoSuchHostedZone (the #1645 shape;
+    // bug-audit 2026-06-20, 1.1).
+    let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
 
     match (method, segs.as_slice()) {
         // ─── Hosted Zones ────────────────────────────────────────────
@@ -263,6 +263,21 @@ mod tests {
         assert_eq!(
             route(&Method::POST, "/2013-04-01/hostedzone/Z123/rrset", ""),
             Some(Route::with_id("ChangeResourceRecordSets", "Z123"))
+        );
+    }
+
+    #[test]
+    fn trailing_slash_collection_routes_to_list() {
+        // botocore/AWS CLI < 1.40 and curl append `/` to a bare collection URI;
+        // it must route to the List op, not GetHostedZone(id="") (1.1).
+        assert_eq!(
+            route(&Method::GET, "/2013-04-01/hostedzone/", ""),
+            Some(Route::just("ListHostedZones"))
+        );
+        // Without a trailing slash still lists.
+        assert_eq!(
+            route(&Method::GET, "/2013-04-01/hostedzone", ""),
+            Some(Route::just("ListHostedZones"))
         );
     }
 }


### PR DESCRIPTION
## Summary

Both routers split the path on `/` keeping empty segments, so a collection root with a trailing slash (`/2013-04-01/hostedzone/`, `/2020-05-31/distribution/`) split to `["hostedzone", ""]` and matched the `{id}` arm with an **empty id** → `GetHostedZone("")` / `GetDistribution("")` → `NoSuchHostedZone` / `NoSuchDistribution`.

botocore / AWS CLI < 1.40 and curl append that trailing slash to a bare collection URI, so every such client got a 404 instead of a listing. Same root cause as #1645 (which fixed it for Lambda).

Fix: filter empty path segments (the canonical Lambda/Scheduler pattern) so a trailing slash routes to the List op.

**Bedrock** was also flagged (finding 1.1) but its router *intentionally* retains empty segments to drive missing-identifier validation for `automated-reasoning-policies` (see the comment in `resolve_action`), and a single `/X/` is ambiguous there between "list" and "missing id". It needs a separate, route-aware fix and is left unchanged here.

Found by the 2026-06-20 bug-hunt audit (finding 1.1).

## Test plan

- `trailing_slash_collection_routes_to_list` (Route53 + CloudFront) — `/hostedzone/` → `ListHostedZones`, `/distribution/` → `ListDistributions`.
- Full router suites: route53 48 passed, cloudfront 39 passed.
- `cargo clippy` clean on all three crates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix trailing-slash routing for collection roots in Route53 and CloudFront. `/2013-04-01/hostedzone/` and `/2020-05-31/distribution/` now call ListHostedZones/ListDistributions instead of Get with an empty ID, avoiding 404s for `botocore`/AWS CLI < 1.40 and `curl`.

- **Bug Fixes**
  - Filter empty path segments in `fakecloud-route53` and `fakecloud-cloudfront` routers so trailing slashes route to List.
  - Added tests to cover these routes; left Bedrock router unchanged due to its different, validation-oriented routing rules.

<sup>Written for commit 3f9d20db64f9dd505ac2bf8861462507650901fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

