### PR TITLE
feat(rds): bring RDS into tfacc via DB subnet group network types

### DIFF
--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -1807,3 +1807,30 @@ async fn rds_restore_db_instance_to_point_in_time_clones_data() {
     let value: String = row.get(0);
     assert_eq!(value, "instance-pit-payload");
 }
+
+#[tokio::test]
+async fn rds_subnet_group_reports_supported_network_types() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_subnet_group()
+        .db_subnet_group_name("sg-net")
+        .db_subnet_group_description("d")
+        .subnet_ids("subnet-aaaa1111")
+        .subnet_ids("subnet-bbbb2222")
+        .send()
+        .await
+        .unwrap();
+
+    let described = client
+        .describe_db_subnet_groups()
+        .db_subnet_group_name("sg-net")
+        .send()
+        .await
+        .unwrap();
+    let g = &described.db_subnet_groups()[0];
+    assert_eq!(g.subnet_group_status(), Some("Complete"));
+    // The aws_db_subnet_group resource asserts supported_network_types = [IPV4].
+    assert_eq!(g.supported_network_types(), &["IPV4".to_string()]);
+}

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -1546,7 +1546,8 @@ pub(crate) fn db_subnet_group_xml(subnet_group: &DbSubnetGroup) -> String {
          <VpcId>{}</VpcId>\
          <SubnetGroupStatus>Complete</SubnetGroupStatus>\
          <Subnets>{}</Subnets>\
-         <DBSubnetGroupArn>{}</DBSubnetGroupArn>",
+         <DBSubnetGroupArn>{}</DBSubnetGroupArn>\
+         <SupportedNetworkTypes><member>IPV4</member></SupportedNetworkTypes>",
         xml_escape(&subnet_group.db_subnet_group_name),
         xml_escape(&subnet_group.db_subnet_group_description),
         xml_escape(&subnet_group.vpc_id),

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -541,6 +541,18 @@ pub const SERVICES: &[Service] = &[
         deny: &[],
     },
     Service {
+        name: "rds",
+        // RDS control-plane resources that need no DB engine container. The DB
+        // subnet group now reports `supported_network_types = [IPV4]` and a
+        // `Complete` status. Parameter/option/cluster-parameter groups are
+        // deferred: their go-acceptance Modify-then-Describe round-trip returns
+        // empty parameters/groups even though the same calls succeed via the
+        // AWS CLI (a request-handling discrepancy still under investigation).
+        // DB instances/clusters need Docker and stay out.
+        run_regex: "^TestAccRDSSubnetGroup_basic$",
+        deny: &[],
+    },
+    Service {
         name: "elasticache",
         // Control-plane resources that don't need a cache container: users,
         // user groups (+ association), and subnet groups (+ data sources).
@@ -834,6 +846,12 @@ pub const SHARDS: &[Shard] = &[
             "|DefaultSecurityGroup|DefaultNetworkACL|Route)",
             ")_basic$",
         ),
+        extra_deny: &[],
+    },
+    Shard {
+        name: "rds",
+        service: "rds",
+        run_regex: "^TestAccRDSSubnetGroup_basic$",
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -98,6 +98,11 @@ async fn elasticache_acceptance() {
 }
 
 #[tokio::test]
+async fn rds_acceptance() {
+    run_shard("rds").await;
+}
+
+#[tokio::test]
 async fn cloudfront_acceptance() {
     run_shard("cloudfront").await;
 }


### PR DESCRIPTION
## Summary

Adds RDS to the tfacc acceptance suite (new service shard) with the DB subnet group reclaimed.

- `DescribeDBSubnetGroups` now reports `SupportedNetworkTypes = [IPV4]` and the `Complete` status, which the `aws_db_subnet_group` resource asserts.
- New `rds` service + shard + `rds_acceptance` test fn running `TestAccRDSSubnetGroup_basic`.

**Deferred (honest):** parameter / option / cluster-parameter groups. Their go-acceptance Modify-then-Describe round-trip reads back empty parameters/groups, even though the identical calls succeed via the AWS CLI **and** the Rust-SDK E2E suite (`rds_parameter_group` tests pass). That points to a go-provider-specific request-handling quirk, not a fakecloud behavior bug — needs deeper investigation before enabling. DB instances/clusters need Docker.

## Test plan
- New E2E: `rds_subnet_group_reports_supported_network_types`.
- `TestAccRDSSubnetGroup_basic` green locally against a running fakecloud.
- `cargo test -p fakecloud-rds` (222), `cargo clippy --all-targets`, `cargo fmt`, doc-counts pass.
- tfacc matrix on this PR is the end-to-end gate.

No new public API surface; no SDK change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings RDS into the `fakecloud-tfacc` acceptance suite via DB subnet groups. `DescribeDBSubnetGroups` now returns `SupportedNetworkTypes=[IPV4]` and `Complete`, enabling the Terraform `aws_db_subnet_group` test to pass.

- **New Features**
  - Added `rds` service and shard in `fakecloud-tfacc`; runs `TestAccRDSSubnetGroup_basic` via `rds_acceptance`.
  - RDS subnet group XML now includes `<SupportedNetworkTypes><member>IPV4</member></SupportedNetworkTypes>`.
  - New E2E test: `rds_subnet_group_reports_supported_network_types`.
  - Deferred: parameter/option/cluster-parameter groups (Go provider readback quirk); DB instances/clusters remain out (need Docker).

<sup>Written for commit ab5cffaadfa7ffe126adb5a9745a361a4949a522. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

