### PR TITLE
fix(lambda): wire-shape aliases, layer ARN on read, function-data-source arn, optional event-invoke age

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -1027,3 +1027,175 @@ async fn lambda_alias_targets_published_version_snapshot() {
     assert_eq!(cfg.code_sha256().unwrap(), v1_sha);
     assert!(cfg.function_arn().unwrap().ends_with(":1"));
 }
+
+#[tokio::test]
+async fn lambda_get_alias_wire_shape_and_routing_removal() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("rc-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    client
+        .publish_version()
+        .function_name("rc-fn")
+        .send()
+        .await
+        .unwrap();
+    client
+        .update_function_code()
+        .function_name("rc-fn")
+        .zip_file(Blob::new(make_zip_with(b"v2\n")))
+        .send()
+        .await
+        .unwrap();
+    client
+        .publish_version()
+        .function_name("rc-fn")
+        .send()
+        .await
+        .unwrap();
+
+    // Create alias with a routing config (90/10 between v1 and v2).
+    client
+        .create_alias()
+        .function_name("rc-fn")
+        .name("live")
+        .function_version("1")
+        .routing_config(
+            aws_sdk_lambda::types::AliasRoutingConfiguration::builder()
+                .additional_version_weights("2", 0.1)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // GetAlias must return the AWS wire shape (PascalCase fields parse into the
+    // typed SDK struct) including the routing config.
+    let got = client
+        .get_alias()
+        .function_name("rc-fn")
+        .name("live")
+        .send()
+        .await
+        .expect("get alias");
+    assert_eq!(got.name(), Some("live"));
+    assert_eq!(got.function_version(), Some("1"));
+    assert!(got.alias_arn().unwrap().ends_with(":live"));
+    assert!(got.revision_id().is_some());
+    assert_eq!(
+        got.routing_config()
+            .and_then(|r| r.additional_version_weights())
+            .and_then(|w| w.get("2"))
+            .copied(),
+        Some(0.1)
+    );
+
+    // Removing the routing config (empty) must clear it, not leave it present.
+    client
+        .update_alias()
+        .function_name("rc-fn")
+        .name("live")
+        .routing_config(aws_sdk_lambda::types::AliasRoutingConfiguration::builder().build())
+        .send()
+        .await
+        .unwrap();
+    let after = client
+        .get_alias()
+        .function_name("rc-fn")
+        .name("live")
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        after
+            .routing_config()
+            .map(|r| r.additional_version_weights().is_none_or(|w| w.is_empty()))
+            .unwrap_or(true),
+        "routing config must be cleared after removal"
+    );
+}
+
+#[tokio::test]
+async fn lambda_get_layer_version_returns_layer_arn() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    let published = client
+        .publish_layer_version()
+        .layer_name("mylayer")
+        .content(
+            aws_sdk_lambda::types::LayerVersionContentInput::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .expect("publish layer");
+    let version = published.version();
+
+    // GetLayerVersion must echo LayerArn (the Terraform resource reads it).
+    let got = client
+        .get_layer_version()
+        .layer_name("mylayer")
+        .version_number(version)
+        .send()
+        .await
+        .expect("get layer version");
+    assert_eq!(
+        got.layer_arn(),
+        Some("arn:aws:lambda:us-east-1:123456789012:layer:mylayer")
+    );
+}
+
+#[tokio::test]
+async fn lambda_event_invoke_config_omits_unset_max_age() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("eic-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Set only the retry attempts; leave MaximumEventAgeInSeconds unset.
+    client
+        .put_function_event_invoke_config()
+        .function_name("eic-fn")
+        .maximum_retry_attempts(1)
+        .send()
+        .await
+        .unwrap();
+
+    let got = client
+        .get_function_event_invoke_config()
+        .function_name("eic-fn")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.maximum_retry_attempts(), Some(1));
+    // AWS does not synthesise a default age, so it comes back unset.
+    assert!(got.maximum_event_age_in_seconds().is_none());
+}

--- a/crates/fakecloud-lambda/src/extras/aliases.rs
+++ b/crates/fakecloud-lambda/src/extras/aliases.rs
@@ -9,6 +9,24 @@ impl LambdaService {
         format!("{function}:{alias}")
     }
 
