### PR TITLE
feat(tfacc): add route53 (14 tests) with REST-XML error fix

### DIFF
--- a/crates/fakecloud-route53/src/service/mod.rs
+++ b/crates/fakecloud-route53/src/service/mod.rs
@@ -452,8 +452,35 @@ impl AwsService for Route53Service {
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
             self.save_snapshot().await;
         }
-        result
+        // Route 53 is a REST-XML service whose error wire format wraps the
+        // error in `<ErrorResponse>` (unlike S3's bare `<Error>`). The shared
+        // dispatcher renders Rest-protocol errors in the S3 shape, so the AWS
+        // SDK can't parse the code and reports `UnknownError` — which broke the
+        // provider's post-destroy `GetHostedZone` check (it expects
+        // `NoSuchHostedZone`). Render the route53-shaped error body here.
+        match result {
+            Ok(resp) => Ok(resp),
+            Err(err) => Ok(route53_error_response(&err, &req.request_id)),
+        }
     }
+}
+
+/// Render an [`AwsServiceError`] as a Route 53 REST-XML `<ErrorResponse>`
+/// document so the AWS SDK can extract the error code.
+fn route53_error_response(err: &AwsServiceError, request_id: &str) -> AwsResponse {
+    let body = format!(
+        "{XML_DECL}<ErrorResponse xmlns=\"{NS}\">\
+         <Error><Type>Sender</Type><Code>{}</Code><Message>{}</Message></Error>\
+         <RequestId>{}</RequestId></ErrorResponse>",
+        esc(err.code()),
+        esc(&err.message()),
+        esc(request_id),
+    );
+    let mut headers = HeaderMap::new();
+    if let Ok(v) = http::HeaderValue::from_str(err.code()) {
+        headers.insert("x-amz-error-code", v);
+    }
+    xml_response(err.status(), body, headers)
 }
 
 // ─── Hosted Zone handlers ────────────────────────────────────────────
@@ -1525,6 +1552,40 @@ mod tests {
             access_key_id: None,
             principal: None,
         }
