### PR TITLE
ci(e2e): drop free-disk from partition jobs (biggest per-partition overhead)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -142,11 +142,14 @@ jobs:
       INSTALL_PODMAN: ${{ matrix.install_podman }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: ./.github/actions/free-disk
+      # No free-disk and no rust-cache here: this job runs prebuilt test binaries
+      # from the archive and never compiles. It downloads the archive + the
+      # fakecloud binary and pulls a few container images (<~10G); the runner's
+      # single ~145G root already has ~117G free, so the free-disk reclaim (a
+      # variable 2-4 min, measured as the single biggest per-partition overhead)
+      # is wasted work on the workflow's critical path.
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
-      # No rust-cache here: this job runs prebuilt test binaries from the archive
-      # produced by e2e-build and never compiles, so there is nothing to cache.
 
       - name: Install podman
         if: matrix.install_podman
@@ -155,10 +158,11 @@ jobs:
       # NOTE: an earlier "Relocate container storage to /mnt" step was removed
       # here. It existed to escape a small root filesystem when /mnt was a large
       # separate ephemeral disk, but current GitHub-hosted runners have a single
-      # ~145G root and no separate /mnt, so the relocation rsynced docker's
-      # data-root from root back onto root — pure overhead (~1.7 min/partition)
-      # with no headroom gained. The free-disk action above still reclaims ~30G,
-      # which is the actual disk-full safety net.
+      # ~145G root (~117G free) and no separate /mnt, so the relocation rsynced
+      # docker's data-root from root back onto root — pure overhead with no
+      # headroom gained. With that much free space the free-disk reclaim is
+      # unnecessary too (removed above); container images for a single partition
+      # stay well under the available room.
       - name: Prune container state before tests
         run: |
           docker system prune -af --volumes || true


### PR DESCRIPTION
## Summary

Steady-state on main showed e2e at ~31 min. Per-job breakdown pinned the cause to
**per-partition overhead, not test time and not queue** (all partitions started
within 3s of the build): `free-disk` ran a variable **2-4 min** on every one of
the 19 partitions, reclaiming ~30G the partition never needs. Partition jobs only
download the archive + fakecloud binary and pull a few container images (<~10G),
and the runner's single ~145G root already has ~117G free.

Remove `free-disk` from the e2e partition jobs (kept in `e2e-build` /
`e2e-fakecloud`, which compile). This drops each partition ~4 min and pulls the
e2e workflow comfortably under the 30 min budget.

Companion to #1877 (same removal on conformance partitions).

## Test plan

- YAML validated.
- CI: confirm all 19 partitions stay green and the e2e workflow wall-clock drops
  below 30 min (target ~26-27).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `./.github/actions/free-disk` from e2e partition jobs to cut per-partition overhead and bring the workflow under 30 minutes. The step is kept in `e2e-build` and `e2e-fakecloud`.

- **Performance**
  - Partition jobs only fetch the archive, `fakecloud`, and a few images (<10G). Runners have ~117G free on a ~145G root, so reclaiming ~30G was wasted time.
  - Expected savings: ~2–4 min per partition. Workflow wall-clock ~26–27 min.

<sup>Written for commit 317b7edab2f46cf205a220c32aa10ee60e042cce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

