### PR TITLE
ci(conformance): partition the run + build test binaries once via nextest archive

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    timeout-minutes: 10
     outputs:
       code: ${{ steps.detect.outputs.code || 'true' }}
     steps:
@@ -40,11 +40,16 @@ jobs:
               - '!LICENSE'
               - '!.gitignore'
 
-  conformance:
+  # Compile the (large) conformance integration-test crate ONCE and ship the
+  # prebuilt binaries as a nextest archive. Previously every conformance run
+  # built and executed all tests serially in a single 2-core job (~69 min of
+  # `nextest run`). Now the build happens here and the run fans out across the
+  # `conformance` matrix below, each partition skipping compilation entirely.
+  conformance-build:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/free-disk
@@ -52,18 +57,105 @@ jobs:
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Disk diagnostics before build
+      # The conformance harness boots this binary per test via its
+      # workspace-relative path (crates/fakecloud-testkit/src/lib.rs), which
+      # resolves identically on every GitHub-hosted runner, so a downloaded
+      # binary works regardless of where the archived test binaries extract.
+      - name: Build fakecloud
+        run: cargo build --bin fakecloud
+
+      - name: Upload fakecloud binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fakecloud-binary-conformance
+          path: target/debug/fakecloud
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Archive conformance test binaries
+        run: cargo nextest archive -P ci -p fakecloud-conformance --archive-file conformance-archive.tar.zst
+
+      - name: Upload conformance test archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fakecloud-conformance-archive
+          path: conformance-archive.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+
+  # Run the prebuilt integration tests across N hash partitions. hash:i/N is a
+  # complete, disjoint partition of the test set, so coverage is exact by
+  # construction (no separate coverage guard needed, unlike the heterogeneous
+  # E2E matrix). Conformance tests are API-level and tolerate a missing Docker
+  # daemon (see lambda_invoke), so no container setup is required here.
+  conformance:
+    name: Conformance ${{ matrix.partition }}
+    needs: [changes, conformance-build]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/free-disk
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
+      # No rust-cache here: this job runs prebuilt test binaries from the archive
+      # produced by conformance-build and never compiles, so nothing to cache.
+
+      - name: Download fakecloud binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: fakecloud-binary-conformance
+          path: target/debug
+
+      - name: Mark fakecloud binary executable
+        run: chmod +x target/debug/fakecloud
+
+      - name: Download conformance test archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: fakecloud-conformance-archive
+
+      - name: Disk diagnostics before nextest
         run: df -h
+
+      # Run prebuilt binaries straight from the archive -- no compilation.
+      # --workspace-remap . points runtime workspace lookups at this checkout
+      # (path matches the build runner on GitHub-hosted runners). Extract under
+      # /mnt so the unpacked binaries don't fill the small root filesystem.
+      - name: Run conformance partition
+        run: |
+          cargo nextest run -P ci \
+            --archive-file conformance-archive.tar.zst \
+            --workspace-remap . \
+            --extract-to /mnt/nextest-conformance --extract-overwrite \
+            --partition "hash:${{ matrix.partition }}"
+
+      - name: Disk diagnostics after nextest
+        if: always()
+        run: df -h
+
+  # The coverage gate: boots fakecloud and probes every operation to confirm no
+  # conformance regression, then audits handwritten-test coverage. It spawns its
+  # own short-lived server and does NOT need the integration-test archive, so it
+  # runs in parallel with the matrix as a small standalone job.
+  conformance-check:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/free-disk
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build server
         run: cargo build --bin fakecloud
-
-      - name: Run conformance integration tests
-        run: cargo nextest run -P ci -p fakecloud-conformance --tests
-
-      - name: Disk diagnostics after tests
-        if: always()
-        run: df -h
 
       - name: Build conformance tool
         run: cargo build -p fakecloud-conformance

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -125,14 +125,13 @@ jobs:
 
       # Run prebuilt binaries straight from the archive -- no compilation.
       # --workspace-remap . points runtime workspace lookups at this checkout
-      # (path matches the build runner on GitHub-hosted runners). Extract under
-      # /mnt so the unpacked binaries don't fill the small root filesystem.
+      # (path matches the build runner on GitHub-hosted runners). nextest extracts
+      # to its own temp dir under /tmp (ample free space on the root fs here).
       - name: Run conformance partition
         run: |
           cargo nextest run -P ci \
             --archive-file conformance-archive.tar.zst \
             --workspace-remap . \
-            --extract-to /mnt/nextest-conformance --extract-overwrite \
             --partition "hash:${{ matrix.partition }}"
 
       - name: Disk diagnostics after nextest


### PR DESCRIPTION
## Summary

Conformance is the #1 CI gate (~79 min). A single 2-core job compiled the large
conformance integration-test crate and then ran every test **serially**
(`Run conformance integration tests` = ~69 min measured).

Restructure into three parallel job kinds, mirroring the nextest archive pattern:

- **conformance-build**: compiles the test crate ONCE via `cargo nextest archive`,
  uploads the prebuilt binaries + the fakecloud server binary as artifacts.
- **conformance (6-way matrix)**: each partition downloads the archive and runs
  `cargo nextest run --archive-file ... --partition hash:i/6`, skipping
  compilation. `hash:i/N` partitions are disjoint and complete, so coverage is
  exact by construction. Conformance tests are API-level and tolerate a missing
  Docker daemon (`lambda_invoke`), so no container setup is needed.
- **conformance-check**: the coverage gate (`check` + `audit`). It boots its own
  short-lived fakecloud and probes every operation, so it needs only the server
  binary -- not the test archive -- and runs in parallel as a small standalone job.

The coverage/audit gate is **unchanged in behavior**; only where it runs moves.
No conformance numbers, validations, or baselines are touched.

## Test plan

- `cargo fmt --all --check` clean; YAML validated.
- CI on this PR: confirm partitions don't recompile, archive run finds the server
  binary, all 6 conformance partitions + the coverage gate are green, and capture
  per-partition wall-clock to tune N if needed.

Part of the CI-to-30min effort (companion to the E2E archive PR #1873).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Partitioned the conformance CI to build test binaries once via `cargo nextest archive` and run them in 6 parallel partitions, removing redundant compilation and keeping the coverage/audit gate unchanged.

- **Refactors**
  - Added `conformance-build` to compile `fakecloud` and archive `fakecloud-conformance` tests; upload artifacts.
  - Added `conformance` 6-way matrix that downloads the archive and runs `cargo nextest run --archive-file ... --partition hash:i/6`; no compile, no Docker.
  - Let `nextest` use its default temp dir for archive extraction (dropped `--extract-to /mnt`) to avoid runner permission issues.
  - Added `conformance-check` to run coverage + audit separately; builds server only and runs in parallel with the matrix.
  - Tightened timeouts and removed unnecessary caching in run jobs.

<sup>Written for commit 8708bee3a69a9499a602b86d3c3ba6df271a4f7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

