### PR TITLE
feat(ec2): VPC default resources, Amazon-provided IPv6, subnet DNS, ENI private DNS + default SG

### DIFF
--- a/crates/fakecloud-e2e/tests/ec2_vpc_control_plane.rs
+++ b/crates/fakecloud-e2e/tests/ec2_vpc_control_plane.rs
@@ -1,0 +1,187 @@
+//! EC2 VPC control-plane field-presence: default resources, IPv6 CIDR
+//! generation, subnet DNS options, and ENI private DNS / default SG.
+
+mod helpers;
+
+use helpers::TestServer;
+
+#[tokio::test]
+async fn create_vpc_provisions_default_resources() {
+    let server = TestServer::start().await;
+    let c = server.ec2_client().await;
+
+    let vpc = c
+        .create_vpc()
+        .cidr_block("10.30.0.0/16")
+        .send()
+        .await
+        .unwrap();
+    let vpc_id = vpc.vpc().unwrap().vpc_id().unwrap().to_string();
+
+    // A `default` security group exists for the new VPC.
+    let sgs = c
+        .describe_security_groups()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("vpc-id")
+                .values(&vpc_id)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(sgs
+        .security_groups()
+        .iter()
+        .any(|g| g.group_name() == Some("default")));
+
+    // A default network ACL exists for the new VPC.
+    let acls = c
+        .describe_network_acls()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("vpc-id")
+                .values(&vpc_id)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(acls
+        .network_acls()
+        .iter()
+        .any(|a| a.is_default() == Some(true)));
+
+    // A main route table exists for the new VPC.
+    let rts = c
+        .describe_route_tables()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("vpc-id")
+                .values(&vpc_id)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(rts
+        .route_tables()
+        .iter()
+        .any(|rt| rt.associations().iter().any(|a| a.main() == Some(true))));
+}
+
+#[tokio::test]
+async fn create_vpc_with_amazon_provided_ipv6() {
+    let server = TestServer::start().await;
+    let c = server.ec2_client().await;
+
+    let vpc = c
+        .create_vpc()
+        .cidr_block("10.31.0.0/16")
+        .amazon_provided_ipv6_cidr_block(true)
+        .send()
+        .await
+        .unwrap();
+    let set = vpc.vpc().unwrap().ipv6_cidr_block_association_set();
+    assert_eq!(set.len(), 1);
+    assert!(set[0].ipv6_cidr_block().unwrap().ends_with("::/56"));
+
+    // Associating IPv6 separately works too, and the association is filterable.
+    let vpc2 = c
+        .create_vpc()
+        .cidr_block("10.32.0.0/16")
+        .send()
+        .await
+        .unwrap();
+    let vpc2_id = vpc2.vpc().unwrap().vpc_id().unwrap().to_string();
+    let assoc = c
+        .associate_vpc_cidr_block()
+        .vpc_id(&vpc2_id)
+        .amazon_provided_ipv6_cidr_block(true)
+        .send()
+        .await
+        .unwrap();
+    let assoc_id = assoc
+        .ipv6_cidr_block_association()
+        .unwrap()
+        .association_id()
+        .unwrap()
+        .to_string();
+    let described = c
+        .describe_vpcs()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("ipv6-cidr-block-association.association-id")
+                .values(&assoc_id)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(described.vpcs().len(), 1);
+    assert_eq!(described.vpcs()[0].vpc_id(), Some(vpc2_id.as_str()));
+}
+
+#[tokio::test]
+async fn subnet_reports_private_dns_hostname_type() {
+    let server = TestServer::start().await;
+    let c = server.ec2_client().await;
+
+    let vpc = c
+        .create_vpc()
+        .cidr_block("10.33.0.0/16")
+        .send()
+        .await
+        .unwrap();
+    let vpc_id = vpc.vpc().unwrap().vpc_id().unwrap().to_string();
+    let subnet = c
+        .create_subnet()
+        .vpc_id(&vpc_id)
+        .cidr_block("10.33.1.0/24")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        subnet
+            .subnet()
+            .unwrap()
+            .private_dns_name_options_on_launch()
+            .and_then(|o| o.hostname_type())
+            .map(|h| h.as_str()),
+        Some("ip-name")
+    );
+}
+
+#[tokio::test]
+async fn network_interface_derives_private_dns_and_default_sg() {
+    let server = TestServer::start().await;
+    let c = server.ec2_client().await;
+
+    let vpc = c
+        .create_vpc()
+        .cidr_block("10.34.0.0/16")
+        .send()
+        .await
+        .unwrap();
+    let vpc_id = vpc.vpc().unwrap().vpc_id().unwrap().to_string();
+    let subnet = c
+        .create_subnet()
+        .vpc_id(&vpc_id)
+        .cidr_block("10.34.0.0/24")
+        .send()
+        .await
+        .unwrap();
+    let subnet_id = subnet.subnet().unwrap().subnet_id().unwrap().to_string();
+
+    let eni = c
+        .create_network_interface()
+        .subnet_id(&subnet_id)
+        .private_ip_address("10.34.0.20")
+        .send()
+        .await
+        .unwrap();
+    let n = eni.network_interface().unwrap();
+    assert_eq!(n.private_dns_name(), Some("ip-10-34-0-20.ec2.internal"));
+    // No SecurityGroupId was given, so the VPC's default SG is attached.
+    assert_eq!(n.groups().len(), 1);
+}

