### PR TITLE
fix(kinesis): GetRecords reports real MillisBehindLatest, not a 0/1 flag

### DIFF
--- a/crates/fakecloud-e2e/tests/kinesis.rs
+++ b/crates/fakecloud-e2e/tests/kinesis.rs
@@ -487,3 +487,72 @@ async fn kinesis_update_shard_count_reshard_lineage_matches_aws() {
     assert_eq!(closed.len(), 4, "scaling 2 -> 3 must close 4 shards");
     assert_eq!(open.len(), 3, "scaling 2 -> 3 must leave 3 open shards");
 }
+
+#[tokio::test]
+async fn kinesis_get_records_reports_real_millis_behind_latest() {
+    let server = TestServer::start().await;
+    let client = server.kinesis_client().await;
+
+    let put = client
+        .create_stream()
+        .stream_name("lag")
+        .shard_count(1)
+        .send()
+        .await;
+    assert!(put.is_ok());
+
+    // First record, then a >1s gap, then a second record. Reading only the
+    // first leaves the consumer ~1s behind the tip.
+    let first = client
+        .put_record()
+        .stream_name("lag")
+        .partition_key("k")
+        .data(Blob::new(b"first"))
+        .send()
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+    client
+        .put_record()
+        .stream_name("lag")
+        .partition_key("k")
+        .data(Blob::new(b"second"))
+        .send()
+        .await
+        .unwrap();
+
+    let it = client
+        .get_shard_iterator()
+        .stream_name("lag")
+        .shard_id(first.shard_id())
+        .shard_iterator_type(ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let recs = client
+        .get_records()
+        .shard_iterator(it.shard_iterator().unwrap())
+        .limit(1)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(recs.records().len(), 1);
+    // The last returned record is ~1.1s behind the tip, so MillisBehindLatest
+    // must reflect a real gap (>= ~1000ms), not the old 0/1 flag.
+    let lag = recs.millis_behind_latest().unwrap_or(0);
+    assert!(
+        lag >= 1000,
+        "expected real lag >= 1000ms behind tip, got {lag}"
+    );
+
+    // Reading the rest catches up: MillisBehindLatest returns to 0.
+    let it2 = recs.next_shard_iterator().unwrap();
+    let caught_up = client
+        .get_records()
+        .shard_iterator(it2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(caught_up.millis_behind_latest(), Some(0));
+}

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -585,7 +585,18 @@ impl KinesisService {
         let total_records = shard.records.len();
         let shard_closed = !shard.is_open;
 
-        let millis_behind_latest = if end_index < total_records { 1 } else { 0 };
+        // MillisBehindLatest is the real time gap between the last record
+        // returned in this batch and the newest (tip) record in the shard —
+        // not a 0/1 flag. Consumers (Lambda ESM IteratorAge alarms, KCL
+        // catch-up detection, Flink watermarks) use it to gauge how far
+        // behind they are. Zero when caught up or the batch is empty.
+        let millis_behind_latest = if end_index >= total_records || end_index == 0 {
+            0
+        } else {
+            let last_returned = shard.records[end_index - 1].approximate_arrival_timestamp;
+            let tip = shard.records[total_records - 1].approximate_arrival_timestamp;
+            (tip - last_returned).num_milliseconds().max(0)
+        };
 
         // A shard closed by SplitShard/MergeShards and then fully read returns a
         // null NextShardIterator, signalling the consumer to move on to the


### PR DESCRIPTION
## Summary

`GetRecords` set `MillisBehindLatest = if end_index < total_records { 1 } else { 0 }` — a has-more flag with no temporal meaning. Consumers treat this as a real lag metric (Lambda ESM `IteratorAge` alarms, KCL catch-up detection, Flink watermarks), so they were all silently wrong.

It now reports the actual millisecond gap between the last record returned in the batch and the newest (tip) record in the shard, and `0` when caught up or the batch is empty.

## Non-code surface
No new API surface. No SDK/docs/metadata change applies (checked).

## Test plan
- New E2E `kinesis_get_records_reports_real_millis_behind_latest`: two records ~1.1s apart, read only the first → `MillisBehindLatest >= 1000`; reading the rest → `0`.
- `cargo test -p fakecloud-kinesis --lib` (117) passes; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kinesis GetRecords to return a real MillisBehindLatest value: the millisecond gap between the batch’s last record and the shard tip. This aligns with AWS and restores correct IteratorAge/lag behavior for Lambda, KCL, and Flink.

- **Bug Fixes**
  - Compute MillisBehindLatest from approximate_arrival_timestamp; returns 0 when caught up or the batch is empty.
  - Add an E2E test: two records ~1.1s apart, first read shows lag ≥1000ms, next read returns 0.

<sup>Written for commit 9969c631490c3d7e90d9cf99af2f22b3093b7ee8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

