### PR TITLE
fix(route53): private-zone VPC association

### DIFF
--- a/crates/fakecloud-e2e/tests/route53_vpc_delegation_geo_tags.rs
+++ b/crates/fakecloud-e2e/tests/route53_vpc_delegation_geo_tags.rs
@@ -66,10 +66,13 @@ async fn vpc_association_lifecycle() {
         .send()
         .await
         .expect("list by vpc");
+    // ListHostedZonesByVPC reports the bare zone id (no `/hostedzone/` prefix),
+    // matching AWS; the create response carries the prefixed form.
+    let bare_zone = zone.trim_start_matches("/hostedzone/");
     assert!(by_vpc
         .hosted_zone_summaries()
         .iter()
-        .any(|s| s.hosted_zone_id() == zone));
+        .any(|s| s.hosted_zone_id() == bare_zone));
 
     // Disassociate the second VPC (still leaves vpc-aaaa).
     r53.disassociate_vpc_from_hosted_zone()
@@ -422,4 +425,39 @@ async fn tags_for_unknown_resource_errors() {
         .send()
         .await;
     assert!(bad.is_err(), "unknown hosted zone tag list must fail");
+}
+
+#[tokio::test]
+async fn create_zone_with_vpc_is_implicitly_private_with_name_servers() {
+    let server = TestServer::start().await;
+    let r53 = server.route53_client().await;
+
+    // Providing a VPC (without setting private_zone) makes the zone private,
+    // and a private zone still carries NS records the provider reads.
+    let created = r53
+        .create_hosted_zone()
+        .name("implicit-private.example.com")
+        .caller_reference("impl-1")
+        .vpc(vpc("vpc-cccc"))
+        .send()
+        .await
+        .expect("zone");
+    assert_eq!(
+        created
+            .hosted_zone()
+            .unwrap()
+            .config()
+            .unwrap()
+            .private_zone(),
+        true
+    );
+    let zone_id = created.hosted_zone().unwrap().id().to_string();
+
+    let got = r53
+        .get_hosted_zone()
+        .id(&zone_id)
+        .send()
+        .await
+        .expect("get zone");
+    assert!(!got.delegation_set().unwrap().name_servers().is_empty());
 }

