### PR TITLE
fix(cognito): stale pagination token ends listing instead of restarting at page 1

### DIFF
--- a/crates/fakecloud-cognito/src/service/branding.rs
+++ b/crates/fakecloud-cognito/src/service/branding.rs
@@ -341,13 +341,15 @@ impl CognitoService {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
-        let start = next_token
-            .and_then(|t| {
-                terms_list
-                    .iter()
-                    .position(|term| term["TermsId"].as_str() == Some(t))
-            })
-            .unwrap_or(0);
+        // A stale token (its item was deleted) ends the listing rather than
+        // silently restarting at page 1 (bug-audit 2026-06-20, 1.14).
+        let start = match next_token {
+            None => 0,
+            Some(t) => terms_list
+                .iter()
+                .position(|term| term["TermsId"].as_str() == Some(t))
+                .unwrap_or(terms_list.len()),
+        };
 
         let page: Vec<serde_json::Value> = terms_list
             .iter()
@@ -702,9 +704,13 @@ impl CognitoService {
 
         let creds: &[WebAuthnCredential] = all_creds.map(|v| v.as_slice()).unwrap_or(&[]);
 
-        let start = next_token
-            .and_then(|t| creds.iter().position(|c| c.credential_id == t))
-            .unwrap_or(0);
+        let start = match next_token {
+            None => 0,
+            Some(t) => creds
+                .iter()
+                .position(|c| c.credential_id == t)
+                .unwrap_or(creds.len()),
+        };
 
         let page: Vec<serde_json::Value> = creds
             .iter()

--- a/crates/fakecloud-cognito/src/service/groups.rs
+++ b/crates/fakecloud-cognito/src/service/groups.rs
@@ -179,10 +179,12 @@ impl CognitoService {
         groups.sort_by_key(|g| g.creation_date);
 
         let start_idx = if let Some(token) = next_token {
+            // A stale token (its group was deleted) must end the listing, not
+            // silently restart at page 1 (bug-audit 2026-06-20, 1.14).
             groups
                 .iter()
                 .position(|g| g.group_name == token)
-                .unwrap_or(0)
+                .unwrap_or(groups.len())
         } else {
             0
         };
@@ -362,10 +364,12 @@ impl CognitoService {
         groups.sort_by_key(|g| g.creation_date);
 
         let start_idx = if let Some(token) = next_token {
+            // A stale token (its group was deleted) must end the listing, not
+            // silently restart at page 1 (bug-audit 2026-06-20, 1.14).
             groups
                 .iter()
                 .position(|g| g.group_name == token)
-                .unwrap_or(0)
+                .unwrap_or(groups.len())
         } else {
             0
         };
@@ -443,7 +447,7 @@ impl CognitoService {
             users_in_group
                 .iter()
                 .position(|u| u.username == token)
-                .unwrap_or(0)
+                .unwrap_or(users_in_group.len())
         } else {
             0
         };

--- a/crates/fakecloud-cognito/src/service/identity_pools.rs
+++ b/crates/fakecloud-cognito/src/service/identity_pools.rs
@@ -445,7 +445,7 @@ impl CognitoIdentityService {
             pools
                 .iter()
                 .position(|p| p.identity_pool_id == token)
-                .unwrap_or(0)
+                .unwrap_or(pools.len())
         } else {
             0
         };
@@ -635,7 +635,7 @@ impl CognitoIdentityService {
             identities
                 .iter()
                 .position(|i| i.identity_id == token)
-                .unwrap_or(0)
+                .unwrap_or(identities.len())
         } else {
             0
         };

--- a/crates/fakecloud-cognito/src/service/identity_providers.rs
+++ b/crates/fakecloud-cognito/src/service/identity_providers.rs
@@ -212,7 +212,7 @@ impl CognitoService {
             providers
                 .iter()
                 .position(|p| p.provider_name == token)
-                .unwrap_or(0)
+                .unwrap_or(providers.len())
         } else {
             0
         };

--- a/crates/fakecloud-cognito/src/service/legacy.rs
+++ b/crates/fakecloud-cognito/src/service/legacy.rs
@@ -238,9 +238,15 @@ impl CognitoService {
             .filter(|e| e.user_pool_id == pool_id && e.username == username)
             .collect();
 
-        let start = next_token
-            .and_then(|t| events.iter().position(|e| e.event_id == t))
-            .unwrap_or(0);
+        // A stale token (its event aged out) ends the listing rather than
+        // silently restarting at page 1 (bug-audit 2026-06-20, 1.14).
+        let start = match next_token {
+            None => 0,
+            Some(t) => events
+                .iter()
+                .position(|e| e.event_id == t)
+                .unwrap_or(events.len()),
+        };
 
         let page: Vec<Value> = events
             .iter()

--- a/crates/fakecloud-cognito/src/service/misc.rs
+++ b/crates/fakecloud-cognito/src/service/misc.rs
@@ -229,9 +229,15 @@ impl CognitoService {
         let mut devices: Vec<&Device> = user.devices.values().collect();
         devices.sort_by_key(|a| a.device_create_date);
 
-        let start = pagination_token
-            .and_then(|t| devices.iter().position(|d| d.device_key == t))
-            .unwrap_or(0);
+        // A stale token (its device was forgotten) ends the listing rather
+        // than silently restarting at page 1 (bug-audit 2026-06-20, 1.14).
+        let start = match pagination_token {
+            None => 0,
+            Some(t) => devices
+                .iter()
+                .position(|d| d.device_key == t)
+                .unwrap_or(devices.len()),
+        };
 
         let page = &devices[start..devices.len().min(start + limit)];
         let next_token = if start + limit < devices.len() {
@@ -524,9 +530,15 @@ impl CognitoService {
         let mut devices: Vec<&Device> = user.devices.values().collect();
         devices.sort_by_key(|a| a.device_create_date);
 
-        let start = pagination_token
-            .and_then(|t| devices.iter().position(|d| d.device_key == t))
-            .unwrap_or(0);
+        // A stale token (its device was forgotten) ends the listing rather
+        // than silently restarting at page 1 (bug-audit 2026-06-20, 1.14).
+        let start = match pagination_token {
+            None => 0,
+            Some(t) => devices
+                .iter()
+                .position(|d| d.device_key == t)
+                .unwrap_or(devices.len()),
+        };
 
         let page = &devices[start..devices.len().min(start + limit)];
         let next_token = if start + limit < devices.len() {
@@ -961,9 +973,15 @@ impl CognitoService {
             .unwrap_or_default();
         jobs.sort_by_key(|a| a.creation_date);
 
-        let start = pagination_token
-            .and_then(|t| jobs.iter().position(|j| j.job_id == t))
-            .unwrap_or(0);
+        // A stale token (its job was pruned) ends the listing rather than
+        // silently restarting at page 1 (bug-audit 2026-06-20, 1.14).
+        let start = match pagination_token {
+            None => 0,
+            Some(t) => jobs
+                .iter()
+                .position(|j| j.job_id == t)
+                .unwrap_or(jobs.len()),
+        };
 
         let page = &jobs[start..jobs.len().min(start + max_results)];
         let next_token = if start + max_results < jobs.len() {

--- a/crates/fakecloud-cognito/src/service/resource_servers.rs
+++ b/crates/fakecloud-cognito/src/service/resource_servers.rs
@@ -184,7 +184,7 @@ impl CognitoService {
             servers
                 .iter()
                 .position(|s| s.identifier == token)
-                .unwrap_or(0)
+                .unwrap_or(servers.len())
         } else {
             0
         };

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -1733,6 +1733,42 @@ fn setup_svc_with_pool() -> (CognitoService, String) {
 }
 
 #[test]
+fn list_groups_stale_token_does_not_restart_at_page_one() {
+    // A NextToken whose group was deleted between calls must end the listing,
+    // not silently restart at page 1 (bug-audit 2026-06-20, 1.14).
+    let (svc, pool_id) = setup_svc_with_pool();
+    for name in ["aaa", "bbb", "ccc"] {
+        let body = format!(r#"{{"UserPoolId":"{pool_id}","GroupName":"{name}"}}"#);
+        svc.create_group(&make_req("CreateGroup", &body)).unwrap();
+    }
+
+    // Page 1 of 2 -> aaa, bbb with NextToken pointing at ccc.
+    let body = format!(r#"{{"UserPoolId":"{pool_id}","Limit":2}}"#);
+    let resp = svc.list_groups(&make_req("ListGroups", &body)).unwrap();
+    let b: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(b["Groups"].as_array().unwrap().len(), 2);
+    let token = b["NextToken"]
+        .as_str()
+        .expect("NextToken present")
+        .to_string();
+
+    // Delete the group the token points at, then resume with the now-stale
+    // token: the page must be empty, NOT a restart that re-returns aaa/bbb.
+    let del = format!(r#"{{"UserPoolId":"{pool_id}","GroupName":"{token}"}}"#);
+    svc.delete_group(&make_req("DeleteGroup", &del)).unwrap();
+
+    let body = format!(r#"{{"UserPoolId":"{pool_id}","Limit":2,"NextToken":"{token}"}}"#);
+    let resp = svc.list_groups(&make_req("ListGroups", &body)).unwrap();
+    let b: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        b["Groups"].as_array().unwrap().len(),
+        0,
+        "stale token must yield an empty page, not page 1: {b}"
+    );
+    assert!(b.get("NextToken").is_none());
+}
+
+#[test]
 fn list_users_requires_user_pool_id() {
     let (svc, _) = setup_svc_with_pool();
 

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -475,7 +475,10 @@ impl CognitoService {
 
         // Find start index from NextToken
         let start_idx = if let Some(token) = next_token {
-            pools.iter().position(|p| p.id == token).unwrap_or(0)
+            pools
+                .iter()
+                .position(|p| p.id == token)
+                .unwrap_or(pools.len())
         } else {
             0
         };
@@ -851,7 +854,7 @@ impl CognitoService {
             clients
                 .iter()
                 .position(|c| c.client_id == token)
-                .unwrap_or(0)
+                .unwrap_or(clients.len())
         } else {
             0
         };

--- a/crates/fakecloud-cognito/src/service/users.rs
+++ b/crates/fakecloud-cognito/src/service/users.rs
@@ -577,7 +577,10 @@ impl CognitoService {
 
         // Find start index from PaginationToken
         let start_idx = if let Some(token) = pagination_token {
-            users.iter().position(|u| u.username == token).unwrap_or(0)
+            users
+                .iter()
+                .position(|u| u.username == token)
+                .unwrap_or(users.len())
         } else {
             0
         };


### PR DESCRIPTION
## Summary
Every Cognito List* op resolved its `NextToken` / `PaginationToken` with `position(...).unwrap_or(0)` (or `and_then(...).unwrap_or(0)`). When the token's item was deleted between calls, `position` returned `None` and the listing silently restarted at page 1, so a paginating client re-processed the whole list and could loop forever.

Resolve a not-found token to the end of the list (an empty final page with no further token) instead of 0, across: user pools, user pool clients, users, groups, users-in-group, identity providers, resource servers, identity pools, identities, branding terms, webauthn credentials, auth events, devices, and user import jobs. The no-token (first page) case still starts at 0.

Bug-audit 2026-06-20, finding 1.14 (Cognito portion).

## Test plan
- New `list_groups_stale_token_does_not_restart_at_page_one`: page with a NextToken, delete the group it points at, resume -> empty page with no NextToken (not a page-1 restart).
- `cargo test -p fakecloud-cognito` green (334 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Cognito pagination so a stale NextToken/PaginationToken ends the listing with an empty final page instead of restarting at page 1. This prevents clients from reprocessing items or looping when the referenced item was deleted between requests.

- **Bug Fixes**
  - Apply consistent handling across all Cognito List* endpoints: user pools, user pool clients, users, groups, users-in-group, identity providers, resource servers, identity pools, identities, branding terms, WebAuthn credentials, auth events, devices, and user import jobs. First page (no token) still starts at 0.
  - Add regression test `list_groups_stale_token_does_not_restart_at_page_one`; existing Cognito tests pass.

<sup>Written for commit 7e3a19db6950da49b2ebaa9b98c2c091d20b9c14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

