### PR TITLE
fix(ecs): delete task-scoped docker volumes when a task stops

### DIFF
--- a/crates/fakecloud-e2e/tests/ecs_volumes.rs
+++ b/crates/fakecloud-e2e/tests/ecs_volumes.rs
@@ -18,9 +18,21 @@ mod helpers;
 use std::time::Duration;
 
 use aws_sdk_ecs::types::{
-    ContainerDefinition, EfsVolumeConfiguration, HostVolumeProperties, MountPoint, Volume,
+    ContainerDefinition, DockerVolumeConfiguration, EfsVolumeConfiguration, HostVolumeProperties,
+    MountPoint, Scope, Volume,
 };
 use helpers::TestServer;
+
+/// True if a docker volume with this name currently exists.
+fn docker_volume_exists(name: &str) -> bool {
+    std::process::Command::new("docker")
+        .args(["volume", "inspect", name])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
 
 fn docker_available() -> bool {
     std::process::Command::new("docker")
@@ -288,4 +300,115 @@ async fn ecs_efs_stub_is_shared_across_tasks() {
     // Cleanup: remove the stub directory so successive test runs on
     // the same machine don't accumulate.
     let _ = std::fs::remove_dir_all(format!("/tmp/fakecloud/efs/{fs_id}"));
+}
+
+/// AWS deletes a task-scoped docker volume when the task stops, but keeps a
+/// `scope=shared` one. After a task that mounts both stops, the task-scoped
+/// volume must be gone and the shared volume must remain.
+#[tokio::test]
+async fn ecs_task_scoped_docker_volume_removed_on_stop() {
+    if !require_docker_or_skip("ecs_task_scoped_docker_volume_removed_on_stop") {
+        return;
+    }
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+
+    let unique = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let task_vol = format!("fc-ecs-task-{unique}");
+    let shared_vol = format!("fc-ecs-shared-{unique}");
+
+    ecs.create_cluster()
+        .cluster_name("vol-scope-cluster")
+        .send()
+        .await
+        .unwrap();
+
+    ecs.register_task_definition()
+        .family("vol-scope-family")
+        .volumes(
+            Volume::builder()
+                .name(&task_vol)
+                .docker_volume_configuration(
+                    DockerVolumeConfiguration::builder()
+                        .scope(Scope::Task)
+                        .build(),
+                )
+                .build(),
+        )
+        .volumes(
+            Volume::builder()
+                .name(&shared_vol)
+                .docker_volume_configuration(
+                    DockerVolumeConfiguration::builder()
+                        .scope(Scope::Shared)
+                        .autoprovision(true)
+                        .build(),
+                )
+                .build(),
+        )
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("writer")
+                .image("public.ecr.aws/docker/library/alpine:3.20")
+                .essential(true)
+                .mount_points(
+                    MountPoint::builder()
+                        .source_volume(&task_vol)
+                        .container_path("/mnt/task")
+                        .build(),
+                )
+                .mount_points(
+                    MountPoint::builder()
+                        .source_volume(&shared_vol)
+                        .container_path("/mnt/shared")
+                        .build(),
+                )
+                .command("sh")
+                .command("-c")
+                .command("echo x > /mnt/task/f && echo x > /mnt/shared/f")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let run = ecs
+        .run_task()
+        .cluster("vol-scope-cluster")
+        .task_definition("vol-scope-family")
+        .send()
+        .await
+        .unwrap();
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+    wait_stopped(&ecs, "vol-scope-cluster", &arn).await;
+
+    // The teardown removes containers then volumes; give it a moment to run
+    // the volume rm after the task flips to STOPPED.
+    let mut task_gone = false;
+    for _ in 0..40 {
+        if !docker_volume_exists(&task_vol) {
+            task_gone = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    assert!(
+        task_gone,
+        "task-scoped docker volume {task_vol} should be removed when the task stops"
+    );
+    assert!(
+        docker_volume_exists(&shared_vol),
+        "scope=shared docker volume {shared_vol} should survive the task stopping"
+    );
+
+    let _ = std::process::Command::new("docker")
+        .args(["volume", "rm", "-f", &shared_vol])
+        .status();
 }

--- a/crates/fakecloud-ecs/src/runtime/k8s.rs
+++ b/crates/fakecloud-ecs/src/runtime/k8s.rs
@@ -954,6 +954,7 @@ mod tests {
             source: "scratch".to_string(),
             container_path: "/data".to_string(),
             read_only: false,
+            cleanup_on_stop: true,
         };
         a.volume_mounts = vec![vm.clone()];
         b.volume_mounts = vec![vm];

--- a/crates/fakecloud-ecs/src/runtime/mod.rs
+++ b/crates/fakecloud-ecs/src/runtime/mod.rs
@@ -351,6 +351,12 @@ pub(crate) struct VolumeMount {
     /// `-v` flag so the bind/named volume is read-only inside the
     /// container. Defaults to false (read-write) when omitted.
     pub read_only: bool,
+    /// Whether `source` is a task-scoped docker named volume that should be
+    /// removed when the task stops, matching AWS: anonymous "Docker volumes"
+    /// and `dockerVolumeConfiguration` with `scope=task` are deleted on task
+    /// teardown. `false` for host bind mounts, EFS/FSx shared stubs, and
+    /// `scope=shared` docker volumes, which persist independently of the task.
+    pub cleanup_on_stop: bool,
 }
 
 /// One `ulimits` entry. Becomes `--ulimit <name>=<soft>:<hard>`.
@@ -660,11 +666,49 @@ fn resolve_mount_point(
         .unwrap_or(false);
     let volume = volumes_by_name.get(source_volume)?;
     let source = resolve_volume_source(source_volume, volume)?;
+    let cleanup_on_stop = volume_is_task_scoped(volume);
     Some(VolumeMount {
         source,
         container_path,
         read_only,
+        cleanup_on_stop,
     })
+}
+
+/// Whether a task-definition `volumes[]` entry is a task-scoped docker named
+/// volume that AWS deletes when the task stops. Mirrors the kind matching in
+/// [`resolve_volume_source`]:
+/// - host bind with a non-empty `sourcePath` -> persists on the host: `false`.
+/// - EFS / FSx -> shared filesystem, persists: `false`.
+/// - `dockerVolumeConfiguration` -> task-scoped unless `scope=shared`.
+/// - bare entry (or host with empty `sourcePath`) -> anonymous task-scoped
+///   docker volume: `true`.
+fn volume_is_task_scoped(volume: &serde_json::Value) -> bool {
+    if let Some(host) = volume.get("host") {
+        if let Some(path) = host.get("sourcePath").and_then(|v| v.as_str()) {
+            if !path.is_empty() {
+                return false;
+            }
+        }
+    }
+    if volume.get("efsVolumeConfiguration").is_some()
+        || volume
+            .get("fsxWindowsFileServerVolumeConfiguration")
+            .is_some()
+    {
+        return false;
+    }
+    if let Some(docker) = volume.get("dockerVolumeConfiguration") {
+        // Default scope for an ECS docker volume is `task`; only `shared`
+        // volumes outlive the task.
+        let scope = docker
+            .get("scope")
+            .and_then(|v| v.as_str())
+            .unwrap_or("task");
+        return scope != "shared";
+    }
+    // Bare volume entry (or host with empty sourcePath): anonymous task volume.
+    true
 }
 
 /// Map a single task-definition `volumes[]` entry to the source side of a
@@ -2397,6 +2441,7 @@ mod tests {
                 source: "/host/path".into(),
                 container_path: "/in/container".into(),
                 read_only: true,
+                cleanup_on_stop: false,
             }],
             ulimits: Vec::new(),
             linux_parameters: None,
@@ -2487,6 +2532,53 @@ mod tests {
         let resolved = resolve_mount_point(&mp, &volumes).expect("resolved");
         assert_eq!(resolved.source, "named-vol");
         assert_eq!(resolved.container_path, "/data");
+    }
+
+    /// Only task-scoped docker volumes are flagged for removal on task stop;
+    /// host binds, EFS/FSx shared stubs and scope=shared volumes persist.
+    #[test]
+    fn cleanup_on_stop_matches_aws_volume_scope() {
+        let cases = [
+            // (volume json, expected cleanup_on_stop)
+            (
+                serde_json::json!({ "name": "v", "host": { "sourcePath": "/data" } }),
+                false,
+            ),
+            (
+                serde_json::json!({ "name": "v", "efsVolumeConfiguration": { "fileSystemId": "fs-a" } }),
+                false,
+            ),
+            (
+                serde_json::json!({ "name": "v", "fsxWindowsFileServerVolumeConfiguration": { "fileSystemId": "fs-b" } }),
+                false,
+            ),
+            (
+                serde_json::json!({ "name": "v", "dockerVolumeConfiguration": { "scope": "shared" } }),
+                false,
+            ),
+            (
+                serde_json::json!({ "name": "v", "dockerVolumeConfiguration": { "scope": "task" } }),
+                true,
+            ),
+            // scope omitted defaults to task.
+            (
+                serde_json::json!({ "name": "v", "dockerVolumeConfiguration": {} }),
+                true,
+            ),
+            // bare entry and empty host sourcePath -> anonymous task volume.
+            (serde_json::json!({ "name": "v" }), true),
+            (
+                serde_json::json!({ "name": "v", "host": { "sourcePath": "" } }),
+                true,
+            ),
+        ];
+        for (vol, expected) in cases {
+            assert_eq!(
+                volume_is_task_scoped(&vol),
+                expected,
+                "unexpected cleanup_on_stop for {vol}"
+            );
+        }
     }
 
     /// FSx for Windows uses the same stub-directory pattern as EFS but

--- a/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
+++ b/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
@@ -487,6 +487,26 @@ impl EcsRuntime {
                 .output()
                 .await;
         }
+        // Reap task-scoped docker volumes (anonymous "Docker volumes" and
+        // `dockerVolumeConfiguration` with scope=task), matching AWS, which
+        // deletes them when the task stops. Host binds, EFS/FSx stubs and
+        // scope=shared volumes are left in place — they outlive the task.
+        // `volume rm` is best-effort and no-ops on a volume still in use.
+        let mut task_volumes: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
+        for rp in &resolved_plans {
+            for vm in &rp.plan.volume_mounts {
+                if vm.cleanup_on_stop {
+                    task_volumes.insert(vm.source.clone());
+                }
+            }
+        }
+        for vol in &task_volumes {
+            let _ = Command::new(&self.cli)
+                .args(["volume", "rm", "-f", vol])
+                .output()
+                .await;
+        }
         // Clean up the per-task docker network for awsvpc.
         if network_created {
             let _ = Command::new(&self.cli)


### PR DESCRIPTION
## Summary

Batch 3 of container data-plane durability — the AWS-faithful half for ECS. Research showed ECS task *containers* correctly do not recover across restart (matching AWS), and shared/EFS volumes already persist via stable names, so the real gap was the opposite of a durability gap: **task-scoped docker volumes leaked**.

ECS mounts task-definition `volumes[]` as real `docker -v` flags but never removed the docker named volumes it created. Anonymous "Docker volumes" and `dockerVolumeConfiguration` with `scope=task` therefore leaked on every task stop. AWS deletes task-scoped volumes when the task stops; only host binds, EFS/FSx and `scope=shared` volumes outlive it.

- Tag each `VolumeMount` with `cleanup_on_stop`, derived from the volume kind via `volume_is_task_scoped` (task-scoped docker/anonymous -> true; host / EFS / FSx / scope=shared -> false).
- On task teardown, after reaping containers, `docker volume rm` the unique task-scoped sources (best-effort; no-op if still in use).

## Test plan

- `cargo clippy -p fakecloud-ecs --all-targets -- -D warnings` -- clean.
- Unit test mapping every volume kind (host / EFS / FSx / scope=shared / scope=task / scope-omitted / bare / empty-host) to the correct `cleanup_on_stop` flag.
- Docker-gated E2E: a `scope=task` docker volume is gone after the task reaches STOPPED, while a `scope=shared` volume survives.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes task-scoped Docker volumes when an ECS task stops to match AWS behavior and stop leaking named/anonymous volumes.

- **Bug Fixes**
  - Add `cleanup_on_stop` to each `VolumeMount`, set via `volume_is_task_scoped` (task-scoped/anonymous -> true; host/EFS/FSx/scope=shared -> false).
  - On task teardown, after containers exit, remove unique task-scoped volumes with `docker volume rm` (best-effort).
  - Tests: unit cases for all volume kinds; Docker E2E confirms `scope=task` is removed and `scope=shared` persists.

<sup>Written for commit e5c5cee404856b6579b19ed9649ff7a162aa3c94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

