### PR TITLE
fix(apigateway): apply dropped PATCH fields across v1 Update handlers

### DIFF
--- a/crates/fakecloud-apigateway/src/service_integrations.rs
+++ b/crates/fakecloud-apigateway/src/service_integrations.rs
@@ -142,7 +142,7 @@ impl ApiGatewayService {
             .get_mut(&key)
             .ok_or_else(|| not_found("Integration not found"))?;
         apply_patch_operations(req, |op, path, value| {
-            if op != "replace" && op != "add" {
+            if op != "replace" && op != "add" && op != "remove" {
                 return;
             }
             match path {
@@ -154,6 +154,33 @@ impl ApiGatewayService {
                 }
                 "/timeoutInMillis" => {
                     integration.timeout_in_millis = value.as_i64().map(|v| v as i32);
+                }
+                // Previously dropped (bug-audit 2026-06-20, 1.21).
+                "/credentials" => integration.credentials = value.as_str().map(String::from),
+                "/connectionType" => integration.connection_type = value.as_str().map(String::from),
+                "/contentHandling" => {
+                    integration.content_handling = value.as_str().map(String::from)
+                }
+                "/passthroughBehavior" => {
+                    if let Some(s) = value.as_str() {
+                        integration.passthrough_behavior = s.to_string();
+                    }
+                }
+                _ if path.starts_with("/requestParameters/") => {
+                    let k = path.trim_start_matches("/requestParameters/").to_string();
+                    if op == "remove" {
+                        integration.request_parameters.remove(&k);
+                    } else if let Some(v) = value.as_str() {
+                        integration.request_parameters.insert(k, v.to_string());
+                    }
+                }
+                _ if path.starts_with("/requestTemplates/") => {
+                    let k = path.trim_start_matches("/requestTemplates/").to_string();
+                    if op == "remove" {
+                        integration.request_templates.remove(&k);
+                    } else if let Some(v) = value.as_str() {
+                        integration.request_templates.insert(k, v.to_string());
+                    }
                 }
                 _ => {}
             }

--- a/crates/fakecloud-apigateway/src/service_rest_api_resources.rs
+++ b/crates/fakecloud-apigateway/src/service_rest_api_resources.rs
@@ -165,20 +165,26 @@ impl ApiGatewayService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request_account(req));
         // UpdateAccount input is { patchOperations: [...] }; the Account
-        // output shape does not include patchOperations. Apply the ops
-        // (best-effort) and never echo input-only fields.
-        if let Ok(patch) = serde_json::from_slice::<Value>(&req.body) {
-            if let (Some(target), Some(extras)) =
-                (state.account_settings.as_object_mut(), patch.as_object())
-            {
-                for (k, v) in extras {
-                    if k == "patchOperations" {
-                        continue;
-                    }
-                    target.insert(k.clone(), v.clone());
+        // output shape does not include patchOperations. The old code only
+        // copied (non-existent) top-level body fields and so ignored the patch
+        // ops entirely -- cloudwatchRoleArn could never be set (bug-audit
+        // 2026-06-20, 1.21). Apply each op to account_settings instead.
+        apply_patch_operations(req, |op, path, value| {
+            if op != "replace" && op != "add" && op != "remove" {
+                return;
+            }
+            let key = path.trim_start_matches('/').to_string();
+            if key.is_empty() {
+                return;
+            }
+            if let Some(obj) = state.account_settings.as_object_mut() {
+                if op == "remove" {
+                    obj.remove(&key);
+                } else {
+                    obj.insert(key, value.clone());
                 }
             }
-        }
+        });
         ok(state.account_settings.clone())
     }
 

--- a/crates/fakecloud-apigateway/src/service_stages.rs
+++ b/crates/fakecloud-apigateway/src/service_stages.rs
@@ -165,6 +165,33 @@ impl ApiGatewayService {
                         s.tracing_enabled = b;
                     }
                 }
+                // Previously dropped (bug-audit 2026-06-20, 1.21).
+                "/cacheClusterEnabled" => {
+                    if let Some(b) = value.as_bool() {
+                        s.cache_cluster_enabled = b;
+                    } else if let Some(v) = value.as_str() {
+                        s.cache_cluster_enabled = v == "true";
+                    }
+                }
+                "/cacheClusterSize" => s.cache_cluster_size = value.as_str().map(String::from),
+                "/webAclArn" => s.web_acl_arn = value.as_str().map(String::from),
+                // Per-method settings: AWS PATCHes them at
+                // `/{resourcePath}/{httpMethod}/{setting}` (e.g.
+                // `/~1pets/GET/throttling/rateLimit`). Store each under
+                // method_settings keyed by its path so DescribeStage reflects
+                // the change instead of silently dropping it.
+                _ if path.contains("/throttling/")
+                    || path.contains("/logging/")
+                    || path.contains("/metrics/")
+                    || path.contains("/caching/") =>
+                {
+                    let key = path.trim_start_matches('/').to_string();
+                    if op == "remove" {
+                        s.method_settings.remove(&key);
+                    } else {
+                        s.method_settings.insert(key, value.clone());
+                    }
+                }
                 _ if path.starts_with("/variables/") => {
                     let k = path.trim_start_matches("/variables/").to_string();
                     if op == "remove" {
@@ -178,5 +205,97 @@ impl ApiGatewayService {
         });
         s.last_updated_date = chrono::Utc::now();
         ok(stage_to_json(s))
+    }
+}
+
+#[cfg(test)]
+mod patch_tests {
+    use super::*;
+    use crate::state::Stage;
+    use crate::ApiGatewayService;
+
+    fn patch_req(ops: Value) -> AwsRequest {
+        AwsRequest {
+            service: "apigateway".into(),
+            action: "UpdateStage".into(),
+            region: "us-east-1".into(),
+            account_id: "123456789012".into(),
+            request_id: "rid".into(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(
+                serde_json::to_vec(&json!({ "patchOperations": ops })).unwrap(),
+            ),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::PATCH,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn update_stage_applies_cache_and_webacl_patches() {
+        // cacheClusterEnabled/Size, webAclArn, and per-method settings were
+        // dropped (bug-audit 2026-06-20, 1.21).
+        let state =
+            std::sync::Arc::new(
+                parking_lot::RwLock::new(fakecloud_core::multi_account::MultiAccountState::<
+                    crate::state::ApiGatewayState,
+                >::new("123456789012", "us-east-1", "")),
+            );
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create("123456789012");
+            st.stages.entry("api1".to_string()).or_default().insert(
+                "prod".to_string(),
+                Stage {
+                    stage_name: "prod".into(),
+                    deployment_id: "d1".into(),
+                    description: None,
+                    cache_cluster_enabled: false,
+                    cache_cluster_size: None,
+                    variables: Default::default(),
+                    method_settings: Default::default(),
+                    created_date: chrono::Utc::now(),
+                    last_updated_date: chrono::Utc::now(),
+                    tracing_enabled: false,
+                    web_acl_arn: None,
+                    canary_settings: None,
+                    access_log_settings: None,
+                    tags: Default::default(),
+                },
+            );
+        }
+        let svc = ApiGatewayService::new(state.clone());
+        let params: BTreeMap<String, String> = [
+            ("restApiId".to_string(), "api1".to_string()),
+            ("stageName".to_string(), "prod".to_string()),
+        ]
+        .into_iter()
+        .collect();
+
+        svc.update_stage(
+            &patch_req(json!([
+                { "op": "replace", "path": "/cacheClusterEnabled", "value": "true" },
+                { "op": "replace", "path": "/cacheClusterSize", "value": "0.5" },
+                { "op": "replace", "path": "/webAclArn", "value": "arn:aws:wafv2:::webacl/x" },
+                { "op": "replace", "path": "/~1pets/GET/throttling/rateLimit", "value": "10" },
+            ])),
+            &params,
+        )
+        .unwrap();
+
+        let accounts = state.read();
+        let s = &accounts.get("123456789012").unwrap().stages["api1"]["prod"];
+        assert!(s.cache_cluster_enabled);
+        assert_eq!(s.cache_cluster_size.as_deref(), Some("0.5"));
+        assert_eq!(s.web_acl_arn.as_deref(), Some("arn:aws:wafv2:::webacl/x"));
+        assert!(s
+            .method_settings
+            .contains_key("~1pets/GET/throttling/rateLimit"));
     }
 }

--- a/crates/fakecloud-apigateway/src/service_usage_plans.rs
+++ b/crates/fakecloud-apigateway/src/service_usage_plans.rs
@@ -107,6 +107,23 @@ impl ApiGatewayService {
                     }
                 }
                 "/description" => plan.description = value.as_str().map(String::from),
+                // Throttle/quota patches were dropped, so rate/burst/quota
+                // changes no-op'd and quota metering used stale values
+                // (bug-audit 2026-06-20, 1.21).
+                _ if path.starts_with("/throttle/") => {
+                    let key = path.trim_start_matches("/throttle/").to_string();
+                    let obj = plan.throttle.get_or_insert_with(|| serde_json::json!({}));
+                    if let Some(m) = obj.as_object_mut() {
+                        m.insert(key, value.clone());
+                    }
+                }
+                _ if path.starts_with("/quota/") => {
+                    let key = path.trim_start_matches("/quota/").to_string();
+                    let obj = plan.quota.get_or_insert_with(|| serde_json::json!({}));
+                    if let Some(m) = obj.as_object_mut() {
+                        m.insert(key, value.clone());
+                    }
+                }
                 _ => {}
             }
         });


