### PR TITLE
feat(firehose): persist delivery streams across restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,6 +3754,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "fakecloud-s3",
  "http 1.4.0",
  "parking_lot",

--- a/crates/fakecloud-e2e/tests/firehose_persistence.rs
+++ b/crates/fakecloud-e2e/tests/firehose_persistence.rs
@@ -1,0 +1,113 @@
+mod helpers;
+
+use aws_sdk_firehose::types::{
+    DeliveryStreamEncryptionConfigurationInput, DeliveryStreamType,
+    ExtendedS3DestinationConfiguration, KeyType, Tag,
+};
+use helpers::TestServer;
+
+/// A delivery stream, its destination, tags, and encryption state all survive
+/// a restart in persistent mode.
+#[tokio::test]
+async fn persistence_round_trip_stream_tags_and_encryption() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let fh = server.firehose_client().await;
+
+    fh.create_delivery_stream()
+        .delivery_stream_name("events")
+        .delivery_stream_type(DeliveryStreamType::DirectPut)
+        .extended_s3_destination_configuration(
+            ExtendedS3DestinationConfiguration::builder()
+                .role_arn("arn:aws:iam::123456789012:role/fh")
+                .bucket_arn("arn:aws:s3:::landing")
+                .prefix("raw/")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    fh.tag_delivery_stream()
+        .delivery_stream_name("events")
+        .tags(Tag::builder().key("env").value("prod").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    fh.start_delivery_stream_encryption()
+        .delivery_stream_name("events")
+        .delivery_stream_encryption_configuration_input(
+            DeliveryStreamEncryptionConfigurationInput::builder()
+                .key_type(KeyType::AwsOwnedCmk)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let fh = server.firehose_client().await;
+
+    // Stream + destination survive.
+    let desc = fh
+        .describe_delivery_stream()
+        .delivery_stream_name("events")
+        .send()
+        .await
+        .unwrap();
+    let d = desc.delivery_stream_description().unwrap();
+    assert_eq!(d.delivery_stream_name(), "events");
+    assert_eq!(
+        d.delivery_stream_encryption_configuration()
+            .and_then(|e| e.status())
+            .map(|s| s.as_str()),
+        Some("ENABLED")
+    );
+    let dest = &d.destinations()[0];
+    let s3 = dest.extended_s3_destination_description().unwrap();
+    assert_eq!(s3.bucket_arn(), "arn:aws:s3:::landing");
+    assert_eq!(s3.prefix(), Some("raw/"));
+
+    // Tags survive.
+    let tags = fh
+        .list_tags_for_delivery_stream()
+        .delivery_stream_name("events")
+        .send()
+        .await
+        .unwrap();
+    assert!(tags
+        .tags()
+        .iter()
+        .any(|t| t.key() == "env" && t.value() == Some("prod")));
+}
+
+/// DeleteDeliveryStream durability: a deleted stream stays gone after restart.
+#[tokio::test]
+async fn persistence_delete_stream_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let fh = server.firehose_client().await;
+
+    fh.create_delivery_stream()
+        .delivery_stream_name("ephemeral")
+        .send()
+        .await
+        .unwrap();
+    fh.delete_delivery_stream()
+        .delivery_stream_name("ephemeral")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let fh = server.firehose_client().await;
+
+    let streams = fh.list_delivery_streams().send().await.unwrap();
+    assert!(!streams
+        .delivery_stream_names()
+        .iter()
+        .any(|s| s == "ephemeral"));
+}

--- a/crates/fakecloud-firehose/Cargo.toml
+++ b/crates/fakecloud-firehose/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 fakecloud-s3 = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
@@ -20,6 +21,7 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/fakecloud-firehose/src/lib.rs
+++ b/crates/fakecloud-firehose/src/lib.rs
@@ -5,4 +5,7 @@ pub(crate) mod state;
 
 pub use delivery::FirehoseDeliveryImpl;
 pub use service::FirehoseService;
-pub use state::{DeliveryStream, FirehoseAccounts, S3Destination, SharedFirehoseState};
+pub use state::{
+    DeliveryStream, FirehoseAccounts, FirehoseSnapshot, S3Destination, SharedFirehoseState,
+    FIREHOSE_SNAPSHOT_SCHEMA_VERSION,
+};

--- a/crates/fakecloud-firehose/src/service.rs
+++ b/crates/fakecloud-firehose/src/service.rs
@@ -9,14 +9,30 @@ use fakecloud_aws::arn::Arn;
 use http::StatusCode;
 use parking_lot::RwLock;
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 use fakecloud_s3::{memory_body, S3Object, SharedS3State};
 
 use crate::state::{
-    DeliveryStream, EncryptionConfig, FirehoseAccounts, S3Destination, SharedFirehoseState,
+    DeliveryStream, EncryptionConfig, FirehoseAccounts, FirehoseSnapshot, S3Destination,
+    SharedFirehoseState, FIREHOSE_SNAPSHOT_SCHEMA_VERSION,
 };
+
+/// Actions that mutate persisted Firehose state and therefore must trigger a
+/// snapshot write. PutRecord/PutRecordBatch deliver to S3 (persisted by the S3
+/// store) but do not change Firehose's own state, so they are excluded.
+const MUTATING_ACTIONS: &[&str] = &[
+    "CreateDeliveryStream",
+    "DeleteDeliveryStream",
+    "TagDeliveryStream",
+    "UntagDeliveryStream",
+    "UpdateDestination",
+    "StartDeliveryStreamEncryption",
+    "StopDeliveryStreamEncryption",
+];
 
 const SUPPORTED_ACTIONS: &[&str] = &[
     "CreateDeliveryStream",
@@ -36,11 +52,18 @@ const SUPPORTED_ACTIONS: &[&str] = &[
 pub struct FirehoseService {
     state: SharedFirehoseState,
     s3: Option<SharedS3State>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl FirehoseService {
     pub fn new(state: SharedFirehoseState) -> Self {
-        Self { state, s3: None }
+        Self {
+            state,
+            s3: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
     }
 
     pub fn with_s3(mut self, s3: SharedS3State) -> Self {
@@ -48,8 +71,74 @@ impl FirehoseService {
         self
     }
 
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
     pub fn shared_state(&self) -> SharedFirehoseState {
         Arc::clone(&self.state)
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        save_firehose_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current Firehose state when invoked, or
+    /// `None` in memory mode (no snapshot store). The CloudFormation provisioner
+    /// mutates `state` directly and uses this to write a CFN-provisioned
+    /// resource through to disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_firehose_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current Firehose state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `FirehoseService::save_snapshot` and the
+/// CloudFormation provisioner's post-provision persist hook so both route
+/// through the same serialize-and-write path.
+pub async fn save_firehose_snapshot(
+    state: &SharedFirehoseState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = FirehoseSnapshot {
+        schema_version: FIREHOSE_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write firehose snapshot"),
+        Err(err) => tracing::error!(%err, "firehose snapshot task panicked"),
     }
 }
 
@@ -70,7 +159,8 @@ impl AwsService for FirehoseService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = MUTATING_ACTIONS.contains(&req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateDeliveryStream" => self.create_delivery_stream(&req),
             "DescribeDeliveryStream" => self.describe_delivery_stream(&req),
             "ListDeliveryStreams" => self.list_delivery_streams(&req),
@@ -84,7 +174,11 @@ impl AwsService for FirehoseService {
             "StartDeliveryStreamEncryption" => self.start_delivery_stream_encryption(&req),
             "StopDeliveryStreamEncryption" => self.stop_delivery_stream_encryption(&req),
             other => Err(AwsServiceError::action_not_implemented("firehose", other)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 }
 

--- a/crates/fakecloud-firehose/src/state.rs
+++ b/crates/fakecloud-firehose/src/state.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 pub type SharedFirehoseState = Arc<RwLock<FirehoseAccounts>>;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct FirehoseAccounts {
     pub accounts: BTreeMap<String, FirehoseState>,
 }
@@ -28,7 +28,7 @@ impl FirehoseAccounts {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FirehoseState {
     pub account_id: String,
     pub region: String,
@@ -55,6 +55,17 @@ impl FirehoseState {
             .or_default()
     }
 }
+
+/// On-disk snapshot envelope for Firehose state. Versioned so format changes
+/// fail loudly on upgrade rather than silently mis-parsing.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct FirehoseSnapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<FirehoseAccounts>,
+}
+
+pub const FIREHOSE_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeliveryStream {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2410,8 +2410,61 @@ async fn main() {
     registry.register(route53_service.clone());
     let acm_service = Arc::new(fakecloud_acm::AcmService::new(acm_state.clone()));
     registry.register(acm_service.clone());
-    let firehose_service =
+    let firehose_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("firehose").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_firehose::FirehoseSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_firehose::FIREHOSE_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "firehose persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_firehose::FIREHOSE_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.accounts.len();
+                                *firehose_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded firehose persistence snapshot"
+                                );
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse firehose persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no firehose persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read firehose persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut firehose_service =
         fakecloud_firehose::FirehoseService::new(firehose_state.clone()).with_s3(s3_state.clone());
+    if let Some(store) = firehose_snapshot_store.clone() {
+        firehose_service = firehose_service.with_snapshot_store(store);
+    }
+    if let Some(h) = firehose_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("firehose", h);
+    }
     registry.register(Arc::new(firehose_service));
     let glue_service = fakecloud_glue::GlueService::new(glue_state.clone());
     registry.register(Arc::new(glue_service));


### PR DESCRIPTION
## Summary

Firehose is one of 11 implemented services that did **not** survive a restart even in persistent storage mode, because the crate had no `snapshot_hook`. Persistent mode was uneven internally — exactly the gap fakecloud criticizes in rivals. This closes it for Firehose.

Delivery streams, S3 destinations, tags, and encryption config now write through to disk on every mutating action and restore on startup. The CFN provisioner write-through hook is registered too, so CloudFormation-provisioned Firehose resources persist as well.

This is batch 1 of a sweep across all 11 services lacking `snapshot_hook` (EC2, Glue, Firehose, Organizations, CloudFront, Route53, WAFv2, ACM, Athena, ELBv2, bedrock-agent); Firehose first to validate the pattern end-to-end.

Changes:
- `FirehoseSnapshot` versioned envelope + `FIREHOSE_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook` on `FirehoseService`, following the Kinesis pattern; serialize+write offloaded to the blocking pool, guarded by an async snapshot lock
- server builds the `DiskSnapshotStore`, restores on boot (schema-version checked), and registers the CFN provisioner persist hook
- `Clone` on `FirehoseAccounts`/`FirehoseState` for snapshot cloning
- only state-mutating actions trigger a write (PutRecord/PutRecordBatch deliver to S3, which persists itself)

## Test plan

- `cargo test -p fakecloud-e2e --test firehose_persistence` — 2 new restart-recovery E2E tests pass:
  - stream + destination + tags + encryption survive a restart
  - a deleted stream stays deleted after restart
- `cargo clippy -p fakecloud-firehose --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` (server wiring) clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add persistence for Firehose so delivery streams survive restarts in persistent mode. Streams, destinations, tags, and encryption now save on mutating actions and restore on startup, including CloudFormation-provisioned resources.

- **New Features**
  - Versioned snapshot envelope `FirehoseSnapshot` with `FIREHOSE_SNAPSHOT_SCHEMA_VERSION`.
  - `FirehoseService` supports a snapshot store, uses an async lock, and offloads serialize/write; exposes a `snapshot_hook` for CFN.
  - `fakecloud-server` builds a `DiskSnapshotStore` at `.../firehose/snapshot.json`, loads on boot with schema checks, and registers the CFN write-through hook.
  - Only mutating APIs write snapshots; `PutRecord`/`PutRecordBatch` rely on `S3` persistence.
  - Added E2E restart-recovery tests (round-trip of stream/tags/encryption; delete stays deleted).

<sup>Written for commit 01863ce0f306031be47dca8ccad19615adb9db11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

