### PR TITLE
fix(glue): schema-by-ARN lookup, ML transform schema/id, dev endpoint readiness

### DIFF
--- a/crates/fakecloud-e2e/tests/glue.rs
+++ b/crates/fakecloud-e2e/tests/glue.rs
@@ -855,3 +855,127 @@ async fn get_partition_indexes_not_found_after_table_delete() {
         .expect_err("table gone");
     assert!(err.into_service_error().is_entity_not_found_exception());
 }
+
+#[tokio::test]
+async fn schema_resolves_by_arn() {
+    // GetSchema must resolve a schema by its ARN, parsing both the registry and
+    // schema name out of the `schema/<registry>/<schema>` resource path.
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    let registry_id = aws_sdk_glue::types::RegistryId::builder()
+        .registry_name("my-registry")
+        .build();
+    glue.create_registry()
+        .registry_name("my-registry")
+        .send()
+        .await
+        .expect("create registry");
+
+    let created = glue
+        .create_schema()
+        .registry_id(registry_id)
+        .schema_name("my-schema")
+        .data_format(aws_sdk_glue::types::DataFormat::Avro)
+        .compatibility(aws_sdk_glue::types::Compatibility::Backward)
+        .schema_definition(r#"{"type":"record","name":"r","fields":[]}"#)
+        .send()
+        .await
+        .expect("create schema");
+    let arn = created.schema_arn().expect("schema arn").to_string();
+    assert!(arn.ends_with(":schema/my-registry/my-schema"), "arn={arn}");
+
+    // Look it up purely by ARN (no registry/schema name in the SchemaId).
+    let by_arn = glue
+        .get_schema()
+        .schema_id(
+            aws_sdk_glue::types::SchemaId::builder()
+                .schema_arn(&arn)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("get schema by arn");
+    assert_eq!(by_arn.schema_name(), Some("my-schema"));
+    assert_eq!(by_arn.registry_name(), Some("my-registry"));
+}
+
+#[tokio::test]
+async fn ml_transform_id_prefix_and_computed_schema() {
+    // An ML transform gets a `tfm-` id and reports the schema derived from its
+    // input record table's columns.
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    glue.create_database()
+        .database_input(DatabaseInput::builder().name("ml_db").build().unwrap())
+        .send()
+        .await
+        .expect("create db");
+    glue.create_table()
+        .database_name("ml_db")
+        .table_input(table_input("ml_table"))
+        .send()
+        .await
+        .expect("create table");
+
+    let created = glue
+        .create_ml_transform()
+        .name("my-transform")
+        .role("arn:aws:iam::123456789012:role/glue")
+        .input_record_tables(
+            aws_sdk_glue::types::GlueTable::builder()
+                .database_name("ml_db")
+                .table_name("ml_table")
+                .build()
+                .unwrap(),
+        )
+        .parameters(
+            aws_sdk_glue::types::TransformParameters::builder()
+                .transform_type(aws_sdk_glue::types::TransformType::FindMatches)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create ml transform");
+    let id = created.transform_id().expect("transform id").to_string();
+    assert!(id.starts_with("tfm-"), "id={id}");
+
+    let got = glue
+        .get_ml_transform()
+        .transform_id(&id)
+        .send()
+        .await
+        .expect("get ml transform");
+    // Input table has two columns (id, amount), so the schema has two entries.
+    let schema = got.schema();
+    assert_eq!(schema.len(), 2);
+    assert_eq!(schema[0].name(), Some("id"));
+    assert_eq!(schema[1].name(), Some("amount"));
+}
+
+#[tokio::test]
+async fn dev_endpoint_is_ready_with_default_nodes() {
+    // A dev endpoint is READY at once (nothing to provision) and defaults to 5
+    // nodes when no worker type is given.
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    glue.create_dev_endpoint()
+        .endpoint_name("my-endpoint")
+        .role_arn("arn:aws:iam::123456789012:role/glue")
+        .send()
+        .await
+        .expect("create dev endpoint");
+
+    let got = glue
+        .get_dev_endpoint()
+        .endpoint_name("my-endpoint")
+        .send()
+        .await
+        .expect("get dev endpoint");
+    let ep = got.dev_endpoint().expect("dev endpoint");
+    assert_eq!(ep.status(), Some("READY"));
+    assert_eq!(ep.number_of_nodes(), 5);
+}

--- a/crates/fakecloud-glue/src/blueprints.rs
+++ b/crates/fakecloud-glue/src/blueprints.rs
@@ -208,8 +208,18 @@ impl GlueService {
                 }
             }
         }
-        stored.insert("Status".into(), json!("PROVISIONING"));
+        // A real dev endpoint takes minutes to provision its notebook
+        // environment; fakecloud has nothing to stand up, so it is READY at
+        // once and the provider's creation waiter completes on its first poll
+        // (otherwise it spins for ~15m and times out).
+        stored.insert("Status".into(), json!("READY"));
         stored.insert("CreatedTimestamp".into(), json!(now));
+        stored.insert("LastModifiedTimestamp".into(), json!(now));
+        // AWS defaults a worker-type-less dev endpoint to 5 nodes, which the
+        // resource reads back as `number_of_nodes`.
+        if !stored.contains_key("NumberOfNodes") && !stored.contains_key("WorkerType") {
+            stored.insert("NumberOfNodes".into(), json!(5));
+        }
         let stored = Value::Object(stored);
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id, &req.region);

