### PR TITLE
feat(organizations): persist the organization across restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3946,6 +3946,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "rand 0.8.5",

--- a/crates/fakecloud-e2e/tests/organizations_persistence.rs
+++ b/crates/fakecloud-e2e/tests/organizations_persistence.rs
@@ -1,0 +1,169 @@
+mod helpers;
+
+use aws_sdk_organizations::types::PolicyType;
+use helpers::TestServer;
+
+const DENY_ALL: &str =
+    r#"{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"*","Resource":"*"}]}"#;
+
+async fn wait_for_account_succeeded(
+    orgs: &aws_sdk_organizations::Client,
+    request_id: &str,
+) -> String {
+    for _ in 0..60 {
+        let status = orgs
+            .describe_create_account_status()
+            .create_account_request_id(request_id)
+            .send()
+            .await
+            .unwrap()
+            .create_account_status
+            .unwrap();
+        if status.state().map(|s| s.as_str()) == Some("SUCCEEDED") {
+            return status.account_id().unwrap().to_string();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    panic!("create account never SUCCEEDED");
+}
+
+/// The organization, an OU, an SCP, and an asynchronously-created member
+/// account all survive a restart in persistent mode. The marker OU created
+/// after the account reaches SUCCEEDED forces a durable snapshot capturing the
+/// async completion.
+#[tokio::test]
+async fn persistence_round_trip_org_ou_policy_account() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let orgs = server.organizations_client().await;
+
+    orgs.create_organization().send().await.unwrap();
+    let root_id = orgs.list_roots().send().await.unwrap().roots()[0]
+        .id()
+        .unwrap()
+        .to_string();
+
+    let ou_id = orgs
+        .create_organizational_unit()
+        .parent_id(&root_id)
+        .name("Engineering")
+        .send()
+        .await
+        .unwrap()
+        .organizational_unit
+        .unwrap()
+        .id
+        .unwrap();
+
+    let policy_id = orgs
+        .create_policy()
+        .name("deny-all")
+        .description("deny everything")
+        .content(DENY_ALL)
+        .r#type(PolicyType::ServiceControlPolicy)
+        .send()
+        .await
+        .unwrap()
+        .policy
+        .unwrap()
+        .policy_summary
+        .unwrap()
+        .id
+        .unwrap();
+
+    let req_id = orgs
+        .create_account()
+        .account_name("Dev")
+        .email("dev@example.com")
+        .send()
+        .await
+        .unwrap()
+        .create_account_status
+        .unwrap()
+        .id
+        .unwrap();
+    let account_id = wait_for_account_succeeded(&orgs, &req_id).await;
+
+    // Force a durable snapshot that captures the SUCCEEDED account.
+    orgs.create_organizational_unit()
+        .parent_id(&root_id)
+        .name("marker")
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let orgs = server.organizations_client().await;
+
+    // Org survives.
+    assert!(orgs.describe_organization().send().await.is_ok());
+
+    // OU survives.
+    assert_eq!(
+        orgs.describe_organizational_unit()
+            .organizational_unit_id(&ou_id)
+            .send()
+            .await
+            .unwrap()
+            .organizational_unit()
+            .unwrap()
+            .name(),
+        Some("Engineering")
+    );
+
+    // Policy survives.
+    assert!(orgs
+        .describe_policy()
+        .policy_id(&policy_id)
+        .send()
+        .await
+        .is_ok());
+
+    // The async-created member account survives with its enrollment.
+    let accounts = orgs.list_accounts().send().await.unwrap();
+    assert!(accounts
+        .accounts()
+        .iter()
+        .any(|a| a.id() == Some(account_id.as_str())));
+}
+
+/// A deleted OU stays gone after restart while the org persists.
+#[tokio::test]
+async fn persistence_delete_ou_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let orgs = server.organizations_client().await;
+
+    orgs.create_organization().send().await.unwrap();
+    let root_id = orgs.list_roots().send().await.unwrap().roots()[0]
+        .id()
+        .unwrap()
+        .to_string();
+    let ou_id = orgs
+        .create_organizational_unit()
+        .parent_id(&root_id)
+        .name("ephemeral")
+        .send()
+        .await
+        .unwrap()
+        .organizational_unit
+        .unwrap()
+        .id
+        .unwrap();
+    orgs.delete_organizational_unit()
+        .organizational_unit_id(&ou_id)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let orgs = server.organizations_client().await;
+
+    assert!(orgs.describe_organization().send().await.is_ok());
+    assert!(orgs
+        .describe_organizational_unit()
+        .organizational_unit_id(&ou_id)
+        .send()
+        .await
+        .is_err());
+}

