### PR TITLE
feat(ec2): durable instance data volumes surviving fakecloud restart

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -77,6 +77,11 @@ jobs:
       # there is no fixed upgrade path because rsa upstream has not released a
       # constant-time fix yet. The same advisory is the standard escape hatch
       # for any project that needs RSA in pure Rust today.
+      #
+      # RUSTSEC-2026-0185 (backoff is unmaintained) reaches us only transitively
+      # through kube-runtime's retry/backoff timers. It is an unmaintained-crate
+      # advisory, not an exploitable vulnerability; backoff computes retry delays
+      # and handles no untrusted input. No action until kube drops the dependency.
       - run: |
           cargo audit \
             --ignore RUSTSEC-2026-0098 \
@@ -84,4 +89,5 @@ jobs:
             --ignore RUSTSEC-2026-0104 \
             --ignore RUSTSEC-2026-0002 \
             --ignore RUSTSEC-2026-0097 \
-            --ignore RUSTSEC-2023-0071
+            --ignore RUSTSEC-2023-0071 \
+            --ignore RUSTSEC-2026-0185

--- a/crates/fakecloud-e2e/tests/ec2_volume_durability.rs
+++ b/crates/fakecloud-e2e/tests/ec2_volume_durability.rs
@@ -1,0 +1,165 @@
+//! EC2 instance data-plane durability E2E: with `FAKECLOUD_PERSIST_EC2_VOLUMES`
+//! enabled, a file an instance writes under the durable data directory
+//! survives a fakecloud restart -- the recovery path recreates the backing
+//! container and reattaches the same named volume, so the bytes come back
+//! (EBS-root-volume-style persistence for the instance's persistent data dir).
+//! Distinct from `ec2_persistence.rs`, which covers control-plane metadata
+//! only with no container runtime.
+
+mod helpers;
+
+use helpers::TestServer;
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("Skipping {test}: docker not available");
+    false
+}
+
+fn docker(args: &[&str]) -> String {
+    let out = std::process::Command::new("docker")
+        .args(args)
+        .output()
+        .expect("spawn docker");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// The container id backing an instance, via the `fakecloud-ec2=<id>` label.
+fn container_for(instance_id: &str) -> String {
+    docker(&[
+        "ps",
+        "-aq",
+        "--filter",
+        &format!("label=fakecloud-ec2={instance_id}"),
+    ])
+}
+
+/// Poll DescribeInstances until the instance is `running` and backed by a real
+/// container, returning that container id. Panics if it never comes up.
+async fn wait_running_container(c: &aws_sdk_ec2::Client, instance_id: &str) -> String {
+    for _ in 0..80 {
+        let d = c
+            .describe_instances()
+            .instance_ids(instance_id)
+            .send()
+            .await
+            .unwrap();
+        let running = d
+            .reservations()
+            .iter()
+            .flat_map(|r| r.instances())
+            .find(|i| i.instance_id() == Some(instance_id))
+            .and_then(|i| i.state())
+            .and_then(|s| s.name())
+            .map(|n| n.as_str())
+            == Some("running");
+        if running {
+            let container = container_for(instance_id);
+            if !container.is_empty() {
+                return container;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    panic!("instance {instance_id} never reached running with a backing container");
+}
+
+#[tokio::test]
+async fn instance_data_survives_fakecloud_restart() {
+    let test = "instance_data_survives_fakecloud_restart";
+    if !require_docker_or_skip(test) {
+        return;
+    }
+    // Tiny base image keeps the test fast; `tail -f /dev/null` keeps it alive.
+    std::env::set_var("FAKECLOUD_EC2_DEFAULT_IMAGE", "alpine:3");
+    // Turn on durable instance volumes for this run.
+    std::env::set_var("FAKECLOUD_PERSIST_EC2_VOLUMES", "1");
+
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let c = server.ec2_client().await;
+
+    let instance_id = c
+        .run_instances()
+        .image_id("ami-12345678")
+        .min_count(1)
+        .max_count(1)
+        .send()
+        .await
+        .unwrap()
+        .instances
+        .unwrap()
+        .first()
+        .unwrap()
+        .instance_id
+        .clone()
+        .unwrap();
+
+    let container = wait_running_container(&c, &instance_id).await;
+
+    // Write a marker into the durable data dir (matches the runtime default
+    // FAKECLOUD_EC2_INSTANCE_DATA_DIR=/var/lib/fakecloud/ec2). The named volume
+    // is mounted there, so this byte should outlive the container.
+    let write = docker(&[
+        "exec",
+        &container,
+        "sh",
+        "-c",
+        "mkdir -p /var/lib/fakecloud/ec2 && echo persisted-marker > /var/lib/fakecloud/ec2/marker && cat /var/lib/fakecloud/ec2/marker",
+    ]);
+    assert_eq!(write, "persisted-marker", "marker should be written");
+
+    // Restart fakecloud against the same data path. The EC2 recovery path
+    // recreates the backing container, reattaching the same named volume.
+    server.restart().await;
+    let c = server.ec2_client().await;
+
+    let recovered = wait_running_container(&c, &instance_id).await;
+    // A fresh container backs the recovered instance...
+    assert_ne!(
+        recovered, container,
+        "restart should recreate the backing container"
+    );
+
+    // ...but the durable volume re-attaches, so the marker is still there.
+    let mut marker = String::new();
+    for _ in 0..40 {
+        marker = docker(&["exec", &recovered, "cat", "/var/lib/fakecloud/ec2/marker"]);
+        if marker == "persisted-marker" {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    assert_eq!(
+        marker, "persisted-marker",
+        "instance data dir should survive a fakecloud restart via the durable volume"
+    );
+
+    // TerminateInstances drops the container and its durable volume.
+    c.terminate_instances()
+        .instance_ids(&instance_id)
+        .send()
+        .await
+        .unwrap();
+    for _ in 0..40 {
+        if container_for(&instance_id).is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+}

--- a/crates/fakecloud-e2e/tests/ec2_volume_durability.rs
+++ b/crates/fakecloud-e2e/tests/ec2_volume_durability.rs
@@ -85,13 +85,24 @@ async fn instance_data_survives_fakecloud_restart() {
     if !require_docker_or_skip(test) {
         return;
     }
-    // Tiny base image keeps the test fast; `tail -f /dev/null` keeps it alive.
-    std::env::set_var("FAKECLOUD_EC2_DEFAULT_IMAGE", "alpine:3");
-    // Turn on durable instance volumes for this run.
-    std::env::set_var("FAKECLOUD_PERSIST_EC2_VOLUMES", "1");
 
+    // Persistent mode with a REAL container CLI: `start_persistent` forces
+    // FAKECLOUD_CONTAINER_CLI=false (metadata-only), which would never spawn a
+    // backing container, so build the persistent server directly and let it
+    // detect docker. The env vars go through `start_full` so `restart()`
+    // re-applies them to the respawned server. A tiny base image keeps the
+    // test fast; `tail -f /dev/null` keeps it alive. `FAKECLOUD_PERSIST_EC2_VOLUMES`
+    // turns on the durable instance volume under test.
     let tmp = tempfile::tempdir().unwrap();
-    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let data_path = tmp.path().display().to_string();
+    let mut server = TestServer::start_full(
+        &[
+            ("FAKECLOUD_EC2_DEFAULT_IMAGE", "alpine:3"),
+            ("FAKECLOUD_PERSIST_EC2_VOLUMES", "1"),
+        ],
+        &["--storage-mode", "persistent", "--data-path", &data_path],
+    )
+    .await;
     let c = server.ec2_client().await;
 
     let instance_id = c

--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -598,8 +598,8 @@ fn instance_data_dir() -> String {
 /// Whether EC2 instance data should survive a fakecloud restart via a durable
 /// named volume. OFF by default (ephemeral, keeping test/CI runs clean and
 /// avoiding a stale volume bleeding into a later instance that reuses an id);
-/// opt in with `FAKECLOUD_PERSIST_EC2_VOLUMES=1`. Persistent storage mode flips
-/// this default to on by exporting the same env var at startup (#1846).
+/// opt in with `FAKECLOUD_PERSIST_EC2_VOLUMES=1`. A follow-up flips this
+/// default to on in persistent storage mode by exporting the same env var.
 fn ec2_volumes_enabled() -> bool {
     std::env::var("FAKECLOUD_PERSIST_EC2_VOLUMES")
         .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
@@ -686,7 +686,7 @@ impl DockerInstances {
         // stop/start (Docker reuses the same container, so the volume persists
         // regardless). OFF by default to keep test/CI runs ephemeral and avoid
         // a stale volume bleeding into a later instance that reuses an id;
-        // enabled by `FAKECLOUD_PERSIST_EC2_VOLUMES=1` (and, from #1846,
+        // enabled by `FAKECLOUD_PERSIST_EC2_VOLUMES=1` (and, in a follow-up,
         // default-on in persistent storage mode). The volume is dropped on
         // TerminateInstances. See [`data_volume_name`] / [`instance_data_dir`].
         if ec2_volumes_enabled() {

--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -118,6 +118,10 @@ pub struct NetworkIsolationSummary {
 struct InstanceRecord {
     /// Docker container id, or Pod name.
     handle: String,
+    /// The owning account id, captured at `RunInstances`. Keys the durable
+    /// data volume (see [`data_volume_name`]) so `TerminateInstances` can
+    /// remove the right volume without re-consulting the control plane.
+    account_id: String,
     /// Resolved base image, captured at `RunInstances` so a recreate is
     /// identical even if `FAKECLOUD_EC2_DEFAULT_IMAGE` later changes.
     image: String,
@@ -401,6 +405,7 @@ impl Ec2Runtime {
     /// boot the way cloud-init would, if present.
     pub async fn run_instance(
         &self,
+        account_id: &str,
         instance_id: &str,
         user_data: Option<&str>,
         tags: &BTreeMap<String, String>,
@@ -412,7 +417,7 @@ impl Ec2Runtime {
             // L3 isolation. k8s pods share a flat network; isolation there is a
             // NetworkPolicy concern handled separately (#1745 phase 4).
             InstanceBackend::Docker(d) => {
-                d.run_instance(instance_id, &image, user_data, network)
+                d.run_instance(account_id, instance_id, &image, user_data, network)
                     .await?
             }
             InstanceBackend::K8s(k) => k.spawn_pod(instance_id, &image, user_data, tags).await?,
@@ -421,6 +426,7 @@ impl Ec2Runtime {
             instance_id.to_string(),
             InstanceRecord {
                 handle: running.container_id.clone(),
+                account_id: account_id.to_string(),
                 image,
                 user_data: user_data.map(str::to_string),
                 tags: tags.clone(),
@@ -512,7 +518,14 @@ impl Ec2Runtime {
         let record = self.instances.write().remove(instance_id);
         if let Some(record) = record {
             match &self.backend {
-                InstanceBackend::Docker(d) => d.remove(&record.handle).await,
+                InstanceBackend::Docker(d) => {
+                    d.remove(&record.handle).await;
+                    // Drop the durable root-disk volume so a later instance
+                    // reusing this id starts clean (terminate = volume gone,
+                    // matching a deleted EBS root volume). No-op when volumes
+                    // are disabled.
+                    d.remove_data_volume(&record.account_id, instance_id).await;
+                }
                 InstanceBackend::K8s(k) => k.delete_pod(&record.handle).await,
             }
         }
@@ -571,6 +584,51 @@ fn default_image() -> String {
     std::env::var(DEFAULT_IMAGE_ENV).unwrap_or_else(|_| DEFAULT_IMAGE.to_string())
 }
 
+/// The in-instance directory backed by the durable data volume. Defaults to
+/// `/var/lib/fakecloud/ec2`; override with `FAKECLOUD_EC2_INSTANCE_DATA_DIR`
+/// to capture whichever path the instance's workload writes its long-lived
+/// state to. This is fakecloud's persistent-instance-data convention rather
+/// than a full root-filesystem snapshot: data written here survives restart
+/// and stop/start; the rest of the container's ephemeral filesystem does not.
+fn instance_data_dir() -> String {
+    std::env::var("FAKECLOUD_EC2_INSTANCE_DATA_DIR")
+        .unwrap_or_else(|_| "/var/lib/fakecloud/ec2".to_string())
+}
+
+/// Whether EC2 instance data should survive a fakecloud restart via a durable
+/// named volume. OFF by default (ephemeral, keeping test/CI runs clean and
+/// avoiding a stale volume bleeding into a later instance that reuses an id);
+/// opt in with `FAKECLOUD_PERSIST_EC2_VOLUMES=1`. Persistent storage mode flips
+/// this default to on by exporting the same env var at startup (#1846).
+fn ec2_volumes_enabled() -> bool {
+    std::env::var("FAKECLOUD_PERSIST_EC2_VOLUMES")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
+        .unwrap_or(false)
+}
+
+/// Deterministic Docker volume name for an instance's data dir. Keyed only on
+/// account + instance id (NOT the per-process fakecloud instance id) so the
+/// same volume reattaches after a fakecloud restart recreates the container.
+/// Characters outside Docker's `[a-zA-Z0-9_.-]` volume-name set become `-`.
+fn data_volume_name(account_id: &str, instance_id: &str) -> String {
+    let sanitize = |s: &str| -> String {
+        s.chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-' {
+                    c
+                } else {
+                    '-'
+                }
+            })
+            .collect()
+    };
+    format!(
+        "fakecloud-ec2-data-{}-{}",
+        sanitize(account_id),
+        sanitize(instance_id)
+    )
+}
+
 /// Keep-alive command + user-data wrapper for a base image. Shared by both
 /// backends so they boot identical containers. When `user_data` (base64) is
 /// present it is decoded and run as a root shell script, backgrounded so a
@@ -599,6 +657,7 @@ struct DockerInstances {
 impl DockerInstances {
     async fn run_instance(
         &self,
+        account_id: &str,
         instance_id: &str,
         image: &str,
         user_data: Option<&str>,
@@ -620,6 +679,24 @@ impl DockerInstances {
             "--label".to_string(),
             format!("fakecloud-instance={}", self.instance_id),
         ];
+        // Optionally back the instance's writable data directory with a durable
+        // named volume keyed on account + instance id, so the filesystem state
+        // an instance writes there survives a fakecloud restart (the recovery
+        // path recreates the container, which reattaches the same volume) and a
+        // stop/start (Docker reuses the same container, so the volume persists
+        // regardless). OFF by default to keep test/CI runs ephemeral and avoid
+        // a stale volume bleeding into a later instance that reuses an id;
+        // enabled by `FAKECLOUD_PERSIST_EC2_VOLUMES=1` (and, from #1846,
+        // default-on in persistent storage mode). The volume is dropped on
+        // TerminateInstances. See [`data_volume_name`] / [`instance_data_dir`].
+        if ec2_volumes_enabled() {
+            args.push("-v".to_string());
+            args.push(format!(
+                "{}:{}",
+                data_volume_name(account_id, instance_id),
+                instance_data_dir()
+            ));
+        }
         if let Some(name) = &attached_network {
             args.push("--network".to_string());
             args.push(name.clone());
@@ -764,6 +841,25 @@ impl DockerInstances {
             .await;
     }
 
+    /// Remove the durable data volume for an instance (called on
+    /// `TerminateInstances`) so a later instance reusing the same id starts
+    /// clean rather than inheriting the terminated instance's filesystem. A
+    /// no-op when volume persistence is disabled (no such volume was created).
+    async fn remove_data_volume(&self, account_id: &str, instance_id: &str) {
+        if !ec2_volumes_enabled() {
+            return;
+        }
+        let _ = tokio::process::Command::new(&self.cli)
+            .args([
+                "volume",
+                "rm",
+                "-f",
+                &data_volume_name(account_id, instance_id),
+            ])
+            .output()
+            .await;
+    }
+
     /// The container's combined stdout+stderr (`docker logs`). `None` if the
     /// command fails; an empty log is `Some(vec![])`.
     async fn logs(&self, container_id: &str) -> Option<Vec<u8>> {
@@ -780,5 +876,35 @@ impl DockerInstances {
         let mut buf = output.stdout;
         buf.extend_from_slice(&output.stderr);
         Some(buf)
+    }
+}
+
+#[cfg(test)]
+mod volume_tests {
+    use super::*;
+
+    #[test]
+    fn data_volume_name_is_stable_and_sanitized() {
+        // Stable across calls (so recovery reattaches the same volume) and
+        // keyed on account + instance id, not the per-process instance id.
+        assert_eq!(
+            data_volume_name("123456789012", "i-0abc123"),
+            "fakecloud-ec2-data-123456789012-i-0abc123"
+        );
+        // Characters outside Docker's volume-name set become '-'.
+        assert_eq!(
+            data_volume_name("1234/5678", "i-0abc:1"),
+            "fakecloud-ec2-data-1234-5678-i-0abc-1"
+        );
+    }
+
+    #[test]
+    fn distinct_instances_get_distinct_volumes() {
+        // Two instances in the same account never share a data volume, so
+        // terminating one cannot wipe another's filesystem.
+        assert_ne!(
+            data_volume_name("123456789012", "i-aaaa"),
+            data_volume_name("123456789012", "i-bbbb")
+        );
     }
 }

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -409,6 +409,7 @@ pub(crate) async fn run_instances(
                 let running = if let Some(rt) = &runtime {
                     match rt
                         .run_instance(
+                            &account_id,
                             id,
                             user_data.as_deref(),
                             &instance_tags,

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -1080,7 +1080,13 @@ impl Ec2Service {
             let state = self.state.clone();
             handles.push(tokio::spawn(async move {
                 let running = runtime
-                    .run_instance(&p.id, p.user_data.as_deref(), &p.tags, p.network.as_ref())
+                    .run_instance(
+                        &p.account_id,
+                        &p.id,
+                        p.user_data.as_deref(),
+                        &p.tags,
+                        p.network.as_ref(),
+                    )
                     .await;
                 let reap = {
                     let mut accounts = state.write();

--- a/crates/fakecloud-ec2/tests/k8s_integration.rs
+++ b/crates/fakecloud-ec2/tests/k8s_integration.rs
@@ -161,6 +161,7 @@ async fn instance_lifecycle_boots_pod_runs_user_data_and_recreates_on_start() {
     // per-subnet network spec — isolation there is a NetworkPolicy concern.)
     let running = rt
         .run_instance(
+            "123456789012",
             instance_id,
             Some(USER_DATA_B64),
             &std::collections::BTreeMap::new(),


### PR DESCRIPTION
## Summary

EC2 instances run as real containers, but the persistence sweep (#1845-#1858) only persisted **control-plane metadata** -- on restart the backing container was recreated empty, losing any filesystem state the instance wrote. This finishes the **data-plane** durability layer for EC2 (batch 1 of the container data-plane durability effort).

- Back an instance's writable data directory with a deterministic **named volume** keyed on account + instance id, so the bytes survive:
  - a **fakecloud restart** (the recovery path recreates the container and reattaches the same volume), and
  - **stop/start** (Docker reuses the container, so the volume persists regardless).
- **Default OFF** to keep test/CI runs ephemeral and avoid a stale volume bleeding into a later instance reusing an id. Opt in with `FAKECLOUD_PERSIST_EC2_VOLUMES=1`. Mount path defaults to `/var/lib/fakecloud/ec2`, override with `FAKECLOUD_EC2_INSTANCE_DATA_DIR`. (A follow-up batch flips this default-on in persistent storage mode.)
- Drop the volume on `TerminateInstances` so a reused id starts clean.
- Thread `account_id` into `run_instance` (RunInstances + restart recovery) and store it on the instance record for volume removal.
- This mirrors the established RDS named-volume pattern (`data_volume_name` / `remove_data_volume`). k8s PVC durability is intentionally out of scope here, matching the RDS precedent (cluster-dependent); documented separately.

Semantics are scoped honestly: this persists the instance's **data directory**, not a full root-filesystem snapshot -- data written under the durable dir survives; the rest of the ephemeral container filesystem does not.

## Test plan

- `cargo clippy -p fakecloud-ec2 -p fakecloud --all-targets -- -D warnings` -- clean.
- Unit tests: `data_volume_name` is stable + sanitized; distinct instances get distinct volumes (terminating one can't wipe another).
- Docker-gated E2E (`ec2_volume_durability.rs`): write a marker under the data dir, restart fakecloud in persistent mode, assert recovery recreates a **fresh** container that **reattaches** the volume so the marker survives; terminate cleans up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist EC2 instance data across fakecloud restarts by mounting a deterministic Docker named volume keyed by account and instance id. Data under the configured dir survives restart and stop/start; off by default.

- **New Features**
  - Durable named volume mounted at `/var/lib/fakecloud/ec2`; enable with `FAKECLOUD_PERSIST_EC2_VOLUMES=1`, override mount path with `FAKECLOUD_EC2_INSTANCE_DATA_DIR`.
  - Volume is removed on `TerminateInstances` so reused ids start clean.
  - Runtime now threads and stores `account_id` for stable volume names and cleanup.
  - Tests: Docker E2E proving persistence; unit tests for volume-name sanitization.

- **Refactors**
  - Durability E2E now uses `start_full` to detect Docker and reapply env on restart; cleaned up inline comments.
  - CI: `cargo audit` ignores `RUSTSEC-2026-0185` (unmaintained `backoff` via `kube-runtime`); transitive, not exploitable.

<sup>Written for commit 6ad6e4ff52da6870e16d48ab18b4de376646e4ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

