### PR TITLE
fix(tfacc): resolve all dynamodb and sqs deny-list entries

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -538,6 +538,25 @@ impl DynamoDbService {
             }
         }
 
+        // Prune AttributeDefinitions down to the set actually referenced by
+        // the table key schema and every remaining index's key schema. Real
+        // DynamoDB enforces this invariant: DescribeTable only ever returns
+        // attributes used by a key. When Terraform deletes a GSI (and the
+        // attribute that backed its key), it sends an UpdateTable whose
+        // AttributeDefinitions no longer mention that attribute; without this
+        // prune fakecloud kept the orphan, and the provider's post-apply
+        // refresh saw a stale `attribute {}` block and reported drift.
+        let referenced: std::collections::HashSet<String> = table
+            .key_schema
+            .iter()
+            .chain(table.gsi.iter().flat_map(|g| g.key_schema.iter()))
+            .chain(table.lsi.iter().flat_map(|l| l.key_schema.iter()))
+            .map(|k| k.attribute_name.clone())
+            .collect();
+        table
+            .attribute_definitions
+            .retain(|ad| referenced.contains(&ad.attribute_name));
+
         let table_desc = build_table_description(table);
 
         Self::ok_json(json!({ "TableDescription": table_desc }))

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -5188,3 +5188,54 @@ fn delete_item_legacy_expected_with_or_operator() {
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert!(body.get("Item").is_none(), "item should have been deleted");
 }
