### PR TITLE
fix(apigatewayv2,logs): integration field round-trip + index-policy identifier

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/service/integrations.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/integrations.rs
@@ -33,6 +33,7 @@ impl ApiGatewayV2Service {
             .to_string();
 
         let integration_uri = body["integrationUri"].as_str().map(|s| s.to_string());
+        let integration_method = body["integrationMethod"].as_str().map(|s| s.to_string());
         let payload_format_version = body["payloadFormatVersion"].as_str().map(|s| s.to_string());
         let timeout_in_millis = body["timeoutInMillis"].as_i64();
         let connection_type = body["connectionType"]
@@ -42,26 +43,54 @@ impl ApiGatewayV2Service {
 
         let integration_id = generate_id("integration");
 
-        let integration = Integration {
-            integration_id: integration_id.clone(),
-            integration_type,
-            integration_uri,
-            payload_format_version,
-            timeout_in_millis,
-            connection_type,
-        };
-
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
         // Verify API exists
-        if !state.apis.contains_key(api_id) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "NotFoundException",
-                format!("API not found: {}", api_id),
-            ));
-        }
+        let protocol_type = match state.apis.get(api_id) {
+            Some(api) => api.protocol_type.clone(),
+            None => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "NotFoundException",
+                    format!("API not found: {}", api_id),
+                ));
+            }
+        };
+
+        // AWS applies a protocol-specific default integration timeout when the
+        // request omits one: 29000ms for WEBSOCKET APIs, 30000ms for HTTP APIs.
+        let is_websocket = protocol_type.eq_ignore_ascii_case("WEBSOCKET");
+
+        let timeout_in_millis =
+            Some(timeout_in_millis.unwrap_or(if is_websocket { 29000 } else { 30000 }));
+
+        // WEBSOCKET integrations report a default response selection expression;
+        // an explicit request value overrides it. HTTP APIs leave it unset.
+        let integration_response_selection_expression = body
+            ["integrationResponseSelectionExpression"]
+            .as_str()
+            .map(|s| s.to_string())
+            .or_else(|| is_websocket.then(|| "${integration.response.statuscode}".to_string()));
+
+        // WEBSOCKET integrations default passthrough_behavior to WHEN_NO_MATCH;
+        // HTTP APIs leave it unset. An explicit request value overrides.
+        let passthrough_behavior = body["passthroughBehavior"]
+            .as_str()
+            .map(|s| s.to_string())
+            .or_else(|| is_websocket.then(|| "WHEN_NO_MATCH".to_string()));
+
+        let integration = Integration {
+            integration_id: integration_id.clone(),
+            integration_type,
+            integration_uri,
+            integration_method,
+            integration_response_selection_expression,
+            passthrough_behavior,
+            payload_format_version,
+            timeout_in_millis,
+            connection_type,
+        };
 
         state
             .integrations
