### PR TITLE
fix(bedrock): guardrail policy read-shape + ARN identifier, inference profiles

### DIFF
--- a/crates/fakecloud-bedrock/src/guardrails.rs
+++ b/crates/fakecloud-bedrock/src/guardrails.rs
@@ -7,6 +7,16 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{Guardrail, GuardrailVersion, SharedBedrockState};
 
+/// Normalize a guardrail identifier to its storage key. The API accepts either
+/// the bare guardrail id or the full ARN (`arn:...:guardrail/<id>`); operations
+/// such as CreateGuardrailVersion are called by the provider with the ARN.
+fn guardrail_key(identifier: &str) -> &str {
+    identifier
+        .rsplit_once("guardrail/")
+        .map(|(_, id)| id)
+        .unwrap_or(identifier)
+}
+
 pub(crate) fn create_guardrail(
     state: &SharedBedrockState,
     req: &AwsRequest,
@@ -50,6 +60,7 @@ pub(crate) fn create_guardrail(
         word_policy: body.get("wordPolicyConfig").cloned(),
         sensitive_information_policy: body.get("sensitiveInformationPolicyConfig").cloned(),
         topic_policy: body.get("topicPolicyConfig").cloned(),
+        contextual_grounding_policy: body.get("contextualGroundingPolicyConfig").cloned(),
         created_at: now,
         updated_at: now,
     };
@@ -74,6 +85,7 @@ pub(crate) fn get_guardrail(
     req: &AwsRequest,
     guardrail_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let guardrail_id = guardrail_key(guardrail_id);
     // Check if a specific version is requested
     let version = req.query_params.get("guardrailVersion");
 
@@ -169,6 +181,7 @@ pub(crate) fn update_guardrail(
     guardrail_id: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let guardrail_id = guardrail_key(guardrail_id);
     let mut accts = state.write();
     let s = accts.get_or_create(&req.account_id);
     let guardrail = s.guardrails.get_mut(guardrail_id).ok_or_else(|| {
@@ -203,6 +216,9 @@ pub(crate) fn update_guardrail(
     if let Some(policy) = body.get("topicPolicyConfig") {
         guardrail.topic_policy = Some(policy.clone());
     }
+    if let Some(policy) = body.get("contextualGroundingPolicyConfig") {
+        guardrail.contextual_grounding_policy = Some(policy.clone());
+    }
 
     guardrail.updated_at = Utc::now();
 
@@ -221,6 +237,7 @@ pub(crate) fn delete_guardrail(
     req: &AwsRequest,
     guardrail_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let guardrail_id = guardrail_key(guardrail_id);
     let mut accts = state.write();
     let s = accts.get_or_create(&req.account_id);
     s.guardrails.remove(guardrail_id).ok_or_else(|| {
@@ -243,6 +260,7 @@ pub(crate) fn create_guardrail_version(
     guardrail_id: &str,
     body: &Value,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let guardrail_id = guardrail_key(guardrail_id);
     let mut accts = state.write();
     let s = accts.get_or_create(&req.account_id);
     let guardrail = s.guardrails.get_mut(guardrail_id).ok_or_else(|| {
@@ -276,6 +294,7 @@ pub(crate) fn create_guardrail_version(
         word_policy: guardrail.word_policy.clone(),
         sensitive_information_policy: guardrail.sensitive_information_policy.clone(),
         topic_policy: guardrail.topic_policy.clone(),
+        contextual_grounding_policy: guardrail.contextual_grounding_policy.clone(),
         created_at: now,
     };
 
@@ -299,6 +318,7 @@ pub(crate) fn apply_guardrail(
     guardrail_version: &str,
     body: &[u8],
 ) -> Result<AwsResponse, AwsServiceError> {
+    let guardrail_id = guardrail_key(guardrail_id);
     let input: Value = serde_json::from_slice(body).unwrap_or_default();
 
     let accts = state.read();
@@ -583,6 +603,28 @@ fn evaluate_content_view(guardrail: &GuardrailView<'_>, text: &str) -> Vec<Value
 
 // ── JSON helpers ───────────────────────────────────────────────────
 
+/// Convert a stored guardrail policy (held in the `*Config` request shape) into
+/// the shape Get/DescribeGuardrail returns. AWS drops the `Config` suffix from
+/// the wrapper keys: `filtersConfig` -> `filters`, `topicsConfig` -> `topics`,
+/// `piiEntitiesConfig` -> `piiEntities`, `regexesConfig` -> `regexes`,
+/// `wordsConfig` -> `words`, `managedWordListsConfig` -> `managedWordLists`.
+/// Echoing the request shape verbatim leaves the Terraform provider reading
+/// empty `filters`/`topics`/... and re-planning the policy on every refresh.
+fn policy_read_shape(config: &Value) -> Value {
+    match config {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                let key = k.strip_suffix("Config").unwrap_or(k).to_string();
+                out.insert(key, policy_read_shape(v));
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(policy_read_shape).collect()),
+        other => other.clone(),
+    }
+}
+
 fn guardrail_to_json(g: &Guardrail) -> Value {
     let mut obj = json!({
         "guardrailId": g.guardrail_id,
@@ -598,16 +640,19 @@ fn guardrail_to_json(g: &Guardrail) -> Value {
     });
 
     if let Some(ref policy) = g.content_policy {
-        obj["contentPolicy"] = policy.clone();
+        obj["contentPolicy"] = policy_read_shape(policy);
     }
     if let Some(ref policy) = g.word_policy {
-        obj["wordPolicy"] = policy.clone();
+        obj["wordPolicy"] = policy_read_shape(policy);
     }
     if let Some(ref policy) = g.sensitive_information_policy {
-        obj["sensitiveInformationPolicy"] = policy.clone();
+        obj["sensitiveInformationPolicy"] = policy_read_shape(policy);
     }
     if let Some(ref policy) = g.topic_policy {
-        obj["topicPolicy"] = policy.clone();
+        obj["topicPolicy"] = policy_read_shape(policy);
+    }
+    if let Some(ref policy) = g.contextual_grounding_policy {
+        obj["contextualGroundingPolicy"] = policy_read_shape(policy);
     }
 
     obj
@@ -627,16 +672,19 @@ fn guardrail_version_to_json(gv: &GuardrailVersion) -> Value {
     });
 
     if let Some(ref policy) = gv.content_policy {
-        obj["contentPolicy"] = policy.clone();
+        obj["contentPolicy"] = policy_read_shape(policy);
     }
     if let Some(ref policy) = gv.word_policy {
-        obj["wordPolicy"] = policy.clone();
+        obj["wordPolicy"] = policy_read_shape(policy);
     }
     if let Some(ref policy) = gv.sensitive_information_policy {
-        obj["sensitiveInformationPolicy"] = policy.clone();
+        obj["sensitiveInformationPolicy"] = policy_read_shape(policy);
     }
     if let Some(ref policy) = gv.topic_policy {
-        obj["topicPolicy"] = policy.clone();
+        obj["topicPolicy"] = policy_read_shape(policy);
+    }
+    if let Some(ref policy) = gv.contextual_grounding_policy {
+        obj["contextualGroundingPolicy"] = policy_read_shape(policy);
     }
 
     obj
@@ -682,6 +730,7 @@ mod tests {
             word_policy: None,
             sensitive_information_policy: None,
             topic_policy: None,
+            contextual_grounding_policy: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/crates/fakecloud-bedrock/src/inference_profiles.rs
+++ b/crates/fakecloud-bedrock/src/inference_profiles.rs
@@ -17,9 +17,12 @@ pub(crate) fn create_inference_profile(
         .as_str()
         .unwrap_or(&default_name);
 
-    let profile_id = Uuid::new_v4().to_string();
+    // An application inference profile gets a lowercase-alphanumeric id and an
+    // `application-inference-profile/<id>` ARN (system-defined profiles use the
+    // bare `inference-profile/` resource); the provider asserts this shape.
+    let profile_id = Uuid::new_v4().simple().to_string()[..12].to_string();
     let profile_arn = format!(
-        "arn:aws:bedrock:{}:{}:inference-profile/{}",
+        "arn:aws:bedrock:{}:{}:application-inference-profile/{}",
         req.region, req.account_id, profile_id
     );
 
@@ -29,7 +32,9 @@ pub(crate) fn create_inference_profile(
         inference_profile_name: profile_name.to_string(),
         description: body["description"].as_str().map(|s| s.to_string()),
         model_source: body.get("modelSource").cloned().unwrap_or(json!({})),
-        status: "Active".to_string(),
+        // AWS reports the status in upper case (`ACTIVE`); the provider's
+        // creation waiter compares case-sensitively against `ACTIVE`.
+        status: "ACTIVE".to_string(),
         inference_profile_type: "APPLICATION".to_string(),
         created_at: now,
         updated_at: now,
@@ -69,22 +74,29 @@ pub(crate) fn get_inference_profile(
     let accts = state.read();
     let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
     let s = accts.get(&req.account_id).unwrap_or(&empty);
-    let profile = s
-        .inference_profiles
-        .get(identifier)
-        .or_else(|| {
-            s.inference_profiles.values().find(|p| {
-                p.inference_profile_name == identifier
-                    || p.inference_profile_arn.ends_with(&format!("/{identifier}"))
-            })
+    let profile = match s.inference_profiles.get(identifier).or_else(|| {
+        s.inference_profiles.values().find(|p| {
+            p.inference_profile_name == identifier
+                || p.inference_profile_arn.ends_with(&format!("/{identifier}"))
         })
-        .ok_or_else(|| {
-            AwsServiceError::aws_error(
+    }) {
+        Some(profile) => profile,
+        None => {
+            // Fall back to the AWS-managed system-defined catalogue, resolving
+            // by profile id or ARN suffix.
+            if let Some((id, model)) = SYSTEM_INFERENCE_PROFILES
+                .iter()
+                .find(|(id, _)| *id == identifier || identifier.ends_with(&format!("/{id}")))
+            {
+                return Ok(AwsResponse::ok_json(system_profile_json(req, id, model)));
+            }
+            return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "ResourceNotFoundException",
                 format!("Inference profile {identifier} not found"),
-            )
-        })?;
+            ));
+        }
+    };
 
     // GetInferenceProfileResponse intentionally does not surface the
     // creation-time `modelSource` blob; only the resolved `models` list
@@ -129,11 +141,22 @@ pub(crate) fn list_inference_profiles(
         0
     };
 
-    let page: Vec<Value> = items
-        .iter()
-        .skip(start)
-        .take(max_results)
-        .map(|p| {
+    // SYSTEM_DEFINED (AWS-managed cross-region) profiles exist out of the box;
+    // list them alongside any user-created APPLICATION profiles. A `type`
+    // filter, when present, narrows to one kind.
+    let type_filter = req
+        .query_params
+        .get("type")
+        .or_else(|| req.query_params.get("typeEquals"));
+    let include_application = type_filter.map(|t| t == "APPLICATION").unwrap_or(true);
+    let include_system = type_filter.map(|t| t == "SYSTEM_DEFINED").unwrap_or(true);
+
+    let mut summaries: Vec<Value> = Vec::new();
+    if include_system {
+        summaries.extend(system_profiles(req));
+    }
+    if include_application {
+        summaries.extend(items.iter().map(|p| {
             json!({
                 "inferenceProfileArn": p.inference_profile_arn,
                 "inferenceProfileId": profile_id_from_arn(&p.inference_profile_arn),
@@ -145,14 +168,26 @@ pub(crate) fn list_inference_profiles(
                 "createdAt": p.created_at.to_rfc3339(),
                 "updatedAt": p.updated_at.to_rfc3339(),
             })
-        })
+        }));
+    }
+
+    let total = summaries.len();
+    let page: Vec<Value> = summaries
+        .into_iter()
+        .skip(start)
+        .take(max_results)
         .collect();
 
     let mut resp = json!({ "inferenceProfileSummaries": page });
     let end = start.saturating_add(max_results);
-    if end < items.len() {
-        if let Some(last) = items.get(end - 1) {
-            resp["nextToken"] = json!(last.inference_profile_arn);
+    if end < total {
+        // Page on the last item's id so the caller can continue.
+        if let Some(last) = resp["inferenceProfileSummaries"]
+            .as_array()
+            .and_then(|a| a.last())
+            .and_then(|v| v["inferenceProfileId"].as_str())
+        {
+            resp["nextToken"] = json!(last);
         }
     }
 
@@ -163,6 +198,104 @@ pub(crate) fn list_inference_profiles(
 /// echoes back in the summary, so we just split on `/`.
 fn profile_id_from_arn(arn: &str) -> String {
     arn.rsplit('/').next().unwrap_or(arn).to_string()
+}
+
+/// AWS-managed cross-region (SYSTEM_DEFINED) inference profiles for the US
+/// commercial regions. Each routes to one foundation model across us-east-1 and
+/// us-west-2. Bedrock exposes these out of the box (no create call), so
+/// `ListInferenceProfiles` returns them and the data sources resolve against
+/// them. `(profile_id, foundation_model_id)` pairs; the `us.` prefix is the
+/// geographic routing scope.
+const SYSTEM_INFERENCE_PROFILES: &[(&str, &str)] = &[
+    (
+        "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    ),
+    (
+        "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    ),
+    (
+        "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+        "anthropic.claude-3-5-haiku-20241022-v1:0",
+    ),
+    (
+        "us.anthropic.claude-3-haiku-20240307-v1:0",
+        "anthropic.claude-3-haiku-20240307-v1:0",
+    ),
+    (
+        "us.anthropic.claude-3-sonnet-20240229-v1:0",
+        "anthropic.claude-3-sonnet-20240229-v1:0",
+    ),
+    (
+        "us.anthropic.claude-3-opus-20240229-v1:0",
+        "anthropic.claude-3-opus-20240229-v1:0",
+    ),
+    ("us.amazon.nova-pro-v1:0", "amazon.nova-pro-v1:0"),
+    ("us.amazon.nova-lite-v1:0", "amazon.nova-lite-v1:0"),
+    ("us.amazon.nova-micro-v1:0", "amazon.nova-micro-v1:0"),
+    (
+        "us.meta.llama3-1-8b-instruct-v1:0",
+        "meta.llama3-1-8b-instruct-v1:0",
+    ),
+    (
+        "us.meta.llama3-1-70b-instruct-v1:0",
+        "meta.llama3-1-70b-instruct-v1:0",
+    ),
+    (
+        "us.meta.llama3-2-1b-instruct-v1:0",
+        "meta.llama3-2-1b-instruct-v1:0",
+    ),
+    (
+        "us.meta.llama3-2-3b-instruct-v1:0",
+        "meta.llama3-2-3b-instruct-v1:0",
+    ),
+    (
+        "us.meta.llama3-2-11b-instruct-v1:0",
+        "meta.llama3-2-11b-instruct-v1:0",
+    ),
+    (
+        "us.meta.llama3-2-90b-instruct-v1:0",
+        "meta.llama3-2-90b-instruct-v1:0",
+    ),
+];
+
+/// The US commercial regions a `us.`-scoped system profile routes across.
+const SYSTEM_PROFILE_REGIONS: &[&str] = &["us-east-1", "us-west-2"];
+
+/// Build the JSON summary for one system-defined inference profile.
+fn system_profile_json(req: &AwsRequest, profile_id: &str, model_id: &str) -> Value {
+    let arn = format!(
+        "arn:aws:bedrock:{}:{}:inference-profile/{}",
+        req.region, req.account_id, profile_id
+    );
+    let models: Vec<Value> = SYSTEM_PROFILE_REGIONS
+        .iter()
+        .map(|region| {
+            json!({
+                "modelArn": format!("arn:aws:bedrock:{region}::foundation-model/{model_id}")
+            })
+        })
+        .collect();
+    json!({
+        "inferenceProfileArn": arn,
+        "inferenceProfileId": profile_id,
+        "inferenceProfileName": profile_id,
+        "description": format!("Routes requests to {model_id} across US regions."),
+        "models": models,
+        "status": "ACTIVE",
+        "type": "SYSTEM_DEFINED",
+        "createdAt": "2024-01-01T00:00:00+00:00",
+        "updatedAt": "2024-01-01T00:00:00+00:00",
+    })
+}
+
+/// All system-defined inference-profile summaries, keyed for lookup by id/arn.
+fn system_profiles(req: &AwsRequest) -> Vec<Value> {
+    SYSTEM_INFERENCE_PROFILES
+        .iter()
+        .map(|(id, model)| system_profile_json(req, id, model))
+        .collect()
 }
 
 /// Build the `models` summary list. We try to extract a copyFrom model ARN

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -250,6 +250,8 @@ pub struct Guardrail {
     pub word_policy: Option<serde_json::Value>,
     pub sensitive_information_policy: Option<serde_json::Value>,
     pub topic_policy: Option<serde_json::Value>,
+    #[serde(default)]
+    pub contextual_grounding_policy: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -268,6 +270,8 @@ pub struct GuardrailVersion {
     pub word_policy: Option<serde_json::Value>,
     pub sensitive_information_policy: Option<serde_json::Value>,
     pub topic_policy: Option<serde_json::Value>,
+    #[serde(default)]
+    pub contextual_grounding_policy: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
 }
 

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -2192,3 +2192,106 @@ async fn bedrock_resource_policy_crud() {
         .unwrap();
     assert_eq!(r.status(), 404);
 }
+
+#[tokio::test]
+async fn bedrock_guardrail_content_policy_read_shape_and_arn_identifier() {
+    use aws_sdk_bedrock::types::{
+        GuardrailContentFilterConfig, GuardrailContentFilterType, GuardrailContentPolicyConfig,
+        GuardrailFilterStrength,
+    };
+    let server = TestServer::start().await;
+    let client = server.bedrock_client().await;
+
+    let content_policy = GuardrailContentPolicyConfig::builder()
+        .filters_config(
+            GuardrailContentFilterConfig::builder()
+                .r#type(GuardrailContentFilterType::Hate)
+                .input_strength(GuardrailFilterStrength::Medium)
+                .output_strength(GuardrailFilterStrength::Medium)
+                .build()
+                .unwrap(),
+        )
+        .filters_config(
+            GuardrailContentFilterConfig::builder()
+                .r#type(GuardrailContentFilterType::Violence)
+                .input_strength(GuardrailFilterStrength::High)
+                .output_strength(GuardrailFilterStrength::High)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let created = client
+        .create_guardrail()
+        .name("content-guardrail")
+        .blocked_input_messaging("blocked")
+        .blocked_outputs_messaging("blocked")
+        .content_policy_config(content_policy)
+        .send()
+        .await
+        .unwrap();
+    let arn = created.guardrail_arn().to_string();
+
+    // GetGuardrail must render the stored content policy in its read shape, so
+    // the SDK can parse `content_policy.filters` (not the `*Config` wrapper).
+    let got = client
+        .get_guardrail()
+        .guardrail_identifier(&arn) // resolve by ARN, not just the short id
+        .send()
+        .await
+        .unwrap();
+    let filters = got.content_policy().expect("content policy").filters();
+    assert_eq!(filters.len(), 2);
+    assert_eq!(filters[0].r#type(), &GuardrailContentFilterType::Hate);
+
+    // CreateGuardrailVersion is called by the provider with the ARN identifier.
+    let version = client
+        .create_guardrail_version()
+        .guardrail_identifier(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(!version.version().is_empty());
+}
+
+#[tokio::test]
+async fn bedrock_inference_profiles_catalogue_and_application_arn() {
+    use aws_sdk_bedrock::types::{InferenceProfileModelSource, InferenceProfileType};
+    let server = TestServer::start().await;
+    let client = server.bedrock_client().await;
+
+    // The AWS-managed SYSTEM_DEFINED catalogue is listed out of the box.
+    let listed = client.list_inference_profiles().send().await.unwrap();
+    let summaries = listed.inference_profile_summaries();
+    assert!(!summaries.is_empty());
+    let system = summaries
+        .iter()
+        .find(|s| s.r#type() == &InferenceProfileType::SystemDefined)
+        .expect("a system-defined profile");
+    assert!(system.description().is_some());
+
+    // It resolves via GetInferenceProfile by id.
+    let got = client
+        .get_inference_profile()
+        .inference_profile_identifier(system.inference_profile_id())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.r#type(), &InferenceProfileType::SystemDefined);
+    assert!(!got.models().is_empty());
+
+    // An APPLICATION profile gets the application-inference-profile ARN.
+    let created = client
+        .create_inference_profile()
+        .inference_profile_name("my-app-profile")
+        .model_source(InferenceProfileModelSource::CopyFrom(
+            "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1".to_string(),
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert!(created
+        .inference_profile_arn()
+        .contains("application-inference-profile/"));
+}

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -214,18 +214,17 @@ pub const SERVICES: &[Service] = &[
         // Batch 10 + widen: the foundation-model data sources (single + list),
         // which return the expected ListFoundationModels / GetFoundationModel
         // shapes out of the box.
+        // Batch 16 reclaimed guardrails and inference profiles. GetGuardrail now
+        // renders the stored policies in their read shape (dropping the `Config`
+        // suffix from the wrapper keys, e.g. `filtersConfig` -> `filters`) and
+        // round-trips the contextual-grounding policy, so a guardrail refreshes
+        // cleanly; guardrail ops accept the ARN as the identifier so
+        // CreateGuardrailVersion resolves. Inference profiles report status
+        // `ACTIVE` and an `application-inference-profile/<id>` ARN, and the
+        // AWS-managed SYSTEM_DEFINED cross-region catalogue is listed/resolvable
+        // so the data sources read it.
         run_regex: "^TestAccBedrock[A-Za-z]+_basic$",
-        deny: &[
-            // --- gap: guardrails need the content-policy / topic-policy
-            //     evaluation engine, which fakecloud's Bedrock does not model. ---
-            "TestAccBedrockGuardrail_basic",
-            "TestAccBedrockGuardrailVersion_basic",
-            // --- gap: inference profiles (cross-region model routing) are not
-            //     modelled. ---
-            "TestAccBedrockInferenceProfile_basic",
-            "TestAccBedrockInferenceProfileDataSource_basic",
-            "TestAccBedrockInferenceProfilesDataSource_basic",
-        ],
+        deny: &[],
     },
     Service {
         name: "apigatewayv2",


### PR DESCRIPTION
## Summary

B16 of the tfacc backlog. Reclaims five acceptance tests by fixing real Bedrock response gaps (no gaming, no stubs). All operations already existed; the deny comments were stale.

**Guardrails** (`crates/fakecloud-bedrock/src/guardrails.rs`):
- `GetGuardrail` renders the stored policies in their read shape, dropping the `Config` suffix from the wrapper keys (`filtersConfig` -> `filters`, `topicsConfig` -> `topics`, `piiEntitiesConfig` -> `piiEntities`, etc.). It previously echoed the request shape verbatim, so the provider read empty `filters`/`topics`/... and re-planned the policy on every refresh ("the refresh plan was not empty").
- The contextual-grounding policy is now stored and round-tripped (it wasn't persisted at all before).
- Guardrail ops accept the ARN as the identifier (not only the short id), so `CreateGuardrailVersion` -- which the provider calls with `guardrail_arn` -- resolves instead of returning `ResourceNotFoundException`.
- Unblocks `TestAccBedrockGuardrail_basic` + `TestAccBedrockGuardrailVersion_basic`.

**Inference profiles** (`crates/fakecloud-bedrock/src/inference_profiles.rs`):
- Application profiles report status `ACTIVE` (was `Active`, failing the case-sensitive creation waiter) and an `application-inference-profile/<id>` ARN with a lowercase-alphanumeric id.
- The AWS-managed `SYSTEM_DEFINED` cross-region catalogue (US profiles) is listed by `ListInferenceProfiles` and resolvable by `GetInferenceProfile`, so the inference-profile(s) data sources read it.
- Unblocks `TestAccBedrockInferenceProfile_basic` + `TestAccBedrockInferenceProfileDataSource_basic` + `TestAccBedrockInferenceProfilesDataSource_basic`.

Bedrock deny-list cleared. No new public API surface (behavior fixes on existing operations), so no SDK/docs/website/count changes.

## Test plan
- New e2e: `bedrock_guardrail_content_policy_read_shape_and_arn_identifier`, `bedrock_inference_profiles_catalogue_and_application_arn` -- pass.
- Local tfacc: full `bedrock` shard green.
- `cargo test -p fakecloud-bedrock` (354 pass), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt`, `check-doc-counts.sh` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Bedrock guardrail read shape and ARN handling, and correct inference profile status/ARN plus system catalogue, to match AWS behavior. This unblocks five tfacc acceptance tests with no new API surface.

- **Bug Fixes**
  - Guardrails: GetGuardrail returns the read shape (drops “Config” suffix), contextual-grounding policy is persisted/round-tripped, and all ops accept ARN identifiers (CreateGuardrailVersion resolves).
  - Inference profiles: APPLICATION profiles report status ACTIVE and an `application-inference-profile/<id>` ARN (lowercase id); the AWS-managed SYSTEM_DEFINED US catalogue is listed and resolvable via List/Get.
  - Tests/allowlist: Add e2e cases for guardrails and profiles; clear the Bedrock deny-list (reclaims 5 tfacc tests).

<sup>Written for commit 6cd7b8741eb113608f762d6c6d1c8cb93e22c48b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

