### PR TITLE
fix(iam): paginate GetAccountAuthorizationDetails + honor Filter

### DIFF
--- a/crates/fakecloud-iam/src/iam_service/account.rs
+++ b/crates/fakecloud-iam/src/iam_service/account.rs
@@ -19,10 +19,11 @@ use fakecloud_aws::xml::xml_escape;
 /// Each `<member>` carries the user record plus its inline policies, group
 /// memberships, attached managed policies, and tags — exactly the fields
 /// AWS returns in the same call.
-fn build_user_details_xml(state: &IamState) -> String {
-    state
-        .users
-        .values()
+fn build_user_details_xml(state: &IamState) -> Vec<String> {
+    let mut users: Vec<_> = state.users.values().collect();
+    users.sort_by(|a, b| a.user_name.cmp(&b.user_name));
+    users
+        .into_iter()
         .map(|u| {
             let inline_policies: String = state
                 .user_inline_policies
@@ -73,17 +74,17 @@ fn build_user_details_xml(state: &IamState) -> String {
                 u.path, u.user_name, u.user_id, u.arn, u.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
             )
         })
-        .collect::<Vec<_>>()
-        .join("\n")
+        .collect()
 }
 
 /// Build the `<RoleDetailList>` body for `GetAccountAuthorizationDetails`.
 /// Each `<member>` carries the role plus its inline policies, attached
 /// managed policies, the instance profiles it lives in, and tags.
-fn build_role_details_xml(state: &IamState) -> String {
-    state
-        .roles
-        .values()
+fn build_role_details_xml(state: &IamState) -> Vec<String> {
+    let mut roles: Vec<_> = state.roles.values().collect();
+    roles.sort_by(|a, b| a.role_name.cmp(&b.role_name));
+    roles
+        .into_iter()
         .map(|r| {
             let inline_policies: String = state
                 .role_inline_policies
@@ -140,17 +141,17 @@ fn build_role_details_xml(state: &IamState) -> String {
                 url_encode(&r.assume_role_policy_document),
             )
         })
-        .collect::<Vec<_>>()
-        .join("\n")
+        .collect()
 }
 
 /// Build the `<GroupDetailList>` body for `GetAccountAuthorizationDetails`.
 /// Each `<member>` carries the group plus its inline policies and attached
 /// managed policies.
-fn build_group_details_xml(state: &IamState) -> String {
-    state
-        .groups
-        .values()
+fn build_group_details_xml(state: &IamState) -> Vec<String> {
+    let mut groups: Vec<_> = state.groups.values().collect();
+    groups.sort_by(|a, b| a.group_name.cmp(&b.group_name));
+    groups
+        .into_iter()
         .map(|g| {
             let inline_policies: String = g
                 .inline_policies
@@ -182,8 +183,7 @@ fn build_group_details_xml(state: &IamState) -> String {
                 g.path, g.group_name, g.group_id, g.arn, g.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
             )
         })
-        .collect::<Vec<_>>()
-        .join("\n")
+        .collect()
 }
 
 /// Validate the upper-bound constraints AWS enforces on the password
@@ -294,10 +294,11 @@ fn apply_password_policy_updates(policy: &mut AccountPasswordPolicy, req: &AwsRe
 /// Build the `<Policies>` body for `GetAccountAuthorizationDetails`. Each
 /// `<member>` carries the policy plus the full version list (so a caller
 /// can see every revision the policy has had, not just the default).
-fn build_policy_details_xml(state: &IamState) -> String {
-    state
-        .policies
-        .values()
+fn build_policy_details_xml(state: &IamState) -> Vec<String> {
+    let mut policies: Vec<_> = state.policies.values().collect();
+    policies.sort_by(|a, b| a.arn.cmp(&b.arn));
+    policies
+        .into_iter()
         .map(|p| {
             let versions: String = p
                 .versions
@@ -317,8 +318,7 @@ fn build_policy_details_xml(state: &IamState) -> String {
                 p.attachment_count, p.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
             )
         })
-        .collect::<Vec<_>>()
-        .join("\n")
+        .collect()
 }
 
 impl IamService {
@@ -408,21 +408,99 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let _ = super::validate_list_pagination(req)?;
+        use base64::Engine;
+        let max_items = super::validate_list_pagination(req)? as usize;
         let accounts = self.state.read();
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        let user_details = build_user_details_xml(state);
-        let role_details = build_role_details_xml(state);
-        let group_details = build_group_details_xml(state);
-        let policy_details = build_policy_details_xml(state);
+        // Optional Filter restricts which entity types are returned. Anything
+        // outside this set means "no filter".
+        let filters: Vec<String> = (1..=10)
+            .filter_map(|i| req.query_params.get(&format!("Filter.member.{i}")).cloned())
+            .collect();
+        let want = |cat: &str| filters.is_empty() || filters.iter().any(|f| f == cat);
+
+        // Flatten every entity into one ordered sequence tagged by category so
+        // a single Marker can walk across the four sections (AWS pages the
+        // combined set, not each list independently).
+        #[derive(Clone, Copy)]
+        enum Cat {
+            User,
+            Role,
+            Group,
+            Policy,
+        }
+        let mut combined: Vec<(Cat, String)> = Vec::new();
+        if want("User") {
+            combined.extend(
+                build_user_details_xml(state)
+                    .into_iter()
+                    .map(|f| (Cat::User, f)),
+            );
+        }
+        if want("Role") {
+            combined.extend(
+                build_role_details_xml(state)
+                    .into_iter()
+                    .map(|f| (Cat::Role, f)),
+            );
+        }
+        if want("Group") {
+            combined.extend(
+                build_group_details_xml(state)
+                    .into_iter()
+                    .map(|f| (Cat::Group, f)),
+            );
+        }
+        if want("LocalManagedPolicy") || want("AWSManagedPolicy") {
+            combined.extend(
+                build_policy_details_xml(state)
+                    .into_iter()
+                    .map(|f| (Cat::Policy, f)),
+            );
+        }
+
+        // Marker is an opaque base64 of the resume offset into `combined`.
+        let start: usize = req
+            .query_params
+            .get("Marker")
+            .and_then(|m| base64::engine::general_purpose::STANDARD.decode(m).ok())
+            .and_then(|b| String::from_utf8(b).ok())
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(0)
+            .min(combined.len());
+        let end = start.saturating_add(max_items).min(combined.len());
+        let is_truncated = end < combined.len();
+        let marker_xml = if is_truncated {
+            let token = base64::engine::general_purpose::STANDARD.encode(end.to_string());
+            format!("\n    <Marker>{token}</Marker>")
+        } else {
+            String::new()
+        };
+
+        let mut users = Vec::new();
+        let mut roles = Vec::new();
+        let mut groups = Vec::new();
+        let mut policies = Vec::new();
+        for (cat, frag) in &combined[start..end] {
+            match cat {
+                Cat::User => users.push(frag.clone()),
+                Cat::Role => roles.push(frag.clone()),
+                Cat::Group => groups.push(frag.clone()),
+                Cat::Policy => policies.push(frag.clone()),
+            }
+        }
+        let user_details = users.join("\n");
+        let role_details = roles.join("\n");
+        let group_details = groups.join("\n");
+        let policy_details = policies.join("\n");
 
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <GetAccountAuthorizationDetailsResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <GetAccountAuthorizationDetailsResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_xml}
     <UserDetailList>
 {user_details}
     </UserDetailList>

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -1624,6 +1624,68 @@ fn get_account_authorization_details() {
     assert!(body.contains("<RoleName>auth-role</RoleName>"));
 }
 
+#[test]
+fn get_account_authorization_details_paginates_by_marker() {
+    // MaxItems/Marker were validated then ignored: everything returned with
+    // IsTruncated=false (bug-audit 2026-06-20, 1.14).
+    let svc = make_service();
+    for n in ["aaa", "bbb", "ccc"] {
+        svc.create_user(&make_request("CreateUser", vec![("UserName", n)]))
+            .unwrap();
+    }
+
+    // First page of 2 users is truncated and carries a Marker.
+    let resp = svc
+        .get_account_authorization_details(&make_request(
+            "GetAccountAuthorizationDetails",
+            vec![("MaxItems", "2")],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(body.contains("<IsTruncated>true</IsTruncated>"), "{body}");
+    assert!(body.contains("<UserName>aaa</UserName>"));
+    assert!(body.contains("<UserName>bbb</UserName>"));
+    assert!(!body.contains("<UserName>ccc</UserName>"));
+    let marker = extract_xml_tag(&body, "Marker").to_string();
+    assert!(!marker.is_empty());
+
+    // Resume: the last user, not truncated, no Marker.
+    let resp = svc
+        .get_account_authorization_details(&make_request(
+            "GetAccountAuthorizationDetails",
+            vec![("MaxItems", "2"), ("Marker", &marker)],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(body.contains("<IsTruncated>false</IsTruncated>"), "{body}");
+    assert!(body.contains("<UserName>ccc</UserName>"));
+    assert!(!body.contains("<UserName>aaa</UserName>"));
+}
+
+#[test]
+fn get_account_authorization_details_filter_restricts_types() {
+    // Filter was ignored; with Filter=Role only roles should appear.
+    let svc = make_service();
+    svc.create_user(&make_request("CreateUser", vec![("UserName", "f-user")]))
+        .unwrap();
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    svc.create_role(&make_request(
+        "CreateRole",
+        vec![("RoleName", "f-role"), ("AssumeRolePolicyDocument", trust)],
+    ))
+    .unwrap();
+
+    let resp = svc
+        .get_account_authorization_details(&make_request(
+            "GetAccountAuthorizationDetails",
+            vec![("Filter.member.1", "Role")],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(body.contains("<RoleName>f-role</RoleName>"));
+    assert!(!body.contains("<UserName>f-user</UserName>"), "{body}");
+}
+
 // ---- ListEntitiesForPolicy Tests ----
 
 #[test]


### PR DESCRIPTION
## Summary
GetAccountAuthorizationDetails validated `Marker`/`MaxItems` then discarded them (`let _ = ...`), always returning every user/role/group/policy with `IsTruncated=false`, and ignored the `Filter` param entirely. A client paging a large account never advanced past the first (full) response.

- The four detail builders now return per-entity XML fragments sorted by a stable key (name / ARN).
- Flatten all entities into one ordered sequence so a single `Marker` walks the combined set (AWS pages across the four sections, not each independently), window it by `MaxItems`, regroup the page back into the four lists, and emit `IsTruncated` plus an opaque base64 `Marker` (the resume offset) when more remain.
- Honor `Filter` (`User` / `Role` / `Group` / `LocalManagedPolicy` / `AWSManagedPolicy`).

Bug-audit 2026-06-20, finding 1.14 (IAM portion).

## Test plan
- New `get_account_authorization_details_paginates_by_marker`: three users, MaxItems=2 truncates with a Marker, resuming returns the last user and IsTruncated=false.
- New `get_account_authorization_details_filter_restricts_types`: Filter=Role returns the role and omits the user.
- `cargo test -p fakecloud-iam` green (472 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IAM GetAccountAuthorizationDetails to paginate correctly across all entity types and honor the Filter parameter. Large accounts can now be paged reliably, with deterministic order and accurate IsTruncated/Marker handling.

- **Bug Fixes**
  - Paginate a single combined sequence of users, roles, groups, and policies using `MaxItems` and an opaque base64 `Marker`; set `IsTruncated` when more remain.
  - Honor `Filter` for `User`, `Role`, `Group`, `LocalManagedPolicy`, and `AWSManagedPolicy`.
  - Ensure stable, deterministic ordering by sorting entities (name/ARN), then regroup page results back into their lists for the response.

<sup>Written for commit b3e95be25684063fb8d6244143ef99ea16a79340. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

