### PR TITLE
fix(cloudformation): carry resource properties dropped by 5 provisioner arms

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/dynamodb.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/dynamodb.rs
@@ -157,6 +157,42 @@ impl ResourceProvisioner {
         };
         let stream_arn_attr = stream_arn.clone();
 
+        // Secondary indexes, SSE and tags: parse via the same dynamodb helpers
+        // the native CreateTable uses, so a CFN/SAM table carries its GSIs/LSIs
+        // (otherwise a Query/Scan on the index name fails at runtime), its
+        // encryption config and its tags — instead of provisioning them empty.
+        let null = serde_json::Value::Null;
+        let gsi = fakecloud_dynamodb::parse_gsi(
+            props.get("GlobalSecondaryIndexes").unwrap_or(&null),
+            &billing_mode,
+        );
+        let lsi =
+            fakecloud_dynamodb::parse_lsi(props.get("LocalSecondaryIndexes").unwrap_or(&null));
+        let tags = props
+            .get("Tags")
+            .map(fakecloud_dynamodb::parse_tags)
+            .unwrap_or_default();
+        let (sse_type, sse_kms_key_arn) = match props.get("SSESpecification") {
+            Some(sse_spec)
+                if sse_spec
+                    .get("SSEEnabled")
+                    .and_then(|v| v.as_bool().or_else(|| v.as_str().map(|s| s == "true")))
+                    .unwrap_or(false) =>
+            {
+                let sse_type = sse_spec
+                    .get("SSEType")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("KMS")
+                    .to_string();
+                let kms_key = sse_spec
+                    .get("KMSMasterKeyId")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                (Some(sse_type), kms_key)
+            }
+            _ => (None, None),
+        };
+
         let table = DynamoTable {
             name: table_name.to_string(),
             arn: arn.clone(),
@@ -165,9 +201,9 @@ impl ResourceProvisioner {
             attribute_definitions,
             provisioned_throughput,
             items: Vec::new(),
-            gsi: Vec::new(),
-            lsi: Vec::new(),
-            tags: BTreeMap::new(),
+            gsi,
+            lsi,
+            tags,
             created_at: Utc::now(),
             status: "ACTIVE".to_string(),
             item_count: 0,
@@ -184,8 +220,8 @@ impl ResourceProvisioner {
             stream_view_type,
             stream_arn,
             stream_records: Arc::new(RwLock::new(Vec::new())),
-            sse_type: None,
-            sse_kms_key_arn: None,
+            sse_type,
+            sse_kms_key_arn,
             deletion_protection_enabled,
             on_demand_throughput,
             table_class: props

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/eventbridge.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/eventbridge.rs
@@ -72,7 +72,20 @@ impl ResourceProvisioner {
                 .map(|s| s.to_string()),
             managed_by: None,
             created_by: None,
-            targets: Vec::new(),
+            // Inline `Targets` declared on the CFN resource. Without this the
+            // rule matches events but delivers to nothing (PutEvents only
+            // dispatches to rules with non-empty targets), so a CFN/SAM
+            // schedule or event rule silently fired into the void.
+            targets: props
+                .get("Targets")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter(|t| t.get("Arn").and_then(|v| v.as_str()).is_some())
+                        .map(fakecloud_eventbridge::parse_target)
+                        .collect()
+                })
+                .unwrap_or_default(),
             tags: std::collections::BTreeMap::new(),
             last_fired: None,
         };

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/iam.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/iam.rs
@@ -46,6 +46,16 @@ impl ResourceProvisioner {
             .unwrap_or_default();
 
         let path = props.get("Path").and_then(|v| v.as_str()).unwrap_or("/");
+        let permissions_boundary = props
+            .get("PermissionsBoundary")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let max_session_duration = props
+            .get("MaxSessionDuration")
+            .and_then(|v| v.as_i64())
+            .map(|v| v as i32)
+            .unwrap_or(3600);
+        let tags = parse_iam_tags(props.get("Tags"));
 
         let mut accounts = self.iam_state.write();
         let state = accounts.get_or_create(&self.account_id);
@@ -71,12 +81,51 @@ impl ResourceProvisioner {
                 .get("Description")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string()),
-            max_session_duration: 3600,
-            tags: Vec::new(),
-            permissions_boundary: None,
+            max_session_duration,
+            tags,
+            permissions_boundary,
         };
 
         state.roles.insert(role_name.to_string(), role);
+
+        // Inline policies declared inline on the role. Mirror the IAM user arm
+        // so a CFN/SAM-provisioned role actually carries its grants — without
+        // this, every workload assuming the role is denied under `--iam`
+        // enforcement (the AWS-managed-policy catalog is now real).
+        if let Some(policies) = props.get("Policies").and_then(|v| v.as_array()) {
+            let inline = state
+                .role_inline_policies
+                .entry(role_name.to_string())
+                .or_default();
+            for p in policies {
+                if let (Some(n), Some(doc)) = (
+                    p.get("PolicyName").and_then(|v| v.as_str()),
+                    p.get("PolicyDocument"),
+                ) {
+                    let document = if doc.is_string() {
+                        doc.as_str().unwrap_or("").to_string()
+                    } else {
+                        serde_json::to_string(doc).unwrap_or_default()
+                    };
+                    inline.insert(n.to_string(), document);
+                }
+            }
+        }
+        // Managed policy ARNs attached inline on the role.
+        if let Some(arns) = props.get("ManagedPolicyArns").and_then(|v| v.as_array()) {
+            let attached = state
+                .role_policies
+                .entry(role_name.to_string())
+                .or_default();
+            for a in arns {
+                if let Some(s) = a.as_str() {
+                    if !attached.contains(&s.to_string()) {
+                        attached.push(s.to_string());
+                    }
+                }
+            }
+        }
+
         Ok(ProvisionResult::new(arn.clone())
             .with("Arn", arn)
             .with("RoleId", role_id))

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
@@ -36,11 +36,49 @@ impl ResourceProvisioner {
             state.region, state.account_id, topic_name
         );
 
+        // Carry the topic configuration attributes a CFN topic can set, so
+        // GetTopicAttributes round-trips them instead of returning defaults.
+        let mut attributes = BTreeMap::new();
+        for key in [
+            "DisplayName",
+            "KmsMasterKeyId",
+            "SignatureVersion",
+            "TracingConfig",
+            "ArchivePolicy",
+            "FifoThroughputScope",
+        ] {
+            if let Some(s) = props.get(key).and_then(|v| v.as_str()) {
+                attributes.insert(key.to_string(), s.to_string());
+            }
+        }
+        for key in ["FifoTopic", "ContentBasedDeduplication"] {
+            if let Some(b) = props
+                .get(key)
+                .and_then(|v| v.as_bool().or_else(|| v.as_str().map(|s| s == "true")))
+            {
+                attributes.insert(key.to_string(), b.to_string());
+            }
+        }
+        let tags: Vec<(String, String)> = props
+            .get("Tags")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        Some((
+                            t.get("Key").and_then(|v| v.as_str())?.to_string(),
+                            t.get("Value").and_then(|v| v.as_str())?.to_string(),
+                        ))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let topic = SnsTopic {
             topic_arn: topic_arn.clone(),
             name: topic_name.to_string(),
-            attributes: BTreeMap::new(),
-            tags: Vec::new(),
+            attributes,
+            tags,
             is_fifo: topic_name.ends_with(".fifo"),
             created_at: Utc::now(),
             subscriptions_deleted: 0,
@@ -49,6 +87,35 @@ impl ResourceProvisioner {
         };
 
         state.topics.insert(topic_arn.clone(), topic);
+
+        // Inline `Subscription` list — SAM/CFN's shorthand for attaching
+        // subscriptions at topic-create time. Without this the topic is
+        // created with no subscribers and fan-out is silently broken.
+        if let Some(subs) = props.get("Subscription").and_then(|v| v.as_array()) {
+            for sub in subs {
+                let (Some(protocol), Some(endpoint)) = (
+                    sub.get("Protocol").and_then(|v| v.as_str()),
+                    sub.get("Endpoint").and_then(|v| v.as_str()),
+                ) else {
+                    continue;
+                };
+                let sub_arn = format!("{}:{}", topic_arn, Uuid::new_v4());
+                state.subscriptions.insert(
+                    sub_arn.clone(),
+                    SnsSubscription {
+                        subscription_arn: sub_arn,
+                        topic_arn: topic_arn.clone(),
+                        protocol: protocol.to_string(),
+                        endpoint: endpoint.to_string(),
+                        owner: state.account_id.clone(),
+                        attributes: BTreeMap::new(),
+                        confirmed: true,
+                        confirmation_token: None,
+                    },
+                );
+            }
+        }
+
         Ok(ProvisionResult::new(topic_arn.clone())
             .with("TopicArn", topic_arn)
             .with("TopicName", topic_name))

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sqs.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sqs.rs
@@ -40,17 +40,61 @@ impl ResourceProvisioner {
 
         let is_fifo = queue_name.ends_with(".fifo");
         let mut attributes = std::collections::BTreeMap::new();
+        // Seed the real AWS SQS defaults so a CFN-created queue matches one
+        // created via the API (Terraform refreshes these on every plan and
+        // reports drift if they are absent).
+        attributes.insert("VisibilityTimeout".to_string(), "30".to_string());
+        attributes.insert("DelaySeconds".to_string(), "0".to_string());
+        attributes.insert("MaximumMessageSize".to_string(), "262144".to_string());
+        attributes.insert("MessageRetentionPeriod".to_string(), "345600".to_string());
+        attributes.insert("ReceiveMessageWaitTimeSeconds".to_string(), "0".to_string());
+        attributes.insert(
+            "KmsDataKeyReusePeriodSeconds".to_string(),
+            "300".to_string(),
+        );
+        attributes.insert("SqsManagedSseEnabled".to_string(), "true".to_string());
+        if is_fifo {
+            attributes.insert("FifoQueue".to_string(), "true".to_string());
+            attributes.insert("ContentBasedDeduplication".to_string(), "false".to_string());
+            attributes.insert("DeduplicationScope".to_string(), "queue".to_string());
+            attributes.insert("FifoThroughputLimit".to_string(), "perQueue".to_string());
+        }
+        // Override with provided properties. Object-valued attributes
+        // (RedrivePolicy, RedriveAllowPolicy, Policy) are serialized to compact
+        // JSON and boolean attributes (ContentBasedDeduplication) to their
+        // string form — the previous copy kept only string/integer values, so
+        // these were silently dropped.
         if let Some(obj) = props.as_object() {
             for (k, v) in obj {
-                if k != "QueueName" {
-                    if let Some(s) = v.as_str() {
-                        attributes.insert(k.clone(), s.to_string());
-                    } else if let Some(n) = v.as_i64() {
-                        attributes.insert(k.clone(), n.to_string());
-                    }
+                if k == "QueueName" || k == "Tags" {
+                    continue;
                 }
+                let value = match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Bool(b) => b.to_string(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
+                        serde_json::to_string(v).unwrap_or_default()
+                    }
+                    serde_json::Value::Null => continue,
+                };
+                attributes.insert(k.clone(), value);
             }
         }
+        // A KMS key implies SSE-KMS, so managed SSE is off (mirrors the native
+        // create_queue mutual-exclusion).
+        if attributes
+            .get("KmsMasterKeyId")
+            .is_some_and(|k| !k.is_empty())
+        {
+            attributes.insert("SqsManagedSseEnabled".to_string(), "false".to_string());
+        }
+
+        // Typed RedrivePolicy used for runtime DLQ routing — without it, CFN
+        // queues never route to their dead-letter queue.
+        let redrive_policy = attributes
+            .get("RedrivePolicy")
+            .and_then(|s| fakecloud_sqs::parse_redrive_policy(s));
 
         let queue = SqsQueue {
             queue_name: queue_name.to_string(),
@@ -62,7 +106,7 @@ impl ResourceProvisioner {
             attributes,
             is_fifo,
             dedup_cache: std::collections::BTreeMap::new(),
-            redrive_policy: None,
+            redrive_policy,
             tags: std::collections::BTreeMap::new(),
             next_sequence_number: 0,
             permission_labels: Vec::new(),

--- a/crates/fakecloud-dynamodb/src/lib.rs
+++ b/crates/fakecloud-dynamodb/src/lib.rs
@@ -4,10 +4,11 @@ pub mod streams;
 pub mod streams_dataplane;
 pub mod ttl;
 
+pub use service::helpers::schemas::{parse_gsi, parse_lsi, parse_tags};
 pub use service::DynamoDbService;
 pub use state::{
-    AttributeDefinition, DynamoDbSnapshot, DynamoDbState, DynamoTable, KeySchemaElement,
-    OnDemandThroughput, ProvisionedThroughput, SharedDynamoDbState,
-    DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
+    AttributeDefinition, DynamoDbSnapshot, DynamoDbState, DynamoTable, GlobalSecondaryIndex,
+    KeySchemaElement, LocalSecondaryIndex, OnDemandThroughput, Projection, ProvisionedThroughput,
+    SharedDynamoDbState, DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
 };
 pub use streams_dataplane::DynamoDbStreamsService;

--- a/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
@@ -774,7 +774,7 @@ mod metrics;
 mod partiql;
 mod paths;
 mod request;
-mod schemas;
+pub(crate) mod schemas;
 mod table_descriptions;
 mod table_lookup;
 mod updates;

--- a/crates/fakecloud-dynamodb/src/service/helpers/schemas.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/schemas.rs
@@ -53,7 +53,7 @@ pub(crate) fn parse_provisioned_throughput(
     })
 }
 
-pub(crate) fn parse_gsi(val: &Value, billing_mode: &str) -> Vec<GlobalSecondaryIndex> {
+pub fn parse_gsi(val: &Value, billing_mode: &str) -> Vec<GlobalSecondaryIndex> {
     let Some(arr) = val.as_array() else {
         return Vec::new();
     };
@@ -79,7 +79,7 @@ pub(crate) fn parse_gsi(val: &Value, billing_mode: &str) -> Vec<GlobalSecondaryI
 /// `ProvisionedThroughput` block, and the Terraform provider's `flatten`
 /// code keys `name`/`read_capacity`/`write_capacity` off the presence of
 /// that field — returning `None` would desynchronise state.
-pub(crate) fn parse_gsi_throughput(val: &Value, billing_mode: &str) -> ProvisionedThroughput {
+pub fn parse_gsi_throughput(val: &Value, billing_mode: &str) -> ProvisionedThroughput {
     if billing_mode == "PAY_PER_REQUEST" {
         return ProvisionedThroughput {
             read_capacity_units: 0,
@@ -92,7 +92,7 @@ pub(crate) fn parse_gsi_throughput(val: &Value, billing_mode: &str) -> Provision
     }
 }
 
-pub(crate) fn parse_lsi(val: &Value) -> Vec<LocalSecondaryIndex> {
+pub fn parse_lsi(val: &Value) -> Vec<LocalSecondaryIndex> {
     let Some(arr) = val.as_array() else {
         return Vec::new();
     };
@@ -107,7 +107,7 @@ pub(crate) fn parse_lsi(val: &Value) -> Vec<LocalSecondaryIndex> {
         .collect()
 }
 
-pub(crate) fn parse_tags(val: &Value) -> BTreeMap<String, String> {
+pub fn parse_tags(val: &Value) -> BTreeMap<String, String> {
     let mut tags = BTreeMap::new();
     if let Some(arr) = val.as_array() {
         for tag in arr {

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -471,7 +471,7 @@ impl AwsService for DynamoDbService {
     }
 }
 
-mod helpers;
+pub(crate) mod helpers;
 pub(crate) use helpers::*;
 
 #[cfg(test)]

--- a/crates/fakecloud-e2e/tests/cloudformation_provisioner_properties.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_provisioner_properties.rs
@@ -1,0 +1,216 @@
+//! Regression coverage for CloudFormation provisioner arms that accepted a
+//! resource but dropped the properties that make it functional:
+//!
+//! - `AWS::IAM::Role` dropped `Policies` / `ManagedPolicyArns` (the role
+//!   granted nothing under `--iam` enforcement).
+//! - `AWS::Events::Rule` dropped `Targets` (the rule matched events but
+//!   delivered to nothing).
+//! - `AWS::DynamoDB::Table` dropped GSIs/LSIs (a Query on the index 400s at
+//!   runtime).
+//! - `AWS::SQS::Queue` dropped the typed `RedrivePolicy` and AWS-default
+//!   attributes (DLQ routing never happened; drift vs an API-created queue).
+//! - `AWS::SNS::Topic` dropped its inline `Subscription` list and config
+//!   attributes (fan-out silently broken).
+//!
+//! Each resource is provisioned via CloudFormation, then read back via the
+//! matching service SDK to assert the property survived.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": "cfn-props-role",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [{"Effect": "Allow", "Principal": {"Service": "lambda.amazonaws.com"}, "Action": "sts:AssumeRole"}]
+        },
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"],
+        "Policies": [{
+          "PolicyName": "inline-logs",
+          "PolicyDocument": {"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "logs:PutLogEvents", "Resource": "*"}]}
+        }]
+      }
+    },
+    "Bus": {"Type": "AWS::Events::EventBus", "Properties": {"Name": "cfn-props-bus"}},
+    "TargetQueue": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "cfn-props-target"}},
+    "Rule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Name": "cfn-props-rule",
+        "EventBusName": "cfn-props-bus",
+        "EventPattern": {"source": ["my.app"]},
+        "Targets": [{"Id": "t1", "Arn": {"Fn::GetAtt": ["TargetQueue", "Arn"]}}]
+      }
+    },
+    "Table": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "TableName": "cfn-props-table",
+        "BillingMode": "PAY_PER_REQUEST",
+        "AttributeDefinitions": [
+          {"AttributeName": "pk", "AttributeType": "S"},
+          {"AttributeName": "gsi_pk", "AttributeType": "S"}
+        ],
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "GlobalSecondaryIndexes": [{
+          "IndexName": "by-gsi",
+          "KeySchema": [{"AttributeName": "gsi_pk", "KeyType": "HASH"}],
+          "Projection": {"ProjectionType": "ALL"}
+        }]
+      }
+    },
+    "DlqTarget": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "cfn-props-dlq"}},
+    "MainQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "QueueName": "cfn-props-main",
+        "RedrivePolicy": {"deadLetterTargetArn": {"Fn::GetAtt": ["DlqTarget", "Arn"]}, "maxReceiveCount": 3}
+      }
+    },
+    "SubEndpoint": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "cfn-props-sns-sub"}},
+    "Topic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "TopicName": "cfn-props-topic",
+        "DisplayName": "CFN Props Topic",
+        "Subscription": [{"Protocol": "sqs", "Endpoint": {"Fn::GetAtt": ["SubEndpoint", "Arn"]}}]
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisioner_carries_resource_properties() {
+    let server = TestServer::start().await;
+
+    server
+        .cloudformation_client()
+        .await
+        .create_stack()
+        .stack_name("props")
+        .template_body(TEMPLATE)
+        .capabilities(aws_sdk_cloudformation::types::Capability::CapabilityNamedIam)
+        .send()
+        .await
+        .expect("create_stack");
+
+    // --- IAM Role carries managed + inline policies ---
+    let iam = server.iam_client().await;
+    let attached = iam
+        .list_attached_role_policies()
+        .role_name("cfn-props-role")
+        .send()
+        .await
+        .expect("list_attached_role_policies");
+    assert!(
+        attached
+            .attached_policies()
+            .iter()
+            .any(|p| p.policy_arn() == Some("arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess")),
+        "managed policy not attached: {:?}",
+        attached.attached_policies()
+    );
+    let inline = iam
+        .list_role_policies()
+        .role_name("cfn-props-role")
+        .send()
+        .await
+        .expect("list_role_policies");
+    assert!(
+        inline.policy_names().iter().any(|n| n == "inline-logs"),
+        "inline policy missing: {:?}",
+        inline.policy_names()
+    );
+
+    // --- Events::Rule carries its target ---
+    let events = server.eventbridge_client().await;
+    let targets = events
+        .list_targets_by_rule()
+        .rule("cfn-props-rule")
+        .event_bus_name("cfn-props-bus")
+        .send()
+        .await
+        .expect("list_targets_by_rule");
+    assert_eq!(
+        targets.targets().len(),
+        1,
+        "rule target dropped: {:?}",
+        targets.targets()
+    );
+    assert_eq!(targets.targets()[0].id(), "t1");
+
+    // --- DynamoDB Table carries its GSI ---
+    let ddb = server.dynamodb_client().await;
+    let table = ddb
+        .describe_table()
+        .table_name("cfn-props-table")
+        .send()
+        .await
+        .expect("describe_table");
+    let gsis = table.table().unwrap().global_secondary_indexes();
+    assert_eq!(gsis.len(), 1, "GSI dropped: {gsis:?}");
+    assert_eq!(gsis[0].index_name(), Some("by-gsi"));
+
+    // --- SQS Queue carries RedrivePolicy + AWS defaults ---
+    let sqs = server.sqs_client().await;
+    let url = sqs
+        .get_queue_url()
+        .queue_name("cfn-props-main")
+        .send()
+        .await
+        .expect("get_queue_url")
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::All)
+        .send()
+        .await
+        .expect("get_queue_attributes");
+    let map = attrs.attributes().unwrap();
+    let redrive = map
+        .get(&aws_sdk_sqs::types::QueueAttributeName::RedrivePolicy)
+        .expect("RedrivePolicy present");
+    assert!(
+        redrive.contains("cfn-props-dlq"),
+        "RedrivePolicy lost DLQ target: {redrive}"
+    );
+    assert_eq!(
+        map.get(&aws_sdk_sqs::types::QueueAttributeName::VisibilityTimeout)
+            .map(String::as_str),
+        Some("30"),
+        "AWS default attributes not seeded"
+    );
+
+    // --- SNS Topic carries its inline subscription ---
+    let sns = server.sns_client().await;
+    let topics = sns.list_topics().send().await.expect("list_topics");
+    let topic_arn = topics
+        .topics()
+        .iter()
+        .filter_map(|t| t.topic_arn())
+        .find(|a| a.ends_with(":cfn-props-topic"))
+        .expect("cfn-props-topic exists")
+        .to_string();
+    let subs = sns
+        .list_subscriptions_by_topic()
+        .topic_arn(&topic_arn)
+        .send()
+        .await
+        .expect("list_subscriptions_by_topic");
+    assert_eq!(
+        subs.subscriptions().len(),
+        1,
+        "inline SNS subscription dropped: {:?}",
+        subs.subscriptions()
+    );
+    assert_eq!(subs.subscriptions()[0].protocol(), Some("sqs"));
+}