+
+#[test]
+fn update_table_prunes_attributes_orphaned_by_gsi_delete() {
+    // Real DynamoDB keeps AttributeDefinitions equal to the set of attributes
+    // referenced by the table key + every index key. When a GSI (and the
+    // attribute that backed its key) is deleted, DescribeTable no longer lists
+    // that attribute. Terraform's `aws_dynamodb_table` refresh treats a
+    // lingering orphan as drift, so update_table must prune it.
+    let svc = make_service();
+    svc.create_table(&make_request(
+        "CreateTable",
+        json!({
+            "TableName": "t",
+            "KeySchema": [{ "AttributeName": "pk", "KeyType": "HASH" }],
+            "AttributeDefinitions": [
+                { "AttributeName": "pk", "AttributeType": "S" },
+                { "AttributeName": "gsiKey", "AttributeType": "S" }
+            ],
+            "BillingMode": "PAY_PER_REQUEST",
+            "GlobalSecondaryIndexes": [{
+                "IndexName": "gsi",
+                "KeySchema": [{ "AttributeName": "gsiKey", "KeyType": "HASH" }],
+                "Projection": { "ProjectionType": "ALL" }
+            }]
+        }),
+    ))
+    .unwrap();
+
+    // Delete the GSI; the provider sends the trimmed AttributeDefinitions too.
+    svc.update_table(&make_request(
+        "UpdateTable",
+        json!({
+            "TableName": "t",
+            "AttributeDefinitions": [{ "AttributeName": "pk", "AttributeType": "S" }],
+            "GlobalSecondaryIndexUpdates": [{ "Delete": { "IndexName": "gsi" } }]
+        }),
+    ))
+    .unwrap();
+
+    let resp = svc
+        .describe_table(&make_request("DescribeTable", json!({ "TableName": "t" })))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let attrs: Vec<&str> = body["Table"]["AttributeDefinitions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|a| a["AttributeName"].as_str())
+        .collect();
+    assert_eq!(attrs, ["pk"], "orphaned gsiKey attribute should be pruned");
+}

--- a/crates/fakecloud-kms/src/hook.rs
+++ b/crates/fakecloud-kms/src/hook.rs
@@ -280,6 +280,55 @@ fn normalize_alias(key_id: &str) -> String {
     key_id.strip_prefix("alias/").unwrap_or(key_id).to_string()
 }
 
+/// Canonical AWS-managed service aliases (`alias/aws/<service>`). Real
+/// AWS pre-creates these in every account/region, so `aws kms list-aliases`
+/// returns them on a brand-new account and `data.aws_kms_alias` resolves
+/// them. The Terraform acceptance tests for several services
+/// (e.g. `aws_dynamodb_table` encryption) read `alias/aws/<service>` via
+/// that data source, so they must be listable even before any KMS use.
+pub const DEFAULT_AWS_MANAGED_ALIASES: &[&str] = &[
+    "aws/dynamodb",
+    "aws/s3",
+    "aws/sqs",
+    "aws/sns",
+    "aws/secretsmanager",
+    "aws/ssm",
+    "aws/rds",
+    "aws/lambda",
+    "aws/kinesis",
+    "aws/logs",
+    "aws/ebs",
+    "aws/glue",
+    "aws/elasticache",
+    "aws/backup",
+    "aws/es",
+    "aws/redshift",
+    "aws/xray",
+    "aws/elasticfilesystem",
+    "aws/cloudtrail",
+    "aws/sagemaker",
+];
+
+/// Idempotently provision every [`DEFAULT_AWS_MANAGED_ALIASES`] entry that
+/// isn't already present, so `ListAliases` mirrors real AWS. Provisioning a
+/// missing alias also mints its backing AWS-managed key, matching the
+/// auto-provision-on-first-use path in [`resolve_or_provision`].
+pub fn ensure_default_managed_aliases(state: &mut KmsState, region: &str) {
+    for alias in DEFAULT_AWS_MANAGED_ALIASES {
+        let alias_full = format!("alias/{alias}");
+        if state.aliases.contains_key(&alias_full) {
+            continue;
+        }
+        // `aws/<service>` -> `<service>.amazonaws.com`. The principal only
+        // shapes the default key policy; the data source asserts on the
+        // target key id, not the principal, so an approximate principal is
+        // fine here.
+        let service = alias.strip_prefix("aws/").unwrap_or(alias);
+        let principal = format!("{service}.amazonaws.com");
+        provision_aws_managed_key(state, region, alias, &principal);
+    }
+}
+
 fn provision_aws_managed_key(
     state: &mut KmsState,
     region: &str,

--- a/crates/fakecloud-kms/src/service_aliases.rs
+++ b/crates/fakecloud-kms/src/service_aliases.rs
@@ -176,6 +176,16 @@ impl KmsService {
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
         let marker = body["Marker"].as_str();
 
+        // Mirror real AWS: every account/region already carries the
+        // AWS-managed service aliases (`alias/aws/<service>`). Provision any
+        // missing ones so the listing — and `data.aws_kms_alias` on top of
+        // it — resolves them even before any KMS operation has touched them.
+        {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            crate::hook::ensure_default_managed_aliases(state, &req.region);
+        }
+
         let accounts = self.state.read();
         let empty = KmsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -3100,3 +3100,36 @@ fn encrypt_rsa_key_uses_real_oaep_and_roundtrips() {
         .unwrap();
     assert_eq!(decrypted, plaintext);
 }
+
+#[test]
+fn list_aliases_includes_aws_managed_service_aliases() {
+    // Real AWS pre-creates `alias/aws/<service>` in every account/region, so
+    // ListAliases returns them even before any KMS operation has run — and
+    // `data.aws_kms_alias` (used by several service acceptance tests) relies
+    // on that. A fresh service with no user aliases must still list them.
+    let svc = make_service();
+    let resp = svc
+        .list_aliases(&make_request("ListAliases", json!({})))
+        .unwrap();
+    let body = body_json(resp);
+    let names: Vec<&str> = body["Aliases"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|a| a["AliasName"].as_str())
+        .collect();
+    for expected in ["alias/aws/dynamodb", "alias/aws/s3", "alias/aws/sqs"] {
+        assert!(
+            names.contains(&expected),
+            "ListAliases should include {expected}, got {names:?}"
+        );
+    }
+    // Every managed alias must point at a key that actually resolves.
+    let ddb = body["Aliases"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|a| a["AliasName"] == "alias/aws/dynamodb")
+        .unwrap();
+    assert!(ddb["TargetKeyId"].as_str().is_some_and(|t| !t.is_empty()));
+}

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -200,12 +200,13 @@ pub const SERVICES: &[Service] = &[
             "|QueueRedrivePolicy_basic",
             "|QueueRedriveAllowPolicy_basic)$",
         ),
-        deny: &[
-            // --- hung: runs clean locally but never completes in CI,
-            //          blocking the whole service at the 90m timeout.
-            //          Needs characterisation in a follow-up batch. ---
-            "TestAccSQSQueueRedriveAllowPolicy_basic",
-        ],
+        // Characterised: `TestAccSQSQueueRedriveAllowPolicy_basic` passes
+        // against fakecloud. It is slow (~2m) only because the SQS provider's
+        // `waitQueueAttributesPropagated` enforces `ContinuousTargetOccurence:
+        // 6` at `MinTimeout: 5s` — a client-side stabilisation wait that is
+        // backend-speed-independent. That cost is bounded and well under the
+        // shard timeout, so the test no longer needs to be denied.
+        deny: &[],
     },
     Service {
         name: "dynamodb",
@@ -241,13 +242,10 @@ pub const SERVICES: &[Service] = &[
             "TestAccDynamoDBTable_backupEncryption",
             "TestAccDynamoDBTable_backup_overrideEncryption",
             "TestAccDynamoDBTable_importTable",
-            // --- gap: encryption attribute round-trip ---
-            "TestAccDynamoDBTable_encryption",
-            // --- hung: did not complete in triage run; revisit in a later batch ---
-            "TestAccDynamoDBTable_attributeUpdate",
-            "TestAccDynamoDBTable_extended",
-            "TestAccDynamoDBTable_gsiUpdateNonKeyAttributes",
-            "TestAccDynamoDBTable_gsiUpdateOtherAttributes",
+            // --- unsupportable: the test sleeps 60m in a PreConfig because AWS
+            //     refuses to disable TTL within an hour of enabling it
+            //     (upstream issue #39195), so it can never finish inside CI
+            //     regardless of fakecloud behavior. ---
             "TestAccDynamoDBTable_TTL_updateDisable",
         ],
     },


### PR DESCRIPTION
## Summary

Drains the dynamodb and sqs tfacc deny-lists to zero open entries by fixing the underlying fakecloud gaps (no test gaming).

**DynamoDB**
- `UpdateTable` prunes `AttributeDefinitions` to the attributes referenced by the table key + remaining index keys, matching AWS's invariant that `DescribeTable` returns only referenced attributes. Deleting a GSI (and its backing attribute) no longer leaves an orphan that the Terraform provider sees as drift. Fixes `TestAccDynamoDBTable_extended` and `_attributeUpdate`.
- Un-deny `_gsiUpdateNonKeyAttributes` / `_gsiUpdateOtherAttributes` (already passing).
- Reclassify `_TTL_updateDisable` hung -> unsupportable: the upstream test sleeps 60m in a `PreConfig` (AWS rejects disabling TTL within an hour of enabling it, terraform-provider-aws#39195), so it can never finish in CI regardless of fakecloud.

**KMS**
- `ListAliases` provisions and returns the AWS-managed `alias/aws/<service>` entries present in every real account/region, so `data.aws_kms_alias` resolves them before any KMS op runs. Fixes `TestAccDynamoDBTable_encryption` and unblocks encryption acceptance tests across other services.

**SQS**
- Un-deny `TestAccSQSQueueRedriveAllowPolicy_basic`. It passes; its ~2m runtime is the provider's client-side `waitQueueAttributesPropagated` stabilisation (`ContinuousTargetOccurence: 6` x `MinTimeout: 5s`) — backend-speed-independent, bounded, well under the shard timeout.

## Test plan
- New unit tests: dynamodb prune-on-GSI-delete, kms managed-alias listing.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- Upstream suite (terraform-provider-aws v5.97.0) against local fakecloud:
  - full dynamodb shard: **53 pass, 0 fail**
  - sqs-core shard: **7 pass, 0 fail**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears all DynamoDB and SQS tfacc deny-list entries by fixing `fakecloud-dynamodb` and `fakecloud-kms`. Removes false drift after GSI deletes and unblocks encryption tests.

- **Bug Fixes**
  - DynamoDB: `UpdateTable` now prunes `AttributeDefinitions` to only keys used by the table and remaining indexes. Stops orphaned attributes after GSI delete and fixes `TestAccDynamoDBTable_extended` and `_attributeUpdate`.
  - KMS: `ListAliases` now includes AWS-managed `alias/aws/<service>` by provisioning them on list. `data.aws_kms_alias` resolves before any KMS use, fixing `TestAccDynamoDBTable_encryption` and similar tests.
  - SQS: Un-deny `TestAccSQSQueueRedriveAllowPolicy_basic`. It passes; the ~2m runtime is a client-side stabilization wait and is within shard limits.
  - DynamoDB: Reclassify `TestAccDynamoDBTable_TTL_updateDisable` as unsupportable (upstream sleeps 60m before disable), so it cannot run in CI.

<sup>Written for commit 3344cf532e3c84179e56a43235339fb475532f68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

