### PR TITLE
fix(dynamodb): honor legacy Expected + ConditionalOperator on Put/Update/Delete

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
@@ -406,6 +406,7 @@ pub(crate) enum LegacyConditionRole {
 pub(crate) fn translate_legacy_conditions(
     conditions: &serde_json::Map<String, Value>,
     role: LegacyConditionRole,
+    conditional_operator: &str,
     names: &mut HashMap<String, String>,
     values: &mut HashMap<String, Value>,
 ) -> Result<String, AwsServiceError> {
@@ -451,7 +452,124 @@ pub(crate) fn translate_legacy_conditions(
         fragments.push(build_legacy_fragment(&name_ph, operator, &value_phs, role)?);
     }
 
-    Ok(fragments.join(" AND "))
+    // KeyConditions are always implicitly AND-ed; ConditionalOperator only
+    // applies to the filter forms (QueryFilter/ScanFilter). A single fragment
+    // needs no joiner, so OR vs AND only matters with 2+ conditions.
+    let joiner =
+        if role == LegacyConditionRole::Filter && conditional_operator.eq_ignore_ascii_case("OR") {
+            " OR "
+        } else {
+            " AND "
+        };
+    Ok(fragments.join(joiner))
+}
+
+/// Resolve the effective condition for a write op (Put/Update/Delete): prefer
+/// `ConditionExpression`, otherwise translate the legacy `Expected` map,
+/// injecting its placeholders into `names`/`values`. Supplying both forms is
+/// rejected, matching real DynamoDB.
+pub(crate) fn resolve_write_condition(
+    body: &Value,
+    names: &mut HashMap<String, String>,
+    values: &mut HashMap<String, Value>,
+) -> Result<Option<String>, AwsServiceError> {
+    let expression = body["ConditionExpression"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let expected = body["Expected"].as_object().filter(|m| !m.is_empty());
+    match (expression, expected) {
+        (Some(_), Some(_)) => Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "Can not use both expression and non-expression parameters in the same request: \
+             Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}",
+        )),
+        (Some(expr), None) => Ok(Some(expr.to_string())),
+        (None, Some(expected)) => {
+            let op = body["ConditionalOperator"].as_str().unwrap_or("AND");
+            Ok(Some(translate_legacy_expected(
+                expected, op, names, values,
+            )?))
+        }
+        (None, None) => Ok(None),
+    }
+}
+
+/// Translate a legacy `Expected` map (pre-2014 conditional Put/Update/Delete)
+/// into a ConditionExpression, hoisting attribute names/values into the shared
+/// placeholder maps. `conditional_operator` is `"AND"` (default) or `"OR"`.
+///
+/// Each entry is either the newer `ComparisonOperator`/`AttributeValueList`
+/// form or the legacy `Value`/`Exists` shorthand:
+/// - `Exists: false` -> `attribute_not_exists`
+/// - `Exists: true` (or omitted) with `Value` -> equality
+/// - `Exists: true` without `Value` -> `attribute_exists`
+pub(crate) fn translate_legacy_expected(
+    expected: &serde_json::Map<String, Value>,
+    conditional_operator: &str,
+    names: &mut HashMap<String, String>,
+    values: &mut HashMap<String, Value>,
+) -> Result<String, AwsServiceError> {
+    let mut entries: Vec<(&String, &Value)> = expected.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+
+    let mut fragments: Vec<String> = Vec::with_capacity(entries.len());
+    for (idx, (attr, spec)) in entries.iter().enumerate() {
+        let name_ph = format!("#exp{idx}");
+        names.insert(name_ph.clone(), (*attr).clone());
+
+        // Newer ComparisonOperator form takes precedence when present.
+        if spec.get("ComparisonOperator").is_some() {
+            let operator = spec
+                .get("ComparisonOperator")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let value_list: &[Value] = spec
+                .get("AttributeValueList")
+                .and_then(|v| v.as_array())
+                .map(|a| a.as_slice())
+                .unwrap_or(&[]);
+            let mut value_phs: Vec<String> = Vec::with_capacity(value_list.len());
+            for (vi, v) in value_list.iter().enumerate() {
+                let ph = format!(":expv{idx}_{vi}");
+                values.insert(ph.clone(), v.clone());
+                value_phs.push(ph);
+            }
+            fragments.push(build_legacy_fragment(
+                &name_ph,
+                operator,
+                &value_phs,
+                LegacyConditionRole::Filter,
+            )?);
+            continue;
+        }
+
+        // Legacy Value / Exists shorthand.
+        let exists = spec.get("Exists").and_then(|v| v.as_bool());
+        let value = spec.get("Value");
+        match (exists, value) {
+            (Some(false), _) => fragments.push(format!("attribute_not_exists({name_ph})")),
+            (_, Some(v)) => {
+                let ph = format!(":expv{idx}");
+                values.insert(ph.clone(), v.clone());
+                fragments.push(format!("{name_ph} = {ph}"));
+            }
+            (Some(true), None) => fragments.push(format!("attribute_exists({name_ph})")),
+            (None, None) => {
+                return Err(legacy_validation_err(format!(
+                    "One of Value or Exists must be provided for the Expected condition on attribute {attr}"
+                )));
+            }
+        }
+    }
+
+    let joiner = if conditional_operator.eq_ignore_ascii_case("OR") {
+        " OR "
+    } else {
+        " AND "
+    };
+    Ok(fragments.join(joiner))
 }
 
 fn legacy_validation_err(message: String) -> AwsServiceError {
@@ -627,6 +745,7 @@ mod legacy_translation_tests {
                 "sk": {"AttributeValueList": [{"S": "ord#"}], "ComparisonOperator": "BEGINS_WITH"},
             })),
             LegacyConditionRole::Key,
