### PR TITLE
feat(cloudfront): persist distributions, policies, functions across restart

### DIFF
--- a/crates/fakecloud-cloudfront/src/lib.rs
+++ b/crates/fakecloud-cloudfront/src/lib.rs
@@ -33,4 +33,7 @@ pub const API_PREFIX: &str = "/2020-05-31";
 pub const NAMESPACE: &str = "http://cloudfront.amazonaws.com/doc/2020-05-31/";
 
 pub use service::CloudFrontService;
-pub use state::{CloudFrontAccounts, SharedCloudFrontState, StoredDistribution};
+pub use state::{
+    CloudFrontAccounts, CloudFrontSnapshot, SharedCloudFrontState, StoredDistribution,
+    CLOUDFRONT_SNAPSHOT_SCHEMA_VERSION,
+};

--- a/crates/fakecloud-cloudfront/src/service.rs
+++ b/crates/fakecloud-cloudfront/src/service.rs
@@ -8,18 +8,40 @@ use chrono::Utc;
 use http::header::{HeaderName, HeaderValue, ETAG, IF_MATCH, LOCATION};
 use http::{HeaderMap, StatusCode};
 use parking_lot::RwLock;
+use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError, ResponseBody};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::model::{
     DistributionConfig, DistributionConfigWithTags, InvalidationBatch, TagKeys, Tags as ModelTags,
 };
 use crate::router::{route, Route};
 use crate::state::{
-    CloudFrontAccounts, SharedCloudFrontState, StoredDistribution, StoredInvalidation, Tag,
+    CloudFrontAccounts, CloudFrontSnapshot, SharedCloudFrontState, StoredDistribution,
+    StoredInvalidation, Tag, CLOUDFRONT_SNAPSHOT_SCHEMA_VERSION,
 };
 use crate::xml_io;
+
+/// CloudFront mutating actions share these prefixes; everything else
+/// (`Get*`/`List*`/`Describe*`/`Test*`/`Verify*`) is read-only. Used to decide
+/// when a handled request must trigger a persistence snapshot.
+fn is_mutating_action(action: &str) -> bool {
+    const PREFIXES: &[&str] = &[
+        "Create",
+        "Update",
+        "Delete",
+        "Copy",
+        "Associate",
+        "Disassociate",
+        "Tag",
+        "Untag",
+        "Publish",
+        "Put",
+    ];
+    PREFIXES.iter().any(|p| action.starts_with(p))
+}
 
 pub(crate) const DEFAULT_ACCOUNT: &str = "000000000000";
 
