### PR TITLE
fix(cloudformation): ECR RepositoryUri uses the bound fakecloud endpoint

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ecr.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ecr.rs
@@ -72,16 +72,17 @@ impl ResourceProvisioner {
             .unwrap_or(false);
 
         let mut accounts = self.ecr_state.write();
+        // Use the bound fakecloud endpoint (host:port) for RepositoryUri, like
+        // the direct CreateRepository path -- NOT the public AWS DNS. A CFN-
+        // provisioned repo's GetAtt RepositoryUri must point at fakecloud's own
+        // OCI registry so `docker push` reaches it (bug-audit 2026-06-20, 1.4).
+        let endpoint = accounts.endpoint().to_string();
         let state = accounts.get_or_create(&self.account_id);
         if state.repositories.contains_key(&repository_name) {
             return Err(format!("Repository {repository_name} already exists"));
         }
         let arn = state.repository_arn(&repository_name);
         let registry_id = state.account_id.clone();
-        let endpoint = format!(
-            "{}.dkr.ecr.{}.amazonaws.com",
-            state.account_id, state.region
-        );
         let mut repo = Repository::new(&repository_name, arn.clone(), &registry_id, &endpoint);
         repo.image_tag_mutability = image_tag_mutability;
         repo.image_scanning_configuration.scan_on_push = scan_on_push;

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -6093,6 +6093,30 @@ mod tests {
     }
 
     #[test]
+    fn ecr_repository_uri_uses_bound_endpoint_not_public_dns() {
+        // A CFN-provisioned RepositoryUri must point at fakecloud's own registry
+        // endpoint, not the public AWS DNS, so `docker push` against the GetAtt
+        // RepositoryUri reaches it (bug-audit 2026-06-20, 1.4).
+        let prov = make_provisioner();
+        let sr = prov
+            .create_resource(&make_resource(
+                "AWS::ECR::Repository",
+                "Repo",
+                serde_json::json!({ "RepositoryName": "my-repo" }),
+            ))
+            .expect("ECR repo provisions");
+        let uri = sr
+            .attributes
+            .get("RepositoryUri")
+            .expect("RepositoryUri attribute");
+        assert!(
+            !uri.contains("amazonaws.com"),
+            "RepositoryUri must not use the public ECR DNS, got {uri}"
+        );
+        assert!(uri.contains("my-repo"), "uri should name the repo: {uri}");
+    }
+
+    #[test]
     fn sns_subscription_rejects_nonexistent_topic() {
         let prov = make_provisioner();
         let resource = make_resource(


### PR DESCRIPTION
## Summary

The CFN `AWS::ECR::Repository` provisioner hardcoded `RepositoryUri` as `{account}.dkr.ecr.{region}.amazonaws.com` (public AWS DNS), unlike the direct `CreateRepository` path which uses the bound fakecloud endpoint. So `docker push` against a CFN-provisioned repo's GetAtt `RepositoryUri` never reached fakecloud's own OCI registry. Now it uses `accounts.endpoint()` like the direct path.

Found by the 2026-06-20 bug-hunt audit (finding 1.4).

## Test plan

- `ecr_repository_uri_uses_bound_endpoint_not_public_dns` — a provisioned repo's `RepositoryUri` no longer contains `amazonaws.com` and names the repo.
- Full cloudformation suite passes; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CloudFormation ECR `RepositoryUri` to use the bound fakecloud endpoint instead of the public AWS DNS, so `docker push` to a CFN-provisioned repo reaches fakecloud’s OCI registry. Aligns the CFN path with the direct `CreateRepository` behavior.

- **Bug Fixes**
  - Use `accounts.endpoint()` for `RepositoryUri`; remove `{account}.dkr.ecr.{region}.amazonaws.com`.
  - Add test `ecr_repository_uri_uses_bound_endpoint_not_public_dns` to verify no `amazonaws.com` and that the repo name is present.

<sup>Written for commit ef64bdb46d896bda697da25b48aae38acbded89d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

