### PR TITLE
ci(e2e): fix intermittent SG-enforcement failure (docker network leak -> docker0 fallback)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -308,6 +308,21 @@ jobs:
             got=$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo missing)
             echo "bridge-nf-call-iptables=${got}"
           }
+          # Remove leftover instance containers + per-subnet networks from any
+          # prior attempt. A failed attempt panics *before* the test's own
+          # cleanup runs, so its container and `fakecloud-subnet-<id>` network
+          # leak. Across the 3 retries these accumulate and exhaust Docker's
+          # default address pool; the next `docker network create` then fails and
+          # the runtime falls back to the default bridge (docker0, 172.17.x) —
+          # where same-subnet traffic never reaches fakecloud's per-subnet nft
+          # rules, so the deny "bypasses" and every subsequent attempt fails
+          # identically. Pruning before each attempt makes the retries genuinely
+          # independent (the real fix for this job's intermittent failures).
+          clean_docker() {
+            sudo docker ps -aq --filter "label=fakecloud-ec2" | xargs -r sudo docker rm -f >/dev/null 2>&1 || true
+            sudo docker network ls -q --filter "name=fakecloud-subnet-" | xargs -r sudo docker network rm >/dev/null 2>&1 || true
+            sudo docker network prune -f >/dev/null 2>&1 || true
+          }
           run_once() {
             sudo -E env "PATH=$PATH:/usr/sbin:/sbin" "HOME=$HOME" \
               FAKECLOUD_TEST_SG_ENFORCE=1 CI=1 \
@@ -315,6 +330,7 @@ jobs:
           }
           for attempt in 1 2 3; do
             echo "=== SG enforcement attempt ${attempt}/3 ==="
+            clean_docker
             ensure_bridge_nf
             if run_once; then
               echo "SG enforcement passed on attempt ${attempt}"
@@ -323,12 +339,13 @@ jobs:
             echo "attempt ${attempt} failed; host state at failure:"
             echo "--- bridge-nf-call-iptables ---"; cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo missing
             echo "--- nft fakecloud_ec2 table ---"; sudo nft list table inet fakecloud_ec2 2>/dev/null || echo "(no table)"
-            echo "flushing nft + conntrack before retry"
+            echo "--- docker networks (watch for pool exhaustion / docker0 fallback) ---"; sudo docker network ls || true
+            echo "flushing nft + conntrack + leaked docker state before retry"
             sudo nft flush ruleset || true
             sudo conntrack -F || true
             sleep 3
           done
-          echo "SG enforcement failed all 3 attempts (bridge-nf verified active each attempt -> real enforcement regression, not flake)"
+          echo "SG enforcement failed all 3 independent attempts (clean docker + bridge-nf each attempt -> real enforcement regression, not flake)"
           exit 1
 
       - name: nft ruleset diagnostics


### PR DESCRIPTION
## Summary

Fixes the recurring red on `EC2 SG enforcement (privileged)` (~30% of main runs).

**Root cause** (not a bridge-netfilter race — at failure `bridge-nf-call-iptables=1`
and the deny rule is present): failing attempts' instances land on **`172.17.0.3`
= docker0**, the default bridge, not a fakecloud per-subnet bridge.
`ensure_subnet_network()` (crates/fakecloud-ec2/src/runtime/mod.rs:738) falls back
to the default bridge when `docker network create` fails — and on docker0
same-subnet traffic never reaches fakecloud's per-subnet nft rules, so the deny
"bypasses the forward chain".

**Why `create` fails:** a failed attempt panics *before* the test's own cleanup
(ec2_sg_enforcement_real.rs:282-291), leaking its container + `fakecloud-subnet-<id>`
network. Across the 3 in-job retries these accumulate and exhaust Docker's default
address pool → next `create` fails → docker0 fallback → **all 3 retries fail
identically** (the correlated signature the old `exit 1` message misread as a
"real regression").

**Fix:** prune leftover `fakecloud-ec2` containers + `fakecloud-subnet-*` networks
before each attempt so the retries are genuinely independent and never exhaust the
pool. Adds `docker network ls` to the failure diagnostics.

Evidence: across the last 15 main e2e runs the job failed ~1 in 3, always with the
all-3-attempts-failed signature and 172.17 (docker0) IPs on the later attempts.

## Test plan

- YAML validated.
- CI: the privileged job runs the real deny→allow packet test; confirm it passes
  (and would now recover cleanly on the rare genuine per-attempt env miss instead
  of cascading).

## Note (follow-up candidate, not in this PR)

The deeper latent bug is that `ensure_subnet_network`'s silent docker0 fallback
*defeats* SG enforcement when it triggers. Making it fail loudly (or retry) when
enforcement is enabled would be more correct, but risks the broader e2e suite that
launches instances without caring about enforcement, so it's intentionally left
out of this targeted flake fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky EC2 SG enforcement (privileged) e2e by cleaning leaked Docker networks/containers between retries. Prevents `docker network create` failures and `docker0` fallback that bypasses per-subnet nft rules.

- **Bug Fixes**
  - Run `clean_docker` before each attempt to remove `fakecloud-ec2` containers, `fakecloud-subnet-*` networks, and prune networks.
  - Add `docker network ls` to failure logs and clarify the final failure message.

<sup>Written for commit bb58abf0993ce22fdbbdaa7da8fa338a7238b49f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

