### PR TITLE
feat(tfacc): widen logs to all _basic resource types, fix 3 gaps

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -3436,11 +3436,16 @@ impl ResourceProvisioner {
                     .unwrap_or("1")
                     .to_string();
                 let default_value = t.get("DefaultValue").and_then(|v| v.as_f64());
+                let unit = t
+                    .get("Unit")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 transformations.push(MetricTransformation {
                     metric_name,
                     metric_namespace,
                     metric_value,
                     default_value,
+                    unit,
                 });
             }
         }

--- a/crates/fakecloud-lambda/src/service/publish.rs
+++ b/crates/fakecloud-lambda/src/service/publish.rs
@@ -137,13 +137,6 @@ impl LambdaService {
     }
 
     pub(crate) fn function_config_json(&self, func: &LambdaFunction) -> Value {
-        // AWS always emits Environment with at least an empty Variables map.
-        let env_vars = if func.environment.is_empty() {
-            json!({ "Variables": {} })
-        } else {
-            json!({ "Variables": func.environment })
-        };
-
         let tracing_mode = func.tracing_mode.as_deref().unwrap_or("PassThrough");
         let ephemeral_size = func.ephemeral_storage_size.unwrap_or(512);
 
@@ -162,7 +155,6 @@ impl LambdaService {
             "LastModified": func.last_modified.format("%Y-%m-%dT%H:%M:%S%.3f+0000").to_string(),
             "PackageType": func.package_type,
             "Architectures": func.architectures,
-            "Environment": env_vars,
             "State": "Active",
             "LastUpdateStatus": "Successful",
             "TracingConfig": { "Mode": tracing_mode },
@@ -173,6 +165,14 @@ impl LambdaService {
                 "OptimizationStatus": "Off",
             })),
         });
+        // Only emit Environment when the function actually has variables. AWS
+        // omits the Environment block entirely for a function created without
+        // one; returning `{"Variables":{}}` made the Terraform provider see a
+        // perpetual `variables = {} -> null` diff (surfaced by the CloudWatch
+        // Logs subscription-filter test, which provisions a Lambda destination).
+        if !func.environment.is_empty() {
+            config["Environment"] = json!({ "Variables": func.environment });
+        }
         if let Some(ref kms) = func.kms_key_arn {
             config["KMSKeyArn"] = json!(kms);
         }

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1407,6 +1407,24 @@ async fn list_functions_paginates_by_marker_and_max_items() {
 }
 
 #[tokio::test]
+async fn function_without_environment_omits_environment_block() {
+    // AWS omits the Environment block entirely for a function created without
+    // environment variables. Emitting `{"Variables":{}}` made the Terraform
+    // provider see a perpetual `variables = {} -> null` diff.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "noenv").await;
+
+    let req = make_request(Method::GET, "/2015-03-31/functions/noenv", "");
+    let resp = svc.handle(req).await.unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert!(
+        v["Configuration"].get("Environment").is_none(),
+        "Environment must be omitted when there are no variables, got {}",
+        v["Configuration"]
+    );
+}
+
+#[tokio::test]
 async fn update_function_configuration_round_trips_advanced_fields() {
     // Pre-fix, UpdateFunctionConfiguration silently dropped 9 fields.
     // This asserts that a second GetFunctionConfiguration shows the

--- a/crates/fakecloud-logs/src/service/filters.rs
+++ b/crates/fakecloud-logs/src/service/filters.rs
@@ -281,6 +281,7 @@ impl LogsService {
                 metric_namespace: t["metricNamespace"].as_str().unwrap_or("").to_string(),
                 metric_value: t["metricValue"].as_str().unwrap_or("").to_string(),
                 default_value: t["defaultValue"].as_f64(),
+                unit: t["unit"].as_str().map(str::to_string),
             })
             .collect();
 
