### PR TITLE
fix(athena): merge ConfigurationUpdates correctly in UpdateWorkGroup

### DIFF
--- a/crates/fakecloud-athena/src/service/mod.rs
+++ b/crates/fakecloud-athena/src/service/mod.rs
@@ -1141,6 +1141,51 @@ mod tests {
     }
 
     #[test]
+    fn update_work_group_merges_configuration_updates() {
+        // UpdateWorkGroup stored ConfigurationUpdates verbatim, corrupting
+        // Configuration's shape (bug-audit 2026-06-20, 1.24). It must merge the
+        // updates with the right field mapping and preserve untouched fields.
+        let svc = AthenaService::new(SharedAthenaState::default());
+        svc.create_work_group(&req(
+            "CreateWorkGroup",
+            json!({
+                "Name": "wg",
+                "Configuration": {
+                    "ResultConfiguration": {"OutputLocation": "s3://orig/"},
+                    "PublishCloudWatchMetricsEnabled": false
+                }
+            }),
+        ))
+        .unwrap();
+
+        svc.update_work_group(&req(
+            "UpdateWorkGroup",
+            json!({
+                "WorkGroup": "wg",
+                "ConfigurationUpdates": {
+                    "PublishCloudWatchMetricsEnabled": true,
+                    "ResultConfigurationUpdates": {"OutputLocation": "s3://new/"}
+                }
+            }),
+        ))
+        .unwrap();
+
+        let got = parse_json(
+            &svc.get_work_group(&req("GetWorkGroup", json!({ "WorkGroup": "wg" })))
+                .unwrap(),
+        );
+        let cfg = &got["WorkGroup"]["Configuration"];
+        // ResultConfigurationUpdates merged into ResultConfiguration (right shape).
+        assert_eq!(
+            cfg["ResultConfiguration"]["OutputLocation"], "s3://new/",
+            "{cfg}"
+        );
+        // Scalar update applied; no stray ConfigurationUpdates/ResultConfigurationUpdates keys.
+        assert_eq!(cfg["PublishCloudWatchMetricsEnabled"], true);
+        assert!(cfg.get("ResultConfigurationUpdates").is_none(), "{cfg}");
+    }
+
+    #[test]
     fn start_query_execution_with_named_query_id() {
         let svc = AthenaService::new(SharedAthenaState::default());
         let create_resp = svc

--- a/crates/fakecloud-athena/src/service/work_groups.rs
+++ b/crates/fakecloud-athena/src/service/work_groups.rs
@@ -97,8 +97,71 @@ impl AthenaService {
         if let Some(s) = body.get("State").and_then(Value::as_str) {
             wg.state = s.to_string();
         }
-        if let Some(c) = body.get("ConfigurationUpdates") {
-            wg.configuration = Some(c.clone());
+        // ConfigurationUpdates has a different shape than Configuration
+        // (ResultConfigurationUpdates vs ResultConfiguration, Remove* flags),
+        // so storing it verbatim corrupted GetWorkGroup's Configuration
+        // (bug-audit 2026-06-20, 1.24). Merge the updates into the existing
+        // Configuration with the correct field mapping instead.
+        if let Some(updates) = body.get("ConfigurationUpdates").and_then(Value::as_object) {
+            let mut config = wg
+                .configuration
+                .as_ref()
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            for key in [
+                "EnforceWorkGroupConfiguration",
+                "PublishCloudWatchMetricsEnabled",
+                "RequesterPaysEnabled",
+                "EngineVersion",
+                "BytesScannedCutoffPerQuery",
+                "AdditionalConfiguration",
+                "ExecutionRole",
+                "CustomerContentEncryptionConfiguration",
+            ] {
+                if let Some(v) = updates.get(key) {
+                    config.insert(key.to_string(), v.clone());
+                }
+            }
+            if updates
+                .get("RemoveBytesScannedCutoffPerQuery")
+                .and_then(Value::as_bool)
+                == Some(true)
+            {
+                config.remove("BytesScannedCutoffPerQuery");
+            }
+            if let Some(rcu) = updates
+                .get("ResultConfigurationUpdates")
+                .and_then(Value::as_object)
+            {
+                let mut rc = config
+                    .get("ResultConfiguration")
+                    .and_then(Value::as_object)
+                    .cloned()
+                    .unwrap_or_default();
+                for key in [
+                    "OutputLocation",
+                    "EncryptionConfiguration",
+                    "ExpectedBucketOwner",
+                    "AclConfiguration",
+                ] {
+                    if let Some(v) = rcu.get(key) {
+                        rc.insert(key.to_string(), v.clone());
+                    }
+                }
+                for (flag, field) in [
+                    ("RemoveOutputLocation", "OutputLocation"),
+                    ("RemoveEncryptionConfiguration", "EncryptionConfiguration"),
+                    ("RemoveExpectedBucketOwner", "ExpectedBucketOwner"),
+                    ("RemoveAclConfiguration", "AclConfiguration"),
+                ] {
+                    if rcu.get(flag).and_then(Value::as_bool) == Some(true) {
+                        rc.remove(field);
+                    }
+                }
+                config.insert("ResultConfiguration".to_string(), Value::Object(rc));
+            }
+            wg.configuration = Some(Value::Object(config));
         }
         Ok(AwsResponse::ok_json(json!({})))
     }


### PR DESCRIPTION
## Summary
UpdateWorkGroup stored the `ConfigurationUpdates` shape verbatim as the workgroup `Configuration`, so GetWorkGroup returned a malformed Configuration (`ResultConfigurationUpdates` instead of `ResultConfiguration`, leftover `Remove*` flags) and wiped untouched fields (bug-audit 2026-06-20, finding 1.24).

Merge the updates into the existing Configuration with the correct field mapping:
- scalar passthroughs (EnforceWorkGroupConfiguration, PublishCloudWatchMetricsEnabled, RequesterPaysEnabled, EngineVersion, BytesScannedCutoffPerQuery, etc.)
- `RemoveBytesScannedCutoffPerQuery`
- `ResultConfigurationUpdates` -> `ResultConfiguration` (honoring RemoveOutputLocation / RemoveEncryptionConfiguration / RemoveExpectedBucketOwner / RemoveAclConfiguration)

## Test plan
- New `update_work_group_merges_configuration_updates`: an update changes OutputLocation + a scalar, GetWorkGroup shows the correctly-shaped merged Configuration with no stray `*Updates` keys.
- `cargo test -p fakecloud-athena` green (27 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Athena UpdateWorkGroup to merge ConfigurationUpdates into the existing Configuration, so GetWorkGroup returns a correctly shaped config and preserves untouched fields. Prevents malformed ResultConfiguration and stray Remove* flags.

- **Bug Fixes**
  - Merge updates into existing config; apply scalar fields and handle RemoveBytesScannedCutoffPerQuery.
  - Map ResultConfigurationUpdates to ResultConfiguration and honor RemoveOutputLocation/RemoveEncryptionConfiguration/RemoveExpectedBucketOwner/RemoveAclConfiguration.
  - Add unit test (update_work_group_merges_configuration_updates); suite passes.

<sup>Written for commit ae57e2acb52bff6be75a334c7f9d44ccced1a52f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

