### PR TITLE
feat(ec2): persist VPCs, instances, and network resources across restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,7 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-k8s",
+ "fakecloud-persistence",
  "http 1.4.0",
  "k8s-openapi",
  "kube",

--- a/crates/fakecloud-e2e/tests/ec2_persistence.rs
+++ b/crates/fakecloud-e2e/tests/ec2_persistence.rs
@@ -1,0 +1,141 @@
+mod helpers;
+
+use helpers::TestServer;
+
+/// A VPC, subnet, security group, and instance all survive a restart in
+/// persistent mode. (Metadata-only -- no container runtime in this test.)
+#[tokio::test]
+async fn persistence_round_trip_vpc_subnet_sg_instance() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let ec2 = server.ec2_client().await;
+
+    let vpc_id = ec2
+        .create_vpc()
+        .cidr_block("10.20.0.0/16")
+        .send()
+        .await
+        .unwrap()
+        .vpc
+        .unwrap()
+        .vpc_id
+        .unwrap();
+
+    let subnet_id = ec2
+        .create_subnet()
+        .vpc_id(&vpc_id)
+        .cidr_block("10.20.1.0/24")
+        .send()
+        .await
+        .unwrap()
+        .subnet
+        .unwrap()
+        .subnet_id
+        .unwrap();
+
+    let group_id = ec2
+        .create_security_group()
+        .group_name("persist-sg")
+        .description("persist me")
+        .vpc_id(&vpc_id)
+        .send()
+        .await
+        .unwrap()
+        .group_id
+        .unwrap();
+
+    let instance_id = ec2
+        .run_instances()
+        .image_id("ami-12345678")
+        .min_count(1)
+        .max_count(1)
+        .subnet_id(&subnet_id)
+        .send()
+        .await
+        .unwrap()
+        .instances
+        .unwrap()
+        .first()
+        .unwrap()
+        .instance_id
+        .clone()
+        .unwrap();
+
+    server.restart().await;
+    let ec2 = server.ec2_client().await;
+
+    // VPC survives.
+    assert!(ec2
+        .describe_vpcs()
+        .vpc_ids(&vpc_id)
+        .send()
+        .await
+        .unwrap()
+        .vpcs()
+        .iter()
+        .any(|v| v.vpc_id() == Some(vpc_id.as_str())));
+
+    // Subnet survives.
+    assert!(ec2
+        .describe_subnets()
+        .subnet_ids(&subnet_id)
+        .send()
+        .await
+        .unwrap()
+        .subnets()
+        .iter()
+        .any(|s| s.subnet_id() == Some(subnet_id.as_str())));
+
+    // Security group survives.
+    assert!(ec2
+        .describe_security_groups()
+        .group_ids(&group_id)
+        .send()
+        .await
+        .unwrap()
+        .security_groups()
+        .iter()
+        .any(|g| g.group_id() == Some(group_id.as_str())));
+
+    // Instance survives.
+    let instances = ec2
+        .describe_instances()
+        .instance_ids(&instance_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(instances
+        .reservations()
+        .iter()
+        .flat_map(|r| r.instances())
+        .any(|i| i.instance_id() == Some(instance_id.as_str())));
+}
+
+/// A deleted VPC stays gone after restart.
+#[tokio::test]
+async fn persistence_delete_vpc_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let ec2 = server.ec2_client().await;
+
+    let vpc_id = ec2
+        .create_vpc()
+        .cidr_block("10.30.0.0/16")
+        .send()
+        .await
+        .unwrap()
+        .vpc
+        .unwrap()
+        .vpc_id
+        .unwrap();
+    ec2.delete_vpc().vpc_id(&vpc_id).send().await.unwrap();
+
+    server.restart().await;
+    let ec2 = server.ec2_client().await;
+
+    let vpcs = ec2.describe_vpcs().send().await.unwrap();
+    assert!(!vpcs
+        .vpcs()
+        .iter()
+        .any(|v| v.vpc_id() == Some(vpc_id.as_str())));
+}

--- a/crates/fakecloud-ec2/Cargo.toml
+++ b/crates/fakecloud-ec2/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-k8s = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-ec2/src/lib.rs
+++ b/crates/fakecloud-ec2/src/lib.rs
@@ -15,4 +15,4 @@ pub mod state;
 
 pub use runtime::Ec2Runtime;
 pub use service::Ec2Service;
