### PR TITLE
feat(acm): persist certificates across restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,6 +3074,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "hex",
  "http 1.4.0",
  "parking_lot",

--- a/crates/fakecloud-acm/Cargo.toml
+++ b/crates/fakecloud-acm/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-acm/src/lib.rs
+++ b/crates/fakecloud-acm/src/lib.rs
@@ -3,6 +3,6 @@ pub(crate) mod state;
 
 pub use service::AcmService;
 pub use state::{
-    AccountConfig, AccountState, AcmAccounts, CertificateOptions, DomainValidation, RenewalSummary,
-    SharedAcmState, StoredCertificate,
+    AccountConfig, AccountState, AcmAccounts, AcmSnapshot, CertificateOptions, DomainValidation,
+    RenewalSummary, SharedAcmState, StoredCertificate, ACM_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -12,12 +12,15 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+use tokio::sync::Mutex as AsyncMutex;
+
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    AccountState, AcmAccounts, CertificateOptions, DomainValidation, RenewalSummary,
-    SharedAcmState, StoredCertificate,
+    AccountState, AcmAccounts, AcmSnapshot, CertificateOptions, DomainValidation, RenewalSummary,
+    SharedAcmState, StoredCertificate, ACM_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const SUPPORTED_ACTIONS: &[&str] = &[
@@ -40,6 +43,21 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "SearchCertificates",
 ];
 
+/// Actions that mutate persisted ACM state and therefore must trigger a
+/// snapshot write. Read-only actions (Describe/List/Get/Export/Search) and
+/// ResendValidationEmail (no state change) are excluded.
+const MUTATING_ACTIONS: &[&str] = &[
+    "RequestCertificate",
+    "DeleteCertificate",
+    "ImportCertificate",
+    "RenewCertificate",
+    "RevokeCertificate",
+    "AddTagsToCertificate",
+    "RemoveTagsFromCertificate",
+    "PutAccountConfiguration",
+    "UpdateCertificateOptions",
+];
+
 pub struct AcmService {
     state: SharedAcmState,
     /// How long the auto-issue tick sleeps before flipping a freshly
@@ -52,6 +70,8 @@ pub struct AcmService {
     /// (read at construction time) or via
     /// [`AcmService::with_pending_validation_delay`].
     pending_validation_delay: std::time::Duration,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 /// Default DNS auto-issue delay when `FAKECLOUD_ACM_AUTO_ISSUE_SECS` is
@@ -72,11 +92,138 @@ impl AcmService {
         Self {
             state,
             pending_validation_delay: auto_issue_delay_from_env(),
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
     }
 
     pub fn shared_state(&self) -> SharedAcmState {
         Arc::clone(&self.state)
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        save_acm_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current ACM state when invoked, or `None`
+    /// in memory mode. The CloudFormation provisioner mutates `state` directly
+    /// and uses this to write a CFN-provisioned certificate through to disk,
+    /// the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_acm_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+
+    /// Admin-endpoint flavour of [`set_certificate_status`](Self::set_certificate_status)
+    /// that persists the flip so a forced status survives a restart.
+    pub async fn set_certificate_status_persistent(
+        &self,
+        arn_or_id: &str,
+        status: &str,
+        reason: Option<String>,
+    ) -> bool {
+        let changed = self.set_certificate_status(arn_or_id, status, reason);
+        if changed {
+            self.save_snapshot().await;
+        }
+        changed
+    }
+
+    /// Admin-endpoint flavour of [`approve_certificate`](Self::approve_certificate)
+    /// that persists the flip to `ISSUED`.
+    pub async fn approve_certificate_persistent(&self, arn_or_id: &str) -> bool {
+        self.set_certificate_status_persistent(arn_or_id, "ISSUED", None)
+            .await
+    }
+
+    /// Re-arm the async auto-issue tick for any certificate that was still
+    /// `PENDING_VALIDATION` (DNS, AMAZON_ISSUED) when the previous process
+    /// exited. Without this, a restored pending cert would never transition to
+    /// `ISSUED`. Called by the server after loading a persistence snapshot.
+    pub fn rearm_pending_validations(&self) {
+        let pending: Vec<(String, String)> = {
+            let state = self.state.read();
+            let mut out = Vec::new();
+            for (account_id, account) in state.accounts.iter() {
+                for (arn, cert) in account.certificates.iter() {
+                    if cert.status == "PENDING_VALIDATION"
+                        && cert.cert_type == "AMAZON_ISSUED"
+                        && cert.validation_method.as_deref() == Some("DNS")
+                    {
+                        out.push((account_id.clone(), arn.clone()));
+                    }
+                }
+            }
+            out
+        };
+        for (account_id, arn) in pending {
+            self.spawn_auto_issue_tick(account_id, arn);
+        }
+    }
+
+    /// Spawn the background task that flips a DNS, AMAZON_ISSUED certificate
+    /// from `PENDING_VALIDATION` to `ISSUED` after `pending_validation_delay`,
+    /// then persists the transition. Shared by `request_certificate` and
+    /// `rearm_pending_validations`.
+    fn spawn_auto_issue_tick(&self, account_id: String, arn: String) {
+        let state_for_tick = Arc::clone(&self.state);
+        let delay = self.pending_validation_delay;
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            let flipped = {
+                let mut state = state_for_tick.write();
+                let mut flipped = false;
+                if let Some(account) = state.accounts.get_mut(&account_id) {
+                    if let Some(cert) = account.certificates.get_mut(&arn) {
+                        if cert.status == "PENDING_VALIDATION" && cert.cert_type == "AMAZON_ISSUED"
+                        {
+                            let now = Utc::now();
+                            cert.status = "ISSUED".to_string();
+                            cert.issued_at = Some(now);
+                            cert.renewal_eligibility = "ELIGIBLE".to_string();
+                            for dv in cert.domain_validation.iter_mut() {
+                                dv.validation_status = "SUCCESS".to_string();
+                            }
+                            cert.renewal_summary = Some(RenewalSummary {
+                                renewal_status: "PENDING_AUTO_RENEWAL".to_string(),
+                                domain_validation: cert.domain_validation.clone(),
+                                renewal_status_reason: None,
+                                updated_at: now,
+                            });
+                            flipped = true;
+                        }
+                    }
+                }
+                flipped
+            };
+            if flipped {
+                save_acm_snapshot(&state_for_tick, store, &lock).await;
+            }
+        });
     }
 
     /// Override the auto-issue delay. Used by unit tests so they don't
@@ -203,6 +350,37 @@ impl AcmService {
     }
 }
 
+/// Persist the current ACM state as a snapshot. Offloads the serde + blocking
+/// file write to the Tokio blocking pool. Noop when `store` is `None` (memory
+/// mode). Shared by `AcmService::save_snapshot`, the auto-issue tick, and the
+/// CloudFormation provisioner persist hook so all route through the same
+/// serialize-and-write path.
+pub async fn save_acm_snapshot(
+    state: &SharedAcmState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = AcmSnapshot {
+        schema_version: ACM_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write acm snapshot"),
+        Err(err) => tracing::error!(%err, "acm snapshot task panicked"),
+    }
+}
+
 impl Default for AcmService {
     fn default() -> Self {
         Self::new(Arc::new(RwLock::new(AcmAccounts::new())))
@@ -220,7 +398,8 @@ impl AwsService for AcmService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = MUTATING_ACTIONS.contains(&req.action.as_str());
+        let result = match req.action.as_str() {
             "RequestCertificate" => self.request_certificate(&req),
             "DescribeCertificate" => self.describe_certificate(&req),
             "ListCertificates" => self.list_certificates(&req),
@@ -239,7 +418,11 @@ impl AwsService for AcmService {
             "UpdateCertificateOptions" => self.update_certificate_options(&req),
             "SearchCertificates" => self.search_certificates(&req),
             other => Err(AwsServiceError::action_not_implemented("acm", other)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 }
 
@@ -407,34 +590,7 @@ impl AcmService {
         // ImportCertificate stays ISSUED-on-arrival (its own code path
         // never enters this branch).
         if validation_method == "DNS" {
-            let state_for_tick = Arc::clone(&self.state);
-            let arn_for_tick = arn.clone();
-            let account_for_tick = req.account_id.clone();
-            let delay = self.pending_validation_delay;
-            tokio::spawn(async move {
-                tokio::time::sleep(delay).await;
-                let mut state = state_for_tick.write();
-                if let Some(account) = state.accounts.get_mut(&account_for_tick) {
-                    if let Some(cert) = account.certificates.get_mut(&arn_for_tick) {
-                        if cert.status == "PENDING_VALIDATION" && cert.cert_type == "AMAZON_ISSUED"
-                        {
-                            let now = Utc::now();
-                            cert.status = "ISSUED".to_string();
-                            cert.issued_at = Some(now);
-                            cert.renewal_eligibility = "ELIGIBLE".to_string();
-                            for dv in cert.domain_validation.iter_mut() {
-                                dv.validation_status = "SUCCESS".to_string();
-                            }
-                            cert.renewal_summary = Some(RenewalSummary {
-                                renewal_status: "PENDING_AUTO_RENEWAL".to_string(),
-                                domain_validation: cert.domain_validation.clone(),
-                                renewal_status_reason: None,
-                                updated_at: now,
-                            });
-                        }
-                    }
-                }
-            });
+            self.spawn_auto_issue_tick(req.account_id.clone(), arn.clone());
         }
 
         Ok(AwsResponse::ok_json(json!({ "CertificateArn": arn })))

--- a/crates/fakecloud-acm/src/state.rs
+++ b/crates/fakecloud-acm/src/state.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 pub type SharedAcmState = Arc<RwLock<AcmAccounts>>;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AcmAccounts {
     pub accounts: BTreeMap<String, AccountState>,
 }
@@ -20,7 +20,7 @@ impl AcmAccounts {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AccountState {
     /// Keyed by full certificate ARN.
     pub certificates: BTreeMap<String, StoredCertificate>,
@@ -119,3 +119,14 @@ pub struct CertificateOptions {
     pub certificate_transparency_logging_preference: String,
     pub export: String,
 }
+
+/// On-disk snapshot envelope for ACM state. Versioned so format changes fail
+/// loudly on upgrade rather than silently mis-parsing.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AcmSnapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<AcmAccounts>,
+}
+
+pub const ACM_SNAPSHOT_SCHEMA_VERSION: u32 = 1;

--- a/crates/fakecloud-e2e/tests/acm_persistence.rs
+++ b/crates/fakecloud-e2e/tests/acm_persistence.rs
@@ -1,0 +1,186 @@
+mod helpers;
+
+use std::path::Path;
+
+use aws_sdk_acm::types::{Tag, ValidationMethod};
+use helpers::TestServer;
+
+/// Persistent server with a fast (1s) ACM auto-issue tick so the
+/// PENDING_VALIDATION -> ISSUED transition is observable without long waits.
+async fn start(data_path: &Path) -> TestServer {
+    TestServer::start_full(
+        &[
+            ("FAKECLOUD_CONTAINER_CLI", "false"),
+            ("FAKECLOUD_ACM_AUTO_ISSUE_SECS", "1"),
+        ],
+        &[
+            "--storage-mode",
+            "persistent",
+            "--data-path",
+            &data_path.display().to_string(),
+        ],
+    )
+    .await
+}
+
+async fn wait_for_issued(acm: &aws_sdk_acm::Client, arn: &str) {
+    for _ in 0..50 {
+        let st = acm
+            .describe_certificate()
+            .certificate_arn(arn)
+            .send()
+            .await
+            .unwrap()
+            .certificate
+            .and_then(|c| c.status)
+            .map(|s| s.as_str().to_string());
+        if st.as_deref() == Some("ISSUED") {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    panic!("certificate never reached ISSUED");
+}
+
+/// An issued certificate, its tags, and ISSUED status all survive a restart.
+/// The tag write happens AFTER the cert is ISSUED, forcing a durable snapshot
+/// that captures the auto-issue transition (no reliance on tick-timing races).
+#[tokio::test]
+async fn persistence_issued_cert_and_tags_survive_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = start(tmp.path()).await;
+    let acm = server.acm_client().await;
+
+    let arn = acm
+        .request_certificate()
+        .domain_name("example.com")
+        .validation_method(ValidationMethod::Dns)
+        .send()
+        .await
+        .unwrap()
+        .certificate_arn
+        .unwrap();
+
+    wait_for_issued(&acm, &arn).await;
+
+    acm.add_tags_to_certificate()
+        .certificate_arn(&arn)
+        .tags(Tag::builder().key("env").value("prod").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let acm = server.acm_client().await;
+
+    let cert = acm
+        .describe_certificate()
+        .certificate_arn(&arn)
+        .send()
+        .await
+        .unwrap()
+        .certificate
+        .unwrap();
+    assert_eq!(cert.status().map(|s| s.as_str()), Some("ISSUED"));
+    assert_eq!(cert.domain_name(), Some("example.com"));
+
+    let tags = acm
+        .list_tags_for_certificate()
+        .certificate_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(tags
+        .tags()
+        .iter()
+        .any(|t| t.key() == "env" && t.value() == Some("prod")));
+}
+
+/// A still-pending DNS certificate survives a restart and is re-armed so it
+/// reaches ISSUED after the restart (rearm_pending_validations).
+#[tokio::test]
+async fn persistence_pending_cert_reissues_after_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Long auto-issue delay so the cert is still PENDING when we restart.
+    let mut server = TestServer::start_full(
+        &[
+            ("FAKECLOUD_CONTAINER_CLI", "false"),
+            ("FAKECLOUD_ACM_AUTO_ISSUE_SECS", "3"),
+        ],
+        &[
+            "--storage-mode",
+            "persistent",
+            "--data-path",
+            &tmp.path().display().to_string(),
+        ],
+    )
+    .await;
+    let acm = server.acm_client().await;
+
+    let arn = acm
+        .request_certificate()
+        .domain_name("pending.example.com")
+        .validation_method(ValidationMethod::Dns)
+        .send()
+        .await
+        .unwrap()
+        .certificate_arn
+        .unwrap();
+
+    // Restart well before the 3s tick fires; the cert persists as PENDING.
+    server.restart().await;
+    let acm = server.acm_client().await;
+
+    // Survives restart...
+    let status = acm
+        .describe_certificate()
+        .certificate_arn(&arn)
+        .send()
+        .await
+        .unwrap()
+        .certificate
+        .and_then(|c| c.status)
+        .map(|s| s.as_str().to_string());
+    assert!(
+        matches!(
+            status.as_deref(),
+            Some("PENDING_VALIDATION") | Some("ISSUED")
+        ),
+        "unexpected status after restart: {status:?}"
+    );
+
+    // ...and the re-armed tick still drives it to ISSUED.
+    wait_for_issued(&acm, &arn).await;
+}
+
+/// A deleted certificate stays gone after restart.
+#[tokio::test]
+async fn persistence_delete_cert_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = start(tmp.path()).await;
+    let acm = server.acm_client().await;
+
+    let arn = acm
+        .request_certificate()
+        .domain_name("gone.example.com")
+        .validation_method(ValidationMethod::Dns)
+        .send()
+        .await
+        .unwrap()
+        .certificate_arn
+        .unwrap();
+    acm.delete_certificate()
+        .certificate_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let acm = server.acm_client().await;
+
+    let listed = acm.list_certificates().send().await.unwrap();
+    assert!(!listed
+        .certificate_summary_list()
+        .iter()
+        .any(|c| c.certificate_arn() == Some(arn.as_str())));
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2408,7 +2408,63 @@ async fn main() {
             .with_s3(s3_state.clone()),
     );
     registry.register(route53_service.clone());
-    let acm_service = Arc::new(fakecloud_acm::AcmService::new(acm_state.clone()));
+    let acm_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("acm").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_acm::AcmSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version > fakecloud_acm::ACM_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "acm persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_acm::ACM_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.accounts.len();
+                                *acm_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded acm persistence snapshot"
+                                );
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse acm persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no acm persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read acm persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut acm_inner = fakecloud_acm::AcmService::new(acm_state.clone());
+    if let Some(store) = acm_snapshot_store.clone() {
+        acm_inner = acm_inner.with_snapshot_store(store);
+    }
+    if let Some(h) = acm_inner.snapshot_hook() {
+        cfn_snapshot_hooks.insert("acm", h);
+    }
+    // Re-arm auto-issue ticks for any DNS certs restored as PENDING_VALIDATION
+    // so they still transition to ISSUED after a restart.
+    acm_inner.rearm_pending_validations();
+    let acm_service = Arc::new(acm_inner);
     registry.register(acm_service.clone());
     let firehose_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -7550,7 +7606,10 @@ async fn main() {
                       axum::Json(body): axum::Json<types::AcmCertificateStatusRequest>| {
                     let svc = svc.clone();
                     async move {
-                        if svc.set_certificate_status(&arn_or_id, &body.status, body.reason) {
+                        if svc
+                            .set_certificate_status_persistent(&arn_or_id, &body.status, body.reason)
+                            .await
+                        {
                             axum::http::StatusCode::NO_CONTENT
                         } else {
                             axum::http::StatusCode::NOT_FOUND
@@ -7657,7 +7716,7 @@ async fn main() {
                 move |axum::extract::Path(arn_or_id): axum::extract::Path<String>| {
                     let svc = svc.clone();
                     async move {
-                        if svc.approve_certificate(&arn_or_id) {
+                        if svc.approve_certificate_persistent(&arn_or_id).await {
                             axum::http::StatusCode::NO_CONTENT
                         } else {
                             axum::http::StatusCode::NOT_FOUND


### PR DESCRIPTION
## Summary

ACM is the 2nd of 11 implemented services that did **not** survive a restart in persistent mode (no `snapshot_hook`). Certificates, tags, options, and account config now write through to disk and restore on startup. Batch 2 of the persistence-coverage sweep (batch 1 was Firehose, #1845).

ACM has **async state transitions outside the request handler**, so persistence is wired to cover them — this is the restore-fidelity part, not just request-path snapshots:
- the auto-issue tick (`PENDING_VALIDATION -> ISSUED` for DNS certs) persists the flip after it fires
- the admin `/status` and `/approve` endpoints persist via new `set_certificate_status_persistent` / `approve_certificate_persistent`
- on restore, `rearm_pending_validations()` re-arms the auto-issue tick for any DNS cert restored as `PENDING_VALIDATION`, so it still reaches `ISSUED` after a restart (otherwise a restored pending cert would hang forever)

Changes:
- `AcmSnapshot` versioned envelope + `ACM_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook` on `AcmService`; serialize+write offloaded to the blocking pool under an async lock
- server builds the `DiskSnapshotStore`, restores on boot (schema-version checked), re-arms pending certs, registers the CFN persist hook
- `Clone` on `AcmAccounts`/`AccountState`
- auto-issue tick extracted to a shared `spawn_auto_issue_tick` helper (used by `request_certificate` + restore re-arm)

## Test plan

- `cargo test -p fakecloud-e2e --test acm_persistence` — 3 new restart-recovery E2E tests pass:
  - issued cert + tags survive restart (tag write after ISSUED forces a durable snapshot capturing the auto-issue transition)
  - a still-pending DNS cert survives restart and the re-armed tick drives it to ISSUED
  - a deleted cert stays deleted
- `cargo clippy -p fakecloud-acm --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` (server wiring) clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist ACM certificates, tags, options, and account config to disk in persistent mode and restore them on startup. Covers DNS auto-issue and admin status changes so they survive restarts.

- **New Features**
  - Saves ACM state to `acm/snapshot.json` and restores it on boot with a versioned `AcmSnapshot`.
  - Writes a snapshot after all mutating API calls and after the DNS auto-issue flip; re-arms pending DNS validations on restore.
  - CloudFormation write-through via a snapshot hook; admin `/status` and `/approve` now persist. E2E tests cover issued, pending, and deleted cert cases.

- **Dependencies**
  - Added `fakecloud-persistence` for snapshot storage.

<sup>Written for commit 6b612622c0658116facb1ffbf9b0898f8eb26549. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

