### PR TITLE
fix(logs): anomaly-detector/delivery-destination tags + data-protection identifier

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/logs.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/logs.rs
@@ -190,11 +190,21 @@ impl ResourceProvisioner {
             "arn:aws:logs:{}:{}:delivery-destination:{name}",
             self.region, self.account_id
         );
+        let delivery_destination_type = props
+            .get("DeliveryDestinationType")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| {
+                fakecloud_logs::infer_delivery_destination_type(
+                    configuration.get("destinationResourceArn"),
+                )
+            });
         let dd = DeliveryDestination {
             name: name.clone(),
             arn: arn.clone(),
             output_format,
             delivery_destination_configuration: configuration,
+            delivery_destination_type,
             tags: BTreeMap::new(),
             delivery_destination_policy: policy,
         };

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -2818,3 +2818,118 @@ async fn logs_index_policy_round_trips_without_arn_suffix() {
     assert_eq!(read_id, put_id);
     assert!(!read_id.ends_with(":*"));
 }
+
+#[tokio::test]
+async fn logs_anomaly_detector_tags_listable_by_arn() {
+    // CreateLogAnomalyDetector stores create-time tags, and
+    // ListTagsForResource resolves the anomaly-detector ARN.
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/anom/app")
+        .send()
+        .await
+        .unwrap();
+    let group = client
+        .describe_log_groups()
+        .log_group_name_prefix("/anom/app")
+        .send()
+        .await
+        .unwrap();
+    let group_arn = group.log_groups()[0].arn().unwrap().to_string();
+
+    let created = client
+        .create_log_anomaly_detector()
+        .log_group_arn_list(group_arn)
+        .detector_name("d1")
+        .tags("team", "obs")
+        .send()
+        .await
+        .unwrap();
+    let arn = created.anomaly_detector_arn().unwrap();
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        tags.tags().and_then(|t| t.get("team")).map(String::as_str),
+        Some("obs")
+    );
+}
+
+#[tokio::test]
+async fn logs_data_protection_policy_identifier_round_trips() {
+    // Put/Get echo the supplied logGroupIdentifier verbatim (the bare name),
+    // so the resource's log_group_name does not drift to the ARN form.
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/dp/app")
+        .send()
+        .await
+        .unwrap();
+
+    let doc = r#"{"Name":"p","Version":"2021-06-01","Statement":[{"Sid":"Audit","DataIdentifier":["arn:aws:dataprotection::aws:data-identifier/EmailAddress"],"Operation":{"Audit":{"FindingsDestination":{}}}}]}"#;
+    let put = client
+        .put_data_protection_policy()
+        .log_group_identifier("/dp/app")
+        .policy_document(doc)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(put.log_group_identifier(), Some("/dp/app"));
+
+    let got = client
+        .get_data_protection_policy()
+        .log_group_identifier("/dp/app")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.log_group_identifier(), Some("/dp/app"));
+}
+
+#[tokio::test]
+async fn logs_delivery_destination_reports_type_and_tags() {
+    // PutDeliveryDestination infers the destination type from the destination
+    // resource ARN (CloudWatch Logs -> CWL) and ListTagsForResource resolves
+    // the delivery-destination ARN.
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    let cfg = aws_sdk_cloudwatchlogs::types::DeliveryDestinationConfiguration::builder()
+        .destination_resource_arn("arn:aws:logs:us-east-1:123456789012:log-group:/dest:*")
+        .build()
+        .unwrap();
+    let created = client
+        .put_delivery_destination()
+        .name("dest1")
+        .delivery_destination_configuration(cfg)
+        .tags("team", "obs")
+        .send()
+        .await
+        .unwrap();
+    let dd = created.delivery_destination().unwrap();
+    assert_eq!(
+        dd.delivery_destination_type(),
+        Some(&aws_sdk_cloudwatchlogs::types::DeliveryDestinationType::Cwl)
+    );
+    let arn = dd.arn().unwrap();
+
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        tags.tags().and_then(|t| t.get("team")).map(String::as_str),
+        Some("obs")
+    );
+}

