### PR TITLE
feat(iam): resolve AWS-managed policies from a built-in catalog

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -3550,3 +3550,101 @@ async fn iam_resync_mfa_device_freshens_enable_date() {
         "ResyncMFADevice should freshen EnableDate: before={before_date:?} after={after_date:?}"
     );
 }
+
+#[tokio::test]
+async fn iam_get_aws_managed_policy_from_catalog() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let arn = "arn:aws:iam::aws:policy/AdministratorAccess";
+
+    // GetPolicy resolves the AWS-managed policy without it ever being created.
+    let resp = client.get_policy().policy_arn(arn).send().await.unwrap();
+    let policy = resp.policy().unwrap();
+    assert_eq!(policy.policy_name(), Some("AdministratorAccess"));
+    assert_eq!(policy.arn(), Some(arn));
+    assert_eq!(policy.default_version_id(), Some("v1"));
+    assert!(policy.is_attachable());
+
+    // GetPolicyVersion returns the real default document.
+    let v = client
+        .get_policy_version()
+        .policy_arn(arn)
+        .version_id("v1")
+        .send()
+        .await
+        .unwrap();
+    let pv = v.policy_version().unwrap();
+    assert!(pv.is_default_version());
+    let doc = pv.document().unwrap();
+    // The document is non-empty and carries the policy's statement (assert on
+    // encoding-invariant substrings, since the wire form is URL-encoded).
+    assert!(doc.contains("Statement"), "document missing Statement: {doc}");
+    assert!(doc.contains("Allow"), "document missing Allow effect: {doc}");
+
+    // ListPolicies Scope=AWS surfaces the catalog.
+    let listed = client
+        .list_policies()
+        .scope(aws_sdk_iam::types::PolicyScopeType::Aws)
+        .max_items(1000)
+        .send()
+        .await
+        .unwrap();
+    assert!(listed
+        .policies()
+        .iter()
+        .any(|p| p.arn() == Some(arn)));
+}
+
+#[tokio::test]
+async fn iam_attach_aws_managed_policy_round_trips() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole";
+
+    client
+        .create_role()
+        .role_name("lambda-role")
+        .assume_role_policy_document("{}")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .attach_role_policy()
+        .role_name("lambda-role")
+        .policy_arn(arn)
+        .send()
+        .await
+        .unwrap();
+
+    // ListAttachedRolePolicies returns the managed policy with its real name.
+    let attached = client
+        .list_attached_role_policies()
+        .role_name("lambda-role")
+        .send()
+        .await
+        .unwrap();
+    let p = attached
+        .attached_policies()
+        .iter()
+        .find(|p| p.policy_arn() == Some(arn))
+        .expect("managed policy should be attached");
+    assert_eq!(p.policy_name(), Some("AWSLambdaBasicExecutionRole"));
+
+    // ListEntitiesForPolicy reports the role and GetPolicy reflects the count.
+    let entities = client
+        .list_entities_for_policy()
+        .policy_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(entities
+        .policy_roles()
+        .iter()
+        .any(|r| r.role_name() == Some("lambda-role")));
+
+    let gp = client.get_policy().policy_arn(arn).send().await.unwrap();
+    assert_eq!(gp.policy().unwrap().attachment_count(), Some(1));
+}

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -3579,8 +3579,14 @@ async fn iam_get_aws_managed_policy_from_catalog() {
     let doc = pv.document().unwrap();
     // The document is non-empty and carries the policy's statement (assert on
     // encoding-invariant substrings, since the wire form is URL-encoded).
-    assert!(doc.contains("Statement"), "document missing Statement: {doc}");
-    assert!(doc.contains("Allow"), "document missing Allow effect: {doc}");
+    assert!(
+        doc.contains("Statement"),
+        "document missing Statement: {doc}"
+    );
+    assert!(
+        doc.contains("Allow"),
+        "document missing Allow effect: {doc}"
+    );
 
     // ListPolicies Scope=AWS surfaces the catalog.
     let listed = client
@@ -3590,10 +3596,7 @@ async fn iam_get_aws_managed_policy_from_catalog() {
         .send()
         .await
         .unwrap();
-    assert!(listed
-        .policies()
-        .iter()
-        .any(|p| p.arn() == Some(arn)));
+    assert!(listed.policies().iter().any(|p| p.arn() == Some(arn)));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-iam/src/iam_service/policies.rs
+++ b/crates/fakecloud-iam/src/iam_service/policies.rs
@@ -99,7 +99,7 @@ impl IamService {
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        let policy = state.policies.get(&policy_arn).ok_or_else(|| {
+        let policy = resolve_policy(state, &policy_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
@@ -107,7 +107,7 @@ impl IamService {
             )
         })?;
 
-        let xml = xml_responses::get_policy_response(policy, &req.request_id);
+        let xml = xml_responses::get_policy_response(&policy, &req.request_id);
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 
@@ -186,14 +186,21 @@ impl IamService {
             .unwrap_or(100);
         let marker = req.query_params.get("Marker").cloned();
 
-        let mut policies: Vec<IamPolicy> = state.policies.values().cloned().collect();
+        // Customer-managed (``Local``) policies live in state; AWS-managed
+        // policies come from the seeded catalog. ``Scope`` selects which sets
+        // to include.
+        let mut policies: Vec<IamPolicy> = if matches!(scope, PolicyScope::Aws) {
+            Vec::new()
+        } else {
+            state.policies.values().cloned().collect()
+        };
+        if matches!(scope, PolicyScope::All | PolicyScope::Aws) {
+            for mp in crate::managed_policies::all() {
+                policies.push(mp.to_iam_policy(count_managed_attachments(state, &mp.arn)));
+            }
+        }
         if let Some(prefix) = path_prefix {
             policies.retain(|p| p.path.starts_with(&prefix));
-        }
-        if matches!(scope, PolicyScope::Aws) {
-            // We don't carry any AWS-managed policies in fakecloud, so an
-            // explicit ``Scope=AWS`` filter returns an empty list.
-            policies.clear();
         }
         policies.sort_by(|a, b| a.policy_name.cmp(&b.policy_name));
 
@@ -391,7 +398,7 @@ impl IamService {
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        let policy = state.policies.get(&policy_arn).ok_or_else(|| {
+        let policy = resolve_policy(state, &policy_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
@@ -446,7 +453,7 @@ impl IamService {
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        let policy = state.policies.get(&policy_arn).ok_or_else(|| {
+        let policy = resolve_policy(state, &policy_arn).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
@@ -614,7 +621,9 @@ impl IamService {
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        if !state.policies.contains_key(&policy_arn) {
+        if !state.policies.contains_key(&policy_arn)
+            && crate::managed_policies::lookup(&policy_arn).is_none()
+        {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
@@ -756,4 +765,38 @@ impl CreatePolicyInput {
             tags,
         })
     }
+}
+
+/// Resolve a policy ARN to an owned [`IamPolicy`], looking first in the
+/// account's customer-managed policies and then in the seeded AWS-managed
+/// catalog. Returns `None` if neither holds it.
+fn resolve_policy(state: &crate::state::IamState, arn: &str) -> Option<IamPolicy> {
+    if let Some(p) = state.policies.get(arn) {
+        return Some(p.clone());
+    }
+    crate::managed_policies::lookup(arn)
+        .map(|mp| mp.to_iam_policy(count_managed_attachments(state, arn)))
+}
+
+/// Count how many roles, users, and groups in this account reference the given
+/// policy ARN. AWS-managed policies are not stored in state, so their
+/// `AttachmentCount` is derived on demand from the attachment maps.
+fn count_managed_attachments(state: &crate::state::IamState, arn: &str) -> u32 {
+    let mut count = 0u32;
+    for arns in state.role_policies.values() {
+        if arns.iter().any(|a| a == arn) {
+            count += 1;
+        }
+    }
+    for arns in state.user_policies.values() {
+        if arns.iter().any(|a| a == arn) {
+            count += 1;
+        }
+    }
+    for group in state.groups.values() {
+        if group.attached_policies.iter().any(|a| a == arn) {
+            count += 1;
+        }
+    }
+    count
 }

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -1927,11 +1927,16 @@ fn list_policies_paginates_via_marker() {
         ))
         .unwrap();
     }
+    // Scope=Local isolates the customer-managed policies created above from the
+    // seeded AWS-managed catalog (which Scope=All now also returns).
     let body1 = String::from_utf8_lossy(
-        svc.list_policies(&make_request("ListPolicies", vec![("MaxItems", "2")]))
-            .unwrap()
-            .body
-            .expect_bytes(),
+        svc.list_policies(&make_request(
+            "ListPolicies",
+            vec![("MaxItems", "2"), ("Scope", "Local")],
+        ))
+        .unwrap()
+        .body
+        .expect_bytes(),
     )
     .to_string();
     assert_eq!(count_occurrences(&body1, "<member>"), 2);
@@ -1941,7 +1946,7 @@ fn list_policies_paginates_via_marker() {
     let body2 = String::from_utf8_lossy(
         svc.list_policies(&make_request(
             "ListPolicies",
-            vec![("MaxItems", "2"), ("Marker", &marker)],
+            vec![("MaxItems", "2"), ("Marker", &marker), ("Scope", "Local")],
         ))
         .unwrap()
         .body
@@ -4636,5 +4641,139 @@ fn list_service_specific_credentials_uses_member_framing() {
     assert!(
         body.contains("<member>") && body.contains("codecommit.amazonaws.com"),
         "list should wrap credentials in <member>, got {body}"
+    );
+}
+
+#[test]
+fn get_policy_resolves_aws_managed_from_catalog() {
+    let svc = make_service();
+    let arn = "arn:aws:iam::aws:policy/AdministratorAccess";
+    let resp = svc
+        .get_policy(&make_request("GetPolicy", vec![("PolicyArn", arn)]))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(body.contains(arn), "ARN missing: {body}");
+    assert!(
+        body.contains("<PolicyName>AdministratorAccess</PolicyName>"),
+        "name missing: {body}"
+    );
+    assert!(
+        body.contains("<DefaultVersionId>v1</DefaultVersionId>"),
+        "default version missing: {body}"
+    );
+    assert!(
+        body.contains("<IsAttachable>true</IsAttachable>"),
+        "IsAttachable missing: {body}"
+    );
+}
+
+#[test]
+fn get_policy_unknown_managed_arn_still_not_found() {
+    let svc = make_service();
+    let result = svc.get_policy(&make_request(
+        "GetPolicy",
+        vec![("PolicyArn", "arn:aws:iam::aws:policy/TotallyMadeUpPolicy")],
+    ));
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.code(), "NoSuchEntity");
+    }
+}
+
+#[test]
+fn get_policy_version_resolves_aws_managed_document() {
+    let svc = make_service();
+    let arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess";
+    let resp = svc
+        .get_policy_version(&make_request(
+            "GetPolicyVersion",
+            vec![("PolicyArn", arn), ("VersionId", "v2")],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    // Document is URL-encoded in the response; check an encoded fragment.
+    assert!(body.contains("s3%3A"), "encoded s3 action missing: {body}");
+    assert!(body.contains("<IsDefaultVersion>true</IsDefaultVersion>"));
+}
+
+#[test]
+fn list_policy_versions_resolves_aws_managed() {
+    let svc = make_service();
+    let arn = "arn:aws:iam::aws:policy/AWSLambda_FullAccess";
+    let resp = svc
+        .list_policy_versions(&make_request(
+            "ListPolicyVersions",
+            vec![("PolicyArn", arn)],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(
+        body.contains("<VersionId>v7</VersionId>"),
+        "version missing: {body}"
+    );
+}
+
+#[test]
+fn list_policies_scope_aws_returns_catalog() {
+    let svc = make_service();
+    let resp = svc
+        .list_policies(&make_request("ListPolicies", vec![("Scope", "AWS")]))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(
+        body.contains("arn:aws:iam::aws:policy/AdministratorAccess"),
+        "AdministratorAccess missing from Scope=AWS: {body}"
+    );
+    assert!(
+        body.contains("arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"),
+        "service-role policy missing from Scope=AWS: {body}"
+    );
+}
+
+#[test]
+fn list_policies_scope_local_excludes_catalog() {
+    let svc = make_service();
+    let resp = svc
+        .list_policies(&make_request("ListPolicies", vec![("Scope", "Local")]))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(
+        !body.contains("arn:aws:iam::aws:policy/AdministratorAccess"),
+        "Scope=Local must not include AWS-managed policies: {body}"
+    );
+}
+
+#[test]
+fn list_entities_for_managed_policy_counts_attachments() {
+    let svc = make_service();
+    let arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess";
+    svc.create_role(&make_request(
+        "CreateRole",
+        vec![("RoleName", "reader"), ("AssumeRolePolicyDocument", "{}")],
+    ))
+    .unwrap();
+    svc.attach_role_policy(&make_request(
+        "AttachRolePolicy",
+        vec![("RoleName", "reader"), ("PolicyArn", arn)],
+    ))
+    .unwrap();
+
+    let resp = svc
+        .list_entities_for_policy(&make_request(
+            "ListEntitiesForPolicy",
+            vec![("PolicyArn", arn)],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(body.contains("reader"), "attached role missing: {body}");
+
+    // GetPolicy should now report AttachmentCount=1.
+    let gp = svc
+        .get_policy(&make_request("GetPolicy", vec![("PolicyArn", arn)]))
+        .unwrap();
+    let gp_body = String::from_utf8_lossy(gp.body.expect_bytes()).to_string();
+    assert!(
+        gp_body.contains("<AttachmentCount>1</AttachmentCount>"),
+        "attachment count not reflected: {gp_body}"
     );
 }

--- a/crates/fakecloud-iam/src/lib.rs
+++ b/crates/fakecloud-iam/src/lib.rs
@@ -3,6 +3,7 @@ pub mod condition;
 pub mod credential_resolver;
 pub mod evaluator;
 pub mod iam_service;
+pub mod managed_policies;
 pub mod pass_role;
 pub mod persistence;
 pub mod policy_evaluator;

--- a/crates/fakecloud-iam/src/managed_policies.rs
+++ b/crates/fakecloud-iam/src/managed_policies.rs
@@ -1,0 +1,251 @@
+//! Catalog of well-known AWS-managed IAM policies (`arn:aws:iam::aws:policy/*`).
+//!
+//! AWS-managed policies are not created by users: they exist in every account
+//! under a fixed ARN with a document AWS maintains. Real clients (Terraform,
+//! CDK, the console) routinely attach them to roles/users/groups and then call
+//! `GetPolicy`/`GetPolicyVersion`/`ListPolicyVersions`/`ListPolicies` against
+//! them. fakecloud seeds a curated set so those calls resolve like real AWS
+//! instead of returning `NoSuchEntity`, and so the policy engine can evaluate
+//! the grants they confer.
+//!
+//! The documents embedded in `managed_policies/catalog.json` are the exact
+//! current AWS documents (fetched verbatim from the AWS managed-policy
+//! reference). The set is curated toward the policies most commonly attached in
+//! infrastructure-as-code; it is not the full AWS catalog. An ARN that is not
+//! seeded behaves exactly as before (it can still be attached, but resolves to
+//! `NoSuchEntity` on read), so adding more entries is purely additive.
+
+use std::sync::OnceLock;
+
+use chrono::{DateTime, TimeZone, Utc};
+use serde::Deserialize;
+
+use crate::state::{IamPolicy, PolicyVersion};
+
+/// One entry in the embedded AWS-managed policy catalog.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagedPolicy {
+    pub name: String,
+    pub arn: String,
+    pub path: String,
+    #[serde(rename = "defaultVersionId")]
+    pub default_version_id: String,
+    #[serde(rename = "createDate")]
+    pub create_date: String,
+    pub description: String,
+    pub document: String,
+}
+
+#[derive(Deserialize)]
+struct CatalogFile {
+    policies: Vec<ManagedPolicy>,
+}
+
+const CATALOG_JSON: &str = include_str!("managed_policies/catalog.json");
+
+fn catalog() -> &'static [ManagedPolicy] {
+    static CATALOG: OnceLock<Vec<ManagedPolicy>> = OnceLock::new();
+    CATALOG
+        .get_or_init(|| {
+            let parsed: CatalogFile = serde_json::from_str(CATALOG_JSON)
+                .expect("embedded AWS-managed policy catalog must be valid JSON");
+            parsed.policies
+        })
+        .as_slice()
+}
+
+/// True if the ARN refers to an AWS-managed policy (`arn:aws:iam::aws:policy/...`),
+/// including service-role and aws-service-role policies. Customer-managed ARNs
+/// (`arn:aws:iam::<account-id>:policy/...`) do not match.
+pub fn is_aws_managed_arn(arn: &str) -> bool {
+    arn.contains(":aws:policy/")
+}
+
+/// All seeded AWS-managed policies.
+pub fn all() -> &'static [ManagedPolicy] {
+    catalog()
+}
+
+/// Look up a seeded AWS-managed policy by its full ARN.
+pub fn lookup(arn: &str) -> Option<&'static ManagedPolicy> {
+    catalog().iter().find(|p| p.arn == arn)
+}
+
+/// The default-version policy document for a seeded AWS-managed ARN, if any.
+pub fn default_document(arn: &str) -> Option<&'static str> {
+    lookup(arn).map(|p| p.document.as_str())
+}
+
+impl ManagedPolicy {
+    /// Parse the catalog's ISO-8601 creation timestamp (falls back to the epoch
+    /// if a future catalog entry has a malformed date, which the unit tests
+    /// guard against).
+    pub fn created_at(&self) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(&self.create_date)
+            .map(|d| d.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc.timestamp_opt(0, 0).single().unwrap_or_default())
+    }
+
+    /// A stable `PolicyId` for this managed policy. AWS does not publish the
+    /// real `ANPA...` id per policy, so we derive a deterministic one from the
+    /// name (clients key off the ARN, not the id). Format matches AWS: the
+    /// `ANPA` prefix followed by 17 uppercase base-32 characters.
+    pub fn policy_id(&self) -> String {
+        deterministic_policy_id(&self.name)
+    }
+
+    /// The number of versions after the default; AWS-managed policies in the
+    /// catalog carry only their current default version.
+    fn next_version_num(&self) -> u32 {
+        self.default_version_id
+            .trim_start_matches('v')
+            .parse::<u32>()
+            .unwrap_or(1)
+            .saturating_add(1)
+    }
+
+    /// Build a state-shaped [`IamPolicy`] view of this catalog entry so the
+    /// existing response builders can render it. `attachment_count` is supplied
+    /// by the caller (computed from how many principals reference the ARN).
+    pub fn to_iam_policy(&self, attachment_count: u32) -> IamPolicy {
+        let created_at = self.created_at();
+        IamPolicy {
+            policy_name: self.name.clone(),
+            policy_id: self.policy_id(),
+            arn: self.arn.clone(),
+            path: self.path.clone(),
+            description: self.description.clone(),
+            created_at,
+            tags: Vec::new(),
+            default_version_id: self.default_version_id.clone(),
+            versions: vec![PolicyVersion {
+                version_id: self.default_version_id.clone(),
+                document: self.document.clone(),
+                is_default: true,
+                created_at,
+            }],
+            next_version_num: self.next_version_num(),
+            attachment_count,
+        }
+    }
+}
+
+fn deterministic_policy_id(name: &str) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    // Two FNV-1a passes (forward and reverse) give 128 bits of stable entropy.
+    let mut h1: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in name.bytes() {
+        h1 ^= b as u64;
+        h1 = h1.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    let mut h2: u64 = 0x8422_2325_cbf2_9ce4;
+    for b in name.bytes().rev() {
+        h2 ^= b as u64;
+        h2 = h2.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    let mut bits = ((h1 as u128) << 64) | h2 as u128;
+    let mut out = String::with_capacity(21);
+    out.push_str("ANPA");
+    for _ in 0..17 {
+        out.push(ALPHABET[(bits & 0x1f) as usize] as char);
+        bits >>= 5;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_parses_and_is_nonempty() {
+        assert!(!all().is_empty(), "catalog should seed at least one policy");
+    }
+
+    #[test]
+    fn every_entry_is_managed_with_valid_document() {
+        for p in all() {
+            assert!(
+                is_aws_managed_arn(&p.arn),
+                "catalog ARN must be AWS-managed: {}",
+                p.arn
+            );
+            assert!(
+                p.arn.ends_with(&p.name),
+                "ARN should end with the policy name: {} / {}",
+                p.arn,
+                p.name
+            );
+            // The document must be valid JSON with a Statement element.
+            let v: serde_json::Value =
+                serde_json::from_str(&p.document).expect("policy document must be valid JSON");
+            assert!(
+                v.get("Statement").is_some(),
+                "document for {} must have a Statement",
+                p.name
+            );
+            // Creation date must parse.
+            DateTime::parse_from_rfc3339(&p.create_date)
+                .unwrap_or_else(|_| panic!("createDate must be RFC3339 for {}", p.name));
+            // Service-role policies must declare a matching path.
+            if p.arn.contains(":aws:policy/service-role/") {
+                assert_eq!(p.path, "/service-role/", "path mismatch for {}", p.name);
+            }
+        }
+    }
+
+    #[test]
+    fn arns_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for p in all() {
+            assert!(seen.insert(&p.arn), "duplicate ARN in catalog: {}", p.arn);
+        }
+    }
+
+    #[test]
+    fn lookup_and_default_document_resolve_known_policy() {
+        let arn = "arn:aws:iam::aws:policy/AdministratorAccess";
+        let p = lookup(arn).expect("AdministratorAccess must be seeded");
+        assert_eq!(p.name, "AdministratorAccess");
+        let doc = default_document(arn).expect("must have a default document");
+        assert!(doc.contains("\"Action\":\"*\""));
+        assert!(lookup("arn:aws:iam::aws:policy/DoesNotExist").is_none());
+    }
+
+    #[test]
+    fn customer_arn_is_not_managed() {
+        assert!(!is_aws_managed_arn(
+            "arn:aws:iam::123456789012:policy/MyPolicy"
+        ));
+        assert!(is_aws_managed_arn(
+            "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ));
+    }
+
+    #[test]
+    fn policy_id_is_stable_and_well_formed() {
+        let a = deterministic_policy_id("AdministratorAccess");
+        let b = deterministic_policy_id("AdministratorAccess");
+        assert_eq!(a, b, "policy id must be deterministic");
+        assert!(a.starts_with("ANPA"));
+        assert_eq!(a.len(), 21);
+        assert!(a
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()));
+        assert_ne!(
+            deterministic_policy_id("AdministratorAccess"),
+            deterministic_policy_id("PowerUserAccess"),
+        );
+    }
+
+    #[test]
+    fn to_iam_policy_carries_default_version() {
+        let p = lookup("arn:aws:iam::aws:policy/AmazonS3FullAccess").unwrap();
+        let ip = p.to_iam_policy(3);
+        assert_eq!(ip.attachment_count, 3);
+        assert_eq!(ip.default_version_id, "v2");
+        assert_eq!(ip.versions.len(), 1);
+        assert!(ip.versions[0].is_default);
+        assert_eq!(ip.next_version_num, 3);
+    }
+}

--- a/crates/fakecloud-iam/src/managed_policies/catalog.json
+++ b/crates/fakecloud-iam/src/managed_policies/catalog.json
@@ -1,0 +1,256 @@
+{
+  "policies": [
+    {
+      "name": "AdministratorAccess",
+      "arn": "arn:aws:iam::aws:policy/AdministratorAccess",
+      "path": "/",
+      "defaultVersionId": "v1",
+      "createDate": "2015-02-06T18:39:00Z",
+      "description": "Provides full access to AWS services and resources.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "PowerUserAccess",
+      "arn": "arn:aws:iam::aws:policy/PowerUserAccess",
+      "path": "/",
+      "defaultVersionId": "v12",
+      "createDate": "2015-02-06T18:39:00Z",
+      "description": "Provides full access to AWS services and resources, but does not allow management of Users and groups.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"NotAction\":[\"iam:*\",\"organizations:*\",\"account:*\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":[\"account:GetAccountInformation\",\"account:GetGovCloudAccountInformation\",\"account:GetPrimaryEmail\",\"account:ListRegions\",\"iam:CreateServiceLinkedRole\",\"iam:DeleteServiceLinkedRole\",\"iam:ListRoles\",\"organizations:DescribeEffectivePolicy\",\"organizations:DescribeOrganization\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "IAMFullAccess",
+      "arn": "arn:aws:iam::aws:policy/IAMFullAccess",
+      "path": "/",
+      "defaultVersionId": "v2",
+      "createDate": "2015-02-06T18:40:00Z",
+      "description": "Provides full access to IAM via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"iam:*\",\"organizations:DescribeAccount\",\"organizations:DescribeOrganization\",\"organizations:DescribeOrganizationalUnit\",\"organizations:DescribePolicy\",\"organizations:ListChildren\",\"organizations:ListParents\",\"organizations:ListPoliciesForTarget\",\"organizations:ListRoots\",\"organizations:ListPolicies\",\"organizations:ListTargetsForPolicy\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "IAMReadOnlyAccess",
+      "arn": "arn:aws:iam::aws:policy/IAMReadOnlyAccess",
+      "path": "/",
+      "defaultVersionId": "v4",
+      "createDate": "2015-02-06T18:40:00Z",
+      "description": "Provides read only access to IAM via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"iam:GenerateCredentialReport\",\"iam:GenerateServiceLastAccessedDetails\",\"iam:Get*\",\"iam:List*\",\"iam:SimulateCustomPolicy\",\"iam:SimulatePrincipalPolicy\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AmazonS3FullAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+      "path": "/",
+      "defaultVersionId": "v2",
+      "createDate": "2015-02-06T18:40:00Z",
+      "description": "Provides full access to all buckets via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:*\",\"s3-object-lambda:*\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AmazonS3ReadOnlyAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+      "path": "/",
+      "defaultVersionId": "v3",
+      "createDate": "2015-02-06T18:40:00Z",
+      "description": "Provides read only access to all buckets via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:Get*\",\"s3:List*\",\"s3:Describe*\",\"s3-object-lambda:Get*\",\"s3-object-lambda:List*\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AmazonDynamoDBFullAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
+      "path": "/",
+      "defaultVersionId": "v15",
+      "createDate": "2015-02-06T18:40:00Z",
+      "description": "Provides full access to Amazon DynamoDB via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:*\",\"dax:*\",\"application-autoscaling:DeleteScalingPolicy\",\"application-autoscaling:DeregisterScalableTarget\",\"application-autoscaling:DescribeScalableTargets\",\"application-autoscaling:DescribeScalingActivities\",\"application-autoscaling:DescribeScalingPolicies\",\"application-autoscaling:PutScalingPolicy\",\"application-autoscaling:RegisterScalableTarget\",\"cloudwatch:DeleteAlarms\",\"cloudwatch:DescribeAlarmHistory\",\"cloudwatch:DescribeAlarms\",\"cloudwatch:DescribeAlarmsForMetric\",\"cloudwatch:GetMetricStatistics\",\"cloudwatch:ListMetrics\",\"cloudwatch:PutMetricAlarm\",\"cloudwatch:GetMetricData\",\"datapipeline:ActivatePipeline\",\"datapipeline:CreatePipeline\",\"datapipeline:DeletePipeline\",\"datapipeline:DescribeObjects\",\"datapipeline:DescribePipelines\",\"datapipeline:GetPipelineDefinition\",\"datapipeline:ListPipelines\",\"datapipeline:PutPipelineDefinition\",\"datapipeline:QueryObjects\",\"ec2:DescribeVpcs\",\"ec2:DescribeSubnets\",\"ec2:DescribeSecurityGroups\",\"iam:GetRole\",\"iam:ListRoles\",\"kms:DescribeKey\",\"kms:ListAliases\",\"sns:CreateTopic\",\"sns:DeleteTopic\",\"sns:ListSubscriptions\",\"sns:ListSubscriptionsByTopic\",\"sns:ListTopics\",\"sns:Subscribe\",\"sns:Unsubscribe\",\"sns:SetTopicAttributes\",\"lambda:CreateFunction\",\"lambda:ListFunctions\",\"lambda:ListEventSourceMappings\",\"lambda:CreateEventSourceMapping\",\"lambda:DeleteEventSourceMapping\",\"lambda:GetFunctionConfiguration\",\"lambda:DeleteFunction\",\"resource-groups:ListGroups\",\"resource-groups:ListGroupResources\",\"resource-groups:GetGroup\",\"resource-groups:GetGroupQuery\",\"resource-groups:DeleteGroup\",\"resource-groups:CreateGroup\",\"tag:GetResources\",\"kinesis:ListStreams\",\"kinesis:DescribeStream\",\"kinesis:DescribeStreamSummary\"],\"Effect\":\"Allow\",\"Resource\":\"*\"},{\"Action\":\"cloudwatch:GetInsightRuleReport\",\"Effect\":\"Allow\",\"Resource\":\"arn:aws:cloudwatch:*:*:insight-rule/DynamoDBContributorInsights*\"},{\"Action\":[\"iam:PassRole\"],\"Effect\":\"Allow\",\"Resource\":\"*\",\"Condition\":{\"StringLike\":{\"iam:PassedToService\":[\"application-autoscaling.amazonaws.com\",\"application-autoscaling.amazonaws.com.cn\",\"dax.amazonaws.com\"]}}},{\"Effect\":\"Allow\",\"Action\":[\"iam:CreateServiceLinkedRole\"],\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"iam:AWSServiceName\":[\"replication.dynamodb.amazonaws.com\",\"dax.amazonaws.com\",\"dynamodb.application-autoscaling.amazonaws.com\",\"contributorinsights.dynamodb.amazonaws.com\",\"kinesisreplication.dynamodb.amazonaws.com\"]}}}]}"
+    },
+    {
+      "name": "AmazonEC2FullAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
+      "path": "/",
+      "defaultVersionId": "v5",
+      "createDate": "2015-02-06T18:40:00Z",
+      "description": "Provides full access to Amazon EC2 via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"ec2:*\",\"Effect\":\"Allow\",\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":\"elasticloadbalancing:*\",\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":\"cloudwatch:*\",\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":\"autoscaling:*\",\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":\"iam:CreateServiceLinkedRole\",\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"iam:AWSServiceName\":[\"autoscaling.amazonaws.com\",\"ec2scheduled.amazonaws.com\",\"elasticloadbalancing.amazonaws.com\",\"spot.amazonaws.com\",\"spotfleet.amazonaws.com\",\"transitgateway.amazonaws.com\"]}}}]}"
+    },
+    {
+      "name": "AmazonSQSFullAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonSQSFullAccess",
+      "path": "/",
+      "defaultVersionId": "v1",
+      "createDate": "2015-02-06T18:41:00Z",
+      "description": "Provides full access to Amazon SQS via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"sqs:*\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AmazonSNSFullAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonSNSFullAccess",
+      "path": "/",
+      "defaultVersionId": "v2",
+      "createDate": "2015-02-06T18:41:00Z",
+      "description": "Provides full access to Amazon SNS via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SNSFullAccess\",\"Effect\":\"Allow\",\"Action\":\"sns:*\",\"Resource\":\"*\"},{\"Sid\":\"SMSAccessViaSNS\",\"Effect\":\"Allow\",\"Action\":[\"sms-voice:DescribeVerifiedDestinationNumbers\",\"sms-voice:CreateVerifiedDestinationNumber\",\"sms-voice:SendDestinationNumberVerificationCode\",\"sms-voice:SendTextMessage\",\"sms-voice:DeleteVerifiedDestinationNumber\",\"sms-voice:VerifyDestinationNumber\",\"sms-voice:DescribeAccountAttributes\",\"sms-voice:DescribeSpendLimits\",\"sms-voice:DescribePhoneNumbers\",\"sms-voice:SetTextMessageSpendLimitOverride\",\"sms-voice:DescribeOptedOutNumbers\",\"sms-voice:DeleteOptedOutNumber\"],\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"aws:CalledViaLast\":\"sns.amazonaws.com\"}}}]}"
+    },
+    {
+      "name": "AmazonVPCFullAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonVPCFullAccess",
+      "path": "/",
+      "defaultVersionId": "v13",
+      "createDate": "2015-02-06T18:41:00Z",
+      "description": "Provides full access to Amazon VPC via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AmazonVPCFullAccess\",\"Effect\":\"Allow\",\"Action\":[\"ec2:AcceptVpcPeeringConnection\",\"ec2:AcceptVpcEndpointConnections\",\"ec2:AllocateAddress\",\"ec2:AssignIpv6Addresses\",\"ec2:AssignPrivateIpAddresses\",\"ec2:AssociateAddress\",\"ec2:AssociateDhcpOptions\",\"ec2:AssociateRouteTable\",\"ec2:AssociateSecurityGroupVpc\",\"ec2:AssociateSubnetCidrBlock\",\"ec2:AssociateVpcCidrBlock\",\"ec2:AttachClassicLinkVpc\",\"ec2:AttachInternetGateway\",\"ec2:AttachNetworkInterface\",\"ec2:AttachVpnGateway\",\"ec2:AuthorizeSecurityGroupEgress\",\"ec2:AuthorizeSecurityGroupIngress\",\"ec2:CreateCarrierGateway\",\"ec2:CreateCustomerGateway\",\"ec2:CreateDefaultSubnet\",\"ec2:CreateDefaultVpc\",\"ec2:CreateDhcpOptions\",\"ec2:CreateEgressOnlyInternetGateway\",\"ec2:CreateFlowLogs\",\"ec2:CreateInternetGateway\",\"ec2:CreateLocalGatewayRouteTableVpcAssociation\",\"ec2:CreateNatGateway\",\"ec2:CreateNetworkAcl\",\"ec2:CreateNetworkAclEntry\",\"ec2:CreateNetworkInterface\",\"ec2:CreateNetworkInterfacePermission\",\"ec2:CreateRoute\",\"ec2:CreateRouteTable\",\"ec2:CreateSecurityGroup\",\"ec2:CreateSubnet\",\"ec2:CreateTags\",\"ec2:CreateVpc\",\"ec2:CreateVpcEndpoint\",\"ec2:CreateVpcEndpointConnectionNotification\",\"ec2:CreateVpcEndpointServiceConfiguration\",\"ec2:CreateVpcPeeringConnection\",\"ec2:CreateVpnConnection\",\"ec2:CreateVpnConnectionRoute\",\"ec2:CreateVpnGateway\",\"ec2:DeleteCarrierGateway\",\"ec2:DeleteCustomerGateway\",\"ec2:DeleteDhcpOptions\",\"ec2:DeleteEgressOnlyInternetGateway\",\"ec2:DeleteFlowLogs\",\"ec2:DeleteInternetGateway\",\"ec2:DeleteLocalGatewayRouteTableVpcAssociation\",\"ec2:DeleteNatGateway\",\"ec2:DeleteNetworkAcl\",\"ec2:DeleteNetworkAclEntry\",\"ec2:DeleteNetworkInterface\",\"ec2:DeleteNetworkInterfacePermission\",\"ec2:DeleteRoute\",\"ec2:DeleteRouteTable\",\"ec2:DeleteSecurityGroup\",\"ec2:DeleteSubnet\",\"ec2:DeleteTags\",\"ec2:DeleteVpc\",\"ec2:DeleteVpcEndpoints\",\"ec2:DeleteVpcEndpointConnectionNotifications\",\"ec2:DeleteVpcEndpointServiceConfigurations\",\"ec2:DeleteVpcPeeringConnection\",\"ec2:DeleteVpnConnection\",\"ec2:DeleteVpnConnectionRoute\",\"ec2:DeleteVpnGateway\",\"ec2:DescribeAccountAttributes\",\"ec2:DescribeAddresses\",\"ec2:DescribeAvailabilityZones\",\"ec2:DescribeCarrierGateways\",\"ec2:DescribeClassicLinkInstances\",\"ec2:DescribeCustomerGateways\",\"ec2:DescribeDhcpOptions\",\"ec2:DescribeEgressOnlyInternetGateways\",\"ec2:DescribeFlowLogs\",\"ec2:DescribeInstances\",\"ec2:DescribeInternetGateways\",\"ec2:DescribeIpv6Pools\",\"ec2:DescribeLocalGatewayRouteTables\",\"ec2:DescribeLocalGatewayRouteTableVpcAssociations\",\"ec2:DescribeKeyPairs\",\"ec2:DescribeMovingAddresses\",\"ec2:DescribeNatGateways\",\"ec2:DescribeNetworkAcls\",\"ec2:DescribeNetworkInterfaceAttribute\",\"ec2:DescribeNetworkInterfacePermissions\",\"ec2:DescribeNetworkInterfaces\",\"ec2:DescribePrefixLists\",\"ec2:DescribeRouteTables\",\"ec2:DescribeSecurityGroupReferences\",\"ec2:DescribeSecurityGroupRules\",\"ec2:DescribeSecurityGroups\",\"ec2:DescribeSecurityGroupVpcAssociations\",\"ec2:DescribeStaleSecurityGroups\",\"ec2:DescribeSubnets\",\"ec2:DescribeTags\",\"ec2:DescribeVpcAttribute\",\"ec2:DescribeVpcClassicLink\",\"ec2:DescribeVpcClassicLinkDnsSupport\",\"ec2:DescribeVpcEndpointConnectionNotifications\",\"ec2:DescribeVpcEndpointConnections\",\"ec2:DescribeVpcEndpoints\",\"ec2:DescribeVpcEndpointServiceConfigurations\",\"ec2:DescribeVpcEndpointServicePermissions\",\"ec2:DescribeVpcEndpointServices\",\"ec2:DescribeVpcPeeringConnections\",\"ec2:DescribeVpcs\",\"ec2:DescribeVpnConnections\",\"ec2:DescribeVpnGateways\",\"ec2:DetachClassicLinkVpc\",\"ec2:DetachInternetGateway\",\"ec2:DetachNetworkInterface\",\"ec2:DetachVpnGateway\",\"ec2:DisableVgwRoutePropagation\",\"ec2:DisableVpcClassicLink\",\"ec2:DisableVpcClassicLinkDnsSupport\",\"ec2:DisassociateAddress\",\"ec2:DisassociateRouteTable\",\"ec2:DisassociateSecurityGroupVpc\",\"ec2:DisassociateSubnetCidrBlock\",\"ec2:DisassociateVpcCidrBlock\",\"ec2:EnableVgwRoutePropagation\",\"ec2:EnableVpcClassicLink\",\"ec2:EnableVpcClassicLinkDnsSupport\",\"ec2:GetSecurityGroupsForVpc\",\"ec2:ModifyNetworkInterfaceAttribute\",\"ec2:ModifySecurityGroupRules\",\"ec2:ModifySubnetAttribute\",\"ec2:ModifyVpcAttribute\",\"ec2:ModifyVpcEndpoint\",\"ec2:ModifyVpcEndpointConnectionNotification\",\"ec2:ModifyVpcEndpointServiceConfiguration\",\"ec2:ModifyVpcEndpointServicePermissions\",\"ec2:ModifyVpcPeeringConnectionOptions\",\"ec2:ModifyVpcTenancy\",\"ec2:MoveAddressToVpc\",\"ec2:RejectVpcEndpointConnections\",\"ec2:RejectVpcPeeringConnection\",\"ec2:ReleaseAddress\",\"ec2:ReplaceNetworkAclAssociation\",\"ec2:ReplaceNetworkAclEntry\",\"ec2:ReplaceRoute\",\"ec2:ReplaceRouteTableAssociation\",\"ec2:ResetNetworkInterfaceAttribute\",\"ec2:RestoreAddressToClassic\",\"ec2:RevokeSecurityGroupEgress\",\"ec2:RevokeSecurityGroupIngress\",\"ec2:UnassignIpv6Addresses\",\"ec2:UnassignPrivateIpAddresses\",\"ec2:UpdateSecurityGroupRuleDescriptionsEgress\",\"ec2:UpdateSecurityGroupRuleDescriptionsIngress\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AWSLambda_FullAccess",
+      "arn": "arn:aws:iam::aws:policy/AWSLambda_FullAccess",
+      "path": "/",
+      "defaultVersionId": "v7",
+      "createDate": "2020-11-17T21:14:00Z",
+      "description": "Grants full access to AWS Lambda service, AWS Lambda console features, and other related AWS services.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"cloudformation:DescribeStacks\",\"cloudformation:ListStackResources\",\"cloudwatch:ListMetrics\",\"cloudwatch:GetMetricData\",\"ec2:DescribeSecurityGroups\",\"ec2:DescribeSubnets\",\"ec2:DescribeVpcs\",\"kms:DescribeKey\",\"kms:ListAliases\",\"iam:GetPolicy\",\"iam:GetPolicyVersion\",\"iam:GetRole\",\"iam:GetRolePolicy\",\"iam:ListAttachedRolePolicies\",\"iam:ListRolePolicies\",\"iam:ListRoles\",\"lambda:*\",\"logs:DescribeLogGroups\",\"states:DescribeStateMachine\",\"states:ListStateMachines\",\"tag:GetResources\",\"xray:GetTraceSummaries\",\"xray:BatchGetTraces\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":\"iam:PassRole\",\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"iam:PassedToService\":\"lambda.amazonaws.com\"}}},{\"Effect\":\"Allow\",\"Action\":[\"logs:DescribeLogStreams\",\"logs:GetLogEvents\",\"logs:FilterLogEvents\",\"logs:StartLiveTail\",\"logs:StopLiveTail\"],\"Resource\":\"arn:aws:logs:*:*:log-group:/aws/lambda/*\"},{\"Effect\":\"Allow\",\"Action\":\"iam:CreateServiceLinkedRole\",\"Resource\":\"arn:aws:iam::*:role/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda\",\"Condition\":{\"StringEquals\":{\"iam:AWSServiceName\":\"lambda.amazonaws.com\"}}}]}"
+    },
+    {
+      "name": "CloudWatchFullAccessV2",
+      "arn": "arn:aws:iam::aws:policy/CloudWatchFullAccessV2",
+      "path": "/",
+      "defaultVersionId": "v16",
+      "createDate": "2023-08-01T11:32:00Z",
+      "description": "Provides full access to CloudWatch.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"CloudWatchFullAccessPermissions\",\"Effect\":\"Allow\",\"Action\":[\"application-autoscaling:DescribeScalingPolicies\",\"application-signals:*\",\"autoscaling:DescribeAutoScalingGroups\",\"autoscaling:DescribePolicies\",\"cloudwatch:*\",\"logs:*\",\"sns:CreateTopic\",\"sns:ListSubscriptions\",\"sns:ListSubscriptionsByTopic\",\"sns:ListTopics\",\"sns:Subscribe\",\"iam:GetPolicy\",\"iam:GetPolicyVersion\",\"iam:GetRole\",\"oam:ListSinks\",\"observabilityadmin:GetCentralizationRuleForOrganization\",\"observabilityadmin:ListCentralizationRulesForOrganization\",\"observabilityadmin:CreateCentralizationRuleForOrganization\",\"observabilityadmin:UpdateCentralizationRuleForOrganization\",\"observabilityadmin:DeleteCentralizationRuleForOrganization\",\"observabilityadmin:StartTelemetryEvaluation\",\"observabilityadmin:GetTelemetryEvaluationStatus\",\"observabilityadmin:ListResourceTelemetry\",\"observabilityadmin:StopTelemetryEvaluation\",\"observabilityadmin:StartTelemetryEvaluationForOrganization\",\"observabilityadmin:GetTelemetryEvaluationStatusForOrganization\",\"observabilityadmin:ListResourceTelemetryForOrganization\",\"observabilityadmin:StopTelemetryEvaluationForOrganization\",\"observabilityadmin:CreateTelemetryRule\",\"observabilityadmin:GetTelemetryRule\",\"observabilityadmin:ListTelemetryRules\",\"observabilityadmin:UpdateTelemetryRule\",\"observabilityadmin:DeleteTelemetryRule\",\"observabilityadmin:CreateTelemetryRuleForOrganization\",\"observabilityadmin:GetTelemetryRuleForOrganization\",\"observabilityadmin:ListTelemetryRulesForOrganization\",\"observabilityadmin:UpdateTelemetryRuleForOrganization\",\"observabilityadmin:DeleteTelemetryRuleForOrganization\",\"observabilityadmin:GetTelemetryEnrichmentStatus\",\"observabilityadmin:StartTelemetryEnrichment\",\"observabilityadmin:StopTelemetryEnrichment\",\"observabilityadmin:TagResource\",\"observabilityadmin:UntagResource\",\"observabilityadmin:ListTagsForResource\",\"observabilityadmin:CreateTelemetryPipeline\",\"observabilityadmin:GetTelemetryPipeline\",\"observabilityadmin:UpdateTelemetryPipeline\",\"observabilityadmin:DeleteTelemetryPipeline\",\"observabilityadmin:ListTelemetryPipelines\",\"observabilityadmin:TestTelemetryPipeline\",\"observabilityadmin:ValidateTelemetryPipelineConfiguration\",\"observabilityadmin:CreateS3TableIntegration\",\"observabilityadmin:GetS3TableIntegration\",\"observabilityadmin:ListS3TableIntegrations\",\"observabilityadmin:DeleteS3TableIntegration\",\"rum:*\",\"synthetics:*\",\"xray:*\"],\"Resource\":\"*\"},{\"Sid\":\"CloudWatchApplicationSignalsServiceLinkedRolePermissions\",\"Effect\":\"Allow\",\"Action\":\"iam:CreateServiceLinkedRole\",\"Resource\":\"arn:aws:iam::*:role/aws-service-role/application-signals.cloudwatch.amazonaws.com/AWSServiceRoleForCloudWatchApplicationSignals\",\"Condition\":{\"StringLike\":{\"iam:AWSServiceName\":\"application-signals.cloudwatch.amazonaws.com\"}}},{\"Sid\":\"EventsServicePermissions\",\"Effect\":\"Allow\",\"Action\":\"iam:CreateServiceLinkedRole\",\"Resource\":\"arn:aws:iam::*:role/aws-service-role/events.amazonaws.com/AWSServiceRoleForCloudWatchEvents*\",\"Condition\":{\"StringLike\":{\"iam:AWSServiceName\":\"events.amazonaws.com\"}}},{\"Sid\":\"OAMReadPermissions\",\"Effect\":\"Allow\",\"Action\":[\"oam:ListAttachedLinks\"],\"Resource\":\"arn:aws:oam:*:*:sink/*\"},{\"Sid\":\"CloudWatchCloudTrailPermissions\",\"Effect\":\"Allow\",\"Action\":[\"cloudtrail:CreateServiceLinkedChannel\",\"cloudtrail:GetChannel\"],\"Resource\":\"arn:aws:cloudtrail:*:*:channel/aws-service-channel/application-signals/*\"},{\"Sid\":\"CloudWatchApplicationSignalsCloudTrailListPermissions\",\"Effect\":\"Allow\",\"Action\":[\"cloudtrail:ListChannels\"],\"Resource\":\"*\"},{\"Sid\":\"CloudWatchServiceQuotaPermissions\",\"Effect\":\"Allow\",\"Action\":[\"servicequotas:GetServiceQuota\"],\"Resource\":[\"arn:aws:servicequotas:*:*:s3/*\",\"arn:aws:servicequotas:*:*:dynamodb/*\",\"arn:aws:servicequotas:*:*:kinesis/*\",\"arn:aws:servicequotas:*:*:sns/*\",\"arn:aws:servicequotas:*:*:bedrock/*\",\"arn:aws:servicequotas:*:*:lambda/*\",\"arn:aws:servicequotas:*:*:fargate/*\",\"arn:aws:servicequotas:*:*:elasticloadbalancing/*\",\"arn:aws:servicequotas:*:*:ec2/*\"]},{\"Sid\":\"CloudWatchResourceExplorerPermissions\",\"Effect\":\"Allow\",\"Action\":[\"resource-explorer-2:ListIndexes\",\"resource-explorer-2:Search\"],\"Resource\":[\"arn:aws:resource-explorer-2:*::view/AWSServiceViewForApplicationSignals/service-view\",\"arn:aws:resource-explorer-2:*::view/AWSServiceViewForApplicationSignalsOrgScopeProd/service-view\"]},{\"Sid\":\"CloudWatchResourceExplorerSLRPermissions\",\"Effect\":\"Allow\",\"Action\":[\"iam:CreateServiceLinkedRole\"],\"Resource\":\"arn:aws:iam::*:role/aws-service-role/resource-explorer-2.amazonaws.com/AWSServiceRoleForResourceExplorer\",\"Condition\":{\"StringEquals\":{\"iam:AWSServiceName\":[\"resource-explorer-2.amazonaws.com\"]}}},{\"Sid\":\"CloudWatchResourceExplorerCreateIndexPermissions\",\"Effect\":\"Allow\",\"Action\":[\"resource-explorer-2:CreateIndex\"],\"Resource\":\"arn:aws:resource-explorer-2:*:*:index/*\"},{\"Effect\":\"Allow\",\"Action\":\"iam:PassRole\",\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"iam:PassedToService\":\"logs.amazonaws.com\"},\"ArnLike\":{\"iam:AssociatedResourceArn\":\"arn:aws:observabilityadmin:*:*:s3tableintegration/*\"}}},{\"Effect\":\"Allow\",\"Action\":\"iam:PassRole\",\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"iam:PassedToService\":[\"logs.amazonaws.com\",\"telemetry-pipelines.observabilityadmin.amazonaws.com\"]},\"ArnLike\":{\"iam:AssociatedResourceArn\":\"arn:aws:observabilityadmin:*:*:telemetry-pipeline/*\"}}},{\"Effect\":\"Allow\",\"Action\":[\"s3tables:CreateTableBucket\",\"s3tables:PutTableBucketEncryption\"],\"Resource\":\"arn:aws:s3tables:*:*:bucket/aws-cloudwatch\",\"Condition\":{\"ForAnyValue:StringEquals\":{\"aws:CalledVia\":\"observabilityadmin.amazonaws.com\"}}},{\"Effect\":\"Allow\",\"Action\":[\"s3tables:PutTableBucketPolicy\"],\"Resource\":\"arn:aws:s3tables:*:*:bucket/aws-cloudwatch\"},{\"Sid\":\"LogAlarmScheduledQueryPassRolePermissions\",\"Effect\":\"Allow\",\"Action\":\"iam:PassRole\",\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"iam:PassedToService\":\"logs.amazonaws.com\"},\"ArnLike\":{\"iam:AssociatedResourceArn\":\"arn:aws:logs:*:*:scheduled-query:*\"}}},{\"Sid\":\"LogAlarmLogLinesPassRolePermissions\",\"Effect\":\"Allow\",\"Action\":\"iam:PassRole\",\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"iam:PassedToService\":\"cloudwatch.amazonaws.com\"},\"ArnLike\":{\"iam:AssociatedResourceArn\":\"arn:aws:cloudwatch:*:*:alarm:*\"}}}]}"
+    },
+    {
+      "name": "CloudWatchLogsFullAccess",
+      "arn": "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess",
+      "path": "/",
+      "defaultVersionId": "v8",
+      "createDate": "2015-02-06T18:40:00Z",
+      "description": "Provides full access to CloudWatch Logs",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"CloudWatchLogsFullAccess\",\"Effect\":\"Allow\",\"Action\":[\"logs:*\",\"cloudwatch:GenerateQuery\",\"cloudwatch:GenerateQueryResultsSummary\",\"observabilityadmin:GetS3TableIntegration\",\"observabilityadmin:ListS3TableIntegrations\",\"observabilityadmin:ListTelemetryPipelines\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AmazonKinesisFullAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonKinesisFullAccess",
+      "path": "/",
+      "defaultVersionId": "v1",
+      "createDate": "2015-02-06T18:40:00Z",
+      "description": "Provides full access to all streams via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"kinesis:*\",\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AmazonRDSFullAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonRDSFullAccess",
+      "path": "/",
+      "defaultVersionId": "v14",
+      "createDate": "2015-02-06T18:40:00Z",
+      "description": "Provides full access to Amazon RDS via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"rds:*\",\"application-autoscaling:DeleteScalingPolicy\",\"application-autoscaling:DeregisterScalableTarget\",\"application-autoscaling:DescribeScalableTargets\",\"application-autoscaling:DescribeScalingActivities\",\"application-autoscaling:DescribeScalingPolicies\",\"application-autoscaling:PutScalingPolicy\",\"application-autoscaling:RegisterScalableTarget\",\"cloudwatch:DescribeAlarms\",\"cloudwatch:GetMetricStatistics\",\"cloudwatch:PutMetricAlarm\",\"cloudwatch:DeleteAlarms\",\"cloudwatch:ListMetrics\",\"cloudwatch:GetMetricData\",\"ec2:DescribeAccountAttributes\",\"ec2:DescribeAvailabilityZones\",\"ec2:DescribeCoipPools\",\"ec2:DescribeInternetGateways\",\"ec2:DescribeLocalGatewayRouteTablePermissions\",\"ec2:DescribeLocalGatewayRouteTables\",\"ec2:DescribeLocalGatewayRouteTableVpcAssociations\",\"ec2:DescribeLocalGateways\",\"ec2:DescribeSecurityGroups\",\"ec2:DescribeSubnets\",\"ec2:DescribeVpcAttribute\",\"ec2:DescribeVpcs\",\"ec2:GetCoipPoolUsage\",\"sns:ListSubscriptions\",\"sns:ListTopics\",\"sns:Publish\",\"logs:DescribeLogStreams\",\"logs:GetLogEvents\",\"outposts:GetOutpostInstanceTypes\",\"devops-guru:GetResourceCollection\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":\"pi:*\",\"Resource\":[\"arn:aws:pi:*:*:metrics/rds/*\",\"arn:aws:pi:*:*:perf-reports/rds/*\"]},{\"Effect\":\"Allow\",\"Action\":\"iam:CreateServiceLinkedRole\",\"Resource\":\"*\",\"Condition\":{\"StringLike\":{\"iam:AWSServiceName\":[\"rds.amazonaws.com\",\"rds.application-autoscaling.amazonaws.com\"]}}},{\"Action\":[\"devops-guru:SearchInsights\",\"devops-guru:ListAnomaliesForInsight\"],\"Effect\":\"Allow\",\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"devops-guru:ServiceNames\":[\"RDS\"]},\"Null\":{\"devops-guru:ServiceNames\":\"false\"}}}]}"
+    },
+    {
+      "name": "AmazonECS_FullAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonECS_FullAccess",
+      "path": "/",
+      "defaultVersionId": "v21",
+      "createDate": "2017-11-07T21:36:00Z",
+      "description": "Provides administrative access to Amazon ECS resources and enables ECS features through access to other AWS service resources, including VPCs, Auto Scaling groups, and CloudFormation stacks.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"ECSIntegrationsManagementPolicy\",\"Effect\":\"Allow\",\"Action\":[\"application-autoscaling:DeleteScalingPolicy\",\"application-autoscaling:DeregisterScalableTarget\",\"application-autoscaling:DescribeScalableTargets\",\"application-autoscaling:DescribeScalingActivities\",\"application-autoscaling:DescribeScalingPolicies\",\"application-autoscaling:PutScalingPolicy\",\"application-autoscaling:RegisterScalableTarget\",\"appmesh:DescribeVirtualGateway\",\"appmesh:DescribeVirtualNode\",\"appmesh:ListMeshes\",\"appmesh:ListVirtualGateways\",\"appmesh:ListVirtualNodes\",\"autoscaling:CreateAutoScalingGroup\",\"autoscaling:CreateLaunchConfiguration\",\"autoscaling:DeleteAutoScalingGroup\",\"autoscaling:DeleteLaunchConfiguration\",\"autoscaling:Describe*\",\"autoscaling:UpdateAutoScalingGroup\",\"cloudformation:CreateStack\",\"cloudformation:DeleteStack\",\"cloudformation:DescribeStack*\",\"cloudformation:UpdateStack\",\"cloudwatch:DeleteAlarms\",\"cloudwatch:DescribeAlarms\",\"cloudwatch:GetMetricStatistics\",\"cloudwatch:PutMetricAlarm\",\"codedeploy:BatchGetApplicationRevisions\",\"codedeploy:BatchGetApplications\",\"codedeploy:BatchGetDeploymentGroups\",\"codedeploy:BatchGetDeployments\",\"codedeploy:ContinueDeployment\",\"codedeploy:CreateApplication\",\"codedeploy:CreateDeployment\",\"codedeploy:CreateDeploymentGroup\",\"codedeploy:GetApplication\",\"codedeploy:GetApplicationRevision\",\"codedeploy:GetDeployment\",\"codedeploy:GetDeploymentConfig\",\"codedeploy:GetDeploymentGroup\",\"codedeploy:GetDeploymentTarget\",\"codedeploy:ListApplicationRevisions\",\"codedeploy:ListApplications\",\"codedeploy:ListDeploymentConfigs\",\"codedeploy:ListDeploymentGroups\",\"codedeploy:ListDeployments\",\"codedeploy:ListDeploymentTargets\",\"codedeploy:RegisterApplicationRevision\",\"codedeploy:StopDeployment\",\"ec2:AssociateRouteTable\",\"ec2:AttachInternetGateway\",\"ec2:AuthorizeSecurityGroupIngress\",\"ec2:CancelSpotFleetRequests\",\"ec2:CreateInternetGateway\",\"ec2:CreateLaunchTemplate\",\"ec2:CreateRoute\",\"ec2:CreateRouteTable\",\"ec2:CreateSecurityGroup\",\"ec2:CreateSubnet\",\"ec2:CreateVpc\",\"ec2:DeleteLaunchTemplate\",\"ec2:DeleteSubnet\",\"ec2:DeleteVpc\",\"ec2:Describe*\",\"ec2:DetachInternetGateway\",\"ec2:DisassociateRouteTable\",\"ec2:ModifySubnetAttribute\",\"ec2:ModifyVpcAttribute\",\"ec2:RequestSpotFleet\",\"ec2:RunInstances\",\"ecs:*\",\"elasticfilesystem:DescribeAccessPoints\",\"elasticfilesystem:DescribeFileSystems\",\"elasticloadbalancing:CreateListener\",\"elasticloadbalancing:CreateLoadBalancer\",\"elasticloadbalancing:CreateRule\",\"elasticloadbalancing:CreateTargetGroup\",\"elasticloadbalancing:DeleteListener\",\"elasticloadbalancing:DeleteLoadBalancer\",\"elasticloadbalancing:DeleteRule\",\"elasticloadbalancing:DeleteTargetGroup\",\"elasticloadbalancing:DescribeListeners\",\"elasticloadbalancing:DescribeLoadBalancers\",\"elasticloadbalancing:DescribeRules\",\"elasticloadbalancing:DescribeTargetGroups\",\"events:DeleteRule\",\"events:DescribeRule\",\"events:ListRuleNamesByTarget\",\"events:ListTargetsByRule\",\"events:PutRule\",\"events:PutTargets\",\"events:RemoveTargets\",\"fsx:DescribeFileSystems\",\"iam:ListAttachedRolePolicies\",\"iam:ListInstanceProfiles\",\"iam:ListRoles\",\"lambda:ListFunctions\",\"logs:CreateLogGroup\",\"logs:DescribeLogGroups\",\"logs:FilterLogEvents\",\"route53:CreateHostedZone\",\"route53:DeleteHostedZone\",\"route53:GetHealthCheck\",\"route53:GetHostedZone\",\"route53:ListHostedZonesByName\",\"servicediscovery:CreatePrivateDnsNamespace\",\"servicediscovery:CreateService\",\"servicediscovery:DeleteService\",\"servicediscovery:GetNamespace\",\"servicediscovery:GetOperation\",\"servicediscovery:GetService\",\"servicediscovery:ListNamespaces\",\"servicediscovery:ListServices\",\"servicediscovery:UpdateService\",\"sns:ListTopics\"],\"Resource\":[\"*\"]},{\"Sid\":\"SSMPolicy\",\"Effect\":\"Allow\",\"Action\":[\"ssm:GetParameter\",\"ssm:GetParameters\",\"ssm:GetParametersByPath\"],\"Resource\":\"arn:aws:ssm:*:*:parameter/aws/service/ecs*\"},{\"Sid\":\"ManagedCloudformationResourcesCleanupPolicy\",\"Effect\":\"Allow\",\"Action\":[\"ec2:DeleteInternetGateway\",\"ec2:DeleteRoute\",\"ec2:DeleteRouteTable\",\"ec2:DeleteSecurityGroup\"],\"Resource\":[\"*\"],\"Condition\":{\"StringLike\":{\"ec2:ResourceTag/aws:cloudformation:stack-name\":\"EC2ContainerService-*\"}}},{\"Sid\":\"TasksPassRolePolicy\",\"Action\":\"iam:PassRole\",\"Effect\":\"Allow\",\"Resource\":[\"*\"],\"Condition\":{\"StringLike\":{\"iam:PassedToService\":\"ecs-tasks.amazonaws.com\"}}},{\"Sid\":\"InfrastructurePassRolePolicy\",\"Action\":\"iam:PassRole\",\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:iam::*:role/ecsInfrastructureRole\"],\"Condition\":{\"StringEquals\":{\"iam:PassedToService\":\"ecs.amazonaws.com\"}}},{\"Sid\":\"InstancePassRolePolicy\",\"Action\":\"iam:PassRole\",\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:iam::*:role/ecsInstanceRole*\"],\"Condition\":{\"StringLike\":{\"iam:PassedToService\":[\"ec2.amazonaws.com\",\"ec2.amazonaws.com.cn\"]}}},{\"Sid\":\"AutoScalingPassRolePolicy\",\"Action\":\"iam:PassRole\",\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:iam::*:role/ecsAutoscaleRole*\"],\"Condition\":{\"StringLike\":{\"iam:PassedToService\":[\"application-autoscaling.amazonaws.com\",\"application-autoscaling.amazonaws.com.cn\"]}}},{\"Sid\":\"ServiceLinkedRoleCreationPolicy\",\"Effect\":\"Allow\",\"Action\":\"iam:CreateServiceLinkedRole\",\"Resource\":\"*\",\"Condition\":{\"StringLike\":{\"iam:AWSServiceName\":[\"ecs.amazonaws.com\",\"autoscaling.amazonaws.com\",\"ecs.application-autoscaling.amazonaws.com\",\"spot.amazonaws.com\",\"spotfleet.amazonaws.com\"]}}},{\"Sid\":\"ELBTaggingPolicy\",\"Effect\":\"Allow\",\"Action\":[\"elasticloadbalancing:AddTags\"],\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"elasticloadbalancing:CreateAction\":[\"CreateTargetGroup\",\"CreateRule\",\"CreateListener\",\"CreateLoadBalancer\"]}}}]}"
+    },
+    {
+      "name": "AmazonElastiCacheFullAccess",
+      "arn": "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess",
+      "path": "/",
+      "defaultVersionId": "v3",
+      "createDate": "2015-02-06T18:40:00Z",
+      "description": "Provides full access to Amazon ElastiCache via the AWS Management Console.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"ElastiCacheManagementActions\",\"Effect\":\"Allow\",\"Action\":\"elasticache:*\",\"Resource\":\"*\"},{\"Sid\":\"CreateServiceLinkedRole\",\"Effect\":\"Allow\",\"Action\":\"iam:CreateServiceLinkedRole\",\"Resource\":\"arn:aws:iam::*:role/aws-service-role/elasticache.amazonaws.com/AWSServiceRoleForElastiCache\",\"Condition\":{\"StringLike\":{\"iam:AWSServiceName\":\"elasticache.amazonaws.com\"}}},{\"Sid\":\"CreateVPCEndpoints\",\"Effect\":\"Allow\",\"Action\":\"ec2:CreateVpcEndpoint\",\"Resource\":\"arn:aws:ec2:*:*:vpc-endpoint/*\",\"Condition\":{\"StringLike\":{\"ec2:VpceServiceName\":\"com.amazonaws.elasticache.serverless.*\"}}},{\"Sid\":\"AllowAccessToElastiCacheTaggedVpcEndpoints\",\"Effect\":\"Allow\",\"Action\":[\"ec2:CreateVpcEndpoint\"],\"NotResource\":\"arn:aws:ec2:*:*:vpc-endpoint/*\"},{\"Sid\":\"TagVPCEndpointsOnCreation\",\"Effect\":\"Allow\",\"Action\":[\"ec2:CreateTags\"],\"Resource\":\"arn:aws:ec2:*:*:vpc-endpoint/*\",\"Condition\":{\"StringEquals\":{\"ec2:CreateAction\":\"CreateVpcEndpoint\",\"aws:RequestTag/AmazonElastiCacheManaged\":\"true\"}}},{\"Sid\":\"AllowAccessToEc2\",\"Effect\":\"Allow\",\"Action\":[\"ec2:DescribeVpcs\",\"ec2:DescribeSubnets\",\"ec2:DescribeSecurityGroups\"],\"Resource\":\"*\"},{\"Sid\":\"AllowAccessToKMS\",\"Effect\":\"Allow\",\"Action\":[\"kms:DescribeKey\",\"kms:ListAliases\",\"kms:ListKeys\"],\"Resource\":\"*\"},{\"Sid\":\"AllowAccessToCloudWatch\",\"Effect\":\"Allow\",\"Action\":[\"cloudwatch:GetMetricStatistics\",\"cloudwatch:GetMetricData\"],\"Resource\":\"*\"},{\"Sid\":\"AllowAccessToAutoScaling\",\"Effect\":\"Allow\",\"Action\":[\"application-autoscaling:DescribeScalableTargets\",\"application-autoscaling:DescribeScheduledActions\",\"application-autoscaling:DescribeScalingPolicies\",\"application-autoscaling:DescribeScalingActivities\"],\"Resource\":\"*\"},{\"Sid\":\"DescribeLogGroups\",\"Effect\":\"Allow\",\"Action\":[\"logs:DescribeLogGroups\"],\"Resource\":\"*\"},{\"Sid\":\"ListLogDeliveryStreams\",\"Effect\":\"Allow\",\"Action\":[\"firehose:ListDeliveryStreams\"],\"Resource\":\"*\"},{\"Sid\":\"DescribeS3Buckets\",\"Effect\":\"Allow\",\"Action\":[\"s3:ListAllMyBuckets\"],\"Resource\":\"*\"},{\"Sid\":\"AllowAccessToOutposts\",\"Effect\":\"Allow\",\"Action\":[\"outposts:ListOutposts\"],\"Resource\":\"*\"},{\"Sid\":\"AllowAccessToSNS\",\"Effect\":\"Allow\",\"Action\":[\"sns:ListTopics\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "SecretsManagerReadWrite",
+      "arn": "arn:aws:iam::aws:policy/SecretsManagerReadWrite",
+      "path": "/",
+      "defaultVersionId": "v5",
+      "createDate": "2018-04-04T18:05:00Z",
+      "description": "Provides read/write access to AWS Secrets Manager via the AWS Management Console. Note: this exludes IAM actions, so combine with IAMFullAccess if rotation configuration is required.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"BasePermissions\",\"Effect\":\"Allow\",\"Action\":[\"secretsmanager:*\",\"cloudformation:CreateChangeSet\",\"cloudformation:DescribeChangeSet\",\"cloudformation:DescribeStackResource\",\"cloudformation:DescribeStacks\",\"cloudformation:ExecuteChangeSet\",\"docdb-elastic:GetCluster\",\"docdb-elastic:ListClusters\",\"ec2:DescribeSecurityGroups\",\"ec2:DescribeSubnets\",\"ec2:DescribeVpcs\",\"kms:DescribeKey\",\"kms:ListAliases\",\"kms:ListKeys\",\"lambda:ListFunctions\",\"rds:DescribeDBClusters\",\"rds:DescribeDBInstances\",\"redshift:DescribeClusters\",\"redshift-serverless:ListWorkgroups\",\"redshift-serverless:GetNamespace\",\"tag:GetResources\"],\"Resource\":\"*\"},{\"Sid\":\"LambdaPermissions\",\"Effect\":\"Allow\",\"Action\":[\"lambda:AddPermission\",\"lambda:CreateFunction\",\"lambda:GetFunction\",\"lambda:InvokeFunction\",\"lambda:UpdateFunctionConfiguration\"],\"Resource\":\"arn:aws:lambda:*:*:function:SecretsManager*\"},{\"Sid\":\"SARPermissions\",\"Effect\":\"Allow\",\"Action\":[\"serverlessrepo:CreateCloudFormationChangeSet\",\"serverlessrepo:GetApplication\"],\"Resource\":\"arn:aws:serverlessrepo:*:*:applications/SecretsManager*\"},{\"Sid\":\"S3Permissions\",\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\"],\"Resource\":[\"arn:aws:s3:::awsserverlessrepo-changesets*\",\"arn:aws:s3:::secrets-manager-rotation-apps-*/*\"]}]}"
+    },
+    {
+      "name": "AWSLambdaBasicExecutionRole",
+      "arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+      "path": "/service-role/",
+      "defaultVersionId": "v1",
+      "createDate": "2015-04-09T15:03:00Z",
+      "description": "Provides write permissions to CloudWatch Logs.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AWSLambdaVPCAccessExecutionRole",
+      "arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+      "path": "/service-role/",
+      "defaultVersionId": "v3",
+      "createDate": "2016-02-11T23:15:00Z",
+      "description": "Provides minimum permissions for a Lambda function to execute while accessing a resource within a VPC - create, describe, delete network interfaces and write permissions to CloudWatch Logs.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AWSLambdaVPCAccessExecutionPermissions\",\"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\",\"ec2:CreateNetworkInterface\",\"ec2:DescribeNetworkInterfaces\",\"ec2:DescribeSubnets\",\"ec2:DeleteNetworkInterface\",\"ec2:AssignPrivateIpAddresses\",\"ec2:UnassignPrivateIpAddresses\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AmazonECSTaskExecutionRolePolicy",
+      "arn": "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+      "path": "/service-role/",
+      "defaultVersionId": "v1",
+      "createDate": "2017-11-16T18:48:00Z",
+      "description": "Provides access to other AWS service resources that are required to run Amazon ECS tasks",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"ecr:GetAuthorizationToken\",\"ecr:BatchCheckLayerAvailability\",\"ecr:GetDownloadUrlForLayer\",\"ecr:BatchGetImage\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AWSGlueServiceRole",
+      "arn": "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole",
+      "path": "/service-role/",
+      "defaultVersionId": "v5",
+      "createDate": "2017-08-14T13:37:00Z",
+      "description": "Policy for AWS Glue service role which allows access to related services including EC2, S3, and Cloudwatch Logs",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"glue:*\",\"s3:GetBucketLocation\",\"s3:ListBucket\",\"s3:ListAllMyBuckets\",\"s3:GetBucketAcl\",\"ec2:DescribeVpcEndpoints\",\"ec2:DescribeRouteTables\",\"ec2:CreateNetworkInterface\",\"ec2:DeleteNetworkInterface\",\"ec2:DescribeNetworkInterfaces\",\"ec2:DescribeSecurityGroups\",\"ec2:DescribeSubnets\",\"ec2:DescribeVpcAttribute\",\"iam:ListRolePolicies\",\"iam:GetRole\",\"iam:GetRolePolicy\",\"cloudwatch:PutMetricData\"],\"Resource\":[\"*\"]},{\"Effect\":\"Allow\",\"Action\":[\"s3:CreateBucket\"],\"Resource\":[\"arn:aws:s3:::aws-glue-*\"]},{\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:PutObject\",\"s3:DeleteObject\"],\"Resource\":[\"arn:aws:s3:::aws-glue-*/*\",\"arn:aws:s3:::*/*aws-glue-*/*\"]},{\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\"],\"Resource\":[\"arn:aws:s3:::crawler-public*\",\"arn:aws:s3:::aws-glue-*\"]},{\"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":[\"arn:aws:logs:*:*:*:/aws-glue/*\"]},{\"Effect\":\"Allow\",\"Action\":[\"ec2:CreateTags\",\"ec2:DeleteTags\"],\"Condition\":{\"ForAllValues:StringEquals\":{\"aws:TagKeys\":[\"aws-glue-service-resource\"]}},\"Resource\":[\"arn:aws:ec2:*:*:network-interface/*\",\"arn:aws:ec2:*:*:security-group/*\",\"arn:aws:ec2:*:*:instance/*\"]}]}"
+    },
+    {
+      "name": "AmazonEC2ContainerRegistryReadOnly",
+      "arn": "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+      "path": "/",
+      "defaultVersionId": "v3",
+      "createDate": "2015-12-21T17:04:00Z",
+      "description": "Provides read-only access to Amazon EC2 Container Registry repositories.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"ecr:GetAuthorizationToken\",\"ecr:BatchCheckLayerAvailability\",\"ecr:GetDownloadUrlForLayer\",\"ecr:GetRepositoryPolicy\",\"ecr:DescribeRepositories\",\"ecr:ListImages\",\"ecr:DescribeImages\",\"ecr:BatchGetImage\",\"ecr:GetLifecyclePolicy\",\"ecr:GetLifecyclePolicyPreview\",\"ecr:ListTagsForResource\",\"ecr:DescribeImageScanFindings\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AmazonEC2ContainerRegistryPowerUser",
+      "arn": "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser",
+      "path": "/",
+      "defaultVersionId": "v3",
+      "createDate": "2015-12-21T17:05:00Z",
+      "description": "Provides full access to Amazon EC2 Container Registry repositories, but does not allow repository deletion or policy changes.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"ecr:GetAuthorizationToken\",\"ecr:BatchCheckLayerAvailability\",\"ecr:GetDownloadUrlForLayer\",\"ecr:GetRepositoryPolicy\",\"ecr:DescribeRepositories\",\"ecr:ListImages\",\"ecr:DescribeImages\",\"ecr:BatchGetImage\",\"ecr:GetLifecyclePolicy\",\"ecr:GetLifecyclePolicyPreview\",\"ecr:ListTagsForResource\",\"ecr:DescribeImageScanFindings\",\"ecr:InitiateLayerUpload\",\"ecr:UploadLayerPart\",\"ecr:CompleteLayerUpload\",\"ecr:PutImage\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AmazonEKSClusterPolicy",
+      "arn": "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
+      "path": "/",
+      "defaultVersionId": "v10",
+      "createDate": "2018-05-27T21:06:00Z",
+      "description": "This policy provides Kubernetes the permissions it requires to manage resources on your behalf. Kubernetes requires Ec2:CreateTags permissions to place identifying information on EC2 resources including but not limited to Instances, Security Groups, and Elastic Network Interfaces.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AmazonEKSClusterPolicy\",\"Effect\":\"Allow\",\"Action\":[\"autoscaling:DescribeAutoScalingGroups\",\"autoscaling:UpdateAutoScalingGroup\",\"ec2:AttachVolume\",\"ec2:AuthorizeSecurityGroupIngress\",\"ec2:CreateRoute\",\"ec2:CreateSecurityGroup\",\"ec2:CreateTags\",\"ec2:CreateVolume\",\"ec2:DeleteRoute\",\"ec2:DeleteSecurityGroup\",\"ec2:DeleteVolume\",\"ec2:DescribeInstances\",\"ec2:DescribeRouteTables\",\"ec2:DescribeSecurityGroups\",\"ec2:DescribeSubnets\",\"ec2:DescribeVolumes\",\"ec2:DescribeVolumesModifications\",\"ec2:DescribeVpcs\",\"ec2:DescribeDhcpOptions\",\"ec2:DescribeNetworkInterfaces\",\"ec2:DescribeAvailabilityZones\",\"ec2:DetachVolume\",\"ec2:ModifyInstanceAttribute\",\"ec2:ModifyVolume\",\"ec2:RevokeSecurityGroupIngress\",\"ec2:DescribeAccountAttributes\",\"ec2:DescribeAddresses\",\"ec2:DescribeInternetGateways\",\"ec2:DescribeInstanceTopology\",\"elasticloadbalancing:AddTags\",\"elasticloadbalancing:ApplySecurityGroupsToLoadBalancer\",\"elasticloadbalancing:AttachLoadBalancerToSubnets\",\"elasticloadbalancing:ConfigureHealthCheck\",\"elasticloadbalancing:CreateListener\",\"elasticloadbalancing:CreateLoadBalancer\",\"elasticloadbalancing:CreateLoadBalancerListeners\",\"elasticloadbalancing:CreateLoadBalancerPolicy\",\"elasticloadbalancing:CreateTargetGroup\",\"elasticloadbalancing:DeleteListener\",\"elasticloadbalancing:DeleteLoadBalancer\",\"elasticloadbalancing:DeleteLoadBalancerListeners\",\"elasticloadbalancing:DeleteTargetGroup\",\"elasticloadbalancing:DeregisterInstancesFromLoadBalancer\",\"elasticloadbalancing:DeregisterTargets\",\"elasticloadbalancing:DescribeListeners\",\"elasticloadbalancing:DescribeLoadBalancerAttributes\",\"elasticloadbalancing:DescribeLoadBalancerPolicies\",\"elasticloadbalancing:DescribeLoadBalancers\",\"elasticloadbalancing:DescribeTargetGroupAttributes\",\"elasticloadbalancing:DescribeTargetGroups\",\"elasticloadbalancing:DescribeTargetHealth\",\"elasticloadbalancing:DetachLoadBalancerFromSubnets\",\"elasticloadbalancing:ModifyListener\",\"elasticloadbalancing:ModifyLoadBalancerAttributes\",\"elasticloadbalancing:ModifyTargetGroup\",\"elasticloadbalancing:ModifyTargetGroupAttributes\",\"elasticloadbalancing:RegisterInstancesWithLoadBalancer\",\"elasticloadbalancing:RegisterTargets\",\"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer\",\"elasticloadbalancing:SetLoadBalancerPoliciesOfListener\",\"kms:DescribeKey\"],\"Resource\":\"*\"},{\"Sid\":\"AmazonEKSClusterPolicySLRCreate\",\"Effect\":\"Allow\",\"Action\":\"iam:CreateServiceLinkedRole\",\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"iam:AWSServiceName\":\"elasticloadbalancing.amazonaws.com\"}}},{\"Sid\":\"AmazonEKSClusterPolicyENIDelete\",\"Effect\":\"Allow\",\"Action\":\"ec2:DeleteNetworkInterface\",\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"ec2:ResourceTag/eks:eni:owner\":\"amazon-vpc-cni\"}}}]}"
+    },
+    {
+      "name": "AmazonEKSWorkerNodePolicy",
+      "arn": "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+      "path": "/",
+      "defaultVersionId": "v3",
+      "createDate": "2018-05-27T21:09:00Z",
+      "description": "This policy allows Amazon EKS worker nodes to connect to Amazon EKS Clusters.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"WorkerNodePermissions\",\"Effect\":\"Allow\",\"Action\":[\"ec2:DescribeInstances\",\"ec2:DescribeInstanceTypes\",\"ec2:DescribeRouteTables\",\"ec2:DescribeSecurityGroups\",\"ec2:DescribeSubnets\",\"ec2:DescribeVolumes\",\"ec2:DescribeVolumesModifications\",\"ec2:DescribeVpcs\",\"eks:DescribeCluster\",\"eks-auth:AssumeRoleForPodIdentity\"],\"Resource\":\"*\"}]}"
+    },
+    {
+      "name": "AmazonSSMManagedInstanceCore",
+      "arn": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+      "path": "/",
+      "defaultVersionId": "v2",
+      "createDate": "2019-03-15T17:22:00Z",
+      "description": "The policy for Amazon EC2 Role to enable AWS Systems Manager service core functionality.",
+      "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"ssm:DescribeAssociation\",\"ssm:GetDeployablePatchSnapshotForInstance\",\"ssm:GetDocument\",\"ssm:DescribeDocument\",\"ssm:GetManifest\",\"ssm:GetParameter\",\"ssm:GetParameters\",\"ssm:ListAssociations\",\"ssm:ListInstanceAssociations\",\"ssm:PutInventory\",\"ssm:PutComplianceItems\",\"ssm:PutConfigurePackageResult\",\"ssm:UpdateAssociationStatus\",\"ssm:UpdateInstanceAssociationStatus\",\"ssm:UpdateInstanceInformation\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":[\"ssmmessages:CreateControlChannel\",\"ssmmessages:CreateDataChannel\",\"ssmmessages:OpenControlChannel\",\"ssmmessages:OpenDataChannel\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":[\"ec2messages:AcknowledgeMessage\",\"ec2messages:DeleteMessage\",\"ec2messages:FailMessage\",\"ec2messages:GetEndpoint\",\"ec2messages:GetMessages\",\"ec2messages:SendReply\"],\"Resource\":\"*\"}]}"
+    }
+  ]
+}

--- a/website/content/docs/services/iam.md
+++ b/website/content/docs/services/iam.md
@@ -12,6 +12,7 @@ fakecloud implements **176 of 176** IAM operations at 100% Smithy conformance.
 - **Roles** — CRUD, inline policies, managed policies, trust relationships, instance profile relationships
 - **Groups** — CRUD, user membership, inline and managed policies
 - **Policies** — managed policies, policy versions, attachment, `SimulateCustomPolicy` / `SimulatePrincipalPolicy` run the same evaluator real IAM enforcement uses, so the returned `EvalDecision` (`allowed` / `explicitDeny` / `implicitDeny`) reflects identity policies, resource policies, permission boundaries, session policies, SCPs, and `Condition` blocks rather than being recorded-only stubs
+- **AWS-managed policies** — well-known `arn:aws:iam::aws:policy/*` policies (e.g. `AdministratorAccess`, `PowerUserAccess`, `AmazonS3FullAccess`, `AWSLambdaBasicExecutionRole`, `AmazonECSTaskExecutionRolePolicy`) resolve from a built-in catalog seeded with the exact current AWS policy documents. `GetPolicy`, `GetPolicyVersion`, `ListPolicyVersions`, `ListEntitiesForPolicy`, and `ListPolicies` (`Scope=AWS`) return them like real AWS instead of `NoSuchEntity`, and attaching them to roles/users/groups round-trips through the `ListAttached*` calls with the correct `PolicyName`
 - **Instance profiles** — CRUD, role attachment
 - **OIDC providers** — CRUD, client IDs, thumbprints
 - **SAML providers** — CRUD, metadata documents


### PR DESCRIPTION
## Summary

AWS-managed policy ARNs (`arn:aws:iam::aws:policy/*`) were accepted by the `Attach*` calls but **never inserted into state**, so `GetPolicy` / `GetPolicyVersion` / `ListPolicyVersions` / `ListEntitiesForPolicy` hard-failed with `NoSuchEntity` and `ListPolicies(Scope=AWS)` returned an empty list. That broke the extremely common Terraform/CDK/console flow of attaching an AWS-managed policy (e.g. `AdministratorAccess`, `AWSLambdaBasicExecutionRole`) to a role and then reading it back.

This batch seeds a built-in catalog of 28 of the most-attached AWS-managed policies and makes the read surface resolve them like real AWS.

### What changed
- New `crates/fakecloud-iam/src/managed_policies` module: `catalog.json` (the 28 policies, embedded via `include_str!`) plus `lookup` / `all` / `default_document` and `ManagedPolicy::to_iam_policy`.
- The documents are the **exact current AWS documents**, fetched verbatim from the AWS managed-policy reference (`docs.aws.amazon.com/aws-managed-policy/...`): no stubs, no abbreviation.
- `get_policy` / `get_policy_version` / `list_policy_versions` resolve an ARN from the catalog when it is not held in account state.
- `list_entities_for_policy` accepts seeded managed ARNs.
- `list_policies` returns the catalog for `Scope=All` and `Scope=AWS`; `Scope=Local` stays customer-only (matches real AWS).
- `AttachmentCount` is derived on demand from the attachment maps; `PolicyId` is a deterministic `ANPA...` id (AWS does not publish the real per-policy id; clients key off the ARN).

### Decisions
- **Curated, not exhaustive.** The catalog covers the policies most commonly attached in IaC, not all ~1,400 AWS-managed policies. An ARN that is not seeded behaves exactly as before (attachable, but `NoSuchEntity` on read), so adding entries later is purely additive.
- **`Scope=All` now includes AWS-managed policies** (it previously returned only customer policies). This matches real AWS; the existing `list_policies_paginates_via_marker` test was updated to use `Scope=Local` to isolate customer policies.
- **Enforcement deferred** to a follow-up batch (the evaluator catalog fallback).

## Test plan
- `cargo test -p fakecloud-iam`: 489 unit/service tests pass, including new catalog tests and read-op resolution tests.
- `cargo test -p fakecloud-e2e --test iam managed`: new E2E tests via the AWS SDK, `iam_get_aws_managed_policy_from_catalog` and `iam_attach_aws_managed_policy_round_trips`.
- `cargo clippy -p fakecloud-iam --all-targets` clean; `cargo fmt`.

## Surface
- No new operations or introspection endpoints, so no SDK changes, no conformance-baseline count change, no ops-index/parity change.
- Docs: `website/content/docs/services/iam.md` gains an AWS-managed-policies bullet.

Resolves AWS-managed IAM policies from a built-in catalog so attach-then-read flows work like real AWS and `ListPolicies(Scope=AWS)` returns managed policies instead of empty results.