### PR TITLE
feat(tfacc): add organizations, ecr, and glue services

### DIFF
--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -124,6 +124,61 @@ pub const SERVICES: &[Service] = &[
         ],
     },
     Service {
+        name: "organizations",
+        // Wave 3: the policies-for-target data source smoke. Most other
+        // Organizations resources mutate the singleton org and are exercised
+        // elsewhere.
+        run_regex: "^TestAccOrganizations[A-Za-z]+_basic$",
+        deny: &[],
+    },
+    Service {
+        name: "ecr",
+        // Wave 3: the `_basic` suite for repository/lifecycle/pull-through-cache
+        // policies and their data sources, plus the authorization-token data
+        // source — 8 tests.
+        run_regex: "^TestAccECR[A-Za-z]+_basic$",
+        deny: &[
+            // --- unsupportable: fakecloud reports the repository_url as its
+            //     local registry endpoint (127.0.0.1:port/...) so real
+            //     `docker push`/`pull` work against it; that can't also equal
+            //     the AWS-format `<account>.dkr.ecr.<region>.amazonaws.com` URL
+            //     the resource asserts. ---
+            "TestAccECRRepository_basic",
+            // --- gap: the image data source needs an image actually pushed to
+            //     the registry, which requires a running container engine. ---
+            "TestAccECRImageDataSource_basic",
+            // --- gap: repository creation templates are not implemented. ---
+            "TestAccECRRepositoryCreationTemplate_basic",
+            "TestAccECRRepositoryCreationTemplateDataSource_basic",
+        ],
+    },
+    Service {
+        name: "glue",
+        // Wave 3: the `_basic` suite for the Data Catalog (table + data source),
+        // connections (+ data source), registries (+ data source), data-quality
+        // rulesets, security configurations, user-defined functions, and
+        // workflows — 10 tests.
+        run_regex: "^TestAccGlue[A-Za-z]+_basic$",
+        deny: &[
+            // --- gap: jobs and triggers reference the AWS-managed IAM policy
+            //     `AWSGlueServiceRole`, which fakecloud's IAM does not resolve
+            //     (no AWS-managed policy catalogue). ---
+            "TestAccGlueJob_basic",
+            "TestAccGlueTrigger_basic",
+            // --- gap: partitions omit the `catalog_id` (defaults to the account
+            //     id) on read. ---
+            "TestAccGluePartition_basic",
+            "TestAccGluePartitionIndex_basic",
+            // --- gap: schema registry schemas and ML transforms are not
+            //     implemented. ---
+            "TestAccGlueSchema_basic",
+            "TestAccGlueMlTransform_basic",
+            // --- gap: dev endpoints provision a notebook environment; the test
+            //     polls a creation waiter for ~15m before failing. ---
+            "TestAccGlueDevEndpoint_basic",
+        ],
+    },
+    Service {
         name: "cognitoidp",
         // Batch 11: core `aws_cognito_user_pool` smoke. The fix here is
         // returning five shape blocks with AWS defaults on every
@@ -459,6 +514,24 @@ pub const SHARDS: &[Shard] = &[
         name: "route53",
         service: "route53",
         run_regex: "^TestAccRoute53[A-Za-z]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "organizations",
+        service: "organizations",
+        run_regex: "^TestAccOrganizations[A-Za-z]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "ecr",
+        service: "ecr",
+        run_regex: "^TestAccECR[A-Za-z]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "glue",
+        service: "glue",
+        run_regex: "^TestAccGlue[A-Za-z]+_basic$",
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -300,4 +300,7 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_APIGATEWAYV2", "apigatewayv2"),
     ("AWS_ENDPOINT_URL_BEDROCK", "bedrock"),
     ("AWS_ENDPOINT_URL_ROUTE53", "route53"),
+    ("AWS_ENDPOINT_URL_ORGANIZATIONS", "organizations"),
+    ("AWS_ENDPOINT_URL_ECR", "ecr"),
+    ("AWS_ENDPOINT_URL_GLUE", "glue"),
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -53,6 +53,21 @@ async fn route53_acceptance() {
 }
 
 #[tokio::test]
+async fn organizations_acceptance() {
+    run_shard("organizations").await;
+}
+
+#[tokio::test]
+async fn ecr_acceptance() {
+    run_shard("ecr").await;
+}
+
+#[tokio::test]
+async fn glue_acceptance() {
+    run_shard("glue").await;
+}
+
+#[tokio::test]
 async fn cognitoidp_acceptance() {
     run_shard("cognitoidp").await;
 }

--- a/scripts/check-doc-counts.sh
+++ b/scripts/check-doc-counts.sh
@@ -166,7 +166,7 @@ FILES=(
 # its local context (subset counts, rhetorical comparisons, etc.).
 EXCEPTIONS=(
     # tfacc covers a subset of services
-    "website/content/docs/about/conformance.md:services:16"
+    "website/content/docs/about/conformance.md:services:19"
     # real-AWS parity sandbox covers a subset
     "website/content/docs/about/conformance.md:services:7"
     # rhetorical comparison: "depth-first vs N services at 50%"

--- a/website/content/docs/about/conformance.md
+++ b/website/content/docs/about/conformance.md
@@ -116,7 +116,7 @@ Running both is how fakecloud can claim 100% behavioral parity with a straight f
 
 ### Current coverage
 
-16 services today: `apigatewayv2`, `bedrock`, `cognitoidp`, `dynamodb`, `events` (EventBridge), `iam`, `kinesis`, `kms`, `logs`, `route53`, `s3`, `secretsmanager`, `sns`, `sqs`, `ssm`, `sts`. Coverage per service ranges from a single smoke test to the full `_basic` suite across every resource type (IAM, for example, exercises ~42 resource and data-source types; S3, ~24).
+19 services today: `apigatewayv2`, `bedrock`, `cognitoidp`, `dynamodb`, `ecr`, `events` (EventBridge), `glue`, `iam`, `kinesis`, `kms`, `logs`, `organizations`, `route53`, `s3`, `secretsmanager`, `sns`, `sqs`, `ssm`, `sts`. Coverage per service ranges from a single smoke test to the full `_basic` suite across every resource type (IAM, for example, exercises ~42 resource and data-source types; S3, ~24).
 
 ### Allow-list, not deny-list
 


### PR DESCRIPTION
## Summary

Three new services, **allow-list only** (they pass as-is, no fakecloud changes).

- **organizations** — policies-for-target data source smoke (1 test).
- **ecr** — repository/lifecycle/pull-through-cache policies + data sources, authorization-token data source (8 tests).
- **glue** — Data Catalog table (+ data source), connections (+ data source), registries (+ data source), data-quality rulesets, security configurations, user-defined functions, workflows (10 tests).

Denied with reasons: ECR repository URL (local registry endpoint by design for real docker push/pull), ECR image data source / creation templates; Glue jobs/triggers (unresolved AWS-managed `AWSGlueServiceRole`), partitions (missing `catalog_id`), partition indexes, schemas, ML transforms, dev endpoints (15m waiter).

## Test plan
- Wires `AWS_ENDPOINT_URL_{ORGANIZATIONS,ECR,GLUE}`; doc-counts 16 -> 19; tfacc_shards emits 24 shards.
- Verified vs terraform-provider-aws v5.97.0: **organizations 1/1, ecr 8/8, glue 10/10**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add organizations, ECR, and Glue to tfacc as allow-list-only services with sharded acceptance tests. Increases coverage from 16 to 19 services; no fakecloud behavior changes.

- **New Features**
  - Enabled `organizations` policies-for-target data source (1 test).
  - Enabled `ecr` repository/lifecycle/pull-through-cache policies + data sources and authorization-token data source (8 tests).
  - Enabled `glue` Data Catalog table/connection/registry + data sources, data-quality rulesets, security configurations, UDFs, and workflows (10 tests).
  - Added shards for each service and support for AWS_ENDPOINT_URL_ORGANIZATIONS/ECR/GLUE.
  - Updated docs and doc-count script to reflect 19 services; verified against `terraform-provider-aws` v5.97.0 (org 1/1, ecr 8/8, glue 10/10).
  - Known gaps (deny-listed): ECR repository URL format, image data source/creation templates; Glue jobs/triggers (AWSGlueServiceRole), partitions/partition indexes, schemas, ML transforms, dev endpoints.

<sup>Written for commit 3ca70b1ad70abd1bf275440c0debf911a7b2f34d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

