### PR TITLE
fix(firehose): persist + echo S3 ProcessingConfiguration and format conversion

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -5922,6 +5922,8 @@ fn parse_firehose_s3_destination(value: &serde_json::Value) -> Result<S3Destinat
         buffering_size_mb,
         buffering_interval_seconds,
         compression_format,
+        processing_configuration: None,
+        data_format_conversion_configuration: None,
     })
 }
 

--- a/crates/fakecloud-firehose/src/introspection.rs
+++ b/crates/fakecloud-firehose/src/introspection.rs
@@ -109,6 +109,8 @@ mod tests {
                 buffering_size_mb: None,
                 buffering_interval_seconds: None,
                 compression_format: None,
+                processing_configuration: None,
+                data_format_conversion_configuration: None,
             }),
             tags: BTreeMap::new(),
             encryption,

--- a/crates/fakecloud-firehose/src/service.rs
+++ b/crates/fakecloud-firehose/src/service.rs
@@ -119,6 +119,12 @@ fn parse_s3_destination(val: &Value) -> Result<Option<S3Destination>, AwsService
         buffering_size_mb,
         buffering_interval_seconds,
         compression_format: val["CompressionFormat"].as_str().map(|s| s.to_string()),
+        processing_configuration: val["ProcessingConfiguration"]
+            .is_object()
+            .then(|| val["ProcessingConfiguration"].clone()),
+        data_format_conversion_configuration: val["DataFormatConversionConfiguration"]
+            .is_object()
+            .then(|| val["DataFormatConversionConfiguration"].clone()),
     }))
 }
 
@@ -197,10 +203,19 @@ fn s3_destination_json(dest: &S3Destination) -> Value {
     if let Some(ref p) = dest.error_output_prefix {
         s3["ErrorOutputPrefix"] = json!(p);
     }
+    // ProcessingConfiguration / DataFormatConversionConfiguration are only
+    // valid on the ExtendedS3 shape, not the legacy S3DestinationDescription.
+    let mut extended = s3.clone();
+    if let Some(ref pc) = dest.processing_configuration {
+        extended["ProcessingConfiguration"] = pc.clone();
+    }
+    if let Some(ref dfc) = dest.data_format_conversion_configuration {
+        extended["DataFormatConversionConfiguration"] = dfc.clone();
+    }
     json!({
         "DestinationId": dest.destination_id,
         "S3DestinationDescription": s3,
-        "ExtendedS3DestinationDescription": s3.clone(),
+        "ExtendedS3DestinationDescription": extended,
     })
 }
 
@@ -882,5 +897,43 @@ mod tests {
     #[test]
     fn buffering_interval_above_900_rejected() {
         assert!(validate_buffering(None, Some(1200)).is_err());
+    }
+
+    #[test]
+    fn create_with_processing_configuration_round_trips() {
+        // ProcessingConfiguration (Lambda transform) on an ExtendedS3 destination
+        // was dropped; it must round-trip through DescribeDeliveryStream
+        // (bug-audit 2026-06-20, 1.18).
+        let svc = service();
+        svc.create_delivery_stream(&request(
+            "CreateDeliveryStream",
+            json!({
+                "DeliveryStreamName": "proc-stream",
+                "ExtendedS3DestinationConfiguration": {
+                    "RoleARN": "arn:aws:iam::123456789012:role/fh",
+                    "BucketARN": "arn:aws:s3:::bucket",
+                    "ProcessingConfiguration": {
+                        "Enabled": true,
+                        "Processors": [{ "Type": "Lambda" }]
+                    }
+                }
+            }),
+        ))
+        .unwrap();
+
+        let resp = svc
+            .describe_delivery_stream(&request(
+                "DescribeDeliveryStream",
+                json!({ "DeliveryStreamName": "proc-stream" }),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let dests = &body["DeliveryStreamDescription"]["Destinations"];
+        let ext = &dests[0]["ExtendedS3DestinationDescription"];
+        assert_eq!(ext["ProcessingConfiguration"]["Enabled"], true, "{body}");
+        assert_eq!(
+            ext["ProcessingConfiguration"]["Processors"][0]["Type"],
+            "Lambda"
+        );
     }
 }

--- a/crates/fakecloud-firehose/src/state.rs
+++ b/crates/fakecloud-firehose/src/state.rs
@@ -93,4 +93,11 @@ pub struct S3Destination {
     pub buffering_size_mb: Option<i64>,
     pub buffering_interval_seconds: Option<i64>,
     pub compression_format: Option<String>,
+    /// Lambda data-transformation pipeline; stored + echoed so a Firehose with
+    /// a transform round-trips (bug-audit 2026-06-20, 1.18).
+    #[serde(default)]
+    pub processing_configuration: Option<serde_json::Value>,
+    /// Parquet/ORC conversion config; stored + echoed.
+    #[serde(default)]
+    pub data_format_conversion_configuration: Option<serde_json::Value>,
 }


### PR DESCRIPTION
## Summary

`CreateDeliveryStream` / `UpdateDestination` parsed only the bare S3 destination fields, dropping `ProcessingConfiguration` (the Lambda data transform) and `DataFormatConversionConfiguration` (Parquet/ORC) — the two most common ExtendedS3 features. A Firehose created with a Lambda transform came back from `DescribeDeliveryStream` with no processing config, so Terraform showed a permanent diff and the transform appeared unset.

Fix: store both on `S3Destination`, parse them in `parse_s3_destination` (shared by create + update), and render them under `ExtendedS3DestinationDescription`.

Non-S3 destination types (Redshift / OpenSearch / Splunk / HTTP) remain a larger separate feature; this PR fixes the S3 transform round-trip — the common case. Part of finding 1.18.

## Test plan

- `create_with_processing_configuration_round_trips` — creates a stream with a Lambda `ProcessingConfiguration` and asserts `DescribeDeliveryStream` returns it under `ExtendedS3DestinationDescription`.
- Full firehose suite: 16 passed; cloudformation builds (S3Destination ctor updated there too).
- `cargo clippy -p fakecloud-firehose --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Firehose S3 destinations by persisting and echoing `ProcessingConfiguration` (Lambda transform) and `DataFormatConversionConfiguration` (Parquet/ORC) so they round-trip via DescribeDeliveryStream. This removes perpetual diffs where transforms looked unset.

- **Bug Fixes**
  - Store both fields on `S3Destination`, parse on create/update, and render under `ExtendedS3DestinationDescription` (legacy `S3DestinationDescription` unchanged); `fakecloud-cloudformation` constructor updated to include defaults.
  - Added test to verify round-trip of `ProcessingConfiguration`; suite passes in `fakecloud-firehose`.
  - Scope: S3 only; Redshift/OpenSearch/Splunk/HTTP destinations are unchanged.

<sup>Written for commit 6a1f34c2595608ffcbd4dc7257e77297f4531934. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

