### PR TITLE
fix(cloudformation): persist CFN resources for 9 services missing from snapshot map

### DIFF
--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -95,6 +95,21 @@ fn service_key_for_type(resource_type: &str) -> Option<&'static str> {
         "Bedrock" => "bedrock",
         "Scheduler" => "scheduler",
         "IAM" => "iam",
+        // Services whose CloudFormation namespace differs from their fakecloud
+        // service name, and which were missing from this table: their
+        // provisioner mutates snapshot-backed state directly, so CFN-created
+        // (and CFN-deleted) resources vanished on restart while their
+        // direct-API equivalents persisted (#1766 class). Each has a registered
+        // snapshot hook in the server.
+        "CertificateManager" => "acm",
+        "ElasticLoadBalancingV2" => "elbv2",
+        "CloudFront" => "cloudfront",
+        "Route53" => "route53",
+        "KinesisFirehose" => "firehose",
+        "Glue" => "glue",
+        "WAFv2" => "wafv2",
+        "Athena" => "athena",
+        "Organizations" => "organizations",
         _ => return None,
     })
 }
@@ -3304,12 +3319,43 @@ mod tests {
             Some("eventbridge")
         );
         assert_eq!(service_key_for_type("AWS::Logs::LogGroup"), Some("logs"));
+        assert_eq!(
+            service_key_for_type("AWS::ElastiCache::CacheCluster"),
+            Some("elasticache")
+        );
         // S3 has no snapshot hook (it persists via the S3Store write-through).
         assert_eq!(service_key_for_type("AWS::S3::Bucket"), None);
-        // Non-snapshot-backed services.
+        // Snapshot-backed services whose CFN namespace differs from the
+        // fakecloud service name (these were missing from the map, #1766 class).
         assert_eq!(
             service_key_for_type("AWS::CertificateManager::Certificate"),
-            None
+            Some("acm")
+        );
+        assert_eq!(
+            service_key_for_type("AWS::ElasticLoadBalancingV2::LoadBalancer"),
+            Some("elbv2")
+        );
+        assert_eq!(
+            service_key_for_type("AWS::CloudFront::Distribution"),
+            Some("cloudfront")
+        );
+        assert_eq!(
+            service_key_for_type("AWS::Route53::HostedZone"),
+            Some("route53")
+        );
+        assert_eq!(
+            service_key_for_type("AWS::KinesisFirehose::DeliveryStream"),
+            Some("firehose")
+        );
+        assert_eq!(service_key_for_type("AWS::Glue::Database"), Some("glue"));
+        assert_eq!(service_key_for_type("AWS::WAFv2::WebACL"), Some("wafv2"));
+        assert_eq!(
+            service_key_for_type("AWS::Athena::WorkGroup"),
+            Some("athena")
+        );
+        assert_eq!(
+            service_key_for_type("AWS::Organizations::Organization"),
+            Some("organizations")
         );
         // Malformed / non-AWS types.
         assert_eq!(service_key_for_type("AWS::Lambda"), None);