+    /// Render an alias in the AWS wire shape (PascalCase keys). The stored
+    /// `FunctionAlias` uses snake_case Rust field names for persistence, so it
+    /// must not be serialized directly into a response — the AWS SDK would not
+    /// find `AliasArn`/`Name`/etc and would parse an empty object.
+    fn alias_json(a: &FunctionAlias) -> Value {
+        let mut o = json!({
+            "AliasArn": a.alias_arn,
+            "Name": a.name,
+            "FunctionVersion": a.function_version,
+            "Description": a.description,
+            "RevisionId": a.revision_id,
+        });
+        if let Some(ref rc) = a.routing_config {
+            o["RoutingConfig"] = rc.clone();
+        }
+        o
+    }
+
     pub(super) fn create_alias(
         &self,
         function_name: &str,
@@ -48,12 +66,19 @@ impl LambdaService {
             function_version: version,
             description: body["Description"].as_str().unwrap_or("").to_string(),
             revision_id: id_from_time("rev-"),
-            routing_config: body.get("RoutingConfig").cloned(),
+            routing_config: body
+                .get("RoutingConfig")
+                .filter(|rc| {
+                    rc.get("AdditionalVersionWeights")
+                        .and_then(|w| w.as_object())
+                        .is_some_and(|w| !w.is_empty())
+                })
+                .cloned(),
         };
         state
             .aliases
             .insert(Self::alias_key(function_name, &name), alias.clone());
-        ok(serde_json::to_value(alias).unwrap_or_default())
+        ok(Self::alias_json(&alias))
     }
 
     pub(super) fn get_alias(
@@ -77,7 +102,7 @@ impl LambdaService {
             state
                 .aliases
                 .get(&Self::alias_key(function_name, &alias_name))
-                .map(|a| ok(serde_json::to_value(a).unwrap_or_default()))
+                .map(|a| ok(Self::alias_json(a)))
                 .unwrap_or_else(|| Err(not_found("Alias", &alias_name)))
         })
     }
@@ -101,10 +126,7 @@ impl LambdaService {
                 .collect();
             let (page, next_marker) =
                 crate::service::paginate_marker(aliases, marker, max_items, |a| a.name.clone());
-            let page_json: Vec<Value> = page
-                .iter()
-                .map(|a| serde_json::to_value(a).unwrap_or_default())
-                .collect();
+            let page_json: Vec<Value> = page.iter().map(Self::alias_json).collect();
             ok(json!({"Aliases": page_json, "NextMarker": next_marker}))
         })
     }
