### PR TITLE
fix(dynamodb,elasticache): control-plane drift fixes for tfacc

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/streams.rs
+++ b/crates/fakecloud-dynamodb/src/service/streams.rs
@@ -142,10 +142,13 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
         let stream_arn = require_str(&body, "StreamArn")?;
+        // Precision is optional: real AWS only reports it once the caller set
+        // it, so an unset precision must come back empty (not a synthesised
+        // MILLISECOND default), which the Terraform resource asserts.
         let precision = body["EnableKinesisStreamingConfiguration"]
             ["ApproximateCreationDateTimePrecision"]
             .as_str()
-            .unwrap_or("MILLISECOND");
+            .unwrap_or("");
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -157,13 +160,15 @@ impl DynamoDbService {
             approximate_creation_date_time_precision: precision.to_string(),
         });
 
+        let mut config = json!({});
+        if !precision.is_empty() {
+            config["ApproximateCreationDateTimePrecision"] = json!(precision);
+        }
         Self::ok_json(json!({
             "TableName": table_name,
             "StreamArn": stream_arn,
             "DestinationStatus": "ACTIVE",
-            "EnableKinesisStreamingConfiguration": {
-                "ApproximateCreationDateTimePrecision": precision
-            }
+            "EnableKinesisStreamingConfiguration": config
         }))
     }
 
