### PR TITLE
fix(sqs): SendMessageBatch stores system attributes + applies FIFO dedup

### DIFF
--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -1806,8 +1806,7 @@ async fn fifo_dedup_replays_original_id_and_sequence() {
 #[tokio::test]
 async fn sqs_send_message_batch_stores_system_attributes() {
     use aws_sdk_sqs::types::{
-        MessageSystemAttributeName, MessageSystemAttributeNameForSends,
-        MessageSystemAttributeValue,
+        MessageSystemAttributeName, MessageSystemAttributeNameForSends, MessageSystemAttributeValue,
     };
 
     let server = TestServer::start().await;
@@ -1920,5 +1919,8 @@ async fn sqs_send_message_batch_fifo_content_dedup() {
                 .ok();
         }
     }
-    assert_eq!(received, 1, "content-based dedup must collapse batch duplicates");
+    assert_eq!(
+        received, 1,
+        "content-based dedup must collapse batch duplicates"
+    );
 }

--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -1802,3 +1802,123 @@ async fn fifo_dedup_replays_original_id_and_sequence() {
         .expect("receive");
     assert_eq!(recv.messages().len(), 1, "duplicate must not enqueue twice");
 }
+
+#[tokio::test]
+async fn sqs_send_message_batch_stores_system_attributes() {
+    use aws_sdk_sqs::types::{
+        MessageSystemAttributeName, MessageSystemAttributeNameForSends,
+        MessageSystemAttributeValue,
+    };
+
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let queue_url = client
+        .create_queue()
+        .queue_name("batch-sys-attrs")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+
+    let trace = "Root=1-5759e988-bd862e3fe1be46a994272793";
+    let entry = SendMessageBatchRequestEntry::builder()
+        .id("m1")
+        .message_body("payload")
+        .message_system_attributes(
+            MessageSystemAttributeNameForSends::AwsTraceHeader,
+            MessageSystemAttributeValue::builder()
+                .data_type("String")
+                .string_value(trace)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    client
+        .send_message_batch()
+        .queue_url(&queue_url)
+        .entries(entry)
+        .send()
+        .await
+        .expect("send_message_batch");
+
+    let recv = client
+        .receive_message()
+        .queue_url(&queue_url)
+        .message_system_attribute_names(MessageSystemAttributeName::All)
+        .send()
+        .await
+        .expect("receive");
+    let msg = &recv.messages()[0];
+    // The batch path previously dropped system attributes; the AWSTraceHeader
+    // must survive so X-Ray trace context propagates.
+    assert_eq!(
+        msg.attributes()
+            .and_then(|a| a.get(&MessageSystemAttributeName::AwsTraceHeader))
+            .map(String::as_str),
+        Some(trace),
+        "AWSTraceHeader lost on batch send: {:?}",
+        msg.attributes()
+    );
+}
+
+#[tokio::test]
+async fn sqs_send_message_batch_fifo_content_dedup() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+    let queue_url = client
+        .create_queue()
+        .queue_name("batch-dedup.fifo")
+        .attributes(QueueAttributeName::FifoQueue, "true")
+        .attributes(QueueAttributeName::ContentBasedDeduplication, "true")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+
+    // Two batch entries with identical bodies in the same group: content-based
+    // dedup must collapse them to a single enqueued message.
+    let mk = |id: &str| {
+        SendMessageBatchRequestEntry::builder()
+            .id(id)
+            .message_body("same-body")
+            .message_group_id("g1")
+            .build()
+            .unwrap()
+    };
+    client
+        .send_message_batch()
+        .queue_url(&queue_url)
+        .entries(mk("a"))
+        .entries(mk("b"))
+        .send()
+        .await
+        .expect("send_message_batch");
+
+    let mut received = 0;
+    for _ in 0..3 {
+        let recv = client
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(10)
+            .send()
+            .await
+            .expect("receive");
+        for m in recv.messages() {
+            received += 1;
+            client
+                .delete_message()
+                .queue_url(&queue_url)
+                .receipt_handle(m.receipt_handle().unwrap())
+                .send()
+                .await
+                .ok();
+        }
+    }
+    assert_eq!(received, 1, "content-based dedup must collapse batch duplicates");
+}

--- a/crates/fakecloud-sqs/src/helpers.rs
+++ b/crates/fakecloud-sqs/src/helpers.rs
@@ -248,16 +248,13 @@ pub(crate) fn process_batch_send_entry(
     };
 
     let message_attributes = entry_attributes;
+    // System attributes (e.g. AWSTraceHeader for X-Ray) must be stored, not
+    // dropped — the single-send path stores them, and the batch response
+    // already advertises their MD5, so dropping them silently lost the
+    // X-Ray trace context for batched sends.
     let system_attributes = parse_message_system_attributes(entry);
 
