### PR TITLE
fix(sns): GetSubscriptionAttributes reports real PendingConfirmation

### DIFF
--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -1281,6 +1281,11 @@ impl SnsService {
             .get(&sub_arn)
             .ok_or_else(|| not_found("Subscription"))?;
 
+        // PendingConfirmation reflects the real subscription state: an
+        // http/https subscriber that hasn't confirmed its token is still
+        // pending. Previously hardcoded "false", which hid unconfirmed
+        // subscriptions (bug-audit 2026-06-20, 1.24).
+        let pending = if sub.confirmed { "false" } else { "true" };
         let mut entries = vec![
             format_attr("SubscriptionArn", &sub.subscription_arn),
             format_attr("TopicArn", &sub.topic_arn),
@@ -1288,7 +1293,7 @@ impl SnsService {
             format_attr("Endpoint", &sub.endpoint),
             format_attr("Owner", &sub.owner),
             format_attr("ConfirmationWasAuthenticated", "true"),
-            format_attr("PendingConfirmation", "false"),
+            format_attr("PendingConfirmation", pending),
         ];
 
         // Add RawMessageDelivery from attributes or default

--- a/crates/fakecloud-sns/src/service_tests.rs
+++ b/crates/fakecloud-sns/src/service_tests.rs
@@ -964,6 +964,77 @@ fn get_subscription_attributes_returns_defaults() {
 }
 
 #[test]
+fn get_subscription_attributes_reflects_pending_confirmation() {
+    // PendingConfirmation was hardcoded "false" (bug-audit 2026-06-20, 1.24):
+    // an unconfirmed http subscription must report "true".
+    let (svc, state) = make_sns();
+    assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "pc-topic")])));
+    let topic_arn = "arn:aws:sns:us-east-1:123456789012:pc-topic";
+
+    // http subscriptions stay unconfirmed until the token is confirmed.
+    assert_ok(&svc.subscribe(&sns_request(
+        "Subscribe",
+        vec![
+            ("TopicArn", topic_arn),
+            ("Protocol", "http"),
+            ("Endpoint", "http://example.com/hook"),
+        ],
+    )));
+    // email auto-confirms.
+    assert_ok(&svc.subscribe(&sns_request(
+        "Subscribe",
+        vec![
+            ("TopicArn", topic_arn),
+            ("Protocol", "email"),
+            ("Endpoint", "u@example.com"),
+        ],
+    )));
+
+    let (http_arn, email_arn) = {
+        let s = state.read();
+        let subs = &s.default_ref().subscriptions;
+        let http = subs
+            .values()
+            .find(|sub| sub.protocol == "http")
+            .unwrap()
+            .subscription_arn
+            .clone();
+        let email = subs
+            .values()
+            .find(|sub| sub.protocol == "email")
+            .unwrap()
+            .subscription_arn
+            .clone();
+        (http, email)
+    };
+
+    let http_body = response_body(&svc.get_subscription_attributes(&sns_request(
+        "GetSubscriptionAttributes",
+        vec![("SubscriptionArn", &http_arn)],
+    )));
+    assert!(
+        http_body.contains("<key>PendingConfirmation</key>")
+            && http_body.contains("<value>true</value>"),
+        "http subscription must report PendingConfirmation=true: {http_body}"
+    );
+
+    let email_body = response_body(&svc.get_subscription_attributes(&sns_request(
+        "GetSubscriptionAttributes",
+        vec![("SubscriptionArn", &email_arn)],
+    )));
+    assert!(
+        email_body.contains("<key>PendingConfirmation</key>"),
+        "{email_body}"
+    );
+    // The PendingConfirmation entry for a confirmed sub is false.
+    let pc_idx = email_body.find("PendingConfirmation").unwrap();
+    assert!(
+        email_body[pc_idx..].contains("<value>false</value>"),
+        "email subscription must report PendingConfirmation=false: {email_body}"
+    );
+}
+
+#[test]
 fn set_subscription_attributes_updates_value() {
     let (svc, state) = make_sns();
     assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "setattr-topic")])));


### PR DESCRIPTION
## Summary
`PendingConfirmation` was hardcoded to `"false"`, so an unconfirmed http/https subscription appeared confirmed (bug-audit 2026-06-20, finding 1.24). Render it from the subscription's `confirmed` flag: `"true"` while a confirmation token is outstanding, `"false"` once confirmed (email/sqs/lambda auto-confirm).

## Test plan
- New `get_subscription_attributes_reflects_pending_confirmation`: an http subscription reports `PendingConfirmation=true`, an email subscription reports `false`.
- `cargo test -p fakecloud-sns` green (214 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SNS GetSubscriptionAttributes to return the real PendingConfirmation value. Unconfirmed http/https subscriptions now report "true"; confirmed subscriptions (email/SQS/Lambda auto-confirm) report "false".

- **Bug Fixes**
  - Compute PendingConfirmation from the subscription’s confirmed flag (was hardcoded "false").
  - Added test to verify http reports "true" and email reports "false".

<sup>Written for commit ece978a642a519252c576c3a8d6831ca82b49ef9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