--- a/crates/fakecloud-e2e/tests/cfn_provisioner_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cfn_provisioner_persistence.rs
@@ -22,7 +22,11 @@ const CFN_TEMPLATE: &str = r#"{"Resources":{
   "F":{"Type":"AWS::Lambda::Function","Properties":{
     "FunctionName":"cfn-fn","Runtime":"provided.al2","Handler":"index.handler",
     "Role":"arn:aws:iam::123456789012:role/r",
-    "Code":{"ZipFile":"def handler(event, context):\n    return {}\n"}}}}}"#;
+    "Code":{"ZipFile":"def handler(event, context):\n    return {}\n"}}},
+  "Zone":{"Type":"AWS::Route53::HostedZone","Properties":{"Name":"cfn-zone.example.com."}},
+  "GlueDb":{"Type":"AWS::Glue::Database","Properties":{
+    "CatalogId":"123456789012",
+    "DatabaseInput":{"Name":"cfn_glue_db"}}}}}"#;
 
 fn minimal_zip() -> Vec<u8> {
     use std::io::Write;
@@ -75,6 +79,34 @@ async fn queue_urls(server: &TestServer) -> Vec<String> {
         .unwrap()
         .queue_urls()
         .to_vec()
+}
+
+async fn hosted_zone_names(server: &TestServer) -> Vec<String> {
+    server
+        .route53_client()
+        .await
+        .list_hosted_zones()
+        .send()
+        .await
+        .unwrap()
+        .hosted_zones()
+        .iter()
+        .map(|z| z.name().to_string())
+        .collect()
+}
+
+async fn glue_database_names(server: &TestServer) -> Vec<String> {
+    server
+        .glue_client()
+        .await
+        .get_databases()
+        .send()
+        .await
+        .unwrap()
+        .database_list()
+        .iter()
+        .map(|d| d.name().to_string())
+        .collect()
 }
 
 async fn bucket_names(server: &TestServer) -> Vec<String> {
@@ -206,6 +238,20 @@ async fn cfn_provisioned_resources_survive_restart() {
     assert!(
         buckets.contains(&"api-bucket".to_string()),
         "api-bucket lost: {buckets:?}"
+    );
+
+    // Services whose CFN namespace differs from the fakecloud service name and
+    // were missing from `service_key_for_type` (#1766 class): these vanished on
+    // restart before the fix.
+    let zones = hosted_zone_names(&server).await;
+    assert!(
+        zones.iter().any(|n| n == "cfn-zone.example.com."),
+        "cfn-zone lost: {zones:?}"
+    );
+    let glue_dbs = glue_database_names(&server).await;
+    assert!(
+        glue_dbs.contains(&"cfn_glue_db".to_string()),
+        "cfn_glue_db lost: {glue_dbs:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

`service_key_for_type` in the CloudFormation crate maps a CFN resource type to its owning service's snapshot hook, so `persist_touched_services` can write provisioned state through to disk after a stack op. It was **missing 9 snapshot-backed services** whose CloudFormation namespace differs from the fakecloud service name:

| CFN namespace | hook key |
|---|---|
| `CertificateManager` | `acm` |
| `ElasticLoadBalancingV2` | `elbv2` |
| `CloudFront` | `cloudfront` |
| `Route53` | `route53` |
| `KinesisFirehose` | `firehose` |
| `Glue` | `glue` |
| `WAFv2` | `wafv2` |
| `Athena` | `athena` |
| `Organizations` | `organizations` |

Each has a registered snapshot hook (`fakecloud-server/src/main.rs`) and a working provisioner arm that mutates shared service state directly. With no map entry, the hook was never fired, so in persistent mode a `create-stack` with any of these resources reported `CREATE_COMPLETE` and the resources **vanished on restart** — while the identical resource created via its direct API persisted fine. This is the #1766 "side-channel mutates state but skips the snapshot" class, re-surfaced for the direct CreateStack/UpdateStack/DeleteStack path (`ExecuteChangeSet` already flushed all hooks, so CDK / `aws cloudformation deploy` / `sam deploy` were unaffected).

A unit test had **enshrined the bug**, asserting `AWS::CertificateManager::Certificate` was "non-snapshot-backed" (ACM has a real hook). Corrected here.

## Changes
- Add the 9 missing arms to `service_key_for_type`.
- Fix the unit test to assert the correct `Some(...)` mapping for all 9 (plus an ElastiCache case).
- Extend the `cfn_provisioner_persistence` E2E regression test: a CFN-created Route53 hosted zone + Glue database must survive a restart.

## Non-code surface
No new API surface, flag, field, service, or runtime — internal persistence-routing bugfix. No SDK / docs / website / metadata changes apply (checked).

## Test plan
- `cargo test -p fakecloud-cloudformation --lib service_key_for_type` — passes.
- `cargo test -p fakecloud-e2e --test cfn_provisioner_persistence` — both tests pass (resources survive restart; deleted resources stay gone).
- `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CloudFormation persistence for 9 snapshot-backed services. CFN-created resources for these services now survive restarts.

- **Bug Fixes**
  - Added missing mappings in `service_key_for_type` to fire snapshot hooks: CertificateManager→`acm`, ElasticLoadBalancingV2→`elbv2`, CloudFront, Route53, KinesisFirehose→`firehose`, Glue, WAFv2, Athena, Organizations.
  - Corrected the unit test (ACM is snapshot-backed) and added an ElastiCache case.
  - Extended `fakecloud-e2e` test `cfn_provisioner_persistence` to verify a CFN Route53 hosted zone and Glue database persist across restart.

<sup>Written for commit f2670807daed06b14891782f37caa9898e42aa41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

