### PR TITLE
fix(cognito): apply dropped settable fields in UpdateUserPool

### DIFF
--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -3492,6 +3492,45 @@ fn update_user_pool() {
 }
 
 #[test]
+fn update_user_pool_applies_verification_and_device_config() {
+    // The custom verification copy + device/add-ons configs were silently
+    // dropped by UpdateUserPool (bug-audit 2026-06-20, 1.16).
+    let (svc, _) = make_svc();
+    let pool_id = create_pool(&svc);
+
+    let body = json!({
+        "UserPoolId": pool_id,
+        "EmailVerificationMessage": "Your code is {####}",
+        "SmsVerificationMessage": "SMS {####}",
+        "DeviceConfiguration": { "ChallengeRequiredOnNewDevice": true },
+        "UserPoolAddOns": { "AdvancedSecurityMode": "AUDIT" },
+    });
+    svc.update_user_pool(&make_req("UpdateUserPool", &body.to_string()))
+        .unwrap();
+
+    let resp = svc
+        .describe_user_pool(&make_req(
+            "DescribeUserPool",
+            &json!({ "UserPoolId": pool_id }).to_string(),
+        ))
+        .unwrap();
+    let b = resp_json(&resp);
+    assert_eq!(
+        b["UserPool"]["EmailVerificationMessage"],
+        "Your code is {####}"
+    );
+    assert_eq!(b["UserPool"]["SmsVerificationMessage"], "SMS {####}");
+    assert_eq!(
+        b["UserPool"]["DeviceConfiguration"]["ChallengeRequiredOnNewDevice"],
+        true
+    );
+    assert_eq!(
+        b["UserPool"]["UserPoolAddOns"]["AdvancedSecurityMode"],
+        "AUDIT"
+    );
+}
+
+#[test]
 fn delete_user_pool() {
     let (svc, _) = make_svc();
     let pool_id = create_pool(&svc);

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -353,6 +353,32 @@ impl CognitoService {
             pool.deletion_protection = Some(dp.to_string());
         }
 
+        // Settable fields the handler previously dropped: custom verification
+        // copy and the device/attribute-update/add-ons configs. The most common
+        // UpdateUserPool change (custom verification email/SMS) was silently
+        // lost (bug-audit 2026-06-20, 1.16). Update each only when present.
+        if let Some(s) = body["EmailVerificationMessage"].as_str() {
+            pool.email_verification_message = Some(s.to_string());
+        }
+        if let Some(s) = body["EmailVerificationSubject"].as_str() {
+            pool.email_verification_subject = Some(s.to_string());
+        }
+        if let Some(s) = body["SmsVerificationMessage"].as_str() {
+            pool.sms_verification_message = Some(s.to_string());
+        }
+        if let Some(s) = body["SmsAuthenticationMessage"].as_str() {
+            pool.sms_authentication_message = Some(s.to_string());
+        }
+        if body["DeviceConfiguration"].is_object() {
+            pool.device_configuration = Some(body["DeviceConfiguration"].clone());
+        }
+        if body["UserAttributeUpdateSettings"].is_object() {
+            pool.user_attribute_update_settings = Some(body["UserAttributeUpdateSettings"].clone());
+        }
+        if body["UserPoolAddOns"].is_object() {
+            pool.user_pool_add_ons = Some(body["UserPoolAddOns"].clone());
+        }
+
         pool.last_modified_date = Utc::now();
 
         Ok(AwsResponse::ok_json(json!({})))


### PR DESCRIPTION
## Summary

`UpdateUserPool` ignored seven settable fields: `EmailVerificationMessage`, `EmailVerificationSubject`, `SmsVerificationMessage`, `SmsAuthenticationMessage`, `DeviceConfiguration`, `UserAttributeUpdateSettings`, `UserPoolAddOns`. The most common change — customizing the verification email/SMS copy — silently no-op'd; `DescribeUserPool` kept returning the create-time values.

Fix: apply each when present in the request. All fields already exist on the `UserPool` struct and are rendered by `DescribeUserPool`, so this is purely wiring the reads.

Found by the 2026-06-20 bug-hunt audit (finding 1.16).

## Test plan

- `update_user_pool_applies_verification_and_device_config` — updates EmailVerificationMessage / SmsVerificationMessage / DeviceConfiguration / UserPoolAddOns and asserts `DescribeUserPool` returns each.
- Existing UpdateUserPool tests still pass.
- `cargo clippy -p fakecloud-cognito --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `UpdateUserPool` in `fakecloud-cognito` to apply previously ignored verification and config fields so updates take effect and `DescribeUserPool` returns the new values.

- **Bug Fixes**
  - Apply when provided: EmailVerificationMessage, EmailVerificationSubject, SmsVerificationMessage, SmsAuthenticationMessage, DeviceConfiguration, UserAttributeUpdateSettings, UserPoolAddOns.
  - Added `update_user_pool_applies_verification_and_device_config` test to verify email/SMS copy and device/add-ons updates.

<sup>Written for commit f9e925ed9e623bf6404edab87d30a3ebee4dfdf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