@@ -202,6 +231,14 @@ impl ApiGatewayV2Service {
 
         if let Some(integration_uri) = body["integrationUri"].as_str() {
             integration.integration_uri = Some(integration_uri.to_string());
+        }
+
+        if let Some(integration_method) = body["integrationMethod"].as_str() {
+            integration.integration_method = Some(integration_method.to_string());
+        }
+
+        if let Some(passthrough_behavior) = body["passthroughBehavior"].as_str() {
+            integration.passthrough_behavior = Some(passthrough_behavior.to_string());
         }
 
         if let Some(payload_format_version) = body["payloadFormatVersion"].as_str() {

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -288,6 +288,18 @@ pub struct Integration {
     pub payload_format_version: Option<String>, // "2.0"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_in_millis: Option<i64>,
+    /// HTTP method for an HTTP/HTTP_PROXY integration (e.g. `GET`). Round-tripped
+    /// so the `aws_apigatewayv2_integration` resource doesn't re-plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integration_method: Option<String>,
+    /// Selection expression for the integration response. WEBSOCKET APIs default
+    /// this to `${integration.response.statuscode}`; HTTP APIs leave it unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integration_response_selection_expression: Option<String>,
+    /// Passthrough behavior (`WHEN_NO_MATCH`/`WHEN_NO_TEMPLATES`/`NEVER`).
+    /// WEBSOCKET APIs default to `WHEN_NO_MATCH`; HTTP APIs leave it unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub passthrough_behavior: Option<String>,
     /// "INTERNET" (default) or "VPC_LINK". AWS always reports it, so the
     /// Terraform provider re-plans an integration whose GetIntegration response
     /// omits it.

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
@@ -219,6 +219,18 @@ impl ResourceProvisioner {
                 .get("IntegrationUri")
                 .and_then(|v| v.as_str())
                 .map(String::from),
+            integration_method: props
+                .get("IntegrationMethod")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            integration_response_selection_expression: props
+                .get("IntegrationResponseSelectionExpression")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            passthrough_behavior: props
+                .get("PassthroughBehavior")
+                .and_then(|v| v.as_str())
+                .map(String::from),
             payload_format_version: props
                 .get("PayloadFormatVersion")
                 .and_then(|v| v.as_str())

--- a/crates/fakecloud-e2e/tests/apigatewayv2.rs
+++ b/crates/fakecloud-e2e/tests/apigatewayv2.rs
@@ -379,6 +379,77 @@ async fn test_create_integration() {
 }
 
 #[tokio::test]
+async fn integration_http_api_defaults() {
+    // An HTTP API integration with no timeout reports AWS's 30000ms default and
+    // round-trips integration_method; the WebSocket-only fields stay unset.
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("http-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+    let api_id = api.api_id().unwrap();
+
+    let integration = client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::HttpProxy)
+        .integration_method("GET")
+        .integration_uri("https://example.com")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(integration.timeout_in_millis(), Some(30000));
+    assert_eq!(integration.integration_method(), Some("GET"));
+    assert_eq!(
+        integration.integration_response_selection_expression(),
+        None
+    );
+    assert_eq!(integration.passthrough_behavior(), None);
+}
+
+#[tokio::test]
+async fn integration_websocket_api_defaults() {
+    // A WebSocket API integration defaults timeout to 29000ms and is reported
+    // with the response-selection-expression and passthrough-behavior defaults.
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("ws-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Websocket)
+        .route_selection_expression("$request.body.action")
+        .send()
+        .await
+        .unwrap();
+    let api_id = api.api_id().unwrap();
+
+    let integration = client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::Mock)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(integration.timeout_in_millis(), Some(29000));
+    assert_eq!(
+        integration.integration_response_selection_expression(),
+        Some("${integration.response.statuscode}")
+    );
+    assert_eq!(
+        integration.passthrough_behavior(),
+        Some(&aws_sdk_apigatewayv2::types::PassthroughBehavior::WhenNoMatch)
+    );
+}
+
+#[tokio::test]
 async fn test_get_integration() {
     let server = TestServer::start().await;
     let client = server.apigatewayv2_client().await;

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -2774,3 +2774,47 @@ async fn logs_describe_log_groups_returns_log_group_class() {
         Some(&aws_sdk_cloudwatchlogs::types::LogGroupClass::Standard)
     );
 }
+
+#[tokio::test]
+async fn logs_index_policy_round_trips_without_arn_suffix() {
+    // PutIndexPolicy / DescribeIndexPolicies must report `logGroupIdentifier`
+    // without the `:*` resource suffix that the log-group ARN carries, so the
+    // Terraform resource's `log_group_name` does not force replacement.
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/idx/app")
+        .send()
+        .await
+        .unwrap();
+
+    let doc = r#"{"Fields":["request.method"]}"#;
+    let put = client
+        .put_index_policy()
+        .log_group_identifier("/idx/app")
+        .policy_document(doc)
+        .send()
+        .await
+        .unwrap();
+
+    let put_id = put.index_policy().unwrap().log_group_identifier().unwrap();
+    assert!(
+        !put_id.ends_with(":*"),
+        "logGroupIdentifier must not carry the :* suffix: {put_id}"
+    );
+    assert!(put_id.ends_with("log-group:/idx/app"));
+
+    let described = client
+        .describe_index_policies()
+        .log_group_identifiers("/idx/app")
+        .send()
+        .await
+        .unwrap();
+    let policies = described.index_policies();
+    assert_eq!(policies.len(), 1);
+    let read_id = policies[0].log_group_identifier().unwrap();
+    assert_eq!(read_id, put_id);
+    assert!(!read_id.ends_with(":*"));
+}

--- a/crates/fakecloud-logs/src/service/policies.rs
+++ b/crates/fakecloud-logs/src/service/policies.rs
@@ -559,11 +559,16 @@ impl LogsService {
             });
         }
 
+        // The log-group ARN stored on the group keeps the `:*` resource-suffix;
+        // the index-policy `logGroupIdentifier` reports it without the suffix so
+        // the resource's `log_group_name` round-trips (otherwise the read sees a
+        // `:*`-suffixed identifier and forces replacement).
+        let log_group_identifier = group.arn.trim_end_matches(":*").to_string();
         let result = json!({
             "indexPolicy": {
                 "policyName": policy_name,
                 "policyDocument": policy_document,
-                "logGroupIdentifier": group.arn,
+                "logGroupIdentifier": log_group_identifier,
                 "lastUpdateTime": now,
             }
         });
@@ -601,11 +606,12 @@ impl LogsService {
                 id.to_string()
             };
             if let Some(group) = state.log_groups.get(&group_name) {
+                let log_group_identifier = group.arn.trim_end_matches(":*");
                 for p in &group.index_policies {
                     policies.push(json!({
                         "policyName": p.policy_name,
                         "policyDocument": p.policy_document,
-                        "logGroupIdentifier": group.arn,
+                        "logGroupIdentifier": log_group_identifier,
                         "lastUpdateTime": p.last_updated_time,
                     }));
                 }

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -233,16 +233,19 @@ pub const SERVICES: &[Service] = &[
         // synchronously DEPLOYED, custom domains as AVAILABLE (with a regional
         // endpoint + ipv4), and gave integrations their default
         // `connection_type = INTERNET`, all of which the provider asserts.
-        run_regex: "^TestAccAPIGatewayV2([A-Za-z]+_basic|API_basicHTTP)$",
+        // Batch 13 also restored the integration's `integration_method`,
+        // `integration_response_selection_expression`, and `passthrough_behavior`
+        // fields (the last two with their WEBSOCKET defaults), and gave
+        // integrations their protocol-specific default timeout (29000ms for
+        // WEBSOCKET, 30000ms for HTTP) so the export data source — which renders
+        // the full integration into its OpenAPI document — round-trips cleanly.
+        run_regex:
+            "^TestAccAPIGatewayV2([A-Za-z]+_basic|API_basicHTTP|Integration_basic(HTTP|WebSocket))$",
         deny: &[
             // --- gap: a REQUEST authorizer wires up a real Lambda authorizer
             //     function, which fakecloud cannot stand up without a working
             //     Lambda runtime in this environment. ---
             "TestAccAPIGatewayV2Authorizer_basic",
-            // --- gap: the export data source generates an OpenAPI document
-            //     from the API; fakecloud's export does not yet round-trip
-            //     cleanly against the provider's expectations. ---
-            "TestAccAPIGatewayV2ExportDataSource_basic",
         ],
     },
     Service {
@@ -322,8 +325,6 @@ pub const SERVICES: &[Service] = &[
             //     sources/destinations) is not implemented. ---
             "TestAccLogsDeliveryDestination_basic",
             "TestAccLogsDeliveryDestinationPolicy_basic",
-            // --- gap: field index policies are not implemented. ---
-            "TestAccLogsIndexPolicy_basic",
         ],
     },
     Service {
@@ -663,7 +664,8 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "apigatewayv2",
         service: "apigatewayv2",
-        run_regex: "^TestAccAPIGatewayV2([A-Za-z]+_basic|API_basicHTTP)$",
+        run_regex:
+            "^TestAccAPIGatewayV2([A-Za-z]+_basic|API_basicHTTP|Integration_basic(HTTP|WebSocket))$",
         extra_deny: &[],
     },
     Shard {


### PR DESCRIPTION
## Summary

B13 of the tfacc backlog. Reclaims three acceptance tests by fixing real response-shape gaps (no gaming, no stubs).

**apigatewayv2 integrations** (`crates/fakecloud-apigatewayv2`):
- Round-trip `integration_method` (HTTP method for HTTP/HTTP_PROXY integrations).
- Default `timeout_in_millis` per protocol when omitted: 29000ms WEBSOCKET, 30000ms HTTP.
- Report `integration_response_selection_expression` and `passthrough_behavior` with their WEBSOCKET defaults (`${integration.response.statuscode}` / `WHEN_NO_MATCH`); HTTP APIs leave them unset. Explicit request values override; `UpdateIntegration` honors method/passthrough changes; the CloudFormation provisioner sets all three.
- Unblocks `TestAccAPIGatewayV2ExportDataSource_basic` (it renders the full integration into the OpenAPI document) plus the `Integration_basicHTTP` / `Integration_basicWebSocket` subtests.

**logs index policies** (`crates/fakecloud-logs`):
- `PutIndexPolicy`/`DescribeIndexPolicies` report `logGroupIdentifier` without the `:*` resource suffix the log-group ARN carries, so the resource's `log_group_name` round-trips instead of forcing replacement. Unblocks `TestAccLogsIndexPolicy_basic`.

Allowlist widened: apigatewayv2 regex now includes the Integration HTTP/WebSocket subtests and drops the ExportDataSource deny; logs drops the IndexPolicy deny.

No new public API surface (behavior fixes on existing operations), so no SDK/docs/website/count changes.

## Test plan
- New e2e: `integration_http_api_defaults`, `integration_websocket_api_defaults` (apigatewayv2), `logs_index_policy_round_trips_without_arn_suffix` (logs) — all pass.
- Local tfacc slices green: full apigatewayv2 shard (minus the Lambda-authorizer deny) and full logs shard (minus the unimplemented anomaly/data-protection/delivery denies).
- `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt`, `tfacc_shards` matrix, and `check-doc-counts.sh` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API Gateway V2 integration response shapes and Logs index policy identifiers to match AWS, preventing needless re-plans and restoring Terraform acceptance tests.

- **Bug Fixes**
  - `fakecloud-apigatewayv2`
    - Round-trip `integration_method` for HTTP/HTTP_PROXY integrations.
    - Apply protocol defaults for `timeout_in_millis` when omitted: 30000 (HTTP) and 29000 (WEBSOCKET).
    - Report WebSocket defaults for `integration_response_selection_expression` and `passthrough_behavior`; HTTP leaves both unset.
    - `UpdateIntegration` honors `integration_method` and `passthrough_behavior` changes; `fakecloud-cloudformation` sets these fields.
    - Unblocks TFACC: ExportDataSource_basic and Integration_basicHTTP/WebSocket.
  - `fakecloud-logs`
    - `PutIndexPolicy`/`DescribeIndexPolicies` return `logGroupIdentifier` without the `:*` ARN suffix so `log_group_name` round-trips; unblocks TFACC IndexPolicy_basic.
  - `fakecloud-tfacc`
    - Widened allowlist to include Integration_basic(HTTP|WebSocket) and dropped the IndexPolicy deny.

<sup>Written for commit 3a6e4f309bcb897a7dac8ced61912036df110aae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

