### PR TITLE
fix(rds): populate DbClusterResourceId + render Endpoint/Port/Engine on cluster create/restore

### DIFF
--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -121,18 +121,23 @@ impl RdsService {
             "CreateDBCluster" => {
                 let id = get_param(req, "DBClusterIdentifier").ok_or_else(|| missing("DBClusterIdentifier"))?;
                 let arn = Arn::new("rds", region, &aid, &format!("cluster:{id}")).to_string();
+                let engine = get_param(req, "Engine").unwrap_or_else(|| "aurora-postgresql".to_string());
+                let port = get_param(req, "Port")
+                    .and_then(|p| p.parse::<i64>().ok())
+                    .unwrap_or(if engine.contains("mysql") { 3306 } else { 5432 });
                 let entry = json!({
                     "DBClusterIdentifier": id, "DBClusterArn": arn,
-                    "Status": "available", "Engine": get_param(req, "Engine").unwrap_or_else(|| "aurora-postgresql".to_string()),
+                    "DbClusterResourceId": new_cluster_resource_id(),
+                    "Status": "available", "Engine": engine,
                     "EngineVersion": get_param(req, "EngineVersion").unwrap_or_else(|| "15.3".to_string()),
                     "Endpoint": format!("{id}.cluster-xxx.{region}.rds.amazonaws.com"),
                     "ReaderEndpoint": format!("{id}.cluster-ro-xxx.{region}.rds.amazonaws.com"),
-                    "Port": 5432, "MasterUsername": get_param(req, "MasterUsername").unwrap_or_else(|| "postgres".to_string()),
+                    "Port": port, "MasterUsername": get_param(req, "MasterUsername").unwrap_or_else(|| "postgres".to_string()),
                 });
                 {
                     let mut accounts = write_state!();
                     let state = accounts.get_or_create(&aid);
-                    store(&mut state.extras, "clusters").insert(id.clone(), entry);
+                    store(&mut state.extras, "clusters").insert(id.clone(), entry.clone());
                 }
                 self.emit_event(
                     RdsSourceType::DbCluster,
@@ -142,7 +147,14 @@ impl RdsService {
                     &["creation"],
                     "DB cluster created",
                 );
-                Ok(xml_response("CreateDBCluster", db_cluster_xml(&id, &arn), &rid))
+                Ok(xml_response(
+                    "CreateDBCluster",
+                    format!(
+                        "    <DBCluster>\n{}\n    </DBCluster>",
+                        db_cluster_member_xml(&entry)
+                    ),
+                    &rid,
+                ))
             }
             "DeleteDBCluster" => {
                 let id = get_param(req, "DBClusterIdentifier").ok_or_else(|| missing("DBClusterIdentifier"))?;
@@ -1298,6 +1310,12 @@ impl RdsService {
                         "ReaderEndpoint".to_string(),
                         json!(format!("{target}.cluster-ro-xxx.{region}.rds.amazonaws.com")),
                     );
+                    // Restored cluster is a distinct resource: mint a fresh
+                    // immutable resource id rather than reuse the source's.
+                    obj.insert(
+                        "DbClusterResourceId".to_string(),
+                        json!(new_cluster_resource_id()),
+                    );
                     obj.remove("ReplicationSourceIdentifier");
                     // The new cluster starts empty; the user is expected
                     // to call CreateDBInstance with DBClusterIdentifier
@@ -1325,7 +1343,7 @@ impl RdsService {
                         obj.insert("PendingRestoreDumpB64".to_string(), json!(b64));
                     }
                 }
-                store(&mut state.extras, "clusters").insert(target.clone(), entry);
+                store(&mut state.extras, "clusters").insert(target.clone(), entry.clone());
                 drop(accounts);
                 self.emit_event(
                     RdsSourceType::DbCluster,
@@ -1337,7 +1355,10 @@ impl RdsService {
                 );
                 Ok(xml_response(
                     "RestoreDBClusterFromSnapshot",
-                    db_cluster_xml(&target, &arn),
+                    format!(
+                        "    <DBCluster>\n{}\n    </DBCluster>",
+                        db_cluster_member_xml(&entry)
+                    ),
                     &rid,
                 ))
             }
@@ -1376,6 +1397,10 @@ impl RdsService {
                         "ReaderEndpoint".to_string(),
                         json!(format!("{target}.cluster-ro-xxx.{region}.rds.amazonaws.com")),
                     );
+                    obj.insert(
+                        "DbClusterResourceId".to_string(),
+                        json!(new_cluster_resource_id()),
+                    );
                     obj.remove("DBClusterMembers");
                     obj.remove("WriterDBInstanceIdentifier");
                     if let Some(restore_time) = get_param(req, "RestoreToTime") {
@@ -1385,7 +1410,7 @@ impl RdsService {
                         obj.insert("UseLatestRestorableTime".to_string(), json!(latest));
                     }
                 }
-                store(&mut state.extras, "clusters").insert(target.clone(), entry);
+                store(&mut state.extras, "clusters").insert(target.clone(), entry.clone());
                 drop(accounts);
                 self.emit_event(
                     RdsSourceType::DbCluster,
@@ -1397,7 +1422,10 @@ impl RdsService {
                 );
                 Ok(xml_response(
                     "RestoreDBClusterToPointInTime",
-                    db_cluster_xml(&target, &arn),
+                    format!(
+                        "    <DBCluster>\n{}\n    </DBCluster>",
+                        db_cluster_member_xml(&entry)
+                    ),
                     &rid,
                 ))
             }
@@ -1479,6 +1507,13 @@ impl RdsService {
 }
 
 // ── XML helpers per resource ──
+
+/// Generate a `DbClusterResourceId` in AWS's `cluster-XXXX` form. The suffix
+/// is immutable and survives rename, so IAM auth / CloudWatch dimensions key
+/// on it rather than the cluster identifier.
+pub(crate) fn new_cluster_resource_id() -> String {
+    format!("cluster-{}", uuid::Uuid::new_v4().simple())
+}
 
 pub(crate) fn db_cluster_xml(id: &str, arn: &str) -> String {
     format!(

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -121,6 +121,45 @@ fn describe_events_filters_by_source_identifier() {
 }
 
 #[test]
+fn create_db_cluster_response_renders_computed_fields() {
+    // CreateDBCluster previously returned only id/arn/status via the canned
+    // db_cluster_xml; Endpoint/Port/Engine and DbClusterResourceId were
+    // dropped (bug-audit 2026-06-20, 1.4).
+    let svc = svc();
+    let resp = svc
+        .handle_extra_action(&req(
+            "CreateDBCluster",
+            &[
+                ("DBClusterIdentifier", "c1"),
+                ("Engine", "aurora-mysql"),
+                ("EngineVersion", "8.0"),
+            ],
+        ))
+        .expect("CreateDBCluster");
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<Engine>aurora-mysql</Engine>"), "{body}");
+    assert!(
+        body.contains("<EngineVersion>8.0</EngineVersion>"),
+        "{body}"
+    );
+    assert!(
+        body.contains("<Endpoint>c1.cluster-xxx.us-east-1.rds.amazonaws.com</Endpoint>"),
+        "{body}"
+    );
+    assert!(body.contains("<ReaderEndpoint>"), "{body}");
+    // aurora-mysql defaults to 3306, not the redis-ish 5432.
+    assert!(body.contains("<Port>3306</Port>"), "{body}");
+    assert!(body.contains("<DbClusterResourceId>cluster-"), "{body}");
+
+    // The same fields must survive into DescribeDBClusters.
+    let dr = svc
+        .handle_extra_action(&req("DescribeDBClusters", &[]))
+        .unwrap();
+    let dbody = String::from_utf8(dr.body.expect_bytes().to_vec()).unwrap();
+    assert!(dbody.contains("<DbClusterResourceId>cluster-"), "{dbody}");
+}
+
+#[test]
 fn cluster_lifecycle() {
     // The lifecycle ops require the cluster to actually exist and be
     // in the right state; share a single service so each call sees


### PR DESCRIPTION
## Summary
`CreateDBCluster` returned only `DBClusterIdentifier`/`DBClusterArn`/`Status` via the canned `db_cluster_xml` renderer, silently dropping the `Endpoint`, `ReaderEndpoint`, `Port`, `Engine` and `MasterUsername` it had just stored in state. `DbClusterResourceId` — the immutable id IAM database auth and CloudWatch dimensions key on — was never populated at all.

- Add `new_cluster_resource_id()` (`cluster-<uuid>`); store it at create time.
- Render `CreateDBCluster` / `RestoreDBClusterFromSnapshot` / `RestoreDBClusterToPointInTime` through `db_cluster_member_xml` so the full stored shape is returned, matching `DescribeDBClusters`.
- Mint a fresh resource id on each restore rather than cloning the source cluster's.
- Default `Port` to 3306 for mysql-family engines, 5432 otherwise.

Bug-audit 2026-06-20, finding 1.4.

## Test plan
- New unit test: `CreateDBCluster` response renders Engine/EngineVersion/Endpoint/ReaderEndpoint/Port(3306 for aurora-mysql)/DbClusterResourceId, and the resource id survives into DescribeDBClusters.
- `cargo test -p fakecloud-rds` green; fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate `DbClusterResourceId` and return full cluster details in Create/Restore responses so they match `DescribeDBClusters`. Fixes missing fields and improves IAM DB auth and metrics parity.

- **Bug Fixes**
  - Generate and store `DbClusterResourceId` via `new_cluster_resource_id()`; mint a new one on each restore.
  - Render `CreateDBCluster`, `RestoreDBClusterFromSnapshot`, and `RestoreDBClusterToPointInTime` with `db_cluster_member_xml` to include `Engine`, `EngineVersion`, `Endpoint`, `ReaderEndpoint`, `Port`, and `MasterUsername`.
  - Default `Port` to 3306 for mysql-family engines; 5432 otherwise.
  - Add unit test to assert fields in `CreateDBCluster` and their persistence into `DescribeDBClusters`.

<sup>Written for commit d47e0964b3ccd4582965150f692180958c0c4212. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

