### PR TITLE
ci(e2e): build test binaries once via nextest archive, widen general partitions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,27 +58,10 @@ jobs:
         name: Generate E2E matrix
         run: echo "matrix=$(./target/debug/e2e_nextest_partitions matrix)" >> "$GITHUB_OUTPUT"
 
-      # Build fakecloud once here so every partition job can download the
-      # binary as an artifact instead of rebuilding from scratch. The e2e test
-      # harness boots it via its workspace-relative path
-      # (crates/fakecloud-testkit/src/lib.rs), which resolves identically on every
-      # GitHub-hosted runner, so a downloaded binary works regardless of where the
-      # archived test binaries are extracted.
-      - name: Build fakecloud
-        run: cargo build --bin fakecloud
-
-      - name: Upload fakecloud binary
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: fakecloud-binary-e2e
-          path: target/debug/fakecloud
-          if-no-files-found: error
-          retention-days: 1
-
       # Build the E2E test binaries ONCE and archive them. Every partition job
       # then runs the prebuilt binaries via `--archive-file` instead of
       # recompiling the (large) test crate from scratch — previously ~11.5 min of
-      # redundant compilation paid in each of the ~13 partition jobs.
+      # redundant compilation paid in each of the ~19 partition jobs.
       - name: Archive E2E test binaries
         run: cargo nextest archive -P ci -p fakecloud-e2e --archive-file e2e-archive.tar.zst
 
@@ -87,6 +70,34 @@ jobs:
         with:
           name: fakecloud-e2e-archive
           path: e2e-archive.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+
+  # Build the fakecloud server binary in parallel with the test-archive build so
+  # the partition jobs wait on max(archive, server) rather than their sum. The
+  # harness boots this binary via its workspace-relative path
+  # (crates/fakecloud-testkit/src/lib.rs), which resolves identically on every
+  # GitHub-hosted runner, so a downloaded binary works regardless of where the
+  # archived test binaries extract.
+  e2e-fakecloud:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/free-disk
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build fakecloud
+        run: cargo build --bin fakecloud
+
+      - name: Upload fakecloud binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fakecloud-binary-e2e
+          path: target/debug/fakecloud
           if-no-files-found: error
           retention-days: 1
 
@@ -110,7 +121,7 @@ jobs:
 
   e2e:
     name: E2E ${{ matrix.name }}
-    needs: [changes, e2e-build]
+    needs: [changes, e2e-build, e2e-fakecloud]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -194,14 +194,14 @@ jobs:
 
       # Run the prebuilt test binaries straight from the archive — no compilation.
       # --workspace-remap . points runtime workspace lookups at this checkout (the
-      # path matches the build runner on GitHub-hosted runners). Extract under /mnt
-      # so the unpacked binaries don't fill the small root filesystem.
+      # path matches the build runner on GitHub-hosted runners). nextest extracts
+      # to its own temp dir under /tmp (ample free space on the root fs);
+      # container images still land on the /mnt-relocated docker root.
       - name: Run nextest partition
         run: |
           cmd=(cargo nextest run -P ci
             --archive-file e2e-archive.tar.zst
             --workspace-remap .
-            --extract-to /mnt/nextest-e2e --extract-overwrite
             -E "$NEXTEST_FILTER")
           if [ -n "$NEXTEST_PARTITION" ]; then
             cmd+=(--partition "$NEXTEST_PARTITION")

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build E2E partition tool
@@ -58,7 +59,11 @@ jobs:
         run: echo "matrix=$(./target/debug/e2e_nextest_partitions matrix)" >> "$GITHUB_OUTPUT"
 
       # Build fakecloud once here so every partition job can download the
-      # binary as an artifact instead of rebuilding from scratch.
+      # binary as an artifact instead of rebuilding from scratch. The e2e test
+      # harness boots it via its workspace-relative path
+      # (crates/fakecloud-testkit/src/lib.rs), which resolves identically on every
+      # GitHub-hosted runner, so a downloaded binary works regardless of where the
+      # archived test binaries are extracted.
       - name: Build fakecloud
         run: cargo build --bin fakecloud
 
@@ -67,6 +72,21 @@ jobs:
         with:
           name: fakecloud-binary-e2e
           path: target/debug/fakecloud
