### PR TITLE
fix(kms): bind EncryptionContext into GenerateDataKey blobs

### DIFF
--- a/crates/fakecloud-e2e/tests/kms.rs
+++ b/crates/fakecloud-e2e/tests/kms.rs
@@ -1089,3 +1089,65 @@ async fn kms_re_encrypt_with_destination_context_changes_required_decrypt_contex
         .unwrap();
     assert_eq!(dec.plaintext().unwrap().as_ref(), b"x");
 }
+
+#[tokio::test]
+async fn kms_generate_data_key_binds_encryption_context() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key_id = client
+        .create_key()
+        .send()
+        .await
+        .unwrap()
+        .key_metadata()
+        .unwrap()
+        .key_id()
+        .to_string();
+
+    let dk = client
+        .generate_data_key()
+        .key_id(&key_id)
+        .key_spec(aws_sdk_kms::types::DataKeySpec::Aes256)
+        .encryption_context("app", "prod")
+        .send()
+        .await
+        .unwrap();
+    let blob = dk.ciphertext_blob().unwrap().clone();
+
+    // Decrypt with the SAME context recovers the data key.
+    let ok = client
+        .decrypt()
+        .ciphertext_blob(blob.clone())
+        .encryption_context("app", "prod")
+        .send()
+        .await
+        .expect("decrypt with matching context");
+    assert_eq!(
+        ok.plaintext().unwrap().as_ref(),
+        dk.plaintext().unwrap().as_ref()
+    );
+
+    // Decrypt with NO context must fail (the EC is bound as AAD).
+    assert!(
+        client
+            .decrypt()
+            .ciphertext_blob(blob.clone())
+            .send()
+            .await
+            .is_err(),
+        "decrypt without the encryption context must fail"
+    );
+
+    // Decrypt with a DIFFERENT context must fail.
+    assert!(
+        client
+            .decrypt()
+            .ciphertext_blob(blob)
+            .encryption_context("app", "staging")
+            .send()
+            .await
+            .is_err(),
+        "decrypt with a different encryption context must fail"
+    );
+}

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -372,8 +372,19 @@ impl KmsService {
         let data_key_bytes: Vec<u8> = rand_bytes(num_bytes);
         let plaintext_b64 = base64::engine::general_purpose::STANDARD.encode(&data_key_bytes);
 
-        // Wrap the data key in the AWS-shaped binary blob.
-        let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, &data_key_bytes);
+        // Wrap the data key in the AWS-shaped binary blob, binding the
+        // caller's EncryptionContext into the AAD so Decrypt with the same
+        // context succeeds and Decrypt with a different/absent context fails —
+        // matching real KMS and the Encrypt/ReEncrypt paths. Previously the
+        // context was ignored, so the recommended envelope-encryption pattern
+        // (GenerateDataKey + EncryptionContext) could never decrypt its key.
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let blob = crate::blob::encode_with_context(
+            &state.master_key_bytes,
+            &key.key_id,
+            &data_key_bytes,
+            &ec_aad,
+        );
         let ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(&blob);
 
         Ok(AwsResponse::json(
@@ -951,8 +962,15 @@ impl KmsService {
         let private_plaintext_b64 =
             base64::engine::general_purpose::STANDARD.encode(&private_key_bytes);
 
-        // Wrap the private key in the AWS-shaped binary blob.
-        let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, &private_key_bytes);
+        // Wrap the private key in the AWS-shaped binary blob, binding the
+        // caller's EncryptionContext into the AAD (see GenerateDataKey).
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let blob = crate::blob::encode_with_context(
+            &state.master_key_bytes,
+            &key.key_id,
+            &private_key_bytes,
+            &ec_aad,
+        );
         let private_ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(&blob);
 
         Ok(AwsResponse::json(


### PR DESCRIPTION
## Summary

The `GenerateDataKey` family wrapped the data key with the empty-AAD `blob::encode`, **ignoring the caller's `EncryptionContext`**, while `Encrypt`/`ReEncrypt` correctly bind the context as AES-GCM AAD. Consequences:

- A data key generated with an `EncryptionContext` could **never be decrypted**: `Decrypt` derives the AAD from the supplied context, which didn't match the empty AAD the blob was sealed with → `InvalidCiphertextException`. The recommended envelope-encryption pattern (`GenerateDataKey` + `EncryptionContext`) was non-functional.
- Conversely, decrypting such a blob with **no** context wrongly succeeded.

Fixes all four sites — `GenerateDataKey`, `GenerateDataKeyWithoutPlaintext`, and the two `GenerateDataKeyPair` variants — to compute the canonical EC AAD and seal via `blob::encode_with_context`, exactly as `Encrypt` does.

## Non-code surface
No new API surface — `EncryptionContext` on these operations is already documented/supported; this makes it actually bind. No SDK/docs/metadata change applies (checked).

## Test plan
- New E2E `kms_generate_data_key_binds_encryption_context`: decrypt with the matching context recovers the key; decrypt with no context or a different context fails.
- `cargo test -p fakecloud-kms --lib` (187) passes; `cargo clippy` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the caller’s EncryptionContext into `GenerateDataKey` and `GenerateDataKeyPair` ciphertext blobs so decrypting requires the same context, matching `Encrypt` behavior. This restores working envelope encryption and prevents no-context decrypts from succeeding.

- **Bug Fixes**
  - Use `blob::encode_with_context` to seal data/private keys with AES-GCM AAD from the canonical EncryptionContext.
  - Applied to `GenerateDataKey`, `GenerateDataKeyWithoutPlaintext`, and both `GenerateDataKeyPair` variants.
  - Added an E2E test confirming decrypt succeeds with the matching context and fails without or with a different context.

<sup>Written for commit bbb7d1566faf840bbe2a788e512ccaae6b12d70b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

