### PR TITLE
docs(security): note AWS-managed policy catalog in IAM enforcement scope

### DIFF
--- a/website/content/docs/reference/security.md
+++ b/website/content/docs/reference/security.md
@@ -83,6 +83,7 @@ The policy evaluator implements the essentials of AWS's identity-based policy ev
 - Identity policies attached to:
   - IAM users (inline + managed + via group membership, inline and managed)
   - IAM roles (inline + managed, for assumed-role sessions)
+- Managed policies resolve from both customer-managed policies you create and a built-in catalog of common AWS-managed policies (`arn:aws:iam::aws:policy/*`, e.g. `AdministratorAccess`, `AmazonS3FullAccess`, `AWSLambdaBasicExecutionRole`). Attaching an AWS-managed policy grants its permissions just like a customer-managed one.
 - Empty effective policy set -> implicit deny.
 
 ### Condition block evaluation


### PR DESCRIPTION
## Summary

Final batch of the IAM AWS-managed-policy work: a documentation precision fix. The IAM enforcement reference (`docs/reference/security.md`) listed "managed" identity policies without distinguishing customer-managed from AWS-managed. After the catalog (#1880) and its enforcement (#1881), attaching an AWS-managed policy (`arn:aws:iam::aws:policy/*`) grants its permissions under `--iam soft|strict` just like a customer-managed one. This spells that out so the documented evaluated-policy scope matches the implementation.

## Test plan
- Docs-only change; no code touched. Markdown renders in the existing reference page.

## Surface
- This is the surface sync. Op counts, SDKs, conformance baseline, and ops-index are unchanged across the whole feature (no new operations were added; the work made existing IAM ops resolve and enforce AWS-managed ARNs). `iam.md` was updated in #1880/#1881; this completes the reference docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the IAM security reference to state that AWS‑managed policies (`arn:aws:iam::aws:policy/*`) resolve from our built-in catalog and grant permissions like customer‑managed policies under `--iam` soft/strict. This aligns the documented evaluated-policy scope with current behavior.

<sup>Written for commit 805e87e8f829cfa67a8c4f139018b2f62e49cf30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

