### PR TITLE
fix(apigatewayv2): round-trip REQUEST authorizer fields, enable Lambda authorizer

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/service/authorizers.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/authorizers.rs
@@ -72,6 +72,11 @@ impl ApiGatewayV2Service {
             authorizer_uri,
             identity_source,
             jwt_configuration,
+            authorizer_payload_format_version: body["authorizerPayloadFormatVersion"]
+                .as_str()
+                .map(|s| s.to_string()),
+            authorizer_result_ttl_in_seconds: body["authorizerResultTtlInSeconds"].as_i64(),
+            enable_simple_responses: body["enableSimpleResponses"].as_bool(),
         };
 
         let mut accounts = self.state.write();
@@ -255,6 +260,18 @@ impl ApiGatewayV2Service {
                         format!("Invalid jwtConfiguration: {}", e),
                     )
                 })?);
+        }
+
+        if let Some(v) = body["authorizerPayloadFormatVersion"].as_str() {
+            authorizer.authorizer_payload_format_version = Some(v.to_string());
+        }
+
+        if let Some(v) = body["authorizerResultTtlInSeconds"].as_i64() {
+            authorizer.authorizer_result_ttl_in_seconds = Some(v);
+        }
+
+        if let Some(v) = body["enableSimpleResponses"].as_bool() {
+            authorizer.enable_simple_responses = Some(v);
         }
 
         Ok(AwsResponse::ok_json(json!(authorizer)))

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -378,6 +378,15 @@ pub struct Authorizer {
     pub identity_source: Option<Vec<String>>, // e.g., ["$request.header.Authorization"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jwt_configuration: Option<JwtConfiguration>,
+    /// Payload format version for a REQUEST (Lambda) authorizer (`1.0`/`2.0`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorizer_payload_format_version: Option<String>,
+    /// TTL (seconds) for cached authorizer results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorizer_result_ttl_in_seconds: Option<i64>,
+    /// Whether a `2.0` Lambda authorizer returns a simple boolean response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enable_simple_responses: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
@@ -612,6 +612,14 @@ impl ResourceProvisioner {
                 .map(String::from),
             identity_source,
             jwt_configuration,
+            authorizer_payload_format_version: props
+                .get("AuthorizerPayloadFormatVersion")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            authorizer_result_ttl_in_seconds: props
+                .get("AuthorizerResultTtlInSeconds")
+                .and_then(|v| v.as_i64()),
+            enable_simple_responses: props.get("EnableSimpleResponses").and_then(|v| v.as_bool()),
         };
         let mut accounts = self.apigatewayv2_state.write();
         let state = accounts.get_or_create(&self.account_id);

--- a/crates/fakecloud-e2e/tests/apigatewayv2.rs
+++ b/crates/fakecloud-e2e/tests/apigatewayv2.rs
@@ -1238,6 +1238,64 @@ async fn test_mock_integration() {
 }
 
 #[tokio::test]
+async fn request_authorizer_roundtrips_lambda_fields() {
+    // A REQUEST (Lambda) authorizer round-trips the payload-format-version, the
+    // result TTL, and enable_simple_responses through create -> get -> update,
+    // so the Terraform resource's update step does not re-plan.
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api = client
+        .create_api()
+        .name("auth-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+    let api_id = api.api_id().unwrap();
+
+    let created = client
+        .create_authorizer()
+        .api_id(api_id)
+        .authorizer_type(aws_sdk_apigatewayv2::types::AuthorizerType::Request)
+        .name("lambda-auth")
+        .authorizer_uri("arn:aws:lambda:us-east-1:123456789012:function:authz")
+        .identity_source("$request.header.Authorization")
+        .authorizer_payload_format_version("2.0")
+        .authorizer_result_ttl_in_seconds(300)
+        .enable_simple_responses(false)
+        .send()
+        .await
+        .unwrap();
+    let auth_id = created.authorizer_id().unwrap();
+    assert_eq!(created.authorizer_payload_format_version(), Some("2.0"));
+    assert_eq!(created.authorizer_result_ttl_in_seconds(), Some(300));
+    assert_eq!(created.enable_simple_responses(), Some(false));
+
+    // Flip enable_simple_responses; the read reflects the new value.
+    let updated = client
+        .update_authorizer()
+        .api_id(api_id)
+        .authorizer_id(auth_id)
+        .enable_simple_responses(true)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(updated.enable_simple_responses(), Some(true));
+
+    let got = client
+        .get_authorizer()
+        .api_id(api_id)
+        .authorizer_id(auth_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.enable_simple_responses(), Some(true));
+    assert_eq!(got.authorizer_payload_format_version(), Some("2.0"));
+    assert_eq!(got.authorizer_result_ttl_in_seconds(), Some(300));
+}
+
+#[tokio::test]
 async fn test_authorizer_crud() {
     let server = TestServer::start().await;
     let client = server.apigatewayv2_client().await;

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -243,14 +243,14 @@ pub const SERVICES: &[Service] = &[
         // integrations their protocol-specific default timeout (29000ms for
         // WEBSOCKET, 30000ms for HTTP) so the export data source — which renders
         // the full integration into its OpenAPI document — round-trips cleanly.
+        // Batch 19 reclaimed the REQUEST (Lambda) authorizer: fakecloud stands
+        // up the authorizer Lambda via the container runtime (the same path the
+        // Lambda Function tfacc tests use), and CreateAuthorizer/UpdateAuthorizer
+        // now round-trip enable_simple_responses, authorizer_payload_format_version,
+        // and authorizer_result_ttl_in_seconds so the update step does not drift.
         run_regex:
             "^TestAccAPIGatewayV2([A-Za-z]+_basic|API_basicHTTP|Integration_basic(HTTP|WebSocket))$",
-        deny: &[
-            // --- gap: a REQUEST authorizer wires up a real Lambda authorizer
-            //     function, which fakecloud cannot stand up without a working
-            //     Lambda runtime in this environment. ---
-            "TestAccAPIGatewayV2Authorizer_basic",
-        ],
+        deny: &[],
     },
     Service {
         name: "kinesis",


### PR DESCRIPTION
## Summary

B19 of the tfacc backlog. The REQUEST (Lambda) authorizer acceptance test now passes: fakecloud stands up the authorizer Lambda via the container runtime (the same path the Lambda Function acceptance tests use, proven viable by the secret-rotation batch), and the authorizer round-trips the fields the provider's update step flips.

- Add `enable_simple_responses`, `authorizer_payload_format_version`, and `authorizer_result_ttl_in_seconds` to the `Authorizer` state, parsed in `CreateAuthorizer`/`UpdateAuthorizer` and set by the CloudFormation provisioner. Previously `enable_simple_responses` drifted `false -> true` on every update, failing the test's second (update) step with a non-empty plan.

Un-deny `TestAccAPIGatewayV2Authorizer_basic`. The deny comment ("fakecloud cannot stand up a Lambda runtime in this environment") was stale.

No new public API surface (fields added to an existing operation's I/O), so no SDK/docs/website/count changes.

## Test plan
- New e2e: `request_authorizer_roundtrips_lambda_fields` (create -> update -> get) -- pass.
- Local tfacc: `TestAccAPIGatewayV2Authorizer_basic` passes (spins the authorizer Lambda container, ~40s); full `apigatewayv2` shard green.
- `cargo test -p fakecloud-apigatewayv2` (137 pass), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt`, `check-doc-counts.sh` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes drift for REQUEST (Lambda) authorizers by round-tripping payload format version, result TTL, and simple responses, and enables the Lambda authorizer flow in `apigatewayv2`. Terraform acceptance now passes and the deny is removed.

- **Bug Fixes**
  - Store and round-trip `authorizer_payload_format_version`, `authorizer_result_ttl_in_seconds`, and `enable_simple_responses` in the `Authorizer` state; parsed in Create/Update and set via the `fakecloud-cloudformation` provisioner.
  - Stand up the authorizer Lambda via the container runtime (same path as Lambda Function tests) to support REQUEST authorizers end-to-end.
  - Add e2e `request_authorizer_roundtrips_lambda_fields`; un-deny `TestAccAPIGatewayV2Authorizer_basic` and update the `fakecloud-tfacc` allowlist.

<sup>Written for commit 64ad0ca4f33aa1b6fe6f547eeb4df9bb9dc7b091. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

