### PR TITLE
fix(kms): persist and echo RotationPeriodInDays on key rotation

### DIFF
--- a/crates/fakecloud-kms/src/api.rs
+++ b/crates/fakecloud-kms/src/api.rs
@@ -226,6 +226,7 @@ mod tests {
                     tags: Default::default(),
                     policy: String::new(),
                     key_rotation_enabled: false,
+                    rotation_period_in_days: None,
                     origin: "AWS_KMS".into(),
                     multi_region: false,
                     rotations: Vec::new(),

--- a/crates/fakecloud-kms/src/hook.rs
+++ b/crates/fakecloud-kms/src/hook.rs
@@ -319,6 +319,7 @@ fn provision_aws_managed_key(
         tags: BTreeMap::new(),
         policy,
         key_rotation_enabled: true,
+        rotation_period_in_days: None,
         origin: "AWS_KMS".to_string(),
         multi_region: false,
         rotations: Vec::new(),

--- a/crates/fakecloud-kms/src/provisioner.rs
+++ b/crates/fakecloud-kms/src/provisioner.rs
@@ -205,6 +205,7 @@ pub fn build_kms_key(
         tags: input.tags.clone(),
         policy,
         key_rotation_enabled: input.key_rotation_enabled,
+        rotation_period_in_days: None,
         origin: input.origin.clone(),
         multi_region: input.multi_region,
         rotations: Vec::new(),

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -623,6 +623,7 @@ impl KmsService {
             tags: input.tags,
             policy: key_policy,
             key_rotation_enabled: false,
+            rotation_period_in_days: None,
             origin: input.origin,
             multi_region: input.multi_region,
             rotations: Vec::new(),
@@ -1134,12 +1135,18 @@ impl KmsService {
             )
         })?;
 
+        let mut result = json!({
+            "KeyRotationEnabled": key.key_rotation_enabled,
+        });
+        // AWS echoes the configured cadence (default 365) only while rotation
+        // is enabled.
+        if key.key_rotation_enabled {
+            result["RotationPeriodInDays"] = json!(key.rotation_period_in_days.unwrap_or(365));
+        }
+
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({
-                "KeyRotationEnabled": key.key_rotation_enabled,
-            }))
-            .unwrap(),
+            serde_json::to_string(&result).unwrap(),
         ))
     }
 
@@ -1169,6 +1176,19 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
+        // RotationPeriodInDays is optional; AWS validates 90..=2560 and
+        // defaults to 365. Persist it so GetKeyRotationStatus echoes it back
+        // instead of dropping it (bug-audit 2026-06-20, 1.24).
+        if let Some(period) = body.get("RotationPeriodInDays").and_then(|v| v.as_i64()) {
+            if !(90..=2560).contains(&period) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("RotationPeriodInDays must be between 90 and 2560, got {period}"),
+                ));
+            }
+            key.rotation_period_in_days = Some(period as i32);
+        }
         key.key_rotation_enabled = true;
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
@@ -1358,6 +1378,7 @@ impl KmsService {
             arn: replica_arn,
             deletion_date: None,
             key_rotation_enabled: false,
+            rotation_period_in_days: None,
             multi_region: true,
             rotations: Vec::new(),
             custom_key_store_id: None,

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -2392,6 +2392,53 @@ fn enable_key_rotation_accepts_alias() {
 }
 
 #[test]
+fn enable_key_rotation_persists_rotation_period() {
+    // RotationPeriodInDays was dropped (bug-audit 2026-06-20, 1.24): it must
+    // round-trip through GetKeyRotationStatus, and default to 365.
+    let svc = make_service();
+    let key_id = create_key(&svc);
+
+    // Default cadence is 365 when omitted.
+    svc.enable_key_rotation(&make_request(
+        "EnableKeyRotation",
+        json!({ "KeyId": key_id }),
+    ))
+    .unwrap();
+    let resp = svc
+        .get_key_rotation_status(&make_request(
+            "GetKeyRotationStatus",
+            json!({ "KeyId": key_id }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert!(body["KeyRotationEnabled"].as_bool().unwrap());
+    assert_eq!(body["RotationPeriodInDays"].as_i64(), Some(365));
+
+    // A custom cadence is stored and echoed.
+    svc.enable_key_rotation(&make_request(
+        "EnableKeyRotation",
+        json!({ "KeyId": key_id, "RotationPeriodInDays": 120 }),
+    ))
+    .unwrap();
+    let resp = svc
+        .get_key_rotation_status(&make_request(
+            "GetKeyRotationStatus",
+            json!({ "KeyId": key_id }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["RotationPeriodInDays"].as_i64(), Some(120));
+
+    // Out-of-range cadence is rejected.
+    assert!(svc
+        .enable_key_rotation(&make_request(
+            "EnableKeyRotation",
+            json!({ "KeyId": key_id, "RotationPeriodInDays": 5 }),
+        ))
+        .is_err());
+}
+
+#[test]
 fn enable_disable_key_rotation_unknown_errors() {
     let svc = make_service();
     let req = make_request(

--- a/crates/fakecloud-kms/src/state.rs
+++ b/crates/fakecloud-kms/src/state.rs
@@ -92,6 +92,11 @@ pub struct KmsKey {
     pub tags: BTreeMap<String, String>,
     pub policy: String,
     pub key_rotation_enabled: bool,
+    /// Customer-specified rotation cadence from EnableKeyRotation
+    /// (`RotationPeriodInDays`, 90..2560). `None` means AWS's 365-day
+    /// default. Echoed by GetKeyRotationStatus.
+    #[serde(default)]
+    pub rotation_period_in_days: Option<i32>,
     pub origin: String,
     pub multi_region: bool,
     pub rotations: Vec<KeyRotation>,


### PR DESCRIPTION
## Summary
EnableKeyRotation accepted `RotationPeriodInDays` but dropped it, and GetKeyRotationStatus never returned it (bug-audit 2026-06-20, finding 1.24).

- Store the cadence on the key (validated to 90..=2560).
- Echo `RotationPeriodInDays` from GetKeyRotationStatus while rotation is enabled, defaulting to AWS's 365 when unspecified.

## Test plan
- New `enable_key_rotation_persists_rotation_period`: default 365, custom 120 round-trips, out-of-range rejected.
- `cargo test -p fakecloud-kms` green (185 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix KMS key rotation to persist and return `RotationPeriodInDays`. `EnableKeyRotation` now stores the cadence (validated 90–2560), and `GetKeyRotationStatus` echoes it while enabled, defaulting to 365 when omitted.

<sup>Written for commit cf3e03f397add05e7f5ba38cabfca0499a9327ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

