### PR TITLE
fix(cloudformation): add SES notification topic fields to provisioner (unbreak main)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ses.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ses.rs
@@ -314,6 +314,9 @@ impl ResourceProvisioner {
             mail_from_behavior_on_mx_failure: mail_from_behavior,
             mail_from_domain_status: "Success".to_string(),
             configuration_set_name,
+            bounce_topic: None,
+            complaint_topic: None,
+            delivery_topic: None,
         };
         let mut accounts = self.ses_state.write();
         let state = accounts.get_or_create(&self.account_id);


### PR DESCRIPTION
## Summary

PR #1798 added `bounce_topic`/`complaint_topic`/`delivery_topic` to `EmailIdentity` but missed the constructor in the CloudFormation SES provisioner (`AWS::SES::EmailIdentity`), breaking the **workspace build on main** (E0063: missing fields in `fakecloud_ses::EmailIdentity`).

Initialize the three new fields to `None`. Verified: `cargo build --workspace` and `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` both clean.

Hotfix to restore main (currently red, blocking all other PR CI).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize `bounce_topic`, `complaint_topic`, and `delivery_topic` to None in the CloudFormation SES provisioner (`AWS::SES::EmailIdentity`) to match the `EmailIdentity` struct. This fixes the build break on main.

<sup>Written for commit 6c9c365eb8b01be126fad8ca855eb3aefd963a7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