+          if-no-files-found: error
+          retention-days: 1
+
+      # Build the E2E test binaries ONCE and archive them. Every partition job
+      # then runs the prebuilt binaries via `--archive-file` instead of
+      # recompiling the (large) test crate from scratch — previously ~11.5 min of
+      # redundant compilation paid in each of the ~13 partition jobs.
+      - name: Archive E2E test binaries
+        run: cargo nextest archive -P ci -p fakecloud-e2e --archive-file e2e-archive.tar.zst
+
+      - name: Upload E2E test archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fakecloud-e2e-archive
+          path: e2e-archive.tar.zst
           if-no-files-found: error
           retention-days: 1
 
@@ -106,7 +126,8 @@ jobs:
       - uses: ./.github/actions/free-disk
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # No rust-cache here: this job runs prebuilt test binaries from the archive
+      # produced by e2e-build and never compiles, so there is nothing to cache.
 
       - name: Install podman
         if: matrix.install_podman
@@ -157,6 +178,11 @@ jobs:
       - name: Mark fakecloud binary executable
         run: chmod +x target/debug/fakecloud
 
+      - name: Download E2E test archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: fakecloud-e2e-archive
+
       - name: Disk diagnostics before nextest
         run: |
           echo "=== df -h ==="
@@ -166,9 +192,17 @@ jobs:
           echo "=== ~/.cargo ==="
           du -sh ~/.cargo 2>/dev/null || true
 
+      # Run the prebuilt test binaries straight from the archive — no compilation.
+      # --workspace-remap . points runtime workspace lookups at this checkout (the
+      # path matches the build runner on GitHub-hosted runners). Extract under /mnt
+      # so the unpacked binaries don't fill the small root filesystem.
       - name: Run nextest partition
         run: |
-          cmd=(cargo nextest run -P ci -p fakecloud-e2e -E "$NEXTEST_FILTER")
+          cmd=(cargo nextest run -P ci
+            --archive-file e2e-archive.tar.zst
+            --workspace-remap .
+            --extract-to /mnt/nextest-e2e --extract-overwrite
+            -E "$NEXTEST_FILTER")
           if [ -n "$NEXTEST_PARTITION" ]; then
             cmd+=(--partition "$NEXTEST_PARTITION")
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,15 @@ jobs:
       # then runs the prebuilt binaries via `--archive-file` instead of
       # recompiling the (large) test crate from scratch — previously ~11.5 min of
       # redundant compilation paid in each of the ~19 partition jobs.
+      #
+      # CARGO_PROFILE_TEST_DEBUG=0 strips debuginfo from the archived binaries:
+      # it shrinks both this build and the archive, so the compile, the upload
+      # here, and the download in every partition are all faster (all on the
+      # workflow's critical path). Assertion-failure locations are preserved via
+      # std's #[track_caller], so CI failure output still points at the test line.
       - name: Archive E2E test binaries
+        env:
+          CARGO_PROFILE_TEST_DEBUG: "0"
         run: cargo nextest archive -P ci -p fakecloud-e2e --archive-file e2e-archive.tar.zst
 
       - name: Upload E2E test archive
@@ -144,35 +152,13 @@ jobs:
         if: matrix.install_podman
         run: sudo apt-get update && sudo apt-get install -y podman
 
