### PR TITLE
feat(elbv2): persist load balancers, target groups, listeners across restart

### DIFF
--- a/crates/fakecloud-e2e/tests/elbv2_persistence.rs
+++ b/crates/fakecloud-e2e/tests/elbv2_persistence.rs
@@ -1,0 +1,141 @@
+mod helpers;
+
+use aws_sdk_elasticloadbalancingv2::types::{
+    LoadBalancerTypeEnum, ProtocolEnum, TargetDescription, TargetTypeEnum,
+};
+use helpers::TestServer;
+
+/// Load balancers, target groups, registered targets, and listeners survive a
+/// restart in persistent mode. (Target health is re-derived by the prober.)
+#[tokio::test]
+async fn persistence_round_trip_lb_tg_listener() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let elbv2 = server.elbv2_client().await;
+
+    let lb_arn = elbv2
+        .create_load_balancer()
+        .name("persist-alb")
+        .r#type(LoadBalancerTypeEnum::Application)
+        .send()
+        .await
+        .unwrap()
+        .load_balancers()
+        .first()
+        .unwrap()
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+
+    let tg_arn = elbv2
+        .create_target_group()
+        .name("persist-tg")
+        .protocol(ProtocolEnum::Http)
+        .port(80)
+        .target_type(TargetTypeEnum::Ip)
+        .send()
+        .await
+        .unwrap()
+        .target_groups()
+        .first()
+        .unwrap()
+        .target_group_arn()
+        .unwrap()
+        .to_string();
+
+    elbv2
+        .register_targets()
+        .target_group_arn(&tg_arn)
+        .targets(TargetDescription::builder().id("10.0.0.5").port(80).build())
+        .send()
+        .await
+        .unwrap();
+
+    elbv2
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .protocol(ProtocolEnum::Http)
+        .port(80)
+        .default_actions(
+            aws_sdk_elasticloadbalancingv2::types::Action::builder()
+                .r#type(aws_sdk_elasticloadbalancingv2::types::ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let elbv2 = server.elbv2_client().await;
+
+    // Load balancer survives.
+    let lbs = elbv2
+        .describe_load_balancers()
+        .load_balancer_arns(&lb_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        lbs.load_balancers().first().unwrap().load_balancer_name(),
+        Some("persist-alb")
+    );
+
+    // Target group + registered target survive.
+    let th = elbv2
+        .describe_target_health()
+        .target_group_arn(&tg_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(th
+        .target_health_descriptions()
+        .iter()
+        .any(|d| d.target().and_then(|t| t.id()) == Some("10.0.0.5")));
+
+    // Listener survives.
+    let listeners = elbv2
+        .describe_listeners()
+        .load_balancer_arn(&lb_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(listeners.listeners().len(), 1);
+}
+
+/// A deleted load balancer stays gone after restart.
+#[tokio::test]
+async fn persistence_delete_lb_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let elbv2 = server.elbv2_client().await;
+
+    let lb_arn = elbv2
+        .create_load_balancer()
+        .name("ephemeral-alb")
+        .r#type(LoadBalancerTypeEnum::Application)
+        .send()
+        .await
+        .unwrap()
+        .load_balancers()
+        .first()
+        .unwrap()
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+    elbv2
+        .delete_load_balancer()
+        .load_balancer_arn(&lb_arn)
+        .send()
+        .await
+        .unwrap();
+
+    server.restart().await;
+    let elbv2 = server.elbv2_client().await;
+
+    let lbs = elbv2.describe_load_balancers().send().await.unwrap();
+    assert!(!lbs
+        .load_balancers()
+        .iter()
+        .any(|lb| lb.load_balancer_name() == Some("ephemeral-alb")));
+}

--- a/crates/fakecloud-elbv2/src/lib.rs
+++ b/crates/fakecloud-elbv2/src/lib.rs
@@ -9,8 +9,8 @@ pub const ELBV2_NAMESPACE: &str = "http://elasticloadbalancing.amazonaws.com/doc
 
 pub use service::Elbv2Service;
 pub use state::{
-    Action, AvailabilityZone, Certificate, Elbv2Accounts, FixedResponseConfig, ForwardConfig,
-    Listener, LoadBalancer, LoadBalancerAddress, RedirectConfig, Rule, RuleCondition,
-    SharedElbv2State, Tag, TargetDescription, TargetGroup, TargetGroupTuple, TargetHealth,
-    TrustStore,
+    Action, AvailabilityZone, Certificate, Elbv2Accounts, Elbv2Snapshot, FixedResponseConfig,
+    ForwardConfig, Listener, LoadBalancer, LoadBalancerAddress, RedirectConfig, Rule,
+    RuleCondition, SharedElbv2State, Tag, TargetDescription, TargetGroup, TargetGroupTuple,
+    TargetHealth, TrustStore, ELBV2_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -9,19 +9,31 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 use http::StatusCode;
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::query::{
     optional_query_param, query_metadata_only_xml, query_response_xml, required_query_param,
 };
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use fakecloud_wafv2::SharedWafv2State;
 
-use crate::state::{AvailabilityZone, LoadBalancer, LoadBalancerAddress, SharedElbv2State, Tag};
+use crate::state::{
+    AvailabilityZone, Elbv2Snapshot, LoadBalancer, LoadBalancerAddress, SharedElbv2State, Tag,
+    ELBV2_SNAPSHOT_SCHEMA_VERSION,
+};
 use crate::ELBV2_NAMESPACE;
 
 const NS: &str = ELBV2_NAMESPACE;
+
+/// ELBv2 read actions all start with `Describe` or `Get`; every other action is
+/// a mutation (Create/Delete/Modify/Set/Add/Remove/Register/Deregister). The
+/// inverse formulation guarantees no mutation is ever missed.
+fn is_mutating_action(action: &str) -> bool {
+    !(action.starts_with("Describe") || action.starts_with("Get"))
+}
 
 const ELBV2_SUPPORTED_ACTIONS: &[&str] = &[
     "CreateLoadBalancer",
@@ -94,6 +106,8 @@ pub struct Elbv2Service {
     /// `/_fakecloud/elbv2/waf-counts` admin endpoint can read it.
     waf_count_metrics: Arc<parking_lot::Mutex<std::collections::BTreeMap<String, u64>>>,
     pub region: String,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl Elbv2Service {
@@ -117,6 +131,8 @@ impl Elbv2Service {
             access_logger: parking_lot::Mutex::new(None),
             waf_count_metrics,
             region: "us-east-1".to_string(),
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -132,7 +148,47 @@ impl Elbv2Service {
             access_logger: parking_lot::Mutex::new(None),
             waf_count_metrics: Arc::new(parking_lot::Mutex::new(std::collections::BTreeMap::new())),
             region: "us-east-1".to_string(),
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
+    }
+
+    /// Attach a persistence snapshot store so control-plane mutations are
+    /// written through to disk. Target health is intentionally not persisted --
+    /// the prober re-derives it after a restart.
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        save_elbv2_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current ELBv2 state when invoked, or
+    /// `None` in memory mode. The CloudFormation provisioner mutates `state`
+    /// directly and uses this to write a CFN-provisioned resource through to
+    /// disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_elbv2_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 
     /// Plug in the WAFv2 shared state so the ALB dataplane can resolve
@@ -188,6 +244,37 @@ impl Elbv2Service {
     }
 }
 
+/// Persist the current ELBv2 state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `Elbv2Service::save_snapshot` and the
+/// CloudFormation provisioner persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_elbv2_snapshot(
+    state: &SharedElbv2State,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = Elbv2Snapshot {
+        schema_version: ELBV2_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write elbv2 snapshot"),
+        Err(err) => tracing::error!(%err, "elbv2 snapshot task panicked"),
+    }
+}
+
 #[async_trait]
 impl AwsService for Elbv2Service {
     fn service_name(&self) -> &str {
@@ -195,7 +282,8 @@ impl AwsService for Elbv2Service {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = is_mutating_action(&req.action);
+        let result = match req.action.as_str() {
             "CreateLoadBalancer" => self.create_load_balancer(&req),
             "DescribeLoadBalancers" => self.describe_load_balancers(&req),
             "DeleteLoadBalancer" => self.delete_load_balancer(&req),
@@ -253,7 +341,11 @@ impl AwsService for Elbv2Service {
                 "elasticloadbalancing",
                 &req.action,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 
     fn supported_actions(&self) -> &[&str] {

--- a/crates/fakecloud-elbv2/src/state.rs
+++ b/crates/fakecloud-elbv2/src/state.rs
@@ -7,10 +7,22 @@ use serde::{Deserialize, Serialize};
 
 pub type SharedElbv2State = Arc<RwLock<Elbv2Accounts>>;
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Elbv2Accounts {
     accounts: BTreeMap<String, Elbv2State>,
 }
+
+/// On-disk snapshot envelope for ELBv2 state. Versioned so format changes fail
+/// loudly on upgrade rather than silently mis-parsing. Target health is not
+/// persisted -- the prober re-derives it after a restart.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Elbv2Snapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<Elbv2Accounts>,
+}
+
+pub const ELBV2_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
 
 impl Elbv2Accounts {
     pub fn new() -> Self {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2447,11 +2447,59 @@ async fn main() {
         s3_state.clone(),
     ));
     let elbv2_delivery_bus = Arc::new(DeliveryBus::new().with_s3(s3_delivery_for_elbv2));
-    let elbv2_service = Arc::new(
-        Elbv2Service::new_without_dataplane(elbv2_state.clone())
-            .with_waf_state(wafv2_state.clone())
-            .with_delivery_bus(elbv2_delivery_bus),
-    );
+    let elbv2_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("elbv2").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_elbv2::Elbv2Snapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_elbv2::ELBV2_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "elbv2 persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_elbv2::ELBV2_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                *elbv2_state.write() = accounts;
+                                tracing::info!("loaded elbv2 persistence snapshot");
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse elbv2 persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no elbv2 persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read elbv2 persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut elbv2_inner = Elbv2Service::new_without_dataplane(elbv2_state.clone())
+        .with_waf_state(wafv2_state.clone())
+        .with_delivery_bus(elbv2_delivery_bus);
+    if let Some(store) = elbv2_snapshot_store.clone() {
+        elbv2_inner = elbv2_inner.with_snapshot_store(store);
+    }
+    if let Some(h) = elbv2_inner.snapshot_hook() {
+        cfn_snapshot_hooks.insert("elbv2", h);
+    }
+    let elbv2_service = Arc::new(elbv2_inner);
     elbv2_service.start_dataplane();
     let elbv2_service_for_admin = elbv2_service.clone();
     registry.register(elbv2_service);


### PR DESCRIPTION
## Summary

ELBv2 is the 9th of 11 implemented services that did **not** survive a restart in persistent mode (no `snapshot_hook`). Load balancers, target groups, registered targets, listeners, rules, trust stores, and resource policies now persist and restore. Batch 9 (after #1845/47/49/51/52/53/54/55).

Target **health** is intentionally not persisted — the health prober is re-armed on startup and re-derives it, matching real ELB where health is live runtime state, not durable config.

Changes:
- `Elbv2Snapshot` versioned envelope + `ELBV2_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook` on `Elbv2Service`
- mutating actions detected by inverse predicate (reads are `Describe*`/`Get*`, everything else writes) — verified against the full action list
- server builds the `DiskSnapshotStore`, restores on boot **before** the dataplane spawns, registers the CFN persist hook
- derive `Clone`/`Serialize`/`Deserialize` on `Elbv2Accounts`

## Test plan

- `cargo test -p fakecloud-e2e --test elbv2_persistence` — 2 new restart-recovery E2E tests pass:
  - LB + target group + registered target + listener round-trip a restart
  - a deleted LB stays deleted
- `cargo clippy -p fakecloud-elbv2 --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist ELBv2 resources across restarts in persistent mode, including load balancers, target groups, registered targets, listeners, rules, trust stores, and resource policies. Target health is not persisted and is re-probed on startup.

- **New Features**
  - Added versioned `Elbv2Snapshot` with `ELBV2_SNAPSHOT_SCHEMA_VERSION`.
  - `Elbv2Service` now writes snapshots on successful mutations via `with_snapshot_store`, `save_snapshot`, and `snapshot_hook` (mutations = non-Describe/Get).
  - `fakecloud-server` restores snapshots before the dataplane starts and registers the CFN write-through hook using `DiskSnapshotStore`.
  - Added restart E2E tests; `Elbv2Accounts` now derives `Clone`/`Serialize`/`Deserialize`.

<sup>Written for commit 619939bb603c286efb207e06a554213c29d9a165. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

