### PR TITLE
feat(persistence): default container data volumes on in persistent mode

### DIFF
--- a/crates/fakecloud-e2e/tests/elasticache_persistence.rs
+++ b/crates/fakecloud-e2e/tests/elasticache_persistence.rs
@@ -88,6 +88,110 @@ async fn persistence_cache_cluster_endpoint_works_after_restart() {
     );
 }
 
+/// Send one RESP command to a Redis endpoint and return the raw reply text.
+async fn redis_cmd(stream: &mut tokio::net::TcpStream, cmd: &[u8]) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    stream.write_all(cmd).await.expect("write redis command");
+    let mut buf = [0u8; 512];
+    let n = stream.read(&mut buf).await.expect("read redis reply");
+    String::from_utf8_lossy(&buf[..n]).into_owned()
+}
+
+/// Poll DescribeCacheClusters until the cluster is `available`, returning the
+/// node endpoint port. Panics if it never recovers.
+async fn wait_cache_port(client: &aws_sdk_elasticache::Client, id: &str) -> i32 {
+    for _ in 0..120 {
+        let resp = client
+            .describe_cache_clusters()
+            .cache_cluster_id(id)
+            .show_cache_node_info(true)
+            .send()
+            .await
+            .unwrap();
+        if let Some(cluster) = resp.cache_clusters().first() {
+            if cluster.cache_cluster_status() == Some("available") {
+                if let Some(port) = cluster
+                    .cache_nodes()
+                    .first()
+                    .and_then(|n| n.endpoint())
+                    .and_then(|e| e.port())
+                {
+                    return port;
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+    panic!("cache cluster {id} never reached available with an endpoint port");
+}
+
+/// Data WRITTEN to a Redis cache survives a restart, not just the endpoint.
+/// ElastiCache backs Redis/Valkey with a durable `/data` volume, so a key SET
+/// (and SAVEd to the RDB) before restart is still readable after the backing
+/// container is recreated. The explicit SAVE forces the RDB to the volume so
+/// the abrupt container teardown on restart can't lose the unflushed write.
+#[tokio::test]
+async fn persistence_cache_data_survives_restart() {
+    if !require_docker_or_skip("persistence_cache_data_survives_restart") {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().display().to_string();
+    let extra_args = ["--storage-mode", "persistent", "--data-path", &data_path];
+    let mut server = TestServer::start_full(&[], &extra_args).await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_cluster()
+        .cache_cluster_id("data-cache")
+        .engine("redis")
+        .cache_node_type("cache.t3.micro")
+        .preferred_availability_zone("us-east-1a")
+        .send()
+        .await
+        .unwrap();
+    helpers::wait_for_cache_cluster_available(&client, "data-cache", 120).await;
+    let port = wait_cache_port(&client, "data-cache").await;
+
+    // SET a key, then SAVE so the RDB hits the durable /data volume.
+    {
+        let mut s = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            .await
+            .expect("connect redis to seed");
+        let set = redis_cmd(
+            &mut s,
+            b"*3\r\n$3\r\nSET\r\n$11\r\ndurable-key\r\n$13\r\nsurvive-value\r\n",
+        )
+        .await;
+        assert!(set.starts_with("+OK"), "SET should succeed: {set:?}");
+        let save = redis_cmd(&mut s, b"*1\r\n$4\r\nSAVE\r\n").await;
+        assert!(save.starts_with("+OK"), "SAVE should succeed: {save:?}");
+    }
+
+    drop(client);
+    server.restart().await;
+    let client = server.elasticache_client().await;
+
+    let port = wait_cache_port(&client, "data-cache").await;
+
+    // The recovered container reloads the RDB from the volume; retry GET while
+    // redis finishes loading.
+    let mut value = String::new();
+    for _ in 0..40 {
+        if let Ok(mut s) = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}")).await {
+            value = redis_cmd(&mut s, b"*2\r\n$3\r\nGET\r\n$11\r\ndurable-key\r\n").await;
+            if value.contains("survive-value") {
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(
+        value.contains("survive-value"),
+        "cached key must survive the restart via the durable /data volume, got {value:?}"
+    );
+}
+
 /// Users and user groups survive a restart.
 #[tokio::test]
 async fn persistence_round_trip_user_and_group() {

--- a/crates/fakecloud-e2e/tests/rds_persistence.rs
+++ b/crates/fakecloud-e2e/tests/rds_persistence.rs
@@ -203,6 +203,70 @@ async fn start_stop_db_instance_toggles_backing_container() {
     assert_eq!(value, 1);
 }
 
+/// Data WRITTEN to a DB survives a restart, not just the endpoint. With
+/// persistent mode now defaulting DB data volumes on, a row inserted before
+/// restart is still readable after the backing container is recreated. Without
+/// the durable volume the recovered postgres container would come back empty
+/// and the row would be gone -- this is the data-plane half of persistence.
+#[tokio::test]
+async fn persistence_db_row_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().display().to_string();
+    let extra_args = ["--storage-mode", "persistent", "--data-path", &data_path];
+    let mut server = TestServer::start_full(&[], &extra_args).await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_instance()
+        .db_instance_identifier("rowsurvive-db")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .unwrap();
+    let inst = helpers::wait_for_db_available(&client, "rowsurvive-db", 240).await;
+    let endpoint = inst.endpoint().expect("endpoint");
+    let host = endpoint.address().expect("address").to_string();
+    let port = endpoint.port().expect("port");
+
+    // Seed a row before the restart.
+    {
+        let db = connect_postgres_with_retry(&host, port, "admin", "secret123", "appdb")
+            .await
+            .expect("connect to seed");
+        db.batch_execute(
+            "CREATE TABLE durable (id int primary key, note text); \
+             INSERT INTO durable (id, note) VALUES (1, 'survives-restart');",
+        )
+        .await
+        .expect("seed row");
+    }
+
+    drop(client);
+    server.restart().await;
+    let client = server.rds_client().await;
+
+    let inst = helpers::wait_for_db_available(&client, "rowsurvive-db", 240).await;
+    let endpoint = inst.endpoint().expect("endpoint");
+    let host = endpoint.address().expect("address").to_string();
+    let port = endpoint.port().expect("port");
+
+    let db = connect_postgres_with_retry(&host, port, "admin", "secret123", "appdb")
+        .await
+        .expect("connect to recovered container");
+    let row = db
+        .query_one("SELECT note FROM durable WHERE id = 1", &[])
+        .await
+        .expect("row must survive the restart via the durable data volume");
+    let note: String = row.get(0);
+    assert_eq!(note, "survives-restart");
+}
+
 /// Parameter groups survive a restart.
 #[tokio::test]
 async fn persistence_round_trip_parameter_group() {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -103,6 +103,27 @@ async fn main() {
         Err(err) => fatal_exit(format_args!("invalid persistence configuration: {err}")),
     };
     if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+        // Persistent mode means "state survives restart", so the data INSIDE
+        // container-backed services (RDS databases, EC2 instance data dirs)
+        // should be durable too -- not just the control-plane metadata. Those
+        // runtimes already know how to back a container with a named volume;
+        // they just gate it behind an env var that is off by default (to keep
+        // ephemeral/test runs clean). Default those gates ON here, before the
+        // runtimes are constructed, so persistent mode is durable end-to-end
+        // without extra flags. An explicit user setting always wins.
+        // (ElastiCache already persists Redis/Valkey unconditionally.)
+        for var in [
+            "FAKECLOUD_PERSIST_DB_VOLUMES",
+            "FAKECLOUD_PERSIST_EC2_VOLUMES",
+        ] {
+            if std::env::var_os(var).is_none() {
+                std::env::set_var(var, "1");
+                tracing::debug!(
+                    env = var,
+                    "persistent mode: defaulting container data volumes on"
+                );
+            }
+        }
         if let Some(ref data_path) = persistence_config.data_path {
             if let Err(err) = std::fs::create_dir_all(data_path) {
                 fatal_exit(format_args!(


### PR DESCRIPTION
## Summary

Batch 2 of container data-plane durability. Persistent mode persisted **control-plane metadata** but rebuilt container-backed services **empty**, so the data *inside* them (RDS databases, EC2 instance data dirs) was lost on restart unless the user manually set the per-service volume env vars. This makes persistent mode durable end-to-end with no extra flags.

- **`main.rs`**: in persistent storage mode, default `FAKECLOUD_PERSIST_DB_VOLUMES` and `FAKECLOUD_PERSIST_EC2_VOLUMES` **on** (before the service runtimes are constructed), unless the user already set them (explicit setting always wins). Memory mode stays ephemeral so test/CI runs remain clean and free of cross-test volume contamination.
- **ElastiCache** already persists Redis/Valkey unconditionally (volume at `/data`), so no code change there -- only a test was missing.
- The per-service helpers (`db_volumes_enabled`, `ec2_volumes_enabled`) already read the env var per container spawn, so exporting at startup lights them up automatically.

## Test plan

- `cargo clippy -p fakecloud --all-targets -- -D warnings` -- clean.
- New Docker-gated E2E proving **data** (not just the endpoint) survives a restart:
  - `rds_persistence::persistence_db_row_survives_restart` -- `CREATE TABLE`/`INSERT` a row, restart, assert the row is still readable from the recovered postgres container.
  - `elasticache_persistence::persistence_cache_data_survives_restart` -- `SET` a key + `SAVE` the RDB, restart, assert `GET` returns the value from the recovered redis container.
- Existing persistence tests (control-plane round-trips, endpoint-after-restart) unchanged.

Depends on the EC2 durable-volume work merged in #1863.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make persistent mode actually persist container data by default. RDS and EC2 containers now mount durable volumes automatically, so data survives restarts without extra flags.

- **New Features**
  - In persistent storage mode, set `FAKECLOUD_PERSIST_DB_VOLUMES` and `FAKECLOUD_PERSIST_EC2_VOLUMES` to "1" at startup unless the user already set them. Memory mode stays fully ephemeral.
  - Added E2E tests proving data survives restarts: a Postgres row (RDS) and a Redis key (ElastiCache). ElastiCache already persisted `/data`, so only tests were added.

<sup>Written for commit 2b232ad0d2bf96cb10d8cfb60aa1067747ab7850. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

