### PR TITLE
feat(athena): persist workgroups, catalogs, queries across restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,6 +3173,7 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-glue",
+ "fakecloud-persistence",
  "fakecloud-s3",
  "http 1.4.0",
  "parking_lot",
@@ -3181,6 +3182,7 @@ dependencies = [
  "serde_json",
  "sqlparser",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/crates/fakecloud-athena/Cargo.toml
+++ b/crates/fakecloud-athena/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-glue = { workspace = true }
+fakecloud-persistence = { workspace = true }
 fakecloud-s3 = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
@@ -22,5 +23,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sqlparser = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-athena/src/lib.rs
+++ b/crates/fakecloud-athena/src/lib.rs
@@ -4,5 +4,6 @@ pub(crate) mod state;
 
 pub use service::AthenaService;
 pub use state::{
-    AthenaAccounts, DataCatalog, NamedQuery, PreparedStatement, SharedAthenaState, WorkGroup,
+    AthenaAccounts, AthenaSnapshot, DataCatalog, NamedQuery, PreparedStatement, SharedAthenaState,
+    WorkGroup, ATHENA_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-athena/src/service/mod.rs
+++ b/crates/fakecloud-athena/src/service/mod.rs
@@ -7,20 +7,60 @@ use chrono::Utc;
 use http::StatusCode;
 use parking_lot::RwLock;
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_glue::SharedGlueState;
+use fakecloud_persistence::SnapshotStore;
 use fakecloud_s3::SharedS3State;
 
 use crate::sql::{self, ExecutedQuery};
 use crate::state::{
-    AccountState, AthenaAccounts, Calculation, CapacityAssignmentConfiguration,
+    AccountState, AthenaAccounts, AthenaSnapshot, Calculation, CapacityAssignmentConfiguration,
     CapacityReservation, DataCatalog, NamedQuery, Notebook, PreparedStatement, QueryExecution,
-    Session, SharedAthenaState, WorkGroup,
+    Session, SharedAthenaState, WorkGroup, ATHENA_SNAPSHOT_SCHEMA_VERSION,
 };
+
+/// Actions that mutate persisted Athena state and therefore must trigger a
+/// snapshot write. Read-only actions (Batch*Get/Get*/List*, ExportNotebook,
+/// CreatePresignedNotebookUrl, GetResourceDashboard) are excluded. Query
+/// results are written to S3 (persisted by the S3 store); the QueryExecution
+/// metadata persists here.
+const MUTATING_ACTIONS: &[&str] = &[
+    "CancelCapacityReservation",
+    "CreateCapacityReservation",
+    "CreateDataCatalog",
+    "CreateNamedQuery",
+    "CreateNotebook",
+    "CreatePreparedStatement",
+    "CreateWorkGroup",
+    "DeleteCapacityReservation",
+    "DeleteDataCatalog",
+    "DeleteNamedQuery",
+    "DeleteNotebook",
+    "DeletePreparedStatement",
+    "DeleteWorkGroup",
+    "ImportNotebook",
+    "PutCapacityAssignmentConfiguration",
+    "StartCalculationExecution",
+    "StartQueryExecution",
+    "StartSession",
+    "StopCalculationExecution",
+    "StopQueryExecution",
+    "TagResource",
+    "TerminateSession",
+    "UntagResource",
+    "UpdateCapacityReservation",
+    "UpdateDataCatalog",
+    "UpdateNamedQuery",
+    "UpdateNotebook",
+    "UpdateNotebookMetadata",
+    "UpdatePreparedStatement",
+    "UpdateWorkGroup",
+];
 
 const SUPPORTED_ACTIONS: &[&str] = &[
     "BatchGetNamedQuery",
@@ -99,6 +139,8 @@ pub struct AthenaService {
     state: SharedAthenaState,
     glue: Option<SharedGlueState>,
     s3: Option<SharedS3State>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 mod capacity;
@@ -118,6 +160,8 @@ impl AthenaService {
             state,
             glue: None,
             s3: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -131,8 +175,74 @@ impl AthenaService {
         self
     }
 
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
     pub fn shared_state(&self) -> SharedAthenaState {
         Arc::clone(&self.state)
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        save_athena_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current Athena state when invoked, or
+    /// `None` in memory mode. The CloudFormation provisioner mutates `state`
+    /// directly and uses this to write a CFN-provisioned resource through to
+    /// disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_athena_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current Athena state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `AthenaService::save_snapshot` and the
+/// CloudFormation provisioner persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_athena_snapshot(
+    state: &SharedAthenaState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = AthenaSnapshot {
+        schema_version: ATHENA_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write athena snapshot"),
+        Err(err) => tracing::error!(%err, "athena snapshot task panicked"),
     }
 }
 
@@ -153,7 +263,8 @@ impl AwsService for AthenaService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = MUTATING_ACTIONS.contains(&req.action.as_str());
+        let result = match req.action.as_str() {
             // Workgroups
             "CreateWorkGroup" => self.create_work_group(&req),
             "GetWorkGroup" => self.get_work_group(&req),
@@ -249,7 +360,11 @@ impl AwsService for AthenaService {
             "GetResourceDashboard" => self.get_resource_dashboard(&req),
 
             other => Err(AwsServiceError::action_not_implemented("athena", other)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 }
 

--- a/crates/fakecloud-athena/src/state.rs
+++ b/crates/fakecloud-athena/src/state.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 pub type SharedAthenaState = Arc<RwLock<AthenaAccounts>>;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AthenaAccounts {
     pub accounts: BTreeMap<String, AccountState>,
 }
@@ -21,11 +21,26 @@ impl AthenaAccounts {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+/// On-disk snapshot envelope for Athena state. Versioned so format changes fail
+/// loudly on upgrade rather than silently mis-parsing.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AthenaSnapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<AthenaAccounts>,
+}
+
+pub const ATHENA_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AccountState {
     pub work_groups: BTreeMap<String, WorkGroup>,
     pub data_catalogs: BTreeMap<String, DataCatalog>,
     pub named_queries: BTreeMap<String, NamedQuery>,
+    /// Keyed by `(workgroup, statement_name)`. JSON object keys must be
+    /// strings, so this tuple-keyed map is (de)serialized as a sequence of
+    /// `[workgroup, name, statement]` triples for persistence snapshots.
+    #[serde(with = "prepared_statements_serde")]
     pub prepared_statements: BTreeMap<(String, String), PreparedStatement>,
     pub query_executions: BTreeMap<String, QueryExecution>,
     pub notebooks: BTreeMap<String, Notebook>,
@@ -35,6 +50,36 @@ pub struct AccountState {
     pub capacity_assignment_config: Option<CapacityAssignmentConfiguration>,
     pub tags: BTreeMap<String, BTreeMap<String, String>>,
     pub initialized: bool,
+}
+
+/// (De)serialize a `(workgroup, name) -> PreparedStatement` map as a sequence
+/// of `(workgroup, name, statement)` triples. JSON object keys must be strings,
+/// so the natural tuple-keyed map cannot be serialized directly.
+mod prepared_statements_serde {
+    use std::collections::BTreeMap;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::PreparedStatement;
+
+    pub fn serialize<S: Serializer>(
+        map: &BTreeMap<(String, String), PreparedStatement>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let entries: Vec<(&String, &String, &PreparedStatement)> =
+            map.iter().map(|((wg, name), ps)| (wg, name, ps)).collect();
+        entries.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<BTreeMap<(String, String), PreparedStatement>, D::Error> {
+        let entries: Vec<(String, String, PreparedStatement)> = Vec::deserialize(deserializer)?;
+        Ok(entries
+            .into_iter()
+            .map(|(wg, name, ps)| ((wg, name), ps))
+            .collect())
+    }
 }
 
 impl AccountState {

--- a/crates/fakecloud-e2e/tests/athena_persistence.rs
+++ b/crates/fakecloud-e2e/tests/athena_persistence.rs
@@ -1,0 +1,178 @@
+mod helpers;
+
+use aws_sdk_athena::types::{
+    DataCatalogType, QueryExecutionContext, ResultConfiguration, WorkGroupConfiguration,
+};
+use helpers::TestServer;
+
+/// Workgroups, data catalogs, named queries, prepared statements, and query
+/// executions all survive a restart in persistent mode.
+#[tokio::test]
+async fn persistence_round_trip_core_resources() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let athena = server.athena_client().await;
+
+    athena
+        .create_work_group()
+        .name("analytics")
+        .configuration(
+            WorkGroupConfiguration::builder()
+                .enforce_work_group_configuration(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    athena
+        .create_data_catalog()
+        .name("cat1")
+        .r#type(DataCatalogType::Lambda)
+        .description("lambda catalog")
+        .send()
+        .await
+        .unwrap();
+
+    let nq_id = athena
+        .create_named_query()
+        .name("greet")
+        .database("default")
+        .query_string("SELECT 'hello'")
+        .work_group("primary")
+        .send()
+        .await
+        .unwrap()
+        .named_query_id
+        .unwrap();
+
+    athena
+        .create_prepared_statement()
+        .statement_name("ps1")
+        .work_group("analytics")
+        .query_statement("SELECT ?")
+        .send()
+        .await
+        .unwrap();
+
+    let qid = athena
+        .start_query_execution()
+        .query_string("SELECT 1")
+        .work_group("primary")
+        .query_execution_context(QueryExecutionContext::builder().database("default").build())
+        .result_configuration(
+            ResultConfiguration::builder()
+                .output_location("s3://example-bucket/results/")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .query_execution_id
+        .unwrap();
+
+    server.restart().await;
+    let athena = server.athena_client().await;
+
+    // Workgroup survives.
+    assert_eq!(
+        athena
+            .get_work_group()
+            .work_group("analytics")
+            .send()
+            .await
+            .unwrap()
+            .work_group()
+            .unwrap()
+            .name(),
+        "analytics"
+    );
+
+    // Data catalog survives.
+    assert_eq!(
+        athena
+            .get_data_catalog()
+            .name("cat1")
+            .send()
+            .await
+            .unwrap()
+            .data_catalog()
+            .unwrap()
+            .r#type(),
+        &DataCatalogType::Lambda
+    );
+
+    // Named query survives.
+    assert_eq!(
+        athena
+            .get_named_query()
+            .named_query_id(&nq_id)
+            .send()
+            .await
+            .unwrap()
+            .named_query()
+            .unwrap()
+            .name(),
+        "greet"
+    );
+
+    // Prepared statement survives.
+    assert_eq!(
+        athena
+            .get_prepared_statement()
+            .statement_name("ps1")
+            .work_group("analytics")
+            .send()
+            .await
+            .unwrap()
+            .prepared_statement()
+            .unwrap()
+            .statement_name(),
+        Some("ps1")
+    );
+
+    // Query execution (and its terminal status) survives.
+    let qe = athena
+        .get_query_execution()
+        .query_execution_id(&qid)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        qe.query_execution()
+            .and_then(|q| q.status())
+            .and_then(|s| s.state())
+            .map(|s| s.as_str()),
+        Some("SUCCEEDED")
+    );
+}
+
+/// A deleted workgroup stays gone after restart.
+#[tokio::test]
+async fn persistence_delete_workgroup_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let athena = server.athena_client().await;
+
+    athena
+        .create_work_group()
+        .name("ephemeral")
+        .send()
+        .await
+        .unwrap();
+    athena
+        .delete_work_group()
+        .work_group("ephemeral")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let athena = server.athena_client().await;
+
+    let listed = athena.list_work_groups().send().await.unwrap();
+    assert!(!listed
+        .work_groups()
+        .iter()
+        .any(|w| w.name() == Some("ephemeral")));
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2589,9 +2589,62 @@ async fn main() {
         wafv2_rate_limiter.clone(),
     );
     registry.register(Arc::new(wafv2_service));
-    let athena_service = fakecloud_athena::AthenaService::new(athena_state.clone())
+    let athena_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("athena").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_athena::AthenaSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_athena::ATHENA_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "athena persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_athena::ATHENA_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.accounts.len();
+                                *athena_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded athena persistence snapshot"
+                                );
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse athena persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no athena persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read athena persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut athena_service = fakecloud_athena::AthenaService::new(athena_state.clone())
         .with_glue(glue_state.clone())
         .with_s3(s3_state.clone());
+    if let Some(store) = athena_snapshot_store.clone() {
+        athena_service = athena_service.with_snapshot_store(store);
+    }
+    if let Some(h) = athena_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("athena", h);
+    }
     registry.register(Arc::new(athena_service));
     let mut sfn_service = StepFunctionsService::new(stepfunctions_state.clone());
     let sfn_delivery_bus = {


### PR DESCRIPTION
## Summary

Athena is the 3rd of 11 implemented services that did **not** survive a restart in persistent mode (no `snapshot_hook`). Workgroups, data catalogs, named queries, prepared statements, query executions, notebooks, sessions, calculations, capacity reservations, and tags now write through to disk and restore on startup. Batch 3 of the persistence-coverage sweep (after Firehose #1845, ACM #1847).

All Athena query execution is synchronous (results stored in state + written to S3, which persists itself), so a snapshot-on-mutation covers the full surface — no async reconcile needed (unlike ACM).

### Bug found + fixed by the new E2E test
`prepared_statements` is keyed by a `(workgroup, name)` **tuple**. JSON object keys must be strings, so `serde_json::to_vec` of the whole-state snapshot **errored** the moment a prepared statement existed — and the error path only logs, so every subsequent write was silently dropped (prepared statements + query executions never persisted). Fixed by (de)serializing that field as a sequence of `(workgroup, name, statement)` triples. The restart-recovery E2E caught it.

Changes:
- `AthenaSnapshot` versioned envelope + `ATHENA_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook` on `AthenaService`; serialize+write offloaded to the blocking pool under an async lock
- server builds the `DiskSnapshotStore`, restores on boot (schema-version checked), registers the CFN persist hook
- `Clone` on `AthenaAccounts`/`AccountState`
- tuple-key serde shim for `prepared_statements`

## Test plan

- `cargo test -p fakecloud-e2e --test athena_persistence` — 2 new restart-recovery E2E tests pass:
  - workgroup + data catalog + named query + prepared statement + query-execution status all round-trip a restart
  - a deleted workgroup stays deleted
- `cargo clippy -p fakecloud-athena --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Athena state across restarts in persistent mode. Workgroups, catalogs, named queries, prepared statements, query executions, notebooks, sessions, capacity reservations, and tags now write to disk and restore on startup.

- New Features
  - Added versioned snapshots (`AthenaSnapshot` + `ATHENA_SNAPSHOT_SCHEMA_VERSION`) and snapshot-on-mutation persistence; serialize+write runs in the blocking pool under an async lock.
  - `AthenaService` now supports `with_snapshot_store`, `save_snapshot`, and a CloudFormation snapshot hook for write-through.
  - Server wires `fakecloud-athena` to `fakecloud-persistence` using a disk snapshot store; loads on boot with schema checks and registers the hook.
  - E2E restart-recovery tests added (core resources round-trip; deleted workgroup stays deleted).

- Bug Fixes
  - Fixed `prepared_statements` tuple-key serialization by storing triples `(workgroup, name, statement)` to avoid JSON key errors and lost writes.

<sup>Written for commit 3884de61f908537957d8edae5e851e273cab71e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

