### PR TITLE
fix(cognito): return UserPool.Endpoint in DescribeUserPool

### DIFF
--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1374,6 +1374,12 @@ fn user_pool_to_json(pool: &UserPool) -> Value {
         }).collect::<Vec<Value>>(),
     });
 
+    // AWS always returns the pool's Endpoint (without scheme); Terraform reads
+    // it to wire the OIDC issuer / JWKS URL. The region is embedded in the pool
+    // id (`<region>_<random>`). Previously omitted (bug-audit 2026-06-20, 1.4).
+    let region = pool.id.split('_').next().unwrap_or("us-east-1");
+    obj["Endpoint"] = json!(format!("cognito-idp.{region}.amazonaws.com/{}", pool.id));
+
     if let Some(ref v) = pool.email_verification_message {
         obj["EmailVerificationMessage"] = json!(v);
     }

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -3465,6 +3465,12 @@ fn describe_user_pool() {
     let b = resp_json(&resp);
     assert_eq!(b["UserPool"]["Id"], pool_id);
     assert_eq!(b["UserPool"]["Name"], "test-pool");
+    // Endpoint must be present for Terraform's OIDC issuer/JWKS wiring (1.4).
+    let endpoint = b["UserPool"]["Endpoint"]
+        .as_str()
+        .expect("Endpoint present");
+    assert!(endpoint.starts_with("cognito-idp."), "{endpoint}");
+    assert!(endpoint.ends_with(&pool_id), "{endpoint}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`DescribeUserPool` omitted the `Endpoint` field. Terraform reads `aws_cognito_user_pool.endpoint` to wire the OIDC issuer / JWKS URL, so it resolved empty. Now emits `cognito-idp.<region>.amazonaws.com/<poolId>` (region embedded in the pool id), matching AWS's scheme-less `Endpoint`.

Found by the 2026-06-20 bug-hunt audit (finding 1.4).

## Test plan

- `describe_user_pool` now also asserts `Endpoint` is present and well-formed.
- clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return `UserPool.Endpoint` in `DescribeUserPool` so Terraform can read `aws_cognito_user_pool.endpoint` and wire the OIDC issuer/JWKS URL. Endpoint now matches AWS (scheme-less): `cognito-idp.<region>.amazonaws.com/<poolId>` with region taken from the pool ID.

<sup>Written for commit b1f3695f44654cd17f51d8196916ed4487d13421. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

