### PR TITLE
chore(release): bump workspace to v0.20.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -112,175 +112,175 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.20.1")
+    testImplementation("dev.fakecloud:fakecloud:0.20.2")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.20.1</version>
+    <version>0.20.2</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.20.1"
+version = "0.20.2"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.20.1"
+version = "0.20.2"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Patch release. 111 commits since v0.20.1 — the full bug-hunt 2026-06-20 wave (#1781-#1839: Tier 0-5 fixes across CFN/DynamoDB/Lambda/S3/KMS/Cognito/RDS/ElastiCache/SNS/SQS/IAM/Kinesis/SecretsManager/CloudWatch/Organizations/ELBv2/Athena/Glue/ECR/SSM/Bedrock + pagination, restart persistence, panics, blocking) plus README/CI cleanup. No new services/ops -> patch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the entire `fakecloud` workspace and SDKs to v0.20.2. Patch-only release with bug fixes across core services; no new services or operations.

- **Migration**
  - Rust: update any `fakecloud-*` crate deps to `0.20.2`.
  - Java: `testImplementation("dev.fakecloud:fakecloud:0.20.2")`.
  - Python: `pip install -U fakecloud==0.20.2`.
  - TypeScript: `npm i fakecloud@0.20.2` (or yarn/pnpm equivalent).

<sup>Written for commit bef7ed1ae5809da21977446e8fe83cdc1bc51775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