@@ -129,11 +151,20 @@ impl LambdaService {
         if let Some(d) = body["Description"].as_str() {
             alias.description = d.to_string();
         }
-        if let Some(rc) = body.get("RoutingConfig") {
-            alias.routing_config = Some(rc.clone());
-        }
+        // UpdateAlias replaces the routing config wholesale: an absent or empty
+        // `RoutingConfig.AdditionalVersionWeights` clears it (Terraform removes
+        // the block by sending an empty config). Keeping the old weights would
+        // leave the alias's routing config "still present" after removal.
+        alias.routing_config = body
+            .get("RoutingConfig")
+            .filter(|rc| {
+                rc.get("AdditionalVersionWeights")
+                    .and_then(|w| w.as_object())
+                    .is_some_and(|w| !w.is_empty())
+            })
+            .cloned();
         alias.revision_id = id_from_time("rev-");
-        ok(serde_json::to_value(alias).unwrap_or_default())
+        ok(Self::alias_json(alias))
     }
 
     pub(super) fn delete_alias(

--- a/crates/fakecloud-lambda/src/extras/event_invoke.rs
+++ b/crates/fakecloud-lambda/src/extras/event_invoke.rs
@@ -25,8 +25,12 @@ impl LambdaService {
         // Validate Smithy ranges before persisting:
         //   MaximumEventAgeInSeconds: 60..=21600
         //   MaximumRetryAttempts:     0..=2
-        let event_age = body["MaximumEventAgeInSeconds"].as_i64().unwrap_or(21600);
-        if !(60..=21600).contains(&event_age) {
+        // MaximumEventAgeInSeconds is optional: AWS only reports it once set.
+        // Store 0 as the "unset" sentinel (0 is outside the valid 60..21600
+        // range) so GetFunctionEventInvokeConfig can omit it, which the
+        // Terraform resource reads back as 0.
+        let event_age = body["MaximumEventAgeInSeconds"].as_i64().unwrap_or(0);
+        if event_age != 0 && !(60..=21600).contains(&event_age) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameterValueException",

--- a/crates/fakecloud-lambda/src/extras/layers.rs
+++ b/crates/fakecloud-lambda/src/extras/layers.rs
@@ -236,9 +236,15 @@ impl LambdaService {
             state
                 .layers
                 .get(&layer_name)
-                .and_then(|l| l.versions.iter().find(|v| v.version == version))
-                .map(|v| {
+                .and_then(|l| {
+                    l.versions
+                        .iter()
+                        .find(|v| v.version == version)
+                        .map(|v| (l.layer_arn.clone(), v))
+                })
+                .map(|(layer_arn, v)| {
                     ok(json!({
+                        "LayerArn": layer_arn,
                         "LayerVersionArn": v.layer_version_arn,
                         "Version": v.version,
                         "Description": v.description,
@@ -275,9 +281,15 @@ impl LambdaService {
             state
                 .layers
                 .get(&layer_name)
-                .and_then(|l| l.versions.iter().find(|v| v.version == version))
-                .map(|v| {
+                .and_then(|l| {
+                    l.versions
+                        .iter()
+                        .find(|v| v.version == version)
+                        .map(|v| (l.layer_arn.clone(), v))
+                })
+                .map(|(layer_arn, v)| {
                     ok(json!({
+                        "LayerArn": layer_arn,
                         "LayerVersionArn": v.layer_version_arn,
                         "Version": v.version,
                         "Description": v.description,

--- a/crates/fakecloud-lambda/src/extras/mod.rs
+++ b/crates/fakecloud-lambda/src/extras/mod.rs
@@ -732,6 +732,11 @@ impl LambdaService {
             let mut all: Vec<serde_json::Value> = Vec::new();
             let mut latest = self.function_config_json(func);
             latest["Version"] = json!("$LATEST");
+            // In ListVersionsByFunction, AWS qualifies the $LATEST entry's
+            // FunctionArn with `:$LATEST` (unlike a bare GetFunction). The
+            // Terraform `aws_lambda_function` resource derives `qualified_arn`
+            // from this entry, so it must carry the qualifier.
+            latest["FunctionArn"] = json!(format!("{}:$LATEST", func.function_arn));
             all.push(latest);
             let snapshots = state.function_version_snapshots.get(function_name);
             if let Some(numbered) = state.function_versions.get(function_name) {
@@ -1087,9 +1092,8 @@ fn event_invoke_json(c: &EventInvokeConfig) -> Value {
             Value::Object(map)
         }
     };
-    json!({
+    let mut out = json!({
         "FunctionArn": c.function_arn,
-        "MaximumEventAgeInSeconds": c.maximum_event_age,
         "MaximumRetryAttempts": c.maximum_retry_attempts,
         "DestinationConfig": destination,
         // `LastModified` is bound to Smithy's `Date` shape
@@ -1101,7 +1105,12 @@ fn event_invoke_json(c: &EventInvokeConfig) -> Value {
             .last_modified
             .timestamp_millis() as f64
             / 1000.0,
-    })
+    });
+    // AWS only reports MaximumEventAgeInSeconds once the caller set it.
+    if c.maximum_event_age != 0 {
+        out["MaximumEventAgeInSeconds"] = json!(c.maximum_event_age);
+    }
+    out
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-lambda/src/service/functions.rs
+++ b/crates/fakecloud-lambda/src/service/functions.rs
@@ -204,8 +204,14 @@ impl LambdaService {
 
         let mut config = self.function_config_json(func);
         config["Version"] = json!(version_label);
-        if version_label != "$LATEST" {
+        // When the caller passed an explicit `Qualifier` (including `$LATEST`),
+        // AWS qualifies the returned FunctionArn with it; an unqualified
+        // GetFunction returns the bare ARN. The Terraform function data source
+        // relies on this to derive `qualified_arn`.
+        if qualifier.is_some() {
             config["FunctionArn"] = json!(format!("{}:{version_label}", live.function_arn));
+        }
+        if version_label != "$LATEST" {
             config["MasterArn"] = json!(live.function_arn);
         }
         let code = if let Some(ref uri) = func.image_uri {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -492,13 +492,22 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "lambda",
-        // Function-URL + provisioned-concurrency + layer-version data source.
-        // The function/alias/permission resources need archive handling and a
-        // container runtime and are deferred.
+        // Control-plane metadata resources/data sources that don't need a
+        // container runtime: function URL, provisioned concurrency, layer
+        // versions (+ data source, now returning LayerArn on read), aliases
+        // (response is rendered in the AWS wire shape and routing config clears
+        // on removal), the function data source ($LATEST-qualified arn lineage
+        // via ListVersionsByFunction), and event-invoke config (optional
+        // MaximumEventAgeInSeconds). The `aws_lambda_function` /
+        // `aws_lambda_permission` resources and the functions/runtime-config
+        // data sources share a VPC scaffold that needs Amazon-provided IPv6
+        // CIDR generation (an EC2 feature) and are deferred; code-signing needs
+        // the AWS Signer service.
         run_regex: concat!(
             "^TestAccLambda(",
             "FunctionURL|FunctionURLDataSource",
-            "|LayerVersionDataSource|ProvisionedConcurrencyConfig",
+            "|LayerVersion|LayerVersionDataSource|ProvisionedConcurrencyConfig",
+            "|Alias|FunctionDataSource|FunctionEventInvokeConfig",
             ")_basic$",
         ),
         deny: &[],
@@ -785,7 +794,8 @@ pub const SHARDS: &[Shard] = &[
         run_regex: concat!(
             "^TestAccLambda(",
             "FunctionURL|FunctionURLDataSource",
-            "|LayerVersionDataSource|ProvisionedConcurrencyConfig",
+            "|LayerVersion|LayerVersionDataSource|ProvisionedConcurrencyConfig",
+            "|Alias|FunctionDataSource|FunctionEventInvokeConfig",
             ")_basic$",
         ),
         extra_deny: &[],


### PR DESCRIPTION
## Summary

Implements the real behavior behind several denied lambda acceptance tests (the control-plane metadata resources that don't need a container runtime), then re-widens the allow-list. No gaming.

- **Aliases**: `GetAlias`/`CreateAlias`/`UpdateAlias`/`ListAliases` now render the alias in the AWS wire shape (PascalCase `AliasArn`/`Name`/`FunctionVersion`/...). Previously the stored struct serialized with snake_case names, so the AWS SDK parsed an empty object and the Terraform resource saw the alias as **absent after apply**. `UpdateAlias` also clears the routing config when an empty `RoutingConfig` is sent, so removing the block doesn't leave the weights "still present".
- **LayerVersion**: `GetLayerVersion` (by name and by ARN) now returns `LayerArn`, which the `aws_lambda_layer_version` resource reads back (was empty).
- **Function data source**: `ListVersionsByFunction` qualifies the `$LATEST` entry's `FunctionArn` with `:$LATEST` (as AWS does), and `GetFunction` qualifies the returned arn whenever an explicit `Qualifier` (including `$LATEST`) is passed. Together these make the resource's and data source's `qualified_arn` agree.
- **Event-invoke config**: `MaximumEventAgeInSeconds` is now optional. fakecloud no longer synthesises a 21600 default; an unset age is omitted from `GetFunctionEventInvokeConfig`, which the Terraform resource reads back as `0`.

### tfacc allow-list re-widened
- lambda shard: add `Alias`, `FunctionDataSource`, `FunctionEventInvokeConfig`, `LayerVersion`
- still deferred: `Function`/`Permission` and the functions/runtime-config data sources (shared VPC scaffold needs Amazon-provided IPv6 CIDR generation, an EC2 feature); `CodeSigningConfig` (needs the AWS Signer service)

## Test plan
- New E2E: alias wire-shape + routing-config removal; GetLayerVersion returns LayerArn; event-invoke config omits unset max age.
- Targeted upstream `go test` green locally: LambdaAlias, LambdaFunctionDataSource, LambdaFunctionEventInvokeConfig, LambdaLayerVersion, LambdaLayerVersionDataSource.
- `cargo test -p fakecloud-lambda` (207), `cargo clippy --all-targets`, `cargo fmt`, doc-counts pass. Lambda conformance unaffected (the one local failure is the Docker-gated Invoke test, green in CI).
- tfacc matrix on this PR is the end-to-end gate.

No new public API surface; no SDK change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Lambda alias, layer version, function data source, and event-invoke responses to match AWS so Terraform reads state correctly. Re-enables related `tfacc` tests by widening the Lambda allow-list.

- **Bug Fixes**
  - Aliases: return AWS wire shape (`AliasArn`, `Name`, `FunctionVersion`); `UpdateAlias` clears routing config when empty.
  - LayerVersion: `GetLayerVersion` includes `LayerArn` (by name and by ARN).
  - Function data source: qualify `$LATEST` in `ListVersionsByFunction`; `GetFunction` qualifies `FunctionArn` when a `Qualifier` is sent.
  - Event-invoke config: `MaximumEventAgeInSeconds` is optional; omit when unset.

- **Refactors**
  - Widened Lambda `tfacc` allow-list to include `Alias`, `FunctionDataSource`, `FunctionEventInvokeConfig`, `LayerVersion`; still defers `Function`/`Permission` and functions/runtime-config data sources.

<sup>Written for commit 6ffdc218d459808202f33c6c2dd05906b548dd02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