+            "AND",
             &mut names,
             &mut values,
         )
@@ -658,6 +777,7 @@ mod legacy_translation_tests {
                 },
             })),
             LegacyConditionRole::Key,
+            "AND",
             &mut names,
             &mut values,
         )
@@ -683,6 +803,7 @@ mod legacy_translation_tests {
                 "zzz": {"ComparisonOperator": "NOT_NULL"},
             })),
             LegacyConditionRole::Filter,
+            "AND",
             &mut names,
             &mut values,
         )
@@ -728,6 +849,7 @@ mod legacy_translation_tests {
                 "a": {"AttributeValueList": [{"S": "x"}], "ComparisonOperator": "WAT"},
             })),
             LegacyConditionRole::Filter,
+            "AND",
             &mut names,
             &mut values,
         )
@@ -744,6 +866,7 @@ mod legacy_translation_tests {
                 "n": {"AttributeValueList": [{"N": "10"}], "ComparisonOperator": "BETWEEN"},
             })),
             LegacyConditionRole::Key,
+            "AND",
             &mut names,
             &mut values,
         )
@@ -760,6 +883,7 @@ mod legacy_translation_tests {
                 "a": {"AttributeValueList": [{"S": "x"}], "ComparisonOperator": "CONTAINS"},
             })),
             LegacyConditionRole::Key,