--- a/crates/fakecloud-logs/src/lib.rs
+++ b/crates/fakecloud-logs/src/lib.rs
@@ -6,7 +6,7 @@ pub(crate) mod state;
 pub mod transformer;
 pub(crate) mod validation;
 
-pub use service::LogsService;
+pub use service::{infer_delivery_destination_type, LogsService};
 pub use state::{
     Delivery, DeliveryDestination, DeliverySource, Destination, LogAnomaly, LogEvent, LogGroup,
     LogStream, LogsSnapshot, LogsState, MetricFilter, MetricTransformation, QueryDefinition,

--- a/crates/fakecloud-logs/src/service/anomaly.rs
+++ b/crates/fakecloud-logs/src/service/anomaly.rs
@@ -64,6 +64,14 @@ impl LogsService {
         let evaluation_frequency = body["evaluationFrequency"].as_str().map(|s| s.to_string());
         let filter_pattern = body["filterPattern"].as_str().map(|s| s.to_string());
         let anomaly_visibility_time = body["anomalyVisibilityTime"].as_i64();
+        let tags = body["tags"]
+            .as_object()
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
 
         let now = Utc::now().timestamp_millis();
         let mut accounts = self.state.write();
@@ -84,6 +92,7 @@ impl LogsService {
             creation_time: now,
             last_modified_time: now,
             enabled: true,
+            tags,
         };
 
         state.anomaly_detectors.insert(arn.clone(), detector);

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use crate::validation::*;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
-use super::dd_config_json;
+use super::{dd_config_json, infer_delivery_destination_type};
 use super::{require_str, LogsService};
 use crate::state::{Delivery, DeliveryDestination, DeliverySource};
 
@@ -91,6 +91,16 @@ impl LogsService {
             state.region, state.account_id, name
         );
 
+        // The destination type is either supplied explicitly or inferred from
+        // the destination resource ARN's service: CloudWatch Logs -> CWL,
+        // S3 -> S3, Firehose -> FH, X-Ray -> XRAY.
+        let delivery_destination_type = body["deliveryDestinationType"]
+            .as_str()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
+                infer_delivery_destination_type(config.get("destinationResourceArn"))
+            });
+
         let existing_policy = state
             .delivery_destinations
             .get(&name)
@@ -101,6 +111,7 @@ impl LogsService {
             arn: arn.clone(),
             output_format: output_format.clone(),
             delivery_destination_configuration: config.clone(),
+            delivery_destination_type: delivery_destination_type.clone(),
             tags: tags.clone(),
             delivery_destination_policy: existing_policy,
         };
@@ -121,6 +132,7 @@ impl LogsService {
             "deliveryDestination": {
                 "name": name,
                 "arn": arn,
+                "deliveryDestinationType": delivery_destination_type,
                 "deliveryDestinationConfiguration": config_resp,
             }
         });