@@ -205,6 +227,8 @@ pub struct CloudFrontService {
     /// override the default via the
     /// `FAKECLOUD_CLOUDFRONT_STATUS_DELAY_SEC` env var.
     pub(crate) propagation_delay: std::time::Duration,
+    pub(crate) snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    pub(crate) snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 /// Resolve the default `InProgress` -> `Deployed` delay from the
@@ -234,11 +258,97 @@ impl CloudFrontService {
         Self {
             state,
             propagation_delay: default_propagation_delay(),
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
     }
 
     pub fn shared_state(&self) -> SharedCloudFrontState {
         Arc::clone(&self.state)
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        save_cloudfront_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current CloudFront state when invoked, or
+    /// `None` in memory mode. The CloudFormation provisioner mutates `state`
+    /// directly and uses this to write a CFN-provisioned resource through to
+    /// disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_cloudfront_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+
+    /// Re-arm the propagation tick for any Distribution / DistributionTenant /
+    /// ConnectionGroup / StreamingDistribution that was still `InProgress` when
+    /// the previous process exited, so they still transition to `Deployed`
+    /// after a restart. Called by the server after loading a snapshot.
+    pub fn rearm_in_progress(&self) {
+        let (dists, tenants, groups, streaming) = {
+            let s = self.state.read();
+            let mut dists = Vec::new();
+            let mut tenants = Vec::new();
+            let mut groups = Vec::new();
+            let mut streaming = Vec::new();
+            for account in s.accounts.values() {
+                for (id, d) in &account.distributions {
+                    if d.status == "InProgress" {
+                        dists.push(id.clone());
+                    }
+                }
+                for (id, t) in &account.distribution_tenants {
+                    if t.status == "InProgress" {
+                        tenants.push(id.clone());
+                    }
+                }
+                for (id, g) in &account.connection_groups {
+                    if g.status == "InProgress" {
+                        groups.push(id.clone());
+                    }
+                }
+                for (id, d) in &account.streaming_distributions {
+                    if d.status == "InProgress" {
+                        streaming.push(id.clone());
+                    }
+                }
+            }
+            (dists, tenants, groups, streaming)
+        };
+        for id in dists {
+            self.schedule_distribution_deploy(id);
+        }
+        for id in tenants {
+            self.schedule_distribution_tenant_deploy(id);
+        }
+        for id in groups {
+            self.schedule_connection_group_deploy(id);
+        }
+        for id in streaming {
+            self.schedule_streaming_distribution_deploy(id);
+        }
     }
 
     /// Override the propagation delay used by `CreateDistribution`,
@@ -265,6 +375,47 @@ impl CloudFrontService {
             }
         }
         false
+    }
+
+    /// Admin-endpoint flavour of [`set_distribution_status`](Self::set_distribution_status)
+    /// that persists the forced status so it survives a restart.
+    pub async fn set_distribution_status_persistent(&self, id: &str, status: &str) -> bool {
+        let changed = self.set_distribution_status(id, status);
+        if changed {
+            self.save_snapshot().await;
+        }
+        changed
+    }
+}
+
+/// Persist the current CloudFront state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `CloudFrontService::save_snapshot`, the propagation
+/// ticks, and the CloudFormation provisioner persist hook so all route through
+/// the same serialize-and-write path.
+pub async fn save_cloudfront_snapshot(
+    state: &SharedCloudFrontState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = CloudFrontSnapshot {
+        schema_version: CLOUDFRONT_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write cloudfront snapshot"),
+        Err(err) => tracing::error!(%err, "cloudfront snapshot task panicked"),
     }
 }
 
@@ -296,7 +447,8 @@ impl AwsService for CloudFrontService {
             }
         };
 
