### PR TITLE
feat(wafv2): persist web ACLs, rule groups, IP sets across restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4332,6 +4332,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "percent-encoding",
@@ -4339,6 +4340,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/crates/fakecloud-e2e/tests/wafv2_persistence.rs
+++ b/crates/fakecloud-e2e/tests/wafv2_persistence.rs
@@ -1,0 +1,160 @@
+mod helpers;
+
+use aws_sdk_wafv2::types::{
+    AllowAction, DefaultAction, IpAddressVersion, Regex, Scope, VisibilityConfig,
+};
+use helpers::TestServer;
+
+fn vis(name: &str) -> VisibilityConfig {
+    VisibilityConfig::builder()
+        .sampled_requests_enabled(false)
+        .cloud_watch_metrics_enabled(false)
+        .metric_name(name)
+        .build()
+        .unwrap()
+}
+
+fn allow_default() -> DefaultAction {
+    DefaultAction::builder()
+        .allow(AllowAction::builder().build())
+        .build()
+}
+
+/// Web ACLs, IP sets, and regex pattern sets (all keyed by a (scope, name)
+/// tuple) survive a restart in persistent mode. Exercises the tuple-keyed-map
+/// serde path that would otherwise fail to serialize.
+#[tokio::test]
+async fn persistence_round_trip_acl_ipset_regexset() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let waf = server.wafv2_client().await;
+
+    let acl_id = waf
+        .create_web_acl()
+        .name("acl1")
+        .scope(Scope::Regional)
+        .default_action(allow_default())
+        .visibility_config(vis("acl1"))
+        .description("persist me")
+        .send()
+        .await
+        .unwrap()
+        .summary
+        .unwrap()
+        .id
+        .unwrap();
+
+    let ipset_id = waf
+        .create_ip_set()
+        .name("ips1")
+        .scope(Scope::Regional)
+        .ip_address_version(IpAddressVersion::Ipv4)
+        .addresses("10.0.0.0/8")
+        .send()
+        .await
+        .unwrap()
+        .summary
+        .unwrap()
+        .id
+        .unwrap();
+
+    let regex_id = waf
+        .create_regex_pattern_set()
+        .name("rps1")
+        .scope(Scope::Regional)
+        .regular_expression_list(Regex::builder().regex_string("^/admin").build())
+        .send()
+        .await
+        .unwrap()
+        .summary
+        .unwrap()
+        .id
+        .unwrap();
+
+    server.restart().await;
+    let waf = server.wafv2_client().await;
+
+    let acl = waf
+        .get_web_acl()
+        .name("acl1")
+        .scope(Scope::Regional)
+        .id(&acl_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(acl.web_acl().unwrap().name(), "acl1");
+
+    let ips = waf
+        .get_ip_set()
+        .name("ips1")
+        .scope(Scope::Regional)
+        .id(&ipset_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(ips
+        .ip_set()
+        .unwrap()
+        .addresses()
+        .contains(&"10.0.0.0/8".to_string()));
+
+    let rps = waf
+        .get_regex_pattern_set()
+        .name("rps1")
+        .scope(Scope::Regional)
+        .id(&regex_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(rps
+        .regex_pattern_set()
+        .unwrap()
+        .regular_expression_list()
+        .iter()
+        .any(|r| r.regex_string() == Some("^/admin")));
+}
+
+/// A deleted web ACL stays gone after restart.
+#[tokio::test]
+async fn persistence_delete_web_acl_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let waf = server.wafv2_client().await;
+
+    let summary = waf
+        .create_web_acl()
+        .name("ephemeral")
+        .scope(Scope::Regional)
+        .default_action(allow_default())
+        .visibility_config(vis("ephemeral"))
+        .send()
+        .await
+        .unwrap()
+        .summary
+        .unwrap();
+    let id = summary.id().unwrap().to_owned();
+    let lock = summary.lock_token().unwrap().to_owned();
+
+    waf.delete_web_acl()
+        .name("ephemeral")
+        .scope(Scope::Regional)
+        .id(&id)
+        .lock_token(&lock)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let waf = server.wafv2_client().await;
+
+    let listed = waf
+        .list_web_acls()
+        .scope(Scope::Regional)
+        .send()
+        .await
+        .unwrap();
+    assert!(!listed
+        .web_acls()
+        .iter()
+        .any(|a| a.name() == Some("ephemeral")));
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2584,10 +2584,63 @@ async fn main() {
             app_autoscaling_state.clone(),
         );
     registry.register(Arc::new(app_autoscaling_service));
-    let wafv2_service = fakecloud_wafv2::Wafv2Service::with_rate_limiter(
+    let wafv2_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("wafv2").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_wafv2::Wafv2Snapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_wafv2::WAFV2_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "wafv2 persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_wafv2::WAFV2_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.accounts.len();
+                                *wafv2_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded wafv2 persistence snapshot"
+                                );
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse wafv2 persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no wafv2 persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read wafv2 persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut wafv2_service = fakecloud_wafv2::Wafv2Service::with_rate_limiter(
         wafv2_state.clone(),
         wafv2_rate_limiter.clone(),
     );
+    if let Some(store) = wafv2_snapshot_store.clone() {
+        wafv2_service = wafv2_service.with_snapshot_store(store);
+    }
+    if let Some(h) = wafv2_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("wafv2", h);
+    }
     registry.register(Arc::new(wafv2_service));
     let athena_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {

--- a/crates/fakecloud-wafv2/Cargo.toml
+++ b/crates/fakecloud-wafv2/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
@@ -20,5 +21,6 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-wafv2/src/lib.rs
+++ b/crates/fakecloud-wafv2/src/lib.rs
@@ -11,5 +11,5 @@ pub use inspection::{evaluate_request, Decision, RequestContext, DEFAULT_BODY_IN
 pub use service::Wafv2Service;
 pub use state::{
     AccountState, IpSet, RegexPatternSet, RuleGroup, ScopedKey, SharedWafv2State, Wafv2Accounts,
-    WebAcl,
+    Wafv2Snapshot, WebAcl, WAFV2_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-wafv2/src/service/mod.rs
+++ b/crates/fakecloud-wafv2/src/service/mod.rs
@@ -9,17 +9,51 @@ use chrono::Utc;
 use http::StatusCode;
 use parking_lot::RwLock;
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::evaluator::RateLimiter;
 use crate::state::{
     AccountState, ApiKey, IpSet, RegexPatternSet, RuleGroup, SharedWafv2State, Wafv2Accounts,
-    WebAcl,
+    Wafv2Snapshot, WebAcl, WAFV2_SNAPSHOT_SCHEMA_VERSION,
 };
+
+/// Actions that mutate persisted WAFv2 control-plane state and therefore must
+/// trigger a snapshot write. Read-only actions (Get*/List*/Check*/Describe*)
+/// and data-plane sampled-request telemetry (ephemeral, like introspection
+/// buffers) are excluded.
+const MUTATING_ACTIONS: &[&str] = &[
+    "CreateWebACL",
+    "UpdateWebACL",
+    "DeleteWebACL",
+    "CreateRuleGroup",
+    "UpdateRuleGroup",
+    "DeleteRuleGroup",
+    "CreateIPSet",
+    "UpdateIPSet",
+    "DeleteIPSet",
+    "CreateRegexPatternSet",
+    "UpdateRegexPatternSet",
+    "DeleteRegexPatternSet",
+    "AssociateWebACL",
+    "DisassociateWebACL",
+    "PutLoggingConfiguration",
+    "DeleteLoggingConfiguration",
+    "PutPermissionPolicy",
+    "DeletePermissionPolicy",
+    "TagResource",
+    "UntagResource",
+    "CreateAPIKey",
+    "DeleteAPIKey",
+    "PutManagedRuleSetVersions",
+    "UpdateManagedRuleSetVersionExpiryDate",
+    "DeleteFirewallManagerRuleGroups",
+];
 
 const SUPPORTED_ACTIONS: &[&str] = &[
     "AssociateWebACL",
@@ -82,6 +116,8 @@ const SUPPORTED_ACTIONS: &[&str] = &[
 pub struct Wafv2Service {
     state: SharedWafv2State,
     rate_limiter: Arc<RateLimiter>,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 mod api_keys;
@@ -108,11 +144,48 @@ impl Wafv2Service {
         Self {
             state,
             rate_limiter,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
     }
 
     pub fn shared_state(&self) -> SharedWafv2State {
         Arc::clone(&self.state)
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        save_wafv2_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current WAFv2 state when invoked, or
+    /// `None` in memory mode. The CloudFormation provisioner mutates `state`
+    /// directly and uses this to write a CFN-provisioned resource through to
+    /// disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_wafv2_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 
     /// Shared, in-process [`RateLimiter`] used by `RateBasedStatement`
@@ -121,6 +194,37 @@ impl Wafv2Service {
     /// evaluations through this server share their counters.
     pub fn rate_limiter(&self) -> Arc<RateLimiter> {
         Arc::clone(&self.rate_limiter)
+    }
+}
+
+/// Persist the current WAFv2 state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `Wafv2Service::save_snapshot` and the
+/// CloudFormation provisioner persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_wafv2_snapshot(
+    state: &SharedWafv2State,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = Wafv2Snapshot {
+        schema_version: WAFV2_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write wafv2 snapshot"),
+        Err(err) => tracing::error!(%err, "wafv2 snapshot task panicked"),
     }
 }
 
@@ -141,7 +245,8 @@ impl AwsService for Wafv2Service {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = MUTATING_ACTIONS.contains(&req.action.as_str());
+        let result = match req.action.as_str() {
             "CreateWebACL" => self.create_web_acl(&req),
             "GetWebACL" => self.get_web_acl(&req),
             "ListWebACLs" => self.list_web_acls(&req),
@@ -202,7 +307,11 @@ impl AwsService for Wafv2Service {
             "GetRateBasedStatementManagedKeys" => self.get_rate_based_statement_managed_keys(&req),
             "DeleteFirewallManagerRuleGroups" => self.delete_firewall_manager_rule_groups(&req),
             other => Err(AwsServiceError::action_not_implemented("wafv2", other)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 }
 

--- a/crates/fakecloud-wafv2/src/state.rs
+++ b/crates/fakecloud-wafv2/src/state.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 pub type SharedWafv2State = Arc<RwLock<Wafv2Accounts>>;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Wafv2Accounts {
     pub accounts: BTreeMap<String, AccountState>,
 }
@@ -21,15 +21,30 @@ impl Wafv2Accounts {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+/// On-disk snapshot envelope for WAFv2 state. Versioned so format changes fail
+/// loudly on upgrade rather than silently mis-parsing.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Wafv2Snapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<Wafv2Accounts>,
+}
+
+pub const WAFV2_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AccountState {
     /// Keyed by (scope, name).
+    #[serde(with = "scoped_map_serde")]
     pub web_acls: BTreeMap<ScopedKey, WebAcl>,
     /// Keyed by (scope, name).
+    #[serde(with = "scoped_map_serde")]
     pub rule_groups: BTreeMap<ScopedKey, RuleGroup>,
     /// Keyed by (scope, name).
+    #[serde(with = "scoped_map_serde")]
     pub ip_sets: BTreeMap<ScopedKey, IpSet>,
     /// Keyed by (scope, name).
+    #[serde(with = "scoped_map_serde")]
     pub regex_pattern_sets: BTreeMap<ScopedKey, RegexPatternSet>,
     /// API key tokens keyed by token string.
     pub api_keys: BTreeMap<String, ApiKey>,
@@ -44,11 +59,41 @@ pub struct AccountState {
     /// Vendor-published managed rule sets keyed by (scope, name), set via
     /// PutManagedRuleSetVersions and read by ListManagedRuleSets /
     /// ListAvailableManagedRuleGroupVersions.
-    #[serde(default)]
+    #[serde(default, with = "scoped_map_serde")]
     pub managed_rule_sets: BTreeMap<ScopedKey, ManagedRuleSet>,
 }
 
 pub type ScopedKey = (String, String);
+
+/// (De)serialize a `(scope, name) -> V` map as a sequence of `(scope, name, V)`
+/// triples. JSON object keys must be strings, so a tuple-keyed map cannot be
+/// serialized directly — without this, whole-state snapshot writes fail.
+mod scoped_map_serde {
+    use std::collections::BTreeMap;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::ScopedKey;
+
+    pub fn serialize<S, V>(map: &BTreeMap<ScopedKey, V>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        V: Serialize,
+    {
+        let entries: Vec<(&String, &String, &V)> =
+            map.iter().map(|((a, b), v)| (a, b, v)).collect();
+        entries.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D, V>(deserializer: D) -> Result<BTreeMap<ScopedKey, V>, D::Error>
+    where
+        D: Deserializer<'de>,
+        V: Deserialize<'de>,
+    {
+        let entries: Vec<(String, String, V)> = Vec::deserialize(deserializer)?;
+        Ok(entries.into_iter().map(|(a, b, v)| ((a, b), v)).collect())
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManagedRuleSet {


### PR DESCRIPTION
## Summary

WAFv2 is the 4th of 11 implemented services that did **not** survive a restart in persistent mode (no `snapshot_hook`). Web ACLs, rule groups, IP sets, regex pattern sets, logging configs, permission policies, associations, API keys, managed rule sets, and tags now persist and restore. Batch 4 of the sweep (after Firehose #1845, ACM #1847, Athena #1849).

WAFv2 control-plane ops are synchronous, so a snapshot-on-mutation covers them. Data-plane sampled-request telemetry is intentionally left ephemeral (matches the introspection-buffer reset policy).

### Tuple-keyed maps (same class as the Athena fix)
`web_acls`, `rule_groups`, `ip_sets`, `regex_pattern_sets`, and `managed_rule_sets` are all keyed by `ScopedKey = (scope, name)`. JSON object keys must be strings, so a tuple-keyed map can't serialize directly — a whole-state snapshot would fail silently once any of these existed. Fixed with one **generic** `scoped_map_serde` shim applied to all five fields, (de)serializing each as a sequence of `(scope, name, value)` triples. The E2E test exercises three of these maps across a restart.

Changes:
- `Wafv2Snapshot` versioned envelope + `WAFV2_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook` on `Wafv2Service`
- server builds the `DiskSnapshotStore`, restores on boot, registers the CFN persist hook
- `Clone` on `Wafv2Accounts`/`AccountState`
- generic tuple-key serde shim

## Test plan

- `cargo test -p fakecloud-e2e --test wafv2_persistence` — 2 new restart-recovery E2E tests pass:
  - web ACL + IP set + regex pattern set all round-trip a restart
  - a deleted web ACL stays deleted
- `cargo clippy -p fakecloud-wafv2 --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist WAFv2 resources across restarts in persistent mode. Adds versioned snapshots and fixes tuple-key map serialization; data-plane sampled-request telemetry remains ephemeral.

- **New Features**
  - Wire `fakecloud-server` to load/save `fakecloud-wafv2` snapshots using `fakecloud-persistence::DiskSnapshotStore` and a CFN write-through hook; write on mutating actions, restore on boot (`Wafv2Snapshot`, `WAFV2_SNAPSHOT_SCHEMA_VERSION`).
  - Add a generic serde shim for `(scope, name)` maps used by web ACLs, rule groups, IP sets, regex pattern sets, and managed rule sets to make snapshots serialize/restore correctly.
  - Add E2E restart tests: ACL + IP set + regex set round-trip; deleted ACL stays deleted.

- **Dependencies**
  - Add `fakecloud-persistence` and `tokio` to `fakecloud-wafv2`.

<sup>Written for commit a0fb4a3977dc72984882c13f5c9ee0bc54aeec3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

