### PR TITLE
perf(s3): keep object data-plane writes from starving the async runtime

### DIFF
--- a/crates/fakecloud-s3/src/service/objects/mod.rs
+++ b/crates/fakecloud-s3/src/service/objects/mod.rs
@@ -28,6 +28,24 @@ mod write;
 
 impl S3Service {}
 
+/// Run a blocking closure (synchronous disk IO) without starving the async
+/// runtime. On a multi-threaded tokio runtime this uses `block_in_place` so
+/// the worker hands its other tasks to a sibling thread for the duration of
+/// the IO; on a current-thread runtime (e.g. `#[tokio::test]`) `block_in_place`
+/// would panic, so we just run the closure inline. The lock-hold semantics of
+/// the caller are unchanged — this only stops a large body copy from blocking
+/// unrelated async tasks parked on the same worker.
+pub(crate) fn run_blocking_io<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    use tokio::runtime::{Handle, RuntimeFlavor};
+    match Handle::try_current() {
+        Ok(h) if h.runtime_flavor() == RuntimeFlavor::MultiThread => tokio::task::block_in_place(f),
+        _ => f(),
+    }
+}
+
 /// Build the response body for a full GetObject read. For memory-backed
 /// bodies this returns `ResponseBody::Bytes`; for disk-backed bodies it
 /// opens the file handle eagerly (while the caller still holds the per-state

--- a/crates/fakecloud-s3/src/service/objects/write.rs
+++ b/crates/fakecloud-s3/src/service/objects/write.rs
@@ -522,16 +522,16 @@ impl S3Service {
                 let o = b2.objects.get(key).ok_or_else(|| no_such_key(key))?;
                 object_meta_snapshot(o)
             };
-            let returned_body = self
-                .store
-                .put_object(
+            let returned_body = super::run_blocking_io(|| {
+                self.store.put_object(
                     bucket,
                     key,
                     meta_version.version_id.as_deref(),
                     body_source,
                     &meta_version,
                 )
-                .map_err(crate::service::persistence_error)?;
+            })
+            .map_err(crate::service::persistence_error)?;
             if let Some(b2) = state.buckets.get_mut(bucket) {
                 if let Some(o) = b2.objects.get_mut(key) {
                     o.body = returned_body.clone();
@@ -1036,16 +1036,16 @@ impl S3Service {
         // for the BodyRef rewrite and subsequent replication/notification
         // work below.
         let _ = db;
-        let dest_body_ref = self
-            .store
-            .put_object(
+        let dest_body_ref = super::run_blocking_io(|| {
+            self.store.put_object(
                 dest_bucket,
                 dest_key,
                 dest_meta.version_id.as_deref(),
                 BodySource::Bytes(dest_stored_bytes.clone()),
                 &dest_meta,
             )
-            .map_err(crate::service::persistence_error)?;
+        })
+        .map_err(crate::service::persistence_error)?;
         if let Some(db2) = state.buckets.get_mut(dest_bucket) {
             if let Some(o) = db2.objects.get_mut(dest_key) {
                 o.body = dest_body_ref.clone();

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -859,6 +859,26 @@ async fn upload_part_missing_upload_errors() {
     );
 }
 
+// PutObject's disk write is wrapped in run_blocking_io (bug-audit
+// 2026-06-20, 3.2). On a multi-threaded runtime that path uses
+// block_in_place, which panics if mis-guarded; this exercises it end-to-end.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn put_object_runs_on_multi_thread_runtime() {
+    let svc = make_service();
+    seed_bucket(&svc, "b");
+    let body = b"streamed-under-block-in-place";
+    let req = make_request(Method::PUT, "/b/k", &[], body);
+    let resp = svc
+        .put_object("123456789012", &req, "b", "k")
+        .await
+        .expect("put_object should succeed on a multi-thread runtime");
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let get_req = make_request(Method::GET, "/b/k", &[], b"");
+    let got = svc.get_object("123456789012", &get_req, "b", "k").unwrap();
+    assert_eq!(got.body.expect_bytes(), body);
+}
+
 #[tokio::test]
 async fn mpu_full_lifecycle_creates_object() {
     let svc = make_service();


### PR DESCRIPTION
## Summary
PutObject / CopyObject perform the full-body disk write synchronously on the tokio worker thread, blocking unrelated async tasks parked on the same worker for the duration of a large copy (bug-audit 2026-06-20, finding 3.2).

- Add `run_blocking_io`: on a multi-threaded runtime it uses `tokio::task::block_in_place` so the worker hands its other tasks to a sibling thread during the blocking IO; on a current-thread runtime (used by `#[tokio::test]`) `block_in_place` would panic, so it runs the closure inline.
- Wrap the blocking `store.put_object` calls in PutObject and CopyObject.
- Lock-hold semantics are unchanged; this only stops a large body write from blocking other async tasks on the same worker. Moving the write outside the lock is unsafe here because the store derives the on-disk path from the (non-versioned) key, so the etag/content correspondence relies on the write being serialized under the lock.

On finding 3.1: GetObject already streams disk-backed full bodies via `ResponseBody::File` (only the cheap `open()` syscall runs under the read lock, no full read into RAM), so the full-read concern was already mitigated. Range and SSE-KMS reads still materialize bounded slices, which is inherent to those paths.

## Test plan
- New test `put_object_runs_on_multi_thread_runtime` (flavor = multi_thread): exercises the `block_in_place` path end-to-end and reads the object back.
- `cargo test -p fakecloud-s3` green (364 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop large S3 object writes from starving the async runtime. Blocking disk writes now run via `run_blocking_io` so worker threads hand off other tasks on multi-thread runtimes; lock semantics are unchanged.

- Performance
  - Added `run_blocking_io` using `tokio::task::block_in_place` on multi-thread runtimes; falls back to inline on current-thread runtimes.
  - Wrapped `store.put_object` in `PutObject` and `CopyObject` with `run_blocking_io`.
  - Added test `put_object_runs_on_multi_thread_runtime` to exercise the `block_in_place` path; `GetObject` streaming remains unchanged.

<sup>Written for commit 8a462bcb4921e8bc57b11bbcabe2a5f9cae05d6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

