### PR TITLE
fix(ses): persist + surface identity notification SNS topics

### DIFF
--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -852,6 +852,9 @@ mod tests {
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
             mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: config_set.map(|s| s.to_string()),
+            bounce_topic: None,
+            complaint_topic: None,
+            delivery_topic: None,
         }
     }
 

--- a/crates/fakecloud-ses/src/service/identities.rs
+++ b/crates/fakecloud-ses/src/service/identities.rs
@@ -96,6 +96,9 @@ impl SesV2Service {
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
             mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name,
+            bounce_topic: None,
+            complaint_topic: None,
+            delivery_topic: None,
         };
 
         state.identities.insert(identity_name.clone(), identity);

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -62,6 +62,9 @@ fn seed_identity(state: &SharedSesState, name: &str) {
             mail_from_domain_status: "NotStarted".to_string(),
             dkim_public_key_b64: None,
             configuration_set_name: None,
+            bounce_topic: None,
+            complaint_topic: None,
+            delivery_topic: None,
         },
     );
 }

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -33,6 +33,14 @@ pub struct EmailIdentity {
     pub mail_from_domain_status: String,
     // Configuration set association
     pub configuration_set_name: Option<String>,
+    // SNS notification topics per type, set by SetIdentityNotificationTopic and
+    // surfaced by GetIdentityNotificationAttributes (bug-audit 2026-06-20, 1.19).
+    #[serde(default)]
+    pub bounce_topic: Option<String>,
+    #[serde(default)]
+    pub complaint_topic: Option<String>,
+    #[serde(default)]
+    pub delivery_topic: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -685,6 +685,9 @@ pub(crate) fn verify_email_identity(
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
             mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
+            bounce_topic: None,
+            complaint_topic: None,
+            delivery_topic: None,
         });
     Ok(xml_metadata_only("VerifyEmailIdentity", &req.request_id))
 }
@@ -717,6 +720,9 @@ pub(crate) fn verify_email_address(
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
             mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
+            bounce_topic: None,
+            complaint_topic: None,
+            delivery_topic: None,
         });
     Ok(xml_metadata_only("VerifyEmailAddress", &req.request_id))
 }
@@ -796,6 +802,9 @@ pub(crate) fn verify_domain_identity(
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
             mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
+            bounce_topic: None,
+            complaint_topic: None,
+            delivery_topic: None,
         });
     // Return a verification token
     let token = format!("{:x}{:x}{:x}", rand_u64(), rand_u64(), rand_u64());
@@ -833,6 +842,9 @@ pub(crate) fn verify_domain_dkim(
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
             mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
+            bounce_topic: None,
+            complaint_topic: None,
+            delivery_topic: None,
         });
     // VerifyDomainDkim is the moment SES tells you "ok, I generated DKIM
     // keys, here are the CNAMEs you must publish". Lazily create the
@@ -1042,22 +1054,36 @@ pub(crate) fn set_identity_notification_topic(
     state: &SharedSesState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let _identity = required_param(&req.query_params, "Identity")?;
-    let _notification_type = required_param(&req.query_params, "NotificationType")?;
-    // SnsTopic is optional — if absent, disables notification
-    let _sns_topic = req.query_params.get("SnsTopic");
-    // We store this on the identity but currently don't have notification topic fields.
-    // For fakecloud, accepting the call is sufficient — notifications aren't sent.
-    // Verify identity exists
-    let accounts = state.read();
-    let empty = SesState::new(&req.account_id, &req.region);
-    let st = accounts.get(&req.account_id).unwrap_or(&empty);
-    if !st.identities.contains_key(_identity) {
-        return Err(AwsServiceError::aws_error(
+    let identity = required_param(&req.query_params, "Identity")?;
+    let notification_type = required_param(&req.query_params, "NotificationType")?;
+    // SnsTopic is optional, and an empty value clears the topic (disables SNS
+    // notifications for that type), matching AWS.
+    let topic = req
+        .query_params
+        .get("SnsTopic")
+        .filter(|s| !s.is_empty())
+        .cloned();
+
+    let mut accounts = state.write();
+    let st = accounts.get_or_create(&req.account_id);
+    let id = st.identities.get_mut(identity).ok_or_else(|| {
+        AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "InvalidParameterValue",
-            format!("Identity '{_identity}' does not exist"),
-        ));
+            format!("Identity '{identity}' does not exist"),
+        )
+    })?;
+    match notification_type {
+        "Bounce" => id.bounce_topic = topic,
+        "Complaint" => id.complaint_topic = topic,
+        "Delivery" => id.delivery_topic = topic,
+        other => {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!("Invalid notification type: {other}"),
+            ));
+        }
     }
     Ok(xml_metadata_only(
         "SetIdentityNotificationTopic",
@@ -1111,6 +1137,21 @@ pub(crate) fn get_identity_notification_attributes(
                          <HeadersInDeliveryNotificationsEnabled>false</HeadersInDeliveryNotificationsEnabled>",
                         identity.email_forwarding_enabled,
                     ));
+                    // Per-type SNS topics set via SetIdentityNotificationTopic
+                    // (1.19). Only emitted when configured, like AWS.
+                    if let Some(t) = &identity.bounce_topic {
+                        inner.push_str(&format!("<BounceTopic>{}</BounceTopic>", xml_escape(t)));
+                    }
+                    if let Some(t) = &identity.complaint_topic {
+                        inner.push_str(&format!(
+                            "<ComplaintTopic>{}</ComplaintTopic>",
+                            xml_escape(t)
+                        ));
+                    }
+                    if let Some(t) = &identity.delivery_topic {
+                        inner
+                            .push_str(&format!("<DeliveryTopic>{}</DeliveryTopic>", xml_escape(t)));
+                    }
                 } else {
                     inner.push_str(
                         "<ForwardingEnabled>true</ForwardingEnabled>\

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -42,6 +42,9 @@ fn seed_identity(state: &SharedSesState, name: &str) {
             mail_from_domain_status: "NotStarted".to_string(),
             dkim_public_key_b64: None,
             configuration_set_name: None,
+            bounce_topic: None,
+            complaint_topic: None,
+            delivery_topic: None,
         },
     );
 }
