### PR TITLE
fix(glue): round-trip standard Job fields on Create/UpdateJob

### DIFF
--- a/crates/fakecloud-glue/src/jobs.rs
+++ b/crates/fakecloud-glue/src/jobs.rs
@@ -63,7 +63,21 @@ pub(crate) fn job_to_json(j: &Job) -> Value {
         "WorkerType": j.worker_type,
         "NumberOfWorkers": j.number_of_workers,
         "ExecutionClass": j.execution_class,
+        "Connections": j.connections,
+        "ExecutionProperty": j.execution_property,
+        "SecurityConfiguration": j.security_configuration,
+        "NotificationProperty": j.notification_property,
+        "NonOverridableArguments": j.non_overridable_arguments,
     })
+}
+
+/// Clone a JSON value into `Some` unless it's null/absent.
+fn opt_value(v: &Value) -> Option<Value> {
+    if v.is_null() {
+        None
+    } else {
+        Some(v.clone())
+    }
 }
 
 fn job_run_to_json(r: &JobRun) -> Value {
@@ -110,6 +124,11 @@ impl GlueService {
             worker_type: body["WorkerType"].as_str().map(String::from),
             number_of_workers: body["NumberOfWorkers"].as_i64(),
             execution_class: body["ExecutionClass"].as_str().map(String::from),
+            connections: opt_value(&body["Connections"]),
+            execution_property: opt_value(&body["ExecutionProperty"]),
+            security_configuration: body["SecurityConfiguration"].as_str().map(String::from),
+            notification_property: opt_value(&body["NotificationProperty"]),
+            non_overridable_arguments: parse_string_map(&body["NonOverridableArguments"]),
         };
         state.jobs.insert(name.to_string(), job);
         Ok(AwsResponse::ok_json(json!({ "Name": name })))
@@ -183,6 +202,24 @@ impl GlueService {
         }
         if let Some(n) = update["NumberOfWorkers"].as_i64() {
             job.number_of_workers = Some(n);
+        }
+        if let Some(s) = update["ExecutionClass"].as_str() {
+            job.execution_class = Some(s.to_string());
+        }
+        if !update["Connections"].is_null() {
+            job.connections = opt_value(&update["Connections"]);
+        }
+        if !update["ExecutionProperty"].is_null() {
+            job.execution_property = opt_value(&update["ExecutionProperty"]);
+        }
+        if let Some(s) = update["SecurityConfiguration"].as_str() {
+            job.security_configuration = Some(s.to_string());
+        }
+        if !update["NotificationProperty"].is_null() {
+            job.notification_property = opt_value(&update["NotificationProperty"]);
+        }
+        if update["NonOverridableArguments"].is_object() {
+            job.non_overridable_arguments = parse_string_map(&update["NonOverridableArguments"]);
         }
         job.last_modified_on = Utc::now();
         Ok(AwsResponse::ok_json(json!({ "JobName": name })))
@@ -331,6 +368,57 @@ mod tests {
         assert!(svc
             .get_job(&req("GetJob", json!({"JobName": "etl"})))
             .is_err());
+    }
+
+    #[test]
+    fn create_and_update_job_round_trip_extended_fields() {
+        // Connections / ExecutionProperty / SecurityConfiguration /
+        // NotificationProperty / NonOverridableArguments were dropped
+        // (bug-audit 2026-06-20, 1.24).
+        let svc = GlueService::default();
+        svc.create_job(&req(
+            "CreateJob",
+            json!({
+                "Name": "etl",
+                "Role": "arn:aws:iam::123456789012:role/glue",
+                "Command": {"Name": "glueetl"},
+                "Connections": {"Connections": ["conn-a"]},
+                "ExecutionProperty": {"MaxConcurrentRuns": 3},
+                "SecurityConfiguration": "sec-cfg",
+                "NotificationProperty": {"NotifyDelayAfter": 10},
+                "NonOverridableArguments": {"--locked": "1"}
+            }),
+        ))
+        .unwrap();
+
+        let got = |svc: &GlueService| -> Value {
+            let resp = svc
+                .get_job(&req("GetJob", json!({"JobName": "etl"})))
+                .unwrap();
+            serde_json::from_slice::<Value>(resp.body.expect_bytes()).unwrap()["Job"].clone()
+        };
+        let j = got(&svc);
+        assert_eq!(j["Connections"]["Connections"][0], "conn-a", "{j}");
+        assert_eq!(j["ExecutionProperty"]["MaxConcurrentRuns"], 3);
+        assert_eq!(j["SecurityConfiguration"], "sec-cfg");
+        assert_eq!(j["NotificationProperty"]["NotifyDelayAfter"], 10);
+        assert_eq!(j["NonOverridableArguments"]["--locked"], "1");
+
+        // UpdateJob applies the same fields.
+        svc.update_job(&req(
+            "UpdateJob",
+            json!({
+                "JobName": "etl",
+                "JobUpdate": {
+                    "SecurityConfiguration": "sec-cfg-2",
+                    "ExecutionProperty": {"MaxConcurrentRuns": 7}
+                }
+            }),
+        ))
+        .unwrap();
+        let j = got(&svc);
+        assert_eq!(j["SecurityConfiguration"], "sec-cfg-2");
+        assert_eq!(j["ExecutionProperty"]["MaxConcurrentRuns"], 7);
     }
 
     #[test]

--- a/crates/fakecloud-glue/src/state.rs
+++ b/crates/fakecloud-glue/src/state.rs
@@ -162,6 +162,18 @@ pub struct Job {
     pub worker_type: Option<String>,
     pub number_of_workers: Option<i64>,
     pub execution_class: Option<String>,
+    /// Standard Job fields that were previously accepted then dropped
+    /// (bug-audit 2026-06-20, 1.24). Round-tripped verbatim.
+    #[serde(default)]
+    pub connections: Option<serde_json::Value>,
+    #[serde(default)]
+    pub execution_property: Option<serde_json::Value>,
+    #[serde(default)]
+    pub security_configuration: Option<String>,
+    #[serde(default)]
+    pub notification_property: Option<serde_json::Value>,
+    #[serde(default)]
+    pub non_overridable_arguments: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
CreateJob / UpdateJob dropped `Connections`, `ExecutionProperty` (MaxConcurrentRuns), `SecurityConfiguration`, `NotificationProperty`, and `NonOverridableArguments`, so GetJob never returned them (bug-audit 2026-06-20, finding 1.24).

Store these on the Job struct, parse them on create and update, and render them in GetJob/GetJobs.

## Test plan
- New `create_and_update_job_round_trip_extended_fields`: create with all five fields (verified via GetJob), then UpdateJob changes two (verified).
- `cargo test -p fakecloud-glue` green (26 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Glue Job round-tripping so standard fields are preserved on create/update. `GetJob`/`GetJobs` now return `Connections`, `ExecutionProperty` (MaxConcurrentRuns), `SecurityConfiguration`, `NotificationProperty`, and `NonOverridableArguments`.

- **Bug Fixes**
  - Parse and store these fields in the `Job` struct; include in job responses.
  - Apply updates for these fields in `UpdateJob`.
  - Added test `create_and_update_job_round_trip_extended_fields` to verify create/update round-trip.

<sup>Written for commit 9359ff014e385d1b4d6c1a7c2713910d0c54fbab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