+    }
+
+    #[tokio::test]
+    async fn get_missing_hosted_zone_returns_errorresponse_wrapper() {
+        // Route 53's REST-XML errors must be wrapped in <ErrorResponse> (not
+        // S3's bare <Error>) so the AWS SDK can read the code; otherwise the
+        // provider's post-destroy GetHostedZone check sees "UnknownError".
+        let (svc, _) = svc_with_zone(vec![]);
+        let req = AwsRequest {
+            service: "route53".to_string(),
+            action: "GetHostedZone".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: DEFAULT_ACCOUNT.to_string(),
+            request_id: "rid-1".to_string(),
+            headers: HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec!["2013-04-01".into(), "hostedzone".into(), "ZMISSING".into()],
+            raw_path: "/2013-04-01/hostedzone/ZMISSING".to_string(),
+            raw_query: String::new(),
+            method: http::Method::GET,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        };
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::NOT_FOUND);
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("<ErrorResponse"), "missing wrapper: {body}");
+        assert!(
+            body.contains("<Code>NoSuchHostedZone</Code>"),
+            "missing code: {body}"
+        );
     }
 
     fn extract_record_data(body: &str) -> Vec<String> {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -102,6 +102,28 @@ pub const SERVICES: &[Service] = &[
         deny: &[],
     },
     Service {
+        name: "route53",
+        // Wave 3: the `_basic` suite for hosted zones, records (+ exclusive /
+        // data sources), health checks, DNSSEC, query-logging, delegation sets,
+        // traffic policies (+ instances), and CIDR locations — 14 tests. The
+        // batch made Route 53 render its REST-XML errors in the `<ErrorResponse>`
+        // wrapper (not S3's bare `<Error>`), so the AWS SDK can read the error
+        // code; without it the provider's post-destroy `GetHostedZone` check saw
+        // `UnknownError` and every zone-owning test failed at destroy.
+        run_regex: "^TestAccRoute53[A-Za-z]+_basic$",
+        deny: &[
+            // --- gap: CIDR collection ARN must omit the account id
+            //     (`arn:aws:route53:::cidrcollection/...`); fakecloud includes
+            //     it. ---
+            "TestAccRoute53CIDRCollection_basic",
+            // --- gap: DNSSEC key-signing keys need a computed DS digest_value
+            //     (hex), which fakecloud leaves empty. ---
+            "TestAccRoute53KeySigningKey_basic",
+            // --- gap: VPC zone association apply path. ---
+            "TestAccRoute53ZoneAssociation_basic",
+        ],
+    },
+    Service {
         name: "cognitoidp",
         // Batch 11: core `aws_cognito_user_pool` smoke. The fix here is
         // returning five shape blocks with AWS defaults on every
@@ -431,6 +453,12 @@ pub const SHARDS: &[Shard] = &[
         name: "sts",
         service: "sts",
         run_regex: "^TestAccSTS[A-Za-z]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "route53",
+        service: "route53",
+        run_regex: "^TestAccRoute53[A-Za-z]+_basic$",
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -299,4 +299,5 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_SFN", "sfn"),
     ("AWS_ENDPOINT_URL_APIGATEWAYV2", "apigatewayv2"),
     ("AWS_ENDPOINT_URL_BEDROCK", "bedrock"),
+    ("AWS_ENDPOINT_URL_ROUTE53", "route53"),
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -48,6 +48,11 @@ async fn sts_acceptance() {
 }
 
 #[tokio::test]
+async fn route53_acceptance() {
+    run_shard("route53").await;
+}
+
+#[tokio::test]
 async fn cognitoidp_acceptance() {
     run_shard("cognitoidp").await;
 }

--- a/scripts/check-doc-counts.sh
+++ b/scripts/check-doc-counts.sh
@@ -166,7 +166,7 @@ FILES=(
 # its local context (subset counts, rhetorical comparisons, etc.).
 EXCEPTIONS=(
     # tfacc covers a subset of services
-    "website/content/docs/about/conformance.md:services:15"
+    "website/content/docs/about/conformance.md:services:16"
     # real-AWS parity sandbox covers a subset
     "website/content/docs/about/conformance.md:services:7"
     # rhetorical comparison: "depth-first vs N services at 50%"

--- a/website/content/docs/about/conformance.md
+++ b/website/content/docs/about/conformance.md
@@ -116,7 +116,7 @@ Running both is how fakecloud can claim 100% behavioral parity with a straight f
 
 ### Current coverage
 
-15 services today: `apigatewayv2`, `bedrock`, `cognitoidp`, `dynamodb`, `events` (EventBridge), `iam`, `kinesis`, `kms`, `logs`, `s3`, `secretsmanager`, `sns`, `sqs`, `ssm`, `sts`. Coverage per service ranges from a single smoke test to the full `_basic` suite across every resource type (IAM, for example, exercises ~42 resource and data-source types; S3, ~24).
+16 services today: `apigatewayv2`, `bedrock`, `cognitoidp`, `dynamodb`, `events` (EventBridge), `iam`, `kinesis`, `kms`, `logs`, `route53`, `s3`, `secretsmanager`, `sns`, `sqs`, `ssm`, `sts`. Coverage per service ranges from a single smoke test to the full `_basic` suite across every resource type (IAM, for example, exercises ~42 resource and data-source types; S3, ~24).
 
 ### Allow-list, not deny-list
 


### PR DESCRIPTION
## Summary

Adds Route 53 to the tfacc allow-list — the `_basic` suite for hosted zones, records (+ exclusive / data sources), health checks, DNSSEC, query logging, delegation sets, traffic policies (+ instances), CIDR locations. **14 tests.**

**Real fakecloud fix:** Route 53 now renders its REST-XML errors wrapped in `<ErrorResponse>` (with `<Type>`/`<Code>`/`<Message>`), matching the AWS wire format, instead of S3's bare `<Error>`. The shared dispatcher emits the S3 shape for every Rest-protocol service, so the AWS SDK couldn't extract the error code and reported `UnknownError` — breaking the provider's post-destroy `GetHostedZone` check (expects `NoSuchHostedZone`) and failing every zone-owning test at destroy. **This single fix took route53 from 5 to 14 passing.**

Denied as gaps: CIDR collection (ARN includes account id), DNSSEC key-signing keys (empty digest), VPC zone association.

## Test plan
- New unit test: route53 `<ErrorResponse>` wrapper for a missing zone.
- Wires `AWS_ENDPOINT_URL_ROUTE53`; doc-counts 15 -> 16; clippy clean.
- Shard vs terraform-provider-aws v5.97.0: **14/14** (~3.5m locally, ~14m projected CI).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Route 53 to the tfacc allow-list and fix REST-XML error rendering to match AWS. This enables the `_basic` suite to pass for `route53` (14/14) and unblocks zone destroy checks.

- **New Features**
  - Add `route53` shard to run the `_basic` suite across hosted zones, records, health checks, DNSSEC, query logging, delegation sets, traffic policies (+ instances), and CIDR locations.
  - Wire `AWS_ENDPOINT_URL_ROUTE53`.
  - Update docs to 16 services.
  - Keep denies for gaps: CIDR collection ARN (omit account id), DNSSEC key-signing key digest, VPC zone association.

- **Bug Fixes**
  - Render `route53` REST-XML errors as `<ErrorResponse>` with `<Type>`, `<Code>`, `<Message>`, and `x-amz-error-code`.
  - Lets the AWS SDK read `NoSuchHostedZone`, restoring the provider’s post-destroy `GetHostedZone` check.
  - Add a unit test for the error wrapper.

<sup>Written for commit bc912f100a3e40a4bb2230b513c9f68d2beedbc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

