### PR TITLE
fix(glue): default job timeout + ON_DEMAND trigger state; re-enable tfacc Job/Trigger

### DIFF
--- a/crates/fakecloud-glue/src/jobs.rs
+++ b/crates/fakecloud-glue/src/jobs.rs
@@ -103,6 +103,15 @@ impl GlueService {
         if command.is_null() {
             return Err(missing("Command"));
         }
+        // AWS defaults the job timeout to 2880 minutes (48h) for batch jobs when
+        // unset; streaming jobs (gluestreaming) have no default timeout.
+        let timeout = body["Timeout"].as_i64().or_else(|| {
+            if command["Name"].as_str() == Some("gluestreaming") {
+                None
+            } else {
+                Some(2880)
+            }
+        });
         let now = Utc::now();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id, &req.region);
@@ -118,7 +127,7 @@ impl GlueService {
             command,
             default_arguments: parse_string_map(&body["DefaultArguments"]),
             max_retries: body["MaxRetries"].as_i64().unwrap_or(0),
-            timeout: body["Timeout"].as_i64(),
+            timeout,
             glue_version: body["GlueVersion"].as_str().map(String::from),
             max_capacity: body["MaxCapacity"].as_f64(),
             worker_type: body["WorkerType"].as_str().map(String::from),

--- a/crates/fakecloud-glue/src/tests.rs
+++ b/crates/fakecloud-glue/src/tests.rs
@@ -106,13 +106,77 @@ fn trigger_round_trip_and_missing_required() {
     assert_eq!(got["Trigger"]["Type"], "ON_DEMAND");
     assert_eq!(got["Trigger"]["Actions"][0]["JobName"], "j");
 
+    // StartTrigger on an ON_DEMAND trigger fires a run but leaves it in the
+    // CREATED state (matching AWS); only scheduled/conditional triggers go
+    // ACTIVATED.
     svc.start_trigger(&req("StartTrigger", json!({"Name": "t"})))
         .unwrap();
     let got = body_of(
         svc.get_trigger(&req("GetTrigger", json!({"Name": "t"})))
             .unwrap(),
     );
+    assert_eq!(got["Trigger"]["State"], "CREATED");
+}
+
+#[test]
+fn start_trigger_activates_scheduled_trigger() {
+    let svc = GlueService::default();
+    svc.create_trigger(&req(
+        "CreateTrigger",
+        json!({
+            "Name": "sched",
+            "Type": "SCHEDULED",
+            "Schedule": "cron(0 12 * * ? *)",
+            "Actions": [{"JobName": "j"}]
+        }),
+    ))
+    .unwrap();
+    svc.start_trigger(&req("StartTrigger", json!({"Name": "sched"})))
+        .unwrap();
+    let got = body_of(
+        svc.get_trigger(&req("GetTrigger", json!({"Name": "sched"})))
+            .unwrap(),
+    );
     assert_eq!(got["Trigger"]["State"], "ACTIVATED");
+}
+
+#[test]
+fn create_job_defaults_timeout_to_2880() {
+    let svc = GlueService::default();
+    svc.create_job(&req(
+        "CreateJob",
+        json!({"Name": "j", "Role": "r", "Command": {"Name": "glueetl"}}),
+    ))
+    .unwrap();
+    let got = body_of(
+        svc.get_job(&req("GetJob", json!({"JobName": "j"})))
+            .unwrap(),
+    );
+    assert_eq!(got["Job"]["Timeout"], 2880);
+
+    // Streaming jobs have no default timeout.
+    svc.create_job(&req(
+        "CreateJob",
+        json!({"Name": "s", "Role": "r", "Command": {"Name": "gluestreaming"}}),
+    ))
+    .unwrap();
+    let got = body_of(
+        svc.get_job(&req("GetJob", json!({"JobName": "s"})))
+            .unwrap(),
+    );
+    assert!(got["Job"]["Timeout"].is_null());
+
+    // An explicit timeout is preserved.
+    svc.create_job(&req(
+        "CreateJob",
+        json!({"Name": "x", "Role": "r", "Command": {"Name": "glueetl"}, "Timeout": 60}),
+    ))
+    .unwrap();
+    let got = body_of(
+        svc.get_job(&req("GetJob", json!({"JobName": "x"})))
+            .unwrap(),
+    );
+    assert_eq!(got["Job"]["Timeout"], 60);
 }
 
 #[test]

--- a/crates/fakecloud-glue/src/triggers.rs
+++ b/crates/fakecloud-glue/src/triggers.rs
@@ -135,7 +135,25 @@ impl GlueService {
     }
 
     pub(crate) fn start_trigger(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        self.set_trigger_state(req, "ACTIVATED")
+        // ON_DEMAND triggers fire a single run on StartTrigger but stay in the
+        // CREATED state; only scheduled/conditional triggers transition to
+        // ACTIVATED. Matching AWS here keeps the provider's computed `enabled`
+        // attribute correct (ON_DEMAND + CREATED => enabled = true).
+        let body = req.json_body();
+        let name = req_str(&body, "Name")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let t = st
+            .triggers
+            .get_mut(&name)
+            .ok_or_else(|| entity_not_found(format!("Trigger {name} not found")))?;
+        if let Some(obj) = t.as_object_mut() {
+            let is_on_demand = obj.get("Type").and_then(|v| v.as_str()) == Some("ON_DEMAND");
+            if !is_on_demand {
+                obj.insert("State".into(), json!("ACTIVATED"));
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({ "Name": name })))
     }
 
     pub(crate) fn stop_trigger(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -160,11 +160,9 @@ pub const SERVICES: &[Service] = &[
         // workflows — 10 tests.
         run_regex: "^TestAccGlue[A-Za-z]+_basic$",
         deny: &[
-            // --- gap: jobs and triggers reference the AWS-managed IAM policy
-            //     `AWSGlueServiceRole`, which fakecloud's IAM does not resolve
-            //     (no AWS-managed policy catalogue). ---
-            "TestAccGlueJob_basic",
-            "TestAccGlueTrigger_basic",
+            // (Jobs and triggers reference the AWS-managed IAM policy
+            //  `AWSGlueServiceRole`; fakecloud now resolves it from the
+            //  AWS-managed policy catalogue (#1880), so those tests run.)
             // --- gap: partitions omit the `catalog_id` (defaults to the account
             //     id) on read. ---
             "TestAccGluePartition_basic",


### PR DESCRIPTION
## Summary

Third batch of the IAM AWS-managed-policy work. #1880 made `AWSGlueServiceRole` resolvable, which let the upstream `TestAccGlueJob_basic` and `TestAccGlueTrigger_basic` acceptance tests get past the role-attach step, and they then surfaced two genuine Glue-side gaps. This PR fixes both and removes the two tests from the tfacc deny-list.

### Fixes
- **Job timeout default.** `CreateJob` left `Timeout` unset, so `GetJob` returned `0`. AWS defaults the timeout to **2880 minutes** for batch jobs (`glueetl`/`pythonshell`); streaming jobs (`gluestreaming`) have no default. The provider asserts `2880`.
- **ON_DEMAND trigger state.** `StartTrigger` unconditionally set `State=ACTIVATED`. For `ON_DEMAND` triggers, AWS fires a single run but leaves `State=CREATED`; only scheduled/conditional triggers transition to `ACTIVATED`. The provider derives the trigger's `enabled` attribute from this (`ON_DEMAND` + `CREATED` means `enabled=true`), so the wrong state made `enabled` read `false`.

### tfacc
- Dropped `TestAccGlueJob_basic` and `TestAccGlueTrigger_basic` from the `glue` deny-list (the stale "no AWS-managed policy catalogue" reason no longer applies).

## Test plan
- `cargo test -p fakecloud-glue`: new/updated unit tests covering job timeout default (streaming = none, explicit value preserved), `StartTrigger` leaving `ON_DEMAND` in `CREATED`, and `SCHEDULED` going `ACTIVATED`.
- Local tfacc validation: ran the full `glue` shard against the real terraform-provider-aws v5.97 acceptance suite. It passes, with `TestAccGlueJob_basic` and `TestAccGlueTrigger_basic` now included (previously skipped). Confirmed via TF trace that the provider's `GetTrigger` now yields `enabled=true`.
- `cargo clippy -p fakecloud-glue -p fakecloud-tfacc --all-targets` clean; `cargo fmt`.

## Surface
- No new ops/endpoints, so no SDK / conformance-baseline / ops-index changes. Behavior-only fixes to existing Glue ops; tfacc coverage widens by 2 tests.