### PR TITLE
fix(sts): reject expired tokens in AssumeRoleWithWebIdentity

### DIFF
--- a/crates/fakecloud-iam/src/sts_service/assume.rs
+++ b/crates/fakecloud-iam/src/sts_service/assume.rs
@@ -377,6 +377,27 @@ impl StsService {
         // trust policy gate can fire on real AWS-shaped policies.
         let jwt = decode_jwt(&web_identity_token_owned);
 
+        // Reject an expired token. Real OIDC tokens always carry `exp`; AWS
+        // returns ExpiredTokenException. We don't verify the signature (not a
+        // security boundary), but `exp` enforcement is non-crypto and callers
+        // verifying their security posture expect expired tokens to be rejected
+        // (bug-audit 2026-06-20, 5.1).
+        if let Some(ref claims) = jwt {
+            if let Some(exp) = claims
+                .raw
+                .get("exp")
+                .and_then(|v| v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)))
+            {
+                if exp < chrono::Utc::now().timestamp() {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ExpiredTokenException",
+                        "The web identity token that was passed is expired.",
+                    ));
+                }
+            }
+        }
+
         // Pick the federated provider ARN. Preference order:
         //   1. JWT iss matched against a registered OpenIDConnectProvider —
         //      we use the provider's stored ARN.

--- a/crates/fakecloud-iam/src/sts_service/mod.rs
+++ b/crates/fakecloud-iam/src/sts_service/mod.rs
@@ -980,6 +980,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn assume_role_with_web_identity_rejects_expired_token() {
+        // A JWT whose `exp` is in the past must be rejected with
+        // ExpiredTokenException, not mint fresh credentials (bug-audit
+        // 2026-06-20, 5.1).
+        use base64::Engine;
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithWebIdentity"}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "web-role", trust);
+
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload_json = format!(
+            r#"{{"iss":"https://example.com","aud":"client","sub":"u","exp":{}}}"#,
+            chrono::Utc::now().timestamp() - 3600
+        );
+        let payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload_json.as_bytes());
+        let token = format!("{header}.{payload}.sig");
+
+        let req = sts_request(
+            "AssumeRoleWithWebIdentity",
+            vec![
+                ("RoleArn", &role_arn),
+                ("RoleSessionName", "web-session"),
+                ("WebIdentityToken", &token),
+            ],
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected ExpiredTokenException for an expired token"),
+        };
+        assert_eq!(err.code(), "ExpiredTokenException");
+    }
+
+    #[tokio::test]
     async fn assume_role_with_web_identity_nonexistent_role_denied() {
         // §5.2: a missing role must NOT fall through to credential minting.
         // AWS returns AccessDenied for AssumeRoleWithWebIdentity on a role


### PR DESCRIPTION
## Summary

The web-identity flow parsed `iss`/`aud`/`sub` from the JWT but never checked `exp`, so an expired-but-otherwise-valid OIDC token minted fresh 1-hour credentials — a false PASS for anyone verifying that expired federated tokens are rejected. `ExpiredTokenException` was defined but never raised.

Fix: reject when the token's `exp` (NumericDate, int or float) is in the past. Signature verification stays out of scope (fakecloud is not a security boundary); `exp` enforcement is non-crypto and clients expect it.

Found by the 2026-06-20 bug-hunt audit (finding 5.1, #1751 class).

## Test plan

- `assume_role_with_web_identity_rejects_expired_token` — an expired JWT returns `ExpiredTokenException`; existing web-identity tests (tokens without `exp`) still mint credentials.
- `cargo clippy -p fakecloud-iam --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
STS `AssumeRoleWithWebIdentity` now rejects expired web identity tokens instead of minting credentials. Returns `ExpiredTokenException` when the JWT `exp` is in the past.

- Bug Fixes
  - Enforce JWT `exp` (int or float NumericDate) against current time; aligns with AWS behavior. Signature verification remains out of scope for `fakecloud-iam`.
  - Add test `assume_role_with_web_identity_rejects_expired_token`.

<sup>Written for commit dbb197c8579b6c18ac70c5afddb5e9ef2aa04650. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