-pub use state::{Ec2State, SharedEc2State};
+pub use state::{Ec2Snapshot, Ec2State, SharedEc2State, EC2_SNAPSHOT_SCHEMA_VERSION};

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -38,11 +38,25 @@ use http::StatusCode;
 use parking_lot::RwLock;
 use std::sync::Arc;
 
+use tokio::sync::Mutex as AsyncMutex;
+
 use fakecloud_core::multi_account::MultiAccountState;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::SnapshotStore;
 
 use crate::runtime::Ec2Runtime;
-use crate::state::SharedEc2State;
+use crate::state::{Ec2Snapshot, SharedEc2State, EC2_SNAPSHOT_SCHEMA_VERSION};
+
+/// EC2 read actions all start with `Describe`, `Get`, `Search`, or `List`;
+/// every other action mutates state. The inverse formulation guarantees no
+/// mutation is ever missed, and the hot-path reads (Describe*) are excluded so
+/// polling never triggers a snapshot write.
+fn is_mutating_action(action: &str) -> bool {
+    !(action.starts_with("Describe")
+        || action.starts_with("Get")
+        || action.starts_with("Search")
+        || action.starts_with("List"))
+}
 
 /// Every EC2 action this build implements. The conformance audit cross-checks
 /// this list against the handwritten `#[test_action("ec2", …)]` tests, so an
