### PR TITLE
fix(bedrock): route trailing-slash GET collection paths to List

### DIFF
--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -138,7 +138,23 @@ impl BedrockService {
         let raw = req.raw_path.trim_start_matches('/');
         let segs_owned: Vec<String> = if raw.is_empty() {
             Vec::new()
+        } else if req.method == Method::GET {
+            // botocore < 1.40 and curl append a trailing slash to a bare
+            // collection URI (`GET /foundation-models/`). With empties kept
+            // that split to ["foundation-models", ""] and matched the `{id}`
+            // arm -> GetFoundationModel("") instead of the List op (the #1645
+            // shape; bug-audit 2026-06-20, 1.1). Filter empties on GET so a
+            // trailing slash routes to List. Routes that must still surface a
+            // missing identifier on GET (async-invoke) gate on
+            // `raw_path.ends_with('/')` directly, so they're unaffected.
+            raw.split('/')
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .collect()
         } else {
+            // Non-GET keeps empty segments so missing-`@httpLabel` mutations
+            // (`DELETE /automated-reasoning-policies//`) land on the intended
+            // action with an empty id and emit the correct ValidationException.
             raw.split('/').map(|s| s.to_string()).collect()
         };
         let segs: &[String] = &segs_owned;

--- a/crates/fakecloud-bedrock/src/service_tests.rs
+++ b/crates/fakecloud-bedrock/src/service_tests.rs
@@ -77,6 +77,38 @@ fn resolve_action_list_foundation_models() {
 }
 
 #[test]
+fn resolve_action_trailing_slash_collection_lists() {
+    // botocore < 1.40 / curl append `/` to a bare collection URI; it must
+    // route to List, not GetFoundationModel("") (bug-audit 2026-06-20, 1.1).
+    let req = make_request(Method::GET, "/foundation-models/", "");
+    let (action, id, _) = BedrockService::resolve_action(&req).unwrap();
+    assert_eq!(action, "ListFoundationModels");
+    assert!(id.is_none());
+
+    let req = make_request(Method::GET, "/guardrails/", "");
+    assert_eq!(
+        BedrockService::resolve_action(&req).unwrap().0,
+        "ListGuardrails"
+    );
+}
+
+#[test]
+fn resolve_action_async_invoke_trailing_slash_still_validates() {
+    // async-invoke deliberately routes a trailing slash to GetAsyncInvoke("")
+    // so the length validator surfaces the missing identifier; the GET
+    // empty-filtering must not regress that.
+    let req = make_request(Method::GET, "/async-invoke", "");
+    assert_eq!(
+        BedrockService::resolve_action(&req).unwrap().0,
+        "ListAsyncInvokes"
+    );
+    let req = make_request(Method::GET, "/async-invoke/", "");
+    let (action, id, _) = BedrockService::resolve_action(&req).unwrap();
+    assert_eq!(action, "GetAsyncInvoke");
+    assert_eq!(id.unwrap(), "");
+}
+
+#[test]
 fn resolve_action_get_foundation_model() {
     let req = make_request(
         Method::GET,


### PR DESCRIPTION
## Summary
`GET /foundation-models/` (and other collection roots) split to `["foundation-models", ""]` and matched the `{id}` arm, returning `GetFoundationModel("")` instead of `ListFoundationModels` (the #1645 shape; bug-audit 2026-06-20, finding 1.1). botocore < 1.40 and curl append that trailing slash to a bare collection URI, so those clients got a 404/validation error for every collection listing.

Route53/CloudFront were fixed in #1796; Bedrock was deferred there because its router intentionally retains empty segments to drive missing-identifier validation, so it needed a route-aware fix.

- Filter empty path segments on GET so a trailing slash routes to the List op.
- Non-GET keeps empty segments so missing-`@httpLabel` mutations (e.g. `DELETE /automated-reasoning-policies//`) still land on the intended action with an empty id and emit the correct ValidationException.
- async-invoke's deliberate `GetAsyncInvoke("")` trailing-slash behavior gates on `raw_path` directly, so it is unaffected.

## Test plan
- New `resolve_action_trailing_slash_collection_lists` (foundation-models, guardrails) and `resolve_action_async_invoke_trailing_slash_still_validates`.
- `cargo test -p fakecloud-bedrock` green (354 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix trailing-slash GET routing for Bedrock collection paths. Requests like GET /foundation-models/ now route to List operations instead of Get with an empty id, restoring compatibility with `botocore` < 1.40 and `curl`.

- **Bug Fixes**
  - Filter empty path segments on GET so a trailing slash maps to the List op; keep empties on non-GET so missing `@httpLabel` mutations still raise the correct ValidationException.
  - Preserve async-invoke’s trailing-slash behavior (still routes to Get with empty id). Added tests for collection lists and async-invoke validation.

<sup>Written for commit 3140b4641fbac3e874b9ef632d41cde7b1512a0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

