### PR TITLE
fix(s3): map GetObjectTorrent to its own IAM action

### DIFF
--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -1559,6 +1559,14 @@ fn s3_detect_action(
         }
     }
 
+    // GET on an object with `?torrent` is GetObjectTorrent, authorized under
+    // s3:GetObjectTorrent -- not s3:GetObject. Without this arm a policy that
+    // allows GetObject but not GetObjectTorrent would wrongly permit it
+    // (bug-audit 2026-06-20, 5.3).
+    if is_get && has_key && has("torrent") {
+        return Some("GetObjectTorrent");
+    }
+
     // Plain bucket/object methods.
     match (method, has_key) {
         ("GET", true) => Some("GetObject"),
@@ -2974,6 +2982,22 @@ mod s3_iam_service_prefix_tests {
             action.action_string(),
             "s3-object-lambda:WriteGetObjectResponse"
         );
+    }
+
+    #[test]
+    fn get_object_torrent_maps_to_its_own_action() {
+        // GET object with `?torrent` must authorize under s3:GetObjectTorrent,
+        // not s3:GetObject (bug-audit 2026-06-20, 5.3).
+        let svc = make_service();
+        let action = svc
+            .iam_action_for(&req(Method::GET, "/mybucket/key.txt", &[("torrent", "")]))
+            .expect("must be mapped");
+        assert_eq!(action.action, "GetObjectTorrent");
+        // A plain GET still maps to GetObject.
+        let plain = svc
+            .iam_action_for(&req(Method::GET, "/mybucket/key.txt", &[]))
+            .expect("must be mapped");
+        assert_eq!(plain.action, "GetObject");
     }
 }
 


### PR DESCRIPTION
## Summary

A GET on an object with `?torrent` fell through to the plain `("GET", true) => GetObject` arm in `s3_detect_action`, so it was authorized under `s3:GetObject` instead of `s3:GetObjectTorrent`. A policy that allows `GetObject` but not `GetObjectTorrent` would wrongly permit the torrent fetch.

Fix: add a `?torrent` arm returning `GetObjectTorrent`.

Found by the 2026-06-20 bug-hunt audit (finding 5.3).

## Test plan

- `get_object_torrent_maps_to_its_own_action` — `?torrent` maps to `GetObjectTorrent`; a plain GET still maps to `GetObject`.
- `cargo clippy -p fakecloud-s3 --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix S3 IAM mapping: GET on an object with `?torrent` now maps to `s3:GetObjectTorrent` instead of `s3:GetObject`. This prevents a policy bypass when `GetObject` is allowed but `GetObjectTorrent` is not; plain GET still maps to `GetObject`.

<sup>Written for commit 765622d890cd3df7894af9244dcb62b6fe86be97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