@@ -369,6 +370,8 @@ impl LogsService {
                             "metricName": t.metric_name,
                             "metricNamespace": t.metric_namespace,
                             "metricValue": t.metric_value,
+                            // AWS always reports a unit, defaulting to None.
+                            "unit": t.unit.as_deref().unwrap_or("None"),
                         });
                         if let Some(dv) = t.default_value {
                             obj["defaultValue"] = json!(dv);
@@ -644,6 +647,9 @@ mod tests {
             filters[0]["metricTransformations"][0]["metricName"],
             "ErrorCount"
         );
+        // AWS always reports a unit, defaulting to None when unset — the
+        // Terraform aws_cloudwatch_log_metric_filter resource asserts on it.
+        assert_eq!(filters[0]["metricTransformations"][0]["unit"], "None");
 
         // Describe by metric name
         let req = make_request(

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -214,6 +214,11 @@ pub struct MetricTransformation {
     pub metric_namespace: String,
     pub metric_value: String,
     pub default_value: Option<f64>,
+    /// CloudWatch unit for the published metric. AWS always reports it on
+    /// DescribeMetricFilters, defaulting to `None` when unset, and the
+    /// Terraform `aws_cloudwatch_log_metric_filter` resource asserts on it.
+    #[serde(default)]
+    pub unit: Option<String>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -156,12 +156,29 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "logs",
-        // Batch 6: core `aws_cloudwatch_log_group` smoke. The fix here
-        // is making DescribeLogGroups always return `logGroupClass`
-        // (defaulting to STANDARD), which Terraform's provider asserts
-        // on every refresh.
-        run_regex: "^TestAccLogsGroup_basic$",
-        deny: &[],
+        // Batch 6 + widen: `_basic` smoke for the core CloudWatch Logs
+        // resources and data sources — log group (+ data sources), log stream,
+        // destination (+ policy), resource policy, query definition, metric
+        // filter, and subscription filter. The widen batch added the metric
+        // filter `unit` field (DescribeMetricFilters defaults it to None) and
+        // fixed the Lambda empty-Environment drift the subscription-filter test
+        // surfaced via its Lambda destination.
+        run_regex: "^TestAccLogs[A-Za-z]+_basic$",
+        deny: &[
+            // --- gap: log anomaly detection — needs the anomaly-detector
+            //     engine fakecloud does not model. ---
+            "TestAccLogsAnomalyDetector_basic",
+            // --- gap: data-protection policies — needs the data-protection
+            //     policy engine (audit/deidentify) fakecloud does not model. ---
+            "TestAccLogsDataProtectionPolicy_basic",
+            "TestAccLogsDataProtectionPolicyDocumentDataSource_basic",
+            // --- gap: CloudWatch Logs v2 vended-log delivery (delivery
+            //     sources/destinations) is not implemented. ---
+            "TestAccLogsDeliveryDestination_basic",
+            "TestAccLogsDeliveryDestinationPolicy_basic",
+            // --- gap: field index policies are not implemented. ---
+            "TestAccLogsIndexPolicy_basic",
+        ],
     },
     Service {
         name: "iam",
@@ -342,7 +359,7 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "logs",
         service: "logs",
-        run_regex: "^TestAccLogsGroup_basic$",
+        run_regex: "^TestAccLogs[A-Za-z]+_basic$",
         extra_deny: &[],
     },
     Shard {


### PR DESCRIPTION
## Summary

Widens the `logs` tfacc shard from the log-group smoke to the `_basic` suite for the core CloudWatch Logs resources and data sources — log group (+ data sources), log stream, destination (+ policy), resource policy, query definition, metric filter, subscription filter (10 tests).

Three real fakecloud fixes:
- **Metric filters** now carry/report a `unit` per metric transformation, defaulting to `None` (`DescribeMetricFilters` always returns it; the Terraform resource asserts it).
- **Lambda** function configuration omits the `Environment` block entirely when there are no variables instead of `{"Variables":{}}` — matching AWS. The empty map drove a perpetual `variables = {} -> null` diff surfaced by the subscription-filter test's Lambda destination. Cross-service fix; also benefits the Lambda suite later.
- **CloudFormation** log-metric-filter provisioner threads the new `Unit` through (struct-field sweep).

Advanced CloudWatch Logs features stay denied with **gap** reasons: log anomaly detection, data-protection policies (+ doc data source), v2 vended-log delivery (delivery destination + policy), field index policies.

## Test plan
- New/updated unit tests: metric-filter `unit` default, omitted Lambda `Environment` block.
- `cargo clippy` on lambda/logs/cloudformation/tfacc: clean.
- Widened logs shard vs terraform-provider-aws v5.97.0: **10 pass, 0 fail**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the `logs` tfacc shard to run the `_basic` suite across core CloudWatch Logs resources and data sources. Also fixes metric filter `unit`, omits empty Lambda `Environment`, and threads `Unit` in CloudFormation.

- **New Features**
  - Run `_basic` for: log group (+ data sources), log stream, destination (+ policy), resource policy, query definition, metric filter, subscription filter.
  - Keep advanced features denied with gap reasons: anomaly detection, data-protection policies, v2 vended-log delivery, field index policies.
  - Widened shard passes 10/10 tests against `terraform-provider-aws` v5.97.0.

- **Bug Fixes**
  - Metric filters now include `unit`; `DescribeMetricFilters` reports `None` when unset.
  - Lambda config omits `Environment` when no variables to prevent `variables = {} -> null` drift.
  - CloudFormation log-metric-filter provisioner passes through `Unit`.

<sup>Written for commit e0bf14a71d324642af7c4e4b5fc903c067cc8b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