-    let sequence_number = if cfg.is_fifo {
-        let seq = queue.next_sequence_number;
-        queue.next_sequence_number += 1;
-        Some(seq.to_string())
-    } else {
-        None
-    };
-
+    let md5_of_body = md5_hex(&message_body);
     let md5_of_attrs = if message_attributes.is_empty() {
         None
     } else {
@@ -269,26 +266,72 @@ pub(crate) fn process_batch_send_entry(
         Some(md5_of_message_system_attributes(&system_attributes))
     };
 
+    // FIFO content-based deduplication. The single-send path computes an
+    // effective dedup id (explicit id, else the body SHA-256 when
+    // ContentBasedDeduplication is on) and replays the original
+    // MessageId/SequenceNumber for a duplicate within the 5-minute window
+    // without enqueuing again or advancing the sequence counter. The batch
+    // path skipped all of this, so duplicate-body batched messages all
+    // enqueued.
+    let effective_dedup_id = if cfg.is_fifo {
+        message_dedup_id
+            .clone()
+            .or_else(|| cfg.content_based_dedup.then(|| sha256_hex(&message_body)))
+    } else {
+        None
+    };
+    if cfg.is_fifo {
+        if let Some(ref dedup_id) = effective_dedup_id {
+            queue.dedup_cache.retain(|_, e| e.expiry > cfg.now);
+            if let Some(existing) = queue.dedup_cache.get(dedup_id) {
+                let mut entry_resp = json!({
+                    "Id": id,
+                    "MessageId": existing.message_id,
+                    "MD5OfMessageBody": md5_of_body,
+                });
+                if let Some(ref seq) = existing.sequence_number {
+                    entry_resp["SequenceNumber"] = json!(seq);
+                }
+                if let Some(md5) = &md5_of_attrs {
+                    entry_resp["MD5OfMessageAttributes"] = json!(md5);
+                }
+                if let Some(md5) = &md5_of_system_attrs {
+                    entry_resp["MD5OfMessageSystemAttributes"] = json!(md5);
+                }
+                return Ok(BatchEntryOutcome::Success(entry_resp));
+            }
+        }
+    }
+
+    let sequence_number = if cfg.is_fifo {
+        let seq = queue.next_sequence_number;
+        queue.next_sequence_number += 1;
+        Some(seq.to_string())
+    } else {
+        None
+    };
+
     let msg = SqsMessage {
         message_id: uuid::Uuid::new_v4().to_string(),
         receipt_handle: None,
-        md5_of_body: md5_hex(&message_body),
+        md5_of_body: md5_of_body.clone(),
         body: stored_body_override.unwrap_or(message_body),
         sent_timestamp: cfg.now.timestamp_millis(),
-        attributes: BTreeMap::new(),
+        attributes: system_attributes,
         message_attributes,
         visible_at,
         receive_count: 0,
         message_group_id,
-        message_dedup_id,
+        message_dedup_id: effective_dedup_id.clone(),
         created_at: cfg.now,
         sequence_number: sequence_number.clone(),
     };
+    let message_id = msg.message_id.clone();
 
     let mut entry_resp = json!({
         "Id": id,
-        "MessageId": msg.message_id,
-        "MD5OfMessageBody": msg.md5_of_body,
+        "MessageId": message_id,
+        "MD5OfMessageBody": md5_of_body,
     });
     if let Some(seq) = &sequence_number {
         entry_resp["SequenceNumber"] = json!(seq);
@@ -300,6 +343,19 @@ pub(crate) fn process_batch_send_entry(
         entry_resp["MD5OfMessageSystemAttributes"] = json!(md5);
     }
     queue.messages.push_back(msg);
+
+    if cfg.is_fifo {
+        if let Some(dedup_id) = effective_dedup_id {
+            queue.dedup_cache.insert(
+                dedup_id,
+                crate::state::DedupEntry {
+                    message_id,
+                    sequence_number,
+                    expiry: cfg.now + chrono::Duration::minutes(5),
+                },
+            );
+        }
+    }
     Ok(BatchEntryOutcome::Success(entry_resp))
 }
 


### PR DESCRIPTION
## Summary

The SQS `SendMessageBatch` path diverged from the single-send path in two ways that silently lost data:

1. **System attributes dropped.** Each batched message was built with empty `attributes`. The system attributes (e.g. `AWSTraceHeader` for X-Ray) were parsed and their MD5 returned in the response, but the values themselves were discarded — so X-Ray trace context propagated for `SendMessage` but vanished for `SendMessageBatch`.
2. **FIFO content-based dedup skipped.** The batch path never computed a dedup id, never consulted the dedup cache, and never recorded one. Duplicate-body messages in a content-based-dedup FIFO queue all enqueued instead of collapsing to one.

The batch helper now stores the parsed system attributes on the message and mirrors the single-send dedup logic exactly: effective dedup id (explicit id, else body SHA-256 when `ContentBasedDeduplication` is on), replay of the original `MessageId`/`SequenceNumber` on a duplicate within the 5-minute window (no re-enqueue, no counter advance), and a dedup-cache insert after commit.

## Non-code surface
No new API surface — `SendMessageBatch` and its system-attribute/FIFO semantics are already documented. Behavior is brought in line with `SendMessage`. No SDK/docs/metadata change applies (checked).

## Test plan
- New E2E `sqs_send_message_batch_stores_system_attributes`: a batched `AWSTraceHeader` survives to `ReceiveMessage`.
- New E2E `sqs_send_message_batch_fifo_content_dedup`: two identical-body batch entries collapse to one enqueued message.
- `cargo test -p fakecloud-sqs --lib` (167) + the three `sqs_send_message_batch*` E2E tests pass.
- `cargo clippy -p fakecloud-sqs --all-targets -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SQS `SendMessageBatch` dropping system attributes and skipping FIFO content-based dedup. Batched sends now preserve trace context and match single-send dedup behavior to prevent duplicate enqueues.

- **Bug Fixes**
  - Store system attributes on batched messages (e.g., `AWSTraceHeader`) so they survive to `ReceiveMessage`.
  - Apply FIFO dedup: compute effective dedup ID (explicit or body SHA-256 when content-based), replay original MessageId/SequenceNumber for duplicates within 5 minutes, and update the dedup cache.

<sup>Written for commit e572d90add803047a854117876b391be62edd879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

