### PR TITLE
feat(tfacc): add scheduler service; default target RetryPolicy

### DIFF
--- a/crates/fakecloud-e2e/tests/scheduler.rs
+++ b/crates/fakecloud-e2e/tests/scheduler.rs
@@ -123,6 +123,35 @@ async fn scheduler_create_get_delete_schedule() {
 }
 
 #[tokio::test]
+async fn scheduler_target_reports_default_retry_policy() {
+    // A target created without a RetryPolicy is reported with AWS's defaults:
+    // MaximumEventAgeInSeconds=86400, MaximumRetryAttempts=185. The Terraform
+    // resource reads these unconditionally, so they must always be present.
+    let server = TestServer::start().await;
+    let client = server.scheduler_client().await;
+
+    client
+        .create_schedule()
+        .name("retry-default")
+        .schedule_expression("rate(1 hour)")
+        .flexible_time_window(off_window())
+        .target(sqs_target())
+        .send()
+        .await
+        .expect("create_schedule");
+
+    let got = client
+        .get_schedule()
+        .name("retry-default")
+        .send()
+        .await
+        .expect("get_schedule");
+    let rp = got.target().unwrap().retry_policy().expect("retry_policy");
+    assert_eq!(rp.maximum_event_age_in_seconds(), Some(86400));
+    assert_eq!(rp.maximum_retry_attempts(), Some(185));
+}
+
+#[tokio::test]
 async fn scheduler_update_is_idempotent_upsert() {
     let server = TestServer::start().await;
     let client = server.scheduler_client().await;

--- a/crates/fakecloud-scheduler/src/service.rs
+++ b/crates/fakecloud-scheduler/src/service.rs
@@ -1037,25 +1037,16 @@ fn parse_target(v: Option<&Value>) -> Result<Target, AwsServiceError> {
         dead_letter_config: v.get("DeadLetterConfig").map(|d| DeadLetterConfig {
             arn: d.get("Arn").and_then(|a| a.as_str()).map(String::from),
         }),
-        // AWS always reports a RetryPolicy on a target, defaulting both fields
-        // when the caller omits the block entirely (MaximumEventAgeInSeconds =
-        // 86400 / 24h, MaximumRetryAttempts = 185). The Terraform resource reads
-        // `target.retry_policy.maximum_event_age_in_seconds` /
-        // `maximum_retry_attempts` unconditionally. An explicit 0 is preserved.
-        retry_policy: Some({
-            let p = v.get("RetryPolicy");
-            RetryPolicy {
-                maximum_event_age_in_seconds: Some(
-                    p.and_then(|p| p.get("MaximumEventAgeInSeconds"))
-                        .and_then(|n| n.as_i64())
-                        .unwrap_or(86400),
-                ),
-                maximum_retry_attempts: Some(
-                    p.and_then(|p| p.get("MaximumRetryAttempts"))
-                        .and_then(|n| n.as_i64())
-                        .unwrap_or(185),
-                ),
-            }
+        // Store the RetryPolicy exactly as supplied (None when the caller omits
+        // the block) so the simulated delivery ticker honors the real retry
+        // budget — a schedule with no RetryPolicy retries 0 times. AWS's
+        // reporting defaults (86400 / 185) are applied only in the
+        // GetSchedule serialization, not in stored state.
+        retry_policy: v.get("RetryPolicy").map(|p| RetryPolicy {
+            maximum_event_age_in_seconds: p
+                .get("MaximumEventAgeInSeconds")
+                .and_then(|n| n.as_i64()),
+            maximum_retry_attempts: p.get("MaximumRetryAttempts").and_then(|n| n.as_i64()),
         }),
         sqs_parameters: v.get("SqsParameters").map(|s| SqsParameters {
             message_group_id: s
@@ -1160,14 +1151,26 @@ fn target_json(t: &Target) -> Value {
         }
         out["DeadLetterConfig"] = Value::Object(dl);
     }
-    if let Some(ref p) = t.retry_policy {
+    // AWS always reports a RetryPolicy on a target, defaulting the fields the
+    // caller omitted (MaximumEventAgeInSeconds = 86400 / 24h,
+    // MaximumRetryAttempts = 185). The Terraform resource reads both
+    // unconditionally. Stored state keeps the supplied values (or None) so the
+    // delivery ticker uses the real retry budget; the defaults are presentation
+    // only.
+    {
+        let p = t.retry_policy.as_ref();
         let mut rp = serde_json::Map::new();
-        if let Some(n) = p.maximum_event_age_in_seconds {
-            rp.insert("MaximumEventAgeInSeconds".to_string(), Value::from(n));
-        }
-        if let Some(n) = p.maximum_retry_attempts {
-            rp.insert("MaximumRetryAttempts".to_string(), Value::from(n));
-        }
+        rp.insert(
+            "MaximumEventAgeInSeconds".to_string(),
+            Value::from(
+                p.and_then(|p| p.maximum_event_age_in_seconds)
+                    .unwrap_or(86400),
+            ),
+        );
+        rp.insert(
+            "MaximumRetryAttempts".to_string(),
+            Value::from(p.and_then(|p| p.maximum_retry_attempts).unwrap_or(185)),
+        );
         out["RetryPolicy"] = Value::Object(rp);
     }
     if let Some(ref s) = t.sqs_parameters {

--- a/crates/fakecloud-scheduler/src/service.rs
+++ b/crates/fakecloud-scheduler/src/service.rs
@@ -1037,11 +1037,25 @@ fn parse_target(v: Option<&Value>) -> Result<Target, AwsServiceError> {
         dead_letter_config: v.get("DeadLetterConfig").map(|d| DeadLetterConfig {
             arn: d.get("Arn").and_then(|a| a.as_str()).map(String::from),
         }),
-        retry_policy: v.get("RetryPolicy").map(|p| RetryPolicy {
-            maximum_event_age_in_seconds: p
-                .get("MaximumEventAgeInSeconds")
-                .and_then(|n| n.as_i64()),
-            maximum_retry_attempts: p.get("MaximumRetryAttempts").and_then(|n| n.as_i64()),
+        // AWS always reports a RetryPolicy on a target, defaulting both fields
+        // when the caller omits the block entirely (MaximumEventAgeInSeconds =
+        // 86400 / 24h, MaximumRetryAttempts = 185). The Terraform resource reads
+        // `target.retry_policy.maximum_event_age_in_seconds` /
+        // `maximum_retry_attempts` unconditionally. An explicit 0 is preserved.
+        retry_policy: Some({
+            let p = v.get("RetryPolicy");
+            RetryPolicy {
+                maximum_event_age_in_seconds: Some(
+                    p.and_then(|p| p.get("MaximumEventAgeInSeconds"))
+                        .and_then(|n| n.as_i64())
+                        .unwrap_or(86400),
+                ),
+                maximum_retry_attempts: Some(
+                    p.and_then(|p| p.get("MaximumRetryAttempts"))
+                        .and_then(|n| n.as_i64())
+                        .unwrap_or(185),
+                ),
+            }
         }),
         sqs_parameters: v.get("SqsParameters").map(|s| SqsParameters {
             message_group_id: s

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -593,6 +593,15 @@ pub const SERVICES: &[Service] = &[
         run_regex: "^TestAccSFN(StateMachineDataSource|Activity|ActivityDataSource)_basic$",
         deny: &[],
     },
+    Service {
+        name: "scheduler",
+        // EventBridge Scheduler: the `_basic` smoke for schedules and schedule
+        // groups. A target's RetryPolicy is always reported with AWS's defaults
+        // when omitted (MaximumEventAgeInSeconds=86400, MaximumRetryAttempts=185),
+        // which the resource reads unconditionally.
+        run_regex: "^TestAccScheduler[A-Za-z0-9]+_basic$",
+        deny: &[],
+    },
 ];
 
 /// CI matrix shards. One GitHub Actions job per entry.
@@ -887,6 +896,12 @@ pub const SHARDS: &[Shard] = &[
         name: "sfn",
         service: "sfn",
         run_regex: "^TestAccSFN(StateMachineDataSource|Activity|ActivityDataSource)_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "scheduler",
+        service: "scheduler",
+        run_regex: "^TestAccScheduler[A-Za-z0-9]+_basic$",
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -307,4 +307,5 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_EC2", "ec2"),
     ("AWS_ENDPOINT_URL_ECS", "ecs"),
     ("AWS_ENDPOINT_URL_COGNITO_IDENTITY", "cognito-identity"),
+    ("AWS_ENDPOINT_URL_SCHEDULER", "scheduler"),
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -191,3 +191,8 @@ async fn dynamodb_h_z_acceptance() {
 async fn dynamodb_resources_acceptance() {
     run_shard("dynamodb-resources").await;
 }
+
+#[tokio::test]
+async fn scheduler_acceptance() {
+    run_shard("scheduler").await;
+}


### PR DESCRIPTION
## Summary

First of the new-service tfacc expansion: wire **EventBridge Scheduler** into the acceptance harness (new `Service` + `Shard` + `acc.rs` fn + `AWS_ENDPOINT_URL_SCHEDULER` endpoint var). The `_basic` smoke for schedules and schedule groups now runs and passes.

**Fix:** a schedule target is always reported with a `RetryPolicy`, defaulting both fields when the caller omits the block (`MaximumEventAgeInSeconds=86400` / 24h, `MaximumRetryAttempts=185`); an explicit value (including `0`) is preserved. The Terraform resource reads `target.retry_policy.maximum_event_age_in_seconds` / `maximum_retry_attempts` unconditionally, so they must always be present (previously omitted → "Attribute not found").

No new public API surface (behavior fix on an existing operation's response).

## Test plan
- New e2e `scheduler_target_reports_default_retry_policy` -- pass.
- Local tfacc: full `scheduler` shard green (`TestAccSchedulerSchedule_basic` + `TestAccSchedulerScheduleGroup_basic`).
- `cargo test -p fakecloud-scheduler` (89 pass), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt`, `tfacc_shards` matrix, `check-doc-counts.sh` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds EventBridge Scheduler to `fakecloud-tfacc` acceptance and ensures targets always report a `RetryPolicy` with AWS defaults, applied at serialization only so runtime retries remain correct.

- **New Features**
  - Added `scheduler` service and shard to `fakecloud-tfacc` allowlist; runs `^TestAccScheduler[A-Za-z0-9]+_basic$`.
  - Introduced `AWS_ENDPOINT_URL_SCHEDULER`.

- **Bug Fixes**
  - `fakecloud-scheduler`: `GetSchedule` always returns `RetryPolicy` with defaults `MaximumEventAgeInSeconds=86400` and `MaximumRetryAttempts=185`; stored targets keep only supplied values (or None) so the delivery ticker uses the real retry budget. Explicit values, including 0, are preserved.

<sup>Written for commit 9e33ecdb58d0b8caeb054e89063164b483d273b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

