### PR TITLE
fix(s3): push a new version on versioned CompleteMultipartUpload

### DIFF
--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -713,15 +713,27 @@ impl S3Service {
                 .buckets
                 .get_mut(bucket)
                 .ok_or_else(|| no_such_bucket(bucket))?;
-            b.objects.insert(key.to_string(), obj);
             b.multipart_uploads.remove(upload_id);
+            // On a versioned bucket the completed upload is a NEW version. The
+            // old code never pushed it -- it mutated the last existing version's
+            // body in place (corrupting a prior version, or no-op'ing when none
+            // existed), so the MPU version was missing from ListObjectVersions
+            // and `?versionId=<mpu>` 404'd. Mirror put_object: push the new
+            // object as a version (bug-audit 2026-06-20, 4.1).
             if versioning_enabled {
-                if let Some(versions) = b.object_versions.get_mut(key) {
-                    if let Some(last) = versions.last_mut() {
-                        last.body = returned_body;
+                let versions = b.object_versions.entry(key.to_string()).or_default();
+                // Preserve an untracked pre-versioning current object as the
+                // first version before appending the new one.
+                if versions.is_empty() {
+                    if let Some(existing) = b.objects.get(key) {
+                        if existing.version_id.is_none() {
+                            versions.push(existing.clone());
+                        }
                     }
                 }
+                versions.push(obj.clone());
             }
+            b.objects.insert(key.to_string(), obj);
         }
 
         let mut headers = HeaderMap::new();

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -4589,3 +4589,66 @@ fn access_point_data_plane_routes_to_bucket() {
     assert_eq!(req.path_segments[0], "ap-data-bucket");
     assert_eq!(req.raw_path, "/ap-data-bucket/key.txt");
 }
+
+#[tokio::test]
+async fn mpu_complete_on_versioned_bucket_pushes_new_version() {
+    // On a versioned bucket, CompleteMultipartUpload must add a NEW version
+    // (not mutate/corrupt the prior version's body in place) -- bug-audit
+    // 2026-06-20, 4.1.
+    let svc = make_service();
+    seed_bucket(&svc, "ver");
+    {
+        let mut mas = svc.state.write();
+        let b = mas.default_mut().buckets.get_mut("ver").unwrap();
+        b.versioning = Some("Enabled".to_string());
+    }
+
+    // v1 via a normal PutObject.
+    let put_req = make_request(Method::PUT, "/ver/k", &[], b"original-v1");
+    svc.put_object("123456789012", &put_req, "ver", "k")
+        .await
+        .unwrap();
+
+    // v2 via a single-part multipart upload.
+    let init_req = make_request(Method::POST, "/ver/k", &[("uploads", "")], b"");
+    let resp = svc
+        .create_multipart_upload("123456789012", &init_req, "ver", "k")
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    let start = body.find("<UploadId>").unwrap() + "<UploadId>".len();
+    let end = body.find("</UploadId>").unwrap();
+    let upload_id = body[start..end].to_string();
+
+    let part = b"multipart-v2-body".to_vec();
+    let part_req = make_request(Method::PUT, "/ver/k", &[("partNumber", "1")], &part);
+    let r = svc
+        .upload_part("123456789012", &part_req, "ver", "k", &upload_id, 1)
+        .await
+        .unwrap();
+    let etag = r.headers.get("etag").unwrap().to_str().unwrap().to_string();
+
+    let complete_xml = format!(
+        r#"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>{etag}</ETag></Part></CompleteMultipartUpload>"#,
+    );
+    let complete_req = make_request(
+        Method::POST,
+        "/ver/k",
+        &[("uploadId", &upload_id)],
+        complete_xml.as_bytes(),
+    );
+    svc.complete_multipart_upload("123456789012", &complete_req, "ver", "k", &upload_id)
+        .unwrap();
+
+    let mas = svc.state.read();
+    let b = mas.default_ref().buckets.get("ver").unwrap();
+    let versions = b
+        .object_versions
+        .get("k")
+        .expect("k must be tracked in object_versions");
+    assert_eq!(
+        versions.len(),
+        2,
+        "PutObject + completed MPU must yield 2 versions, got {}",
+        versions.len()
+    );
+}


### PR DESCRIPTION
## Summary

On a versioned bucket, `CompleteMultipartUpload` inserted the completed object into `b.objects` but **never pushed it onto `b.object_versions`**. Instead it mutated the last existing version's body in place — **corrupting a prior version's bytes**, or no-op'ing when none existed. Consequences:

- the MPU version was absent from `ListObjectVersions`,
- `GetObject?versionId=<mpu>` returned `NoSuchVersion`,
- `GetObject?versionId=<older>` could return the wrong bytes (the prior version was clobbered).

Fix: mirror `put_object` — push the completed object as a new version (preserving an untracked pre-versioning current object as the first version).

Found by the 2026-06-20 bug-hunt audit (finding 4.1).

## Test plan

- `mpu_complete_on_versioned_bucket_pushes_new_version` — PutObject (v1) then a completed MPU on a versioned bucket yields **2** versions (before the fix it stayed at 1 and corrupted v1).
- Full S3 suite: 363 passed.
- `cargo clippy -p fakecloud-s3 --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes S3 `CompleteMultipartUpload` on versioned buckets to create a new object version instead of mutating the previous one. Prevents version corruption and ensures `ListObjectVersions` and `GetObject?versionId` return the correct bytes.

- **Bug Fixes**
  - Append the completed MPU result to `b.object_versions` (preserving an untracked pre-versioning current object as the first version when present), then update `b.objects`.
  - Added `mpu_complete_on_versioned_bucket_pushes_new_version` to validate PutObject + MPU produce two versions.

<sup>Written for commit fe8537262d41623eed1208f0da707533bc13a5b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

