### PR TITLE
feat(bedrock-agent): persist agents, flows, knowledge bases across restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,6 +3235,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "serde",

--- a/crates/fakecloud-bedrock-agent/Cargo.toml
+++ b/crates/fakecloud-bedrock-agent/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-bedrock-agent/src/lib.rs
+++ b/crates/fakecloud-bedrock-agent/src/lib.rs
@@ -3,7 +3,7 @@ pub(crate) mod state;
 
 pub use service::BedrockAgentService;
 pub use state::{
-    Agent, AgentAlias, AgentCollaborator, AgentVersion, BedrockAgentAccounts, DataSource, Flow,
-    FlowAlias, FlowVersion, IngestionJob, KnowledgeBase, Prompt, PromptVersion,
-    SharedBedrockAgentState,
+    Agent, AgentAlias, AgentCollaborator, AgentVersion, BedrockAgentAccounts, BedrockAgentSnapshot,
+    DataSource, Flow, FlowAlias, FlowVersion, IngestionJob, KnowledgeBase, Prompt, PromptVersion,
+    SharedBedrockAgentState, BEDROCK_AGENT_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-bedrock-agent/src/service/mod.rs
+++ b/crates/fakecloud-bedrock-agent/src/service/mod.rs
@@ -7,14 +7,23 @@ use fakecloud_aws::arn::Arn;
 use http::{Method, StatusCode};
 use parking_lot::RwLock;
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
     Agent, AgentAlias, AgentCollaborator, AgentKnowledgeBase, AgentVersion, BedrockAgentAccounts,
-    DataSource, Flow, FlowAlias, FlowVersion, IngestionJob, KnowledgeBase, Prompt, PromptVersion,
-    SharedBedrockAgentState,
+    BedrockAgentSnapshot, DataSource, Flow, FlowAlias, FlowVersion, IngestionJob, KnowledgeBase,
+    Prompt, PromptVersion, SharedBedrockAgentState, BEDROCK_AGENT_SNAPSHOT_SCHEMA_VERSION,
 };
