### PR TITLE
fix(lambda): honor Marker/MaxItems pagination + ESM filters on List ops

### DIFF
--- a/crates/fakecloud-lambda/src/extras/account.rs
+++ b/crates/fakecloud-lambda/src/extras/account.rs
@@ -27,7 +27,7 @@ impl LambdaService {
             // Aliases
             "CreateAlias" => self.create_alias(res, req),
             "GetAlias" => self.get_alias(res, req),
-            "ListAliases" => self.list_aliases(res, aid),
+            "ListAliases" => self.list_aliases(res, aid, req),
             "UpdateAlias" => self.update_alias(res, req),
             "DeleteAlias" => self.delete_alias(res, req),
 
@@ -37,7 +37,7 @@ impl LambdaService {
             "GetLayerVersionByArn" => self.get_layer_version_by_arn(req),
             "ListLayers" => {
                 validate_layer_filters(req)?;
-                self.list_layers(aid)
+                self.list_layers(aid, req)
             }
             "ListLayerVersions" => {
                 validate_layer_filters(req)?;
@@ -54,7 +54,7 @@ impl LambdaService {
                         "LayerName exceeds the 140-character maximum",
                     ));
                 }
-                self.list_layer_versions(res, aid)
+                self.list_layer_versions(res, aid, req)
             }
             "DeleteLayerVersion" => self.delete_layer_version(req),
             "GetLayerVersionPolicy" => self.get_layer_version_policy(req),

--- a/crates/fakecloud-lambda/src/extras/aliases.rs
+++ b/crates/fakecloud-lambda/src/extras/aliases.rs
@@ -86,17 +86,26 @@ impl LambdaService {
         &self,
         function_name: &str,
         account_id: &str,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        let marker = req.query_params.get("Marker").map(String::as_str);
+        let max_items = crate::service::marker_page_size(req);
         let region = self.region_for(account_id);
         self.with_state_read(account_id, &region, |state| {
             let prefix = format!("{function_name}:");
-            let aliases: Vec<&FunctionAlias> = state
+            let aliases: Vec<FunctionAlias> = state
                 .aliases
                 .iter()
                 .filter(|(k, _)| k.starts_with(&prefix))
-                .map(|(_, v)| v)
+                .map(|(_, v)| v.clone())
                 .collect();
-            ok(json!({"Aliases": aliases}))
+            let (page, next_marker) =
+                crate::service::paginate_marker(aliases, marker, max_items, |a| a.name.clone());
+            let page_json: Vec<Value> = page
+                .iter()
+                .map(|a| serde_json::to_value(a).unwrap_or_default())
+                .collect();
+            ok(json!({"Aliases": page_json, "NextMarker": next_marker}))
         })
     }
 

--- a/crates/fakecloud-lambda/src/extras/layers.rs
+++ b/crates/fakecloud-lambda/src/extras/layers.rs
@@ -145,7 +145,13 @@ impl LambdaService {
         }))
     }
 
-    pub(super) fn list_layers(&self, account_id: &str) -> Result<AwsResponse, AwsServiceError> {
+    pub(super) fn list_layers(
+        &self,
+        account_id: &str,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let marker = req.query_params.get("Marker").map(String::as_str);
+        let max_items = crate::service::marker_page_size(req);
         let region = self.region_for(account_id);
         self.with_state_read(account_id, &region, |state| {
             let layers: Vec<Value> = state
@@ -166,7 +172,11 @@ impl LambdaService {
                     })
                 })
                 .collect();
-            ok(json!({"Layers": layers}))
+            let (page, next_marker) =
+                crate::service::paginate_marker(layers, marker, max_items, |l| {
+                    l["LayerName"].as_str().unwrap_or_default().to_string()
+                });
+            ok(json!({"Layers": page, "NextMarker": next_marker}))
         })
     }
 
