### PR TITLE
feat(tfacc): widen apigatewayv2 to all _basic resource types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,7 +2971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6666,9 +6666,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -7086,7 +7086,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7179,7 +7179,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7811,10 +7811,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8708,7 +8708,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -42,6 +42,38 @@ fn to_camel(v: Value) -> Value {
 /// Parse the request body as JSON. Keep incoming case-as-is; handlers
 /// read fields in Pascal-case for legibility, but SDK clients send
 /// camel-case per Smithy — so we also merge a Pascal-case copy.
+/// Clone the caller's `DomainNameConfigurations` (defaulting to one empty
+/// config) and stamp each entry with the synchronous-provisioning fields AWS
+/// fills in: `DomainNameStatus = AVAILABLE`, plus a regional endpoint name and
+/// hosted-zone id. The Terraform provider's create-waiter reads
+/// `DomainNameStatus`, so it must be present.
+fn domain_configs_with_status(configs: Option<&Value>, domain: &str) -> Value {
+    let mut arr = match configs.and_then(|c| c.as_array()) {
+        Some(a) if !a.is_empty() => a.clone(),
+        _ => vec![json!({})],
+    };
+    for c in arr.iter_mut() {
+        if let Some(obj) = c.as_object_mut() {
+            if !obj.contains_key("DomainNameStatus") {
+                obj.insert("DomainNameStatus".into(), json!("AVAILABLE"));
+            }
+            if !obj.contains_key("ApiGatewayDomainName") {
+                obj.insert(
+                    "ApiGatewayDomainName".into(),
+                    json!(format!("d-{domain}.execute-api.us-east-1.amazonaws.com")),
+                );
+            }
+            if !obj.contains_key("HostedZoneId") {
+                obj.insert("HostedZoneId".into(), json!("Z1UJRXOUMOOFQ8"));
+            }
+            if !obj.contains_key("IpAddressType") {
+                obj.insert("IpAddressType".into(), json!("ipv4"));
+            }
+        }
+    }
+    Value::Array(arr)
+}
+
 fn body(req: &AwsRequest) -> Value {
     let raw: Value =
         serde_json::from_slice(&req.body).unwrap_or_else(|_| Value::Object(Default::default()));
@@ -295,10 +327,15 @@ impl ApiGatewayV2Service {
                 let name = req_str(&body, "DomainName")?.to_string();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
+                // fakecloud provisions domains synchronously, so each
+                // configuration is immediately AVAILABLE. The Terraform
+                // provider's create-waiter polls GetDomainName for that status.
+                let configs =
+                    domain_configs_with_status(body.get("DomainNameConfigurations"), &name);
                 let mut entry = json!({
                     "DomainName": name,
                     "DomainNameArn": Arn::new("apigateway", "us-east-1", "", &format!("/domainnames/{name}")).to_string(),
-                    "DomainNameConfigurations": body.get("DomainNameConfigurations").cloned().unwrap_or(json!([])),
+                    "DomainNameConfigurations": configs,
                     "ApiMappingSelectionExpression": "$request.basepath",
                     "RoutingMode": "API_MAPPING_ONLY",
                     "Tags": body.get("Tags").cloned().unwrap_or(json!({})),
@@ -337,8 +374,9 @@ impl ApiGatewayV2Service {
                     .domain_names
                     .get_mut(name)
                     .ok_or_else(|| not_found("DomainName", name))?;
-                if let Some(cfgs) = body.get("DomainNameConfigurations") {
-                    entry["DomainNameConfigurations"] = cfgs.clone();
+                if body.get("DomainNameConfigurations").is_some() {
+                    entry["DomainNameConfigurations"] =
+                        domain_configs_with_status(body.get("DomainNameConfigurations"), name);
                 }
                 ok(entry.clone())
             }
@@ -2110,6 +2148,7 @@ mod tests {
                             description: None,
                             created_date: chrono::Utc::now(),
                             auto_deployed: false,
+                            deployment_status: "DEPLOYED".to_string(),
                         },
                     );
             }
@@ -2162,6 +2201,7 @@ mod tests {
                             description: None,
                             created_date: chrono::Utc::now(),
                             auto_deployed: false,
+                            deployment_status: "DEPLOYED".to_string(),
                         },
                     );
             }

--- a/crates/fakecloud-apigatewayv2/src/service/deployments.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/deployments.rs
@@ -30,6 +30,7 @@ impl ApiGatewayV2Service {
             description,
             created_date,
             auto_deployed: false,
+            deployment_status: "DEPLOYED".to_string(),
         };
 
         let mut accounts = self.state.write();

--- a/crates/fakecloud-apigatewayv2/src/service/integrations.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/integrations.rs
@@ -35,6 +35,10 @@ impl ApiGatewayV2Service {
         let integration_uri = body["integrationUri"].as_str().map(|s| s.to_string());
         let payload_format_version = body["payloadFormatVersion"].as_str().map(|s| s.to_string());
         let timeout_in_millis = body["timeoutInMillis"].as_i64();
+        let connection_type = body["connectionType"]
+            .as_str()
+            .unwrap_or("INTERNET")
+            .to_string();
 
         let integration_id = generate_id("integration");
 
@@ -44,6 +48,7 @@ impl ApiGatewayV2Service {
             integration_uri,
             payload_format_version,
             timeout_in_millis,
+            connection_type,
         };
 
         let mut accounts = self.state.write();

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -365,6 +365,9 @@ async fn integration_crud_lifecycle() {
     let b = body_json(&resp);
     let int_id = b["integrationId"].as_str().unwrap().to_string();
     assert_eq!(b["integrationType"], "HTTP_PROXY");
+    // AWS always reports connectionType, defaulting to INTERNET, which the
+    // Terraform provider re-plans an integration without.
+    assert_eq!(b["connectionType"], "INTERNET");
 
     // Get
     let req = make_request(
@@ -475,6 +478,9 @@ async fn deployment_crud() {
     let b = body_json(&resp);
     let dep_id = b["deploymentId"].as_str().unwrap().to_string();
     assert!(dep_id.starts_with("deployment"));
+    // Deployments apply synchronously, so they report DEPLOYED immediately —
+    // the Terraform provider's create-waiter polls for this.
+    assert_eq!(b["deploymentStatus"], "DEPLOYED");
 
     // Get deployment
     let req = make_request(
@@ -2682,4 +2688,21 @@ async fn snapshot_hook_fires_with_store() {
         .snapshot_hook()
         .expect("hook present when a store is set");
     hook().await;
+}
+
+#[tokio::test]
+async fn create_domain_name_reports_available_status() {
+    // AWS provisions custom domains synchronously, so each configuration comes
+    // back AVAILABLE with a regional endpoint and ipv4 — the Terraform
+    // provider's create-waiter polls GetDomainName for DomainNameStatus.
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let body = serde_json::json!({ "domainName": "tfacc.example.com" });
+    let req = make_request(Method::POST, "/v2/domainnames", &body.to_string());
+    let resp = svc.handle(req).await.unwrap();
+    let b = body_json(&resp);
+    let cfg0 = &b["domainNameConfigurations"][0];
+    assert_eq!(cfg0["domainNameStatus"], "AVAILABLE");
+    assert_eq!(cfg0["ipAddressType"], "ipv4");
+    assert!(cfg0["apiGatewayDomainName"].as_str().is_some());
 }

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -288,6 +288,15 @@ pub struct Integration {
     pub payload_format_version: Option<String>, // "2.0"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_in_millis: Option<i64>,
+    /// "INTERNET" (default) or "VPC_LINK". AWS always reports it, so the
+    /// Terraform provider re-plans an integration whose GetIntegration response
+    /// omits it.
+    #[serde(default = "default_connection_type")]
+    pub connection_type: String,
+}
+
+fn default_connection_type() -> String {
+    "INTERNET".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -334,6 +343,15 @@ pub struct Deployment {
     pub description: Option<String>,
     pub created_date: DateTime<Utc>,
     pub auto_deployed: bool,
+    /// fakecloud applies deployments synchronously, so they are immediately
+    /// `DEPLOYED`. The Terraform provider's create-waiter polls GetDeployment
+    /// for this status, so it must be reported.
+    #[serde(default = "default_deployment_status")]
+    pub deployment_status: String,
+}
+
+fn default_deployment_status() -> String {
+    "DEPLOYED".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
@@ -224,6 +224,11 @@ impl ResourceProvisioner {
                 .and_then(|v| v.as_str())
                 .map(String::from),
             timeout_in_millis: props.get("TimeoutInMillis").and_then(|v| v.as_i64()),
+            connection_type: props
+                .get("ConnectionType")
+                .and_then(|v| v.as_str())
+                .unwrap_or("INTERNET")
+                .to_string(),
         };
         state
             .integrations
@@ -511,6 +516,7 @@ impl ResourceProvisioner {
                 .map(String::from),
             created_date: Utc::now(),
             auto_deployed: false,
+            deployment_status: "DEPLOYED".to_string(),
         };
         let mut accounts = self.apigatewayv2_state.write();
         let state = accounts.get_or_create(&self.account_id);

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -115,14 +115,24 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "apigatewayv2",
-        // Batch 9: core `aws_apigatewayv2_api` (HTTP) smoke. The fix
-        // here is making CreateApi return four metadata fields that
-        // real AWS always populates (api_key_selection_expression,
-        // route_selection_expression, disable_execute_api_endpoint,
-        // ip_address_type) — Terraform's provider asserts on each of
-        // them on every refresh.
-        run_regex: "^TestAccAPIGatewayV2API_basicHTTP$",
-        deny: &[],
+        // Batch 9 + widen: the HTTP-API smoke plus the `_basic` suite for the
+        // API Gateway v2 resources and data sources — model, route, route
+        // response, integration response, VPC link (+ data source), deployment,
+        // and custom domain name. The widen batch reported deployments as
+        // synchronously DEPLOYED, custom domains as AVAILABLE (with a regional
+        // endpoint + ipv4), and gave integrations their default
+        // `connection_type = INTERNET`, all of which the provider asserts.
+        run_regex: "^TestAccAPIGatewayV2([A-Za-z]+_basic|API_basicHTTP)$",
+        deny: &[
+            // --- gap: a REQUEST authorizer wires up a real Lambda authorizer
+            //     function, which fakecloud cannot stand up without a working
+            //     Lambda runtime in this environment. ---
+            "TestAccAPIGatewayV2Authorizer_basic",
+            // --- gap: the export data source generates an OpenAPI document
+            //     from the API; fakecloud's export does not yet round-trip
+            //     cleanly against the provider's expectations. ---
+            "TestAccAPIGatewayV2ExportDataSource_basic",
+        ],
     },
     Service {
         name: "kinesis",
@@ -372,7 +382,7 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "apigatewayv2",
         service: "apigatewayv2",
-        run_regex: "^TestAccAPIGatewayV2API_basicHTTP$",
+        run_regex: "^TestAccAPIGatewayV2([A-Za-z]+_basic|API_basicHTTP)$",
         extra_deny: &[],
     },
     Shard {


### PR DESCRIPTION
## Summary

Widens the `apigatewayv2` tfacc shard from the lone HTTP-API smoke to the `_basic` suite — model, route, route response, integration response, VPC link (+ data source), deployment, custom domain name (**9 tests**).

Three real fakecloud fixes:
- **Deployments** report `DeploymentStatus = DEPLOYED` (synchronous), which the provider's create-waiter polls for.
- **Custom domains** report each configuration `AVAILABLE` with a regional endpoint, hosted-zone id, and `ipv4` address type.
- **Integrations** report their default `connection_type = INTERNET` — without it the provider re-plans every integration (this also unblocked the deployment and integration-response tests, which provision an integration).

The CloudFormation provisioner threads the new `deployment_status` and `connection_type` fields.

Denied as **gaps**: `Authorizer` (Lambda REQUEST authorizer needs a working Lambda runtime here), `ExportDataSource` (OpenAPI export round-trip).

## Test plan
- New/extended unit tests: deployment `DEPLOYED`, integration `INTERNET`, domain `AVAILABLE`+`ipv4`.
- `cargo clippy` on apigatewayv2/cloudformation/tfacc: clean.
- Widened shard vs terraform-provider-aws v5.97.0: **9 pass, 0 fail**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widen the `apigatewayv2` TF acceptance shard to run the full `_basic` resource suite and add missing API behaviors needed by the AWS provider; also bump `quinn-proto` to address a security advisory. Result: 9 tests run, 0 fail (terraform-provider-aws v5.97.0).

- **New Features**
  - Update `fakecloud-tfacc` allowlist to run `^TestAccAPIGatewayV2([A-Za-z]+_basic|API_basicHTTP)$`; keep `Authorizer` and `ExportDataSource` denied.

- **Bug Fixes**
  - Deployments now return `deploymentStatus = DEPLOYED` so the provider’s create waiter succeeds.
  - Custom domain configs now include `domainNameStatus = AVAILABLE`, a regional `apiGatewayDomainName`, `hostedZoneId`, and `ipAddressType = ipv4`.
  - Integrations default `connectionType = INTERNET`; `fakecloud-cloudformation` threads `connection_type` and `deployment_status` to resources. Added unit tests.
  - Dependencies: bump `quinn-proto` 0.11.14 → 0.11.15 to resolve RUSTSEC-2026-0185 (no API impact).

<sup>Written for commit b5c1381f46dc906c2a7b44cdc0bf57718c34cf52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