@@ -210,11 +215,17 @@ impl DynamoDbService {
             .kinesis_destinations
             .iter()
             .map(|d| {
-                json!({
+                let mut o = json!({
                     "StreamArn": d.stream_arn,
                     "DestinationStatus": d.destination_status,
-                    "ApproximateCreationDateTimePrecision": d.approximate_creation_date_time_precision
-                })
+                });
+                // Only report precision once it was actually set, so the
+                // Terraform resource reads "" for an unset destination.
+                if !d.approximate_creation_date_time_precision.is_empty() {
+                    o["ApproximateCreationDateTimePrecision"] =
+                        json!(d.approximate_creation_date_time_precision);
+                }
+                o
             })
             .collect();
 
@@ -234,7 +245,7 @@ impl DynamoDbService {
         let precision = body["UpdateKinesisStreamingConfiguration"]
             ["ApproximateCreationDateTimePrecision"]
             .as_str()
-            .unwrap_or("MILLISECOND");
+            .unwrap_or("");
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -248,13 +259,15 @@ impl DynamoDbService {
             dest.approximate_creation_date_time_precision = precision.to_string();
         }
 
+        let mut config = json!({});
+        if !precision.is_empty() {
+            config["ApproximateCreationDateTimePrecision"] = json!(precision);
+        }
         Self::ok_json(json!({
             "TableName": table_name,
             "StreamArn": stream_arn,
             "DestinationStatus": "ACTIVE",
-            "UpdateKinesisStreamingConfiguration": {
-                "ApproximateCreationDateTimePrecision": precision
-            }
+            "UpdateKinesisStreamingConfiguration": config
         }))
     }
 

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -723,8 +723,7 @@ impl DynamoDbService {
         let table = find_table_by_arn_mut(&mut state.tables, resource_arn)?;
         table.resource_policy = Some(policy.to_string());
 
-        let revision_id = uuid::Uuid::new_v4().to_string();
-        Self::ok_json(json!({ "RevisionId": revision_id }))
+        Self::ok_json(json!({ "RevisionId": policy_revision_id(policy) }))
     }
 
     pub(super) fn get_resource_policy(
@@ -740,13 +739,10 @@ impl DynamoDbService {
         let table = find_table_by_arn(&state.tables, resource_arn)?;
 
         match &table.resource_policy {
-            Some(policy) => {
-                let revision_id = uuid::Uuid::new_v4().to_string();
-                Self::ok_json(json!({
-                    "Policy": policy,
-                    "RevisionId": revision_id
-                }))
-            }
+            Some(policy) => Self::ok_json(json!({
+                "Policy": policy,
+                "RevisionId": policy_revision_id(policy)
+            })),
             None => Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "PolicyNotFoundException",
@@ -1848,6 +1844,19 @@ impl DynamoDbService {
             "ImportSummaryList": summaries
         }))
     }
+}
+
+/// Derive a stable `RevisionId` for a resource policy from its content. Real
+/// AWS mints an opaque revision per write; deriving it deterministically means
+/// `PutResourcePolicy` and a later `GetResourcePolicy` (Terraform's
+/// import-state-verify) agree on the same id for the same policy document.
+fn policy_revision_id(policy: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    // `DefaultHasher::new()` is seeded with fixed keys, so this is stable
+    // across calls and processes.
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    policy.hash(&mut h);
+    format!("{:016x}", h.finish())
 }
 
 /// Rewrite a `ValidationException` from the shared schema/throughput parsers

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -1603,7 +1603,7 @@ async fn dynamodb_resource_policy_lifecycle() {
         .send()
         .await
         .unwrap();
-    assert!(resp.revision_id().is_some());
+    let put_revision = resp.revision_id().expect("revision id").to_string();
 
     // Get resource policy
     let resp = client
@@ -1613,6 +1613,10 @@ async fn dynamodb_resource_policy_lifecycle() {
         .await
         .unwrap();
     assert_eq!(resp.policy().unwrap(), policy_doc);
+    // The revision id must be stable for the same policy so Terraform's
+    // import-state-verify round-trips (PutResourcePolicy and GetResourcePolicy
+    // agree on the same id).
+    assert_eq!(resp.revision_id(), Some(put_revision.as_str()));
 
     // Delete resource policy
     client
@@ -1914,7 +1918,8 @@ async fn dynamodb_kinesis_streaming_destination() {
 
     let stream_arn = "arn:aws:kinesis:us-east-1:123456789012:stream/my-stream";
 
-    // Enable
+    // Enable without a precision: AWS does not synthesise a default, so the
+    // field must come back unset (the Terraform resource asserts "").
     let resp = client
         .enable_kinesis_streaming_destination()
         .table_name("KinesisTable")
@@ -1932,6 +1937,9 @@ async fn dynamodb_kinesis_streaming_destination() {
         .await
         .unwrap();
     assert!(!resp.kinesis_data_stream_destinations().is_empty());
+    assert!(resp.kinesis_data_stream_destinations()[0]
+        .approximate_creation_date_time_precision()
+        .is_none());
 
     // Disable
     let resp = client
@@ -1942,6 +1950,65 @@ async fn dynamodb_kinesis_streaming_destination() {
         .await
         .unwrap();
     assert_eq!(resp.destination_status().unwrap().as_str(), "DISABLED");
+}
+
+#[tokio::test]
+async fn dynamodb_kinesis_streaming_destination_echoes_precision() {
+    use aws_sdk_dynamodb::types::{
+        ApproximateCreationDateTimePrecision, EnableKinesisStreamingConfiguration,
+    };
+
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("KTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let stream_arn = "arn:aws:kinesis:us-east-1:123456789012:stream/s";
+    client
+        .enable_kinesis_streaming_destination()
+        .table_name("KTable")
+        .stream_arn(stream_arn)
+        .enable_kinesis_streaming_configuration(
+            EnableKinesisStreamingConfiguration::builder()
+                .approximate_creation_date_time_precision(
+                    ApproximateCreationDateTimePrecision::Microsecond,
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_kinesis_streaming_destination()
+        .table_name("KTable")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.kinesis_data_stream_destinations()[0].approximate_creation_date_time_precision(),
+        Some(&ApproximateCreationDateTimePrecision::Microsecond)
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -3382,3 +3382,104 @@ async fn delete_during_create_does_not_orphan() {
         .await
         .expect("re-create with same id must succeed after delete-during-create");
 }
+
+// ── Control-plane resources that don't need a cache container ──────────────
+
+#[tokio::test]
+async fn elasticache_subnet_group_name_lowercased_and_tags_round_trip() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    // AWS lowercases subnet-group names; create with mixed case and the
+    // response (and later reads) must use the lowercase form.
+    let create = client
+        .create_cache_subnet_group()
+        .cache_subnet_group_name("Mixed-Case-SG")
+        .cache_subnet_group_description("d")
+        .subnet_ids("subnet-aaa111")
+        .tags(
+            aws_sdk_elasticache::types::Tag::builder()
+                .key("Name")
+                .value("Mixed-Case-SG")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let group = create.cache_subnet_group().unwrap();
+    assert_eq!(group.cache_subnet_group_name(), Some("mixed-case-sg"));
+
+    // Describe by the lowercase name resolves it.
+    let described = client
+        .describe_cache_subnet_groups()
+        .cache_subnet_group_name("mixed-case-sg")
+        .send()
+        .await
+        .expect("describe by lowercase name");
+    assert_eq!(described.cache_subnet_groups().len(), 1);
+
+    // Create-time tags round-trip via ListTagsForResource.
+    let arn = group.arn().unwrap();
+    let tags = client
+        .list_tags_for_resource()
+        .resource_name(arn)
+        .send()
+        .await
+        .expect("list tags");
+    assert!(tags
+        .tag_list()
+        .iter()
+        .any(|t| t.key() == Some("Name") && t.value() == Some("Mixed-Case-SG")));
+}
+
+#[tokio::test]
+async fn elasticache_user_group_engine_case_insensitive_and_modify_settles_active() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    // The provider sends the engine uppercase ("REDIS"); AWS accepts it and
+    // stores it lowercase.
+    client
+        .create_user()
+        .user_id("u1")
+        .user_name("u1")
+        .engine("REDIS")
+        .access_string("on ~* +@all")
+        .passwords("abcdefghijabcdefghij")
+        .send()
+        .await
+        .expect("create user with REDIS engine");
+    client
+        .create_user()
+        .user_id("u2")
+        .user_name("u2")
+        .engine("REDIS")
+        .access_string("on ~* +@all")
+        .passwords("abcdefghijabcdefghij")
+        .send()
+        .await
+        .expect("create second user");
+
+    let ug = client
+        .create_user_group()
+        .user_group_id("ug1")
+        .engine("REDIS")
+        .user_ids("u1")
+        .send()
+        .await
+        .expect("create user group with REDIS engine");
+    assert_eq!(ug.engine(), Some("redis"));
+    assert_eq!(ug.status(), Some("active"));
+
+    // Modifying the membership must settle back to `active`, not stay
+    // `modifying` (which would hang the provider's update waiter).
+    let modified = client
+        .modify_user_group()
+        .user_group_id("ug1")
+        .user_ids_to_add("u2")
+        .send()
+        .await
+        .expect("modify user group");
+    assert_eq!(modified.status(), Some("active"));
+    assert_eq!(modified.user_ids().len(), 2);
+}

--- a/crates/fakecloud-elasticache/src/service/subnet_groups.rs
+++ b/crates/fakecloud-elasticache/src/service/subnet_groups.rs
@@ -8,7 +8,10 @@ impl ElastiCacheService {
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let name = required_query_param(request, "CacheSubnetGroupName")?;
+        // ElastiCache forces cache-subnet-group names to lowercase; the
+        // response (and the resource's ID) come back lowercased, so the
+        // Terraform Read queries the lowercase name. Store it canonically.
+        let name = required_query_param(request, "CacheSubnetGroupName")?.to_lowercase();
         let description = required_query_param(request, "CacheSubnetGroupDescription")?;
         // AWS SDKs serialize this list as `SubnetIds.SubnetIdentifier.N`
         // (the @xmlName on the list member). The conformance probe uses the
@@ -16,6 +19,7 @@ impl ElastiCacheService {
         // `parse_query_list_param`, which falls back to `member` if the
         // canonical name yields nothing.
         let subnet_ids = parse_query_list_param(request, "SubnetIds", "SubnetIdentifier");
+        let tags = parse_tags(request)?;
 
         // SubnetIds is @required in the Smithy model but
         // `InvalidParameterValueException` is NOT among
@@ -62,6 +66,10 @@ impl ElastiCacheService {
 
         let xml = cache_subnet_group_xml(&group, &state.region);
         state.register_arn(&group.arn);
+        state.tags.entry(group.arn.clone()).or_default();
+        if !tags.is_empty() {
+            merge_tags(state.tags.entry(group.arn.clone()).or_default(), &tags);
+        }
         state.subnet_groups.insert(name, group);
 
         Ok(AwsResponse::xml(
@@ -79,7 +87,8 @@ impl ElastiCacheService {
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let group_name = optional_query_param(request, "CacheSubnetGroupName");
+        let group_name =
+            optional_query_param(request, "CacheSubnetGroupName").map(|n| n.to_lowercase());
         let max_records = optional_usize_param(request, "MaxRecords")?;
         let marker = optional_query_param(request, "Marker");
 
@@ -134,7 +143,7 @@ impl ElastiCacheService {
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let name = required_query_param(request, "CacheSubnetGroupName")?;
+        let name = required_query_param(request, "CacheSubnetGroupName")?.to_lowercase();
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
@@ -172,7 +181,7 @@ impl ElastiCacheService {
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let name = required_query_param(request, "CacheSubnetGroupName")?;
+        let name = required_query_param(request, "CacheSubnetGroupName")?.to_lowercase();
         let description = optional_query_param(request, "CacheSubnetGroupDescription");
         let subnet_ids = parse_query_list_param(request, "SubnetIds", "SubnetIdentifier");
         if subnet_ids.iter().any(|s| s.trim().is_empty()) {

--- a/crates/fakecloud-elasticache/src/service/users.rs
+++ b/crates/fakecloud-elasticache/src/service/users.rs
@@ -7,7 +7,9 @@ impl ElastiCacheService {
     pub(super) fn create_user(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let user_id = required_query_param(request, "UserId")?;
         let user_name = required_query_param(request, "UserName")?;
-        let engine = required_query_param(request, "Engine")?;
+        // Engine is case-insensitive on the wire (the provider sends "REDIS");
+        // AWS normalises and stores it lowercase, so do the same.
+        let engine = required_query_param(request, "Engine")?.to_lowercase();
         let access_string = required_query_param(request, "AccessString")?;
 
         validate_engine(&engine)?;
@@ -225,7 +227,9 @@ impl ElastiCacheService {
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let user_group_id = required_query_param(request, "UserGroupId")?;
-        let engine = required_query_param(request, "Engine")?;
+        // Engine is case-insensitive on the wire (the provider sends "REDIS");
+        // AWS normalises and stores it lowercase, matching the user records.
+        let engine = required_query_param(request, "Engine")?.to_lowercase();
 
         validate_engine(&engine)?;
 
@@ -458,7 +462,11 @@ impl ElastiCacheService {
                 }
             }
             group.user_ids.retain(|u| !to_remove.contains(u));
-            group.status = "modifying".to_string();
+            // The membership change is applied synchronously, so the group is
+            // immediately back to `active`. Leaving it `modifying` would hang
+            // the provider's update waiter (Pending: modifying, Target: active)
+            // forever, since fakecloud has no async tick to flip it.
+            group.status = "active".to_string();
             // Keep the reverse mapping on each User in sync so that
             // ModifyUser can resolve the correct replication groups.
             for u in &to_add {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -522,7 +522,19 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "elasticache",
-        run_regex: "^TestAccElastiCacheUser_basic$",
+        // Control-plane resources that don't need a cache container: users,
+        // user groups (+ association), and subnet groups (+ data sources).
+        // CreateUser/CreateUserGroup accept the case-insensitive "REDIS"
+        // engine; subnet-group names are lowercased like AWS and round-trip
+        // their tags; ModifyUserGroup settles back to `active` so the
+        // provider's update waiter completes.
+        run_regex: concat!(
+            "^TestAccElastiCache(",
+            "User|UserDataSource",
+            "|UserGroup|UserGroupAssociation",
+            "|SubnetGroup|SubnetGroupDataSource",
+            ")_basic$",
+        ),
         deny: &[],
     },
     Service {
@@ -730,12 +742,11 @@ pub const SHARDS: &[Shard] = &[
     // ─── dynamodb non-table resources ──────────────────────────────
     // The two table shards cover `aws_dynamodb_table` only. This shard adds
     // the other DynamoDB resources and data sources that pass: table item
-    // (+ data source), the table data source, contributor insights, and
-    // tagging. The regex is an explicit positive list — the remaining
-    // non-table resources are deliberately omitted, not denied:
-    //   * kinesis_streaming_destination — `approximate_creation_date_time
-    //     _precision` round-trip,
-    //   * resource_policy — import-state-verify attribute mismatch,
+    // (+ data source), the table data source, contributor insights, tagging,
+    // kinesis streaming destination (optional precision now echoes empty), and
+    // resource policy (revision id is derived from the policy content, so
+    // import-state-verify round-trips). The remaining non-table resources are
+    // deliberately omitted, not denied:
     //   * global_table / table_replica — cross-region replication,
     //   * table_export — S3 export path,
     // each of which needs a dedicated fix and will be added later.
@@ -745,6 +756,7 @@ pub const SHARDS: &[Shard] = &[
         run_regex: concat!(
             "^TestAccDynamoDB(",
             "ContributorInsights|Tag|TableItem|TableItemDataSource|TableDataSource",
+            "|KinesisStreamingDestination|ResourcePolicy",
             ")_basic$",
         ),
         extra_deny: &[],
@@ -798,7 +810,13 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "elasticache",
         service: "elasticache",
-        run_regex: "^TestAccElastiCacheUser_basic$",
+        run_regex: concat!(
+            "^TestAccElastiCache(",
+            "User|UserDataSource",
+            "|UserGroup|UserGroupAssociation",
+            "|SubnetGroup|SubnetGroupDataSource",
+            ")_basic$",
+        ),
         extra_deny: &[],
     },
     Shard {


### PR DESCRIPTION
## Summary

Implements the real behavior behind several denied upstream `terraform-provider-aws` acceptance tests (tfacc backlog, "drift / field-presence + elasticache control-plane"), then re-widens the allow-list. No gaming.

**dynamodb**
- `KinesisStreamingDestination`: an unset `ApproximateCreationDateTimePrecision` is no longer synthesised as `MILLISECOND`. Enable/Update echo only what the caller set, and Describe omits the field when unset — so the Terraform resource reads `""` exactly as against AWS.
- `ResourcePolicy`: `RevisionId` is derived deterministically from the policy document (not a fresh UUID per call), so `PutResourcePolicy` and a later `GetResourcePolicy` (import-state-verify) agree on the same id.

**elasticache** (control-plane, no cache container)
- `CreateUser` / `CreateUserGroup` accept the engine case-insensitively (the provider sends `"REDIS"`) and store it lowercase, matching AWS.
- Cache-subnet-group names are lowercased like AWS — a create with mixed case and a later read by the lowercase name resolve the same group; the read-after-create no longer 404s.
- `CreateCacheSubnetGroup` applies and round-trips create-time tags (the subnet-group data source asserts the tag set), fixing a non-empty plan.
- `ModifyUserGroup` settles the group back to `active` immediately (the change is synchronous) instead of leaving it `modifying` forever, which hung the provider's update waiter.

### tfacc allow-list re-widened
- dynamodb-resources shard: add `KinesisStreamingDestination` + `ResourcePolicy`
- elasticache shard: add `User`/`UserDataSource`, `UserGroup`/`UserGroupAssociation`, `SubnetGroup`/`SubnetGroupDataSource`

## Test plan
- New/updated E2E: ddb resource-policy revision stability + kinesis precision echo/empty; elasticache subnet-group name lowercasing + create-time tags + user-group engine case-insensitivity + modify-settles-active.
- Targeted upstream `go test` slices verified green locally against a running fakecloud (6 elasticache + 2 dynamodb tests).
- `cargo test` (dynamodb/elasticache libs, 232 elasticache + ddb), `cargo clippy --all-targets`, `cargo fmt`, doc-counts all pass.
- tfacc matrix on this PR is the end-to-end gate.

No new public API surface; no SDK change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AWS-parity drift in DynamoDB and ElastiCache control-plane: correct Kinesis streaming precision handling, stable resource‑policy revision IDs, engine case-insensitive inputs, subnet‑group lowercasing + create-time tags, and immediate active status after user‑group modify. Re-widens the tfacc allow‑list to include these resources and data sources.

- **Bug Fixes**
  - DynamoDB: KinesisStreamingDestination no longer synthesizes a default precision; Enable/Update echo only what was set; Describe omits the field when unset.
  - DynamoDB: ResourcePolicy `RevisionId` is derived from the policy content so Put/Get return the same ID.
  - ElastiCache: `CreateUser`/`CreateUserGroup` accept "REDIS" and store the engine as "redis".
  - ElastiCache: Cache subnet-group names are stored lowercase; create-time tags are applied and returned via ListTagsForResource.
  - ElastiCache: `ModifyUserGroup` returns status `active` immediately after membership changes.

<sup>Written for commit 809176a889d9e0632aaea6d8fa76e78e5ff92287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