@@ -174,7 +184,10 @@ impl LambdaService {
         &self,
         layer_name: &str,
         account_id: &str,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        let marker = req.query_params.get("Marker").map(String::as_str);
+        let max_items = crate::service::marker_page_size(req);
         let region = self.region_for(account_id);
         self.with_state_read(account_id, &region, |state| {
             let versions: Vec<Value> = state
@@ -197,7 +210,13 @@ impl LambdaService {
                         .collect()
                 })
                 .unwrap_or_default();
-            ok(json!({"LayerVersions": versions}))
+            // Paginate by Version using a zero-padded key so the string sort
+            // matches numeric order (preserving the existing ascending order).
+            let (page, next_marker) =
+                crate::service::paginate_marker(versions, marker, max_items, |v| {
+                    format!("{:020}", v["Version"].as_i64().unwrap_or(0))
+                });
+            ok(json!({"LayerVersions": page, "NextMarker": next_marker}))
         })
     }
 

--- a/crates/fakecloud-lambda/src/service/functions.rs
+++ b/crates/fakecloud-lambda/src/service/functions.rs
@@ -373,6 +373,8 @@ impl LambdaService {
         &self,
         account_id: &str,
         function_version: Option<&str>,
+        marker: Option<&str>,
+        max_items: Option<usize>,
     ) -> Result<AwsResponse, AwsServiceError> {
         // `FunctionVersion` is an enum with the single member `ALL`; reject
         // any other value rather than silently ignoring it.
@@ -394,14 +396,14 @@ impl LambdaService {
             .map(|f| self.function_config_json(f))
             .collect();
 
-        // AWS's documented example carries `NextMarker` as a string even
-        // on the final page. We don't paginate yet, so emit an empty
-        // string rather than a true sentinel — closer to AWS's
-        // observed behavior than omitting the field, and string-typed
-        // so strict shape validators don't trip.
+        // Honor Marker/MaxItems. AWS orders ListFunctions by FunctionName and
+        // carries NextMarker as a string even on the final page (empty there).
+        let (page, next_marker) = super::paginate_marker(functions, marker, max_items, |f| {
+            f["FunctionName"].as_str().unwrap_or_default().to_string()
+        });
         let response = json!({
-            "Functions": functions,
-            "NextMarker": "",
+            "Functions": page,
+            "NextMarker": next_marker,
         });
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))

--- a/crates/fakecloud-lambda/src/service/mod.rs
+++ b/crates/fakecloud-lambda/src/service/mod.rs
@@ -425,6 +425,57 @@ fn is_function_name_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '-' || c == '_'
 }
 
+/// Lambda's `Marker`/`MaxItems` list pagination. The items are sorted by their
+/// opaque per-item key (`marker_of`) for a stable order, then sliced: a
+/// non-empty `Marker` resumes after the item whose key equals it, and
+/// `MaxItems` bounds the page. Returns `(page, next_marker)` where the marker
+/// is the last returned item's key when more remain, else `""` (AWS emits an
+/// empty-string `NextMarker` on the final page rather than omitting it).
+///
+/// An unrecognised marker (its item was deleted between calls) yields an empty
+/// final page, matching AWS's "resume past the end" behaviour.
+pub(crate) fn paginate_marker<T, F>(
+    mut items: Vec<T>,
+    marker: Option<&str>,
+    max_items: Option<usize>,
+    marker_of: F,
+) -> (Vec<T>, String)
+where
+    F: Fn(&T) -> String,
+{
+    items.sort_by_key(&marker_of);
+
+    let start = match marker {
+        Some(m) if !m.is_empty() => items
+            .iter()
+            .position(|it| marker_of(it) == m)
+            .map(|p| p + 1)
+            .unwrap_or(items.len()),
+        _ => 0,
+    };
+    if start >= items.len() {
+        return (Vec::new(), String::new());
+    }
+
+    let limit = max_items.filter(|&n| n > 0).unwrap_or(usize::MAX);
+    let end = start.saturating_add(limit).min(items.len());
+    let next_marker = if end < items.len() {
+        marker_of(&items[end - 1])
+    } else {
+        String::new()
+    };
+    let page: Vec<T> = items.drain(start..end).collect();
+    (page, next_marker)
+}
+
+/// Parse `MaxItems` from the query (already range-validated upstream) into a
+/// page size, returning `None` when absent.
+pub(crate) fn marker_page_size(req: &AwsRequest) -> Option<usize> {
+    req.query_params
+        .get("MaxItems")
+        .and_then(|s| s.parse::<usize>().ok())
+}
+
 /// AWS bounds `EphemeralStorage.Size` to `[512, 10240]` MiB. Anything
 /// outside that range is rejected at the API edge with
 /// `InvalidParameterValueException`, matching the real Lambda control
