### PR TITLE
fix(apigatewayv2): actually delete deployments in DeleteDeployment

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -1007,8 +1007,21 @@ impl ApiGatewayV2Service {
                 no_content()
             }
             "DeleteDeployment" => {
-                api_id.ok_or_else(|| missing("ApiId"))?;
-                resource_id.ok_or_else(|| missing("DeploymentId"))?;
+                let api = api_id.ok_or_else(|| missing("ApiId"))?;
+                let dep = resource_id.ok_or_else(|| missing("DeploymentId"))?;
+                // The old handler returned 204 without removing anything, so
+                // deployments accumulated and were un-deletable (bug-audit
+                // 2026-06-20, 1.23). Validate the deployment exists (AWS returns
+                // NotFound otherwise) and actually remove it.
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(aid);
+                let deployments = state
+                    .deployments
+                    .get_mut(api)
+                    .ok_or_else(|| not_found("Deployment", dep))?;
+                if deployments.remove(dep).is_none() {
+                    return Err(not_found("Deployment", dep));
+                }
                 no_content()
             }
             "UpdateDeployment" => {
@@ -2079,13 +2092,58 @@ mod tests {
             Some("a1"),
             Some("prod"),
         );
-        ok(
-            "DeleteDeployment",
-            "",
-            &["v2", "apis", "a1", "deployments", "d1"],
-            Some("a1"),
-            Some("d1"),
-        );
+        // DeleteDeployment now validates + removes. Seed one, delete it,
+        // confirm it's gone, and that a second delete 404s (1.23).
+        {
+            let s = svc();
+            {
+                let mut accounts = s.state.write();
+                let state = accounts.get_or_create("000000000000");
+                state
+                    .deployments
+                    .entry("a1".to_string())
+                    .or_default()
+                    .insert(
+                        "d1".to_string(),
+                        crate::state::Deployment {
+                            deployment_id: "d1".to_string(),
+                            description: None,
+                            created_date: chrono::Utc::now(),
+                            auto_deployed: false,
+                        },
+                    );
+            }
+            run(
+                &s,
+                "DeleteDeployment",
+                "",
+                &["v2", "apis", "a1", "deployments", "d1"],
+                Some("a1"),
+                Some("d1"),
+            );
+            assert!(
+                s.state
+                    .read()
+                    .get("000000000000")
+                    .and_then(|st| st.deployments.get("a1"))
+                    .map(|d| !d.contains_key("d1"))
+                    .unwrap_or(true),
+                "DeleteDeployment must remove the deployment"
+            );
+            // Deleting the now-missing deployment is a NotFound.
+            assert!(s
+                .handle_extra_action(
+                    "DeleteDeployment",
+                    &req(
+                        "DeleteDeployment",
+                        "",
+                        &["v2", "apis", "a1", "deployments", "d1"],
+                    ),
+                    Some("a1"),
+                    Some("d1"),
+                )
+                .is_err());
+        }
         // UpdateDeployment now validates the deployment exists. Seed one
         // into a fresh service and exercise the patch on the real entry.
         {


### PR DESCRIPTION
## Summary

`DeleteDeployment` returned `204` without removing anything, so deployments accumulated and were un-deletable; the existing test only asserted the 204 and masked it. Now it validates the deployment exists (AWS returns `NotFound` otherwise) and removes it from state.

Found by the 2026-06-20 bug-hunt audit (finding 1.23).

## Test plan

- Seeds a deployment, deletes it, asserts it's removed, and that a second delete on the now-missing deployment returns an error.
- Full apigatewayv2 suite: 136 passed.
- `cargo clippy -p fakecloud-apigatewayv2 --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DeleteDeployment in `fakecloud-apigatewayv2` to actually remove deployments and match AWS by returning NotFound when the deployment doesn’t exist. Adds a test that seeds and deletes a deployment, confirms it’s gone, and checks a second delete fails.

<sup>Written for commit 122a62832ae29fa5103e48169a461ea5f9ce6dee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

