### PR TITLE
feat(tfacc): widen ssm parameter family and secretsmanager

### DIFF
--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -225,20 +225,35 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "ssm",
-        // Batch 4: core `aws_ssm_parameter` smoke. The fix here is making
-        // `lookup_param` tolerate the `name:version` selector that real
-        // AWS accepts on GetParameter / ListTagsForResource — without it
-        // the upstream import-with-version step fails with
-        // InvalidResourceId.
-        run_regex: "^TestAccSSMParameter_basic$",
+        // Batch 4 + widen: the `aws_ssm_parameter` family (parameter, its data
+        // sources, the ephemeral resource, the by-path data source) plus
+        // resource data sync. These pass against fakecloud as-is. The regex is
+        // an explicit positive list rather than `^TestAccSSM..._basic$`
+        // because the broader SSM resources (document, association, the
+        // maintenance-window family, patch baselines) panic the upstream test
+        // binary mid-run today; they are left for a dedicated SSM batch rather
+        // than denied one-by-one.
+        run_regex: concat!(
+            "^TestAccSSM(",
+            "Parameter|ParameterDataSource|ParameterEphemeral",
+            "|ParametersByPathDataSource|ResourceDataSync",
+            ")_basic$",
+        ),
         deny: &[],
     },
     Service {
         name: "secretsmanager",
-        // Batch 4: core `aws_secretsmanager_secret` smoke. Passes against
-        // fakecloud out of the box — no fakecloud-side changes needed.
-        run_regex: "^TestAccSecretsManagerSecret_basic$",
-        deny: &[],
+        // Batch 4 + widen: `_basic` smoke for the Secrets Manager resources and
+        // data sources — secret (+ data source), secret policy, secret version
+        // data sources, random-password data source and ephemeral resource.
+        // Passes against fakecloud out of the box.
+        run_regex: "^TestAccSecretsManager[A-Za-z]+_basic$",
+        deny: &[
+            // --- gap: secret rotation drives a Lambda rotation function on a
+            //     schedule, which fakecloud does not orchestrate. ---
+            "TestAccSecretsManagerSecretRotation_basic",
+            "TestAccSecretsManagerSecretRotationDataSource_basic",
+        ],
     },
     Service {
         name: "sqs",
@@ -382,13 +397,18 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "ssm",
         service: "ssm",
-        run_regex: "^TestAccSSMParameter_basic$",
+        run_regex: concat!(
+            "^TestAccSSM(",
+            "Parameter|ParameterDataSource|ParameterEphemeral",
+            "|ParametersByPathDataSource|ResourceDataSync",
+            ")_basic$",
+        ),
         extra_deny: &[],
     },
     Shard {
         name: "secretsmanager",
         service: "secretsmanager",
-        run_regex: "^TestAccSecretsManagerSecret_basic$",
+        run_regex: "^TestAccSecretsManager[A-Za-z]+_basic$",
         extra_deny: &[],
     },
     // ─── sqs split into core + encryption ──────────────────────────


### PR DESCRIPTION
## Summary

Allowlist-only widen of two services.

- **secretsmanager** -> `_basic` suite for every resource/data source (secret + data source, secret policy, secret version data sources, random-password data source + ephemeral resource). 8 tests, pass as-is. **SecretRotation** (+ data source) stays denied as a **gap** — it drives a Lambda rotation function on a schedule fakecloud doesn't orchestrate.
- **ssm** -> the `aws_ssm_parameter` family (parameter, data sources, ephemeral, by-path data source) + resource data sync (5 tests). Explicit positive regex rather than `^TestAccSSM..._basic$` because the broader SSM resources (document, association, maintenance-window family, patch baselines) panic the upstream test binary mid-run today; left for a dedicated SSM batch.

## Test plan
- Allowlist-only; `tfacc_shards` emits a valid matrix.
- Verified vs terraform-provider-aws v5.97.0: **ssm 5/5, secretsmanager 8/8**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the tfacc allowlist to run SSM parameter-family and Secrets Manager `_basic` tests, increasing coverage while avoiding unstable SSM suites. Uses explicit positive regex and keeps SecretRotation denied; all selected tests pass (ssm 5/5, secretsmanager 8/8) on terraform-provider-aws v5.97.0.

- **New Features**
  - ssm: enable `aws_ssm_parameter` family and `ResourceDataSync` via `^TestAccSSM(Parameter|ParameterDataSource|ParameterEphemeral|ParametersByPathDataSource|ResourceDataSync)_basic$`; skip other SSM resources for now due to upstream panics.
  - secretsmanager: enable `_basic` for Secret (+ data source), SecretPolicy, SecretVersion data sources, RandomPassword data source, and Ephemeral; deny SecretRotation (+ data source) since it requires Lambda scheduling not supported.

<sup>Written for commit 73558a02872aacc37f478dcd90db853ebea13770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