@@ -1238,6 +1289,8 @@ impl AwsService for LambdaService {
             "ListFunctions" => self.list_functions(
                 aid,
                 req.query_params.get("FunctionVersion").map(String::as_str),
+                req.query_params.get("Marker").map(String::as_str),
+                marker_page_size(&req),
             ),
             "GetFunction" => self.get_function(
                 &req,
@@ -1326,7 +1379,7 @@ impl AwsService for LambdaService {
                         ));
                     }
                 }
-                self.list_event_source_mappings(aid)
+                self.list_event_source_mappings(aid, &req)
             }
             "GetEventSourceMapping" => {
                 self.get_event_source_mapping(resource_name.as_deref().unwrap_or(""), aid)

--- a/crates/fakecloud-lambda/src/service_event_sources.rs
+++ b/crates/fakecloud-lambda/src/service_event_sources.rs
@@ -220,18 +220,48 @@ impl LambdaService {
     pub(super) fn list_event_source_mappings(
         &self,
         account_id: &str,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        let marker = req.query_params.get("Marker").map(String::as_str);
+        let max_items = crate::service::marker_page_size(req);
+        // Optional FunctionName / EventSourceArn filters. FunctionName may
+        // arrive as a bare name or an ARN; match on the ARN suffix so either
+        // form selects the right mappings.
+        let function_filter = req
+            .query_params
+            .get("FunctionName")
+            .map(|f| crate::service::normalize_function_name(f));
+        let event_source_filter = req.query_params.get("EventSourceArn").cloned();
+
         let accounts = self.state.read();
         let empty = LambdaState::new(account_id, "");
         let state = accounts.get(account_id).unwrap_or(&empty);
-        let mappings: Vec<Value> = state
+        let mappings: Vec<crate::state::EventSourceMapping> = state
             .event_source_mappings
             .values()
+            .filter(|m| {
+                function_filter
+                    .as_deref()
+                    .is_none_or(|f| crate::service::normalize_function_name(&m.function_arn) == f)
+            })
+            .filter(|m| {
+                event_source_filter
+                    .as_deref()
+                    .is_none_or(|e| m.event_source_arn == e)
+            })
+            .cloned()
+            .collect();
+
+        let (page, next_marker) =
+            crate::service::paginate_marker(mappings, marker, max_items, |m| m.uuid.clone());
+        let mappings_json: Vec<Value> = page
+            .iter()
             .map(|m| self.event_source_mapping_json(m))
             .collect();
 
         let response = json!({
-            "EventSourceMappings": mappings,
+            "EventSourceMappings": mappings_json,
+            "NextMarker": next_marker,
         });
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1333,15 +1333,77 @@ async fn delete_event_source_mapping_unknown_errors() {
 #[tokio::test]
 async fn list_functions_empty_ok() {
     let svc = LambdaService::new(make_state());
-    let resp = svc.list_functions("123456789012", None).unwrap();
+    let resp = svc
+        .list_functions("123456789012", None, None, None)
+        .unwrap();
     assert_eq!(resp.status, http::StatusCode::OK);
 }
 
 #[tokio::test]
 async fn list_event_source_mappings_empty_ok() {
     let svc = LambdaService::new(make_state());
-    let resp = svc.list_event_source_mappings("123456789012").unwrap();
+    let req = make_request(Method::GET, "/2015-03-31/event-source-mappings", "");
+    let resp = svc
+        .list_event_source_mappings("123456789012", &req)
+        .unwrap();
     assert_eq!(resp.status, http::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn list_functions_paginates_by_marker_and_max_items() {
+    use serde_json::Value;
+    let svc = LambdaService::new(make_state());
+    // Seed five functions out of name order.
+    for name in ["fn-c", "fn-a", "fn-e", "fn-b", "fn-d"] {
+        let body = format!(
+            r#"{{"FunctionName":"{name}","Runtime":"python3.12","Role":"arn:aws:iam::123456789012:role/r","Handler":"h","Code":{{"ZipFile":""}}}}"#
+        );
+        let req = make_request(Method::POST, "/2015-03-31/functions", &body);
+        svc.create_function(&req).unwrap();
+    }
+
+    // First page of 2 -> fn-a, fn-b, with a NextMarker.
+    let resp = svc
+        .list_functions("123456789012", None, None, Some(2))
+        .unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let names: Vec<&str> = v["Functions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["FunctionName"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["fn-a", "fn-b"]);
+    let marker = v["NextMarker"].as_str().unwrap().to_string();
+    assert_eq!(marker, "fn-b");
+
+    // Resume: next page of 2 -> fn-c, fn-d.
+    let resp = svc
+        .list_functions("123456789012", None, Some(&marker), Some(2))
+        .unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let names: Vec<&str> = v["Functions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["FunctionName"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["fn-c", "fn-d"]);
+
+    // Final page: fn-e, empty NextMarker.
+    let marker2 = v["NextMarker"].as_str().unwrap().to_string();
+    let resp = svc
+        .list_functions("123456789012", None, Some(&marker2), Some(2))
+        .unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let names: Vec<&str> = v["Functions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["FunctionName"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["fn-e"]);
+    assert_eq!(v["NextMarker"].as_str().unwrap(), "");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
ListFunctions / ListAliases / ListLayers / ListLayerVersions / ListEventSourceMappings validated `MaxItems` but then returned every item with an empty `NextMarker`, so clients paging through a large account either looped forever or only ever saw the first page. ListEventSourceMappings additionally ignored its `FunctionName` / `EventSourceArn` filters.

- Add `paginate_marker`: stable-sorts items by an opaque per-item key, resumes after a non-empty `Marker`, bounds the page by `MaxItems`, and returns the last returned item's key as `NextMarker` (empty string on the final page, matching AWS's observed shape). An unrecognised marker yields an empty final page.
- Thread `Marker` / `MaxItems` into all five list operations.
- ListEventSourceMappings now filters by `FunctionName` (bare name or ARN) and `EventSourceArn` before paginating.

Bug-audit 2026-06-20, finding 1.14 (Lambda portion).

## Test plan
- New test `list_functions_paginates_by_marker_and_max_items`: seeds five functions out of order, walks three pages of 2, asserts order/NextMarker round-trip and empty marker on the last page.
- Existing list_*_empty_ok tests updated to the new signatures.
- `cargo test -p fakecloud-lambda` green (205 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Lambda list pagination to honor `Marker`/`MaxItems` and return a correct `NextMarker`, preventing endless loops on large accounts. Also applies `FunctionName`/`EventSourceArn` filters to `ListEventSourceMappings` before pagination.

- **Bug Fixes**
  - Paginate `ListFunctions`, `ListAliases`, `ListLayers`, `ListLayerVersions`, and `ListEventSourceMappings` with stable ordering; return the last item’s key as `NextMarker` (empty on the final page).
  - `ListEventSourceMappings` now filters by `FunctionName` (bare name or ARN) and `EventSourceArn` before pagination.
  - Added `paginate_marker` and `marker_page_size` helpers; threaded `Marker`/`MaxItems` through handlers; added a pagination test for `ListFunctions` and updated existing tests.

<sup>Written for commit badf4bfbbcc629c82518c80c66fb6546e806ddb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

