### PR TITLE
fix(cloudwatch): persist and echo ThresholdMetricId on PutMetricAlarm

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudwatch.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudwatch.rs
@@ -125,6 +125,10 @@ impl ResourceProvisioner {
             comparison_operator,
             treat_missing_data,
             evaluate_low_sample_count_percentile,
+            threshold_metric_id: props
+                .get("ThresholdMetricId")
+                .and_then(|v| v.as_str())
+                .map(String::from),
             configuration_updated_timestamp: now,
             alarm_configuration_updated_timestamp: now,
         };

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -980,6 +980,9 @@ impl CloudWatchService {
         let treat_missing_data = optional_query_param(req, "TreatMissingData");
         let evaluate_low_sample_count_percentile =
             optional_query_param(req, "EvaluateLowSampleCountPercentile");
+        // Anomaly-detection alarms reference a metric-math id instead of a
+        // static Threshold; previously accepted then dropped (1.24).
+        let threshold_metric_id = optional_query_param(req, "ThresholdMetricId");
         let dimensions = parse_dimensions_query(req, "Dimensions");
 
         let mut ok_actions = Vec::new();
@@ -1038,6 +1041,7 @@ impl CloudWatchService {
             comparison_operator: comparison,
             treat_missing_data,
             evaluate_low_sample_count_percentile,
+            threshold_metric_id,
             configuration_updated_timestamp: existing
                 .as_ref()
                 .map(|a| a.configuration_updated_timestamp)
@@ -1490,6 +1494,12 @@ fn render_alarm(alarm: &MetricAlarm) -> String {
     }
     if let Some(t) = alarm.threshold {
         s.push_str(&format!("<Threshold>{t}</Threshold>"));
+    }
+    if let Some(tid) = &alarm.threshold_metric_id {
+        s.push_str(&format!(
+            "<ThresholdMetricId>{}</ThresholdMetricId>",
+            xml_escape(tid)
+        ));
     }
     s.push_str(&format!(
         "<ComparisonOperator>{}</ComparisonOperator>",

--- a/crates/fakecloud-cloudwatch/src/state.rs
+++ b/crates/fakecloud-cloudwatch/src/state.rs
@@ -242,6 +242,11 @@ pub struct MetricAlarm {
     pub comparison_operator: String,
     pub treat_missing_data: Option<String>,
     pub evaluate_low_sample_count_percentile: Option<String>,
+    /// `ThresholdMetricId` — references the metric-math id that produces an
+    /// anomaly-detection band (used with the `*UpperThreshold` /
+    /// `*LowerThreshold` comparison operators instead of a static Threshold).
+    #[serde(default)]
+    pub threshold_metric_id: Option<String>,
     pub configuration_updated_timestamp: DateTime<Utc>,
     pub alarm_configuration_updated_timestamp: DateTime<Utc>,
 }

--- a/crates/fakecloud-cloudwatch/src/tests.rs
+++ b/crates/fakecloud-cloudwatch/src/tests.rs
@@ -344,6 +344,38 @@ async fn list_tags_missing_arn_errors() {
 }
 
 #[tokio::test]
+async fn put_metric_alarm_round_trips_threshold_metric_id() {
+    // ThresholdMetricId (anomaly-detection band) was accepted then dropped
+    // (bug-audit 2026-06-20, 1.24); DescribeAlarms must echo it.
+    let svc = service();
+    call(
+        &svc,
+        "PutMetricAlarm",
+        &[
+            ("AlarmName", "anomaly-alarm"),
+            ("Namespace", "AWS/EC2"),
+            ("MetricName", "CPUUtilization"),
+            ("ComparisonOperator", "GreaterThanUpperThreshold"),
+            ("ThresholdMetricId", "ad1"),
+            ("EvaluationPeriods", "1"),
+        ],
+    )
+    .await;
+
+    let described = call(
+        &svc,
+        "DescribeAlarms",
+        &[("AlarmNames.member.1", "anomaly-alarm")],
+    )
+    .await;
+    let body = body_of(&described);
+    assert!(
+        body.contains("<ThresholdMetricId>ad1</ThresholdMetricId>"),
+        "DescribeAlarms must echo ThresholdMetricId: {body}"
+    );
+}
+
+#[tokio::test]
 async fn introspection_lists_metric_and_composite_alarms() {
     use crate::introspection::list_all_alarms;
     let svc = service();


### PR DESCRIPTION
## Summary
PutMetricAlarm validated `ThresholdMetricId` but dropped it, so anomaly-detection alarms (which reference a metric-math band id with the `*UpperThreshold` / `*LowerThreshold` comparison operators instead of a static `Threshold`) lost their threshold reference, and DescribeAlarms never returned it (bug-audit 2026-06-20, finding 1.24).

Store `ThresholdMetricId` on the alarm and render it in DescribeAlarms; the CFN `AWS::CloudWatch::Alarm` provisioner reads it too.

Note: the metric-math `Metrics` array on alarms (metric-math alarms) is a separate sub-feature and is not part of this change.

## Test plan
- New `put_metric_alarm_round_trips_threshold_metric_id`: an anomaly alarm's ThresholdMetricId is echoed by DescribeAlarms.
- `cargo test -p fakecloud-cloudwatch` green (19 passed); fmt + clippy -D warnings clean on cloudwatch + cloudformation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CloudWatch `PutMetricAlarm` dropping `ThresholdMetricId`. Anomaly-detection alarms now keep and return the band id in `DescribeAlarms`, matching AWS behavior.

- **Bug Fixes**
  - Persist `ThresholdMetricId` on alarms and include it in `DescribeAlarms`.
  - CloudFormation `AWS::CloudWatch::Alarm` provisioner now reads `ThresholdMetricId`.
  - Added test to verify round-trip of `ThresholdMetricId` for anomaly alarms.

<sup>Written for commit 24704f70d842a8a9e1158466abe19b75930f1305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

