### PR TITLE
fix(rds): render ModifyDBCluster fields in DescribeDBClusters

### DIFF
--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -1077,6 +1077,46 @@ fn modify_db_cluster_persists_extended_fields() {
 }
 
 #[test]
+fn describe_db_clusters_renders_modified_fields() {
+    // ModifyDBCluster persisted these, but the DescribeDBClusters renderer
+    // omitted them, so a describe echoed the create-time defaults
+    // (bug-audit 2026-06-20, 1.17).
+    let svc = svc();
+    create_cluster(&svc, "c1");
+    svc.handle_extra_action(&req(
+        "ModifyDBCluster",
+        &[
+            ("DBClusterIdentifier", "c1"),
+            ("StorageType", "io1"),
+            ("Iops", "3000"),
+            ("BacktrackWindow", "86400"),
+            ("EnableIAMDatabaseAuthentication", "true"),
+            ("ServerlessV2ScalingConfiguration.MinCapacity", "0.5"),
+            ("ServerlessV2ScalingConfiguration.MaxCapacity", "8.0"),
+        ],
+    ))
+    .expect("ModifyDBCluster");
+
+    let resp = svc
+        .handle_extra_action(&req("DescribeDBClusters", &[]))
+        .expect("DescribeDBClusters");
+    let xml = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(xml.contains("<StorageType>io1</StorageType>"), "{xml}");
+    assert!(xml.contains("<Iops>3000</Iops>"), "{xml}");
+    assert!(
+        xml.contains("<BacktrackWindow>86400</BacktrackWindow>"),
+        "{xml}"
+    );
+    assert!(
+        xml.contains("<IAMDatabaseAuthenticationEnabled>true</IAMDatabaseAuthenticationEnabled>"),
+        "{xml}"
+    );
+    assert!(xml.contains("<ServerlessV2ScalingConfiguration>"), "{xml}");
+    assert!(xml.contains("<MinCapacity>0.5</MinCapacity>"), "{xml}");
+    assert!(xml.contains("<MaxCapacity>8.0</MaxCapacity>"), "{xml}");
+}
+
+#[test]
 fn failover_db_cluster_picks_replica_when_no_target() {
     let svc = svc();
     create_cluster(&svc, "c1");

--- a/crates/fakecloud-rds/src/extras/xml_renderers.rs
+++ b/crates/fakecloud-rds/src/extras/xml_renderers.rs
@@ -194,6 +194,73 @@ pub(super) fn db_cluster_member_xml(v: &Value) -> String {
         }
         out.push_str("          </DBClusterMembers>\n");
     }
+
+    // Scalar fields ModifyDBCluster (and CreateDBCluster) persist that the
+    // hand-written renderer above omitted, so DescribeDBClusters reflects a
+    // modify instead of always echoing the create-time defaults (bug-audit
+    // 2026-06-20, 1.17). Keys already rendered above are deliberately excluded.
+    for key in [
+        "StorageType",
+        "DBClusterInstanceClass",
+        "EngineMode",
+        "NetworkType",
+        "MonitoringRoleArn",
+        "PerformanceInsightsKMSKeyId",
+        "Domain",
+        "DomainIAMRoleName",
+        "CACertificateIdentifier",
+        "MasterUserSecretKmsKeyId",
+        "AwsBackupRecoveryPointArn",
+        "GlobalWriteForwardingStatus",
+        "LocalWriteForwardingStatus",
+    ] {
+        if let Some(s) = v[key].as_str() {
+            out.push_str(&format!("          <{key}>{}</{key}>\n", xml_escape(s)));
+        }
+    }
+    for key in [
+        "Iops",
+        "BacktrackWindow",
+        "MonitoringInterval",
+        "PerformanceInsightsRetentionPeriod",
+    ] {
+        if let Some(n) = v[key].as_i64() {
+            out.push_str(&format!("          <{key}>{n}</{key}>\n"));
+        }
+    }
+    for key in [
+        "IAMDatabaseAuthenticationEnabled",
+        "CopyTagsToSnapshot",
+        "AutoMinorVersionUpgrade",
+        "HttpEndpointEnabled",
+        "PerformanceInsightsEnabled",
+        "ManageMasterUserPassword",
+    ] {
+        if let Some(b) = v[key].as_bool() {
+            out.push_str(&format!("          <{key}>{b}</{key}>\n"));
+        }
+    }
+    // ServerlessV2ScalingConfiguration is stored as flattened
+    // `ServerlessV2ScalingConfiguration.{Min,Max}Capacity` keys; render it back
+    // as the nested element AWS returns.
+    let v2_min = v["ServerlessV2ScalingConfiguration.MinCapacity"].as_str();
+    let v2_max = v["ServerlessV2ScalingConfiguration.MaxCapacity"].as_str();
+    if v2_min.is_some() || v2_max.is_some() {
+        out.push_str("          <ServerlessV2ScalingConfiguration>\n");
+        if let Some(m) = v2_min {
+            out.push_str(&format!(
+                "            <MinCapacity>{}</MinCapacity>\n",
+                xml_escape(m)
+            ));
+        }
+        if let Some(m) = v2_max {
+            out.push_str(&format!(
+                "            <MaxCapacity>{}</MaxCapacity>\n",
+                xml_escape(m)
+            ));
+        }
+        out.push_str("          </ServerlessV2ScalingConfiguration>\n");
+    }
     out
 }
 


### PR DESCRIPTION
## Summary

`ModifyDBCluster` persisted ~20 mutable cluster fields, but the `DescribeDBClusters` XML renderer only emitted a subset — so a describe after a modify echoed the **create-time defaults** for `StorageType`, `Iops`, `BacktrackWindow`, `IAMDatabaseAuthenticationEnabled`, `ServerlessV2ScalingConfiguration`, the monitoring / performance-insights fields, and others. The data was already in state; only the renderer lagged (a pure render gap).

Fix: render the omitted scalar fields (string/int/bool) and the nested `ServerlessV2ScalingConfiguration` element, excluding the keys already emitted so nothing double-renders.

Found by the 2026-06-20 bug-hunt audit (finding 1.17).

## Test plan

- `describe_db_clusters_renders_modified_fields` — modifies StorageType/Iops/BacktrackWindow/IAM-auth/ServerlessV2 and asserts `DescribeDBClusters` XML now contains each.
- Full RDS suite: 219 passed.
- `cargo clippy -p fakecloud-rds --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `DescribeDBClusters` XML to include fields updated by `ModifyDBCluster`, so describes now reflect changes instead of create-time defaults. Adds the nested `ServerlessV2ScalingConfiguration` and missing scalar fields like `StorageType`, `Iops`, `BacktrackWindow`, and IAM auth.

- Bug Fixes
  - Render previously omitted scalar fields (string/int/bool) and the nested `ServerlessV2ScalingConfiguration` from flattened keys.
  - Added `describe_db_clusters_renders_modified_fields` test; full RDS suite passes and `clippy` is clean.

<sup>Written for commit 3c444ea400b2a662867f0c5e065214957349501b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