### PR DESCRIPTION
## Summary

Four REST API (v1) PATCH handlers silently dropped most operations (finding 1.21):

- **UpdateStage** ignored `/cacheClusterEnabled`, `/cacheClusterSize`, `/webAclArn`, and per-method settings (throttling/logging/metrics/caching).
- **UpdateUsagePlan** ignored `/throttle/*` and `/quota/*` — rate/burst/quota changes no-op'd and quota metering used stale values.
- **UpdateIntegration** ignored `/credentials`, `/connectionType`, `/contentHandling`, `/passthroughBehavior`, `/requestParameters/*`, `/requestTemplates/*`.
- **UpdateAccount** ignored `patchOperations` entirely, so `cloudwatchRoleArn` could never be set.

Each now applies its ops using the fields the structs already carry and render.

## Test plan

- `update_stage_applies_cache_and_webacl_patches` — cacheClusterEnabled/Size, webAclArn, and a per-method throttling setting all persist (representative of the shared `apply_patch_operations` pattern used by all four handlers).
- Full apigateway suite passes; `cargo clippy -p fakecloud-apigateway --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v1 API Gateway PATCH handlers so previously ignored fields are applied. Updates to stages, usage plans, integrations, and account settings now persist and show up in reads.

- **Bug Fixes**
  - UpdateStage: apply cache settings, `webAclArn`, and per-method throttling/logging/metrics/caching; supports add/replace/remove.
  - UpdateUsagePlan: apply `/throttle/*` and `/quota/*` patches so rate/burst/quota changes take effect.
  - UpdateIntegration: handle `/credentials`, `/connectionType`, `/contentHandling`, `/passthroughBehavior`, `/requestParameters/*`, `/requestTemplates/*`; supports add/replace/remove.
  - UpdateAccount: apply `patchOperations` to `account_settings` (e.g., `cloudwatchRoleArn`); supports add/replace/remove.

<sup>Written for commit 2c3a1eed20393d42008264f2c2539101c1897872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

