### PR TITLE
fix(lambda,ec2): enable Lambda Function/Permission via subnet IPv6, SG ports, default logging

### DIFF
--- a/crates/fakecloud-e2e/tests/ec2_vpc_control_plane.rs
+++ b/crates/fakecloud-e2e/tests/ec2_vpc_control_plane.rs
@@ -185,3 +185,118 @@ async fn network_interface_derives_private_dns_and_default_sg() {
     // No SecurityGroupId was given, so the VPC's default SG is attached.
     assert_eq!(n.groups().len(), 1);
 }
+
+#[tokio::test]
+async fn subnet_ipv6_association_and_assign_on_creation() {
+    let server = TestServer::start().await;
+    let c = server.ec2_client().await;
+
+    let vpc = c
+        .create_vpc()
+        .cidr_block("10.50.0.0/16")
+        .amazon_provided_ipv6_cidr_block(true)
+        .send()
+        .await
+        .unwrap();
+    let vpc_id = vpc.vpc().unwrap().vpc_id().unwrap().to_string();
+
+    let subnet = c
+        .create_subnet()
+        .vpc_id(&vpc_id)
+        .cidr_block("10.50.1.0/24")
+        .ipv6_cidr_block("2600:1f16:abc:1::/64")
+        .send()
+        .await
+        .unwrap();
+    let subnet_id = subnet.subnet().unwrap().subnet_id().unwrap().to_string();
+    let set = subnet.subnet().unwrap().ipv6_cidr_block_association_set();
+    assert_eq!(set.len(), 1);
+    let assoc_id = set[0].association_id().unwrap().to_string();
+
+    // ModifySubnetAttribute flips AssignIpv6AddressOnCreation, which must then
+    // round-trip on DescribeSubnets (the resource waits for `true`).
+    c.modify_subnet_attribute()
+        .subnet_id(&subnet_id)
+        .assign_ipv6_address_on_creation(
+            aws_sdk_ec2::types::AttributeBooleanValue::builder()
+                .value(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // The association is filterable, and the assign flag persists on read.
+    let described = c
+        .describe_subnets()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("ipv6-cidr-block-association.association-id")
+                .values(&assoc_id)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(described.subnets().len(), 1);
+    assert_eq!(described.subnets()[0].subnet_id(), Some(subnet_id.as_str()));
+    assert_eq!(
+        described.subnets()[0].assign_ipv6_address_on_creation(),
+        Some(true)
+    );
+}
+
+#[tokio::test]
+async fn security_group_all_traffic_rule_omits_ports() {
+    let server = TestServer::start().await;
+    let c = server.ec2_client().await;
+
+    let vpc = c
+        .create_vpc()
+        .cidr_block("10.51.0.0/16")
+        .send()
+        .await
+        .unwrap();
+    let vpc_id = vpc.vpc().unwrap().vpc_id().unwrap().to_string();
+
+    let sg = c
+        .create_security_group()
+        .group_name("all-traffic-sg")
+        .description("d")
+        .vpc_id(&vpc_id)
+        .send()
+        .await
+        .unwrap();
+    let sg_id = sg.group_id().unwrap().to_string();
+
+    c.authorize_security_group_egress()
+        .group_id(&sg_id)
+        .ip_permissions(
+            aws_sdk_ec2::types::IpPermission::builder()
+                .ip_protocol("-1")
+                .ip_ranges(
+                    aws_sdk_ec2::types::IpRange::builder()
+                        .cidr_ip("0.0.0.0/0")
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let described = c
+        .describe_security_groups()
+        .group_ids(&sg_id)
+        .send()
+        .await
+        .unwrap();
+    let egress = described.security_groups()[0].ip_permissions_egress();
+    // The all-traffic (`-1`) rule must report no port range (AWS omits them).
+    let all = egress
+        .iter()
+        .find(|p| p.ip_protocol() == Some("-1"))
+        .expect("all-traffic egress rule");
+    assert!(all.from_port().is_none());
+    assert!(all.to_port().is_none());
+}

--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -1199,3 +1199,82 @@ async fn lambda_event_invoke_config_omits_unset_max_age() {
     // AWS does not synthesise a default age, so it comes back unset.
     assert!(got.maximum_event_age_in_seconds().is_none());
 }
+
+#[tokio::test]
+async fn lambda_get_function_returns_default_logging_config() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("lg-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let got = client
+        .get_function()
+        .function_name("lg-fn")
+        .send()
+        .await
+        .unwrap();
+    let lc = got
+        .configuration()
+        .and_then(|c| c.logging_config())
+        .expect("default logging config");
+    assert_eq!(
+        lc.log_format(),
+        Some(&aws_sdk_lambda::types::LogFormat::Text)
+    );
+    assert_eq!(lc.log_group(), Some("/aws/lambda/lg-fn"));
+}
+
+#[tokio::test]
+async fn lambda_add_permission_round_trips_event_source_token() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("est-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .add_permission()
+        .function_name("est-fn")
+        .statement_id("s1")
+        .action("lambda:InvokeFunction")
+        .principal("events.amazonaws.com")
+        .event_source_token("my-token")
+        .send()
+        .await
+        .unwrap();
+
+    let policy = client
+        .get_policy()
+        .function_name("est-fn")
+        .send()
+        .await
+        .unwrap();
+    let doc: serde_json::Value = serde_json::from_str(policy.policy().unwrap()).unwrap();
+    let cond = &doc["Statement"][0]["Condition"]["StringEquals"]["lambda:EventSourceToken"];
+    assert_eq!(cond.as_str(), Some("my-token"));
+}

--- a/crates/fakecloud-ec2/src/defaults.rs
+++ b/crates/fakecloud-ec2/src/defaults.rs
@@ -157,6 +157,7 @@ pub(crate) fn bootstrap_default_network(state: &mut Ec2State) {
                 map_customer_owned_ip_on_launch: false,
                 enable_dns64: false,
                 private_dns_hostname_type: "ip-name".to_string(),
+                ipv6_cidr_block: None,
             },
         );
         subnet_ids.push(subnet_id);

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -51,12 +51,20 @@ fn rule_xml(r: &SecurityGroupRule, owner: &str, region: &str) -> String {
 
 /// Render one `<item>` IpPermission from a rule.
 fn ip_permission_xml(r: &SecurityGroupRule) -> String {
-    let mut inner = format!(
-        "{}<fromPort>{}</fromPort><toPort>{}</toPort>",
-        ec2_elem("ipProtocol", &r.ip_protocol),
-        r.from_port,
-        r.to_port,
-    );
+    // For the "all traffic" protocol (`-1`), AWS omits FromPort/ToPort entirely;
+    // the provider then normalises them to 0. Emitting `-1` here makes the
+    // `aws_security_group` resource see a perpetual port diff. tcp/udp/icmp
+    // always carry their port range.
+    let mut inner = if r.ip_protocol == "-1" {
+        ec2_elem("ipProtocol", &r.ip_protocol)
+    } else {
+        format!(
+            "{}<fromPort>{}</fromPort><toPort>{}</toPort>",
+            ec2_elem("ipProtocol", &r.ip_protocol),
+            r.from_port,
+            r.to_port,
+        )
+    };
     let mut ranges = String::new();
     if let Some(c) = &r.cidr_ipv4 {
         ranges.push_str(&format!(

--- a/crates/fakecloud-ec2/src/service/subnet.rs
+++ b/crates/fakecloud-ec2/src/service/subnet.rs
@@ -12,8 +12,19 @@ use crate::state::{Ec2State, Subnet, SubnetCidrReservation, Tag};
 
 /// Render the inner XML of a `<subnet>` element (lowerCamel wire names).
 pub(crate) fn subnet_xml(s: &Subnet, tags: &[Tag], owner: &str, region: &str) -> String {
+    let ipv6_set = match &s.ipv6_cidr_block {
+        Some(cidr) => {
+            let item = format!(
+                "{}{}<ipv6CidrBlockState><state>associated</state></ipv6CidrBlockState>",
+                ec2_elem("associationId", &subnet_ipv6_assoc_id(&s.subnet_id)),
+                ec2_elem("ipv6CidrBlock", cidr),
+            );
+            ec2_list("ipv6CidrBlockAssociationSet", &[item])
+        }
+        None => String::new(),
+    };
     format!(
-        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
         ec2_elem("subnetId", &s.subnet_id),
         ec2_elem("state", &s.state),
         ec2_elem("vpcId", &s.vpc_id),
@@ -33,6 +44,10 @@ pub(crate) fn subnet_xml(s: &Subnet, tags: &[Tag], owner: &str, region: &str) ->
             "<mapCustomerOwnedIpOnLaunch>{}</mapCustomerOwnedIpOnLaunch>",
             s.map_customer_owned_ip_on_launch
         ),
+        format_args!(
+            "<assignIpv6AddressOnCreation>{}</assignIpv6AddressOnCreation>",
+            s.assign_ipv6_address_on_creation
+        ),
         ec2_elem("ownerId", owner),
         ec2_elem(
             "subnetArn",
@@ -46,6 +61,7 @@ pub(crate) fn subnet_xml(s: &Subnet, tags: &[Tag], owner: &str, region: &str) ->
             "<privateDnsNameOptionsOnLaunch><hostnameType>{}</hostnameType><enableResourceNameDnsARecord>false</enableResourceNameDnsARecord><enableResourceNameDnsAAAARecord>false</enableResourceNameDnsAAAARecord></privateDnsNameOptionsOnLaunch>",
             s.private_dns_hostname_type
         ),
+        ipv6_set,
         super::tags::tag_set_xml(tags),
     )
 }
@@ -77,7 +93,13 @@ fn build_subnet(vpc_id: String, cidr: String, az: &str, default_for_az: bool) ->
         map_customer_owned_ip_on_launch: false,
         enable_dns64: false,
         private_dns_hostname_type: "ip-name".to_string(),
+        ipv6_cidr_block: None,
     }
+}
+
+/// Deterministic association id for a subnet's IPv6 CIDR.
+fn subnet_ipv6_assoc_id(subnet_id: &str) -> String {
+    format!("subnet-cidr-assoc-ipv6-{}", &subnet_id[7..])
 }
 
 fn default_az(req: &AwsRequest) -> String {
@@ -107,7 +129,22 @@ pub(crate) fn create_subnet(
         .cloned()
         .unwrap_or_else(|| "10.0.0.0/24".to_string());
     let az = default_az(req);
-    let subnet = build_subnet(vpc_id, cidr, &az, false);
+    let mut subnet = build_subnet(vpc_id, cidr, &az, false);
+    // CreateSubnet may carry an IPv6 CIDR; the resource then waits for the
+    // association to appear in DescribeSubnets.
+    if let Some(ipv6) = req.query_params.get("Ipv6CidrBlock") {
+        if !ipv6.is_empty() {
+            subnet.ipv6_cidr_block = Some(ipv6.clone());
+        }
+    }
+    if req
+        .query_params
+        .get("AssignIpv6AddressOnCreation")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+    {
+        subnet.assign_ipv6_address_on_creation = true;
+    }
     let id = subnet.subnet_id.clone();
     let owner = req.account_id.clone();
     let region = req.region.clone();
@@ -282,6 +319,14 @@ fn subnet_matches(s: &Subnet, tags: &[Tag], filters: &[Filter]) -> bool {
             "availability-zone" => vec![s.availability_zone.clone()],
             "state" => vec![s.state.clone()],
             "default-for-az" => vec![s.default_for_az.to_string()],
+            "ipv6-cidr-block-association.association-id" => s
+                .ipv6_cidr_block
+                .as_ref()
+                .map(|_| vec![subnet_ipv6_assoc_id(&s.subnet_id)])
+                .unwrap_or_default(),
+            "ipv6-cidr-block-association.ipv6-cidr-block" => {
+                s.ipv6_cidr_block.clone().into_iter().collect()
+            }
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
@@ -343,8 +388,16 @@ pub(crate) fn associate_subnet_cidr_block(
         .get("Ipv6CidrBlock")
         .cloned()
         .unwrap_or_else(|| "2600:1f00::/64".to_string());
-    let assoc_id = gen_id("subnet-cidr-assoc");
-    let _ = svc;
+    let assoc_id = subnet_ipv6_assoc_id(&subnet_id);
+    // Persist on the subnet so DescribeSubnets reports the association; the
+    // resource waits for it via the returned association id.
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        if let Some(s) = state.subnets.get_mut(&subnet_id) {
+            s.ipv6_cidr_block = Some(ipv6.clone());
+        }
+    }
     let body = format!(
         "{}<ipv6CidrBlockAssociation>{}{}<ipv6CidrBlockState><state>associated</state></ipv6CidrBlockState></ipv6CidrBlockAssociation>",
         ec2_elem("subnetId", &subnet_id),

--- a/crates/fakecloud-ec2/src/service/vpc.rs
+++ b/crates/fakecloud-ec2/src/service/vpc.rs
@@ -65,15 +65,17 @@ pub(crate) fn vpc_xml(vpc: &Vpc, tags: &[Tag], owner_id: &str) -> String {
 
 /// Deterministic Amazon-style IPv6 /56 for a VPC. Real Amazon CIDRs come from
 /// `2600:1f00::/24`; we derive a stable suffix from the VPC id so reads are
-/// consistent.
+/// consistent. A /56 puts the network boundary at the high byte of the 4th
+/// hextet, so the low byte (and everything after) MUST be zero — otherwise the
+/// CIDR has host bits set and Terraform's `cidrsubnet()` rejects it.
 fn generated_ipv6_cidr(vpc_id: &str) -> String {
     let h = vpc_id
         .bytes()
         .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
     format!(
-        "2600:1f16:{:04x}:{:04x}::/56",
+        "2600:1f16:{:04x}:{:02x}00::/56",
         (h >> 16) & 0xffff,
-        h & 0xffff
+        h & 0xff
     )
 }
 

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -104,6 +104,11 @@ pub struct Subnet {
     pub enable_dns64: bool,
     /// `ip-name` | `resource-name`.
     pub private_dns_hostname_type: String,
+    /// IPv6 /64 associated with the subnet (via CreateSubnet `Ipv6CidrBlock` or
+    /// AssociateSubnetCidrBlock). Reported in the `ipv6CidrBlockAssociationSet`;
+    /// the `aws_subnet` resource waits for this association.
+    #[serde(default)]
+    pub ipv6_cidr_block: Option<String>,
 }
 
 /// A CIDR reservation within a subnet.

--- a/crates/fakecloud-lambda/src/extras/runtime.rs
+++ b/crates/fakecloud-lambda/src/extras/runtime.rs
@@ -74,11 +74,17 @@ impl LambdaService {
         state
             .runtime_management
             .insert(format!("{function_name}:{qualifier}"), cfg.clone());
-        ok(json!({
+        let mut resp = json!({
             "FunctionArn": Arn::new("lambda", &state.region, &state.account_id, &format!("function:{function_name}:{qualifier}")).to_string(),
             "UpdateRuntimeOn": cfg.update_runtime_on,
-            "RuntimeVersionArn": cfg.runtime_version_arn,
-        }))
+        });
+        // RuntimeVersionArn is an ARN-typed field; an empty value fails the
+        // SDK's client-side ARN validation, so omit it when unset (Auto /
+        // FunctionUpdate modes carry no pinned runtime version).
+        if !cfg.runtime_version_arn.is_empty() {
+            resp["RuntimeVersionArn"] = json!(cfg.runtime_version_arn);
+        }
+        ok(resp)
     }
 
     pub(super) fn get_runtime_management(
@@ -97,14 +103,17 @@ impl LambdaService {
                     update_runtime_on: "Auto".to_string(),
                     runtime_version_arn: String::new(),
                 });
-            ok(json!({
+            let mut resp = json!({
                 "FunctionArn": format!(
                     "arn:aws:lambda:{}:{}:function:{}:{}",
                     state.region, state.account_id, function_name, qualifier
                 ),
                 "UpdateRuntimeOn": cfg.update_runtime_on,
-                "RuntimeVersionArn": cfg.runtime_version_arn,
-            }))
+            });
+            if !cfg.runtime_version_arn.is_empty() {
+                resp["RuntimeVersionArn"] = json!(cfg.runtime_version_arn);
+            }
+            ok(resp)
         })
     }
 }

--- a/crates/fakecloud-lambda/src/service/publish.rs
+++ b/crates/fakecloud-lambda/src/service/publish.rs
@@ -185,9 +185,15 @@ impl LambdaService {
         if !func.file_system_configs.is_empty() {
             config["FileSystemConfigs"] = json!(func.file_system_configs);
         }
-        if let Some(ref lg) = func.logging_config {
-            config["LoggingConfig"] = lg.clone();
-        }
+        // Every function has a LoggingConfig: AWS defaults it to Text format
+        // delivering to `/aws/lambda/<name>`. The Terraform resource asserts a
+        // populated `logging_config` block even when the caller set none.
+        config["LoggingConfig"] = func.logging_config.clone().unwrap_or_else(|| {
+            json!({
+                "LogFormat": "Text",
+                "LogGroup": format!("/aws/lambda/{}", func.function_name),
+            })
+        });
         if let Some(ref ic) = func.image_config {
             config["ImageConfigResponse"] = json!({ "ImageConfig": ic });
         }

--- a/crates/fakecloud-lambda/src/service_permissions.rs
+++ b/crates/fakecloud-lambda/src/service_permissions.rs
@@ -69,6 +69,10 @@ impl LambdaService {
             .get("SourceAccount")
             .and_then(|v| v.as_str())
             .map(str::to_string);
+        let event_source_token = body
+            .get("EventSourceToken")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
 
         // `Qualifier` scopes the policy to a specific numbered version
         // snapshot. AWS keeps a separate resource policy per qualifier
@@ -133,11 +137,18 @@ impl LambdaService {
         if let Some(arn) = source_arn.as_ref() {
             condition.insert("ArnLike".to_string(), json!({ "aws:SourceArn": arn }));
         }
+        // SourceAccount and EventSourceToken both surface as `StringEquals`
+        // condition keys; AWS merges them into one operator block, and the
+        // Terraform resource reads `event_source_token` back from here.
+        let mut string_equals = serde_json::Map::new();
         if let Some(acct) = source_account.as_ref() {
-            condition.insert(
-                "StringEquals".to_string(),
-                json!({ "aws:SourceAccount": acct }),
-            );
+            string_equals.insert("aws:SourceAccount".to_string(), json!(acct));
+        }
+        if let Some(token) = event_source_token.as_ref() {
+            string_equals.insert("lambda:EventSourceToken".to_string(), json!(token));
+        }
+        if !string_equals.is_empty() {
+            condition.insert("StringEquals".to_string(), Value::Object(string_equals));
         }
 
         // Store the Action verbatim — AWS round-trips whatever string

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -494,17 +494,19 @@ pub const SERVICES: &[Service] = &[
         // versions (+ data source, now returning LayerArn on read), aliases
         // (response is rendered in the AWS wire shape and routing config clears
         // on removal), the function data source ($LATEST-qualified arn lineage
-        // via ListVersionsByFunction), and event-invoke config (optional
-        // MaximumEventAgeInSeconds). The `aws_lambda_function` /
-        // `aws_lambda_permission` resources and the functions/runtime-config
-        // data sources share a VPC scaffold that needs Amazon-provided IPv6
-        // CIDR generation (an EC2 feature) and are deferred; code-signing needs
-        // the AWS Signer service.
+        // via ListVersionsByFunction), event-invoke config (optional
+        // MaximumEventAgeInSeconds), and now the core function resource +
+        // permission + functions data source. The function VPC scaffold rides
+        // on the EC2 VPC/subnet IPv6 generation, the security-group all-traffic
+        // port representation, and a default LoggingConfig. RuntimeManagement
+        // config is deferred (its CheckDestroy reads an unset id attribute);
+        // code-signing needs the AWS Signer service.
         run_regex: concat!(
             "^TestAccLambda(",
             "FunctionURL|FunctionURLDataSource",
             "|LayerVersion|LayerVersionDataSource|ProvisionedConcurrencyConfig",
             "|Alias|FunctionDataSource|FunctionEventInvokeConfig",
+            "|Function|Permission|FunctionsDataSource",
             ")_basic$",
         ),
         deny: &[],
@@ -805,6 +807,7 @@ pub const SHARDS: &[Shard] = &[
             "FunctionURL|FunctionURLDataSource",
             "|LayerVersion|LayerVersionDataSource|ProvisionedConcurrencyConfig",
             "|Alias|FunctionDataSource|FunctionEventInvokeConfig",
+            "|Function|Permission|FunctionsDataSource",
             ")_basic$",
         ),
         extra_deny: &[],


### PR DESCRIPTION
## Summary

Reclaims the Lambda **function** resource + **permission** + **functions data source** by completing the EC2 VPC scaffold they provision and a few Lambda response fields. (Builds on B6's VPC IPv6 work.)

**lambda**
- `AddPermission` round-trips `EventSourceToken` as a `StringEquals` condition key (`lambda:EventSourceToken`), so the resource imports cleanly.
- `GetFunctionConfiguration` always returns a `LoggingConfig`: AWS defaults it to Text format delivering to `/aws/lambda/<name>`, which the resource asserts even when the caller set none.
- `Get`/`PutRuntimeManagementConfig` omit `RuntimeVersionArn` when unset (the ARN-typed field fails the SDK's client-side validation on an empty value).

**ec2** (completes the function's VPC scaffold)
- The generated VPC IPv6 /56 now zeroes the host bits at the /56 boundary, so Terraform's `cidrsubnet()` accepts it when carving subnet /64s.
- Subnets carry an IPv6 CIDR (via `CreateSubnet Ipv6CidrBlock` or `AssociateSubnetCidrBlock`), reported in the `ipv6CidrBlockAssociationSet` and filterable by `ipv6-cidr-block-association.association-id`; `assignIpv6AddressOnCreation` is emitted on `DescribeSubnets` so the resource's update waiter completes.
- Security-group rules for the all-traffic protocol (`-1`) omit `FromPort`/`ToPort`, matching AWS — emitting `-1` left `aws_security_group` with a perpetual port diff.

### tfacc allow-list re-widened
- lambda shard: add `Function`, `Permission`, `FunctionsDataSource`
- deferred: `RuntimeManagementConfig` (CheckDestroy reads an unset id attribute); `CodeSigningConfig` (needs AWS Signer)

## Test plan
- New E2E: lambda default LoggingConfig + permission event-source-token; ec2 subnet IPv6 association + assign-on-creation round-trip + security-group all-traffic port omission.
- `go test` green locally: LambdaFunction/Permission/FunctionsDataSource, plus a full 12-test EC2 VPC regression sweep (no regression from the SG/subnet changes).
- `cargo test -p fakecloud-ec2` (54) + `-p fakecloud-lambda` (207), `cargo clippy --all-targets`, `cargo fmt`, doc-counts pass.
- tfacc matrix on this PR is the end-to-end gate.

Adds a `Subnet.ipv6_cidr_block` state field (serde-default, backward compatible). No new public API surface; no SDK change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables Lambda Function, Permission, and Functions data source by completing the EC2 VPC/subnet IPv6 scaffold and aligning Lambda responses with AWS defaults. Fixes SG all-traffic port rendering and VPC IPv6 generation so the Lambda VPC setup converges.

- **New Features**
  - Subnets support IPv6 CIDR on create/associate, expose `ipv6CidrBlockAssociationSet`, filter by `ipv6-cidr-block-association.association-id`, and return `assignIpv6AddressOnCreation` (adds `Subnet.ipv6_cidr_block`, backward compatible).
  - `GetFunctionConfiguration` always returns a default LoggingConfig (Text, `/aws/lambda/<name>`).
  - tfacc allowlist widened to include `Function`, `Permission`, and `FunctionsDataSource`.

- **Bug Fixes**
  - Generated VPC IPv6 `/56` zeroes host bits so `cidrsubnet()` works when carving `/64`s.
  - SG rules with protocol `-1` omit `FromPort`/`ToPort`, matching AWS (`aws_security_group` no longer diffs).
  - `AddPermission` round-trips `EventSourceToken` as `StringEquals` → `lambda:EventSourceToken`; runtime management APIs omit empty `RuntimeVersionArn`.

<sup>Written for commit 09ee06fe7a86930cbf92885430dcf99cce167ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

