### PR TITLE
fix(ssm): apply schedule fields in UpdateMaintenanceWindow

### DIFF
--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -336,6 +336,21 @@ impl SsmService {
         if body.get("Description").is_some() {
             mw.description = body["Description"].as_str().map(|s| s.to_string());
         }
+        // ScheduleTimezone / ScheduleOffset / StartDate / EndDate were accepted
+        // (ScheduleOffset even validated) but dropped on update (bug-audit
+        // 2026-06-20, 1.24).
+        if let Some(tz) = body["ScheduleTimezone"].as_str() {
+            mw.schedule_timezone = Some(tz.to_string());
+        }
+        if let Some(offset) = body["ScheduleOffset"].as_i64() {
+            mw.schedule_offset = Some(offset);
+        }
+        if let Some(sd) = body["StartDate"].as_str() {
+            mw.start_date = Some(sd.to_string());
+        }
+        if let Some(ed) = body["EndDate"].as_str() {
+            mw.end_date = Some(ed.to_string());
+        }
 
         let mut resp = json!({
             "WindowId": mw.id,
@@ -348,6 +363,18 @@ impl SsmService {
         });
         if let Some(ref desc) = mw.description {
             resp["Description"] = json!(desc);
+        }
+        if let Some(ref tz) = mw.schedule_timezone {
+            resp["ScheduleTimezone"] = json!(tz);
+        }
+        if let Some(offset) = mw.schedule_offset {
+            resp["ScheduleOffset"] = json!(offset);
+        }
+        if let Some(ref sd) = mw.start_date {
+            resp["StartDate"] = json!(sd);
+        }
+        if let Some(ref ed) = mw.end_date {
+            resp["EndDate"] = json!(ed);
         }
 
         Ok(AwsResponse::ok_json(resp))

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -3750,6 +3750,58 @@ fn update_maintenance_window_not_found() {
 }
 
 #[test]
+fn update_maintenance_window_applies_schedule_fields() {
+    // ScheduleTimezone/ScheduleOffset/StartDate/EndDate were dropped on update
+    // (ScheduleOffset even validated) -- bug-audit 2026-06-20, 1.24.
+    let svc = make_service();
+    let create = svc
+        .create_maintenance_window(&make_request(
+            "CreateMaintenanceWindow",
+            json!({
+                "Name": "win",
+                "Schedule": "rate(7 days)",
+                "Duration": 2,
+                "Cutoff": 1,
+                "AllowUnassociatedTargets": false
+            }),
+        ))
+        .unwrap();
+    let cb: Value = serde_json::from_slice(create.body.expect_bytes()).unwrap();
+    let window_id = cb["WindowId"].as_str().unwrap().to_string();
+
+    let resp = svc
+        .update_maintenance_window(&make_request(
+            "UpdateMaintenanceWindow",
+            json!({
+                "WindowId": window_id,
+                "ScheduleTimezone": "America/New_York",
+                "ScheduleOffset": 2,
+                "StartDate": "2026-07-01T00:00:00Z",
+                "EndDate": "2026-12-31T00:00:00Z"
+            }),
+        ))
+        .unwrap();
+    let b: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(b["ScheduleTimezone"], "America/New_York", "{b}");
+    assert_eq!(b["ScheduleOffset"], 2);
+    assert_eq!(b["StartDate"], "2026-07-01T00:00:00Z");
+    assert_eq!(b["EndDate"], "2026-12-31T00:00:00Z");
+
+    // Persisted: DescribeMaintenanceWindows reflects them too.
+    let d = svc
+        .describe_maintenance_windows(&make_request("DescribeMaintenanceWindows", json!({})))
+        .unwrap();
+    let db: Value = serde_json::from_slice(d.body.expect_bytes()).unwrap();
+    let win = db["WindowIdentities"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|w| w["WindowId"] == window_id.as_str())
+        .unwrap();
+    assert_eq!(win["ScheduleTimezone"], "America/New_York", "{win}");
+}
+
+#[test]
 fn register_target_unknown_window_errors() {
     let svc = make_service();
     let req = make_request(


### PR DESCRIPTION
## Summary
UpdateMaintenanceWindow validated `ScheduleOffset` but never applied it, and dropped `ScheduleTimezone` / `StartDate` / `EndDate`, so those create-time fields couldn't be changed and the update response (and DescribeMaintenanceWindows) lost them (bug-audit 2026-06-20, finding 1.24).

Apply `ScheduleTimezone` / `ScheduleOffset` / `StartDate` / `EndDate` on update and echo them in the response.

The sibling SSM update ops named in the finding (UpdateAssociation, UpdateOpsItem, UpdatePatchBaseline) were already complete, so this is the only genuine gap in that cluster.

## Test plan
- New `update_maintenance_window_applies_schedule_fields`: update sets all four fields, verified in the response and in DescribeMaintenanceWindows.
- `cargo test -p fakecloud-ssm` green (225 passed); fmt + clippy -D warnings clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UpdateMaintenanceWindow dropping schedule fields. The update now persists and returns ScheduleTimezone, ScheduleOffset, StartDate, and EndDate, keeping DescribeMaintenanceWindows accurate; added a test to cover this.

<sup>Written for commit 4b17ac52ae2682f93c9ee89b7dbfadd840f0cebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

