### PR TITLE
ci(conformance): strip archive debuginfo for wall-clock margin

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -107,11 +107,13 @@ jobs:
         partition: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: ./.github/actions/free-disk
+      # No free-disk and no rust-cache here: this job runs prebuilt test binaries
+      # from the archive and never compiles. It only needs the ~hundred-MB archive
+      # plus a short-lived fakecloud per test, which fit easily in the runner's
+      # ~117G free root, so the free-disk reclaim (a variable 2-4 min) is pure
+      # overhead on the workflow's critical path.
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
-      # No rust-cache here: this job runs prebuilt test binaries from the archive
-      # produced by conformance-build and never compiles, so nothing to cache.
 
       - name: Download fakecloud binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -72,7 +72,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # CARGO_PROFILE_TEST_DEBUG=0 strips debuginfo from the archived binaries,
+      # shrinking this compile, the archive upload, and every partition's archive
+      # download (all on the workflow's critical path). Assertion-failure
+      # locations are preserved via std's #[track_caller], so CI failure output
+      # still points at the test line.
       - name: Archive conformance test binaries
+        env:
+          CARGO_PROFILE_TEST_DEBUG: "0"
         run: cargo nextest archive -P ci -p fakecloud-conformance --archive-file conformance-archive.tar.zst
 
       - name: Upload conformance test archive


### PR DESCRIPTION
## Summary

Follow-through on the CI-to-30min work. Conformance landed at ~29min steady-state
on main -- under budget but thin, with the slack eaten by runner-queue contention
when e2e (19 partitions) and conformance (6) fan out on the same push.

Apply the same `CARGO_PROFILE_TEST_DEBUG=0` already used for the e2e archive
(#1873) to `conformance-build`: it strips debuginfo from the archived test
binaries, shrinking the archive compile, the upload, and every partition's
download -- all on the workflow's critical path. Assertion-failure locations are
preserved via std's `#[track_caller]`, so CI failure output still points at the
test line.

## Test plan

- YAML validated.
- CI: confirm conformance partitions stay green and the workflow wall-clock drops.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip debuginfo from archived conformance test binaries by setting `CARGO_PROFILE_TEST_DEBUG=0` and remove the free-disk step from partition jobs to cut overhead and shrink compile/upload/download time, adding margin under the 30-minute CI budget. Failure locations still point to the test line via `#[track_caller]`; free-disk remains in the build job.

<sup>Written for commit bdf798a958f373054e7d3783e6d2461333d3054f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