-      # The lambda-runtimes partitions pull several large language-runtime
-      # images and stack container layers during the run, which can exhaust the
-      # root filesystem even after free-disk-space (the recurring "No space left
-      # on device" flake). Move container storage onto the runner's much larger
-      # ephemeral /mnt disk so image/layer growth no longer fills `/`.
-      - name: Relocate container storage to /mnt
-        run: |
-          echo "=== disk before relocation ==="; df -h / /mnt || df -h /
-          # Docker: move data-root to /mnt and symlink so the daemon config and
-          # any preinstalled images are preserved.
-          sudo systemctl stop docker docker.socket || true
-          sudo mkdir -p /mnt/docker
-          if [ -d /var/lib/docker ] && [ ! -L /var/lib/docker ]; then
-            sudo rsync -a /var/lib/docker/ /mnt/docker/ || true
-            sudo rm -rf /var/lib/docker
-          fi
-          sudo ln -sfn /mnt/docker /var/lib/docker
-          sudo systemctl start docker
-          # Podman (rootless): point graphroot/runroot at /mnt as well.
-          if [ "$INSTALL_PODMAN" = "true" ]; then
-            sudo mkdir -p /mnt/podman-storage /mnt/podman-run
-            sudo chown -R "$USER" /mnt/podman-storage /mnt/podman-run
-            mkdir -p ~/.config/containers
-            printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/podman-storage"\nrunroot = "/mnt/podman-run"\n' > ~/.config/containers/storage.conf
-          fi
-          echo "=== docker info root + disk after ==="
-          docker info --format '{{.DockerRootDir}}' || true
-          df -h / /mnt || df -h /
-
+      # NOTE: an earlier "Relocate container storage to /mnt" step was removed
+      # here. It existed to escape a small root filesystem when /mnt was a large
+      # separate ephemeral disk, but current GitHub-hosted runners have a single
+      # ~145G root and no separate /mnt, so the relocation rsynced docker's
+      # data-root from root back onto root — pure overhead (~1.7 min/partition)
+      # with no headroom gained. The free-disk action above still reclaims ~30G,
+      # which is the actual disk-full safety net.
       - name: Prune container state before tests
         run: |
           docker system prune -af --volumes || true

--- a/crates/fakecloud-e2e/src/bin/e2e_nextest_partitions.rs
+++ b/crates/fakecloud-e2e/src/bin/e2e_nextest_partitions.rs
@@ -78,17 +78,33 @@ struct Partition {
     install_podman: bool,
 }
 