--- a/crates/fakecloud-organizations/Cargo.toml
+++ b/crates/fakecloud-organizations/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-organizations/src/lib.rs
+++ b/crates/fakecloud-organizations/src/lib.rs
@@ -5,6 +5,7 @@ pub(crate) mod state;
 
 pub use service::OrganizationsService;
 pub use state::{
-    MemberAccount, OrganizationState, OrganizationalUnit, Policy, ResponsibilityTransfer,
-    SharedOrganizationsState, FEATURE_SET_ALL, FEATURE_SET_CONSOLIDATED_BILLING, POLICY_TYPE_SCP,
+    MemberAccount, OrganizationState, OrganizationalUnit, OrganizationsSnapshot, Policy,
+    ResponsibilityTransfer, SharedOrganizationsState, FEATURE_SET_ALL,
+    FEATURE_SET_CONSOLIDATED_BILLING, ORGANIZATIONS_SNAPSHOT_SCHEMA_VERSION, POLICY_TYPE_SCP,
 };

--- a/crates/fakecloud-organizations/src/service/accounts.rs
+++ b/crates/fakecloud-organizations/src/service/accounts.rs
@@ -114,6 +114,8 @@ impl OrganizationsService {
     /// AWS `CreateAccount` so SDK callers can observe both phases.
     pub(super) fn spawn_create_account_completion(&self, request_id: String) {
         let state = self.state.clone();
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
         let delay = {
             let mut rng = rand::thread_rng();
             let span = CREATE_ACCOUNT_MAX_DELAY.saturating_sub(CREATE_ACCOUNT_MIN_DELAY);
@@ -126,9 +128,18 @@ impl OrganizationsService {
         };
         tokio::spawn(async move {
             tokio::time::sleep(delay).await;
-            let mut guard = state.write();
-            if let Some(org) = guard.as_mut() {
-                org.complete_create_account(&request_id);
+            let completed = {
+                let mut guard = state.write();
+                match guard.as_mut() {
+                    Some(org) => {
+                        org.complete_create_account(&request_id);
+                        true
+                    }
+                    None => false,
+                }
+            };
+            if completed {
+                super::save_organizations_snapshot(&state, store, &lock).await;
             }
         });
     }

--- a/crates/fakecloud-organizations/src/service/mod.rs
+++ b/crates/fakecloud-organizations/src/service/mod.rs
@@ -7,13 +7,23 @@ use fakecloud_core::pagination::paginate_checked;
 use http::StatusCode;
 use rand::Rng;
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    MemberAccount, OrgError, OrganizationState, OrganizationalUnit, Policy,
-    SharedOrganizationsState, FEATURE_SET_ALL, FEATURE_SET_CONSOLIDATED_BILLING, POLICY_TYPE_SCP,
+    MemberAccount, OrgError, OrganizationState, OrganizationalUnit, OrganizationsSnapshot, Policy,
+    SharedOrganizationsState, FEATURE_SET_ALL, FEATURE_SET_CONSOLIDATED_BILLING,
+    ORGANIZATIONS_SNAPSHOT_SCHEMA_VERSION, POLICY_TYPE_SCP,
 };
+
+/// Organizations read actions all start with `Describe` or `List`; every other
+/// action is a mutation. The inverse formulation guarantees no mutation is ever
+/// missed.
+fn is_mutating_action(action: &str) -> bool {
+    !(action.starts_with("Describe") || action.starts_with("List"))
+}
 
 /// Bounds for the synthetic delay before a `CreateAccount` request
 /// flips from `IN_PROGRESS` to `SUCCEEDED`. Real AWS takes minutes; a
@@ -92,6 +102,8 @@ pub static ORGANIZATIONS_ACTIONS: &[&str] = &[
 
 pub struct OrganizationsService {
     state: SharedOrganizationsState,
+    pub(crate) snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    pub(crate) snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 mod accounts;
@@ -108,12 +120,72 @@ mod tags;
 
 impl OrganizationsService {
     pub fn new(state: SharedOrganizationsState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
     }
 
     pub fn shared() -> (Arc<Self>, SharedOrganizationsState) {
         let state: SharedOrganizationsState = Arc::new(parking_lot::RwLock::new(None));
         (Arc::new(Self::new(state.clone())), state)
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    pub(crate) async fn save_snapshot(&self) {
+        save_organizations_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current Organizations state when invoked,
+    /// or `None` in memory mode. The CloudFormation provisioner mutates `state`
+    /// directly and uses this to write a CFN-provisioned resource through to
+    /// disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_organizations_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+
+    /// Re-arm the completion tick for any `CreateAccount` request restored as
+    /// `IN_PROGRESS`, so it still transitions to `SUCCEEDED` after a restart.
+    /// Called by the server after loading a snapshot.
+    pub fn rearm_in_progress_account_creations(&self) {
+        let pending: Vec<String> = {
+            let guard = self.state.read();
+            match guard.as_ref() {
+                Some(org) => org
+                    .create_account_requests
+                    .iter()
+                    .filter(|(_, s)| s.state == "IN_PROGRESS")
+                    .map(|(id, _)| id.clone())
+                    .collect(),
+                None => Vec::new(),
+            }
+        };
+        for request_id in pending {
+            self.spawn_create_account_completion(request_id);
+        }
     }
 
     /// Read-side helper: enforce that an org exists and the caller is a
@@ -195,7 +267,8 @@ impl AwsService for OrganizationsService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(&req.action);
+        let result = match req.action.as_str() {
             "CreateOrganization" => self.create_organization(&req),
             "DescribeOrganization" => self.describe_organization(&req),
             "DeleteOrganization" => self.delete_organization(&req),
@@ -275,11 +348,46 @@ impl AwsService for OrganizationsService {
                 "organizations",
                 &req.action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {
         ORGANIZATIONS_ACTIONS
+    }
+}
+
+/// Persist the current Organizations state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `OrganizationsService::save_snapshot`, the
+/// CreateAccount completion tick, and the CloudFormation provisioner persist
+/// hook so all route through the same serialize-and-write path.
+pub async fn save_organizations_snapshot(
+    state: &SharedOrganizationsState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = OrganizationsSnapshot {
+        schema_version: ORGANIZATIONS_SNAPSHOT_SCHEMA_VERSION,
+        organization: state.read().clone(),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write organizations snapshot"),
+        Err(err) => tracing::error!(%err, "organizations snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -25,6 +25,18 @@ pub const FULL_AWS_ACCESS_POLICY_DESCRIPTION: &str = "Allows access to every ope
 pub const FULL_AWS_ACCESS_POLICY_CONTENT: &str =
     r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
 
+/// On-disk snapshot envelope for Organizations state. Versioned so format
+/// changes fail loudly on upgrade rather than silently mis-parsing. The whole
+/// org is a single optional value (`None` until `CreateOrganization`).
+#[derive(Clone, Serialize, Deserialize)]
+pub struct OrganizationsSnapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub organization: Option<OrganizationState>,
+}
+
+pub const ORGANIZATIONS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OrganizationState {
     pub org_id: String,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1616,9 +1616,66 @@ async fn main() {
     if let Some(store) = kms_snapshot_store {
         kms_hook_adapter.set_snapshot_store(store);
     }
-    registry.register(Arc::new(OrganizationsService::new(
-        organizations_state.clone(),
-    )));
+    let organizations_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("organizations").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_organizations::OrganizationsSnapshot>(
+                        &bytes,
+                    ) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_organizations::ORGANIZATIONS_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "organizations persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_organizations::ORGANIZATIONS_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            let present = snapshot.organization.is_some();
+                            *organizations_state.write() = snapshot.organization;
+                            tracing::info!(
+                                organization = present,
+                                "loaded organizations persistence snapshot"
+                            );
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse organizations persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no organizations persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read organizations persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut organizations_inner = OrganizationsService::new(organizations_state.clone());
+    if let Some(store) = organizations_snapshot_store.clone() {
+        organizations_inner = organizations_inner.with_snapshot_store(store);
+    }
+    if let Some(h) = organizations_inner.snapshot_hook() {
+        cfn_snapshot_hooks.insert("organizations", h);
+    }
+    // Re-arm CreateAccount completion ticks for requests restored as IN_PROGRESS.
+    organizations_inner.rearm_in_progress_account_creations();
+    // Hook shared with the create-admin admin endpoint, which auto-enrolls an
+    // account into the org directly and must persist that through to disk.
+    let organizations_persist_hook = organizations_inner.snapshot_hook();
+    registry.register(Arc::new(organizations_inner));
     // EC2 (ec2Query protocol). Instances are backed by the optional container
     // runtime (Docker/Podman); persistence is wired in later batches. We keep a
     // clone of the shared state so the introspection router can expose
@@ -7671,16 +7728,24 @@ async fn main() {
             axum::routing::post({
                 let iam = iam_state.clone();
                 let orgs = organizations_state.clone();
+                let persist = organizations_persist_hook.clone();
                 move |axum::Json(body): axum::Json<types::CreateAdminRequest>| {
                     let iam = iam.clone();
                     let orgs = orgs.clone();
+                    let persist = persist.clone();
                     async move {
-                        axum::Json(reset::create_admin_in_account(
+                        let resp = reset::create_admin_in_account(
                             &iam,
                             &orgs,
                             &body.account_id,
                             &body.user_name,
-                        ))
+                        );
+                        // The helper may auto-enroll the account into the org;
+                        // persist that mutation through to disk.
+                        if let Some(hook) = &persist {
+                            hook().await;
+                        }
+                        axum::Json(resp)
                     }
                 }
             }),


### PR DESCRIPTION
## Summary

Organizations is the 8th of 11 implemented services that did **not** survive a restart in persistent mode (no `snapshot_hook`). The organization — its OUs, member accounts, policies, attachments, handshakes, service-access, delegated admins, responsibility transfers, and tags — is a single process-wide value (`Option<OrganizationState>`); it now persists and restores. Batch 8 (after #1845/47/49/51/52/53/54).

### Async CreateAccount (ACM-class restore fidelity)
`CreateAccount` completes asynchronously (`IN_PROGRESS -> SUCCEEDED` via a spawned tick), so persistence covers it:
- the completion tick persists the flip and the newly-enrolled member account
- on restore, `rearm_in_progress_account_creations()` re-arms the tick for any request restored as `IN_PROGRESS`
- the `/_fakecloud/iam/create-admin` admin endpoint (which auto-enrolls an account into the org root directly, bypassing the request handler) persists through the shared snapshot hook

Changes:
- `OrganizationsSnapshot` versioned envelope wrapping `Option<OrganizationState>` + `ORGANIZATIONS_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook` on `OrganizationsService`
- mutating actions detected by inverse predicate (reads are `Describe*`/`List*`, everything else writes) — verified against the full action list
- server builds the `DiskSnapshotStore`, restores on boot, re-arms in-progress account creations, registers the CFN persist hook

## Test plan

- `cargo test -p fakecloud-e2e --test organizations_persistence` — 2 new restart-recovery E2E tests pass:
  - org + OU + SCP + an async-created member account all round-trip a restart (marker OU after SUCCEEDED forces a durable snapshot)
  - a deleted OU stays deleted while the org persists
- `cargo clippy -p fakecloud-organizations --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Organizations state across restarts in persistent mode. Snapshots cover the org, OUs, policies, tags, and async CreateAccount, and are restored on boot.

- **New Features**
  - Versioned `OrganizationsSnapshot` with schema guard; stored via `DiskSnapshotStore` and loaded at startup.
  - Persist after successful mutations (everything except `Describe*`/`List*` actions).
  - `OrganizationsService`: `with_snapshot_store`, `save_snapshot`, and `snapshot_hook` for CloudFormation and create-admin write-through.
  - Async `CreateAccount`: completion now saves a snapshot; in-progress requests are rearmed on restore.

- **Dependencies**
  - Added `fakecloud-persistence`.

<sup>Written for commit 30c9fd0c14db31f1f246e568d8ad1583ddfb561c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

