### PR TITLE
fix(elbv2): apply MutualAuthentication on ModifyListener

### DIFF
--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -1437,6 +1437,12 @@ impl Elbv2Service {
         if !alpn.is_empty() {
             listener.alpn_policy = alpn;
         }
+        // MutualAuthentication was dropped on modify, so a listener could never
+        // turn mTLS on/off or change its trust store after creation (bug-audit
+        // 2026-06-20, 1.24).
+        if let Some(mtls) = parse_mutual_authentication(req) {
+            listener.mutual_authentication = Some(mtls);
+        }
         let xml = render_listener_xml(listener);
         Ok(xml_resp(
             "ModifyListener",

--- a/crates/fakecloud-elbv2/src/service_tests.rs
+++ b/crates/fakecloud-elbv2/src/service_tests.rs
@@ -298,6 +298,62 @@ async fn create_lb_and_tg_for_listener_test(svc: &Elbv2Service) -> (String, Stri
 }
 
 #[tokio::test]
+async fn modify_listener_applies_mutual_authentication() {
+    // ModifyListener dropped MutualAuthentication (bug-audit 2026-06-20, 1.24):
+    // a listener could never toggle mTLS or change its trust store.
+    let svc = svc();
+    let (lb_arn, tg_arn) = create_lb_and_tg_for_listener_test(&svc).await;
+    svc.handle(req(
+        "CreateListener",
+        &[
+            ("LoadBalancerArn", &lb_arn),
+            ("Protocol", "HTTP"),
+            ("Port", "80"),
+            ("DefaultActions.member.1.Type", "forward"),
+            ("DefaultActions.member.1.TargetGroupArn", &tg_arn),
+        ],
+    ))
+    .await
+    .unwrap();
+    let listener_arn = {
+        let st = svc.state.read();
+        st.get("123456789012")
+            .unwrap()
+            .listeners
+            .keys()
+            .next()
+            .unwrap()
+            .clone()
+    };
+
+    let resp = svc
+        .handle(req(
+            "ModifyListener",
+            &[
+                ("ListenerArn", &listener_arn),
+                ("MutualAuthentication.Mode", "verify"),
+                (
+                    "MutualAuthentication.TrustStoreArn",
+                    "arn:aws:elasticloadbalancing:us-east-1:123456789012:truststore/ts/abc",
+                ),
+            ],
+        ))
+        .await
+        .unwrap();
+    let body = body_string(&resp);
+    assert!(body.contains("<Mode>verify</Mode>"), "{body}");
+    assert!(body.contains("truststore/ts/abc"), "{body}");
+
+    // Persisted, not just echoed.
+    let st = svc.state.read();
+    let mtls = st.get("123456789012").unwrap().listeners[&listener_arn]
+        .mutual_authentication
+        .as_ref()
+        .unwrap();
+    assert_eq!(mtls.mode.as_deref(), Some("verify"));
+}
+
+#[tokio::test]
 async fn create_listener_rejects_invalid_protocol() {
     let svc = svc();
     let (lb_arn, tg_arn) = create_lb_and_tg_for_listener_test(&svc).await;


### PR DESCRIPTION
## Summary
ModifyListener never updated the listener's `MutualAuthentication`, so a listener could not toggle mTLS on/off or change its trust store after creation (bug-audit 2026-06-20, finding 1.24). Parse `MutualAuthentication.*` and update the listener when present, mirroring CreateListener.

## Test plan
- New `modify_listener_applies_mutual_authentication`: ModifyListener sets Mode=verify + TrustStoreArn; the response and stored state reflect it.
- `cargo test -p fakecloud-elbv2` green (46 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply `MutualAuthentication` on `ModifyListener` so existing listeners can enable/disable mTLS or change the trust store. Mirrors `CreateListener` and persists the setting in state and response.

- **Bug Fixes**
  - Parse and store `MutualAuthentication.*` during `ModifyListener`.
  - Include `Mode` and `TrustStoreArn` in the XML response; persist to listener state.
  - Added test `modify_listener_applies_mutual_authentication`.

<sup>Written for commit 595d9fdd2b0cb542e78c9be3c6641aff0cb0e676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

