### PR TITLE
feat(glue): persist catalog, jobs, and resources across restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,6 +3778,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "regex",

--- a/crates/fakecloud-e2e/tests/glue_persistence.rs
+++ b/crates/fakecloud-e2e/tests/glue_persistence.rs
@@ -1,0 +1,117 @@
+mod helpers;
+
+use aws_sdk_glue::types::{Column, DatabaseInput, JobCommand, StorageDescriptor, TableInput};
+use helpers::TestServer;
+
+fn table_input(name: &str) -> TableInput {
+    TableInput::builder()
+        .name(name)
+        .table_type("EXTERNAL_TABLE")
+        .storage_descriptor(
+            StorageDescriptor::builder()
+                .columns(
+                    Column::builder()
+                        .name("id")
+                        .r#type("string")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .build()
+        .unwrap()
+}
+
+/// Databases, tables, and jobs survive a restart in persistent mode.
+#[tokio::test]
+async fn persistence_round_trip_database_table_job() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let glue = server.glue_client().await;
+
+    glue.create_database()
+        .database_input(DatabaseInput::builder().name("warehouse").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+    glue.create_table()
+        .database_name("warehouse")
+        .table_input(table_input("orders"))
+        .send()
+        .await
+        .unwrap();
+    glue.create_job()
+        .name("etl-job")
+        .role("arn:aws:iam::123456789012:role/glue")
+        .command(
+            JobCommand::builder()
+                .name("glueetl")
+                .script_location("s3://example/script.py")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let glue = server.glue_client().await;
+
+    assert_eq!(
+        glue.get_database()
+            .name("warehouse")
+            .send()
+            .await
+            .unwrap()
+            .database()
+            .unwrap()
+            .name(),
+        "warehouse"
+    );
+    assert_eq!(
+        glue.get_table()
+            .database_name("warehouse")
+            .name("orders")
+            .send()
+            .await
+            .unwrap()
+            .table()
+            .unwrap()
+            .name(),
+        "orders"
+    );
+    assert_eq!(
+        glue.get_job()
+            .job_name("etl-job")
+            .send()
+            .await
+            .unwrap()
+            .job()
+            .unwrap()
+            .name(),
+        Some("etl-job")
+    );
+}
+
+/// A deleted database stays gone after restart.
+#[tokio::test]
+async fn persistence_delete_database_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let glue = server.glue_client().await;
+
+    glue.create_database()
+        .database_input(DatabaseInput::builder().name("ephemeral").build().unwrap())
+        .send()
+        .await
+        .unwrap();
+    glue.delete_database()
+        .name("ephemeral")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let glue = server.glue_client().await;
+
+    assert!(glue.get_database().name("ephemeral").send().await.is_err());
+}

--- a/crates/fakecloud-glue/Cargo.toml
+++ b/crates/fakecloud-glue/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
@@ -19,6 +20,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/fakecloud-glue/src/lib.rs
+++ b/crates/fakecloud-glue/src/lib.rs
@@ -21,5 +21,6 @@ pub(crate) mod triggers;
 
 pub use service::GlueService;
 pub use state::{
-    Column, Database, GlueAccounts, GlueState, Partition, SharedGlueState, StorageDescriptor, Table,
+    Column, Database, GlueAccounts, GlueSnapshot, GlueState, Partition, SharedGlueState,
+    StorageDescriptor, Table, GLUE_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-glue/src/service.rs
+++ b/crates/fakecloud-glue/src/service.rs
@@ -6,12 +6,28 @@ use chrono::Utc;
 use http::StatusCode;
 use parking_lot::RwLock;
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    Column, Database, GlueAccounts, Partition, SerdeInfo, SharedGlueState, StorageDescriptor, Table,
+    Column, Database, GlueAccounts, GlueSnapshot, Partition, SerdeInfo, SharedGlueState,
+    StorageDescriptor, Table, GLUE_SNAPSHOT_SCHEMA_VERSION,
 };
+
+/// Glue read actions all start with one of these verbs; every other action is
+/// a mutation (Create/Update/Delete/BatchCreate/BatchDelete/BatchPut/BatchStop/
+/// BatchUpdate/Cancel/Import/Modify/Put/Register/Remove/Reset/Resume/Run/Start/
+/// Stop/Tag/Untag). Used to decide when a handled request must trigger a
+/// persistence snapshot. The inverse formulation guarantees no mutation is
+/// ever missed.
+fn is_mutating_action(action: &str) -> bool {
+    const READ_PREFIXES: &[&str] = &[
+        "BatchGet", "Get", "List", "Search", "Query", "Check", "Describe", "Test",
+    ];
+    !READ_PREFIXES.iter().any(|p| action.starts_with(p))
+}
 
 const SUPPORTED_ACTIONS: &[&str] = &[
     "BatchCreatePartition",
@@ -285,15 +301,87 @@ const SUPPORTED_ACTIONS: &[&str] = &[
 
 pub struct GlueService {
     pub(crate) state: SharedGlueState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl GlueService {
     pub fn new(state: SharedGlueState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
     }
 
     pub fn shared_state(&self) -> SharedGlueState {
         Arc::clone(&self.state)
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        save_glue_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current Glue state when invoked, or
+    /// `None` in memory mode. The CloudFormation provisioner mutates `state`
+    /// directly and uses this to write a CFN-provisioned resource through to
+    /// disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_glue_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current Glue state as a snapshot. Offloads the serde + blocking
+/// file write to the Tokio blocking pool. Noop when `store` is `None` (memory
+/// mode). Shared by `GlueService::save_snapshot` and the CloudFormation
+/// provisioner persist hook so both route through the same serialize-and-write
+/// path.
+pub async fn save_glue_snapshot(
+    state: &SharedGlueState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = GlueSnapshot {
+        schema_version: GLUE_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write glue snapshot"),
+        Err(err) => tracing::error!(%err, "glue snapshot task panicked"),
     }
 }
 
@@ -317,7 +405,8 @@ impl AwsService for GlueService {
         // Server-side input validation (lengths/ranges/enums) runs before any
         // handler, mirroring AWS's request-validation phase.
         crate::common::validate_constraints(&req.action, &req.json_body())?;
-        match req.action.as_str() {
+        let mutates = is_mutating_action(&req.action);
+        let result = match req.action.as_str() {
             "BatchCreatePartition" => self.batch_create_partition(&req),
             "BatchDeleteConnection" => self.batch_delete_connection(&req),
             "BatchDeletePartition" => self.batch_delete_partition(&req),
@@ -638,7 +727,11 @@ impl AwsService for GlueService {
             "UpdateUserDefinedFunction" => self.update_user_defined_function(&req),
             "UpdateWorkflow" => self.update_workflow(&req),
             other => Err(AwsServiceError::action_not_implemented("glue", other)),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 }
 

--- a/crates/fakecloud-glue/src/state.rs
+++ b/crates/fakecloud-glue/src/state.rs
@@ -14,10 +14,21 @@ pub type JsonStore = BTreeMap<String, Value>;
 
 pub type SharedGlueState = Arc<RwLock<GlueAccounts>>;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct GlueAccounts {
     pub accounts: BTreeMap<String, GlueState>,
 }
+
+/// On-disk snapshot envelope for Glue state. Versioned so format changes fail
+/// loudly on upgrade rather than silently mis-parsing.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct GlueSnapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<GlueAccounts>,
+}
+
+pub const GLUE_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
 
 impl GlueAccounts {
     pub fn new() -> Self {
@@ -35,7 +46,7 @@ impl GlueAccounts {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct GlueState {
     #[serde(default)]
     pub account_id: String,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2632,7 +2632,60 @@ async fn main() {
         cfn_snapshot_hooks.insert("firehose", h);
     }
     registry.register(Arc::new(firehose_service));
-    let glue_service = fakecloud_glue::GlueService::new(glue_state.clone());
+    let glue_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("glue").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_glue::GlueSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_glue::GLUE_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "glue persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_glue::GLUE_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.accounts.len();
+                                *glue_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded glue persistence snapshot"
+                                );
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse glue persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no glue persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read glue persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut glue_service = fakecloud_glue::GlueService::new(glue_state.clone());
+    if let Some(store) = glue_snapshot_store.clone() {
+        glue_service = glue_service.with_snapshot_store(store);
+    }
+    if let Some(h) = glue_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("glue", h);
+    }
     registry.register(Arc::new(glue_service));
     let cloudwatch_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {


### PR DESCRIPTION
## Summary

Glue is the 7th of 11 implemented services that did **not** survive a restart in persistent mode (no `snapshot_hook`). Databases, tables, partitions, jobs, job runs, and all the JSON-backed control-plane families (crawlers, classifiers, connections, triggers, workflows, blueprints, schemas, security configs, sessions, etc.) now persist and restore. Batch 7 (after #1845/47/49/51/52/53).

Glue is fully **synchronous** (job runs complete inline, no spawned tasks), so a snapshot-on-mutation covers the entire surface — no async reconcile needed.

### Mutation detection
Glue's action surface is huge and its `Batch*` actions split read (`BatchGet*`) vs write (`BatchCreate/Delete/Put/Stop/Update*`), which makes a forward prefix list error-prone. Instead an **inverse predicate**: reads start with `Get/List/Describe/Search/Query/Check/BatchGet/Test`; everything else is a write. Verified against the full routed action list — this guarantees no mutation is ever silently skipped.

Changes:
- `GlueSnapshot` versioned envelope + `GLUE_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook` on `GlueService`
- server builds the `DiskSnapshotStore`, restores on boot, registers the CFN persist hook
- `Clone` on `GlueAccounts`/`GlueState`; `tokio` promoted from dev-dep to dep

## Test plan

- `cargo test -p fakecloud-e2e --test glue_persistence` — 2 new restart-recovery E2E tests pass:
  - database + table + job round-trip a restart
  - a deleted database stays deleted
- `cargo clippy -p fakecloud-glue --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Glue catalog, jobs, and JSON-backed resources across restarts in persistent mode. State is snapshotted on every write and restored on startup.

- **New Features**
  - Snapshot on mutation using an inverse predicate for action detection; guarantees all writes persist.
  - `GlueSnapshot` with `GLUE_SNAPSHOT_SCHEMA_VERSION`; server restores from disk and registers a CFN write-through `snapshot_hook`.
  - `GlueService` adds `with_snapshot_store`, `save_snapshot`, and `snapshot_hook`.
  - E2E tests in `fakecloud-e2e` verify restart round-trip and that deletions stay deleted.

- **Dependencies**
  - Added `fakecloud-persistence`.
  - Promoted `tokio` to a normal dependency in `fakecloud-glue`.

<sup>Written for commit 3d359ef8e325b8451911746af24000cd5d7afac7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

