### PR TITLE
fix(iam): attribute MatchedStatements to source policies in policy simulation

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_simulate.rs
+++ b/crates/fakecloud-e2e/tests/iam_simulate.rs
@@ -44,6 +44,51 @@ async fn simulate_custom_policy_allows_matching_action() {
         "expected allowed, got {:?}",
         r.eval_decision()
     );
+    // An allow is attributed to the matching statement's source policy.
+    let matched = r.matched_statements();
+    assert_eq!(matched.len(), 1);
+    assert_eq!(matched[0].source_policy_id(), Some("PolicyInputList.1"));
+    assert_eq!(
+        matched[0].source_policy_type().map(|t| t.as_str()),
+        Some("IAM Policy")
+    );
+}
+
+#[tokio::test]
+async fn simulate_principal_policy_matched_statement_names_inline_policy() {
+    // SimulatePrincipalPolicy attributes the decision to the user's inline
+    // policy, identified as `user_<user>_<policy>` with type "IAM Policy".
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    iam.create_user().user_name("alice").send().await.unwrap();
+    iam.put_user_policy()
+        .user_name("alice")
+        .policy_name("AllowS3Get")
+        .policy_document(ALLOW_S3_GET)
+        .send()
+        .await
+        .unwrap();
+    let user = iam.get_user().user_name("alice").send().await.unwrap();
+    let arn = user.user().unwrap().arn().to_string();
+
+    let resp = iam
+        .simulate_principal_policy()
+        .policy_source_arn(arn)
+        .action_names("s3:GetObject")
+        .resource_arns("arn:aws:s3:::bucket/key")
+        .send()
+        .await
+        .unwrap();
+    let r = &resp.evaluation_results()[0];
+    assert_eq!(r.eval_decision().as_str(), "allowed");
+    let matched = r.matched_statements();
+    assert_eq!(matched.len(), 1);
+    assert_eq!(matched[0].source_policy_id(), Some("user_alice_AllowS3Get"));
+    assert_eq!(
+        matched[0].source_policy_type().map(|t| t.as_str()),
+        Some("IAM Policy")
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -239,6 +239,29 @@ impl PolicyDocument {
     pub fn statement_count(&self) -> usize {
         self.statements.len()
     }
+
+    /// Count the identity-policy statements in this document that match the
+    /// request's action + resource (and condition, if any) and carry the given
+    /// effect (`allow` selects `Allow`, otherwise `Deny`). Used by policy
+    /// simulation to attribute `MatchedStatements` provenance: a statement that
+    /// contributed to the decision is reported with its source policy id.
+    /// Statements carrying a `Principal`/`NotPrincipal` (resource-policy only)
+    /// are never identity matches.
+    pub fn matching_identity_statements(&self, request: &EvalRequest<'_>, allow: bool) -> usize {
+        let want = if allow { Effect::Allow } else { Effect::Deny };
+        self.statements
+            .iter()
+            .filter(|s| matches!(s.principal, PrincipalPattern::None))
+            .filter(|s| s.effect == want)
+            .filter(|s| action_matches(&s.action, &request.action))
+            .filter(|s| resource_matches(&s.resource, &request.resource))
+            .filter(|s| {
+                s.condition
+                    .as_ref()
+                    .is_none_or(|c| c.matches(&request.context))
+            })
+            .count()
+    }
 }
 
 fn parse_statement(value: &Value) -> Option<ParsedStatement> {

--- a/crates/fakecloud-iam/src/iam_service/extras.rs
+++ b/crates/fakecloud-iam/src/iam_service/extras.rs
@@ -95,8 +95,13 @@ fn collect_member_list(req: &AwsRequest, prefix: &str) -> Vec<String> {
 /// the same docs into both the evaluator (via `PolicyDocument::parse`)
 /// and the condition-key scanner used to populate
 /// `MissingContextValues`.
-fn collect_principal_policy_jsons(state: &IamState, source_arn: &str) -> Vec<String> {
-    let mut out: Vec<String> = Vec::new();
+/// Resolve a principal's identity policy set as `(source_policy_id, document)`
+/// pairs. The `source_policy_id` mirrors AWS's policy-simulation naming: a
+/// managed policy is identified by its policy name, while an inline policy is
+/// `<principal-kind>_<principal-name>_<policy-name>` (e.g.
+/// `user_alice_AllowS3`). All carry the `IAM Policy` source type.
+fn collect_principal_policy_sources(state: &IamState, source_arn: &str) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
     let (kind, name) = match parse_principal_arn(source_arn) {
         Some(p) => p,
         None => return out,
@@ -119,13 +124,17 @@ fn collect_principal_policy_jsons(state: &IamState, source_arn: &str) -> Vec<Str
                 .unwrap_or_default(),
         ),
     };
+    let kind_prefix = match kind {
+        PrincipalKind::User => "user",
+        PrincipalKind::Role => "role",
+    };
     for arn in &managed {
         if let Some(doc) = managed_default_doc(state, arn) {
-            out.push(doc);
+            out.push((managed_policy_source_id(arn), doc));
         }
     }
-    for doc in inline.values() {
-        out.push(doc.clone());
+    for (policy_name, doc) in &inline {
+        out.push((format!("{kind_prefix}_{name}_{policy_name}"), doc.clone()));
     }
     // Users inherit every policy attached to a group they belong to —
     // both managed and inline. Roles can't be group members so this
@@ -137,15 +146,24 @@ fn collect_principal_policy_jsons(state: &IamState, source_arn: &str) -> Vec<Str
             }
             for arn in &group.attached_policies {
                 if let Some(doc) = managed_default_doc(state, arn) {
-                    out.push(doc);
+                    out.push((managed_policy_source_id(arn), doc));
                 }
             }
-            for doc in group.inline_policies.values() {
-                out.push(doc.clone());
+            for (policy_name, doc) in &group.inline_policies {
+                out.push((
+                    format!("group_{}_{}", group.group_name, policy_name),
+                    doc.clone(),
+                ));
             }
         }
     }
     out
+}
+
+/// A managed policy's simulation source id is its policy name — the last path
+/// segment of its ARN.
+fn managed_policy_source_id(arn: &str) -> String {
+    arn.rsplit('/').next().unwrap_or(arn).to_string()
 }
 
 /// Resolve a managed policy ARN to its default-version document, looking first
@@ -993,18 +1011,26 @@ impl IamService {
         // We collect the raw JSON alongside the parsed `PolicyDocument`
         // so MissingContextValues can scan the *resolved* doc set
         // (principal + group + boundary), not just the request inputs.
-        let mut identity_docs: Vec<PolicyDocument> = Vec::new();
+        // Each identity-side document is tracked with its simulation source id
+        // so MatchedStatements can attribute the decision to a policy.
+        let mut identity_sources: Vec<(String, PolicyDocument)> = Vec::new();
         let mut raw_policy_jsons: Vec<String> = Vec::new();
         let mut caller_arn: Option<String> = req.query_params.get("CallerArn").cloned();
         let mut boundary_docs: Option<Vec<PolicyDocument>> = None;
 
         match action {
             "SimulateCustomPolicy" => {
-                for body in collect_member_list(req, "PolicyInputList.member.") {
-                    identity_docs.push(PolicyDocument::parse(&body));
+                for (i, body) in collect_member_list(req, "PolicyInputList.member.")
+                    .into_iter()
+                    .enumerate()
+                {
+                    identity_sources.push((
+                        format!("PolicyInputList.{}", i + 1),
+                        PolicyDocument::parse(&body),
+                    ));
                     raw_policy_jsons.push(body);
                 }
-                if identity_docs.is_empty() {
+                if identity_sources.is_empty() {
                     return Err(AwsServiceError::aws_error(
                         StatusCode::BAD_REQUEST,
                         "InvalidInput",
@@ -1035,11 +1061,10 @@ impl IamService {
                 let accounts = self.state.read();
                 let empty = IamState::new(&req.account_id);
                 let state = accounts.get(&req.account_id).unwrap_or(&empty);
-                let resolved = collect_principal_policy_jsons(state, source_arn);
-                for body in &resolved {
-                    identity_docs.push(PolicyDocument::parse(body));
+                for (source_id, body) in collect_principal_policy_sources(state, source_arn) {
+                    identity_sources.push((source_id, PolicyDocument::parse(&body)));
+                    raw_policy_jsons.push(body);
                 }
-                raw_policy_jsons.extend(resolved);
                 if let Some(boundary_arn) = principal_boundary(state, source_arn) {
                     if let Some(p) = state.policies.get(&boundary_arn) {
                         if let Some(v) = p.versions.iter().find(|v| v.is_default) {
@@ -1049,13 +1074,24 @@ impl IamService {
                     }
                 }
                 // Add policies attached via PolicyInputList overlay.
-                for body in collect_member_list(req, "PolicyInputList.member.") {
-                    identity_docs.push(PolicyDocument::parse(&body));
+                for (i, body) in collect_member_list(req, "PolicyInputList.member.")
+                    .into_iter()
+                    .enumerate()
+                {
+                    identity_sources.push((
+                        format!("PolicyInputList.{}", i + 1),
+                        PolicyDocument::parse(&body),
+                    ));
                     raw_policy_jsons.push(body);
                 }
             }
             _ => {}
         }
+
+        let identity_docs: Vec<PolicyDocument> = identity_sources
+            .iter()
+            .map(|(_, doc)| doc.clone())
+            .collect();
 
         let principal_arn_str = caller_arn
             .clone()
@@ -1105,15 +1141,39 @@ impl IamService {
                     Decision::ImplicitDeny => "implicitDeny",
                     Decision::ExplicitDeny => "explicitDeny",
                 };
+                // Attribute the matched statements to their source policies.
+                // An Allow decision is backed by the matching Allow statements;
+                // an explicit Deny by the matching Deny statements. An implicit
+                // deny matched nothing, so it reports no statements.
+                let matched_xml: String = match decision {
+                    Decision::ImplicitDeny => String::new(),
+                    other => {
+                        let want_allow = matches!(other, Decision::Allow);
+                        identity_sources
+                            .iter()
+                            .flat_map(|(source_id, doc)| {
+                                let n = doc.matching_identity_statements(&eval_req, want_allow);
+                                std::iter::repeat_with(move || source_id.clone()).take(n)
+                            })
+                            .map(|source_id| {
+                                format!(
+                                    "<member><SourcePolicyId>{}</SourcePolicyId><SourcePolicyType>IAM Policy</SourcePolicyType></member>",
+                                    xml_escape(&source_id)
+                                )
+                            })
+                            .collect()
+                    }
+                };
                 let missing_xml: String = missing_keys
                     .iter()
                     .map(|k| format!("<member>{}</member>", xml_escape(k)))
                     .collect();
                 members.push_str(&format!(
-                    "<member><EvalActionName>{}</EvalActionName><EvalResourceName>{}</EvalResourceName><EvalDecision>{}</EvalDecision><MatchedStatements/><MissingContextValues>{}</MissingContextValues></member>",
+                    "<member><EvalActionName>{}</EvalActionName><EvalResourceName>{}</EvalResourceName><EvalDecision>{}</EvalDecision><MatchedStatements>{}</MatchedStatements><MissingContextValues>{}</MissingContextValues></member>",
                     xml_escape(action_name),
                     xml_escape(resource),
                     decision_str,
+                    matched_xml,
                     missing_xml,
                 ));
             }

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -342,14 +342,14 @@ pub const SERVICES: &[Service] = &[
         // fakecloud-side fixes that unblocked server certificates (trailing-PEM
         // newline), the STS global-endpoint token version in GetAccountSummary,
         // and ListServiceSpecificCredentials `<member>` framing.
+        // Batch 21: Simulate{Custom,Principal}Policy now attribute their
+        // MatchedStatements to the source policy. Each resolved identity policy
+        // is tracked with its simulation source id (a managed policy by its
+        // name, an inline policy as `<kind>_<principal>_<policy>`), and the
+        // evaluator exposes which statements matched the action/resource for the
+        // decision, so the data source reads source_policy_id/source_policy_type.
         run_regex: "^TestAccIAM[A-Za-z]+_basic$",
         deny: &[
-            // --- gap: SimulatePrincipalPolicy returns no per-statement
-            //          MatchedStatements detail (source_policy_id /
-            //          source_policy_type), which the data source asserts.
-            //          Needs the policy simulator to track which statement
-            //          produced each decision. ---
-            "TestAccIAMPrincipalPolicySimulationDataSource_basic",
             // (RolesDataSource now passes: accounts seed the default
             //  AWSServiceRoleForSupport / TrustedAdvisor service-linked roles
             //  like real AWS, so a fresh ListRoles is non-empty.)


### PR DESCRIPTION
## Summary

B21 of the tfacc backlog. `SimulateCustomPolicy` / `SimulatePrincipalPolicy` now populate each `EvaluationResult`'s `MatchedStatements` with the source policy that produced the decision, which the `aws_iam_principal_policy_simulation` data source reads as `source_policy_id` / `source_policy_type` (previously always emitted `<MatchedStatements/>`, so those attributes were "not found").

- Each resolved identity policy is tracked with its simulation source id: a managed policy by its policy name, an inline policy as `<kind>_<principal>_<policy>` (e.g. `user_alice_AllowS3Get`), and `PolicyInputList` entries as `PolicyInputList.<n>`. All report source type `IAM Policy`.
- The evaluator gains `PolicyDocument::matching_identity_statements`, which counts the statements matching the request's action/resource (and condition) for a given effect -- so an Allow decision attributes the matching Allow statements, an explicit Deny the matching Deny statements, and an implicit deny matches none.

Un-deny `TestAccIAMPrincipalPolicySimulationDataSource_basic`.

No new public API surface (fields populated on an existing operation's response), so no SDK/docs/website/count changes.

## Test plan
- New e2e: matched-statement provenance for both `simulate_custom_policy_allows_matching_action` (PolicyInputList.1) and `simulate_principal_policy_matched_statement_names_inline_policy` (user_alice_AllowS3Get) -- pass.
- Local tfacc: `TestAccIAMPrincipalPolicySimulationDataSource_basic` passes; an IAM policy/user-policy/role-policy/group-policy slice stays green (no regression).
- `cargo test -p fakecloud-iam` (492 pass), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate `MatchedStatements` in IAM policy simulations so each decision is attributed to the policy that matched. This fixes missing `source_policy_id`/`source_policy_type` in the `aws_iam_principal_policy_simulation` data source.

- **Bug Fixes**
  - `SimulateCustomPolicy` and `SimulatePrincipalPolicy` now emit `MatchedStatements` with `SourcePolicyId` and `SourcePolicyType` = "IAM Policy".
  - Track identity policies with stable IDs: managed by policy name; inline as `<kind>_<principal>_<policy>` (e.g. `user_alice_AllowS3Get`); `PolicyInputList` as `PolicyInputList.<n>`.
  - Add `PolicyDocument::matching_identity_statements` to attribute matching Allow/Deny statements; implicit deny reports none.
  - Un-deny `TestAccIAMPrincipalPolicySimulationDataSource_basic` and add e2e tests for custom and principal simulations.

<sup>Written for commit 4a72b1e029b26e02a91660120be854010eadbfb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