@@ -868,6 +882,8 @@ pub struct Ec2Service {
     /// Optional container runtime backing instances with real containers.
     /// `None` runs the metadata-only control plane (no Docker/Podman/k8s).
     pub(crate) runtime: Option<Arc<Ec2Runtime>>,
+    pub(crate) snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    pub(crate) snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl Ec2Service {
@@ -880,6 +896,8 @@ impl Ec2Service {
                 "",
             ))),
             runtime: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -889,6 +907,8 @@ impl Ec2Service {
         Self {
             state,
             runtime: None,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 
@@ -897,6 +917,44 @@ impl Ec2Service {
     pub fn with_runtime(mut self, runtime: Option<Arc<Ec2Runtime>>) -> Self {
         self.runtime = runtime;
         self
+    }
+
+    /// Attach a persistence snapshot store so control-plane mutations are
+    /// written through to disk. Backing containers are reconciled separately on
+    /// restart via [`Ec2Service::recover_persisted_containers`].
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Persist current state as a snapshot. Held across the
+    /// clone-serialize-write sequence to prevent stale-last writes, with serde
+    /// + file I/O offloaded to the blocking pool.
+    async fn save_snapshot(&self) {
+        save_ec2_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// Build a hook that persists the current EC2 state when invoked, or `None`
+    /// in memory mode. The CloudFormation provisioner mutates `state` directly
+    /// and uses this to write a CFN-provisioned resource through to disk, the
+    /// same way a direct mutating API call would.
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_ec2_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 
     /// Clone the shared state handle so the server can expose read-only
@@ -1095,6 +1153,38 @@ impl Default for Ec2Service {
     }
 }
 
+/// Persist the current EC2 state as a snapshot. Offloads the serde + blocking
+/// file write to the Tokio blocking pool. Noop when `store` is `None` (memory
+/// mode). Shared by `Ec2Service::save_snapshot` and the CloudFormation
+/// provisioner persist hook so both route through the same serialize-and-write
+/// path. Backing containers are not serialized; they are reconciled on restart
+/// via `Ec2Service::recover_persisted_containers`.
+pub async fn save_ec2_snapshot(
+    state: &SharedEc2State,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = Ec2Snapshot {
+        schema_version: EC2_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write ec2 snapshot"),
+        Err(err) => tracing::error!(%err, "ec2 snapshot task panicked"),
+    }
+}
+
 #[async_trait]
 impl AwsService for Ec2Service {
     fn service_name(&self) -> &str {
@@ -1106,7 +1196,8 @@ impl AwsService for Ec2Service {
     }
 
     async fn handle(&self, request: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match request.action.as_str() {
+        let mutates = is_mutating_action(&request.action);
+        let result = match request.action.as_str() {
             "CreateTags" => tags::create_tags(self, &request),
             "DeleteTags" => tags::delete_tags(self, &request),
             "DescribeTags" => tags::describe_tags(self, &request),
@@ -2518,7 +2609,11 @@ impl AwsService for Ec2Service {
                 "InvalidAction",
                 format!("The action {other} is not valid for this web service."),
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 }
 

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -14,6 +14,19 @@ use serde::{Deserialize, Serialize};
 /// Shared, account-partitioned EC2 state handle.
 pub type SharedEc2State = Arc<RwLock<fakecloud_core::multi_account::MultiAccountState<Ec2State>>>;
 
+/// On-disk snapshot envelope for EC2 state. Versioned so format changes fail
+/// loudly on upgrade rather than silently mis-parsing. Backing containers are
+/// not serialized -- on restore the server reconciles them via
+/// `Ec2Service::recover_persisted_containers`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ec2Snapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<fakecloud_core::multi_account::MultiAccountState<Ec2State>>,
+}
+
+pub const EC2_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
 impl fakecloud_core::multi_account::AccountState for Ec2State {
     fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
         Self::new(account_id, region)

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1680,7 +1680,60 @@ async fn main() {
     // runtime (Docker/Podman); persistence is wired in later batches. We keep a
     // clone of the shared state so the introspection router can expose
     // `GET /_fakecloud/ec2/instances`.
-    let ec2_service = Ec2Service::with_state(ec2_state.clone()).with_runtime(ec2_runtime.clone());
+    let ec2_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("ec2").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_ec2::Ec2Snapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version > fakecloud_ec2::EC2_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "ec2 persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_ec2::EC2_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *ec2_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded ec2 persistence snapshot"
+                                );
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse ec2 persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no ec2 persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read ec2 persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut ec2_service =
+        Ec2Service::with_state(ec2_state.clone()).with_runtime(ec2_runtime.clone());
+    if let Some(store) = ec2_snapshot_store.clone() {
+        ec2_service = ec2_service.with_snapshot_store(store);
+    }
+    if let Some(h) = ec2_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("ec2", h);
+    }
     let ec2_introspection_state = ec2_state.clone();
     // Separate clones for the instance-networks introspection endpoint (#1745),
     // which also needs the runtime to report the isolation backend + SG


### PR DESCRIPTION
## Summary

EC2 is the **11th and final** implemented service that did **not** survive a restart in persistent mode (no `snapshot_hook`). The full account-partitioned control plane — VPCs, subnets, security groups, instances, ENIs, volumes, route tables, IGW/NAT GW, NACLs, EIPs, endpoints, transit gateways, IPAM, and the rest — now persists and restores. This **completes persistence coverage across all 41 implemented services**.

### Container reconcile (issue #1338 class) — already wired
Backing containers are **not** serialized. On restart the server already calls `recover_persisted_containers()`, which flips persisted `running`/`pending` instances to `pending` and respawns fresh containers (the prior process's were removed by the PID-scoped reaper). This batch simply provides the persisted state for that existing reconcile path to act on, mirroring RDS/ElastiCache.

### Mutation detection
EC2's action surface is huge (767 ops). Reads are `Describe*`/`Get*`/`Search*`/`List*`; everything else mutates (inverse predicate). Crucially the hot-path reads (`DescribeInstances` etc., polled constantly) are `Describe*` and so are **excluded** — polling never triggers a snapshot write.

Changes:
- `Ec2Snapshot` versioned envelope over `MultiAccountState<Ec2State>` + `EC2_SNAPSHOT_SCHEMA_VERSION`
- `with_snapshot_store` / `save_snapshot` / `snapshot_hook` on `Ec2Service`
- server builds the `DiskSnapshotStore`, restores on boot **before** the existing `recover_persisted_containers()` call, registers the CFN persist hook

## Test plan

- `cargo test -p fakecloud-e2e --test ec2_persistence` — 2 new restart-recovery E2E tests pass:
  - VPC + subnet + security group + instance round-trip a restart
  - a deleted VPC stays deleted
- `cargo clippy -p fakecloud-ec2 --all-targets -- -D warnings` clean
- `cargo build -p fakecloud` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist EC2 control-plane state across restarts in persistent mode. VPCs, subnets, security groups, instances, and related network resources now survive server restarts; containers are reconciled on boot.

- **New Features**
  - Write EC2 state to disk via `fakecloud-persistence` and restore it on startup before container reconcile.
  - Snapshot only on mutations; `Describe*`/`Get*`/`Search*`/`List*` reads are excluded to avoid hot-path writes.
  - Add `Ec2Snapshot` (versioned) and `with_snapshot_store`/`save_snapshot`/`snapshot_hook` on `Ec2Service`; server wires `ec2/snapshot.json` and registers the CFN hook.
  - Add E2E tests: VPC/subnet/SG/instance round-trip across restart, and deleted VPC stays deleted.

<sup>Written for commit 803424457516166d6e25e2e0ef632374766507df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

