### PR TITLE
feat(route53): persist hosted zones, records, traffic policies across restart

### DIFF
--- a/crates/fakecloud-e2e/tests/route53_persistence.rs
+++ b/crates/fakecloud-e2e/tests/route53_persistence.rs
@@ -1,0 +1,132 @@
+mod helpers;
+
+use aws_sdk_route53::types::{
+    Change, ChangeAction, ChangeBatch, ResourceRecord, ResourceRecordSet, RrType,
+};
+use helpers::TestServer;
+
+const POLICY_DOC: &str = r#"{"AWSPolicyFormatVersion":"2015-10-01","RecordType":"A","Endpoints":{"main":{"Type":"value","Value":"203.0.113.10"}},"StartEndpoint":"main"}"#;
+
+/// Hosted zones, record sets, and traffic policies (the latter keyed by a
+/// (id, version) tuple) all survive a restart in persistent mode.
+#[tokio::test]
+async fn persistence_round_trip_zone_records_traffic_policy() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let r53 = server.route53_client().await;
+
+    let zone = r53
+        .create_hosted_zone()
+        .name("persist.example.com")
+        .caller_reference("persist-zone-1")
+        .send()
+        .await
+        .unwrap()
+        .hosted_zone
+        .unwrap()
+        .id;
+
+    let rrset = ResourceRecordSet::builder()
+        .name("www.persist.example.com.")
+        .r#type(RrType::A)
+        .ttl(60)
+        .resource_records(
+            ResourceRecord::builder()
+                .value("203.0.113.10")
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    r53.change_resource_record_sets()
+        .hosted_zone_id(&zone)
+        .change_batch(
+            ChangeBatch::builder()
+                .changes(
+                    Change::builder()
+                        .action(ChangeAction::Create)
+                        .resource_record_set(rrset)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let policy_id = r53
+        .create_traffic_policy()
+        .name("persist-policy")
+        .document(POLICY_DOC)
+        .send()
+        .await
+        .unwrap()
+        .traffic_policy
+        .unwrap()
+        .id;
+
+    server.restart().await;
+    let r53 = server.route53_client().await;
+
+    // Zone survives.
+    assert_eq!(
+        r53.get_hosted_zone()
+            .id(&zone)
+            .send()
+            .await
+            .unwrap()
+            .hosted_zone()
+            .unwrap()
+            .name(),
+        "persist.example.com."
+    );
+
+    // Record set survives.
+    let rrsets = r53
+        .list_resource_record_sets()
+        .hosted_zone_id(&zone)
+        .send()
+        .await
+        .unwrap();
+    assert!(rrsets
+        .resource_record_sets()
+        .iter()
+        .any(|r| r.name() == "www.persist.example.com." && r.r#type() == &RrType::A));
+
+    // Traffic policy (tuple-keyed) survives.
+    let pol = r53
+        .get_traffic_policy()
+        .id(&policy_id)
+        .version(1)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(pol.traffic_policy().unwrap().id(), policy_id);
+}
+
+/// A deleted hosted zone stays gone after restart.
+#[tokio::test]
+async fn persistence_delete_zone_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let r53 = server.route53_client().await;
+
+    let zone = r53
+        .create_hosted_zone()
+        .name("ephemeral.example.com")
+        .caller_reference("ephemeral-1")
+        .send()
+        .await
+        .unwrap()
+        .hosted_zone
+        .unwrap()
+        .id;
+    r53.delete_hosted_zone().id(&zone).send().await.unwrap();
+
+    server.restart().await;
+    let r53 = server.route53_client().await;
+
+    assert!(r53.get_hosted_zone().id(&zone).send().await.is_err());
+}

--- a/crates/fakecloud-route53/src/lib.rs
+++ b/crates/fakecloud-route53/src/lib.rs
@@ -18,6 +18,6 @@ pub const NAMESPACE: &str = "https://route53.amazonaws.com/doc/2013-04-01/";
 
 pub use service::{DnssecSignature, Route53Service};
 pub use state::{
-    AccountState, HealthCheckStatus, Route53Accounts, SharedRoute53State, StoredHealthCheck,
-    StoredHostedZone, StoredKeySigningKey,
+    AccountState, HealthCheckStatus, Route53Accounts, Route53Snapshot, SharedRoute53State,
+    StoredHealthCheck, StoredHostedZone, StoredKeySigningKey, ROUTE53_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-route53/src/service/mod.rs
+++ b/crates/fakecloud-route53/src/service/mod.rs
@@ -8,10 +8,12 @@ use bytes::Bytes;
 use chrono::Utc;
 use http::{HeaderMap, StatusCode};
 use parking_lot::RwLock;
+use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError, ResponseBody};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::model::{
     AssociateVpcRequest, ChangeCidrCollectionRequest, ChangeResourceRecordSetsRequest,
@@ -26,10 +28,10 @@ use crate::model::{
 };
 use crate::router::{route, Route};
 use crate::state::{
-    AccountState, HealthCheckStatus, Route53Accounts, SharedRoute53State, StoredChange,
-    StoredCidrCollection, StoredHealthCheck, StoredHostedZone, StoredKeySigningKey,
+    AccountState, HealthCheckStatus, Route53Accounts, Route53Snapshot, SharedRoute53State,
+    StoredChange, StoredCidrCollection, StoredHealthCheck, StoredHostedZone, StoredKeySigningKey,
     StoredQueryLoggingConfig, StoredReusableDelegationSet, StoredTrafficPolicy,
-    StoredTrafficPolicyInstance,
+    StoredTrafficPolicyInstance, ROUTE53_SNAPSHOT_SCHEMA_VERSION,
 };
 use crate::xml_io;
 
@@ -132,6 +134,8 @@ pub struct Route53Service {
     /// or virtual-hosted bucket endpoint resolve only when the bucket
     /// exists.
     pub(crate) s3_state: Option<fakecloud_s3::SharedS3State>,
+    pub(crate) snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    pub(crate) snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 mod cidr;
@@ -150,7 +154,59 @@ impl Route53Service {
             elbv2_state: None,
             cloudfront_state: None,
             s3_state: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        save_route53_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current Route 53 state when invoked, or
+    /// `None` in memory mode. The CloudFormation provisioner mutates `state`
+    /// directly and uses this to write a CFN-provisioned resource through to
+    /// disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_route53_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+
+    /// Admin-endpoint flavour of [`set_health_check_status`](Self::set_health_check_status)
+    /// that persists the override so it survives a restart.
+    pub async fn set_health_check_status_persistent(
+        &self,
+        id: &str,
+        status: HealthCheckStatus,
+        reason: Option<String>,
+    ) -> bool {
+        let changed = self.set_health_check_status(id, status, reason);
+        if changed {
+            self.save_snapshot().await;
+        }
+        changed
     }
 
     /// Wire CloudWatch Logs so `TestDNSAnswer` calls against a zone
@@ -210,6 +266,74 @@ pub struct DnssecSignature {
     pub rrset_type: String,
 }
 
+/// Actions that mutate persisted Route 53 state and therefore must trigger a
+/// snapshot write. Read-only actions (Get*/List*/Test*) are excluded.
+const MUTATING_ACTIONS: &[&str] = &[
+    "CreateHostedZone",
+    "DeleteHostedZone",
+    "UpdateHostedZoneComment",
+    "UpdateHostedZoneFeatures",
+    "ChangeResourceRecordSets",
+    "CreateHealthCheck",
+    "UpdateHealthCheck",
+    "DeleteHealthCheck",
+    "CreateTrafficPolicy",
+    "CreateTrafficPolicyVersion",
+    "DeleteTrafficPolicy",
+    "CreateTrafficPolicyInstance",
+    "UpdateTrafficPolicyInstance",
+    "DeleteTrafficPolicyInstance",
+    "EnableHostedZoneDNSSEC",
+    "DisableHostedZoneDNSSEC",
+    "CreateKeySigningKey",
+    "DeleteKeySigningKey",
+    "ActivateKeySigningKey",
+    "DeactivateKeySigningKey",
+    "CreateQueryLoggingConfig",
+    "DeleteQueryLoggingConfig",
+    "CreateCidrCollection",
+    "ChangeCidrCollection",
+    "DeleteCidrCollection",
+    "AssociateVPCWithHostedZone",
+    "DisassociateVPCFromHostedZone",
+    "CreateVPCAssociationAuthorization",
+    "DeleteVPCAssociationAuthorization",
+    "CreateReusableDelegationSet",
+    "DeleteReusableDelegationSet",
+    "ChangeTagsForResource",
+];
+
+/// Persist the current Route 53 state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `Route53Service::save_snapshot` and the
+/// CloudFormation provisioner persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_route53_snapshot(
+    state: &SharedRoute53State,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = Route53Snapshot {
+        schema_version: ROUTE53_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write route53 snapshot"),
+        Err(err) => tracing::error!(%err, "route53 snapshot task panicked"),
+    }
+}
+
 #[async_trait]
 impl AwsService for Route53Service {
     fn service_name(&self) -> &str {
@@ -232,7 +356,8 @@ impl AwsService for Route53Service {
             }
         };
 
-        match resolved.action {
+        let mutates = MUTATING_ACTIONS.contains(&resolved.action);
+        let result = match resolved.action {
             "CreateHostedZone" => self.create_hosted_zone(&req),
             "GetHostedZone" => self.get_hosted_zone(&resolved),
             "DeleteHostedZone" => self.delete_hosted_zone(&resolved),
@@ -323,7 +448,11 @@ impl AwsService for Route53Service {
                 "InvalidAction",
                 format!("Route 53 action {other} is not implemented yet"),
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 }
 

--- a/crates/fakecloud-route53/src/state.rs
+++ b/crates/fakecloud-route53/src/state.rs
@@ -11,9 +11,55 @@ use crate::model::{HealthCheckConfig, HostedZoneFeatures, ResourceRecordSet, VPC
 
 pub type SharedRoute53State = Arc<RwLock<Route53Accounts>>;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Route53Accounts {
     pub accounts: BTreeMap<String, AccountState>,
+}
+
+/// On-disk snapshot envelope for Route 53 state. Versioned so format changes
+/// fail loudly on upgrade rather than silently mis-parsing.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Route53Snapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<Route53Accounts>,
+}
+
+pub const ROUTE53_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+/// (De)serialize a `(A, B) -> V` map as a sequence of `(A, B, V)` triples. JSON
+/// object keys must be strings, so tuple-keyed maps (traffic policies keyed by
+/// `(id, version)`, KSKs / tags keyed by `(a, b)`) cannot be serialized
+/// directly — without this, whole-state snapshot writes fail.
+mod tuple2_map_serde {
+    use std::collections::BTreeMap;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S, A, B, V>(
+        map: &BTreeMap<(A, B), V>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        A: Serialize,
+        B: Serialize,
+        V: Serialize,
+    {
+        let entries: Vec<(&A, &B, &V)> = map.iter().map(|((a, b), v)| (a, b, v)).collect();
+        entries.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D, A, B, V>(deserializer: D) -> Result<BTreeMap<(A, B), V>, D::Error>
+    where
+        D: Deserializer<'de>,
+        A: Deserialize<'de> + Ord,
+        B: Deserialize<'de> + Ord,
+        V: Deserialize<'de>,
+    {
+        let entries: Vec<(A, B, V)> = Vec::deserialize(deserializer)?;
+        Ok(entries.into_iter().map(|(a, b, v)| ((a, b), v)).collect())
+    }
 }
 
 impl Route53Accounts {
@@ -34,19 +80,21 @@ impl Route53Accounts {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AccountState {
     pub hosted_zones: BTreeMap<String, StoredHostedZone>,
     pub changes: BTreeMap<String, StoredChange>,
     pub health_checks: BTreeMap<String, StoredHealthCheck>,
     /// Keyed by `(traffic_policy_id, version)`. Each `CreateTrafficPolicyVersion`
     /// inserts a new entry alongside the existing versions.
+    #[serde(with = "tuple2_map_serde")]
     pub traffic_policies: BTreeMap<(String, i64), StoredTrafficPolicy>,
     pub traffic_policy_instances: BTreeMap<String, StoredTrafficPolicyInstance>,
     /// Per-zone DNSSEC `ServeSignature` status (SIGNING / NOT_SIGNING). Absent
     /// entries are treated as NOT_SIGNING.
     pub dnssec_status: BTreeMap<String, String>,
     /// Keyed by `(hosted_zone_id, ksk_name)`.
+    #[serde(with = "tuple2_map_serde")]
     pub key_signing_keys: BTreeMap<(String, String), StoredKeySigningKey>,
     pub query_logging_configs: BTreeMap<String, StoredQueryLoggingConfig>,
     pub cidr_collections: BTreeMap<String, StoredCidrCollection>,
@@ -56,6 +104,7 @@ pub struct AccountState {
     /// Tag bag keyed by `(resource_type, resource_id)`. Both supported
     /// resource types ("healthcheck", "hostedzone") share the bag; the
     /// resource-type discriminator is in the key tuple.
+    #[serde(with = "tuple2_map_serde")]
     pub tags: BTreeMap<(String, String), BTreeMap<String, String>>,
 }
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2400,13 +2400,65 @@ async fn main() {
     registry.register(elbv2_service);
     let cloudfront_service = Arc::new(CloudFrontService::new(cloudfront_state.clone()));
     registry.register(cloudfront_service.clone());
-    let route53_service = Arc::new(
-        fakecloud_route53::Route53Service::new(route53_state.clone())
-            .with_logs(logs_state.clone())
-            .with_elbv2(elbv2_state.clone())
-            .with_cloudfront(cloudfront_state.clone())
-            .with_s3(s3_state.clone()),
-    );
+    let route53_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("route53").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_route53::Route53Snapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_route53::ROUTE53_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "route53 persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_route53::ROUTE53_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *route53_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded route53 persistence snapshot"
+                                );
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse route53 persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no route53 persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read route53 persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut route53_inner = fakecloud_route53::Route53Service::new(route53_state.clone())
+        .with_logs(logs_state.clone())
+        .with_elbv2(elbv2_state.clone())
+        .with_cloudfront(cloudfront_state.clone())
+        .with_s3(s3_state.clone());
+    if let Some(store) = route53_snapshot_store.clone() {
+        route53_inner = route53_inner.with_snapshot_store(store);
+    }
+    if let Some(h) = route53_inner.snapshot_hook() {
+        cfn_snapshot_hooks.insert("route53", h);
+    }
+    let route53_service = Arc::new(route53_inner);
     registry.register(route53_service.clone());
     let acm_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -7624,7 +7676,10 @@ async fn main() {
                                 fakecloud_route53::HealthCheckStatus::Unknown
                             }
                         };
-                        if svc.set_health_check_status(&id, status, body.reason) {
+                        if svc
+                            .set_health_check_status_persistent(&id, status, body.reason)
+                            .await
+                        {
                             axum::http::StatusCode::NO_CONTENT
                         } else {
                             axum::http::StatusCode::NOT_FOUND


### PR DESCRIPTION
## Summary

Route 53 is the 5th of 11 implemented services that did **not** survive a restart in persistent mode (no `snapshot_hook`). Hosted zones, record sets, health checks, traffic policies (+versions), traffic-policy instances, DNSSEC status, key signing keys, query-logging configs, CIDR collections, reusable delegation sets, VPC authorizations, and tags now persist and restore. Batch 5 (after Firehose #1845, ACM #1847, Athena #1849, WAFv2 #1851).

### Tuple-keyed maps (same class as Athena/WAFv2)
`traffic_policies` is keyed by `(id, version)` — note the `i64` second element — and `key_signing_keys` / `tags` by `(String, String)`. JSON object keys must be strings, so all three use a **generic** `tuple2_map_serde` shim (parameterized over both key components + value), serializing each as a sequence of triples. Without it the whole-state snapshot would silently fail once any traffic policy / KSK / tag existed.

Changes:
- `Route53Snapshot` versioned envelope + `ROUTE53_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook`; mutating actions (resolved via the router) persist after success
- admin health-check-status endpoint persists via new `set_health_check_status_persistent`
- server builds the `DiskSnapshotStore`, restores on boot, registers the CFN persist hook
- `Clone` on `Route53Accounts`/`AccountState`
- generic 2-tuple-key serde shim

## Test plan

- `cargo test -p fakecloud-e2e --test route53_persistence` — 2 new restart-recovery E2E tests pass:
  - hosted zone + record set + traffic policy round-trip a restart
  - a deleted hosted zone stays deleted
- `cargo clippy -p fakecloud-route53 --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Route 53 state across restarts in persistent mode. Adds disk snapshots and restore-on-boot so hosted zones, records, and traffic policies survive restarts.

- Versioned snapshot envelope `Route53Snapshot` with `ROUTE53_SNAPSHOT_SCHEMA_VERSION` in `fakecloud-route53`.
- Mutating Route 53 actions now trigger an async snapshot write after success.
- `Route53Service`: `with_snapshot_store`, `save_snapshot`, and a CFN `snapshot_hook` to persist CFN-provisioned resources.
- `fakecloud-server`: loads `route53/snapshot.json` on startup, wires `fakecloud_persistence::DiskSnapshotStore`, and registers the CFN hook.
- Admin health-check status uses `set_health_check_status_persistent` so overrides survive restarts.
- Tuple-keyed maps (traffic policies, key-signing keys, tags) use a generic serde shim to serialize `(A, B) -> V` maps.
- E2E tests: zone + RR set + traffic policy round-trip across restart; deleted zone remains deleted.

<sup>Written for commit 3377075d7a9b9fbca8caf83ec24d2094e33eeed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

