### PR TITLE
fix(secretsmanager): paginate ListSecretVersionIds by MaxResults/NextToken

### DIFF
--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -1096,15 +1096,37 @@ impl SecretsManagerService {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
         validate_optional_string_length("nextToken", body["NextToken"].as_str(), 1, 4096)?;
+        validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 1, 100)?;
+        let max_results = body["MaxResults"].as_i64().unwrap_or(100) as usize;
+        let next_token = body["NextToken"].as_str();
 
         let accounts = self.state.read();
         let empty = SecretsManagerState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let secret = self.find_secret_ref(state, &secret_id)?;
 
-        let versions: Vec<Value> = secret
-            .versions
-            .values()
+        // Stable order so the NextToken (a version id) resumes deterministically:
+        // newest first by CreatedDate, version id as a tiebreaker.
+        let mut versions: Vec<&_> = secret.versions.values().collect();
+        versions.sort_by(|a, b| {
+            b.created_at
+                .cmp(&a.created_at)
+                .then_with(|| a.version_id.cmp(&b.version_id))
+        });
+
+        let start_idx = if let Some(token) = next_token {
+            versions
+                .iter()
+                .position(|v| v.version_id == token)
+                .unwrap_or(versions.len())
+        } else {
+            0
+        };
+
+        let page: Vec<Value> = versions
+            .iter()
+            .skip(start_idx)
+            .take(max_results)
             .map(|v| {
                 json!({
                     "VersionId": v.version_id,
@@ -1114,11 +1136,16 @@ impl SecretsManagerService {
             })
             .collect();
 
-        let response = json!({
+        let mut response = json!({
             "ARN": secret.arn,
             "Name": secret.name,
-            "Versions": versions,
+            "Versions": page,
         });
+        if start_idx + max_results < versions.len() {
+            if let Some(next) = versions.get(start_idx + max_results) {
+                response["NextToken"] = json!(next.version_id);
+            }
+        }
 
         Ok(AwsResponse::ok_json(response))
     }

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -1621,6 +1621,53 @@ async fn list_secret_version_ids() {
     assert_eq!(b["Versions"].as_array().unwrap().len(), 2);
 }
 
+#[tokio::test]
+async fn list_secret_version_ids_paginates_by_token() {
+    // MaxResults/NextToken were ignored: every version returned at once with
+    // no token (bug-audit 2026-06-20, 1.14).
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "pager", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+    svc.handle(make_request(
+        "PutSecretValue",
+        r#"{"SecretId": "pager", "SecretString": "v2"}"#,
+    ))
+    .await
+    .unwrap();
+
+    // Two staged versions (AWSCURRENT + AWSPREVIOUS); page 1 of 1 carries a
+    // NextToken.
+    let resp = svc
+        .handle(make_request(
+            "ListSecretVersionIds",
+            r#"{"SecretId": "pager", "MaxResults": 1}"#,
+        ))
+        .await
+        .unwrap();
+    let b: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(b["Versions"].as_array().unwrap().len(), 1);
+    let token = b["NextToken"]
+        .as_str()
+        .expect("NextToken present")
+        .to_string();
+
+    // Resume: remaining version, no NextToken.
+    let body = format!(r#"{{"SecretId": "pager", "MaxResults": 1, "NextToken": "{token}"}}"#);
+    let resp = svc
+        .handle(make_request("ListSecretVersionIds", &body))
+        .await
+        .unwrap();
+    let b: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(b["Versions"].as_array().unwrap().len(), 1);
+    assert!(b.get("NextToken").is_none());
+}
+
 // ── DescribeSecret with rotation info ──
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
ListSecretVersionIds validated `NextToken` but returned every version at once and never emitted a token, so a paging client looped on the first response. It also ignored `MaxResults` entirely.

- Sort versions newest-first (CreatedDate, version id as tiebreak) for a stable order.
- Honor `MaxResults` (1..100), resume after the `NextToken` version id, and emit `NextToken` (the next page's first version id) when more remain, mirroring the existing ListSecrets pagination convention.

Bug-audit 2026-06-20, finding 1.14 (SecretsManager portion).

## Test plan
- New test `list_secret_version_ids_paginates_by_token`: two staged versions, MaxResults=1 returns a NextToken, resuming yields the remaining version with no token.
- `cargo test -p fakecloud-secretsmanager` green; fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes infinite loop in paging clients by implementing proper pagination for ListSecretVersionIds. Results are sorted newest-first and a NextToken is returned when more results remain.

- **Bug Fixes**
  - Enforce MaxResults range (1–100) with a 100 default.
  - Provide a stable order: CreatedDate desc, then version id.
  - Resume after the provided NextToken version id; emit the next page’s token when applicable.
  - Add test that pages two versions with MaxResults=1 and verifies token handoff.

<sup>Written for commit 0aa3b2e3659e190fb55953f1cd9c3012b544b637. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

