### PR TITLE
fix(ecr): apply all fields in UpdateRepositoryCreationTemplate

### DIFF
--- a/crates/fakecloud-ecr/src/service/templates.rs
+++ b/crates/fakecloud-ecr/src/service/templates.rs
@@ -168,6 +168,32 @@ impl EcrService {
         if let Some(arr) = body.get("resourceTags").and_then(|v| v.as_array()) {
             tpl.resource_tags = arr.clone();
         }
+        // customRoleArn / repositoryPolicy / lifecyclePolicy /
+        // encryptionConfiguration were dropped on update (bug-audit
+        // 2026-06-20, 1.24).
+        if let Some(role) = opt_str(&body, "customRoleArn") {
+            tpl.custom_role_arn = Some(role.to_string());
+        }
+        if let Some(p) = opt_str(&body, "repositoryPolicy") {
+            tpl.repository_policy = Some(p.to_string());
+        }
+        if let Some(p) = opt_str(&body, "lifecyclePolicy") {
+            tpl.lifecycle_policy = Some(p.to_string());
+        }
+        if let Some(v) = body.get("encryptionConfiguration") {
+            use crate::state::EncryptionConfiguration as Enc;
+            tpl.encryption_configuration = Some(Enc {
+                encryption_type: v
+                    .get("encryptionType")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("AES256")
+                    .to_string(),
+                kms_key: v
+                    .get("kmsKey")
+                    .and_then(|x| x.as_str())
+                    .map(|s| s.to_string()),
+            });
+        }
         tpl.updated_at = Utc::now();
         Ok(AwsResponse::ok_json(json!({
             "registryId": state.account_id,

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -605,6 +605,48 @@ mod replication_tests {
     }
 
     #[test]
+    fn update_repository_creation_template_applies_all_fields() {
+        // customRoleArn / repositoryPolicy / lifecyclePolicy /
+        // encryptionConfiguration were dropped on update (bug-audit
+        // 2026-06-20, 1.24).
+        let (svc, _state) = fixture(Vec::new());
+        svc.create_repository_creation_template(&make_request(
+            "CreateRepositoryCreationTemplate",
+            json!({"prefix": "team/", "appliedFor": ["PULL_THROUGH_CACHE"]}),
+        ))
+        .unwrap();
+
+        svc.update_repository_creation_template(&make_request(
+            "UpdateRepositoryCreationTemplate",
+            json!({
+                "prefix": "team/",
+                "customRoleArn": "arn:aws:iam::111111111111:role/r",
+                "repositoryPolicy": "{\"Version\":\"2012-10-17\"}",
+                "lifecyclePolicy": "{\"rules\":[]}",
+                "encryptionConfiguration": {"encryptionType": "KMS", "kmsKey": "arn:kms:key"}
+            }),
+        ))
+        .unwrap();
+
+        let resp = svc
+            .describe_repository_creation_templates(&make_request(
+                "DescribeRepositoryCreationTemplates",
+                json!({"prefixes": ["team/"]}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let tpl = &body["repositoryCreationTemplates"][0];
+        assert_eq!(
+            tpl["customRoleArn"], "arn:aws:iam::111111111111:role/r",
+            "{tpl}"
+        );
+        assert_eq!(tpl["repositoryPolicy"], "{\"Version\":\"2012-10-17\"}");
+        assert_eq!(tpl["lifecyclePolicy"], "{\"rules\":[]}");
+        assert_eq!(tpl["encryptionConfiguration"]["encryptionType"], "KMS");
+        assert_eq!(tpl["encryptionConfiguration"]["kmsKey"], "arn:kms:key");
+    }
+
+    #[test]
     fn put_image_triggers_replication_to_configured_destination() {
         const SOURCE: &str = "111111111111";
         const TARGET: &str = "222222222222";


### PR DESCRIPTION
## Summary
UpdateRepositoryCreationTemplate only updated `description` / `imageTagMutability` / `appliedFor` / `resourceTags`, dropping `customRoleArn`, `repositoryPolicy`, `lifecyclePolicy`, and `encryptionConfiguration` that CreateRepositoryCreationTemplate accepts (bug-audit 2026-06-20, finding 1.24).

Apply those four on update too so DescribeRepositoryCreationTemplates reflects the change.

## Test plan
- New `update_repository_creation_template_applies_all_fields`: create a template then update all four previously-dropped fields, verified via DescribeRepositoryCreationTemplates.
- `cargo test -p fakecloud-ecr` green (68 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `UpdateRepositoryCreationTemplate` so all supported fields are applied and visible in `DescribeRepositoryCreationTemplates`. Prevents dropped role, policy, lifecycle, and encryption settings.

- **Bug Fixes**
  - Persist `customRoleArn`, `repositoryPolicy`, `lifecyclePolicy`, and `encryptionConfiguration` on update.
  - Added test `update_repository_creation_template_applies_all_fields`; all `fakecloud-ecr` tests pass.

<sup>Written for commit c9cf8cfaa8927c7f5a2f3e0a76ae9334938b565d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

