### PR TITLE
fix(cognito): federated identity providers + user-pool domain CloudFront/S3

### DIFF
--- a/crates/fakecloud-cognito/src/service/identity_providers.rs
+++ b/crates/fakecloud-cognito/src/service/identity_providers.rs
@@ -11,8 +11,8 @@ use crate::state::IdentityProvider;
 use crate::state::CognitoState;
 
 use super::{
-    ensure_user_pool_exists, identity_provider_to_json, parse_string_map, require_str,
-    validate_provider_type, CognitoService,
+    default_attribute_mapping, ensure_user_pool_exists, identity_provider_to_json,
+    parse_string_map, require_str, validate_provider_type, CognitoService,
 };
 
 impl CognitoService {
@@ -29,7 +29,12 @@ impl CognitoService {
         validate_provider_type(provider_type)?;
 
         let provider_details = parse_string_map(&body["ProviderDetails"]);
-        let attribute_mapping = parse_string_map(&body["AttributeMapping"]);
+        // Social providers get a default `username` mapping when the caller
+        // omits one, matching Cognito's behavior the Terraform provider asserts.
+        let mut attribute_mapping = parse_string_map(&body["AttributeMapping"]);
+        if attribute_mapping.is_empty() {
+            attribute_mapping = default_attribute_mapping(provider_type);
+        }
         let idp_identifiers = body["IdpIdentifiers"]
             .as_array()
             .map(|arr| {

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1175,6 +1175,21 @@ fn validate_provider_type(provider_type: &str) -> Result<(), AwsServiceError> {
     Ok(())
 }
 
+/// Cognito injects a default `username` attribute mapping for the social
+/// identity providers when the caller does not supply one. The mapped source
+/// attribute is the provider's subject claim: `sub` for Google and Sign in with
+/// Apple, `id` for Facebook, and `user_id` for Login with Amazon. SAML and OIDC
+/// providers have no default mapping.
+fn default_attribute_mapping(provider_type: &str) -> BTreeMap<String, String> {
+    let subject = match provider_type {
+        "Google" | "SignInWithApple" => "sub",
+        "Facebook" => "id",
+        "LoginWithAmazon" => "user_id",
+        _ => return BTreeMap::new(),
+    };
+    BTreeMap::from([("username".to_string(), subject.to_string())])
+}
+
 fn parse_string_map(val: &Value) -> BTreeMap<String, String> {
     val.as_object()
         .map(|obj| {
@@ -1223,20 +1238,44 @@ fn resource_server_to_json(rs: &ResourceServer) -> Value {
 }
 
 fn domain_description_to_json(d: &UserPoolDomain, account_id: &str) -> Value {
+    // Every Cognito hosted-UI domain (prefix or custom) is fronted by a
+    // CloudFront distribution and backed by a managed S3 assets bucket; AWS
+    // reports both on DescribeUserPoolDomain. The Terraform resource surfaces
+    // `cloudfront_distribution`/`cloudfront_distribution_arn` (both from
+    // CloudFrontDistribution) and `s3_bucket`, all of which it asserts are set.
     let mut val = json!({
         "UserPoolId": d.user_pool_id,
         "AWSAccountId": account_id,
         "Domain": d.domain,
         "Status": d.status,
         "Version": "20130630",
+        "CloudFrontDistribution": cloudfront_distribution_domain(&d.domain),
+        "S3Bucket": "aws-cognito-prod-iad-assets",
     });
     if let Some(ref config) = d.custom_domain_config {
         val["CustomDomainConfig"] = json!({
             "CertificateArn": config.certificate_arn,
         });
-        val["CloudFrontDistribution"] = json!(format!("d111111abcdef8.cloudfront.net"));
     }
     val
+}
+
+/// Derive a stable CloudFront distribution domain name for a Cognito hosted-UI
+/// domain. CloudFront domains are `d<13 lowercase base32 chars>.cloudfront.net`;
+/// we hash the Cognito domain so repeated describes return the same value.
+fn cloudfront_distribution_domain(domain: &str) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in domain.bytes() {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz234567";
+    let mut suffix = String::with_capacity(13);
+    for i in 0..13 {
+        let idx = ((hash >> (i * 5)) & 0x1f) as usize % ALPHABET.len();
+        suffix.push(ALPHABET[idx] as char);
+    }
+    format!("d{suffix}.cloudfront.net")
 }
 
 /// Convert a User to the JSON format AWS returns (for ListUsers and AdminCreateUser response).

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -3406,6 +3406,66 @@ async fn cognito_create_describe_identity_provider() {
 }
 
 #[tokio::test]
+async fn cognito_social_provider_default_attribute_mapping() {
+    // A social provider created without an explicit AttributeMapping gets
+    // Cognito's default `username` mapping: `sub` for Google, `id` for Facebook.
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("default-map-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap();
+
+    let google = client
+        .create_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("Google")
+        .provider_type(IdentityProviderTypeType::Google)
+        .provider_details("client_id", "id")
+        .provider_details("client_secret", "secret")
+        .provider_details("authorize_scopes", "email")
+        .send()
+        .await
+        .expect("create google idp");
+    assert_eq!(
+        google
+            .identity_provider()
+            .unwrap()
+            .attribute_mapping()
+            .unwrap()
+            .get("username")
+            .map(String::as_str),
+        Some("sub")
+    );
+
+    let facebook = client
+        .create_identity_provider()
+        .user_pool_id(pool_id)
+        .provider_name("Facebook")
+        .provider_type(IdentityProviderTypeType::Facebook)
+        .provider_details("client_id", "id")
+        .provider_details("client_secret", "secret")
+        .provider_details("authorize_scopes", "email")
+        .send()
+        .await
+        .expect("create facebook idp");
+    assert_eq!(
+        facebook
+            .identity_provider()
+            .unwrap()
+            .attribute_mapping()
+            .unwrap()
+            .get("username")
+            .map(String::as_str),
+        Some("id")
+    );
+}
+
+#[tokio::test]
 async fn cognito_update_identity_provider() {
     let server = TestServer::start().await;
     let client = server.cognito_client().await;
@@ -3808,6 +3868,28 @@ async fn cognito_create_describe_domain() {
     assert_eq!(desc.domain().unwrap(), "my-test-domain");
     assert_eq!(desc.user_pool_id().unwrap(), pool_id);
     assert_eq!(desc.status().unwrap(), &DomainStatusType::Active);
+    // Every hosted-UI domain is fronted by a CloudFront distribution and backed
+    // by a managed S3 assets bucket; both are reported even for prefix domains.
+    let cf = desc.cloud_front_distribution().unwrap();
+    assert!(
+        cf.ends_with(".cloudfront.net"),
+        "unexpected CloudFront domain: {cf}"
+    );
+    assert!(!desc.s3_bucket().unwrap().is_empty());
+    // The CloudFront domain is stable across describes.
+    let again = client
+        .describe_user_pool_domain()
+        .domain("my-test-domain")
+        .send()
+        .await
+        .expect("describe domain again");
+    assert_eq!(
+        again
+            .domain_description()
+            .unwrap()
+            .cloud_front_distribution(),
+        Some(cf)
+    );
 
     // Describe non-existent should return empty DomainDescription (not an error)
     let result = client

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -195,17 +195,18 @@ pub const SERVICES: &[Service] = &[
         // signing-certificate data source. The widen batch added the user-pool
         // client defaults the provider asserts (AuthSessionValidity = 3,
         // RefreshTokenValidity = 30, EnablePropagateAdditionalUserContextData).
+        // Batch 14 added federated identity providers (social providers get the
+        // default `username` attribute mapping Cognito injects — `sub` for
+        // Google/Apple, `id` for Facebook, `user_id` for Login with Amazon) and
+        // user-pool domains (DescribeUserPoolDomain now reports the fronting
+        // CloudFront distribution domain and the managed S3 assets bucket, which
+        // the resource surfaces as cloudfront_distribution/_arn and s3_bucket).
         run_regex: "^TestAccCognitoIDP[A-Za-z]+_basic$",
         deny: &[
-            // --- gap: federated identity providers need real SAML/OIDC
-            //     metadata handling and attribute-mapping round-trip. ---
-            "TestAccCognitoIDPIdentityProvider_basic",
-            // --- gap: a user-pool domain provisions a CloudFront distribution
-            //     (cloudfront_distribution / _arn), which fakecloud's Cognito
-            //     does not stand up. ---
-            "TestAccCognitoIDPUserPoolDomain_basic",
-            // --- gap: managed (AWS-provisioned) user-pool clients are created
-            //     by other AWS services, not directly; not modelled. ---
+            // --- unsupportable: a managed user-pool client is auto-created by a
+            //     companion AWS service; this test stands up an
+            //     `aws_opensearch_domain` (named `AmazonOpenSearchService-...`)
+            //     to provision it, and fakecloud does not implement OpenSearch. ---
             "TestAccCognitoIDPManagedUserPoolClient_basic",
         ],
     },


### PR DESCRIPTION
## Summary

B14 of the tfacc backlog. Reclaims two acceptance tests by filling real Cognito response-shape gaps (no gaming, no stubs).

**Identity providers** (`crates/fakecloud-cognito`):
- A social provider created without an explicit `AttributeMapping` now gets Cognito's default `username` mapping, keyed to the provider's subject claim: `sub` for Google and Sign in with Apple, `id` for Facebook, `user_id` for Login with Amazon. SAML/OIDC keep no default. The provider's `attribute_mapping.username` assertion drove this.
- Unblocks `TestAccCognitoIDPIdentityProvider_basic`.

**User-pool domains**:
- `DescribeUserPoolDomain` now reports the fronting CloudFront distribution domain (a stable per-domain `d<...>.cloudfront.net`) and the managed S3 assets bucket for every hosted-UI domain (prefix or custom), which the resource surfaces as `cloudfront_distribution` / `cloudfront_distribution_arn` / `s3_bucket`.
- Unblocks `TestAccCognitoIDPUserPoolDomain_basic`.

Allowlist widened; the remaining `TestAccCognitoIDPManagedUserPoolClient_basic` deny is sharpened — it provisions an `aws_opensearch_domain` (the companion service that auto-creates the managed client), and fakecloud does not implement OpenSearch.

No new public API surface (behavior fixes on existing operations), so no SDK/docs/website/count changes.

## Test plan
- New/extended e2e: `cognito_social_provider_default_attribute_mapping` and the CloudFront/S3 assertions in `cognito_create_describe_domain` — pass.
- Local tfacc: full `cognitoidp` shard green (minus the OpenSearch-dependent managed-client deny).
- `cargo test -p fakecloud-cognito` (336 pass), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt`, `check-doc-counts.sh` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cognito federated IdP defaults and user‑pool domain metadata to match AWS responses. Restores two tfacc tests: TestAccCognitoIDPIdentityProvider_basic and TestAccCognitoIDPUserPoolDomain_basic.

- **Bug Fixes**
  - Social providers without `AttributeMapping` now get a default `username`: Google/SignInWithApple → `sub`, Facebook → `id`, LoginWithAmazon → `user_id`; SAML/OIDC unchanged.
  - `DescribeUserPoolDomain` now returns the CloudFront distribution domain (stable `d<...>.cloudfront.net`) and the managed S3 assets bucket; exposed as `cloudfront_distribution`/`cloudfront_distribution_arn` and `s3_bucket`.
  - tfacc allowlist widened; keep deny for managed user‑pool client test (it provisions an `aws_opensearch_domain`, which fakecloud does not implement).

<sup>Written for commit f5fb155d74d2f0f51d18d08aa539cdc0d6c991dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