@@ -1800,4 +1803,70 @@ fn test_send_bounce_v1_missing_recipient() {
         Err(e) => assert_eq!(e.code(), "MissingParameter"),
         Ok(_) => panic!("expected MissingParameter"),
     }
+}
+
+#[test]
+fn set_and_get_identity_notification_topic() {
+    // SetIdentityNotificationTopic was a silent no-op and
+    // GetIdentityNotificationAttributes never emitted the topics, so SNS
+    // bounce/complaint wiring was lost (bug-audit 2026-06-20, 1.19).
+    let state = make_state();
+    handle_v1_action(
+        &state,
+        &make_v1_request("VerifyEmailIdentity", vec![("EmailAddress", "a@test.com")]),
+    )
+    .unwrap();
+
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "SetIdentityNotificationTopic",
+            vec![
+                ("Identity", "a@test.com"),
+                ("NotificationType", "Bounce"),
+                ("SnsTopic", "arn:aws:sns:us-east-1:123456789012:bounces"),
+            ],
+        ),
+    )
+    .unwrap();
+
+    let resp = handle_v1_action(
+        &state,
+        &make_v1_request(
+            "GetIdentityNotificationAttributes",
+            vec![("Identities.member.1", "a@test.com")],
+        ),
+    )
+    .unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(
+        body.contains("<BounceTopic>arn:aws:sns:us-east-1:123456789012:bounces</BounceTopic>"),
+        "{body}"
+    );
+    // Untouched types are not emitted.
+    assert!(!body.contains("<ComplaintTopic>"), "{body}");
+
+    // An empty SnsTopic clears it.
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "SetIdentityNotificationTopic",
+            vec![
+                ("Identity", "a@test.com"),
+                ("NotificationType", "Bounce"),
+                ("SnsTopic", ""),
+            ],
+        ),
+    )
+    .unwrap();
+    let resp = handle_v1_action(
+        &state,
+        &make_v1_request(
+            "GetIdentityNotificationAttributes",
+            vec![("Identities.member.1", "a@test.com")],
+        ),
+    )
+    .unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(!body.contains("<BounceTopic>"), "cleared: {body}");
 }


### PR DESCRIPTION
## Summary

`SetIdentityNotificationTopic` verified the identity existed and then stored **nothing** — `EmailIdentity` had no topic fields — and `GetIdentityNotificationAttributes` never emitted `BounceTopic`/`ComplaintTopic`/`DeliveryTopic`. So wiring SNS bounce/complaint/delivery notifications was a complete no-op: the round-trip lost the topic ARNs entirely.

Fix: add per-type topic fields to `EmailIdentity`, persist the supplied `SnsTopic` under the right `NotificationType` (an empty `SnsTopic` clears it, like AWS), reject an unknown `NotificationType`, and render the configured topics in `GetIdentityNotificationAttributes`.

Found by the 2026-06-20 bug-hunt audit (finding 1.19).

## Test plan

- `set_and_get_identity_notification_topic` — sets a Bounce topic, asserts `GetIdentityNotificationAttributes` returns `<BounceTopic>` (and not the untouched `<ComplaintTopic>`), then clears it with an empty `SnsTopic` and asserts it's gone.
- Full SES suite: 250 passed.
- `cargo clippy -p fakecloud-ses --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist and surface SNS topics for SES identity notifications so Bounce/Complaint/Delivery wiring works end-to-end. `SetIdentityNotificationTopic` now saves per-type topics and `GetIdentityNotificationAttributes` returns them.

- **Bug Fixes**
  - Added `bounce_topic`, `complaint_topic`, `delivery_topic` to identity state.
  - `SetIdentityNotificationTopic`: saves by `NotificationType`; empty `SnsTopic` clears; rejects invalid types.
  - `GetIdentityNotificationAttributes`: emits configured topics only.
  - Added test `set_and_get_identity_notification_topic`; full SES suite passing.

<sup>Written for commit 46354e4fb8544ab2825162009f1a6b63b4756256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

