### PR TITLE
feat(tfacc): widen bedrock + add dynamodb non-table resources shard

### DIFF
--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -104,14 +104,21 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "bedrock",
-        // Batch 10: `data.aws_bedrock_foundation_models` data source
-        // smoke. fakecloud's Bedrock implementation already returns the
-        // expected ListFoundationModels shape, so this passes out of
-        // the box. Resource tests (model invocation, guardrails) need
-        // the Bedrock runtime container path to be plumbed through TF
-        // and are deferred to a later batch.
-        run_regex: "^TestAccBedrockFoundationModelsDataSource_basic$",
-        deny: &[],
+        // Batch 10 + widen: the foundation-model data sources (single + list),
+        // which return the expected ListFoundationModels / GetFoundationModel
+        // shapes out of the box.
+        run_regex: "^TestAccBedrock[A-Za-z]+_basic$",
+        deny: &[
+            // --- gap: guardrails need the content-policy / topic-policy
+            //     evaluation engine, which fakecloud's Bedrock does not model. ---
+            "TestAccBedrockGuardrail_basic",
+            "TestAccBedrockGuardrailVersion_basic",
+            // --- gap: inference profiles (cross-region model routing) are not
+            //     modelled. ---
+            "TestAccBedrockInferenceProfile_basic",
+            "TestAccBedrockInferenceProfileDataSource_basic",
+            "TestAccBedrockInferenceProfilesDataSource_basic",
+        ],
     },
     Service {
         name: "apigatewayv2",
@@ -376,7 +383,7 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "bedrock",
         service: "bedrock",
-        run_regex: "^TestAccBedrockFoundationModelsDataSource_basic$",
+        run_regex: "^TestAccBedrock[A-Za-z]+_basic$",
         extra_deny: &[],
     },
     Shard {
@@ -483,6 +490,28 @@ pub const SHARDS: &[Shard] = &[
         name: "dynamodb-h-z",
         service: "dynamodb",
         run_regex: "^TestAccDynamoDBTable_[^a-gA-G]",
+        extra_deny: &[],
+    },
+    // ─── dynamodb non-table resources ──────────────────────────────
+    // The two table shards cover `aws_dynamodb_table` only. This shard adds
+    // the other DynamoDB resources and data sources that pass: table item
+    // (+ data source), the table data source, contributor insights, and
+    // tagging. The regex is an explicit positive list — the remaining
+    // non-table resources are deliberately omitted, not denied:
+    //   * kinesis_streaming_destination — `approximate_creation_date_time
+    //     _precision` round-trip,
+    //   * resource_policy — import-state-verify attribute mismatch,
+    //   * global_table / table_replica — cross-region replication,
+    //   * table_export — S3 export path,
+    // each of which needs a dedicated fix and will be added later.
+    Shard {
+        name: "dynamodb-resources",
+        service: "dynamodb",
+        run_regex: concat!(
+            "^TestAccDynamoDB(",
+            "ContributorInsights|Tag|TableItem|TableItemDataSource|TableDataSource",
+            ")_basic$",
+        ),
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -101,3 +101,8 @@ async fn dynamodb_a_g_acceptance() {
 async fn dynamodb_h_z_acceptance() {
     run_shard("dynamodb-h-z").await;
 }
+
+#[tokio::test]
+async fn dynamodb_resources_acceptance() {
+    run_shard("dynamodb-resources").await;
+}


### PR DESCRIPTION
## Summary

Finishes the Wave-2 widens with two allowlist-only changes.

- **bedrock** -> both foundation-model data sources (single + list). Guardrails and inference profiles stay denied as **gaps** (guardrail evaluation engine; cross-region model routing).
- **dynamodb-resources** (new shard) -> DynamoDB resources beyond `aws_dynamodb_table`: table item (+ data source), table data source, contributor insights, tagging (5 tests). Remaining non-table resources (`kinesis_streaming_destination`, `resource_policy`, `global_table`/`replica`, `table_export`) are deliberately omitted with documented reasons, pending dedicated fixes.

## Test plan
- Allowlist + shard-list + one new `#[tokio::test]`; `tfacc_shards` emits 16 shards.
- Verified vs terraform-provider-aws v5.97.0: **bedrock 2/2, dynamodb-resources 5/5**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands Bedrock acceptance coverage to both foundation‑model data sources and adds a `dynamodb-resources` shard for non-table DynamoDB resources. Improves test coverage while keeping known gaps denied.

- **New Features**
  - Bedrock: run single and list foundation‑model data sources; keep guardrails and inference profiles denied (missing evaluation engine and cross‑region routing).
  - DynamoDB: new `dynamodb-resources` shard for table item (+ data source), table data source, contributor insights, and tagging; omit `kinesis_streaming_destination`, `resource_policy`, `global_table`/`replica`, and `table_export` pending fixes.
  - Test harness: updated allowlist and shard list; `tfacc_shards` now emits 16 shards; added `dynamodb_resources_acceptance` test. Verified against `terraform-provider-aws` v5.97.0: Bedrock 2/2, DynamoDB-resources 5/5.

<sup>Written for commit f63dca353f442a6b1fff265debdaa3fb943c9e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

