### PR TITLE
fix(kinesis): emit and honor NextToken in ListStreams

### DIFF
--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -353,13 +353,25 @@ impl KinesisService {
         validate_optional_json_range("Limit", &body["Limit"], 1, 10000)?;
         let limit = body["Limit"].as_i64().unwrap_or(100).min(100);
 
+        // NextToken (an opaque base64 of the last returned stream name) takes
+        // precedence over ExclusiveStartStreamName, matching AWS where the two
+        // are alternative ways to resume the same listing.
+        let resume_after: Option<String> = match body["NextToken"].as_str() {
+            Some(tok) => base64::engine::general_purpose::STANDARD
+                .decode(tok)
+                .ok()
+                .and_then(|b| String::from_utf8(b).ok()),
+            None => exclusive_start.map(String::from),
+        };
+
         let accounts = self.state.read();
         let empty = KinesisState::new(&request.account_id, &request.region);
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let mut names: Vec<String> = state.streams.keys().cloned().collect();
         names.sort();
 
-        let start = exclusive_start
+        let start = resume_after
+            .as_deref()
             .and_then(|name| {
                 names
                     .iter()
@@ -371,6 +383,13 @@ impl KinesisService {
         let page_len = remaining.min(limit as usize);
         let has_more_streams = remaining > page_len;
         let selected: Vec<String> = names.into_iter().skip(start).take(page_len).collect();
+        let next_token = if has_more_streams {
+            selected
+                .last()
+                .map(|name| base64::engine::general_purpose::STANDARD.encode(name))
+        } else {
+            None
+        };
         let summaries: Vec<Value> = selected
             .iter()
             .filter_map(|name| state.streams.get(name))
@@ -387,11 +406,15 @@ impl KinesisService {
             })
             .collect();
 
-        Ok(AwsResponse::ok_json(json!({
+        let mut response = json!({
             "HasMoreStreams": has_more_streams,
             "StreamNames": selected,
             "StreamSummaries": summaries
-        })))
+        });
+        if let Some(token) = next_token {
+            response["NextToken"] = json!(token);
+        }
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn delete_stream(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -407,6 +407,40 @@ fn list_streams_sorts_and_paginates() {
 }
 
 #[test]
+fn list_streams_nexttoken_round_trips() {
+    // NextToken was validated but never emitted or honored (bug-audit
+    // 2026-06-20, 1.14): a token-paging client looped on page one.
+    let (svc, _) = make_service();
+    for name in ["charlie", "alpha", "bravo"] {
+        create_stream_action(&svc, name, 1);
+    }
+
+    // First page returns a NextToken alongside HasMoreStreams.
+    let resp = svc
+        .list_streams(&request("ListStreams", json!({ "Limit": 2 })))
+        .unwrap();
+    let body = json_response(resp);
+    let names: Vec<String> = serde_json::from_value(body["StreamNames"].clone()).unwrap();
+    assert_eq!(names, vec!["alpha", "bravo"]);
+    assert_eq!(body["HasMoreStreams"], json!(true));
+    let token = body["NextToken"]
+        .as_str()
+        .expect("NextToken present")
+        .to_string();
+
+    // Resuming with the token (not ExclusiveStartStreamName) yields the rest
+    // and drops NextToken on the final page.
+    let resp = svc
+        .list_streams(&request("ListStreams", json!({ "NextToken": token })))
+        .unwrap();
+    let body = json_response(resp);
+    let names: Vec<String> = serde_json::from_value(body["StreamNames"].clone()).unwrap();
+    assert_eq!(names, vec!["charlie"]);
+    assert_eq!(body["HasMoreStreams"], json!(false));
+    assert!(body.get("NextToken").is_none());
+}
+
+#[test]
 fn delete_stream_unknown_errors() {
     let (svc, _) = make_service();
     assert_code_kinesis(


### PR DESCRIPTION
## Summary
ListStreams validated `NextToken` but never returned it or used it to resume, so a client paging by token (the modern aws-sdk paginators) looped on page one. Only `ExclusiveStartStreamName` worked.

- Return a `NextToken` (opaque base64 of the last returned stream name) whenever `HasMoreStreams` is true.
- Resume after that name when a `NextToken` is supplied, taking precedence over `ExclusiveStartStreamName` (matching AWS, where the two are alternative ways to resume the same listing).

Bug-audit 2026-06-20, finding 1.14 (Kinesis portion).

## Test plan
- New test `list_streams_nexttoken_round_trips`: first page returns a NextToken, resuming with it yields the rest and drops NextToken on the final page.
- `cargo test -p fakecloud-kinesis` green; fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kinesis ListStreams pagination to emit and honor NextToken, matching AWS behavior. Prevents token-based clients from looping on the first page; `ExclusiveStartStreamName` still works.

- **Bug Fixes**
  - Return `NextToken` (base64 of the last returned stream name) when `HasMoreStreams` is true.
  - When `NextToken` is provided, resume after that name; it takes precedence over `ExclusiveStartStreamName`.
  - Added test `list_streams_nexttoken_round_trips` to verify round-trip and final-page behavior.

<sup>Written for commit 34a07ae6eb34442d4dbbd5fa982adb11099e5a00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

