### PR TITLE
fix(sqs): honor queue ReceiveMessageWaitTimeSeconds for long polling

### DIFF
--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -342,12 +342,19 @@ impl SqsService {
             .ok_or_else(|| missing_param("QueueUrl"))?
             .to_string();
 
-        // Resolve the queue URL (might be a name)
-        let queue_url = {
+        // Resolve the queue URL (might be a name) and read its configured
+        // long-poll default in the same lock acquisition.
+        let (queue_url, queue_wait_default) = {
             let _accts = self.state.read();
             let _empty = crate::state::SqsState::new(&req.account_id, &req.region, "");
             let state = _accts.get(&req.account_id).unwrap_or(&_empty);
-            resolve_queue_url(&queue_url_input, state).ok_or_else(queue_not_found)?
+            let url = resolve_queue_url(&queue_url_input, state).ok_or_else(queue_not_found)?;
+            let default = state
+                .queues
+                .get(&url)
+                .and_then(|q| q.attributes.get("ReceiveMessageWaitTimeSeconds"))
+                .and_then(|v| v.parse::<i64>().ok());
+            (url, default)
         };
 
         let max_messages_raw = val_as_i64(&body["MaxNumberOfMessages"]);
@@ -382,7 +389,14 @@ impl SqsService {
                 ));
             }
         }
-        let wait_time_seconds = wait_time_raw.unwrap_or(0).clamp(0, 20) as u64;
+        // When the request omits WaitTimeSeconds, AWS applies the queue's
+        // ReceiveMessageWaitTimeSeconds attribute (queue-level long polling).
+        // Previously the queue default was ignored and every poll was a
+        // short poll (bug-audit 2026-06-20, 1.24).
+        let wait_time_seconds = wait_time_raw
+            .or(queue_wait_default)
+            .unwrap_or(0)
+            .clamp(0, 20) as u64;
 
         // Parse requested system attributes
         let attribute_names: Option<Vec<String>> = body["AttributeNames"].as_array().map(|arr| {

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -1607,6 +1607,54 @@ fn send_message_batch_queue_not_found() {
 // ── Delete message batch ──
 
 #[tokio::test]
+async fn receive_honors_queue_receive_wait_time_default() {
+    // ReceiveMessageWaitTimeSeconds on the queue must drive long polling when
+    // the request omits WaitTimeSeconds (bug-audit 2026-06-20, 1.24). Empty
+    // queue + 1s queue default => the receive blocks ~1s, then returns empty.
+    let svc = make_service();
+    let url = create_queue(&svc, "longpoll-q");
+    svc.set_queue_attributes(&make_request(
+        "SetQueueAttributes",
+        json!({"QueueUrl": url, "Attributes": {"ReceiveMessageWaitTimeSeconds": "1"}}),
+    ))
+    .unwrap();
+
+    let start = std::time::Instant::now();
+    let resp = svc
+        .receive_message(&make_request("ReceiveMessage", json!({"QueueUrl": url})))
+        .await
+        .unwrap();
+    let elapsed = start.elapsed();
+    let b = body_json(resp);
+    assert!(
+        b.get("Messages")
+            .and_then(|m| m.as_array())
+            .is_none_or(|a| a.is_empty()),
+        "empty queue should return no messages"
+    );
+    assert!(
+        elapsed >= std::time::Duration::from_millis(900),
+        "receive should have long-polled ~1s from the queue default, took {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+async fn receive_short_polls_when_no_wait_configured() {
+    // Control: no queue default and no request WaitTimeSeconds => short poll,
+    // returns immediately even when empty.
+    let svc = make_service();
+    let url = create_queue(&svc, "shortpoll-q");
+    let start = std::time::Instant::now();
+    svc.receive_message(&make_request("ReceiveMessage", json!({"QueueUrl": url})))
+        .await
+        .unwrap();
+    assert!(
+        start.elapsed() < std::time::Duration::from_millis(500),
+        "short poll should return promptly"
+    );
+}
+
+#[tokio::test]
 async fn delete_message_batch_removes_messages() {
     let svc = make_service();
     let url = create_queue(&svc, "del-batch-q");


### PR DESCRIPTION
## Summary
ReceiveMessage only used the request's `WaitTimeSeconds`; when omitted it defaulted to 0 (short poll) and ignored the queue's `ReceiveMessageWaitTimeSeconds` attribute, so queue-level long polling never worked (bug-audit 2026-06-20, finding 1.24).

Read the queue's `ReceiveMessageWaitTimeSeconds` in the same lock that resolves the URL and fall back to it when the request omits `WaitTimeSeconds`, matching AWS (request value takes precedence, queue default otherwise).

## Test plan
- New `receive_honors_queue_receive_wait_time_default`: empty queue with a 1s queue default long-polls ~1s then returns empty.
- New `receive_short_polls_when_no_wait_configured` control: returns promptly with no default.
- `cargo test -p fakecloud-sqs` green (167 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SQS ReceiveMessage to honor the queue’s `ReceiveMessageWaitTimeSeconds` when the request omits `WaitTimeSeconds`. Enables queue-level long polling; behavior now matches AWS precedence (request value overrides queue default).

- **Bug Fixes**
  - Read the queue’s `ReceiveMessageWaitTimeSeconds` under the same lock as URL resolution and use it as the fallback.
  - Clamp wait to 0–20s; short poll when no wait is configured.
  - Added tests: `receive_honors_queue_receive_wait_time_default` and `receive_short_polls_when_no_wait_configured`.

<sup>Written for commit 679f7702e2f9d0a341c5936dedfaec2fd20e1845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

