### PR TITLE
fix(organizations): apply create-time Tags on CreateOrganizationalUnit/CreatePolicy

### DIFF
--- a/crates/fakecloud-organizations/src/service/ous.rs
+++ b/crates/fakecloud-organizations/src/service/ous.rs
@@ -14,6 +14,12 @@ impl OrganizationsService {
         self.require_member_management(&guard, &req.account_id)?;
         let org = guard.as_mut().unwrap();
         let ou = org.create_ou(parent_id, name).map_err(org_error_to_aws)?;
+        // Apply create-time Tags so ListTagsForResource reflects them without a
+        // follow-up TagResource (bug-audit 2026-06-20, 1.24).
+        let tags = parse_tags(body.get("Tags"));
+        if !tags.is_empty() {
+            org.set_resource_tags(&ou.id, &tags);
+        }
         Ok(AwsResponse::ok_json(
             json!({ "OrganizationalUnit": ou_payload(&ou) }),
         ))

--- a/crates/fakecloud-organizations/src/service/policies.rs
+++ b/crates/fakecloud-organizations/src/service/policies.rs
@@ -37,6 +37,12 @@ impl OrganizationsService {
         let policy = org
             .create_policy(name, description, content, policy_type)
             .map_err(org_error_to_aws)?;
+        // Apply create-time Tags so ListTagsForResource reflects them without a
+        // follow-up TagResource (bug-audit 2026-06-20, 1.24).
+        let tags = parse_tags(body.get("Tags"));
+        if !tags.is_empty() {
+            org.set_resource_tags(&policy.id, &tags);
+        }
         Ok(AwsResponse::ok_json(
             json!({ "Policy": policy_with_content(&policy) }),
         ))

--- a/crates/fakecloud-organizations/src/service/tests.rs
+++ b/crates/fakecloud-organizations/src/service/tests.rs
@@ -259,6 +259,88 @@ async fn create_ou_happy_path_and_describe() {
 }
 
 #[tokio::test]
+async fn create_ou_applies_create_time_tags() {
+    // Create-time Tags were dropped (bug-audit 2026-06-20, 1.24); they must be
+    // visible via ListTagsForResource without a follow-up TagResource.
+    let (svc, _state) = OrganizationsService::shared();
+    let root_id = create_org_with_root(&svc).await;
+    let created = svc
+        .handle(req_with(
+            "111111111111",
+            "CreateOrganizationalUnit",
+            json!({
+                "ParentId": root_id,
+                "Name": "eng",
+                "Tags": [{"Key": "team", "Value": "platform"}]
+            }),
+        ))
+        .await
+        .unwrap();
+    let ou_id = body_json(&created)["OrganizationalUnit"]["Id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let listed = svc
+        .handle(req_with(
+            "111111111111",
+            "ListTagsForResource",
+            json!({"ResourceId": ou_id}),
+        ))
+        .await
+        .unwrap();
+    let v = body_json(&listed);
+    let tags = v["Tags"].as_array().unwrap();
+    assert!(
+        tags.iter()
+            .any(|t| t["Key"] == "team" && t["Value"] == "platform"),
+        "create-time tag must be listed: {v}"
+    );
+}
+
+#[tokio::test]
+async fn create_policy_applies_create_time_tags() {
+    let (svc, _state) = OrganizationsService::shared();
+    create_org_with_root(&svc).await;
+    let created = svc
+        .handle(req_with(
+            "111111111111",
+            "CreatePolicy",
+            json!({
+                "Name": "p1",
+                "Description": "d",
+                "Type": "SERVICE_CONTROL_POLICY",
+                "Content": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}]}",
+                "Tags": [{"Key": "env", "Value": "prod"}]
+            }),
+        ))
+        .await
+        .unwrap();
+    let policy_id = body_json(&created)["Policy"]["PolicySummary"]["Id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let listed = svc
+        .handle(req_with(
+            "111111111111",
+            "ListTagsForResource",
+            json!({"ResourceId": policy_id}),
+        ))
+        .await
+        .unwrap();
+    let v = body_json(&listed);
+    assert!(
+        v["Tags"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|t| t["Key"] == "env" && t["Value"] == "prod"),
+        "create-time tag must be listed: {v}"
+    );
+}
+
+#[tokio::test]
 async fn create_ou_missing_parent_id_rejected() {
     let (svc, _state) = OrganizationsService::shared();
     create_org_with_root(&svc).await;


### PR DESCRIPTION
## Summary
CreateOrganizationalUnit and CreatePolicy accepted a `Tags` array but dropped it, so ListTagsForResource returned nothing until a separate TagResource call (bug-audit 2026-06-20, finding 1.24).

Parse `Tags` at create time and store them against the new resource id via `set_resource_tags`, matching AWS (create-time tags are visible immediately).

Note: CreateAccount tags ride the async account-creation completion path and are tracked separately.

## Test plan
- New `create_ou_applies_create_time_tags` and `create_policy_applies_create_time_tags`: a create-time tag is returned by ListTagsForResource.
- `cargo test -p fakecloud-organizations` green (137 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped create-time tags in Organizations: `CreateOrganizationalUnit` and `CreatePolicy` now persist `Tags` so `ListTagsForResource` shows them without a follow-up `TagResource`. Matches AWS behavior.

- **Bug Fixes**
  - Apply create-time `Tags` via `set_resource_tags` for new OUs and policies.
  - Add tests to verify tags are immediately returned by `ListTagsForResource`.

<sup>Written for commit c977d34eb9757ffdcbbd9a1ec18b268cc709597d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

