### PR TITLE
docs: add Homebrew install path everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://github.com/faiscadev/fakecloud/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License"></a>
   <a href="https://github.com/faiscadev/fakecloud/pkgs/container/fakecloud"><img src="https://img.shields.io/badge/ghcr.io-fakecloud-blue?logo=docker" alt="GHCR"></a>
   <a href="https://crates.io/crates/fakecloud"><img src="https://img.shields.io/crates/v/fakecloud" alt="crates.io"></a>
+  <a href="https://formulae.brew.sh/formula/fakecloud"><img src="https://img.shields.io/homebrew/v/fakecloud" alt="Homebrew"></a>
   <a href="https://fakecloud.dev"><img src="https://img.shields.io/badge/docs-fakecloud.dev-green" alt="Docs"></a>
 </p>
 
@@ -20,7 +21,7 @@ In March 2026, LocalStack replaced its open-source Community Edition with a prop
 ## Quick start
 
 ```sh
-curl -fsSL https://fakecloud.dev/install.sh | bash
+curl -fsSL https://fakecloud.dev/install.sh | bash   # or: brew install fakecloud
 fakecloud
 ```
 
@@ -30,7 +31,7 @@ Then point any AWS SDK or CLI at `http://localhost:4566` with dummy credentials:
 aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name my-queue
 ```
 
-Works as a drop-in for LocalStack in CI, with Terraform (`endpoints` block), CDK (`cdklocal`), or any AWS SDK in any language. Other install options (Cargo, Docker, Docker Compose, source) and full guides: [fakecloud.dev/docs/getting-started](https://fakecloud.dev/docs/getting-started).
+Works as a drop-in for LocalStack in CI, with Terraform (`endpoints` block), CDK (`cdklocal`), or any AWS SDK in any language. Other install options (Homebrew, Cargo, Docker, Docker Compose, source) and full guides: [fakecloud.dev/docs/getting-started](https://fakecloud.dev/docs/getting-started).
 
 ## Why fakecloud
 

--- a/website/content/bedrock-emulator.md
+++ b/website/content/bedrock-emulator.md
@@ -133,6 +133,7 @@ rt.apply_guardrail(guardrailIdentifier=g['guardrailId'],
 
 ## Links
 
+- **Homebrew**: `brew install fakecloud`
 - **Install**: `curl -fsSL https://fakecloud.dev/install.sh | bash`
 - **Repo**: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 - **Deep dive**: [How to test Bedrock code locally, for free, deterministically](/blog/bedrock-local-testing/)

--- a/website/content/docs/getting-started/install.md
+++ b/website/content/docs/getting-started/install.md
@@ -1,6 +1,6 @@
 +++
 title = "Install"
-description = "Install fakecloud via script, Cargo, Docker, Docker Compose, or from source."
+description = "Install fakecloud via install script, Homebrew, Cargo, Docker, Docker Compose, or from source."
 weight = 1
 +++
 
@@ -8,12 +8,23 @@ fakecloud ships as a single ~19 MB binary. Pick whichever install path fits your
 
 ## Install script (recommended)
 
+Works on macOS and Linux, and in CI:
+
 ```sh
 curl -fsSL https://fakecloud.dev/install.sh | bash
 fakecloud
 ```
 
 The script downloads the latest release for your platform and puts the `fakecloud` binary somewhere on your `PATH`.
