### PR TITLE
fix(iam): canonical service-linked-role names + seed default SLRs

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -162,9 +162,11 @@ async fn iam_roles() {
         .unwrap();
     assert_eq!(resp.role().unwrap().role_name(), "test-role");
 
-    // List
+    // List — the account also ships the default service-linked roles AWS
+    // auto-creates, so assert the created role is present rather than an
+    // exact count.
     let resp = client.list_roles().send().await.unwrap();
-    assert_eq!(resp.roles().len(), 1);
+    assert!(resp.roles().iter().any(|r| r.role_name() == "test-role"));
 
     // Delete
     client
@@ -174,8 +176,9 @@ async fn iam_roles() {
         .await
         .unwrap();
 
+    // The created role is gone; only the default service-linked roles remain.
     let resp = client.list_roles().send().await.unwrap();
-    assert_eq!(resp.roles().len(), 0);
+    assert!(resp.roles().iter().all(|r| r.role_name() != "test-role"));
 }
 
 #[tokio::test]
@@ -3658,4 +3661,34 @@ async fn iam_attach_aws_managed_policy_round_trips() {
 
     let gp = client.get_policy().policy_arn(arn).send().await.unwrap();
     assert_eq!(gp.policy().unwrap().attachment_count(), Some(1));
+}
+
+#[tokio::test]
+async fn iam_service_linked_role_canonical_name() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    // The Inspector SLR name is not a naive capitalisation of the principal.
+    let resp = client
+        .create_service_linked_role()
+        .aws_service_name("inspector.amazonaws.com")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.role().unwrap().role_name(),
+        "AWSServiceRoleForAmazonInspector"
+    );
+}
+
+#[tokio::test]
+async fn iam_account_seeds_default_service_linked_roles() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    // A fresh account lists the default SLRs AWS auto-creates.
+    let resp = client.list_roles().send().await.unwrap();
+    let names: Vec<&str> = resp.roles().iter().map(|r| r.role_name()).collect();
+    assert!(names.contains(&"AWSServiceRoleForSupport"));
+    assert!(names.contains(&"AWSServiceRoleForTrustedAdvisor"));
 }

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -80,6 +80,32 @@ fn derive_service_linked_role_name(aws_service_name: &str, custom_suffix: Option
         "elasticbeanstalk" => "ElasticBeanstalk".to_string(),
         "elasticloadbalancing" => "ElasticLoadBalancing".to_string(),
         "elasticmapreduce" => "ElasticMapReduce".to_string(),
+        // Documented service-linked-role suffixes that don't follow the
+        // title-case-the-principal rule. AWS mints `AWSServiceRoleFor<Suffix>`
+        // with these exact spellings; deriving them mechanically would produce
+        // wrong names (e.g. `inspector` -> `AmazonInspector`).
+        "inspector" => "AmazonInspector".to_string(),
+        "inspector2" => "AmazonInspector2".to_string(),
+        "ec2" | "ec2-instance-connect" => "EC2InstanceConnect".to_string(),
+        "ssm" => "AmazonSSM".to_string(),
+        "rds" => "RDS".to_string(),
+        "elasticache" => "ElastiCache".to_string(),
+        "ecs" => "ECS".to_string(),
+        "eks" => "AmazonEKS".to_string(),
+        " eks-nodegroup" | "eks-nodegroup" => "AmazonEKSNodegroup".to_string(),
+        "opensearchservice" => "AmazonOpenSearchService".to_string(),
+        "es" => "AmazonElasticsearchService".to_string(),
+        "guardduty" => "AmazonGuardDuty".to_string(),
+        "macie" => "AmazonMacie".to_string(),
+        "config" => "Config".to_string(),
+        "cloudtrail" => "CloudTrail".to_string(),
+        "organizations" => "Organizations".to_string(),
+        "sso" => "SSO".to_string(),
+        "kafka" => "Kafka".to_string(),
+        "globalaccelerator" => "GlobalAccelerator".to_string(),
+        "dynamodb" => "DynamoDBReplication".to_string(),
+        "lakeformation" => "LakeFormationDataAccess".to_string(),
+        "s3" => "S3StorageLens".to_string(),
         s if s.contains('.') => {
             let parts: Vec<&str> = s.splitn(2, '.').collect();
             let prefix = parts[0];

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -1634,11 +1634,13 @@ fn get_account_authorization_details_paginates_by_marker() {
             .unwrap();
     }
 
-    // First page of 2 users is truncated and carries a Marker.
+    // First page of 2 users is truncated and carries a Marker. Scope to
+    // `Filter=User` so the default service-linked roles every account ships
+    // don't interleave with the users this test paginates.
     let resp = svc
         .get_account_authorization_details(&make_request(
             "GetAccountAuthorizationDetails",
-            vec![("MaxItems", "2")],
+            vec![("MaxItems", "2"), ("Filter.member.1", "User")],
         ))
         .unwrap();
     let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
@@ -1653,7 +1655,11 @@ fn get_account_authorization_details_paginates_by_marker() {
     let resp = svc
         .get_account_authorization_details(&make_request(
             "GetAccountAuthorizationDetails",
-            vec![("MaxItems", "2"), ("Marker", &marker)],
+            vec![
+                ("MaxItems", "2"),
+                ("Marker", &marker),
+                ("Filter.member.1", "User"),
+            ],
         ))
         .unwrap();
     let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();

--- a/crates/fakecloud-iam/src/state.rs
+++ b/crates/fakecloud-iam/src/state.rs
@@ -430,7 +430,7 @@ pub struct OrganizationsAccessReport {
 
 impl IamState {
     pub fn new(account_id: &str) -> Self {
-        Self {
+        let mut state = Self {
             account_id: account_id.to_string(),
             users: BTreeMap::new(),
             access_keys: BTreeMap::new(),
@@ -465,6 +465,42 @@ impl IamState {
             global_endpoint_token_version: None,
             delegation_requests: BTreeMap::new(),
             outbound_web_identity_federation_enabled: false,
+        };
+        state.seed_default_service_linked_roles();
+        state
+    }
+
+    /// AWS accounts ship with a handful of service-linked roles created
+    /// automatically (Support, Trusted Advisor, ...). `aws_iam_roles` and other
+    /// callers expect a non-empty `ListRoles` on a fresh account, so seed them.
+    fn seed_default_service_linked_roles(&mut self) {
+        let now = Utc::now();
+        for (service, name) in [
+            ("support.amazonaws.com", "AWSServiceRoleForSupport"),
+            (
+                "trustedadvisor.amazonaws.com",
+                "AWSServiceRoleForTrustedAdvisor",
+            ),
+        ] {
+            let path = format!("/aws-service-role/{service}/");
+            let arn = format!("arn:aws:iam::{}:role{}{}", self.account_id, path, name);
+            self.roles.insert(
+                name.to_string(),
+                IamRole {
+                    role_name: name.to_string(),
+                    role_id: format!("AROA{:0>17}", name.len()),
+                    arn,
+                    path,
+                    assume_role_policy_document: format!(
+                        "{{\"Version\":\"2012-10-17\",\"Statement\":[{{\"Effect\":\"Allow\",\"Principal\":{{\"Service\":\"{service}\"}},\"Action\":\"sts:AssumeRole\"}}]}}"
+                    ),
+                    created_at: now,
+                    description: None,
+                    max_session_duration: 3600,
+                    tags: Vec::new(),
+                    permissions_boundary: None,
+                },
+            );
         }
     }
 

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -344,18 +344,12 @@ pub const SERVICES: &[Service] = &[
             //          Needs the policy simulator to track which statement
             //          produced each decision. ---
             "TestAccIAMPrincipalPolicySimulationDataSource_basic",
-            // --- gap: the data source lists existing roles and asserts the
-            //          account is non-empty. Real accounts always carry
-            //          AWS-managed service-linked roles; fakecloud seeds none,
-            //          so a fresh account lists zero. Seeding default SLRs would
-            //          perturb other tests' exact role counts, so deferred. ---
-            "TestAccIAMRolesDataSource_basic",
-            // --- gap: CreateServiceLinkedRole derives the role name by naive
-            //          capitalisation (AWSServiceRoleForinspector) instead of
-            //          AWS's per-service canonical name
-            //          (AWSServiceRoleForAmazonInspector). Needs a
-            //          service-principal -> SLR-name mapping table. ---
-            "TestAccIAMServiceLinkedRole_basic",
+            // (RolesDataSource now passes: accounts seed the default
+            //  AWSServiceRoleForSupport / TrustedAdvisor service-linked roles
+            //  like real AWS, so a fresh ListRoles is non-empty.)
+            // (ServiceLinkedRole now passes: CreateServiceLinkedRole maps the
+            //  service principal to AWS's canonical SLR name via a documented
+            //  table — e.g. inspector -> AWSServiceRoleForAmazonInspector.)
         ],
     },
     Service {


### PR DESCRIPTION
## Summary

Reclaims two IAM tfacc tests.

- **ServiceLinkedRole**: `CreateServiceLinkedRole` maps the service principal to AWS's canonical SLR name via a documented table (e.g. `inspector.amazonaws.com` -> `AWSServiceRoleForAmazonInspector`) instead of the previous naive capitalisation (`AWSServiceRoleForinspector`).
- **RolesDataSource**: every IAM account now seeds the default service-linked roles AWS auto-creates (`AWSServiceRoleForSupport`, `AWSServiceRoleForTrustedAdvisor`), so a fresh `ListRoles` is non-empty — which the `aws_iam_roles` data source asserts.

Two unit/e2e tests that assumed an empty fresh account (exact role counts) are updated to assert presence rather than count, matching AWS.

**Verified no regression:** IAM conformance (45 actions incl. `ListRoles` / `GetAccountAuthorizationDetails`) green; iam tfacc role-family tests (Role, RoleDataSource, RolePolicy, InstanceProfile, RolesDataSource, ServiceLinkedRole) all pass.

**Deferred:** `PrincipalPolicySimulation` — needs the policy simulator to track per-statement provenance (`source_policy_id` / `source_policy_type`); its own batch.

## Test plan
- New E2E: canonical Inspector SLR name; default-SLR seeding visible via `ListRoles`.
- `go test` green: IAMServiceLinkedRole, IAMRolesDataSource (+ role-family regression sweep).
- `cargo test -p fakecloud-iam` (492), iam E2E (76), iam conformance (45), `cargo clippy`, `cargo fmt`, doc-counts pass.
- tfacc matrix on this PR is the end-to-end gate.

No new public API surface; no SDK change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns IAM behavior with AWS by using canonical service-linked role names and seeding default SLRs (Support, Trusted Advisor) so a fresh ListRoles is non-empty. Re-enables the ServiceLinkedRole and RolesDataSource tfacc tests.

- **Bug Fixes**
  - CreateServiceLinkedRole maps service principals to AWS’s canonical SLR names (e.g., inspector -> AWSServiceRoleForAmazonInspector).
  - Seed default SLRs on new accounts; tests assert presence instead of counts; scope GetAccountAuthorizationDetails pagination to Filter=User.
  - Un-deny tfacc allowlist entries for RolesDataSource and ServiceLinkedRole; conformance and role-family tests pass.

<sup>Written for commit fc3e2106133360946b69b7d4100350e6a91645f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

