### PR TITLE
fix(secretsmanager): persist replica regions in Replicate/RemoveRegionsFromReplication

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/secrets.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/secrets.rs
@@ -112,6 +112,7 @@ impl ResourceProvisioner {
             rotation_rules: None,
             last_rotated_at: None,
             resource_policy: None,
+            replica_regions: Vec::new(),
         };
         state.secrets.insert(arn.clone(), secret);
 

--- a/crates/fakecloud-secretsmanager/src/rotation.rs
+++ b/crates/fakecloud-secretsmanager/src/rotation.rs
@@ -259,6 +259,7 @@ mod tests {
             }),
             last_rotated_at: last_rotated,
             resource_policy: None,
+            replica_regions: Vec::new(),
         }
     }
 

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -283,6 +283,7 @@ impl SecretsManagerService {
             rotation_rules: None,
             last_rotated_at: None,
             resource_policy: None,
+            replica_regions: Vec::new(),
         };
 
         state.secrets.insert(input.name.clone(), secret);
@@ -874,6 +875,9 @@ impl SecretsManagerService {
         }
         if let Some(last_rotated) = secret.last_rotated_at {
             response["LastRotatedDate"] = json!(last_rotated.timestamp_millis() as f64 / 1000.0);
+        }
+        if !secret.replica_regions.is_empty() {
+            response["ReplicationStatus"] = replication_status_json(&secret.replica_regions);
         }
         // Calculate NextRotationDate if rotation is enabled
         if secret.rotation_enabled == Some(true) {
@@ -1803,15 +1807,27 @@ impl SecretsManagerService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
+        // AddReplicaRegions[].Region — the regions to replicate into.
+        let add_regions: Vec<String> = body["AddReplicaRegions"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|r| r["Region"].as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
 
-        let accounts = self.state.read();
-        let empty = SecretsManagerState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let secret = self.find_secret_ref(state, &secret_id)?;
-
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
+        for region in add_regions {
+            if !secret.replica_regions.contains(&region) {
+                secret.replica_regions.push(region);
+            }
+        }
         let response = json!({
             "ARN": secret.arn,
-            "ReplicationStatus": [],
+            "ReplicationStatus": replication_status_json(&secret.replica_regions),
         });
         Ok(AwsResponse::ok_json(response))
     }
@@ -1822,15 +1838,24 @@ impl SecretsManagerService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let secret_id = require_secret_id(&body)?;
+        let remove_regions: Vec<String> = body["RemoveReplicaRegions"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|r| r.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
 
-        let accounts = self.state.read();
-        let empty = SecretsManagerState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let secret = self.find_secret_ref(state, &secret_id)?;
-
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let secret = self.find_secret_mut(state, &secret_id)?;
+        secret
+            .replica_regions
+            .retain(|r| !remove_regions.contains(r));
         let response = json!({
             "ARN": secret.arn,
-            "ReplicationStatus": [],
+            "ReplicationStatus": replication_status_json(&secret.replica_regions),
         });
         Ok(AwsResponse::ok_json(response))
     }
@@ -2128,6 +2153,23 @@ pub(crate) use service_helpers::*;
 /// error is `InvalidParameterException`. Translate at the dispatcher
 /// boundary so the wire-level error code matches real AWS without
 /// duplicating every validator.
+/// Build the `ReplicationStatus` array from a secret's replica regions.
+/// Each replica reports `InSync`, matching a healthy replication.
+fn replication_status_json(regions: &[String]) -> Value {
+    Value::Array(
+        regions
+            .iter()
+            .map(|r| {
+                json!({
+                    "Region": r,
+                    "Status": "InSync",
+                    "StatusMessage": "Replication succeeded",
+                })
+            })
+            .collect(),
+    )
+}
+
 fn remap_validation_error(err: AwsServiceError) -> AwsServiceError {
     match err {
         AwsServiceError::AwsError {

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -233,6 +233,56 @@ async fn test_replication_ops_return_arn() {
 }
 
 #[tokio::test]
+async fn replicate_secret_to_regions_persists_replicas() {
+    // ReplicateSecretToRegions was a no-op returning empty ReplicationStatus
+    // (bug-audit 2026-06-20, 1.24): the added regions must persist and show up
+    // in ReplicationStatus and DescribeSecret, and be removable.
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "repl", "SecretString": "v"}"#,
+    ))
+    .await
+    .unwrap();
+
+    let resp = svc
+        .handle(make_request(
+            "ReplicateSecretToRegions",
+            r#"{"SecretId": "repl", "AddReplicaRegions": [{"Region": "us-west-2"}, {"Region": "eu-west-1"}]}"#,
+        ))
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let statuses = body["ReplicationStatus"].as_array().unwrap();
+    assert_eq!(statuses.len(), 2, "{body}");
+    assert!(statuses
+        .iter()
+        .any(|s| s["Region"] == "us-west-2" && s["Status"] == "InSync"));
+
+    // DescribeSecret reflects the replicas.
+    let d = svc
+        .handle(make_request("DescribeSecret", r#"{"SecretId": "repl"}"#))
+        .await
+        .unwrap();
+    let db: Value = serde_json::from_slice(d.body.expect_bytes()).unwrap();
+    assert_eq!(db["ReplicationStatus"].as_array().unwrap().len(), 2);
+
+    // Removing one region drops it.
+    let r = svc
+        .handle(make_request(
+            "RemoveRegionsFromReplication",
+            r#"{"SecretId": "repl", "RemoveReplicaRegions": ["us-west-2"]}"#,
+        ))
+        .await
+        .unwrap();
+    let rb: Value = serde_json::from_slice(r.body.expect_bytes()).unwrap();
+    let left = rb["ReplicationStatus"].as_array().unwrap();
+    assert_eq!(left.len(), 1);
+    assert_eq!(left[0]["Region"], "eu-west-1");
+}
+
+#[tokio::test]
 async fn test_secret_id_length_validation() {
     let state = make_state();
     let svc = SecretsManagerService::new(state);
@@ -2114,6 +2164,7 @@ fn test_filter_name_prefix() {
         rotation_rules: None,
         last_rotated_at: None,
         resource_policy: None,
+        replica_regions: Vec::new(),
     };
     assert!(filter_name(&secret, &["prod/"]));
     assert!(!filter_name(&secret, &["staging/"]));
@@ -2140,6 +2191,7 @@ fn test_filter_tag_value() {
         rotation_rules: None,
         last_rotated_at: None,
         resource_policy: None,
+        replica_regions: Vec::new(),
     };
     assert!(filter_tag_value(&secret, &["prod"]));
     assert!(!filter_tag_value(&secret, &["staging"]));
@@ -2166,6 +2218,7 @@ fn test_filter_all_searches_name_desc_tags() {
         rotation_rules: None,
         last_rotated_at: None,
         resource_policy: None,
+        replica_regions: Vec::new(),
     };
     // Matches name
     assert!(filter_all(&secret, &["my"]));

--- a/crates/fakecloud-secretsmanager/src/state.rs
+++ b/crates/fakecloud-secretsmanager/src/state.rs
@@ -23,6 +23,10 @@ pub struct Secret {
     pub rotation_rules: Option<RotationRules>,
     pub last_rotated_at: Option<DateTime<Utc>>,
     pub resource_policy: Option<String>,
+    /// Replica regions added via ReplicateSecretToRegions. Reflected in
+    /// ReplicationStatus on describe/replicate responses.
+    #[serde(default)]
+    pub replica_regions: Vec<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -118,6 +122,7 @@ mod tests {
                 rotation_rules: None,
                 last_rotated_at: None,
                 resource_policy: None,
+                replica_regions: Vec::new(),
             },
         );
         state.reset();


### PR DESCRIPTION
## Summary
ReplicateSecretToRegions and RemoveRegionsFromReplication were no-ops that returned an empty `ReplicationStatus` and ignored `AddReplicaRegions` / `RemoveReplicaRegions` (bug-audit 2026-06-20, finding 1.24).

- Store replica regions on the secret.
- Return a `ReplicationStatus` (InSync per region) from both ops, and render it in DescribeSecret.
- RemoveRegionsFromReplication drops the named regions.

## Test plan
- New `replicate_secret_to_regions_persists_replicas`: add two regions (reflected in ReplicationStatus + DescribeSecret), remove one, the other remains.
- `cargo test -p fakecloud-secretsmanager` green (112 passed); fmt + clippy -D warnings clean on secretsmanager + cloudformation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes no-op replication ops by persisting replica regions and returning accurate ReplicationStatus. DescribeSecret now shows replica regions; RemoveRegionsFromReplication removes them.

- **Bug Fixes**
  - Store `replica_regions` on secrets; update on ReplicateSecretToRegions and RemoveRegionsFromReplication.
  - Return ReplicationStatus (InSync per region) from both ops and include it in DescribeSecret.
  - Add test covering add/remove flow; initialize new secrets with an empty replica list.

<sup>Written for commit 0923027e2aecdae9b422d4c704925cdf1f126974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