@@ -166,6 +178,7 @@ impl LogsService {
         let mut obj = json!({
             "name": dd.name,
             "arn": dd.arn,
+            "deliveryDestinationType": dd.delivery_destination_type,
             "deliveryDestinationConfiguration": dd_config_json(&dd.delivery_destination_configuration),
         });
         if let Some(ref fmt) = dd.output_format {
@@ -196,6 +209,7 @@ impl LogsService {
                 let mut obj = json!({
                     "name": dd.name,
                     "arn": dd.arn,
+                    "deliveryDestinationType": dd.delivery_destination_type,
                     "deliveryDestinationConfiguration": dd_config_json(&dd.delivery_destination_configuration),
                 });
                 if let Some(ref fmt) = dd.output_format {

--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -445,6 +445,21 @@ fn dd_config_json(config: &std::collections::BTreeMap<String, String>) -> Value 
     Value::Object(m)
 }
 
+/// Infer a delivery destination's type from its destination resource ARN's
+/// service. Defaults to `CWL` (the most common case) when the ARN is absent or
+/// unrecognised.
+pub fn infer_delivery_destination_type(destination_arn: Option<&String>) -> String {
+    let arn = destination_arn.map(String::as_str).unwrap_or("");
+    let service = arn.split(':').nth(2).unwrap_or("");
+    match service {
+        "s3" => "S3",
+        "firehose" => "FH",
+        "xray" => "XRAY",
+        _ => "CWL",
+    }
+    .to_string()
+}
+
 fn generate_sequence_token() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let nanos = SystemTime::now()

--- a/crates/fakecloud-logs/src/service/policies.rs
+++ b/crates/fakecloud-logs/src/service/policies.rs
@@ -369,7 +369,10 @@ impl LogsService {
                 format!("The specified log group does not exist: {group_name}"),
             )
         })?;
-        let log_group_id_resp = group.arn.clone();
+        // Echo back the identifier exactly as supplied (AWS round-trips it), so
+        // the resource's `log_group_name` matches the configured value instead of
+        // drifting to the ARN form.
+        let log_group_id_resp = log_group_id.clone();
 
         group.data_protection_policy = Some(DataProtectionPolicy {
             policy_document: policy_document.clone(),
@@ -427,7 +430,7 @@ impl LogsService {
         })?;
 
         let mut result = json!({
-            "logGroupIdentifier": group.arn,
+            "logGroupIdentifier": log_group_id,
         });
         if let Some(ref dp) = group.data_protection_policy {
             result["policyDocument"] = json!(dp.policy_document);

--- a/crates/fakecloud-logs/src/service/tags.rs
+++ b/crates/fakecloud-logs/src/service/tags.rs
@@ -270,6 +270,22 @@ impl LogsService {
             ));
         }
 
+        // Try anomaly detector
+        if let Some(detector) = state.anomaly_detectors.get(arn) {
+            return Ok(AwsResponse::json(
+                StatusCode::OK,
+                serde_json::to_string(&json!({ "tags": detector.tags })).unwrap(),
+            ));
+        }
+
+        // Try delivery destination (keyed by name, so match on the ARN field)
+        if let Some(dest) = state.delivery_destinations.values().find(|d| d.arn == arn) {
+            return Ok(AwsResponse::json(
+                StatusCode::OK,
+                serde_json::to_string(&json!({ "tags": dest.tags })).unwrap(),
+            ));
+        }
+
         Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "ResourceNotFoundException",

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -280,6 +280,10 @@ pub struct DeliveryDestination {
     pub arn: String,
     pub output_format: Option<String>,
     pub delivery_destination_configuration: BTreeMap<String, String>,
+    /// `CWL`/`S3`/`FH`/`XRAY` — derived from the destination resource ARN when
+    /// the caller does not specify it. AWS always reports it on read.
+    #[serde(default)]
+    pub delivery_destination_type: String,
     pub tags: BTreeMap<String, String>,
     pub delivery_destination_policy: Option<String>,
 }
@@ -365,6 +369,8 @@ pub struct AnomalyDetector {
     pub creation_time: i64,
     pub last_modified_time: i64,
     pub enabled: bool,
+    #[serde(default)]
+    pub tags: BTreeMap<String, String>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -316,19 +316,21 @@ pub const SERVICES: &[Service] = &[
         // filter `unit` field (DescribeMetricFilters defaults it to None) and
         // fixed the Lambda empty-Environment drift the subscription-filter test
         // surfaced via its Lambda destination.
+        // Batch 17 reclaimed anomaly detectors (ListTagsForResource now resolves
+        // their ARNs), data-protection policies (the put/get echo the supplied
+        // logGroupIdentifier verbatim so log_group_name round-trips), and the
+        // vended-log delivery destinations (DescribeDeliveryDestination reports
+        // the destination type — derived from the destination resource ARN — and
+        // ListTagsForResource resolves delivery-destination ARNs).
         run_regex: "^TestAccLogs[A-Za-z]+_basic$",
         deny: &[
-            // --- gap: log anomaly detection — needs the anomaly-detector
-            //     engine fakecloud does not model. ---
-            "TestAccLogsAnomalyDetector_basic",
-            // --- gap: data-protection policies — needs the data-protection
-            //     policy engine (audit/deidentify) fakecloud does not model. ---
-            "TestAccLogsDataProtectionPolicy_basic",
+            // --- gap: this data source's document GENERATION round-trips, but
+            //     its acceptance config provisions a Firehose delivery stream as
+            //     a findings destination, which drifts on Firehose's
+            //     `extended_s3_configuration` computed defaults (custom_time_zone,
+            //     s3_backup_mode) and the cross-service `LogDeliveryEnabled`
+            //     auto-tag. That is a Firehose-fidelity gap, not a logs one. ---
             "TestAccLogsDataProtectionPolicyDocumentDataSource_basic",
-            // --- gap: CloudWatch Logs v2 vended-log delivery (delivery
-            //     sources/destinations) is not implemented. ---
-            "TestAccLogsDeliveryDestination_basic",
-            "TestAccLogsDeliveryDestinationPolicy_basic",
         ],
     },
     Service {


### PR DESCRIPTION
## Summary

B17 of the tfacc backlog. Reclaims four acceptance tests by fixing real CloudWatch Logs response gaps (no gaming, no stubs). All operations already existed; the deny comments were stale.

- **ListTagsForResource** now resolves anomaly-detector and delivery-destination ARNs (the latter is keyed by name, so it matches on the stored ARN field). Anomaly detectors gained a `tags` field, stored from `CreateLogAnomalyDetector`. Unblocks `AnomalyDetector` + `DeliveryDestinationPolicy`.
- **Data-protection policies**: `PutDataProtectionPolicy`/`GetDataProtectionPolicy` echo the supplied `logGroupIdentifier` verbatim (AWS round-trips it) instead of the `:*`-suffixed ARN, so the resource's `log_group_name` matches the configured value. Unblocks `DataProtectionPolicy`.
- **Delivery destinations** carry a `delivery_destination_type`, derived from the destination resource ARN's service (CloudWatch Logs -> `CWL`, S3 -> `S3`, Firehose -> `FH`, X-Ray -> `XRAY`) when not supplied, and reported on `Get`/`DescribeDeliveryDestination`. Unblocks `DeliveryDestination`.

`DataProtectionPolicyDocumentDataSource` stays denied with a sharpened reason: its document generation round-trips, but its acceptance config drifts on a Firehose delivery stream's `extended_s3_configuration` computed defaults (`custom_time_zone`, `s3_backup_mode`) and the cross-service `LogDeliveryEnabled` auto-tag — a Firehose-fidelity gap, not a logs one.

No new public API surface (behavior fixes on existing operations), so no SDK/docs/website/count changes.

## Test plan
- New e2e: `logs_anomaly_detector_tags_listable_by_arn`, `logs_data_protection_policy_identifier_round_trips`, `logs_delivery_destination_reports_type_and_tags` -- pass.
- Local tfacc: full `logs` shard green (minus the documented Firehose-dependent deny).
- `cargo test -p fakecloud-logs` (301 pass), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt`, `check-doc-counts.sh` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CloudWatch Logs response gaps to make tags listable for anomaly detectors and delivery destinations, and to round-trip data-protection identifiers correctly. Reclaims four tfacc acceptance tests with no new APIs.

- **Bug Fixes**
  - `ListTagsForResource` now resolves anomaly-detector and delivery-destination ARNs; anomaly detectors store create-time `tags` from `CreateLogAnomalyDetector` (unblocks AnomalyDetector, DeliveryDestinationPolicy).
  - `PutDataProtectionPolicy`/`GetDataProtectionPolicy` echo the supplied `logGroupIdentifier` (no `:*` ARN suffix), keeping `log_group_name` stable (unblocks DataProtectionPolicy).
  - Delivery destinations infer `delivery_destination_type` from `destinationResourceArn` service (`CWL`/`S3`/`FH`/`XRAY`) when not provided, and return it from `Get`/`DescribeDeliveryDestination` (unblocks DeliveryDestination).
  - Sharpened deny note for `DataProtectionPolicyDocumentDataSource`: drift is due to Firehose defaults and the `LogDeliveryEnabled` tag (Firehose fidelity gap).

<sup>Written for commit 72c9abee6f9ebdb5b488ea21c8860ec46b9d6285. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