--- a/crates/fakecloud-ec2/src/defaults.rs
+++ b/crates/fakecloud-ec2/src/defaults.rs
@@ -120,6 +120,7 @@ pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
             enable_dns_support: true,
             enable_dns_hostnames: true,
             cidr_associations: Vec::new(),
+            ipv6_cidr_block: None,
         },
     );
 
@@ -261,6 +262,93 @@ pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
             associations: nacl_associations,
         },
     );
+}
+
+/// Create the implicit resources AWS provisions for every newly-created VPC: a
+/// `default` security group, a default network ACL, and a main route table
+/// (with the `local` route). The `aws_vpc` resource reads back
+/// `default_security_group_id`, `default_network_acl_id`,
+/// `default_route_table_id`, and `main_route_table_id`, all derived from these.
+/// Ids are deterministic functions of the VPC id so read-path fallbacks agree.
+pub(crate) fn create_vpc_default_resources(state: &mut Ec2State, vpc_id: &str, cidr: &str) {
+    let account = state.account_id.clone();
+    let rtb_id = deterministic_id("rtb", &account, &format!("{vpc_id}-main-rtb"));
+    let acl_id = deterministic_id("acl", &account, &format!("{vpc_id}-default-acl"));
+    let sg_id = deterministic_id("sg", &account, &format!("{vpc_id}-default-sg"));
+
+    state
+        .route_tables
+        .entry(rtb_id.clone())
+        .or_insert_with(|| RouteTable {
+            route_table_id: rtb_id.clone(),
+            vpc_id: vpc_id.to_string(),
+            routes: vec![Route {
+                destination_cidr_block: Some(cidr.to_string()),
+                gateway_id: Some("local".to_string()),
+                ..Default::default()
+            }],
+            associations: vec![RouteTableAssociation {
+                association_id: deterministic_id("rtbassoc", &account, &format!("{vpc_id}-main")),
+                route_table_id: rtb_id.clone(),
+                subnet_id: None,
+                gateway_id: None,
+                main: true,
+            }],
+        });
+
+    state
+        .security_groups
+        .entry(sg_id.clone())
+        .or_insert_with(|| SecurityGroup {
+            group_id: sg_id.clone(),
+            group_name: "default".to_string(),
+            description: "default VPC security group".to_string(),
+            vpc_id: vpc_id.to_string(),
+            rules: vec![
+                SecurityGroupRule {
+                    rule_id: deterministic_id("sgr", &account, &format!("{vpc_id}-sg-ingress")),
+                    group_id: sg_id.clone(),
+                    is_egress: false,
+                    ip_protocol: "-1".to_string(),
+                    from_port: -1,
+                    to_port: -1,
+                    cidr_ipv4: None,
+                    cidr_ipv6: None,
+                    prefix_list_id: None,
+                    referenced_group_id: Some(sg_id.clone()),
+                    description: String::new(),
+                },
+                SecurityGroupRule {
+                    rule_id: deterministic_id("sgr", &account, &format!("{vpc_id}-sg-egress")),
+                    group_id: sg_id.clone(),
+                    is_egress: true,
+                    ip_protocol: "-1".to_string(),
+                    from_port: -1,
+                    to_port: -1,
+                    cidr_ipv4: Some("0.0.0.0/0".to_string()),
+                    cidr_ipv6: None,
+                    prefix_list_id: None,
+                    referenced_group_id: None,
+                    description: String::new(),
+                },
+            ],
+        });
+
+    state
+        .network_acls
+        .entry(acl_id.clone())
+        .or_insert_with(|| NetworkAcl {
+            network_acl_id: acl_id.clone(),
+            vpc_id: vpc_id.to_string(),
+            is_default: true,
+            entries: vec![
+                allow_all_entry(false),
+                deny_all_entry(false),
+                allow_all_entry(true),
+                deny_all_entry(true),
+            ],
+            associations: Vec::new(),
+        });
 }
 
 fn allow_all_entry(egress: bool) -> NetworkAclEntry {

--- a/crates/fakecloud-ec2/src/service/eni.rs
+++ b/crates/fakecloud-ec2/src/service/eni.rs
@@ -37,7 +37,7 @@ fn eni_xml(n: &NetworkInterface, tags: &[Tag], owner: &str) -> String {
         .map(|a| format!("<attachment>{}</attachment>", attachment_inner(a)))
         .unwrap_or_default();
     format!(
-        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
         ec2_elem("networkInterfaceId", &n.network_interface_id),
         ec2_elem("subnetId", &n.subnet_id),
         ec2_elem("vpcId", &n.vpc_id),
@@ -46,6 +46,12 @@ fn eni_xml(n: &NetworkInterface, tags: &[Tag], owner: &str) -> String {
         ec2_elem("ownerId", owner),
         ec2_elem("macAddress", &n.mac_address),
         ec2_elem("privateIpAddress", &n.private_ip_address),
+        // AWS derives the private DNS name from the primary private IP; the
+        // `aws_network_interface` resource reads it back.
+        ec2_elem(
+            "privateDnsName",
+            &format!("ip-{}.ec2.internal", n.private_ip_address.replace('.', "-"))
+        ),
         format_args!("<sourceDestCheck>{}</sourceDestCheck>", n.source_dest_check),
         ec2_elem("status", &n.status),
         ec2_elem("interfaceType", &n.interface_type),
@@ -77,10 +83,33 @@ pub(crate) fn create_network_interface(
         &["efa", "efa-only", "branch", "trunk"],
     )?;
     let id = gen_id("eni");
+    // Resolve the subnet's VPC, and default the security group to that VPC's
+    // `default` group when the caller specified none (AWS does this, and the
+    // `aws_network_interface` resource asserts `security_groups.# == 1`).
+    let (resolved_vpc_id, default_groups) = {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let vpc_id = state
+            .subnets
+            .get(&subnet_id)
+            .map(|s| s.vpc_id.clone())
+            .unwrap_or_default();
+        let mut groups = indexed_list(&req.query_params, "SecurityGroupId");
+        if groups.is_empty() {
+            if let Some(default_sg) = state
+                .security_groups
+                .values()
+                .find(|g| g.vpc_id == vpc_id && g.group_name == "default")
+            {
+                groups.push(default_sg.group_id.clone());
+            }
+        }
+        (vpc_id, groups)
+    };
     let eni = NetworkInterface {
         network_interface_id: id.clone(),
         subnet_id,
-        vpc_id: String::new(),
+        vpc_id: resolved_vpc_id,
         availability_zone: format!(
             "{}a",
             if req.region.is_empty() {
@@ -107,7 +136,7 @@ pub(crate) fn create_network_interface(
             .cloned()
             .unwrap_or_else(|| "interface".to_string()),
         source_dest_check: true,
-        group_ids: indexed_list(&req.query_params, "SecurityGroupId"),
+        group_ids: default_groups,
         private_ips: Vec::new(),
         ipv6_addresses: Vec::new(),
         attachment: None,

--- a/crates/fakecloud-ec2/src/service/subnet.rs
+++ b/crates/fakecloud-ec2/src/service/subnet.rs
@@ -13,7 +13,7 @@ use crate::state::{Ec2State, Subnet, SubnetCidrReservation, Tag};
 /// Render the inner XML of a `<subnet>` element (lowerCamel wire names).
 pub(crate) fn subnet_xml(s: &Subnet, tags: &[Tag], owner: &str, region: &str) -> String {
     format!(
-        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
         ec2_elem("subnetId", &s.subnet_id),
         ec2_elem("state", &s.state),
         ec2_elem("vpcId", &s.vpc_id),
@@ -39,6 +39,13 @@ pub(crate) fn subnet_xml(s: &Subnet, tags: &[Tag], owner: &str, region: &str) ->
             &format!("arn:aws:ec2:{region}:{owner}:subnet/{}", s.subnet_id),
         ),
         format_args!("<enableDns64>{}</enableDns64>", s.enable_dns64),
+        // The `aws_subnet` resource reads `private_dns_hostname_type_on_launch`
+        // (and the DNS-record toggles) from this block; AWS defaults the
+        // hostname type to `ip-name`.
+        format_args!(
+            "<privateDnsNameOptionsOnLaunch><hostnameType>{}</hostnameType><enableResourceNameDnsARecord>false</enableResourceNameDnsARecord><enableResourceNameDnsAAAARecord>false</enableResourceNameDnsAAAARecord></privateDnsNameOptionsOnLaunch>",
+            s.private_dns_hostname_type
+        ),
         super::tags::tag_set_xml(tags),
     )
 }

--- a/crates/fakecloud-ec2/src/service/vpc.rs
+++ b/crates/fakecloud-ec2/src/service/vpc.rs
@@ -29,8 +29,27 @@ pub(crate) fn vpc_xml(vpc: &Vpc, tags: &[Tag], owner_id: &str) -> String {
     })
     .collect();
 
+    // When an Amazon-provided IPv6 CIDR was assigned, report it in the
+    // `ipv6CidrBlockAssociationSet`. The `aws_vpc` resource reads
+    // `ipv6_cidr_block` (and infers `assign_generated_ipv6_cidr_block`) here.
+    let ipv6_set = match &vpc.ipv6_cidr_block {
+        Some(cidr) => {
+            let item = format!(
+                "{}{}<ipv6CidrBlockState><state>associated</state></ipv6CidrBlockState>{}",
+                ec2_elem(
+                    "associationId",
+                    &format!("vpc-cidr-assoc-ipv6-{}", &vpc.vpc_id[4..])
+                ),
+                ec2_elem("ipv6CidrBlock", cidr),
+                ec2_elem("ipv6Pool", "Amazon"),
+            );
+            ec2_list("ipv6CidrBlockAssociationSet", &[item])
+        }
+        None => String::new(),
+    };
+
     format!(
-        "{}{}{}{}{}{}{}{}{}",
+        "{}{}{}{}{}{}{}{}{}{}",
         ec2_elem("vpcId", &vpc.vpc_id),
         ec2_elem("state", &vpc.state),
         ec2_elem("cidrBlock", &vpc.cidr_block),
@@ -39,7 +58,22 @@ pub(crate) fn vpc_xml(vpc: &Vpc, tags: &[Tag], owner_id: &str) -> String {
         format_args!("<isDefault>{}</isDefault>", vpc.is_default),
         ec2_elem("ownerId", owner_id),
         ec2_list("cidrBlockAssociationSet", &cidr_assocs),
+        ipv6_set,
         super::tags::tag_set_xml(tags),
+    )
+}
+
+/// Deterministic Amazon-style IPv6 /56 for a VPC. Real Amazon CIDRs come from
+/// `2600:1f00::/24`; we derive a stable suffix from the VPC id so reads are
+/// consistent.
+fn generated_ipv6_cidr(vpc_id: &str) -> String {
+    let h = vpc_id
+        .bytes()
+        .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
+    format!(
+        "2600:1f16:{:04x}:{:04x}::/56",
+        (h >> 16) & 0xffff,
+        h & 0xffff
     )
 }
 
@@ -53,6 +87,14 @@ fn vpc_matches(vpc: &Vpc, tags: &[Tag], filters: &[Filter]) -> bool {
             "dhcp-options-id" => vec![vpc.dhcp_options_id.clone()],
             "state" => vec![vpc.state.clone()],
             "isDefault" | "is-default" => vec![vpc.is_default.to_string()],
+            "ipv6-cidr-block-association.association-id" => vpc
+                .ipv6_cidr_block
+                .as_ref()
+                .map(|_| vec![format!("vpc-cidr-assoc-ipv6-{}", &vpc.vpc_id[4..])])
+                .unwrap_or_default(),
+            "ipv6-cidr-block-association.ipv6-cidr-block" => {
+                vpc.ipv6_cidr_block.clone().into_iter().collect()
+            }
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
@@ -88,8 +130,18 @@ pub(crate) fn create_vpc(
         .get("InstanceTenancy")
         .cloned()
         .unwrap_or_else(|| "default".to_string());
-    let vpc = build_vpc(cidr, tenancy, false);
+    let mut vpc = build_vpc(cidr, tenancy, false);
     let vpc_id = vpc.vpc_id.clone();
+    // `AmazonProvidedIpv6CidrBlock=true` requests an Amazon-assigned /56; the
+    // `aws_vpc` resource then expects `ipv6_cidr_block` to be set.
+    if req
+        .query_params
+        .get("AmazonProvidedIpv6CidrBlock")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+    {
+        vpc.ipv6_cidr_block = Some(generated_ipv6_cidr(&vpc_id));
+    }
 
     let owner = req.account_id.clone();
     let body = {
@@ -98,6 +150,9 @@ pub(crate) fn create_vpc(
         crate::service::tags::apply_tag_specifications(state, &req.query_params, &vpc_id, "vpc");
         let tags = state.tags_for(&vpc_id).to_vec();
         state.vpcs.insert(vpc_id.clone(), vpc.clone());
+        // AWS provisions a default SG, default NACL, and main route table for
+        // every new VPC; the `aws_vpc` resource reads their ids back.
+        crate::defaults::create_vpc_default_resources(state, &vpc_id, &vpc.cidr_block);
         format!("<vpc>{}</vpc>", vpc_xml(&vpc, &tags, &owner))
     };
     Ok(Ec2Service::respond("CreateVpc", &req.request_id, &body))
@@ -149,6 +204,7 @@ fn build_vpc(cidr: String, tenancy: String, is_default: bool) -> Vpc {
         enable_dns_support: true,
         enable_dns_hostnames: is_default,
         cidr_associations: Vec::new(),
+        ipv6_cidr_block: None,
     }
 }
 
@@ -290,6 +346,38 @@ pub(crate) fn associate_vpc_cidr_block(
 ) -> Result<AwsResponse, AwsServiceError> {
     let vpc_id = require(&req.query_params, "VpcId")?;
     let cidr = req.query_params.get("CidrBlock").cloned();
+
+    // IPv6: `AmazonProvidedIpv6CidrBlock=true` assigns a /56. The resource
+    // waits (DescribeVpcs) for the returned association id to show up, so the
+    // id here must match the one vpc_xml renders.
+    if req
+        .query_params
+        .get("AmazonProvidedIpv6CidrBlock")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+    {
+        let ipv6 = generated_ipv6_cidr(&vpc_id);
+        let assoc_id = format!("vpc-cidr-assoc-ipv6-{}", &vpc_id[4..]);
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            if let Some(vpc) = state.vpcs.get_mut(&vpc_id) {
+                vpc.ipv6_cidr_block = Some(ipv6.clone());
+            }
+        }
+        let body = format!(
+            "{}<ipv6CidrBlockAssociation>{}{}{}<ipv6CidrBlockState><state>associated</state></ipv6CidrBlockState></ipv6CidrBlockAssociation>",
+            ec2_elem("vpcId", &vpc_id),
+            ec2_elem("associationId", &assoc_id),
+            ec2_elem("ipv6CidrBlock", &ipv6),
+            ec2_elem("ipv6Pool", "Amazon"),
+        );
+        return Ok(Ec2Service::respond(
+            "AssociateVpcCidrBlock",
+            &req.request_id,
+            &body,
+        ));
+    }
 
     let assoc = VpcCidrAssoc {
         association_id: gen_id("vpc-cidr-assoc"),

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -64,6 +64,12 @@ pub struct Vpc {
     pub enable_dns_hostnames: bool,
     #[serde(default)]
     pub cidr_associations: Vec<VpcCidrAssoc>,
+    /// Amazon-provided IPv6 /56 CIDR, set when the VPC was created (or updated)
+    /// with `AmazonProvidedIpv6CidrBlock=true`. Reported in the
+    /// `Ipv6CidrBlockAssociationSet`; the `aws_vpc` resource reads
+    /// `ipv6_cidr_block` / `assign_generated_ipv6_cidr_block` from it.
+    #[serde(default)]
+    pub ipv6_cidr_block: Option<String>,
 }
 
 /// One `key -> values` entry in a DHCP options set.

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -512,9 +512,21 @@ pub const SERVICES: &[Service] = &[
     },
     Service {
         name: "ec2",
-        // Elastic IPs and key pairs. The wider EC2 surface (VPC/subnet/SG/...)
-        // is large and is being brought in incrementally elsewhere.
-        run_regex: "^TestAccEC2(EIP|EIPsDataSource|KeyPair)_basic$",
+        // Elastic IPs, key pairs, and the core VPC control plane. CreateVpc now
+        // provisions the default SG / default NACL / main route table (so
+        // `aws_vpc` reads back the four default-resource ids) and honors
+        // `AmazonProvidedIpv6CidrBlock` (a generated /56, also via
+        // AssociateVpcCidrBlock); subnets report `private_dns_name_options`;
+        // ENIs derive `private_dns_name` and default to the VPC's `default`
+        // security group. The remaining EC2 surface is brought in incrementally.
+        run_regex: concat!(
+            "^TestAcc(",
+            "EC2(EIP|EIPsDataSource|KeyPair)",
+            "|VPC(|Subnet|SecurityGroup|RouteTable|InternetGateway|NetworkACL",
+            "|NetworkInterface|DHCPOptions|EgressOnlyInternetGateway",
+            "|DefaultSecurityGroup|DefaultNetworkACL|Route)",
+            ")_basic$",
+        ),
         deny: &[],
     },
     Service {
@@ -801,7 +813,14 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "ec2",
         service: "ec2",
-        run_regex: "^TestAccEC2(EIP|EIPsDataSource|KeyPair)_basic$",
+        run_regex: concat!(
+            "^TestAcc(",
+            "EC2(EIP|EIPsDataSource|KeyPair)",
+            "|VPC(|Subnet|SecurityGroup|RouteTable|InternetGateway|NetworkACL",
+            "|NetworkInterface|DHCPOptions|EgressOnlyInternetGateway",
+            "|DefaultSecurityGroup|DefaultNetworkACL|Route)",
+            ")_basic$",
+        ),
         extra_deny: &[],
     },
     Shard {


### PR DESCRIPTION
## Summary

Brings the core EC2 VPC control plane into the tfacc suite by filling several field-presence and default-resource gaps the upstream resources assert. Reclaims **14** EC2 `_basic` tests (from 3).

- **CreateVpc default resources**: now provisions the implicit resources AWS creates for every VPC — a `default` security group, a default network ACL, and a main route table (with the `local` route) — so the `aws_vpc` resource reads back `default_security_group_id`, `default_network_acl_id`, `default_route_table_id`, and `main_route_table_id`.
- **VPC IPv6**: `AmazonProvidedIpv6CidrBlock=true` (on `CreateVpc` and the separate `AssociateVpcCidrBlock` path) assigns a generated /56, reported in the `ipv6CidrBlockAssociationSet`. `DescribeVpcs` now honors the `ipv6-cidr-block-association.association-id` / `.ipv6-cidr-block` filters so the resource's association waiter (a singular find) resolves.
- **Subnets** report `privateDnsNameOptionsOnLaunch.hostnameType` (default `ip-name`).
- **Network interfaces** derive `privateDnsName` from the primary private IP and default to the subnet VPC's `default` security group when none is specified.

### tfacc allow-list re-widened (ec2 shard)
VPC, Subnet, SecurityGroup (+ Default), RouteTable, Route, InternetGateway, NetworkACL (+ Default), NetworkInterface, DHCPOptions, EgressOnlyInternetGateway. Deferred: DefaultRouteTable (negative-test error pattern), MainRouteTableAssociation, NetworkACLAssociation (need `association.main` / `association.subnet-id` describe filters).

## Test plan
- New E2E (`ec2_vpc_control_plane.rs`): default-resource provisioning, Amazon-provided IPv6 (create + associate + filter), subnet DNS hostname type, ENI private DNS + default SG.
- 14 upstream `go test` VPC-family `_basic` tests green locally against a running fakecloud.
- `cargo test -p fakecloud-ec2` (54) and `-p fakecloud-cloudformation` (238), `cargo clippy --all-targets`, `cargo fmt`, doc-counts pass.
- tfacc matrix on this PR is the end-to-end gate.

Adds a `Vpc.ipv6_cidr_block` state field (serde-default, backward compatible). No new public API surface; no SDK change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements core EC2 VPC control plane behavior to unblock tfacc: default VPC resources, Amazon-provided IPv6, subnet DNS options, and ENI private DNS + default SG.

- **New Features**
  - VPC creation now provisions default resources: `default` security group, default network ACL, and a main route table (with `local`), and exposes their IDs.
  - IPv6: `AmazonProvidedIpv6CidrBlock=true` on CreateVpc and `AssociateVpcCidrBlock` assigns a deterministic /56, reported in `ipv6CidrBlockAssociationSet`; `DescribeVpcs` supports `ipv6-cidr-block-association.association-id` and `.ipv6-cidr-block` filters. Stored in VPC state as `ipv6_cidr_block` (serde-default, backward compatible).
  - Subnets return `privateDnsNameOptionsOnLaunch.hostnameType` (default `ip-name`). ENIs derive `privateDnsName` from the primary private IP and default to the VPC’s `default` security group when none is given.
  - `fakecloud-tfacc` allowlist expanded to cover the VPC core: VPC, Subnet, SecurityGroup (incl. Default), RouteTable/Route, InternetGateway, NetworkACL (incl. Default), NetworkInterface, DHCPOptions, EgressOnlyInternetGateway. Deferred: DefaultRouteTable, MainRouteTableAssociation, NetworkACLAssociation.

<sup>Written for commit b31a5ac053f6e0ff76afad21439aa8cd5f6b315e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