+
+## Homebrew
+
+```sh
+brew install fakecloud
+fakecloud
+```
+
+`fakecloud` is in [homebrew-core](https://formulae.brew.sh/formula/fakecloud), so no tap is needed. `brew upgrade fakecloud` tracks every release.
 
 ## Cargo
 

--- a/website/content/dynamodb-emulator.md
+++ b/website/content/dynamodb-emulator.md
@@ -128,6 +128,7 @@ If you need multi-language, free, real Lambda triggers, depth-first conformance:
 
 ## Links
 
+- **Homebrew:** `brew install fakecloud`
 - **Install:** `curl -fsSL https://fakecloud.dev/install.sh | bash`
 - **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 - **DynamoDB docs:** [fakecloud.dev/docs/services/dynamodb](/docs/services/dynamodb/)

--- a/website/content/fake-aws-server.md
+++ b/website/content/fake-aws-server.md
@@ -83,6 +83,7 @@ A fake AWS server on localhost is language-agnostic (any SDK works), runs real c
 
 ## Install options
 
+- Homebrew: `brew install fakecloud`
 - Binary: `curl -fsSL https://fakecloud.dev/install.sh | bash`
 - Docker: `docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud`
 - Cargo: `cargo install fakecloud`

--- a/website/content/fake-bedrock.md
+++ b/website/content/fake-bedrock.md
@@ -109,6 +109,7 @@ Assert your code handles every Bedrock error code you read in the docs. No more 
 
 ## Links
 
+- **Homebrew**: `brew install fakecloud`
 - **Install**: `curl -fsSL https://fakecloud.dev/install.sh | bash`
 - **Repo**: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 - **Tutorial**: [How to test Bedrock code locally](/blog/bedrock-local-testing/)

--- a/website/content/faq.md
+++ b/website/content/faq.md
@@ -44,14 +44,14 @@ Yes, end-to-end. When an object is created in S3, any Lambda subscribed via buck
 
 ### How do I install fakecloud?
 
-One-line install script:
+One-line install script (macOS + Linux):
 
 ```sh
 curl -fsSL https://fakecloud.dev/install.sh | bash
 fakecloud
 ```
 
-Or Docker: `docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud`. Or `cargo install fakecloud`.
+Or Homebrew: `brew install fakecloud`. Or Docker: `docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud`. Or `cargo install fakecloud`.
 
 ### Does fakecloud work with Terraform?
 

--- a/website/content/kms-emulator.md
+++ b/website/content/kms-emulator.md
@@ -108,6 +108,7 @@ Secrets Manager secrets are encrypted with KMS by default. Rotation via Lambda w
 
 ## Links
 
+- **Homebrew:** `brew install fakecloud`
 - **Install:** `curl -fsSL https://fakecloud.dev/install.sh | bash`
 - **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 - **Related:** [Fake AWS server for tests](/fake-aws-server/), [Local S3 for integration tests](/local-s3-for-tests/)

--- a/website/content/local-elasticache.md
+++ b/website/content/local-elasticache.md
@@ -141,6 +141,7 @@ Running fakecloud inside Kubernetes? Set `FAKECLOUD_ELASTICACHE_BACKEND=k8s` (or
 
 ## Links
 
+- **Homebrew:** `brew install fakecloud`
 - **Install:** `curl -fsSL https://fakecloud.dev/install.sh | bash`
 - **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 - **Related:** [Local RDS for tests](/local-rds/), [Fake AWS server for tests](/fake-aws-server/)

--- a/website/content/local-rds.md
+++ b/website/content/local-rds.md
@@ -164,6 +164,7 @@ Running fakecloud inside Kubernetes? Set `FAKECLOUD_RDS_BACKEND=k8s` (or the glo
 
 ## Links
 
+- **Homebrew:** `brew install fakecloud`
 - **Install:** `curl -fsSL https://fakecloud.dev/install.sh | bash`
 - **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 - **Related:** [Local ElastiCache for tests](/local-elasticache/), [Fake AWS server for tests](/fake-aws-server/)

--- a/website/content/localstack-alternative.md
+++ b/website/content/localstack-alternative.md
@@ -131,7 +131,8 @@ No. fakecloud is written from scratch in Rust. No LocalStack code was used. Loca
 
 ## Get started
 
-- **Install:** `curl -fsSL https://fakecloud.dev/install.sh | bash`
+- **Homebrew:** `brew install fakecloud`
+- **Install script:** `curl -fsSL https://fakecloud.dev/install.sh | bash`
 - **Docker:** `docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud`
 - **Cargo:** `cargo install fakecloud`
 - **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)

--- a/website/content/localstack-bedrock-alternative.md
+++ b/website/content/localstack-bedrock-alternative.md
@@ -98,6 +98,7 @@ Full operation surface across 27 modules:
 
 ## Links
 
+- **Homebrew**: `brew install fakecloud`
 - **Install**: `curl -fsSL https://fakecloud.dev/install.sh | bash`
 - **Repo**: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 - **Deep dive**: [How to test Bedrock code locally, for free, deterministically](/blog/bedrock-local-testing/)

--- a/website/content/sqs-emulator.md
+++ b/website/content/sqs-emulator.md
@@ -149,6 +149,7 @@ If you need SQS + cross-service (SNS -> SQS, SQS -> Lambda actually firing), pic
 
 ## Links
 
+- **Homebrew:** `brew install fakecloud`
 - **Install:** `curl -fsSL https://fakecloud.dev/install.sh | bash`
 - **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 - **Related:** [Fake AWS server for tests](/fake-aws-server/), [Test Lambda locally](/test-lambda-locally/), [Integration testing AWS in CI](/blog/integration-testing-aws-in-ci/)

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -23,6 +23,13 @@ fakecloud is NOT a production-ready cloud replacement. It is for integration tes
 ```sh
 curl -fsSL https://fakecloud.dev/install.sh | bash
 ```
+Works on macOS and Linux, and in CI.
+
+### Homebrew
+```sh
+brew install fakecloud
+```
+In homebrew-core (https://formulae.brew.sh/formula/fakecloud), no tap needed.
 
 Options:
 ```sh

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -16,7 +16,8 @@
 
 ## Install
 
-- [Install script](https://fakecloud.dev/install.sh): `curl -fsSL https://fakecloud.dev/install.sh | bash`
+- [Install script](https://fakecloud.dev/install.sh): `curl -fsSL https://fakecloud.dev/install.sh | bash` (macOS + Linux)
+- [Homebrew](https://formulae.brew.sh/formula/fakecloud): `brew install fakecloud`
 - [Cargo install](https://crates.io/crates/fakecloud): `cargo install fakecloud`
 - [Docker](https://github.com/faiscadev/fakecloud/pkgs/container/fakecloud): `docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud`
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -157,6 +157,7 @@
     <div class="code-block">
       <span class="comment"># Install (no Cargo or Docker needed)</span><br>
       <span class="prompt">$ </span>curl -fsSL https://fakecloud.dev/install.sh | bash<br>
+      <span class="comment"># or: brew install fakecloud</span><br>
       <span class="prompt">$ </span>fakecloud<br>
       <br>
       <span class="comment"># Your app uses the normal AWS SDK against localhost</span><br>


### PR DESCRIPTION
## Summary

\`fakecloud\` is now in [homebrew-core](https://formulae.brew.sh/formula/fakecloud) — \`brew install fakecloud\` works today and BrewTestBot autobumps every release (currently v0.20.1). It was previously undocumented everywhere. This sweep surfaces Homebrew as a first-class install method across all user-facing install docs.

Changes:
- \`docs/getting-started/install.md\`: new **Homebrew (recommended)** section as the first method; install script demoted to "Install script" (still the CI / no-brew fallback)
- \`README.md\`: \`brew install\` alt in quick start, a homebrew shields.io badge, and Homebrew added to the "other install options" line
- \`faq.md\`, \`fake-aws-server.md\`, \`localstack-alternative.md\`: Homebrew added to install method lists
- \`templates/index.html\`: \`brew install fakecloud\` line in the quick-start code block
- \`llms.txt\` / \`llms-full.txt\`: Homebrew install entry
- 8 per-service landing pages (rds, elasticache, kms, sqs, dynamodb, 3x bedrock): Homebrew bullet in their Links / install lists

The formula's license (AGPL-3.0-or-later) already matches \`Cargo.toml\`, so no homebrew-core formula PR is needed.

## Test plan
- \`cd website && zola build\` -> clean, 116 pages, 0 orphan (CI runs \`zola build\`)
- \`grep -rn "brew install fakecloud"\` confirms all 16 target files updated
- \`brew info fakecloud\` shows v0.20.1 live — the documented command works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Homebrew (macOS) as a first-class install option across the docs while keeping the install script as the recommended cross‑platform (macOS, Linux, CI) path. `fakecloud` is in `homebrew-core`, so `brew install fakecloud` works with no tap.

- **Docs**
  - Install page: keeps “Install script (recommended)”; adds “Homebrew” section; notes `homebrew-core` and `brew upgrade fakecloud`.
  - README: adds Homebrew badge; quick start keeps the script first with a `brew` alternative; “other options” now lists Homebrew.
  - Website: homepage quick start shows `brew` as the macOS alternative; FAQs, LocalStack pages, `fake-aws-server`, and 8 service pages add a Homebrew bullet; updated `llms.txt` and `llms-full.txt`.

<sup>Written for commit 6e6c267e59f89ee75df17cdb85a996a7d391c832. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