--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -109,7 +109,7 @@ pub(crate) fn parse_tags(body: &Value) -> BTreeMap<String, String> {
     tags
 }
 
-pub(crate) fn parse_target(target: &Value) -> EventTarget {
+pub fn parse_target(target: &Value) -> EventTarget {
     EventTarget {
         id: target["Id"].as_str().unwrap_or("").to_string(),
         arn: target["Arn"].as_str().unwrap_or("").to_string(),

--- a/crates/fakecloud-eventbridge/src/lib.rs
+++ b/crates/fakecloud-eventbridge/src/lib.rs
@@ -5,8 +5,9 @@ pub(crate) mod service;
 pub mod simulation;
 pub(crate) mod state;
 
+pub use service::helpers::parse_target;
 pub use service::EventBridgeService;
 pub use state::{
     ApiDestination, Archive, Connection, Endpoint, EventBridgeSnapshot, EventBridgeState, EventBus,
-    EventRule, SharedEventBridgeState, EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
+    EventRule, EventTarget, SharedEventBridgeState, EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -1644,7 +1644,7 @@ mod service_endpoints;
 mod service_partner_sources;
 
 #[path = "helpers.rs"]
-mod helpers;
+pub(crate) mod helpers;
 pub(crate) use helpers::*;
 
 #[cfg(test)]

--- a/crates/fakecloud-sqs/src/helpers.rs
+++ b/crates/fakecloud-sqs/src/helpers.rs
@@ -78,7 +78,7 @@ pub(crate) fn canonicalize_json_attr(name: &str, value: String) -> String {
 /// a typed `RedrivePolicy`. AWS accepts both string and integer encodings
 /// of `maxReceiveCount`, so we tolerate both. Returns `None` for any
 /// parse failure (the caller treats it as "no redrive policy").
-pub(crate) fn parse_redrive_policy(attr_str: &str) -> Option<RedrivePolicy> {
+pub fn parse_redrive_policy(attr_str: &str) -> Option<RedrivePolicy> {
     let rp: Value = serde_json::from_str(attr_str).ok()?;
     let dead_letter_target_arn = rp["deadLetterTargetArn"].as_str()?.to_string();
     let max_receive_count = rp["maxReceiveCount"]

--- a/crates/fakecloud-sqs/src/lib.rs
+++ b/crates/fakecloud-sqs/src/lib.rs
@@ -4,7 +4,9 @@ pub(crate) mod service;
 pub mod simulation;
 pub(crate) mod state;
 
+pub use service::helpers::parse_redrive_policy;
 pub use service::SqsService;
 pub use state::{
-    SharedSqsState, SqsMessage, SqsQueue, SqsSnapshot, SqsState, SQS_SNAPSHOT_SCHEMA_VERSION,
+    RedrivePolicy, SharedSqsState, SqsMessage, SqsQueue, SqsSnapshot, SqsState,
+    SQS_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-sqs/src/service/mod.rs
+++ b/crates/fakecloud-sqs/src/service/mod.rs
@@ -585,7 +585,7 @@ const SQS_NS: &str = "http://queue.amazonaws.com/doc/2012-11-05/";
 impl SqsService {}
 
 #[path = "../helpers.rs"]
-mod helpers;
+pub(crate) mod helpers;
 pub(crate) use helpers::*;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Five CloudFormation provisioner arms accepted a resource and returned `CREATE_COMPLETE` but dropped the properties that make it functional — the stack looked healthy while the resource silently misbehaved. Each is the "provisioner re-derives the service's Create and loses properties" root cause.

| Resource | Dropped | Symptom |
|---|---|---|
| `AWS::IAM::Role` | `Policies`, `ManagedPolicyArns`, `PermissionsBoundary`, `Tags`, `MaxSessionDuration` | Under real IAM enforcement (#1880) the role granted **nothing** — workloads assuming it were denied |
| `AWS::Events::Rule` | `Targets` | Rule matched events but **delivered to nothing** (PutEvents only dispatches to rules with targets) |
| `AWS::DynamoDB::Table` | GSIs/LSIs, SSE, Tags | Query/Scan on the index name **400s at runtime** |
| `AWS::SQS::Queue` | typed `RedrivePolicy`, AWS-default attributes | **DLQ routing never happened**; drift vs an API-created queue |
| `AWS::SNS::Topic` | inline `Subscription` list, config attributes | **Fan-out silently broken** (topic had no subscribers) |

Each arm now reuses the service's own parser instead of re-deriving:
- IAM Role mirrors the working IAM user arm.
- Events::Rule uses the shared `eventbridge::parse_target`.
- DynamoDB uses the shared `dynamodb::parse_gsi`/`parse_lsi`/`parse_tags`.
- SQS seeds the real defaults + uses `sqs::parse_redrive_policy`.
- SNS carries config attributes, Tags, and materializes inline subscriptions.

## Non-code surface
Exports a few parsers/types from the eventbridge, dynamodb and sqs crates (single source of truth). No new user-facing API/flag/field/service — internal CFN provisioner fidelity fix. No SDK/docs/website/metadata change applies (checked: these resource types and properties are already documented as supported).

## Test plan
- New E2E `cloudformation_provisioner_properties`: provisions an IAM Role (managed + inline policies), Events::Rule (target), DynamoDB Table (GSI), SQS Queue (RedrivePolicy + defaults) and SNS Topic (inline subscription), then reads each property back via its service SDK. Passes.
- `cargo test --lib` for fakecloud-{cloudformation,eventbridge,dynamodb,sqs} — all green (942 tests).
- `cargo clippy --all-targets -D warnings` on the touched crates — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CloudFormation provisioners so IAM Role, EventBridge Rule, DynamoDB Table, SQS Queue, and SNS Topic keep their declared properties and behave correctly. Reuses each service’s parsers to prevent property loss and adds an end-to-end test covering all five resources.

- **Bug Fixes**
  - IAM Role: preserves `Policies`, `ManagedPolicyArns`, `PermissionsBoundary`, `Tags`, and `MaxSessionDuration`; attaches inline and managed policies.
  - EventBridge Rule: carries `Targets` via shared parser; events now deliver to targets.
  - DynamoDB Table: preserves GSIs/LSIs, SSE, and `Tags`; index queries now work.
  - SQS Queue: seeds real AWS defaults, keeps bool/object attributes, and parses typed `RedrivePolicy`; DLQ routing works and no drift vs API-created queues.
  - SNS Topic: carries config attributes and inline `Subscription` list (and `Tags`); fan-out works.

- **Dependencies**
  - Export shared helpers/types for single source of truth: `fakecloud-eventbridge::parse_target`, `fakecloud-dynamodb::{parse_gsi, parse_lsi, parse_tags}`, `fakecloud-sqs::parse_redrive_policy`.
  - Internal-only changes; no user-facing flags or APIs.

<sup>Written for commit ffb9f3942c35936fb3898f4d17c6776f30aeaa45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

