### PR TITLE
fix(elasticache): recover mid-transition resources on restart

### DIFF
--- a/crates/fakecloud-elasticache/src/service/mod.rs
+++ b/crates/fakecloud-elasticache/src/service/mod.rs
@@ -158,6 +158,15 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "TestMigration",
 ];
 
+/// On restart, recovery must re-drive every resource that isn't being torn
+/// down -- not just `available` ones. A resource snapshotted mid-transition
+/// (creating/modifying/rebooting/starting) would otherwise never have its
+/// background task re-spawned and stay stuck forever (bug-audit 2026-06-20,
+/// 4.5).
+pub(crate) fn is_recoverable_status(status: &str) -> bool {
+    !matches!(status, "deleting" | "deleted")
+}
+
 pub struct ElastiCacheService {
     state: SharedElastiCacheState,
     runtime: Option<Arc<ElastiCacheRuntime>>,
@@ -254,7 +263,12 @@ impl ElastiCacheService {
             for (_, state) in accounts.iter_mut() {
                 let account_id = state.account_id.clone();
                 for (id, cluster) in state.cache_clusters.iter_mut() {
-                    if cluster.cache_cluster_status == "available" {
+                    // Re-drive anything not being torn down. The old code only
+                    // recovered "available" resources, so one snapshotted
+                    // mid-transition (creating/modifying/rebooting) was never
+                    // re-spawned and stayed stuck forever (bug-audit 2026-06-20,
+                    // 4.5).
+                    if is_recoverable_status(&cluster.cache_cluster_status) {
                         cluster.cache_cluster_status = "starting".to_string();
                         clusters.push(PendingCluster {
                             account_id: account_id.clone(),
@@ -264,7 +278,7 @@ impl ElastiCacheService {
                     }
                 }
                 for (id, rg) in state.replication_groups.iter_mut() {
-                    if rg.status == "available" {
+                    if is_recoverable_status(&rg.status) {
                         rg.status = "starting".to_string();
                         replications.push(PendingReplication {
                             account_id: account_id.clone(),
@@ -274,7 +288,7 @@ impl ElastiCacheService {
                     }
                 }
                 for (name, sc) in state.serverless_caches.iter_mut() {
-                    if sc.status == "available" {
+                    if is_recoverable_status(&sc.status) {
                         sc.status = "creating".to_string();
                         serverless.push(PendingServerless {
                             account_id: account_id.clone(),

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -4813,3 +4813,17 @@ async fn snapshot_hook_fires_with_store() {
         .expect("hook present when a store is set");
     hook().await;
 }
+
+#[test]
+fn recovery_predicate_redrives_transient_states() {
+    use crate::service::is_recoverable_status;
+    // Mid-transition states must be recovered (re-driven) on restart.
+    assert!(is_recoverable_status("available"));
+    assert!(is_recoverable_status("creating"));
+    assert!(is_recoverable_status("modifying"));
+    assert!(is_recoverable_status("rebooting cache cluster nodes"));
+    assert!(is_recoverable_status("starting"));
+    // Resources being torn down are not.
+    assert!(!is_recoverable_status("deleting"));
+    assert!(!is_recoverable_status("deleted"));
+}


### PR DESCRIPTION
## Summary

`recover_persisted_containers` only re-drove resources with status `"available"`, so a cluster / replication group / serverless cache snapshotted **mid-transition** (`creating` / `modifying` / `rebooting` / `starting`) was never re-spawned and stayed stuck in that state forever after a restart.

Fix: re-drive any resource that isn't being torn down (not `deleting`/`deleted`), via the new `is_recoverable_status` predicate — mirroring RDS recovery, which already includes the transient states.

Found by the 2026-06-20 bug-hunt audit (finding 4.5).

## Test plan

- `recovery_predicate_redrives_transient_states` — available + transient states are recoverable; deleting/deleted are not.
- Full elasticache suite passes; `cargo clippy -p fakecloud-elasticache --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ElastiCache recovery on restart by re-driving resources stuck in transient states, not just "available". Prevents clusters, replication groups, and serverless caches from getting stuck after a restart.

- **Bug Fixes**
  - Use a recoverable-status predicate that excludes only `deleting`/`deleted`.
  - Re-drive clusters, replication groups, and serverless caches; reset to starting/creating so background tasks respawn.
  - Add unit test for the predicate; mirrors RDS recovery behavior.

<sup>Written for commit 9fefdedbcac0354e9aa0bc740b1c9b1034b19c4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

