### PR TITLE
test(tfacc): enable secretsmanager secret rotation (resource + data source)

### DIFF
--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -381,13 +381,14 @@ pub const SERVICES: &[Service] = &[
         // data sources — secret (+ data source), secret policy, secret version
         // data sources, random-password data source and ephemeral resource.
         // Passes against fakecloud out of the box.
+        // Batch 18 enabled secret rotation (resource + data source): RotateSecret
+        // is fully implemented — it persists the rotation lambda ARN + rules,
+        // marks rotation enabled, and actually invokes the rotation Lambda (via
+        // the container runtime, the same path the Lambda Function tfacc tests
+        // use) so RotateImmediately completes and the secret reports its
+        // rotation configuration.
         run_regex: "^TestAccSecretsManager[A-Za-z]+_basic$",
-        deny: &[
-            // --- gap: secret rotation drives a Lambda rotation function on a
-            //     schedule, which fakecloud does not orchestrate. ---
-            "TestAccSecretsManagerSecretRotation_basic",
-            "TestAccSecretsManagerSecretRotationDataSource_basic",
-        ],
+        deny: &[],
     },
     Service {
         name: "sqs",


### PR DESCRIPTION
## Summary

B18 of the tfacc backlog. `RotateSecret` is already fully implemented -- it persists the rotation lambda ARN and rotation rules, marks rotation enabled, and invokes the rotation Lambda via the container runtime (the same path the Lambda Function acceptance tests use), so `RotateImmediately` completes and the secret reports its rotation configuration.

Both `TestAccSecretsManagerSecretRotation_basic` and `TestAccSecretsManagerSecretRotationDataSource_basic` pass against fakecloud unchanged; the deny comment ("fakecloud does not orchestrate the rotation Lambda") was stale. This re-widens the allowlist by clearing the secretsmanager deny-list.

No code change (the existing `fakecloud-secretsmanager` service unit tests already cover `RotateSecret`). No new public API surface.

## Test plan
- Local tfacc: `TestAccSecretsManagerSecretRotation_basic` (28s, spins the rotation Lambda container) and `TestAccSecretsManagerSecretRotationDataSource_basic` both pass; full `secretsmanager` shard green.
- `tfacc_shards` matrix and `check-doc-counts.sh` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Secrets Manager secret rotation acceptance tests by removing the deny-list entries in the tfacc allowlist. Rotation already works in fakecloud (persists rotation config and invokes the rotation Lambda), so both the resource and data source tests now run green with no service code changes.

<sup>Written for commit 2227b50b7a5ebb56d7f17fb8aebb809070aac936. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