-const PARTITIONS: [Partition; 10] = [
+// The "general" set is the long pole of the E2E run (~31 min of test execution
+// across two hash partitions). Now that test binaries are compiled once and
+// shipped as a nextest archive, each partition only pays its share of test
+// runtime, so splitting general four ways brings each well under the CI budget.
+const PARTITIONS: [Partition; 12] = [
     Partition {
         name: "general-1",
         filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
-        partition: Some("hash:1/2"),
+        partition: Some("hash:1/4"),
         install_podman: false,
     },
     Partition {
         name: "general-2",
         filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
-        partition: Some("hash:2/2"),
+        partition: Some("hash:2/4"),
+        install_podman: false,
+    },
+    Partition {
+        name: "general-3",
+        filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
+        partition: Some("hash:3/4"),
+        install_podman: false,
+    },
+    Partition {
+        name: "general-4",
+        filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
+        partition: Some("hash:4/4"),
         install_podman: false,
     },
     Partition {
@@ -440,10 +456,12 @@ mod tests {
     #[test]
     fn check_partitions_accepts_exact_coverage() {
         let lister = FakeLister::with_partitions(
-            &["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+            &["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"],
             &[
                 (partition_key("general-1"), &["a"]),
                 (partition_key("general-2"), &["b"]),
+                (partition_key("general-3"), &["k"]),
+                (partition_key("general-4"), &["l"]),
                 (partition_key("lambda-api"), &["c"]),
                 (partition_key("lambda-runtimes-python"), &["d"]),
                 (partition_key("lambda-runtimes-nodejs"), &["e"]),
@@ -461,10 +479,14 @@ mod tests {
     #[test]
     fn check_partitions_rejects_missing_tests() {
         let lister = FakeLister::with_partitions(
-            &["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "missing"],
+            &[
+                "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "missing",
+            ],
             &[
                 (partition_key("general-1"), &["a"]),
                 (partition_key("general-2"), &["b"]),
+                (partition_key("general-3"), &["k"]),
+                (partition_key("general-4"), &["l"]),
                 (partition_key("lambda-api"), &["c"]),
                 (partition_key("lambda-runtimes-python"), &["d"]),
                 (partition_key("lambda-runtimes-nodejs"), &["e"]),
@@ -482,10 +504,12 @@ mod tests {
     #[test]
     fn check_partitions_rejects_overlaps() {
         let lister = FakeLister::with_partitions(
-            &["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+            &["a", "b", "c", "d", "e", "f", "g", "h", "i", "k", "l"],
             &[
                 (partition_key("general-1"), &["a"]),
                 (partition_key("general-2"), &["a"]),
+                (partition_key("general-3"), &["k"]),
+                (partition_key("general-4"), &["l"]),
                 (partition_key("lambda-api"), &["b"]),
                 (partition_key("lambda-runtimes-python"), &["c"]),
                 (partition_key("lambda-runtimes-nodejs"), &["d"]),
@@ -503,10 +527,12 @@ mod tests {
     #[test]
     fn check_partitions_rejects_empty_partition() {
         let lister = FakeLister::with_partitions(
-            &["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+            &["a", "b", "c", "d", "e", "f", "g", "h", "i", "k", "l"],
             &[
                 (partition_key("general-1"), &["a"]),
                 (partition_key("general-2"), &["b"]),
+                (partition_key("general-3"), &["k"]),
+                (partition_key("general-4"), &["l"]),
                 (partition_key("lambda-api"), &[]),
                 (partition_key("lambda-runtimes-python"), &["c"]),
                 (partition_key("lambda-runtimes-nodejs"), &["d"]),

--- a/crates/fakecloud-e2e/src/bin/e2e_nextest_partitions.rs
+++ b/crates/fakecloud-e2e/src/bin/e2e_nextest_partitions.rs
@@ -78,33 +78,61 @@ struct Partition {
     install_podman: bool,
 }
 
-// The "general" set is the long pole of the E2E run (~31 min of test execution
-// across two hash partitions). Now that test binaries are compiled once and
-// shipped as a nextest archive, each partition only pays its share of test
-// runtime, so splitting general four ways brings each well under the CI budget.
-const PARTITIONS: [Partition; 12] = [
+// Each E2E partition runs prebuilt binaries from a shared nextest archive (no
+// per-partition compile), and every partition job waits on the single build
+// anchor, so the workflow's wall-clock is `build + slowest partition`. The set
+// below is sized so no single partition's test runtime dominates: the heavy
+// "general" group fans out 8 ways (~55 min of total test execution), the two
+// slowest lambda runtime families (python ~12 min, nodejs ~10 min) are hash-split
+// in two, and the container-CLI tests split by runtime (docker vs podman) so the
+// podman-only job is the only one paying the podman install.
+const PARTITIONS: [Partition; 19] = [
     Partition {
         name: "general-1",
         filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
-        partition: Some("hash:1/4"),
+        partition: Some("hash:1/8"),
         install_podman: false,
     },
     Partition {
         name: "general-2",
         filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
-        partition: Some("hash:2/4"),
+        partition: Some("hash:2/8"),
         install_podman: false,
     },
     Partition {
         name: "general-3",
         filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
-        partition: Some("hash:3/4"),
+        partition: Some("hash:3/8"),
         install_podman: false,
     },
     Partition {
         name: "general-4",
         filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
-        partition: Some("hash:4/4"),
+        partition: Some("hash:4/8"),
+        install_podman: false,
+    },
+    Partition {
+        name: "general-5",
+        filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
+        partition: Some("hash:5/8"),
+        install_podman: false,
+    },
+    Partition {
+        name: "general-6",
+        filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
+        partition: Some("hash:6/8"),
+        install_podman: false,
+    },
+    Partition {
+        name: "general-7",
+        filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
+        partition: Some("hash:7/8"),
+        install_podman: false,
+    },
+    Partition {
+        name: "general-8",
+        filter: "package(fakecloud-e2e) and not binary(lambda) and not binary(lambda_invoke)",
+        partition: Some("hash:8/8"),
         install_podman: false,
     },
     Partition {
@@ -115,15 +143,27 @@ const PARTITIONS: [Partition; 12] = [
         install_podman: false,
     },
     Partition {
-        name: "lambda-runtimes-python",
+        name: "lambda-runtimes-python-1",
         filter: LAMBDA_RUNTIME_PYTHON_FILTER,
-        partition: None,
+        partition: Some("hash:1/2"),
         install_podman: false,
     },
     Partition {
-        name: "lambda-runtimes-nodejs",
+        name: "lambda-runtimes-python-2",
+        filter: LAMBDA_RUNTIME_PYTHON_FILTER,
+        partition: Some("hash:2/2"),
+        install_podman: false,
+    },
+    Partition {
+        name: "lambda-runtimes-nodejs-1",
         filter: LAMBDA_RUNTIME_NODEJS_FILTER,
-        partition: None,
+        partition: Some("hash:1/2"),
+        install_podman: false,
+    },
+    Partition {
+        name: "lambda-runtimes-nodejs-2",
+        filter: LAMBDA_RUNTIME_NODEJS_FILTER,
+        partition: Some("hash:2/2"),
         install_podman: false,
     },
     Partition {
@@ -151,8 +191,14 @@ const PARTITIONS: [Partition; 12] = [
         install_podman: false,
     },
     Partition {
-        name: "lambda-container-clis",
-        filter: "binary(lambda) and (test(lambda_invoke_docker) | test(lambda_invoke_podman))",
+        name: "lambda-container-docker",
+        filter: "binary(lambda) and test(lambda_invoke_docker)",
+        partition: None,
+        install_podman: false,
+    },
+    Partition {
+        name: "lambda-container-podman",
+        filter: "binary(lambda) and test(lambda_invoke_podman)",
         partition: None,
         install_podman: true,
     },
@@ -307,11 +353,17 @@ fn check_partitions(lister: &dyn NextestLister) -> Result<(), DynError> {
 }
 
 fn validate_partition_layout() -> Result<(), DynError> {
-    for name in LAMBDA_RUNTIME_FAMILY_PARTITIONS {
-        if !PARTITIONS.iter().any(|partition| partition.name == name) {
-            return Err(
-                SimpleError(format!("missing explicit lambda runtime partition {name}")).into(),
-            );
+    // Each runtime family must keep at least one dedicated partition. Families
+    // whose runtime is slow enough may be hash-split into `<family>-1`,
+    // `<family>-2`, ...; matching by prefix accepts both the single-partition
+    // and the split form while still catching an accidentally-dropped family.
+    for prefix in LAMBDA_RUNTIME_FAMILY_PARTITIONS {
+        let matches = |name: &str| name == prefix || name.starts_with(&format!("{prefix}-"));
+        if !PARTITIONS.iter().any(|partition| matches(partition.name)) {
+            return Err(SimpleError(format!(
+                "missing explicit lambda runtime partition {prefix}"
+            ))
+            .into());
         }
     }
 
@@ -453,110 +505,86 @@ mod tests {
         );
     }
 
+    // One synthetic test per real partition, in PARTITIONS order:
+    // a..h = general-1..8, i = lambda-api, j/k = python-1/2, l/m = nodejs-1/2,
+    // n = ruby, o = provided, p = java, q = dotnet, r = docker, s = podman.
+    fn exact_coverage_cases() -> Vec<(PartitionKey, &'static [&'static str])> {
+        vec![
+            (partition_key("general-1"), &["a"]),
+            (partition_key("general-2"), &["b"]),
+            (partition_key("general-3"), &["c"]),
+            (partition_key("general-4"), &["d"]),
+            (partition_key("general-5"), &["e"]),
+            (partition_key("general-6"), &["f"]),
+            (partition_key("general-7"), &["g"]),
+            (partition_key("general-8"), &["h"]),
+            (partition_key("lambda-api"), &["i"]),
+            (partition_key("lambda-runtimes-python-1"), &["j"]),
+            (partition_key("lambda-runtimes-python-2"), &["k"]),
+            (partition_key("lambda-runtimes-nodejs-1"), &["l"]),
+            (partition_key("lambda-runtimes-nodejs-2"), &["m"]),
+            (partition_key("lambda-runtimes-ruby"), &["n"]),
+            (partition_key("lambda-runtimes-provided"), &["o"]),
+            (partition_key("lambda-runtimes-java"), &["p"]),
+            (partition_key("lambda-runtimes-dotnet"), &["q"]),
+            (partition_key("lambda-container-docker"), &["r"]),
+            (partition_key("lambda-container-podman"), &["s"]),
+        ]
+    }
+
+    const ALL_TESTS: &[&str] = &[
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r",
+        "s",
+    ];
+
     #[test]
     fn check_partitions_accepts_exact_coverage() {
-        let lister = FakeLister::with_partitions(
-            &["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"],
-            &[
-                (partition_key("general-1"), &["a"]),
-                (partition_key("general-2"), &["b"]),
-                (partition_key("general-3"), &["k"]),
-                (partition_key("general-4"), &["l"]),
-                (partition_key("lambda-api"), &["c"]),
-                (partition_key("lambda-runtimes-python"), &["d"]),
-                (partition_key("lambda-runtimes-nodejs"), &["e"]),
-                (partition_key("lambda-runtimes-ruby"), &["f"]),
-                (partition_key("lambda-runtimes-provided"), &["g"]),
-                (partition_key("lambda-runtimes-java"), &["h"]),
-                (partition_key("lambda-runtimes-dotnet"), &["i"]),
-                (partition_key("lambda-container-clis"), &["j"]),
-            ],
-        );
-
+        let lister = FakeLister::with_partitions(ALL_TESTS, &exact_coverage_cases());
         assert!(check_partitions(&lister).is_ok());
     }
 
     #[test]
     fn check_partitions_rejects_missing_tests() {
-        let lister = FakeLister::with_partitions(
-            &[
-                "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "missing",
-            ],
-            &[
-                (partition_key("general-1"), &["a"]),
-                (partition_key("general-2"), &["b"]),
-                (partition_key("general-3"), &["k"]),
-                (partition_key("general-4"), &["l"]),
-                (partition_key("lambda-api"), &["c"]),
-                (partition_key("lambda-runtimes-python"), &["d"]),
-                (partition_key("lambda-runtimes-nodejs"), &["e"]),
-                (partition_key("lambda-runtimes-ruby"), &["f"]),
-                (partition_key("lambda-runtimes-provided"), &["g"]),
-                (partition_key("lambda-runtimes-java"), &["h"]),
-                (partition_key("lambda-runtimes-dotnet"), &["i"]),
-                (partition_key("lambda-container-clis"), &["j"]),
-            ],
-        );
-
+        let mut expected = ALL_TESTS.to_vec();
+        expected.push("missing");
+        let lister = FakeLister::with_partitions(&expected, &exact_coverage_cases());
         assert!(check_partitions(&lister).is_err());
     }
 
     #[test]
     fn check_partitions_rejects_overlaps() {
-        let lister = FakeLister::with_partitions(
-            &["a", "b", "c", "d", "e", "f", "g", "h", "i", "k", "l"],
-            &[
-                (partition_key("general-1"), &["a"]),
-                (partition_key("general-2"), &["a"]),
-                (partition_key("general-3"), &["k"]),
-                (partition_key("general-4"), &["l"]),
-                (partition_key("lambda-api"), &["b"]),
-                (partition_key("lambda-runtimes-python"), &["c"]),
-                (partition_key("lambda-runtimes-nodejs"), &["d"]),
-                (partition_key("lambda-runtimes-ruby"), &["e"]),
-                (partition_key("lambda-runtimes-provided"), &["f"]),
-                (partition_key("lambda-runtimes-java"), &["g"]),
-                (partition_key("lambda-runtimes-dotnet"), &["h"]),
-                (partition_key("lambda-container-clis"), &["i"]),
-            ],
-        );
-
+        // general-2 duplicates general-1's "a"; drop "b" from expected so the
+        // only discrepancy is the overlap.
+        let mut cases = exact_coverage_cases();
+        cases[1].1 = &["a"];
+        let expected: Vec<&str> = ALL_TESTS.iter().copied().filter(|t| *t != "b").collect();
+        let lister = FakeLister::with_partitions(&expected, &cases);
         assert!(check_partitions(&lister).is_err());
     }
 
     #[test]
     fn check_partitions_rejects_empty_partition() {
-        let lister = FakeLister::with_partitions(
-            &["a", "b", "c", "d", "e", "f", "g", "h", "i", "k", "l"],
-            &[
-                (partition_key("general-1"), &["a"]),
-                (partition_key("general-2"), &["b"]),
-                (partition_key("general-3"), &["k"]),
-                (partition_key("general-4"), &["l"]),
-                (partition_key("lambda-api"), &[]),
-                (partition_key("lambda-runtimes-python"), &["c"]),
-                (partition_key("lambda-runtimes-nodejs"), &["d"]),
-                (partition_key("lambda-runtimes-ruby"), &["e"]),
-                (partition_key("lambda-runtimes-provided"), &["f"]),
-                (partition_key("lambda-runtimes-java"), &["g"]),
-                (partition_key("lambda-runtimes-dotnet"), &["h"]),
-                (partition_key("lambda-container-clis"), &["i"]),
-            ],
-        );
-
+        // lambda-api selects nothing; drop its "i" from expected.
+        let mut cases = exact_coverage_cases();
+        cases[8].1 = &[];
+        let expected: Vec<&str> = ALL_TESTS.iter().copied().filter(|t| *t != "i").collect();
+        let lister = FakeLister::with_partitions(&expected, &cases);
         assert!(check_partitions(&lister).is_err());
     }
 
     #[test]
     fn lambda_runtime_family_partitions_are_explicit() {
         validate_partition_layout().unwrap();
-        assert_eq!(
-            PARTITIONS
-                .iter()
-                .filter(|partition| partition.name.starts_with("lambda-runtimes-"))
-                .count(),
-            LAMBDA_RUNTIME_FAMILY_PARTITIONS.len()
-        );
+        // Every runtime family is represented by at least one partition (some
+        // families are hash-split into `<family>-1`/`-2`, so the partition count
+        // is >= the number of families).
+        for prefix in LAMBDA_RUNTIME_FAMILY_PARTITIONS {
+            assert!(
+                PARTITIONS.iter().any(|partition| partition.name == prefix
+                    || partition.name.starts_with(&format!("{prefix}-"))),
+                "no partition for runtime family {prefix}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

E2E was the #2 CI gate (~54-64 min). Two structural wastes drove it:

1. **Redundant compilation** -- every partition job recompiled the large
   `fakecloud-e2e` test crate from scratch (~11.5 min measured), paid ~10x per run.
2. **Too-coarse fan-out** -- the heavy "general" set ran across only 2 hash
   partitions, so one partition executed ~31 min of tests (928 run) on top of its
   own compile (~43 min wall).

This PR adopts the canonical nextest **archive once, run-partition many** pattern:

- `e2e-build` runs `cargo nextest archive` once -> uploads prebuilt test binaries.
- Each partition downloads the archive and runs `cargo nextest run --archive-file
  ... --workspace-remap .` (extracted under `/mnt`), **skipping compilation**.
  `rust-cache` removed from partition jobs (they no longer build).
- "general" split from 2 -> 4 hash partitions.

The fakecloud server binary is still shipped as its own artifact; the harness
locates it via a workspace-relative path that resolves identically on every
GitHub-hosted runner, so it works regardless of where the archive extracts.

This is step 1 of the CI-to-30min effort. It proves the archive mechanism on CI
and yields real per-partition timings; a follow-up will split whichever
lambda/container partitions the measured data shows still exceed budget, and the
same archive+partition treatment lands on conformance (the #1 gate at ~79 min).

## Test plan

- `cargo test -p fakecloud-e2e --bin e2e_nextest_partitions` (partition coverage
  guard) passes; matrix emits 12 partitions; `cargo fmt --all --check` clean.
- CI on this PR: confirm no partition recompiles, archive run finds the server
  binary, all E2E partitions green, and capture per-partition wall-clock.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up E2E CI by archiving `fakecloud-e2e` test binaries once with `cargo nextest archive` and running all partitions from that archive. Parallelize the server build, widen partitions, and remove obsolete steps to cut wall-clock time.

- **Refactors**
  - Add archive step in `e2e-build` with `CARGO_PROFILE_TEST_DEBUG=0`; upload `fakecloud-e2e-archive`; keep `fakecloud` server as a separate artifact; install `taiki-e/install-action` for `nextest`.
  - New `e2e-fakecloud` job builds the server in parallel with the archive; `e2e` jobs now depend on both.
  - Partition jobs download the archive and run `cargo nextest run --archive-file ... --workspace-remap .`; drop `--extract-to /mnt` and remove `Swatinem/rust-cache`.
  - Remove the per-partition container-storage relocation step; rely on the free-disk action instead.
  - Expand partitions 10→19: "general" 2→8; hash-split `lambda` python and nodejs into 2 each; split container CLIs into docker-only and podman-only (only the podman job installs podman); update guard/validation to support hash-split families and keep exact coverage.

<sup>Written for commit 6f39f5aa22bfc23e584ad7878b60dd18807375b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

