### PR TITLE
fix(cloudformation): resolve Fn::ImportValue in properties + apply Parameter defaults

### DIFF
--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -328,7 +328,8 @@ impl CloudFormationService {
                     .map(|s| s.to_ascii_uppercase())
                     .unwrap_or_else(|| "UPDATE".to_string());
 
-                let cs_params = CloudFormationService::extract_parameters(&params);
+                let mut cs_params = CloudFormationService::extract_parameters(&params);
+                CloudFormationService::merge_parameter_defaults(&mut cs_params, &template_body);
                 let cs_tags = CloudFormationService::extract_tags(&params);
                 let cs_notif = CloudFormationService::extract_notification_arns(&params);
 
@@ -915,6 +916,11 @@ impl CloudFormationService {
 
                 let provisioner = self.provisioner(&found_stack_id, &aid, &req.region);
 
+                // Cross-stack exports for `Fn::ImportValue` in resource
+                // properties (1.5); collected before the write lock.
+                let cs_imports =
+                    CloudFormationService::collect_account_imports(&self.state, &aid, None);
+
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
 
@@ -949,6 +955,7 @@ impl CloudFormationService {
                         &template_body,
                         &cs_params,
                         &provisioner,
+                        &cs_imports,
                     );
                     let sid = stack.stack_id.clone();
                     let sname = stack.name.clone();

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
@@ -117,6 +117,7 @@ impl ResourceProvisioner {
             &parsed.resources,
             &template_body,
             &child_parameters,
+            &std::collections::BTreeMap::new(),
         )
         .map_err(|e| format!("Failed to provision nested stack: {e}"))?;
 

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -142,6 +142,7 @@ pub(crate) fn provision_stack_resources(
     resource_defs: &[template::ResourceDefinition],
     template_body: &str,
     parameters: &BTreeMap<String, String>,
+    imports: &BTreeMap<String, String>,
 ) -> Result<Vec<StackResource>, AwsServiceError> {
     let mut resources = Vec::new();
     let mut physical_ids: BTreeMap<String, String> = BTreeMap::new();
@@ -169,6 +170,7 @@ pub(crate) fn provision_stack_resources(
                 parameters,
                 &physical_ids,
                 &attributes,
+                imports,
             )
             .map_err(|e| {
                 // `ValidationError` isn't declared on CreateStack/UpdateStack;
@@ -219,6 +221,7 @@ pub(crate) fn provision_stack_resources(
                 parameters,
                 &physical_ids,
                 &attributes,
+                imports,
             )
             .unwrap_or_else(|_| resource_def.clone());
             let err = provisioner.create_resource(&resolved_def).unwrap_err();
@@ -478,6 +481,43 @@ impl CloudFormationService {
         result
     }
 
+    /// Fill in declared `Parameters.<Name>.Default` for any parameter the
+    /// caller didn't supply. Without this a `Ref` to an omitted-but-defaulted
+    /// parameter baked the bare parameter name instead of its default -- common
+    /// in hand-written CFN and `aws cloudformation deploy` without
+    /// `--parameter-overrides` (bug-audit 2026-06-20, 1.6).
+    pub(crate) fn merge_parameter_defaults(
+        parameters: &mut BTreeMap<String, String>,
+        template_body: &str,
+    ) {
+        let value: serde_json::Value = if template_body.trim_start().starts_with('{') {
+            match serde_json::from_str(template_body) {
+                Ok(v) => v,
+                Err(_) => return,
+            }
+        } else {
+            match serde_yaml::from_str(template_body) {
+                Ok(v) => v,
+                Err(_) => return,
+            }
+        };
+        let Some(decls) = value.get("Parameters").and_then(|v| v.as_object()) else {
+            return;
+        };
+        for (name, spec) in decls {
+            if parameters.contains_key(name) {
+                continue;
+            }
+            if let Some(default) = spec.get("Default") {
+                let s = default
+                    .as_str()
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| default.to_string());
+                parameters.insert(name.clone(), s);
+            }
+        }
+    }
+
     pub(crate) fn extract_notification_arns(params: &BTreeMap<String, String>) -> Vec<String> {
         let mut arns = Vec::new();
         for i in 1.. {
@@ -518,7 +558,7 @@ impl CloudFormationService {
     /// `state.exports` registry. `skip_stack` removes any export owned by
     /// the named stack — used during update so a stack doesn't import its
     /// own previous-revision export.
-    fn collect_account_imports(
+    pub(crate) fn collect_account_imports(
         state: &SharedCloudFormationState,
         account_id: &str,
         skip_stack: Option<&str>,
@@ -758,6 +798,7 @@ impl CloudFormationService {
 
         let tags = Self::extract_tags(&params);
         let mut parameters = Self::extract_parameters(&params);
+        Self::merge_parameter_defaults(&mut parameters, template_body);
         let notification_arns = Self::extract_notification_arns(&params);
 
         // Seed AWS::* pseudo-parameters with stack-context values so
@@ -947,8 +988,18 @@ impl CloudFormationService {
         let provision_result = {
             let template_body = template_body.clone();
             let parameters = parameters.clone();
+            // Cross-stack exports this account already published, so a resource
+            // property using `Fn::ImportValue` resolves to the real value
+            // instead of an empty string (bug-audit 2026-06-20, 1.5).
+            let imports = Self::collect_account_imports(&state, &account_id, Some(&stack_name));
             tokio::task::spawn_blocking(move || {
-                provision_stack_resources(&provisioner, &resource_defs, &template_body, &parameters)
+                provision_stack_resources(
+                    &provisioner,
+                    &resource_defs,
+                    &template_body,
+                    &parameters,
+                    &imports,
+                )
             })
             .await
         };
@@ -1423,6 +1474,12 @@ impl CloudFormationService {
 
         let provisioner = self.provisioner(&found_stack_id, &req.account_id, &req.region);
 
+        // Cross-stack exports for `Fn::ImportValue` in resource properties (1.5).
+        // Computed before the write lock (collect_account_imports takes a read
+        // lock and returns an owned map).
+        let imports =
+            Self::collect_account_imports(&self.state, &req.account_id, Some(&input.stack_name));
+
         // All `RwLockWriteGuard` work happens inside this block so the (non-Send)
         // guard is released before the persist `.await` below, keeping the
         // handler future `Send`. The block yields everything the post-lock tail
@@ -1476,6 +1533,7 @@ impl CloudFormationService {
                     &input.template_body,
                     &input.parameters,
                     &provisioner,
+                    &imports,
                 );
 
                 let stack_id = stack.stack_id.clone();
@@ -1842,10 +1900,12 @@ impl UpdateStackInput {
         // undeclared `ValidationError`.
         let template_body = params.get("TemplateBody").cloned().unwrap_or_default();
 
+        let mut parameters = CloudFormationService::extract_parameters(&params);
+        CloudFormationService::merge_parameter_defaults(&mut parameters, &template_body);
         Ok(Self {
             stack_name,
             template_body,
-            parameters: CloudFormationService::extract_parameters(&params),
+            parameters,
             tags: CloudFormationService::extract_tags(&params),
             notification_arns: CloudFormationService::extract_notification_arns(&params),
         })
@@ -1897,6 +1957,7 @@ pub(crate) fn apply_resource_updates(
     template_body: &str,
     parameters: &BTreeMap<String, String>,
     provisioner: &crate::resource_provisioner::ResourceProvisioner,
+    imports: &BTreeMap<String, String>,
 ) -> Result<Vec<ResourceChange>, String> {
     let mut changes: Vec<ResourceChange> = Vec::new();
     let old_logical_ids: std::collections::HashSet<String> = stack
@@ -1955,6 +2016,7 @@ pub(crate) fn apply_resource_updates(
             parameters,
             &physical_ids,
             &attributes,
+            imports,
         )
         .map_err(|e| {
             format!(
@@ -2200,6 +2262,30 @@ mod tests {
     use parking_lot::RwLock;
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    #[test]
+    fn merge_parameter_defaults_fills_omitted_params() {
+        // §1.6: a parameter the caller omitted gets its declared Default, so a
+        // Ref to it resolves to the default instead of the bare param name.
+        let template = r#"{
+            "Parameters": {
+                "InstanceType": {"Type": "String", "Default": "t3.micro"},
+                "Count": {"Type": "Number", "Default": 3},
+                "Supplied": {"Type": "String", "Default": "dflt"}
+            },
+            "Resources": {}
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("Supplied".to_string(), "override".to_string());
+        CloudFormationService::merge_parameter_defaults(&mut params, template);
+        assert_eq!(
+            params.get("InstanceType").map(String::as_str),
+            Some("t3.micro")
+        );
+        assert_eq!(params.get("Count").map(String::as_str), Some("3"));
+        // A supplied value is not overwritten by the default.
+        assert_eq!(params.get("Supplied").map(String::as_str), Some("override"));
+    }
 
     fn make_service() -> CloudFormationService {
         let cf_state = Arc::new(RwLock::new(

--- a/crates/fakecloud-cloudformation/src/template/mod.rs
+++ b/crates/fakecloud-cloudformation/src/template/mod.rs
@@ -1684,6 +1684,7 @@ Resources:
             &params,
             &BTreeMap::new(),
             &BTreeMap::new(),
+            &BTreeMap::new(),
         )
         .unwrap();
         let props = reresolved.properties.as_object().unwrap();
@@ -2120,6 +2121,7 @@ Resources:
         let reresolved = resolve_resource_properties_with_attrs(
             resource,
             template,
+            &BTreeMap::new(),
             &BTreeMap::new(),
             &BTreeMap::new(),
             &BTreeMap::new(),

--- a/crates/fakecloud-cloudformation/src/template/resolution.rs
+++ b/crates/fakecloud-cloudformation/src/template/resolution.rs
@@ -15,6 +15,7 @@ pub fn resolve_resource_properties(
         parameters,
         resource_physical_ids,
         &BTreeMap::new(),
+        &BTreeMap::new(),
     )
 }
 
@@ -26,6 +27,7 @@ pub fn resolve_resource_properties_with_attrs(
     parameters: &BTreeMap<String, String>,
     resource_physical_ids: &BTreeMap<String, String>,
     resource_attributes: &BTreeMap<String, BTreeMap<String, String>>,
+    imports: &BTreeMap<String, String>,
 ) -> Result<ResourceDefinition, String> {
     let value: Value = if template_body.trim_start().starts_with('{') {
         serde_json::from_str(template_body).map_err(|e| format!("Invalid JSON template: {e}"))?
@@ -67,7 +69,7 @@ pub fn resolve_resource_properties_with_attrs(
         resources_obj,
         resource_physical_ids,
         resource_attributes,
-        &BTreeMap::new(),
+        imports,
         &conditions,
     );
     let resolved = strip_no_value(resolved);
@@ -339,6 +341,32 @@ mod dependency_order_tests {
         assert!(pos("A") < pos("B"), "GetAtt edge");
         assert!(pos("A") < pos("C"), "Fn::Sub edge");
         assert!(pos("A") < pos("D"), "DependsOn edge");
+    }
+
+    #[test]
+    fn import_value_in_property_resolves_from_imports() {
+        // §1.5: Fn::ImportValue inside a resource property must resolve to the
+        // real exported value, not the empty string the old code baked.
+        let template = r#"{
+            "Resources": {
+                "Q": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": {"Fn::ImportValue": "SharedQueueName"}}}
+            }
+        }"#;
+        let mut imports = BTreeMap::new();
+        imports.insert("SharedQueueName".to_string(), "shared-q".to_string());
+        let resolved = resolve_resource_properties_with_attrs(
+            &rd("Q", "AWS::SQS::Queue"),
+            template,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &imports,
+        )
+        .unwrap();
+        assert_eq!(
+            resolved.properties["QueueName"],
+            serde_json::json!("shared-q")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two CFN reference-resolution gaps (findings 1.5 + 1.6):

**1.5** — `resolve_resource_properties_with_attrs` passed an **empty** imports map, so `Fn::ImportValue` inside a resource property always baked an empty string. The exports map was built and threaded into Outputs resolution but not into property resolution. This threads the real cross-stack exports (`collect_account_imports`) through `provision_stack_resources` and `apply_resource_updates` (CreateStack / UpdateStack / ExecuteChangeSet) so a property using `Fn::ImportValue` resolves to the exported value — a core multi-stack CDK/CFN pattern.

**1.6** — nothing read a parameter's declared `Default`, so a `Ref` to an omitted-but-defaulted parameter baked the bare parameter name. Adds `merge_parameter_defaults` (applied on CreateStack / CreateChangeSet) to fill omitted parameters from the template's `Parameters.<Name>.Default`. A caller-supplied value is never overwritten.

## Test plan

- `import_value_in_property_resolves_from_imports` — `Fn::ImportValue` in a property resolves to the export value.
- `merge_parameter_defaults_fills_omitted_params` — omitted params get their Default (string + number); supplied values aren't overwritten.
- Full CFN suite: 237 passed.
- `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CloudFormation reference resolution so `Fn::ImportValue` in resource properties uses real cross-stack exports, and omitted Parameters use their declared Defaults so `Ref` resolves correctly.

- **Bug Fixes**
  - Thread account exports into resource property resolution during stack creates, updates, and change sets, so `Fn::ImportValue` returns the exported value.
  - Apply template Parameter Defaults when a parameter is omitted; never override caller-supplied values.
  - Added tests for both cases.

<sup>Written for commit 58288af8311f2766fa3347e02b4a8eb2f8dbf109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