+            "AND",
             &mut names,
             &mut values,
         )

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -10,8 +10,8 @@ use super::{
     apply_update_expression, build_consumed_capacity, build_item_collection_metrics,
     evaluate_condition, extract_key, get_table, get_table_mut, parse_expression_attribute_names,
     parse_expression_attribute_values, project_item, require_object, require_str,
-    return_consumed_mode, return_icm_mode, validate_key_attributes_in_key, validate_key_in_item,
-    AttributeValue, DynamoDbService,
+    resolve_write_condition, return_consumed_mode, return_icm_mode, validate_key_attributes_in_key,
+    validate_key_in_item, AttributeValue, DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -20,9 +20,10 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
         let item = require_object(&body, "Item")?;
-        let condition = body["ConditionExpression"].as_str().map(|s| s.to_string());
-        let expr_attr_names = parse_expression_attribute_names(&body);
-        let expr_attr_values = parse_expression_attribute_values(&body);
+        let mut expr_attr_names = parse_expression_attribute_names(&body);
+        let mut expr_attr_values = parse_expression_attribute_values(&body);
+        let condition =
+            resolve_write_condition(&body, &mut expr_attr_names, &mut expr_attr_values)?;
         let return_values = body["ReturnValues"].as_str().unwrap_or("NONE").to_string();
         let return_consumed = return_consumed_mode(&body).to_string();
         let return_icm = return_icm_mode(&body).to_string();
@@ -40,7 +41,7 @@ impl DynamoDbService {
             let key = extract_key(table, &item);
             let existing_idx = table.find_item_index(&key);
 
-            if let Some(ref cond) = condition {
+            if let Some(cond) = condition.as_deref() {
                 let existing = existing_idx.map(|i| &table.items[i]);
                 evaluate_condition(cond, existing, &expr_attr_names, &expr_attr_values)?;
             }
@@ -247,13 +248,14 @@ impl DynamoDbService {
             let region = state.region.clone();
             let table = get_table_mut(&mut state.tables, table_name)?;
 
-            let condition = body["ConditionExpression"].as_str();
-            let expr_attr_names = parse_expression_attribute_names(&body);
-            let expr_attr_values = parse_expression_attribute_values(&body);
+            let mut expr_attr_names = parse_expression_attribute_names(&body);
+            let mut expr_attr_values = parse_expression_attribute_values(&body);
+            let condition =
+                resolve_write_condition(&body, &mut expr_attr_names, &mut expr_attr_values)?;
 
             let existing_idx = table.find_item_index(&key);
 
-            if let Some(cond) = condition {
+            if let Some(cond) = condition.as_deref() {
                 let existing = existing_idx.map(|i| &table.items[i]);
                 evaluate_condition(cond, existing, &expr_attr_names, &expr_attr_values)?;
             }
@@ -338,14 +340,15 @@ impl DynamoDbService {
 
         validate_key_attributes_in_key(table, &key)?;
 
-        let condition = body["ConditionExpression"].as_str();
-        let expr_attr_names = parse_expression_attribute_names(&body);
-        let expr_attr_values = parse_expression_attribute_values(&body);
+        let mut expr_attr_names = parse_expression_attribute_names(&body);
+        let mut expr_attr_values = parse_expression_attribute_values(&body);
+        let condition =
+            resolve_write_condition(&body, &mut expr_attr_names, &mut expr_attr_values)?;
         let update_expression = body["UpdateExpression"].as_str();
 
         let existing_idx = table.find_item_index(&key);
 
-        if let Some(cond) = condition {
+        if let Some(cond) = condition.as_deref() {
             let existing = existing_idx.map(|i| &table.items[i]);
             evaluate_condition(cond, existing, &expr_attr_names, &expr_attr_values)?;
         }

--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -578,6 +578,7 @@ fn resolve_legacy_or_expression(
     names: &mut HashMap<String, String>,
     values: &mut HashMap<String, Value>,
 ) -> Result<Option<String>, AwsServiceError> {
+    let conditional_operator = body["ConditionalOperator"].as_str().unwrap_or("AND");
     let expression = body[expression_param]
         .as_str()
         .map(str::trim)
@@ -595,7 +596,11 @@ fn resolve_legacy_or_expression(
         )),
         (Some(expr), None) => Ok(Some(expr.to_string())),
         (None, Some(legacy)) => Ok(Some(translate_legacy_conditions(
-            legacy, role, names, values,
+            legacy,
+            role,
+            conditional_operator,
+            names,
+            values,
         )?)),
         (None, None) => Ok(None),
     }

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -5111,3 +5111,80 @@ fn update_item_applies_legacy_attribute_updates() {
     assert_eq!(item["name"]["S"], "alice", "PUT must store the attribute");
     assert_eq!(item["n"]["N"], "8", "ADD must increment 5 + 3 = 8");
 }
+
+#[test]
+fn put_item_honors_legacy_expected() {
+    // Legacy Expected (pre-2014 conditional writes) was ignored on Put/Delete
+    // (bug-audit 2026-06-20, 1.2): a put-if-absent guard silently overwrote.
+    let svc = make_service();
+    create_test_table(&svc);
+
+    // Exists:false guard succeeds for a brand-new key.
+    svc.put_item(&make_request(
+        "PutItem",
+        json!({
+            "TableName": "test-table",
+            "Item": { "pk": { "S": "u1" }, "v": { "N": "1" } },
+            "Expected": { "pk": { "Exists": false } }
+        }),
+    ))
+    .expect("first put-if-absent should succeed");
+
+    // Same guard now fails because the item exists.
+    let err = svc.put_item(&make_request(
+        "PutItem",
+        json!({
+            "TableName": "test-table",
+            "Item": { "pk": { "S": "u1" }, "v": { "N": "2" } },
+            "Expected": { "pk": { "Exists": false } }
+        }),
+    ));
+    assert!(err.is_err(), "put-if-absent must fail when key exists");
+
+    // Value equality guard (implicit EQ) succeeds when it matches.
+    svc.put_item(&make_request(
+        "PutItem",
+        json!({
+            "TableName": "test-table",
+            "Item": { "pk": { "S": "u1" }, "v": { "N": "3" } },
+            "Expected": { "v": { "Value": { "N": "1" } } }
+        }),
+    ))
+    .expect("equality guard should match stored value");
+}
+
+#[test]
+fn delete_item_legacy_expected_with_or_operator() {
+    // ConditionalOperator:OR was hard-coded to AND (bug-audit 2026-06-20, 1.2).
+    let svc = make_service();
+    create_test_table(&svc);
+    svc.put_item(&make_request(
+        "PutItem",
+        json!({ "TableName": "test-table", "Item": { "pk": { "S": "u1" }, "status": { "S": "active" }, "n": { "N": "5" } } }),
+    ))
+    .unwrap();
+
+    // Only the status condition holds; with OR the delete must still proceed.
+    svc.delete_item(&make_request(
+        "DeleteItem",
+        json!({
+            "TableName": "test-table",
+            "Key": { "pk": { "S": "u1" } },
+            "ConditionalOperator": "OR",
+            "Expected": {
+                "status": { "Value": { "S": "active" } },
+                "n": { "Value": { "N": "999" } }
+            }
+        }),
+    ))
+    .expect("OR condition should pass when one branch holds");
+
+    let resp = svc
+        .get_item(&make_request(
+            "GetItem",
+            json!({ "TableName": "test-table", "Key": { "pk": { "S": "u1" } } }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert!(body.get("Item").is_none(), "item should have been deleted");
+}


### PR DESCRIPTION
## Summary
`PutItem`/`UpdateItem`/`DeleteItem` only evaluated `ConditionExpression`; the legacy `Expected` map (pre-2014 conditional writes, still emitted by pinned SDKs and the Terraform AWS provider) was silently ignored — so a classic put-if-absent (`Expected: {pk: {Exists: false}}`) would happily overwrite. `ConditionalOperator: OR` was also hard-coded to `AND` in the legacy QueryFilter/ScanFilter translation.

- Add `translate_legacy_expected`: maps each `Expected` entry (legacy `Value`/`Exists` shorthand or newer `ComparisonOperator`/`AttributeValueList`) into a ConditionExpression fragment, joined by `ConditionalOperator` (`AND` default / `OR`).
- Add `resolve_write_condition`: prefers `ConditionExpression`, otherwise translates `Expected`; rejects supplying both, matching real DynamoDB.
- Thread `conditional_operator` through `translate_legacy_conditions` so `OR` is honored for QueryFilter/ScanFilter (KeyConditions stay implicitly AND).

Bug-audit 2026-06-20, finding 1.2 (the AttributeUpdates half shipped in #1801).

## Test plan
- New unit tests: put-if-absent guard succeeds then fails once the key exists; equality guard matches stored value; DeleteItem with `ConditionalOperator: OR` proceeds when only one branch holds.
- `cargo test -p fakecloud-dynamodb` green (313 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB conditional writes to honor legacy Expected and ConditionalOperator on PutItem/UpdateItem/DeleteItem, preventing silent overwrites and aligning with AWS behavior. Also makes legacy QueryFilter/ScanFilter respect OR.

- **Bug Fixes**
  - For writes, evaluate `Expected` when `ConditionExpression` is not provided; supports AND/OR and both Value/Exists and ComparisonOperator forms.
  - Reject requests that include both `ConditionExpression` and `Expected`, matching DynamoDB validation.
  - Respect `ConditionalOperator: OR` when translating legacy QueryFilter/ScanFilter (KeyConditions remain AND).
  - Added unit tests for put-if-absent, equality guard, and DeleteItem with OR.

<sup>Written for commit b8adc8b77fdd981fae9b9b6c1cfc8e46fd440e1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