--- a/crates/fakecloud-e2e/tests/route53_vpc_delegation_geo_tags.rs
+++ b/crates/fakecloud-e2e/tests/route53_vpc_delegation_geo_tags.rs
@@ -442,15 +442,12 @@ async fn create_zone_with_vpc_is_implicitly_private_with_name_servers() {
         .send()
         .await
         .expect("zone");
-    assert_eq!(
-        created
-            .hosted_zone()
-            .unwrap()
-            .config()
-            .unwrap()
-            .private_zone(),
-        true
-    );
+    assert!(created
+        .hosted_zone()
+        .unwrap()
+        .config()
+        .unwrap()
+        .private_zone());
     let zone_id = created.hosted_zone().unwrap().id().to_string();
 
     let got = r53

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -963,10 +963,9 @@ impl Route53Service {
         body.push_str("<HostedZoneSummaries>");
         for (id, name) in &summaries {
             body.push_str("<HostedZoneSummary>");
-            body.push_str(&format!(
-                "<HostedZoneId>/hostedzone/{}</HostedZoneId>",
-                esc(id)
-            ));
+            // HostedZoneId in a summary is the bare id (no `/hostedzone/`
+            // prefix); the SDK validates the id pattern and rejects the prefix.
+            body.push_str(&format!("<HostedZoneId>{}</HostedZoneId>", esc(id)));
             body.push_str(&format!("<Name>{}</Name>", esc(name)));
             body.push_str("<Owner>");
             body.push_str(&format!("<OwningAccount>{DEFAULT_ACCOUNT}</OwningAccount>",));

--- a/crates/fakecloud-route53/src/service/hosted_zones.rs
+++ b/crates/fakecloud-route53/src/service/hosted_zones.rs
@@ -19,14 +19,16 @@ impl Route53Service {
         if !name.ends_with('.') {
             name.push('.');
         }
-        let private_zone = cfg
-            .hosted_zone_config
-            .as_ref()
-            .and_then(|c| c.private_zone)
-            .unwrap_or(false);
-        if private_zone && cfg.vpc.is_none() {
-            return Err(invalid_argument("Private hosted zone must include a VPC"));
-        }
+        // A hosted zone is private iff it is created with a VPC association.
+        // AWS treats `HostedZoneConfig.PrivateZone` as a read-only output, not
+        // an input — supplying a VPC is what makes the zone private — so don't
+        // require the caller to set it.
+        let private_zone = cfg.vpc.is_some()
+            || cfg
+                .hosted_zone_config
+                .as_ref()
+                .and_then(|c| c.private_zone)
+                .unwrap_or(false);
         let comment = cfg
             .hosted_zone_config
             .as_ref()
@@ -55,11 +57,11 @@ impl Route53Service {
         let now = Utc::now();
         let name_servers = synth_name_servers(&id);
         let vpcs = cfg.vpc.into_iter().collect();
-        let default_records = if private_zone {
-            Vec::new()
-        } else {
-            default_zone_records(&name, &name_servers)
-        };
+        // Both public and private hosted zones carry default NS + SOA records.
+        // The Terraform provider reads a private zone's name servers from its
+        // NS record set (findNameServersByZone), so omitting them made the
+        // resource read crash on an empty name-server list.
+        let default_records = default_zone_records(&name, &name_servers);
         let zone = StoredHostedZone {
             id: id.clone(),
             name: name.clone(),

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -114,11 +114,14 @@ pub const SERVICES: &[Service] = &[
         deny: &[
             // (CIDR collection ARN now omits the account id —
             //  `arn:aws:route53:::cidrcollection/...` — so that test runs.)
-            // --- gap: DNSSEC key-signing keys need a computed DS digest_value
-            //     (hex), which fakecloud leaves empty. ---
+            // --- gap: DNSSEC key-signing keys need real DNSSEC crypto derived
+            //     from the referenced KMS key — public_key, dnskey_record,
+            //     ds_record, and the SHA-256 digest_value (keytag + DS digest).
+            //     A focused follow-up. ---
             "TestAccRoute53KeySigningKey_basic",
-            // --- gap: VPC zone association apply path. ---
-            "TestAccRoute53ZoneAssociation_basic",
+            // (Private-zone VPC association now works: a zone created with a VPC
+            //  is private and carries default NS/SOA records, and
+            //  ListHostedZonesByVPC returns a bare HostedZoneId.)
         ],
     },
     Service {


### PR DESCRIPTION
## Summary

Reclaims `Route53ZoneAssociation`.

- A hosted zone created **with a VPC** is now implicitly **private** (AWS treats `HostedZoneConfig.PrivateZone` as read-only output; supplying a VPC is what makes a zone private), so `AssociateVPCWithHostedZone` is accepted instead of rejected as a public zone.
- Private zones now carry the default **NS + SOA records** like public zones. The provider reads a private zone's name servers from its NS record set (`findNameServersByZone`); omitting them crashed the resource read on an empty list.
- `ListHostedZonesByVPC` reports the **bare** `HostedZoneId` (no `/hostedzone/` prefix); the SDK validates the id pattern and rejected the prefixed form.

### tfacc allow-list
- un-deny `Route53ZoneAssociation`
- deferred: `Route53KeySigningKey` (needs real DNSSEC crypto from the KMS key: `public_key`, `dnskey_record`, `ds_record`, SHA-256 `digest_value`)

## Test plan
- New E2E: create-zone-with-vpc is implicitly private + has name servers. Updated the existing VPC-association lifecycle assertion for the bare zone id.
- `go test` green: Route53ZoneAssociation + a Zone/Record/HealthCheck/DelegationSet regression sweep.
- `cargo test -p fakecloud-route53` (40), route53 E2E (13 + 13), `cargo clippy`, `cargo fmt`, doc-counts pass.
- tfacc matrix on this PR is the end-to-end gate.

No new public API surface; no SDK change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Route 53 VPC association by matching AWS: zones created with a VPC are implicitly private, private zones include default NS/SOA, and `ListHostedZonesByVPC` returns a bare `HostedZoneId`. This restores the `Route53ZoneAssociation` test in `fakecloud-tfacc`.

- **Bug Fixes**
  - Fixed a clippy lint in tests by using `assert!` instead of `assert_eq!(..., true)`.

<sup>Written for commit 9a0aa9396794e85695bf6eadde4ffc333c4a1a1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