--- a/crates/fakecloud-glue/src/ml.rs
+++ b/crates/fakecloud-glue/src/ml.rs
@@ -35,7 +35,9 @@ impl GlueService {
         req_present(&body, "InputRecordTables")?;
         req_present(&body, "Parameters")?;
         req_str(&body, "Role")?;
-        let id = new_id();
+        // Glue ML transform ids carry a `tfm-` prefix; the resource ARN is
+        // `mlTransform/<id>`, which the provider asserts matches `tfm-.+`.
+        let id = format!("tfm-{}", new_id());
         let now = now_ts();
         let stored = crate::common::entity(
             &body,
@@ -61,11 +63,44 @@ impl GlueService {
         let body = req.json_body();
         let id = req_str(&body, "TransformId")?;
         let accounts = self.state.read();
-        let t = accounts
+        let state = accounts
             .get(&req.account_id)
-            .and_then(|s| s.ml_transforms.get(id))
             .ok_or_else(|| entity_not_found(format!("MLTransform {id} not found")))?;
-        Ok(AwsResponse::ok_json(t.clone()))
+        let t = state
+            .ml_transforms
+            .get(id)
+            .ok_or_else(|| entity_not_found(format!("MLTransform {id} not found")))?;
+        let mut out = t.clone();
+        // AWS computes the transform's `Schema` from the columns of its input
+        // record table; the Terraform resource reads it back as `schema`.
+        if let Some(schema) = self.input_table_schema(state, &req.region, t) {
+            out["Schema"] = schema;
+        }
+        Ok(AwsResponse::ok_json(out))
+    }
+
+    /// Build the `Schema` list (`[{Name, DataType}]`) for an ML transform from
+    /// the columns of its first input record table, mirroring how AWS derives a
+    /// transform's schema from the catalog table it reads.
+    fn input_table_schema(
+        &self,
+        state: &crate::state::GlueState,
+        region: &str,
+        transform: &Value,
+    ) -> Option<Value> {
+        let table_ref = transform
+            .get("InputRecordTables")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())?;
+        let db_name = table_ref.get("DatabaseName").and_then(|v| v.as_str())?;
+        let table_name = table_ref.get("TableName").and_then(|v| v.as_str())?;
+        let table = state.dbs_in(region)?.get(db_name)?.tables.get(table_name)?;
+        let columns = &table.storage_descriptor.as_ref()?.columns;
+        let schema: Vec<Value> = columns
+            .iter()
+            .map(|c| json!({ "Name": c.name, "DataType": c.column_type }))
+            .collect();
+        Some(json!(schema))
     }
 
     pub(crate) fn get_ml_transforms(

--- a/crates/fakecloud-glue/src/schema_registry.rs
+++ b/crates/fakecloud-glue/src/schema_registry.rs
@@ -22,18 +22,24 @@ fn registry_name(id: &Value) -> Option<String> {
 }
 
 /// Resolve a schema's storage key (registry/schema) from a `SchemaId`.
+///
+/// A `SchemaId` identifies a schema either by `RegistryName` + `SchemaName` or
+/// by `SchemaArn`. The ARN's resource path is `schema/<registry>/<schema>`, so
+/// both the registry and schema name must come out of the ARN — not just the
+/// trailing segment (otherwise a by-ARN lookup keys off the wrong registry).
 fn schema_key(id: &Value) -> Option<String> {
-    let reg = id
-        .get("RegistryName")
-        .and_then(|v| v.as_str())
-        .unwrap_or("default-registry");
     if let Some(name) = id.get("SchemaName").and_then(|v| v.as_str()) {
+        let reg = id
+            .get("RegistryName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("default-registry");
         return Some(format!("{reg}\u{1f}{name}"));
     }
-    id.get("SchemaArn")
-        .and_then(|v| v.as_str())
-        .and_then(|arn| arn.rsplit('/').next())
-        .map(|name| format!("{reg}\u{1f}{name}"))
+    let arn = id.get("SchemaArn").and_then(|v| v.as_str())?;
+    // `...:schema/<registry>/<schema>` -> ("<registry>", "<schema>")
+    let resource = arn.split(":schema/").nth(1).unwrap_or(arn);
+    let (reg, name) = resource.split_once('/')?;
+    Some(format!("{reg}\u{1f}{name}"))
 }
 
 impl GlueService {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -159,6 +159,13 @@ pub const SERVICES: &[Service] = &[
         // connections (+ data source), registries (+ data source), data-quality
         // rulesets, security configurations, user-defined functions, and
         // workflows — 10 tests.
+        // Batch 15 reclaimed schema registry schemas, ML transforms, and dev
+        // endpoints: GetSchema resolves a schema by ARN (parsing both the
+        // registry and schema name out of the `schema/<reg>/<name>` path); ML
+        // transforms carry a `tfm-` id prefix and report the `Schema` computed
+        // from their input table's columns; dev endpoints settle to READY at
+        // once (fakecloud has no notebook env to provision) and default to 5
+        // nodes when no worker type is given.
         run_regex: "^TestAccGlue[A-Za-z]+_basic$",
         deny: &[
             // (Jobs and triggers reference the AWS-managed IAM policy
@@ -168,13 +175,6 @@ pub const SERVICES: &[Service] = &[
             //  round-trips (bucket/sort/skewed columns), and
             //  GetPartitionIndexes raises EntityNotFound on a deleted table,
             //  so the partition + partition-index tests run.)
-            // --- gap: schema registry schemas and ML transforms are not
-            //     implemented. ---
-            "TestAccGlueSchema_basic",
-            "TestAccGlueMlTransform_basic",
-            // --- gap: dev endpoints provision a notebook environment; the test
-            //     polls a creation waiter for ~15m before failing. ---
-            "TestAccGlueDevEndpoint_basic",
         ],
     },
     Service {


### PR DESCRIPTION
## Summary

B15 of the tfacc backlog. Reclaims three acceptance tests by fixing real Glue response gaps (no gaming, no stubs). All three operations already existed; the deny comments calling them "not implemented" were stale — the failures were behavioral.

**Schema registry** (`crates/fakecloud-glue/src/schema_registry.rs`):
- `GetSchema` resolves a schema by ARN, parsing both the registry and schema name out of the `schema/<registry>/<schema>` resource path. It previously kept only the trailing segment and keyed off the wrong registry, so a by-ARN lookup raised `EntityNotFoundException` and the resource's creation waiter failed. Unblocks `TestAccGlueSchema_basic`.

**ML transforms** (`crates/fakecloud-glue/src/ml.rs`):
- Transform ids carry the AWS `tfm-` prefix, so the resource ARN matches `mlTransform/tfm-...`.
- `GetMLTransform` reports the `Schema` computed from the columns of its first input record table, which the resource reads back as `schema`. Unblocks `TestAccGlueMlTransform_basic`.

**Dev endpoints** (`crates/fakecloud-glue/src/blueprints.rs`):
- A dev endpoint settles to `READY` immediately — fakecloud has no notebook environment to provision, so the creation waiter completes on its first poll instead of spinning ~15m — and defaults to 5 nodes when no worker type is given. Unblocks `TestAccGlueDevEndpoint_basic`.

All three glue denies removed. No new public API surface (behavior fixes on existing operations), so no SDK/docs/website/count changes.

## Test plan
- New e2e: `schema_resolves_by_arn`, `ml_transform_id_prefix_and_computed_schema`, `dev_endpoint_is_ready_with_default_nodes` — pass.
- Local tfacc: full `glue` shard green.
- `cargo test -p fakecloud-glue` (28 pass), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt`, `check-doc-counts.sh` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Glue behavior to match AWS: schema lookup by ARN, ML transform id and computed schema, and dev endpoint readiness/default nodes. Unblocks `TestAccGlueSchema_basic`, `TestAccGlueMlTransform_basic`, and `TestAccGlueDevEndpoint_basic` in the tfacc suite.

- **Bug Fixes**
  - `GetSchema` now resolves by ARN, parsing both registry and schema from `schema/<registry>/<schema>` to avoid wrong-registry lookups.
  - ML transforms use `tfm-<id>` and `GetMLTransform` returns `Schema` derived from the first input table’s columns.
  - Dev endpoints report `READY` immediately and default to 5 nodes when no `WorkerType` is provided.

<sup>Written for commit 0ace5f26b9dafaec6e76720720f4aa986fda0622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

