### PR TITLE
feat(tfacc): widen sns and kms to all _basic resource types

### DIFF
--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -609,16 +609,26 @@ impl KmsService {
             ));
         }
 
+        // A key created with `Origin=EXTERNAL` has no key material yet, so AWS
+        // returns it disabled in the `PendingImport` state until
+        // ImportKeyMaterial runs. fakecloud previously created every key
+        // Enabled, which the Terraform `aws_kms_external_key` resource caught
+        // as `enabled = true` where it expected `false`.
+        let pending_import = input.origin == "EXTERNAL";
         let key = KmsKey {
             key_id: key_id.clone(),
             arn: arn.clone(),
             creation_date: now,
             description: input.description,
-            enabled: true,
+            enabled: !pending_import,
             key_usage: input.key_usage,
             key_spec: input.key_spec,
             key_manager: "CUSTOMER".to_string(),
-            key_state: "Enabled".to_string(),
+            key_state: if pending_import {
+                "PendingImport".to_string()
+            } else {
+                "Enabled".to_string()
+            },
             deletion_date: None,
             tags: input.tags,
             policy: key_policy,

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -3133,3 +3133,31 @@ fn list_aliases_includes_aws_managed_service_aliases() {
         .unwrap();
     assert!(ddb["TargetKeyId"].as_str().is_some_and(|t| !t.is_empty()));
 }
+
+#[test]
+fn create_external_origin_key_is_pending_import_and_disabled() {
+    // A key created with Origin=EXTERNAL has no material yet, so AWS returns it
+    // disabled in KeyState PendingImport until ImportKeyMaterial runs. The
+    // Terraform aws_kms_external_key resource asserts enabled=false on create.
+    let svc = make_service();
+    let resp = svc
+        .create_key(&make_request("CreateKey", json!({ "Origin": "EXTERNAL" })))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let md = &body["KeyMetadata"];
+    assert_eq!(
+        md["Enabled"],
+        json!(false),
+        "external key should be disabled"
+    );
+    assert_eq!(md["KeyState"], json!("PendingImport"));
+    assert_eq!(md["Origin"], json!("EXTERNAL"));
+
+    // A normal (AWS_KMS) key is still created Enabled.
+    let resp = svc
+        .create_key(&make_request("CreateKey", json!({})))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["KeyMetadata"]["Enabled"], json!(true));
+    assert_eq!(body["KeyMetadata"]["KeyState"], json!("Enabled"));
+}

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -1709,8 +1709,11 @@ impl SnsService {
     fn put_data_protection_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let resource_arn = required(req, "ResourceArn")?;
         let policy = required(req, "DataProtectionPolicy")?;
-        // Validate JSON.
-        if serde_json::from_str::<Value>(&policy).is_err() {
+        // AWS accepts an empty DataProtectionPolicy to clear the topic's
+        // policy (this is how the Terraform resource deletes it). Only a
+        // non-empty value must be valid JSON.
+        let clearing = policy.trim().is_empty();
+        if !clearing && serde_json::from_str::<Value>(&policy).is_err() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameter",
@@ -1722,7 +1725,11 @@ impl SnsService {
         if !state.topics.contains_key(&resource_arn) {
             return Err(not_found("Topic"));
         }
-        state.data_protection_policies.insert(resource_arn, policy);
+        if clearing {
+            state.data_protection_policies.remove(&resource_arn);
+        } else {
+            state.data_protection_policies.insert(resource_arn, policy);
+        }
         Ok(xml_resp(
             &format!(
                 r#"<PutDataProtectionPolicyResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">

--- a/crates/fakecloud-sns/src/service_tests.rs
+++ b/crates/fakecloud-sns/src/service_tests.rs
@@ -3205,6 +3205,42 @@ fn put_then_get_data_protection_policy_round_trips() {
 }
 
 #[test]
+fn put_empty_data_protection_policy_clears_it() {
+    // AWS accepts an empty DataProtectionPolicy to remove the policy; the
+    // Terraform resource sends "" on delete. fakecloud must not reject it as
+    // invalid JSON, and the policy must actually be cleared.
+    let (svc, _) = make_sns();
+    svc.create_topic(&sns_request("CreateTopic", vec![("Name", "dpp-clear")]))
+        .unwrap();
+    let arn = "arn:aws:sns:us-east-1:123456789012:dpp-clear";
+    svc.put_data_protection_policy(&sns_request(
+        "PutDataProtectionPolicy",
+        vec![
+            ("ResourceArn", arn),
+            ("DataProtectionPolicy", r#"{"Name":"p"}"#),
+        ],
+    ))
+    .unwrap();
+    // Empty body must succeed and clear.
+    svc.put_data_protection_policy(&sns_request(
+        "PutDataProtectionPolicy",
+        vec![("ResourceArn", arn), ("DataProtectionPolicy", "")],
+    ))
+    .unwrap();
+    let resp = svc
+        .get_data_protection_policy(&sns_request(
+            "GetDataProtectionPolicy",
+            vec![("ResourceArn", arn)],
+        ))
+        .unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(
+        !body.contains("&quot;Name&quot;"),
+        "policy not cleared: {body}"
+    );
+}
+
+#[test]
 fn get_data_protection_policy_unknown_topic_errors() {
     let (svc, _) = make_sns();
     let req = sns_request(

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -119,9 +119,12 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "sns",
-        // Batch 7: core `aws_sns_topic` smoke. Passes against fakecloud
-        // out of the box.
-        run_regex: "^TestAccSNSTopic_basic$",
+        // Batch 7 + widen: `_basic` smoke for every SNS resource and data
+        // source — topic, topic policy, topic subscription, topic data source,
+        // and the data-protection policy (which the widen batch fixed: AWS
+        // accepts an empty DataProtectionPolicy to clear it, fakecloud used to
+        // reject the empty body the provider sends on delete).
+        run_regex: "^TestAccSNS[A-Za-z]+_basic$",
         deny: &[],
     },
     Service {
@@ -136,10 +139,20 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "kms",
-        // Batch 6: core `aws_kms_key` smoke. Passes against fakecloud
-        // out of the box.
-        run_regex: "^TestAccKMSKey_basic$",
-        deny: &[],
+        // Batch 6 + widen: `_basic` smoke for every KMS resource and data
+        // source — keys, aliases, grants, key policies, ciphertext (data key)
+        // and its data source, public-key and secrets data sources, and
+        // external keys. The widen batch fixed external keys: an `EXTERNAL`
+        // origin key has no material yet, so it must come back disabled in
+        // `PendingImport`, which the provider asserts.
+        run_regex: "^TestAccKMS[A-Za-z]+_basic$",
+        deny: &[
+            // --- unsupportable: multi-region (replica) keys need cross-region
+            //     key replication, which fakecloud's single-region KMS state
+            //     does not model. ---
+            "TestAccKMSReplicaKey_basic",
+            "TestAccKMSReplicaExternalKey_basic",
+        ],
     },
     Service {
         name: "logs",
@@ -311,7 +324,7 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "sns",
         service: "sns",
-        run_regex: "^TestAccSNSTopic_basic$",
+        run_regex: "^TestAccSNS[A-Za-z]+_basic$",
         extra_deny: &[],
     },
     Shard {
@@ -323,7 +336,7 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "kms",
         service: "kms",
-        run_regex: "^TestAccKMSKey_basic$",
+        run_regex: "^TestAccKMS[A-Za-z]+_basic$",
         extra_deny: &[],
     },
     Shard {


### PR DESCRIPTION
## Summary

Widens the `sns` and `kms` tfacc shards from a single key/topic smoke to the `_basic` suite across every resource and data source.

- **SNS** -> topic, topic policy, topic subscription, topic data source, data protection policy (5 tests).
- **KMS** -> keys, aliases, grants, key policies, ciphertext + data source, public-key and secrets data sources, external keys (10 tests).

Two real fakecloud fixes (no gaming):
- **SNS** `PutDataProtectionPolicy` now accepts an empty policy body to clear the policy (how the Terraform resource deletes it); it previously rejected the empty body as invalid JSON, so `destroy` failed.
- **KMS** keys created with `Origin=EXTERNAL` come back disabled in `PendingImport` (no key material yet) instead of `Enabled`, matching AWS and the `aws_kms_external_key` assertion.

Multi-region replica keys (`ReplicaKey`, `ReplicaExternalKey`) stay denied as **unsupportable** — fakecloud's single-region KMS state doesn't model cross-region replication.

## Test plan
- New unit tests: SNS empty-DPP clear, KMS external-origin PendingImport.
- `cargo clippy -p fakecloud-kms -p fakecloud-sns -p fakecloud-tfacc --all-targets -- -D warnings`: clean.
- Widened shards vs terraform-provider-aws v5.97.0: **sns 5/5, kms 10/10**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened `fakecloud-tfacc` SNS and KMS shards to run the full `_basic` suite across resources and data sources, and fixed `fakecloud-sns` and `fakecloud-kms` to match AWS behavior. All widened tests pass against `terraform-provider-aws` v5.97.0 (sns 5/5, kms 10/10).

- New Features
  - SNS: run `_basic` for topic, topic policy, subscription, topic data source, and data protection policy.
  - KMS: run `_basic` for keys, aliases, grants, key policies, ciphertext + data source, public-key and secrets data sources, and external keys; deny replica key tests as unsupportable.

- Bug Fixes
  - SNS: `PutDataProtectionPolicy` accepts an empty body to clear the policy.
  - KMS: `Origin=EXTERNAL` keys are created Disabled with `KeyState=PendingImport` (matches `aws_kms_external_key`).

<sup>Written for commit 2b7fc0beb9a9f029d936d7be99e5cab49e900444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