-        match resolved.action {
+        let mutates = is_mutating_action(resolved.action);
+        let result = match resolved.action {
             "CreateDistribution" => self.create_distribution(&req, false),
             "CreateDistributionWithTags" => self.create_distribution(&req, true),
             "GetDistribution" => self.get_distribution(&resolved),
@@ -503,7 +655,11 @@ impl AwsService for CloudFrontService {
                 "InvalidAction",
                 format!("CloudFront action {other} is not implemented yet"),
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 }
 
@@ -604,16 +760,26 @@ impl CloudFrontService {
     fn schedule_distribution_deploy(&self, id: String) {
         let state = Arc::clone(&self.state);
         let delay = self.propagation_delay;
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
         tokio::spawn(async move {
             tokio::time::sleep(delay).await;
-            let mut s = state.write();
-            for account in s.accounts.values_mut() {
-                if let Some(d) = account.distributions.get_mut(&id) {
-                    if d.status == "InProgress" {
-                        d.status = "Deployed".to_string();
+            let flipped = {
+                let mut s = state.write();
+                let mut flipped = false;
+                for account in s.accounts.values_mut() {
+                    if let Some(d) = account.distributions.get_mut(&id) {
+                        if d.status == "InProgress" {
+                            d.status = "Deployed".to_string();
+                            flipped = true;
+                        }
+                        break;
                     }
-                    return;
                 }
+                flipped
+            };
+            if flipped {
+                save_cloudfront_snapshot(&state, store, &lock).await;
             }
         });
     }
@@ -622,16 +788,26 @@ impl CloudFrontService {
     pub(crate) fn schedule_distribution_tenant_deploy(&self, id: String) {
         let state = Arc::clone(&self.state);
         let delay = self.propagation_delay;
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
         tokio::spawn(async move {
             tokio::time::sleep(delay).await;
-            let mut s = state.write();
-            for account in s.accounts.values_mut() {
-                if let Some(t) = account.distribution_tenants.get_mut(&id) {
-                    if t.status == "InProgress" {
-                        t.status = "Deployed".to_string();
+            let flipped = {
+                let mut s = state.write();
+                let mut flipped = false;
+                for account in s.accounts.values_mut() {
+                    if let Some(t) = account.distribution_tenants.get_mut(&id) {
+                        if t.status == "InProgress" {
+                            t.status = "Deployed".to_string();
+                            flipped = true;
+                        }
+                        break;
                     }
-                    return;
                 }
+                flipped
+            };
+            if flipped {
+                save_cloudfront_snapshot(&state, store, &lock).await;
             }
         });
     }
@@ -640,16 +816,26 @@ impl CloudFrontService {
     pub(crate) fn schedule_connection_group_deploy(&self, id: String) {
         let state = Arc::clone(&self.state);
         let delay = self.propagation_delay;
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
         tokio::spawn(async move {
             tokio::time::sleep(delay).await;
-            let mut s = state.write();
-            for account in s.accounts.values_mut() {
-                if let Some(g) = account.connection_groups.get_mut(&id) {
-                    if g.status == "InProgress" {
-                        g.status = "Deployed".to_string();
+            let flipped = {
+                let mut s = state.write();
+                let mut flipped = false;
+                for account in s.accounts.values_mut() {
+                    if let Some(g) = account.connection_groups.get_mut(&id) {
+                        if g.status == "InProgress" {
+                            g.status = "Deployed".to_string();
+                            flipped = true;
+                        }
+                        break;
                     }
-                    return;
                 }
+                flipped
+            };
+            if flipped {
+                save_cloudfront_snapshot(&state, store, &lock).await;
             }
         });
     }
@@ -661,16 +847,26 @@ impl CloudFrontService {
     pub(crate) fn schedule_streaming_distribution_deploy(&self, id: String) {
         let state = Arc::clone(&self.state);
         let delay = self.propagation_delay;
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
         tokio::spawn(async move {
             tokio::time::sleep(delay).await;
-            let mut s = state.write();
-            for account in s.accounts.values_mut() {
-                if let Some(d) = account.streaming_distributions.get_mut(&id) {
-                    if d.status == "InProgress" {
-                        d.status = "Deployed".to_string();
+            let flipped = {
+                let mut s = state.write();
+                let mut flipped = false;
+                for account in s.accounts.values_mut() {
+                    if let Some(d) = account.streaming_distributions.get_mut(&id) {
+                        if d.status == "InProgress" {
+                            d.status = "Deployed".to_string();
+                            flipped = true;
+                        }
+                        break;
                     }
-                    return;
                 }
+                flipped
+            };
+            if flipped {
+                save_cloudfront_snapshot(&state, store, &lock).await;
             }
         });
     }

--- a/crates/fakecloud-cloudfront/src/state.rs
+++ b/crates/fakecloud-cloudfront/src/state.rs
@@ -27,10 +27,21 @@ use crate::tenants::{StoredDistributionTenant, StoredTenantInvalidation};
 
 pub type SharedCloudFrontState = Arc<RwLock<CloudFrontAccounts>>;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct CloudFrontAccounts {
     pub accounts: BTreeMap<String, AccountState>,
 }
+
+/// On-disk snapshot envelope for CloudFront state. Versioned so format changes
+/// fail loudly on upgrade rather than silently mis-parsing.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CloudFrontSnapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<CloudFrontAccounts>,
+}
+
+pub const CLOUDFRONT_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
 
 impl CloudFrontAccounts {
     pub fn new() -> Self {
@@ -50,7 +61,7 @@ impl CloudFrontAccounts {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AccountState {
     pub distributions: BTreeMap<String, StoredDistribution>,
     pub invalidations: BTreeMap<String, StoredInvalidation>,

--- a/crates/fakecloud-e2e/tests/cloudfront_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cloudfront_persistence.rs
@@ -1,0 +1,169 @@
+//! CloudFront persistence (restart-recovery) E2E tests.
+#![allow(deprecated)]
+
+mod helpers;
+
+use std::path::Path;
+
+use aws_sdk_cloudfront::types::{
+    CookiePreference, DefaultCacheBehavior, DistributionConfig, ForwardedValues, Headers,
+    ItemSelection, Origin, Origins, PublicKeyConfig, ViewerProtocolPolicy,
+};
+use helpers::TestServer;
+
+const SAMPLE_KEY: &str =
+    "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALfm1u9C7VXhhRnD\n-----END PUBLIC KEY-----";
+
+fn minimal_config(caller_ref: &str) -> DistributionConfig {
+    DistributionConfig::builder()
+        .caller_reference(caller_ref)
+        .comment("persist")
+        .enabled(true)
+        .origins(
+            Origins::builder()
+                .quantity(1)
+                .items(
+                    Origin::builder()
+                        .id("primary")
+                        .domain_name("example.com")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .default_cache_behavior(
+            DefaultCacheBehavior::builder()
+                .target_origin_id("primary")
+                .viewer_protocol_policy(ViewerProtocolPolicy::AllowAll)
+                .forwarded_values(
+                    ForwardedValues::builder()
+                        .query_string(false)
+                        .cookies(
+                            CookiePreference::builder()
+                                .forward(ItemSelection::None)
+                                .build()
+                                .unwrap(),
+                        )
+                        .headers(Headers::builder().quantity(0).build().unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .min_ttl(0)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+async fn start(data_path: &Path, status_delay: &str) -> TestServer {
+    TestServer::start_full(
+        &[
+            ("FAKECLOUD_CONTAINER_CLI", "false"),
+            ("FAKECLOUD_CLOUDFRONT_STATUS_DELAY_SEC", status_delay),
+        ],
+        &[
+            "--storage-mode",
+            "persistent",
+            "--data-path",
+            &data_path.display().to_string(),
+        ],
+    )
+    .await
+}
+
+async fn wait_for_status(cf: &aws_sdk_cloudfront::Client, id: &str, want: &str) {
+    for _ in 0..50 {
+        let st = cf
+            .get_distribution()
+            .id(id)
+            .send()
+            .await
+            .unwrap()
+            .distribution()
+            .map(|d| d.status().to_string());
+        if st.as_deref() == Some(want) {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    panic!("distribution never reached {want}");
+}
+
+/// A deployed distribution and a public key survive a restart. The public key
+/// is created AFTER the distribution reaches Deployed, forcing a durable
+/// snapshot that captures the propagation transition.
+#[tokio::test]
+async fn persistence_distribution_and_public_key_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = start(tmp.path(), "0").await;
+    let cf = server.cloudfront_client().await;
+
+    let dist_id = cf
+        .create_distribution()
+        .distribution_config(minimal_config("persist-dist-1"))
+        .send()
+        .await
+        .unwrap()
+        .distribution()
+        .unwrap()
+        .id()
+        .to_string();
+
+    wait_for_status(&cf, &dist_id, "Deployed").await;
+
+    cf.create_public_key()
+        .public_key_config(
+            PublicKeyConfig::builder()
+                .caller_reference("pk-1")
+                .name("pk-1")
+                .encoded_key(SAMPLE_KEY)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let cf = server.cloudfront_client().await;
+
+    let dist = cf.get_distribution().id(&dist_id).send().await.unwrap();
+    assert_eq!(dist.distribution().unwrap().status(), "Deployed");
+
+    let keys = cf.list_public_keys().send().await.unwrap();
+    assert!(keys
+        .public_key_list()
+        .map(|l| l.items().iter().any(|k| k.name() == "pk-1"))
+        .unwrap_or(false));
+}
+
+/// A distribution still InProgress at restart survives and the re-armed
+/// propagation tick still drives it to Deployed afterward.
+#[tokio::test]
+async fn persistence_inprogress_distribution_reissues_after_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Long propagation delay so the distribution is still InProgress at restart.
+    let mut server = start(tmp.path(), "3").await;
+    let cf = server.cloudfront_client().await;
+
+    let dist_id = cf
+        .create_distribution()
+        .distribution_config(minimal_config("persist-dist-inprog"))
+        .send()
+        .await
+        .unwrap()
+        .distribution()
+        .unwrap()
+        .id()
+        .to_string();
+
+    // Restart well before the 3s tick fires; persists as InProgress.
+    server.restart().await;
+    let cf = server.cloudfront_client().await;
+
+    // Survives restart, then the re-armed tick drives it to Deployed.
+    assert!(cf.get_distribution().id(&dist_id).send().await.is_ok());
+    wait_for_status(&cf, &dist_id, "Deployed").await;
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2398,7 +2398,65 @@ async fn main() {
     elbv2_service.start_dataplane();
     let elbv2_service_for_admin = elbv2_service.clone();
     registry.register(elbv2_service);
-    let cloudfront_service = Arc::new(CloudFrontService::new(cloudfront_state.clone()));
+    let cloudfront_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("cloudfront").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_cloudfront::CloudFrontSnapshot>(&bytes)
+                    {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_cloudfront::CLOUDFRONT_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "cloudfront persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_cloudfront::CLOUDFRONT_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *cloudfront_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded cloudfront persistence snapshot"
+                                );
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse cloudfront persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no cloudfront persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read cloudfront persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut cloudfront_inner = CloudFrontService::new(cloudfront_state.clone());
+    if let Some(store) = cloudfront_snapshot_store.clone() {
+        cloudfront_inner = cloudfront_inner.with_snapshot_store(store);
+    }
+    if let Some(h) = cloudfront_inner.snapshot_hook() {
+        cfn_snapshot_hooks.insert("cloudfront", h);
+    }
+    // Re-arm propagation ticks for resources restored as InProgress so they
+    // still transition to Deployed after a restart.
+    cloudfront_inner.rearm_in_progress();
+    let cloudfront_service = Arc::new(cloudfront_inner);
     registry.register(cloudfront_service.clone());
     let route53_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
@@ -7896,7 +7954,10 @@ async fn main() {
                 >| {
                     let svc = svc.clone();
                     async move {
-                        if svc.set_distribution_status(&id, &body.status) {
+                        if svc
+                            .set_distribution_status_persistent(&id, &body.status)
+                            .await
+                        {
                             axum::http::StatusCode::NO_CONTENT
                         } else {
                             axum::http::StatusCode::NOT_FOUND


### PR DESCRIPTION
## Summary

CloudFront is the 6th of 11 implemented services that did **not** survive a restart in persistent mode (no `snapshot_hook`). The full control-plane surface — distributions, invalidations, OAC/OAI, all policy types, functions, public keys, key groups, key value stores, field-level encryption, realtime log configs, VPC origins, anycast IP lists, trust stores, resource policies, streaming distributions, connection groups, distribution tenants, and tags — now persists and restores. Batch 6 (after Firehose #1845, ACM #1847, Athena #1849, WAFv2 #1851, Route53 #1852).

### Async deploy ticks (ACM-class restore fidelity, ×4)
CloudFront resources deploy asynchronously (`InProgress -> Deployed`) via spawned propagation ticks. Persistence covers them:
- each of the 4 ticks (distribution / tenant / connection group / streaming distribution) persists the flip after it fires
- the admin status endpoint persists via `set_distribution_status_persistent`
- on restore, `rearm_in_progress()` re-arms the tick for every resource left `InProgress` so it still reaches `Deployed` (otherwise a restored in-progress resource would hang)

Changes:
- `CloudFrontSnapshot` versioned envelope + `CLOUDFRONT_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook` on `CloudFrontService`
- mutating actions detected by prefix (Create/Update/Delete/Copy/Associate/Disassociate/Tag/Untag/Publish/Put) — verified complete against all 169 routed actions; reads are Get/List/Describe/Test/Verify
- server builds the `DiskSnapshotStore`, restores on boot, re-arms in-progress resources, registers the CFN persist hook
- `Clone` on `CloudFrontAccounts`/`AccountState`

## Test plan

- `cargo test -p fakecloud-e2e --test cloudfront_persistence` — 2 new restart-recovery E2E tests pass:
  - a deployed distribution + public key round-trip a restart (public key created after Deployed forces a durable snapshot capturing the transition)
  - an InProgress distribution survives a restart and the re-armed tick drives it to Deployed
- `cargo clippy -p fakecloud-cloudfront --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist CloudFront state to disk in persistent mode and restore it on startup. All resources now survive restarts, and in-progress deploys resume and complete after reboot.

- **New Features**
  - Added a versioned `CloudFrontSnapshot` and schema; snapshots are saved after successful mutating actions and deploy tick flips.
  - Server loads the snapshot on boot, registers a CloudFormation write-through `snapshot_hook`, and re-arms delayed deploys for distributions, tenants, connection groups, and streaming distributions.
  - Persistence covers distributions, invalidations, OAC/OAI, all policy types, functions, public keys, key groups, key value stores, field-level encryption, realtime log configs, VPC origins, anycast IP lists, trust stores, resource policies, streaming distributions, connection groups, distribution tenants, and tags.
  - Added `set_distribution_status_persistent` to persist admin-forced status changes.
  - Added E2E tests for restart round-trip and in-progress recovery.

<sup>Written for commit ee6d9e9a081310b7fd840159beab38625fd68b8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

