### PR TITLE
feat(tfacc): widen events and kinesis to all _basic resource types

### DIFF
--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -411,7 +411,17 @@ impl EventBridgeService {
         let (page, next_token) = paginate(&filtered, body["NextToken"].as_str(), limit);
         let buses: Vec<Value> = page
             .iter()
-            .map(|b| json!({ "Name": b.name, "Arn": b.arn }))
+            .map(|b| {
+                // Mirror DescribeEventBus: ListEventBuses also reports the
+                // bus creation/last-modified times, which the Terraform
+                // aws_cloudwatch_event_buses data source expects to be set.
+                json!({
+                    "Name": b.name,
+                    "Arn": b.arn,
+                    "CreationTime": b.creation_time.timestamp() as f64,
+                    "LastModifiedTime": b.last_modified_time.timestamp() as f64,
+                })
+            })
             .collect();
         let mut resp = json!({ "EventBuses": buses });
         if let Some(token) = next_token {
@@ -510,10 +520,18 @@ impl EventBridgeService {
         // PolicyLengthExceededException, ConcurrentModificationException,
         // OperationDisabledException, and InternalException. We accept any
         // action string and just record the statement.
+        // A `*` principal means "any account" and is stored verbatim, not as
+        // an account-root ARN. The Terraform aws_cloudwatch_event_permission
+        // resource reads the principal back and asserts it is exactly "*".
+        let principal_value = if principal == "*" {
+            json!("*")
+        } else {
+            json!({ "AWS": Arn::global("iam", principal, "root").to_string() })
+        };
         let statement = json!({
             "Sid": statement_id,
             "Effect": "Allow",
-            "Principal": { "AWS": Arn::global("iam", principal, "root").to_string() },
+            "Principal": principal_value,
             "Action": action,
             "Resource": bus.arn,
         });
@@ -526,6 +544,10 @@ impl EventBridgeService {
         });
 
         if let Some(stmts) = policy["Statement"].as_array_mut() {
+            // PutPermission with an existing StatementId replaces that
+            // statement (e.g. changing its principal), it does not stack a
+            // second one. Drop any prior statement with the same Sid first.
+            stmts.retain(|s| s["Sid"].as_str() != Some(statement_id));
             stmts.push(statement);
         }
 

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -3381,3 +3381,76 @@ async fn snapshot_hook_fires_with_store() {
     // Must not panic; exercises the closure and the snapshot save path.
     hook().await;
 }
+
+#[test]
+fn put_permission_star_principal_stored_verbatim() {
+    // A `*` principal means "any account" and must be stored as "*", not an
+    // account-root ARN. The Terraform aws_cloudwatch_event_permission resource
+    // reads it back and asserts principal == "*".
+    let svc = make_service();
+    svc.put_permission(&make_request(
+        "PutPermission",
+        json!({ "Action": "events:PutEvents", "Principal": "*", "StatementId": "s1" }),
+    ))
+    .unwrap();
+    let resp = svc
+        .describe_event_bus(&make_request(
+            "DescribeEventBus",
+            json!({ "Name": "default" }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let policy = body["Policy"].as_str().unwrap();
+    assert!(
+        policy.contains("\"Principal\":\"*\""),
+        "star principal should be stored verbatim, got {policy}"
+    );
+}
+
+#[test]
+fn put_permission_same_statement_id_replaces() {
+    // PutPermission with an existing StatementId replaces that statement (e.g.
+    // changing its principal) rather than stacking a duplicate.
+    let svc = make_service();
+    svc.put_permission(&make_request(
+        "PutPermission",
+        json!({ "Action": "events:PutEvents", "Principal": "111111111111", "StatementId": "s1" }),
+    ))
+    .unwrap();
+    svc.put_permission(&make_request(
+        "PutPermission",
+        json!({ "Action": "events:PutEvents", "Principal": "*", "StatementId": "s1" }),
+    ))
+    .unwrap();
+    let resp = svc
+        .describe_event_bus(&make_request(
+            "DescribeEventBus",
+            json!({ "Name": "default" }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let policy: Value = serde_json::from_str(body["Policy"].as_str().unwrap()).unwrap();
+    let stmts = policy["Statement"].as_array().unwrap();
+    assert_eq!(
+        stmts.len(),
+        1,
+        "duplicate Sid should be replaced, not stacked"
+    );
+    assert_eq!(stmts[0]["Principal"], json!("*"));
+}
+
+#[test]
+fn list_event_buses_includes_creation_time() {
+    // The aws_cloudwatch_event_buses data source expects each bus to report a
+    // creation time; ListEventBuses must surface it like DescribeEventBus.
+    let svc = make_service();
+    let resp = svc
+        .list_event_buses(&make_request("ListEventBuses", json!({})))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let first = &body["EventBuses"][0];
+    assert!(
+        first["CreationTime"].is_number(),
+        "ListEventBuses entry should carry CreationTime, got {first}"
+    );
+}

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -255,6 +255,19 @@ impl KinesisService {
             ));
         }
 
+        // CreateStream accepts an initial Tags map. Terraform's
+        // aws_kinesis_stream sets tags at create time and treats a missing tag
+        // on the next read as drift, so they must be persisted here rather than
+        // dropped (callers can still AddTagsToStream later).
+        let tags: std::collections::BTreeMap<String, String> = body["Tags"]
+            .as_object()
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let stream = KinesisStream {
             stream_name: stream_name.to_string(),
             stream_arn: state.stream_arn(stream_name),
@@ -266,7 +279,7 @@ impl KinesisService {
             key_id: None,
             shard_count: effective_shard_count,
             open_shard_count: effective_shard_count,
-            tags: std::collections::BTreeMap::new(),
+            tags,
             shards: build_stream_shards(effective_shard_count),
             next_shard_index: effective_shard_count,
             enhanced_metrics: Vec::new(),
@@ -325,10 +338,21 @@ impl KinesisService {
             .filter(|c| c.stream_arn == stream.stream_arn)
             .count();
 
+        // StreamDescriptionSummary carries EnhancedMonitoring just like the
+        // full DescribeStream output. The Terraform aws_kinesis_stream data
+        // source reads `shard_level_metrics` from here (it calls
+        // DescribeStreamSummary), so it must be present.
+        let enhanced_monitoring = if stream.enhanced_metrics.is_empty() {
+            json!([{ "ShardLevelMetrics": Vec::<String>::new() }])
+        } else {
+            json!([{ "ShardLevelMetrics": stream.enhanced_metrics }])
+        };
+
         Ok(AwsResponse::ok_json(json!({
             "StreamDescriptionSummary": {
                 "ConsumerCount": consumer_count,
                 "EncryptionType": stream.encryption_type,
+                "EnhancedMonitoring": enhanced_monitoring,
                 "KeyId": stream.key_id.as_deref().unwrap_or_default(),
                 "OpenShardCount": stream.open_shard_count,
                 "RetentionPeriodHours": stream.retention_period_hours,

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -366,6 +366,12 @@ fn describe_stream_summary_counts_consumers() {
     let body = json_response(resp);
     assert_eq!(body["StreamDescriptionSummary"]["ConsumerCount"], json!(0));
     assert_eq!(body["StreamDescriptionSummary"]["OpenShardCount"], json!(1));
+    // EnhancedMonitoring must be present so the aws_kinesis_stream data source
+    // (which reads DescribeStreamSummary) can populate shard_level_metrics.
+    assert_eq!(
+        body["StreamDescriptionSummary"]["EnhancedMonitoring"][0]["ShardLevelMetrics"],
+        json!([])
+    );
 }
 
 #[test]
@@ -1911,4 +1917,29 @@ async fn snapshot_hook_fires_with_store() {
         .expect("hook present when a store is set");
     // Must not panic; exercises the closure and the snapshot save path.
     hook().await;
+}
+
+#[test]
+fn create_stream_persists_initial_tags() {
+    // CreateStream accepts an initial Tags map; Terraform's aws_kinesis_stream
+    // sets tags at create and treats a missing tag on the next read as drift.
+    let (svc, _) = make_service();
+    svc.create_stream(&request(
+        "CreateStream",
+        json!({ "StreamName": "tagged", "ShardCount": 1, "Tags": { "Name": "tagged" } }),
+    ))
+    .unwrap();
+    let resp = svc
+        .list_tags_for_stream(&request(
+            "ListTagsForStream",
+            json!({ "StreamName": "tagged" }),
+        ))
+        .unwrap();
+    let body = json_response(resp);
+    let tags = body["Tags"].as_array().unwrap();
+    assert!(
+        tags.iter()
+            .any(|t| t["Key"] == "Name" && t["Value"] == "tagged"),
+        "initial CreateStream tags should persist, got {body}"
+    );
 }

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -109,13 +109,18 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "kinesis",
-        // Batch 8: core `aws_kinesis_stream` smoke. The fix here is
-        // making `IncreaseStreamRetentionPeriod` accept same-value as a
-        // no-op — real AWS does this despite what the API docs say,
-        // and the upstream provider unconditionally calls it with the
-        // default 24h on every create.
-        run_regex: "^TestAccKinesisStream_basic$",
-        deny: &[],
+        // Batch 8 + widen: `_basic` smoke for the Kinesis stream resources and
+        // data sources. The widen batch added EnhancedMonitoring to
+        // DescribeStreamSummary (so the data source reads `shard_level_metrics`)
+        // and made CreateStream persist its initial Tags.
+        run_regex: "^TestAccKinesis[A-Za-z]+_basic$",
+        deny: &[
+            // --- gap: the data source asserts a closed-shard count produced by
+            //     a split/merge sequence; fakecloud's shard-lineage accounting
+            //     closes fewer shards than real Kinesis (4 expected, 2 closed),
+            //     which needs fuller split/merge parent-shard tracking. ---
+            "TestAccKinesisStreamDataSource_basic",
+        ],
     },
     Service {
         name: "sns",
@@ -129,13 +134,19 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "events",
-        // Batch 7: core EventBridge `aws_cloudwatch_event_bus` and
-        // `aws_cloudwatch_event_rule` smokes. Both pass out of the box.
-        // Note: the upstream service directory is `events`, not
-        // `eventbridge` — Terraform uses the legacy CloudWatch Events
-        // naming.
-        run_regex: "^TestAccEvents(Bus|Rule)_basic$",
-        deny: &[],
+        // Batch 7 + widen: `_basic` smoke for the EventBridge resources and
+        // data sources — event bus (+ buses data source), rule, target,
+        // permission, connection, API destination, archive, and more. The
+        // widen batch fixed PutPermission's `*` principal (stored verbatim,
+        // not as an account-root ARN) and added CreationTime/LastModifiedTime
+        // to ListEventBuses. Note: the upstream service directory is `events`,
+        // not `eventbridge` — Terraform uses the legacy CloudWatch Events name.
+        run_regex: "^TestAccEvents[A-Za-z]+_basic$",
+        deny: &[
+            // --- gap: EventBridge global endpoints need multi-region event
+            //     replication / failover, which fakecloud does not model. ---
+            "TestAccEventsEndpoint_basic",
+        ],
     },
     Service {
         name: "kms",
@@ -335,7 +346,7 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "kinesis",
         service: "kinesis",
-        run_regex: "^TestAccKinesisStream_basic$",
+        run_regex: "^TestAccKinesis[A-Za-z]+_basic$",
         extra_deny: &[],
     },
     Shard {
@@ -347,7 +358,7 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "events",
         service: "events",
-        run_regex: "^TestAccEvents(Bus|Rule)_basic$",
+        run_regex: "^TestAccEvents[A-Za-z]+_basic$",
         extra_deny: &[],
     },
     Shard {


### PR DESCRIPTION
## Summary

Widens the `events` (EventBridge) and `kinesis` tfacc shards to the `_basic` suite across their resources and data sources.

- **events** -> bus, buses data source, rule, target, permission, connection, API destination, archive, ... (10 tests)
- **kinesis** -> stream resources + data sources (3 tests)

Four real fakecloud fixes:
- **EventBridge PutPermission**: stores a `*` principal verbatim (not an account-root ARN), and **replaces** an existing statement when the same `StatementId` is re-used instead of stacking a duplicate (the permission test changes a statement's principal in place).
- **ListEventBuses**: reports `CreationTime`/`LastModifiedTime` like `DescribeEventBus` (the `aws_cloudwatch_event_buses` data source expects it).
- **Kinesis DescribeStreamSummary**: includes `EnhancedMonitoring`, so the `aws_kinesis_stream` data source reads `shard_level_metrics`.
- **Kinesis CreateStream**: persists its initial `Tags` map instead of dropping it.

Denied with honest reasons: `TestAccKinesisStreamDataSource_basic` (**gap** — asserts a closed-shard count from a split/merge sequence needing fuller shard-lineage accounting); `TestAccEventsEndpoint_basic` (**gap** — global endpoints need multi-region failover).

## Test plan
- New unit tests: PutPermission `*`-principal + same-Sid replace, ListEventBuses CreationTime, DescribeStreamSummary EnhancedMonitoring, CreateStream tags.
- `cargo clippy` on eventbridge/kinesis/tfacc: clean.
- Widened shards vs terraform-provider-aws v5.97.0: **events 10/10, kinesis 3/3**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands `fakecloud-tfacc` shards for EventBridge and Kinesis to run all `_basic` resources/data sources, and fixes `fakecloud` behavior to match Terraform. Verified passing vs `terraform-provider-aws` v5.97.0: events 10/10, kinesis 3/3.

- **New Features**
  - EventBridge: run `^TestAccEvents[A-Za-z]+_basic$` (bus, buses data source, rule, target, permission, connection, API destination, archive).
  - Kinesis: run `^TestAccKinesis[A-Za-z]+_basic$` (stream resources and data sources).
  - Deny for known gaps: `TestAccKinesisStreamDataSource_basic` (closed-shard lineage), `TestAccEventsEndpoint_basic` (global endpoint failover).

- **Bug Fixes**
  - EventBridge PutPermission: store `"*"` principal verbatim; replace existing statement on same `StatementId`.
  - ListEventBuses: add `CreationTime` and `LastModifiedTime`.
  - Kinesis DescribeStreamSummary: include `EnhancedMonitoring` for `shard_level_metrics`.
  - Kinesis CreateStream: persist initial `Tags`.

<sup>Written for commit 94cbb8f14abcee0b47c2c8f1f7037abf0cd1b73c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

