### PR TITLE
feat(tfacc): add s3 (24 tests) and sts to the acceptance suite

### DIFF
--- a/crates/fakecloud-s3/src/service/objects/read.rs
+++ b/crates/fakecloud-s3/src/service/objects/read.rs
@@ -8,6 +8,17 @@ use super::*;
 /// bodies (and persisted state), so a crafted value must never crash the
 /// read path. AWS itself only ever stores the validated enum values, so a
 /// well-behaved object always round-trips its header.
+/// True when the request opted into checksum retrieval via
+/// `x-amz-checksum-mode: ENABLED`. AWS only returns a stored object checksum on
+/// GetObject/HeadObject when this is set.
+fn checksum_mode_enabled(req: &AwsRequest) -> bool {
+    req.headers
+        .get("x-amz-checksum-mode")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.eq_ignore_ascii_case("ENABLED"))
+        .unwrap_or(false)
+}
+
 fn insert_str_header(headers: &mut HeaderMap, name: &'static str, value: &str) {
     if let Ok(v) = value.parse::<http::header::HeaderValue>() {
         headers.insert(name, v);
@@ -136,6 +147,12 @@ impl S3Service {
         // path; skip-if-invalid mirrors the object-lock guards below.
         if let Some(algo) = &obj.sse_algorithm {
             insert_str_header(&mut headers, "x-amz-server-side-encryption", algo);
+        } else {
+            // Every S3 object is encrypted at rest with SSE-S3 (AES256) by
+            // default, and AWS reports that on GetObject/HeadObject. The
+            // Terraform `aws_s3_object` resource asserts `server_side_encryption
+            // = AES256`, so emit it when no other algorithm was set.
+            insert_str_header(&mut headers, "x-amz-server-side-encryption", "AES256");
         }
         if let Some(kid) = &obj.sse_kms_key_id {
             insert_str_header(
@@ -290,8 +307,13 @@ impl S3Service {
                 full_body_response(state, &obj.body)?
             };
         }
-        // Only include checksum headers for full (non-range) responses
-        if !is_range_request {
+        // Only include checksum headers for full (non-range) responses, and
+        // only when the caller opted in with `x-amz-checksum-mode: ENABLED`.
+        // AWS does not echo a stored object checksum on a plain GetObject (the
+        // Go SDK auto-attaches a CRC32 on PutObject, but Terraform reads the
+        // object without enabling checksum mode and expects `checksum_crc32`
+        // to be empty).
+        if !is_range_request && checksum_mode_enabled(req) {
             if let Some(algo) = &obj.checksum_algorithm {
                 if let Some(val) = &obj.checksum_value {
                     let hn = format!("x-amz-checksum-{}", algo.to_lowercase());
@@ -485,6 +507,12 @@ impl S3Service {
         // skip-if-invalid helper rather than .parse().unwrap().
         if let Some(algo) = &obj.sse_algorithm {
             insert_str_header(&mut headers, "x-amz-server-side-encryption", algo);
+        } else {
+            // Every S3 object is encrypted at rest with SSE-S3 (AES256) by
+            // default, and AWS reports that on GetObject/HeadObject. The
+            // Terraform `aws_s3_object` resource asserts `server_side_encryption
+            // = AES256`, so emit it when no other algorithm was set.
+            insert_str_header(&mut headers, "x-amz-server-side-encryption", "AES256");
         }
         if let Some(kid) = &obj.sse_kms_key_id {
             insert_str_header(
@@ -523,13 +551,17 @@ impl S3Service {
             };
             headers.insert("x-amz-restore", restore_val.parse().unwrap());
         }
-        // Checksum headers (returned when ChecksumMode=ENABLED or always if set)
-        if let Some(algo) = &obj.checksum_algorithm {
-            if let Some(val) = &obj.checksum_value {
-                let hn = format!("x-amz-checksum-{}", algo.to_lowercase());
-                if let Ok(name) = hn.parse::<http::header::HeaderName>() {
-                    if let Ok(hv) = val.parse() {
-                        headers.insert(name, hv);
+        // Checksum headers are only returned when the caller sets
+        // `x-amz-checksum-mode: ENABLED`; AWS does not echo them on a plain
+        // HeadObject even though one is stored.
+        if checksum_mode_enabled(req) {
+            if let Some(algo) = &obj.checksum_algorithm {
+                if let Some(val) = &obj.checksum_value {
+                    let hn = format!("x-amz-checksum-{}", algo.to_lowercase());
+                    if let Ok(name) = hn.parse::<http::header::HeaderName>() {
+                        if let Ok(hv) = val.parse() {
+                            headers.insert(name, hv);
+                        }
                     }
                 }
             }

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -2244,6 +2244,47 @@ async fn head_object_returns_headers() {
 }
 
 #[tokio::test]
+async fn head_object_defaults_sse_and_gates_checksum_on_mode() {
+    let svc = make_service();
+    seed_bucket(&svc, "sse");
+
+    // PUT with a CRC32 checksum requested (the Go SDK does this automatically).
+    let mut put = make_request(Method::PUT, "/sse/f.txt", &[], b"12345");
+    put.headers.insert(
+        "x-amz-checksum-algorithm",
+        http::HeaderValue::from_static("CRC32"),
+    );
+    svc.put_object("123456789012", &put, "sse", "f.txt")
+        .await
+        .unwrap();
+
+    // HEAD without checksum mode: SSE defaults to AES256, no checksum header.
+    let req = make_request(Method::HEAD, "/sse/f.txt", &[], b"");
+    let resp = svc
+        .head_object("123456789012", &req, "sse", "f.txt")
+        .unwrap();
+    assert_eq!(
+        resp.headers.get("x-amz-server-side-encryption").unwrap(),
+        "AES256"
+    );
+    assert!(
+        resp.headers.get("x-amz-checksum-crc32").is_none(),
+        "checksum must not be returned without x-amz-checksum-mode: ENABLED"
+    );
+
+    // HEAD with checksum mode enabled: the stored checksum is returned.
+    let mut req = make_request(Method::HEAD, "/sse/f.txt", &[], b"");
+    req.headers.insert(
+        "x-amz-checksum-mode",
+        http::HeaderValue::from_static("ENABLED"),
+    );
+    let resp = svc
+        .head_object("123456789012", &req, "sse", "f.txt")
+        .unwrap();
+    assert!(resp.headers.get("x-amz-checksum-crc32").is_some());
+}
+
+#[tokio::test]
 async fn delete_object_via_handler() {
     let svc = make_service();
     seed_bucket(&svc, "del");

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -71,6 +71,37 @@ pub fn shard_deny_list(shard: &Shard) -> Vec<&'static str> {
 
 pub const SERVICES: &[Service] = &[
     Service {
+        name: "s3",
+        // Wave 3: the `_basic` suite for the S3 bucket sub-resources, bucket
+        // and object data sources, and the object resources. 24 tests. The
+        // batch made GetObject/HeadObject report the default SSE-S3 (AES256)
+        // encryption and stop echoing a stored checksum unless the caller sets
+        // `x-amz-checksum-mode: ENABLED`, which the object tests assert.
+        run_regex: "^TestAccS3[A-Za-z]+_basic$",
+        deny: &[
+            // --- gap: bucket logging / inventory leave the destination bucket
+            //     non-empty at destroy time (force-destroy / log-object
+            //     cleanup) — CheckDestroy fails with BucketNotEmpty. ---
+            "TestAccS3BucketLogging_basic",
+            "TestAccS3BucketInventory_basic",
+            // --- gap: replication configuration is cross-region. ---
+            "TestAccS3BucketReplicationConfiguration_basic",
+            // --- unsupportable: S3 Express One Zone directory buckets are a
+            //     separate API surface (ListDirectoryBuckets, etc.) not
+            //     implemented. ---
+            "TestAccS3DirectoryBucket_basic",
+            "TestAccS3DirectoryBucketsDataSource_basic",
+        ],
+    },
+    Service {
+        name: "sts",
+        // Wave 3: the `aws_caller_identity` data source smoke. STS's other
+        // surfaces (AssumeRole, GetSessionToken) are request actions, not
+        // Terraform-managed resources.
+        run_regex: "^TestAccSTS[A-Za-z]+_basic$",
+        deny: &[],
+    },
+    Service {
         name: "cognitoidp",
         // Batch 11: core `aws_cognito_user_pool` smoke. The fix here is
         // returning five shape blocks with AWS defaults on every
@@ -374,6 +405,18 @@ pub const SERVICES: &[Service] = &[
 /// from double-running the same tests.
 pub const SHARDS: &[Shard] = &[
     // ─── unsharded services (1 shard each) ─────────────────────────
+    Shard {
+        name: "s3",
+        service: "s3",
+        run_regex: "^TestAccS3[A-Za-z]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "sts",
+        service: "sts",
+        run_regex: "^TestAccSTS[A-Za-z]+_basic$",
+        extra_deny: &[],
+    },
     Shard {
         name: "cognitoidp",
         service: "cognitoidp",

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -405,10 +405,26 @@ pub const SERVICES: &[Service] = &[
 /// from double-running the same tests.
 pub const SHARDS: &[Shard] = &[
     // ─── unsharded services (1 shard each) ─────────────────────────
+    // s3 split three ways: the full `_basic` set runs ~24 tests, each of which
+    // creates a bucket, applies a sub-resource config, and destroys it. On a
+    // 2-core CI runner that exceeds the 60-minute job budget, so partition the
+    // bucket sub-resources A-L / M-Z and run the object resources separately.
     Shard {
-        name: "s3",
+        name: "s3-buckets-a",
         service: "s3",
-        run_regex: "^TestAccS3[A-Za-z]+_basic$",
+        run_regex: "^TestAccS3Bucket[A-L][A-Za-z]*_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "s3-buckets-b",
+        service: "s3",
+        run_regex: "^TestAccS3Bucket[M-Z][A-Za-z]*_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "s3-objects",
+        service: "s3",
+        run_regex: "^TestAccS3(Object|Canonical)[A-Za-z]*_basic$",
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -28,6 +28,16 @@ async fn run_shard(name: &str) {
 }
 
 #[tokio::test]
+async fn s3_acceptance() {
+    run_shard("s3").await;
+}
+
+#[tokio::test]
+async fn sts_acceptance() {
+    run_shard("sts").await;
+}
+
+#[tokio::test]
 async fn cognitoidp_acceptance() {
     run_shard("cognitoidp").await;
 }

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -28,8 +28,18 @@ async fn run_shard(name: &str) {
 }
 
 #[tokio::test]
-async fn s3_acceptance() {
-    run_shard("s3").await;
+async fn s3_buckets_a_acceptance() {
+    run_shard("s3-buckets-a").await;
+}
+
+#[tokio::test]
+async fn s3_buckets_b_acceptance() {
+    run_shard("s3-buckets-b").await;
+}
+
+#[tokio::test]
+async fn s3_objects_acceptance() {
+    run_shard("s3-objects").await;
 }
 
 #[tokio::test]

--- a/scripts/check-doc-counts.sh
+++ b/scripts/check-doc-counts.sh
@@ -166,7 +166,7 @@ FILES=(
 # its local context (subset counts, rhetorical comparisons, etc.).
 EXCEPTIONS=(
     # tfacc covers a subset of services
-    "website/content/docs/about/conformance.md:services:13"
+    "website/content/docs/about/conformance.md:services:15"
     # real-AWS parity sandbox covers a subset
     "website/content/docs/about/conformance.md:services:7"
     # rhetorical comparison: "depth-first vs N services at 50%"

--- a/website/content/docs/about/conformance.md
+++ b/website/content/docs/about/conformance.md
@@ -116,7 +116,7 @@ Running both is how fakecloud can claim 100% behavioral parity with a straight f
 
 ### Current coverage
 
-13 services today: `apigatewayv2`, `bedrock`, `cognitoidp`, `dynamodb`, `events` (EventBridge), `iam`, `kinesis`, `kms`, `logs`, `secretsmanager`, `sns`, `sqs`, `ssm`. Coverage per service ranges from a single smoke test to the full `_basic` suite across every resource type (IAM, for example, exercises ~42 resource and data-source types).
+15 services today: `apigatewayv2`, `bedrock`, `cognitoidp`, `dynamodb`, `events` (EventBridge), `iam`, `kinesis`, `kms`, `logs`, `s3`, `secretsmanager`, `sns`, `sqs`, `ssm`, `sts`. Coverage per service ranges from a single smoke test to the full `_basic` suite across every resource type (IAM, for example, exercises ~42 resource and data-source types; S3, ~24).
 
 ### Allow-list, not deny-list
 


### PR DESCRIPTION
## Summary

Adds two new services to the tfacc allow-list.

**s3** — `_basic` suite for the bucket sub-resources (ACL, CORS, lifecycle, versioning, website, object-lock, encryption, public-access-block, ownership controls, accelerate, analytics, intelligent-tiering, metric, policy), the bucket/object data sources, and the object resources — **24 tests**.

Two real fakecloud fixes unblocked the object resources:
- `GetObject`/`HeadObject` report the default SSE-S3 (`AES256`) encryption AWS applies to every object (the `aws_s3_object` resource asserts it).
- They no longer echo a stored checksum unless the caller sets `x-amz-checksum-mode: ENABLED` — the Go SDK auto-attaches a CRC32 on PutObject, but Terraform reads without enabling checksum mode and expects `checksum_crc32` empty.

**sts** — the `aws_caller_identity` data source smoke.

Denied with reasons: bucket logging/inventory (`BucketNotEmpty` at destroy), replication (cross-region), S3 Express directory buckets (unsupportable).

## Test plan
- New unit test: SSE default + checksum-mode gating.
- doc-counts updated (tfacc service count 13 -> 15); clippy clean.
- New shards vs terraform-provider-aws v5.97.0: **s3 24/24, sts 1/1**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `s3` (24 tests) and `sts` to the `tfacc` acceptance suite, and split S3 into three shards to fit CI timeouts. Includes S3 parity fixes for default SSE-S3 reporting and checksum header gating; coverage now 15 services.

- **New Features**
  - Allowlist `s3` and `sts` in `tfacc`.
  - `s3`: run `_basic` suite for bucket sub-resources, bucket/object data sources, and object resources (24 tests); deny bucket logging/inventory, replication, and S3 Express directory buckets.
  - CI: split S3 into three shards — buckets A–L, buckets M–Z, and objects.
  - Update docs and service count to 15.

- **Bug Fixes**
  - S3 `GetObject`/`HeadObject`: emit default SSE-S3 (`AES256`) when unset.
  - Return checksum headers only when `x-amz-checksum-mode: ENABLED`; added unit test.

<sup>Written for commit b1c5c5c39e6d05c8bfb3a571fd263165c12d18c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

