### PR TITLE
feat(tfacc): widen cognitoidp to all _basic resource types

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cognito.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cognito.rs
@@ -220,7 +220,12 @@ impl ResourceProvisioner {
             token_validity_units: None,
             access_token_validity: props.get("AccessTokenValidity").and_then(|v| v.as_i64()),
             id_token_validity: props.get("IdTokenValidity").and_then(|v| v.as_i64()),
-            refresh_token_validity: props.get("RefreshTokenValidity").and_then(|v| v.as_i64()),
+            refresh_token_validity: Some(
+                props
+                    .get("RefreshTokenValidity")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(30),
+            ),
             callback_urls: parse_cognito_string_array(props.get("CallbackURLs")),
             logout_urls: parse_cognito_string_array(props.get("LogoutURLs")),
             supported_identity_providers: parse_cognito_string_array(
@@ -244,7 +249,16 @@ impl ResourceProvisioner {
                 .get("EnableTokenRevocation")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(true),
-            auth_session_validity: props.get("AuthSessionValidity").and_then(|v| v.as_i64()),
+            auth_session_validity: Some(
+                props
+                    .get("AuthSessionValidity")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(3),
+            ),
+            enable_propagate_additional_user_context_data: props
+                .get("EnablePropagateAdditionalUserContextData")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
             client_secrets: Vec::new(),
             refresh_token_rotation: None,
         };

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -872,9 +872,7 @@ fn user_pool_client_to_json(client: &UserPoolClient) -> Value {
     if let Some(v) = client.id_token_validity {
         obj["IdTokenValidity"] = json!(v);
     }
-    if let Some(v) = client.refresh_token_validity {
-        obj["RefreshTokenValidity"] = json!(v);
-    }
+    obj["RefreshTokenValidity"] = json!(client.refresh_token_validity.unwrap_or(30));
     if !client.callback_urls.is_empty() {
         obj["CallbackURLs"] = json!(client.callback_urls);
     }
@@ -899,9 +897,10 @@ fn user_pool_client_to_json(client: &UserPoolClient) -> Value {
     if !client.write_attributes.is_empty() {
         obj["WriteAttributes"] = json!(client.write_attributes);
     }
-    if let Some(v) = client.auth_session_validity {
-        obj["AuthSessionValidity"] = json!(v);
-    }
+    // AWS always reports these two; AuthSessionValidity defaults to 3.
+    obj["AuthSessionValidity"] = json!(client.auth_session_validity.unwrap_or(3));
+    obj["EnablePropagateAdditionalUserContextData"] =
+        json!(client.enable_propagate_additional_user_context_data);
     if let Some(ref rot) = client.refresh_token_rotation {
         let mut r = json!({"Feature": rot.feature});
         if let Some(g) = rot.retry_grace_period_seconds {

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -2176,6 +2176,45 @@ fn auth_events_recorded_on_sign_up() {
     assert!(st.auth_events[0].success);
 }
 
+#[test]
+fn user_pool_client_reports_aws_defaults() {
+    // A client created without token-validity / ASF options must still report
+    // the AWS defaults the Terraform provider asserts: AuthSessionValidity = 3,
+    // RefreshTokenValidity = 30, EnablePropagateAdditionalUserContextData =
+    // false (and access/id token validity left at 0).
+    let state = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4569",
+        ),
+    ));
+    let svc = CognitoService::new(state);
+
+    let resp =
+        block_on(svc.create_user_pool(&make_req("CreateUserPool", r#"{"PoolName":"p"}"#))).unwrap();
+    let pool: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let pool_id = pool["UserPool"]["Id"].as_str().unwrap().to_string();
+
+    let body = serde_json::to_string(&json!({
+        "UserPoolId": pool_id,
+        "ClientName": "c",
+        "ExplicitAuthFlows": ["ADMIN_NO_SRP_AUTH"]
+    }))
+    .unwrap();
+    let resp = svc
+        .create_user_pool_client(&make_req("CreateUserPoolClient", &body))
+        .unwrap();
+    let c: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let client = &c["UserPoolClient"];
+    assert_eq!(client["AuthSessionValidity"], json!(3));
+    assert_eq!(client["RefreshTokenValidity"], json!(30));
+    assert_eq!(
+        client["EnablePropagateAdditionalUserContextData"],
+        json!(false)
+    );
+}
+
 /// 1.27: SignUp + InitiateAuth must enforce SECRET_HASH for app clients
 /// that have a secret.
 #[test]

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -566,7 +566,9 @@ impl CognitoService {
             token_validity_units: parse_token_validity_units(&body["TokenValidityUnits"]),
             access_token_validity: body["AccessTokenValidity"].as_i64(),
             id_token_validity: body["IdTokenValidity"].as_i64(),
-            refresh_token_validity: body["RefreshTokenValidity"].as_i64(),
+            // AWS defaults RefreshTokenValidity to 30 (days) when unset and
+            // always reports it; access/id token validity stay unset (0).
+            refresh_token_validity: Some(body["RefreshTokenValidity"].as_i64().unwrap_or(30)),
             callback_urls: parse_string_array(&body["CallbackURLs"]),
             logout_urls: parse_string_array(&body["LogoutURLs"]),
             supported_identity_providers: parse_string_array(&body["SupportedIdentityProviders"]),
@@ -583,7 +585,13 @@ impl CognitoService {
             creation_date: now,
             last_modified_date: now,
             enable_token_revocation: body["EnableTokenRevocation"].as_bool().unwrap_or(true),
-            auth_session_validity: body["AuthSessionValidity"].as_i64(),
+            // AWS defaults AuthSessionValidity to 3 (minutes) when unset and
+            // always reports it.
+            auth_session_validity: Some(body["AuthSessionValidity"].as_i64().unwrap_or(3)),
+            enable_propagate_additional_user_context_data: body
+                ["EnablePropagateAdditionalUserContextData"]
+                .as_bool()
+                .unwrap_or(false),
             client_secrets: Vec::new(),
             refresh_token_rotation: parse_refresh_token_rotation(&body["RefreshTokenRotation"]),
         };
@@ -759,6 +767,9 @@ impl CognitoService {
         }
         if let Some(v) = body["AuthSessionValidity"].as_i64() {
             client.auth_session_validity = Some(v);
+        }
+        if let Some(v) = body["EnablePropagateAdditionalUserContextData"].as_bool() {
+            client.enable_propagate_additional_user_context_data = v;
         }
 
         client.last_modified_date = Utc::now();

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -553,6 +553,11 @@ pub struct UserPoolClient {
     pub last_modified_date: DateTime<Utc>,
     pub enable_token_revocation: bool,
     pub auth_session_validity: Option<i64>,
+    /// Whether ASF (advanced security) propagates additional user-context data
+    /// to the issued tokens. AWS reports this on every DescribeUserPoolClient,
+    /// defaulting to false.
+    #[serde(default)]
+    pub enable_propagate_additional_user_context_data: bool,
     /// Additional client secrets (beyond the primary client_secret)
     pub client_secrets: Vec<ClientSecretDescriptor>,
     /// "ENABLED" rotates refresh token on every refresh-token grant

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -82,8 +82,25 @@ pub const SERVICES: &[Service] = &[
         // `user_pool_tier = ESSENTIALS`, and a non-empty
         // `account_recovery_setting`. None of these were emitted
         // unless the caller set them at create time.
-        run_regex: "^TestAccCognitoIDPUserPool_basic$",
-        deny: &[],
+        // Widen: `_basic` smoke for the Cognito user-pool resources and data
+        // sources — user pool (+ data sources), user pool client (+ data
+        // sources), resource server, users and groups (+ data sources), and the
+        // signing-certificate data source. The widen batch added the user-pool
+        // client defaults the provider asserts (AuthSessionValidity = 3,
+        // RefreshTokenValidity = 30, EnablePropagateAdditionalUserContextData).
+        run_regex: "^TestAccCognitoIDP[A-Za-z]+_basic$",
+        deny: &[
+            // --- gap: federated identity providers need real SAML/OIDC
+            //     metadata handling and attribute-mapping round-trip. ---
+            "TestAccCognitoIDPIdentityProvider_basic",
+            // --- gap: a user-pool domain provisions a CloudFront distribution
+            //     (cloudfront_distribution / _arn), which fakecloud's Cognito
+            //     does not stand up. ---
+            "TestAccCognitoIDPUserPoolDomain_basic",
+            // --- gap: managed (AWS-provisioned) user-pool clients are created
+            //     by other AWS services, not directly; not modelled. ---
+            "TestAccCognitoIDPManagedUserPoolClient_basic",
+        ],
     },
     Service {
         name: "bedrock",
@@ -343,7 +360,7 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "cognitoidp",
         service: "cognitoidp",
-        run_regex: "^TestAccCognitoIDPUserPool_basic$",
+        run_regex: "^TestAccCognitoIDP[A-Za-z]+_basic$",
         extra_deny: &[],
     },
     Shard {


### PR DESCRIPTION
## Summary

Widens the `cognitoidp` tfacc shard from the lone user-pool smoke to the `_basic` suite across the Cognito user-pool resources and data sources — user pool (+ data sources), user pool client (+ data sources), resource server, users, groups (+ data sources), signing-certificate data source. **13 tests (was 1).**

Real fakecloud fix: `DescribeUserPoolClient` now reports the defaults the `aws_cognito_user_pool_client` resource asserts even when unset — `AuthSessionValidity` -> 3, `RefreshTokenValidity` -> 30, `EnablePropagateAdditionalUserContextData` (new field) -> false. The CloudFormation user-pool-client provisioner threads the same defaults.

Denied with **gap** reasons: `IdentityProvider` (SAML/OIDC federation + attribute-mapping round-trip), `UserPoolDomain` (needs a CloudFront distribution), `ManagedUserPoolClient` (provisioned by other AWS services).

## Test plan
- New unit test: user-pool-client AWS defaults.
- `cargo clippy` on cognito/cloudformation/tfacc: clean.
- Widened shard vs terraform-provider-aws v5.97.0: **13 pass, 0 fail**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the `cognitoidp` tfacc shard to all `_basic` Cognito user‑pool resources and data sources. Also aligns `DescribeUserPoolClient` with AWS defaults so Terraform expectations pass.

- **New Features**
  - Widened shard to run `^TestAccCognitoIDP[A-Za-z]+_basic$`; kept gaps denied: IdentityProvider (SAML/OIDC), UserPoolDomain (CloudFront), ManagedUserPoolClient (AWS‑managed).
  - `DescribeUserPoolClient` now returns AWS defaults: AuthSessionValidity=3, RefreshTokenValidity=30, `EnablePropagateAdditionalUserContextData`=false; CloudFormation provisioner applies the same; unit test added; 13/13 passing against `terraform-provider-aws` v5.97.0.

<sup>Written for commit adbe0cf93c26e0735dcab615ac2d9422eadf1d07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

