### PR TITLE
fix(route53): report full DNSSEC material on key-signing keys

### DIFF
--- a/crates/fakecloud-e2e/tests/route53_dnssec_querylog_cidr.rs
+++ b/crates/fakecloud-e2e/tests/route53_dnssec_querylog_cidr.rs
@@ -96,6 +96,22 @@ async fn ksk_lifecycle_and_status_transitions() {
     assert_eq!(ksk.name(), Some("primary_ksk"));
     assert_eq!(ksk.status(), Some("INACTIVE"));
     assert_eq!(ksk.flag(), 257);
+    // The response carries the full DNSSEC material derived from the keypair.
+    assert!(ksk.key_tag() > 0);
+    let public_key = ksk.public_key().expect("public_key");
+    assert!(!public_key.is_empty());
+    let digest_value = ksk.digest_value().expect("digest_value");
+    assert_eq!(digest_value.len(), 64);
+    assert!(digest_value
+        .chars()
+        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_lowercase()));
+    let dnskey_record = ksk.dnskey_record().expect("dnskey_record");
+    assert_eq!(dnskey_record, format!("257 3 13 {public_key}"));
+    let ds_record = ksk.ds_record().expect("ds_record");
+    assert_eq!(
+        ds_record,
+        format!("{} 13 2 {}", ksk.key_tag(), digest_value)
+    );
 
     // Cannot delete an ACTIVE KSK; flip to ACTIVE first to confirm guard.
     r53.activate_key_signing_key()

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -619,6 +619,25 @@ pub(crate) fn push_key_signing_key_inner(out: &mut String, k: &StoredKeySigningK
          <DigestAlgorithmType>2</DigestAlgorithmType>",
     );
     out.push_str(&format!("<KeyTag>{}</KeyTag>", k.key_tag));
+    // Re-derive the (deterministic) DNSSEC key material so the response carries
+    // the DNSKEY public key, the DNSKEY/DS presentation records, and the DS
+    // digest the Terraform resource asserts. AWS reports the DS digest in upper
+    // case hex; the DNSKEY/DS records use the standard zone-file presentation.
+    let material = crate::dnssec::derive_keypair(&k.hosted_zone_id, &k.name);
+    let public_key_b64 = crate::dnssec::b64(&material.dnskey_public_key);
+    let digest_upper = k.ds_digest_hex.to_uppercase();
+    let dnskey_record = format!("257 3 13 {public_key_b64}");
+    let ds_record = format!("{} 13 2 {}", k.key_tag, digest_upper);
+    out.push_str(&format!("<PublicKey>{}</PublicKey>", esc(&public_key_b64)));
+    out.push_str(&format!(
+        "<DigestValue>{}</DigestValue>",
+        esc(&digest_upper)
+    ));
+    out.push_str(&format!(
+        "<DNSKEYRecord>{}</DNSKEYRecord>",
+        esc(&dnskey_record)
+    ));
+    out.push_str(&format!("<DSRecord>{}</DSRecord>", esc(&ds_record)));
     out.push_str(&format!("<Status>{}</Status>", esc(&k.status)));
     out.push_str(&format!(
         "<CreatedDate>{}</CreatedDate>",

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -114,11 +114,13 @@ pub const SERVICES: &[Service] = &[
         deny: &[
             // (CIDR collection ARN now omits the account id —
             //  `arn:aws:route53:::cidrcollection/...` — so that test runs.)
-            // --- gap: DNSSEC key-signing keys need real DNSSEC crypto derived
-            //     from the referenced KMS key — public_key, dnskey_record,
-            //     ds_record, and the SHA-256 digest_value (keytag + DS digest).
-            //     A focused follow-up. ---
-            "TestAccRoute53KeySigningKey_basic",
+            // (Batch 20: DNSSEC key-signing keys now report the full DNSSEC
+            //  material — the CreateKeySigningKey/GetDNSSEC response carries the
+            //  base64 PublicKey, the DNSKEY/DS presentation records, and the
+            //  upper-case SHA-256 DigestValue, all derived deterministically from
+            //  the (zone, ksk-name) keypair fakecloud already generates — so the
+            //  resource's public_key/dnskey_record/ds_record/digest_value
+            //  assertions pass.)
             // (Private-zone VPC association now works: a zone created with a VPC
             //  is private and carries default NS/SOA records, and
             //  ListHostedZonesByVPC returns a bare HostedZoneId.)


### PR DESCRIPTION
## Summary

B20 of the tfacc backlog. The `CreateKeySigningKey` / `GetDNSSEC` responses now carry the DNSSEC presentation fields the `aws_route53_key_signing_key` resource asserts:

- `PublicKey` -- base64 of the DNSKEY public key
- `DNSKEYRecord` -- `257 3 13 <pubkey>`
- `DSRecord` -- `<keytag> 13 2 <digest>`
- `DigestValue` -- upper-case SHA-256 DS digest

They are derived deterministically from the (zone, ksk-name) ECDSA P-256 keypair fakecloud already generates -- the DS digest, key tag, and keypair were all already computed (in `crates/fakecloud-route53/src/dnssec.rs`); the response XML in `push_key_signing_key_inner` simply omitted these four fields. Unblocks `TestAccRoute53KeySigningKey_basic`.

No new public API surface (fields added to an existing operation's response), so no SDK/docs/website/count changes.

## Test plan
- Extended e2e `ksk_lifecycle_and_status_transitions` to assert all four fields (public_key non-empty, 64-char upper-hex digest, DNSKEY/DS presentation records) -- pass.
- Local tfacc: `TestAccRoute53KeySigningKey_basic` passes; full `route53` shard green (182s).
- `cargo test -p fakecloud-route53`, `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt`, `check-doc-counts.sh` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose full DNSSEC material on Route 53 key-signing key responses. Adds PublicKey, DNSKEYRecord, DSRecord, and upper-case DigestValue to unblock Terraform `aws_route53_key_signing_key`.

- **Bug Fixes**
  - Include PublicKey (base64), DNSKEYRecord ("257 3 13 <pubkey>"), DSRecord ("<keytag> 13 2 <digest>"), and upper-case SHA-256 DigestValue in CreateKeySigningKey/GetDNSSEC responses.
  - Derive values deterministically from the existing ECDSA P-256 keypair; no new API surface.
  - Extend e2e to assert the fields and enable `TestAccRoute53KeySigningKey_basic`.

<sup>Written for commit 2c8d80f537dc5b843b3e70e6e33a8caf96f6df71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