+
+/// Bedrock Agent read actions all start with `Get`, `List`, or `Validate`;
+/// every other action is a mutation. The inverse formulation guarantees no
+/// mutation is ever missed.
+fn is_mutating_action(action: &str) -> bool {
+    !(action.starts_with("Get") || action.starts_with("List") || action.starts_with("Validate"))
+}
 
 const SUPPORTED_ACTIONS: &[&str] = &[
     "CreateAgent",
@@ -93,6 +102,8 @@ const SUPPORTED_ACTIONS: &[&str] = &[
 
 pub struct BedrockAgentService {
     state: SharedBedrockAgentState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 mod agents;
@@ -104,11 +115,50 @@ mod tags;
 
 impl BedrockAgentService {
     pub fn new(state: SharedBedrockAgentState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
     }
 
     pub fn shared_state(&self) -> SharedBedrockAgentState {
         Arc::clone(&self.state)
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        save_bedrock_agent_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current Bedrock Agent state when invoked,
+    /// or `None` in memory mode. The CloudFormation provisioner mutates `state`
+    /// directly and uses this to write a CFN-provisioned resource through to
+    /// disk, the same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_bedrock_agent_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 
     fn resolve_action(req: &AwsRequest) -> Option<(&'static str, Vec<(String, String)>)> {
@@ -585,7 +635,8 @@ impl AwsService for BedrockAgentService {
 
         validate_inputs(action, &req)?;
 
-        match action {
+        let mutates = is_mutating_action(action);
+        let result = match action {
             "CreateAgent" => self.create_agent(&req),
             "CreateAgentActionGroup" => self.create_agent_action_group(&req),
             "CreateAgentAlias" => self.create_agent_alias(&req),
@@ -664,7 +715,42 @@ impl AwsService for BedrockAgentService {
                 "bedrock-agent",
                 other,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
+    }
+}
+
+/// Persist the current Bedrock Agent state as a snapshot. Offloads the serde +
+/// blocking file write to the Tokio blocking pool. Noop when `store` is `None`
+/// (memory mode). Shared by `BedrockAgentService::save_snapshot` and the
+/// CloudFormation provisioner persist hook so both route through the same
+/// serialize-and-write path.
+pub async fn save_bedrock_agent_snapshot(
+    state: &SharedBedrockAgentState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = BedrockAgentSnapshot {
+        schema_version: BEDROCK_AGENT_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write bedrock-agent snapshot"),
+        Err(err) => tracing::error!(%err, "bedrock-agent snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-bedrock-agent/src/state.rs
+++ b/crates/fakecloud-bedrock-agent/src/state.rs
@@ -7,10 +7,21 @@ use serde::{Deserialize, Serialize};
 
 pub type SharedBedrockAgentState = Arc<RwLock<BedrockAgentAccounts>>;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct BedrockAgentAccounts {
     pub accounts: BTreeMap<String, BedrockAgentState>,
 }
+
+/// On-disk snapshot envelope for Bedrock Agent state. Versioned so format
+/// changes fail loudly on upgrade rather than silently mis-parsing.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct BedrockAgentSnapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<BedrockAgentAccounts>,
+}
+
+pub const BEDROCK_AGENT_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
 
 impl BedrockAgentAccounts {
     pub fn new() -> Self {
@@ -32,7 +43,7 @@ impl BedrockAgentAccounts {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct BedrockAgentState {
     pub account_id: String,
     pub region: String,

--- a/crates/fakecloud-e2e/tests/bedrock_agent_persistence.rs
+++ b/crates/fakecloud-e2e/tests/bedrock_agent_persistence.rs
@@ -1,0 +1,72 @@
+mod helpers;
+
+use helpers::TestServer;
+
+/// An agent (with its configured fields) survives a restart in persistent mode.
+#[tokio::test]
+async fn persistence_round_trip_agent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let ba = server.bedrock_agent_client().await;
+
+    let agent_id = ba
+        .create_agent()
+        .agent_name("persist-agent")
+        .instruction("Be helpful and concise for testing.")
+        .foundation_model("anthropic.claude-3-5-sonnet-20241022-v2:0")
+        .send()
+        .await
+        .unwrap()
+        .agent()
+        .unwrap()
+        .agent_id()
+        .to_string();
+
+    server.restart().await;
+    let ba = server.bedrock_agent_client().await;
+
+    let agent = ba
+        .get_agent()
+        .agent_id(&agent_id)
+        .send()
+        .await
+        .unwrap()
+        .agent
+        .unwrap();
+    assert_eq!(agent.agent_name(), "persist-agent");
+    assert_eq!(
+        agent.foundation_model(),
+        Some("anthropic.claude-3-5-sonnet-20241022-v2:0")
+    );
+    assert_eq!(
+        agent.instruction(),
+        Some("Be helpful and concise for testing.")
+    );
+}
+
+/// A deleted agent stays gone after restart.
+#[tokio::test]
+async fn persistence_delete_agent_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let ba = server.bedrock_agent_client().await;
+
+    let agent_id = ba
+        .create_agent()
+        .agent_name("ephemeral-agent")
+        .instruction("Temporary agent for testing.")
+        .foundation_model("anthropic.claude-3-5-sonnet-20241022-v2:0")
+        .send()
+        .await
+        .unwrap()
+        .agent()
+        .unwrap()
+        .agent_id()
+        .to_string();
+    ba.delete_agent().agent_id(&agent_id).send().await.unwrap();
+
+    server.restart().await;
+    let ba = server.bedrock_agent_client().await;
+
+    assert!(ba.get_agent().agent_id(&agent_id).send().await.is_err());
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3299,9 +3299,63 @@ async fn main() {
         cfn_snapshot_hooks.insert("bedrock", h);
     }
     registry.register(Arc::new(bedrock_service));
-    registry.register(Arc::new(BedrockAgentService::new(
-        bedrock_agent_state.clone(),
-    )));
+    let bedrock_agent_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("bedrock-agent").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_bedrock_agent::BedrockAgentSnapshot>(
+                        &bytes,
+                    ) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_bedrock_agent::BEDROCK_AGENT_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "bedrock-agent persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_bedrock_agent::BEDROCK_AGENT_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.accounts.len();
+                                *bedrock_agent_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded bedrock-agent persistence snapshot"
+                                );
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse bedrock-agent persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no bedrock-agent persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read bedrock-agent persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut bedrock_agent_service = BedrockAgentService::new(bedrock_agent_state.clone());
+    if let Some(store) = bedrock_agent_snapshot_store.clone() {
+        bedrock_agent_service = bedrock_agent_service.with_snapshot_store(store);
+    }
+    if let Some(h) = bedrock_agent_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("bedrock-agent", h);
+    }
+    registry.register(Arc::new(bedrock_agent_service));
     registry.register(Arc::new(
         BedrockAgentRuntimeService::new(bedrock_agent_runtime_state.clone())
             .with_agent_state(bedrock_agent_state.clone()),


### PR DESCRIPTION
## Summary

Bedrock Agent is the **11th and final** implemented service that did **not** survive a restart in persistent mode (no `snapshot_hook`). Agents (+ action groups, aliases, versions, collaborators, KB associations), data sources, flows (+ aliases, versions), knowledge bases, ingestion jobs, prompts (+ versions), and tags now persist and restore. Batch 10 of the sweep.

The service is fully **synchronous** (no spawned tasks), so a snapshot-on-mutation covers the whole surface.

Changes:
- `BedrockAgentSnapshot` versioned envelope + `BEDROCK_AGENT_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook` on `BedrockAgentService`
- mutating actions detected by inverse predicate (reads are `Get*`/`List*`/`Validate*`, everything else writes) — verified against the full action list
- server builds the `DiskSnapshotStore`, restores on boot, registers the CFN persist hook
- `Clone` on `BedrockAgentAccounts`/`BedrockAgentState`

**This completes the persistence-coverage sweep across all 11 services that previously lacked `snapshot_hook`** (Firehose #1845, ACM #1847, Athena #1849, WAFv2 #1851, Route53 #1852, CloudFront #1853, Glue #1854, Organizations #1855, ELBv2 #1856, and EC2 to follow).

## Test plan

- `cargo test -p fakecloud-e2e --test bedrock_agent_persistence` — 2 new restart-recovery E2E tests pass:
  - an agent (name + foundation model + instruction) round-trips a restart
  - a deleted agent stays deleted
- `cargo clippy -p fakecloud-bedrock-agent --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Bedrock Agent state across restarts in persistent mode. Agents, flows, knowledge bases, prompts, and related resources are saved to disk and restored on startup.

- **New Features**
  - Snapshot-on-mutation in `BedrockAgentService` using `fakecloud-persistence`; adds versioned `BedrockAgentSnapshot` and `BEDROCK_AGENT_SNAPSHOT_SCHEMA_VERSION`.
  - Server restores from `bedrock-agent/snapshot.json` and registers a CFN write-through `snapshot_hook`.
  - Mutations auto-detected (non-Get/List/Validate) and trigger snapshots; service is sync so coverage is complete.
  - E2E restart tests for create round-trip and delete persistence.

- **Dependencies**
  - Add `fakecloud-persistence` to `fakecloud-bedrock-agent`.

<sup>Written for commit c15f81281f313fb001de6da69b4ec4168e10f514. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

