### PR TITLE
docs(persistence): document the newly-persisted services

### DIFF
--- a/website/content/docs/reference/persistence.md
+++ b/website/content/docs/reference/persistence.md
@@ -22,6 +22,8 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 
 ## What's persisted
 
+Every implemented service persists its control-plane state in this mode — a snapshot is written to disk on every mutation and reloaded on startup. The highlights below note what each captures.
+
 - **S3** — buckets, objects, versions, delete markers, multipart uploads (resumable across restarts), and every bucket subresource: tags, lifecycle, CORS, policy, notification, logging, website, public access block, object lock, replication, ownership, inventory, encryption, ACL, accelerate. Written to disk on every mutation and reloaded on startup.
 - **SQS** — queues, attributes, tags, in-flight and delayed messages.
 - **SNS** — topics, subscriptions, attributes, tags, platform applications and endpoints, SMS settings.
@@ -42,6 +44,18 @@ FAKECLOUD_STORAGE_MODE=persistent FAKECLOUD_DATA_PATH=/var/lib/fakecloud fakeclo
 - **RDS** — DB instances (configuration, credentials, tags), DB snapshots (including dump data), subnet groups, parameter groups.
 - **ElastiCache** — cache clusters, replication groups, global replication groups, subnet groups, parameter groups, users, user groups, snapshots, serverless caches and snapshots, reserved cache nodes, tags.
 - **Bedrock** — guardrails, guardrail versions, customization jobs, provisioned throughputs, logging config, async invocations, custom models, deployments, model import/copy/invocation jobs, evaluation jobs, inference profiles, prompt routers, resource policies, marketplace endpoints, foundation model agreements, automated reasoning policies/test cases/workflows, tags. The `/_fakecloud/bedrock/invocations` introspection buffer and simulation config (custom responses, response rules, fault rules) reset on restart.
+- **Bedrock Agent** — agents (action groups, aliases, versions, collaborators, knowledge-base associations), data sources, flows (aliases, versions), knowledge bases, ingestion jobs, prompts and prompt versions, tags.
+- **EC2** — VPCs, subnets, security groups, instances, ENIs, EBS volumes, route tables, internet/NAT gateways, NACLs, Elastic IPs, VPC endpoints, transit gateways, IPAM, and the rest of the account-partitioned control plane. Backing instance containers are reconciled on restart: a persisted `running`/`pending` instance is flipped to `pending` and a fresh container is respawned (the prior process's was removed by the reaper).
+- **Route 53** — hosted zones, record sets, health checks, traffic policies and versions, traffic policy instances, DNSSEC status, key signing keys, query-logging configs, CIDR collections, reusable delegation sets, VPC authorizations, tags.
+- **CloudFront** — distributions, invalidations, origin access controls/identities, cache / origin-request / response-headers / continuous-deployment policies, functions, public keys, key groups, key value stores, field-level encryption, realtime log configs, VPC origins, anycast IP lists, trust stores, resource policies, streaming distributions, connection groups, distribution tenants, tags. A distribution left `InProgress` at shutdown resumes its deploy and reaches `Deployed` after restart.
+- **ELBv2** — load balancers, target groups, registered targets, listeners, rules, trust stores, resource policies. Target health is not persisted; the health prober re-derives it on startup.
+- **WAF v2** — web ACLs, rule groups, IP sets, regex pattern sets, logging configs, permission policies, web-ACL associations, API keys, managed rule sets, tags. Data-plane sampled-request telemetry resets on restart.
+- **ACM** — certificates (status, domains, validation, chains), tags, account config. A certificate left `PENDING_VALIDATION` (DNS) resumes auto-issue and reaches `ISSUED` after restart.
+- **Glue** — databases, tables, partitions, jobs and job runs, crawlers, classifiers, connections, triggers, workflows, blueprints, schemas, security configs, sessions, and the rest of the Data Catalog.
+- **Athena** — workgroups, data catalogs, named queries, prepared statements, query executions, notebooks, sessions, calculations, capacity reservations, tags.
+- **Firehose** — delivery streams, destinations, tags, and server-side encryption config.
+- **Organizations** — the organization, OUs, member accounts, service control policies and attachments, handshakes, enabled service access, delegated administrators, responsibility transfers, tags. A `CreateAccount` request left `IN_PROGRESS` resumes and reaches `SUCCEEDED` after restart.
+- **Everything else** — API Gateway v1, ECR, ECS, EventBridge Scheduler, CloudWatch (alarms and dashboards), Application Auto Scaling, and Cognito Identity likewise persist their full control-plane state.
 
 ## Version compatibility
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -93,7 +93,8 @@ CloudWatch Logs, CloudWatch (Metrics & Alarms), KMS, CloudFormation, SES,
 Cognito User Pools, Cognito Identity, Kinesis, Firehose, RDS, ElastiCache,
 Step Functions, API Gateway v1, API Gateway v2, Bedrock, Bedrock Agent,
 Bedrock Agent Runtime, Bedrock Runtime, ECR, ECS, Elastic Load Balancing v2,
-CloudFront, Route 53, WAF v2, Application Auto Scaling, Athena, ACM, and Glue. State is
+CloudFront, Route 53, WAF v2, Application Auto Scaling, Athena, ACM, Glue,
+EC2, and Organizations. State is
 written to disk on every mutation and reloaded on startup.
 
 The data directory is guarded by `fakecloud.version.toml`. A format mismatch


### PR DESCRIPTION
## Summary

Follow-up doc-sync for the persistence-coverage sweep (#1845–#1858), which made the 11 remaining services survive restart. The reference doc's "What's persisted" list still enumerated only the original ~20 services, and the `llms-full.txt` "All 41 persisted" line omitted two services from its enumeration.

- **`persistence.md`** — lead with the fact that every implemented service persists, then add per-service highlights for **Bedrock Agent, EC2, Route 53, CloudFront, ELBv2, WAF v2, ACM, Glue, Athena, Firehose, and Organizations** (including the async-transition resume notes for ACM/CloudFront/Organizations and the EC2 container-reconcile behavior), plus a catch-all bullet for API Gateway v1, ECR, ECS, EventBridge Scheduler, CloudWatch, Application Auto Scaling, and Cognito Identity.
- **`llms-full.txt`** — the "All 41 services are fully persisted" sentence listed ~39 services; **EC2** and **Organizations** were missing. Added.

## Not changed (intentional)

- **SDKs** — the persistence feature adds **no `/_fakecloud/*` introspection endpoint**; it's a behavioral property observable through the normal AWS Describe/Get APIs after a restart. The introspection SDKs wrap `/_fakecloud/*`, so nothing to add. (A persistence-status endpoint would be a separate feature, not doc-sync — and persistence config is static, low test value vs the real round-trip assertion the E2Es already do.)
- **README** — already links to the persistence reference page; no per-service claim to update. Left as-is (recently trimmed; not re-bloating).
- **parity.md** — its per-service persistence prose is pre-existing and concerns non-swept services; out of scope.

## Test plan

- `scripts/check-doc-counts.sh` passes (no count gate touched).
- Docs-only change; no Rust modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the persistence docs to state that all implemented services persist and added highlights for the 11 newly covered services, including resume/reconcile notes where relevant. Fixed the "All 41 services" list in `llms-full.txt` by adding EC2 and Organizations.

<sup>Written for commit 91416d5d8c4938079769218889ad16f6054be5a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

