### PR TITLE
fix(s3): paginate ListMultipartUploads + fix MPU complete double-write + 0-byte part panic

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -4704,3 +4704,114 @@ async fn s3_inventory_does_not_deliver_report_by_default() {
         "no inventory report object by default"
     );
 }
+
+#[tokio::test]
+async fn s3_list_multipart_uploads_paginates() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+    client
+        .create_bucket()
+        .bucket("mp-page")
+        .send()
+        .await
+        .unwrap();
+
+    for k in ["a.bin", "b.bin", "c.bin"] {
+        client
+            .create_multipart_upload()
+            .bucket("mp-page")
+            .key(k)
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // max-uploads is honored and IsTruncated + NextKeyMarker are real.
+    let page1 = client
+        .list_multipart_uploads()
+        .bucket("mp-page")
+        .max_uploads(2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page1.uploads().len(), 2, "max-uploads ignored");
+    assert_eq!(page1.is_truncated(), Some(true));
+    assert!(page1.next_key_marker().is_some());
+
+    // Second page resumes from the marker and returns the remainder.
+    let page2 = client
+        .list_multipart_uploads()
+        .bucket("mp-page")
+        .max_uploads(2)
+        .key_marker(page1.next_key_marker().unwrap())
+        .upload_id_marker(page1.next_upload_id_marker().unwrap_or_default())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page2.uploads().len(), 1, "pagination did not resume");
+    assert_eq!(page2.is_truncated(), Some(false));
+}
+
+#[tokio::test]
+async fn s3_get_zero_byte_multipart_part_does_not_panic() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+    client
+        .create_bucket()
+        .bucket("mp-empty")
+        .send()
+        .await
+        .unwrap();
+
+    let init = client
+        .create_multipart_upload()
+        .bucket("mp-empty")
+        .key("empty.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = init.upload_id().unwrap().to_string();
+
+    // A single, empty (0-byte) part — AWS allows the last/only part to be empty.
+    let part = client
+        .upload_part()
+        .bucket("mp-empty")
+        .key("empty.bin")
+        .upload_id(&upload_id)
+        .part_number(1)
+        .body(ByteStream::from(Vec::new()))
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .complete_multipart_upload()
+        .bucket("mp-empty")
+        .key("empty.bin")
+        .upload_id(&upload_id)
+        .multipart_upload(
+            aws_sdk_s3::types::CompletedMultipartUpload::builder()
+                .parts(
+                    aws_sdk_s3::types::CompletedPart::builder()
+                        .part_number(1)
+                        .e_tag(part.e_tag().unwrap())
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Reading the 0-byte part by partNumber must not panic / drop the
+    // connection (previously `0 + 0 - 1` underflowed).
+    let got = client
+        .get_object()
+        .bucket("mp-empty")
+        .key("empty.bin")
+        .part_number(1)
+        .send()
+        .await
+        .expect("get 0-byte part must succeed");
+    assert_eq!(got.content_length(), Some(0));
+}

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -378,7 +378,7 @@ impl AwsService for S3Service {
                 && key.is_none()
                 && req.query_params.contains_key("uploads")
             {
-                return self.list_multipart_uploads(account_id, b);
+                return self.list_multipart_uploads(account_id, b, &req.query_params);
             }
 
             // GET /{bucket}/{key}?uploadId=X — ListParts

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -4,7 +4,7 @@ use http::{HeaderMap, StatusCode};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
-use fakecloud_persistence::BodySource;
+use fakecloud_persistence::{BodyRef, BodySource};
 
 use crate::persistence::{mpu_init_snapshot, object_meta_snapshot};
 use crate::state::{MultipartUpload, S3Object, UploadPart};
@@ -624,7 +624,7 @@ impl S3Service {
             .as_deref()
             .and_then(|algo| super::compute_composite_checksum(algo, &part_checksum_digests));
         let data = Bytes::from(combined_data);
-        let store_body = data.clone();
+        let object_size = data.len() as u64;
 
         let tags = if let Some(ref tagging) = upload.tagging {
             parse_url_encoded_tags(tagging).into_iter().collect()
@@ -693,21 +693,22 @@ impl S3Service {
                     return Err(precondition_failed("If-None-Match"));
                 }
             }
-            // Checks passed — persist, then commit to memory, all under the lock.
-            self.store
+            // Checks passed — persist, then commit to memory, all under the
+            // lock. In disk mode `mpu_complete` streams the parts straight into
+            // the object file and returns a disk-backed ref; use it as the
+            // object body instead of writing the whole object a SECOND time
+            // from RAM via `put_object`. The old double-write held the entire
+            // object resident twice and wrote it to disk twice, OOMing large
+            // completes (bug-hunt 2026-06-24, 4.1). In memory mode
+            // `mpu_complete` returns an empty placeholder, so the in-memory
+            // body set at construction is kept.
+            let assembled_body = self
+                .store
                 .mpu_complete(bucket, upload_id, key, meta.version_id.as_deref(), &meta)
                 .map_err(super::persistence_error)?;
-            let returned_body = self
-                .store
-                .put_object(
-                    bucket,
-                    key,
-                    meta.version_id.as_deref(),
-                    BodySource::Bytes(store_body.clone()),
-                    &meta,
-                )
-                .map_err(super::persistence_error)?;
-            obj.body = returned_body.clone();
+            if !matches!(assembled_body, BodyRef::Memory(_)) {
+                obj.body = assembled_body;
+            }
             let b = accts
                 .get_or_create(account_id)
                 .buckets
@@ -785,7 +786,7 @@ impl S3Service {
         // cannot deadlock against an outstanding write.
         let bucket_name = bucket.to_string();
         let obj_key = key.to_string();
-        let obj_size = store_body.len() as u64;
+        let obj_size = object_size;
         let obj_etag = etag.clone();
         if let Some(ref config) = notification_config {
             super::deliver_notifications(
@@ -856,6 +857,7 @@ impl S3Service {
         &self,
         account_id: &str,
         bucket: &str,
+        query: &std::collections::HashMap<String, String>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let accts = self.state.read();
         let __empty = crate::state::S3State::new(account_id, "us-east-1");
@@ -865,10 +867,70 @@ impl S3Service {
             .get(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
 
+        let prefix = query.get("prefix").cloned().unwrap_or_default();
+        let delimiter = query.get("delimiter").cloned().unwrap_or_default();
+        let key_marker = query.get("key-marker").cloned().unwrap_or_default();
+        let upload_id_marker = query.get("upload-id-marker").cloned().unwrap_or_default();
+        // AWS clamps max-uploads to 1..=1000, defaulting to 1000.
+        let max_uploads = query
+            .get("max-uploads")
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(1000)
+            .clamp(1, 1000);
+
+        // AWS orders ListMultipartUploads by key, then by upload-id.
+        let mut sorted_uploads: Vec<_> = b
+            .multipart_uploads
+            .values()
+            .filter(|u| u.key.starts_with(&prefix))
+            .collect();
+        sorted_uploads.sort_by(|a, c| a.key.cmp(&c.key).then(a.upload_id.cmp(&c.upload_id)));
+
+        // Skip everything at or before (key-marker, upload-id-marker). With an
+        // upload-id-marker the boundary key is resumed mid-way; without one,
+        // every upload up to and including the marker key is skipped.
+        let after_marker = |key: &str, upload_id: &str| -> bool {
+            if key_marker.is_empty() {
+                return true;
+            }
+            match key.cmp(key_marker.as_str()) {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Less => false,
+                std::cmp::Ordering::Equal => {
+                    !upload_id_marker.is_empty() && upload_id > upload_id_marker.as_str()
+                }
+            }
+        };
+
         let mut uploads_xml = String::new();
-        let mut sorted_uploads: Vec<_> = b.multipart_uploads.values().collect();
-        sorted_uploads.sort_by_key(|u| &u.key);
-        for upload in &sorted_uploads {
+        let mut common_prefixes: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
+        let mut emitted = 0usize;
+        let mut is_truncated = false;
+        let mut next_key_marker = String::new();
+        let mut next_upload_id_marker = String::new();
+
+        for upload in sorted_uploads
+            .iter()
+            .filter(|u| after_marker(&u.key, &u.upload_id))
+        {
+            // Roll keys up under a delimiter into CommonPrefixes (deduped),
+            // matching ListObjects semantics.
+            if !delimiter.is_empty() {
+                let rest = &upload.key[prefix.len()..];
+                if let Some(idx) = rest.find(&delimiter) {
+                    let cp = format!("{}{}", prefix, &rest[..idx + delimiter.len()]);
+                    common_prefixes.insert(cp);
+                    continue;
+                }
+            }
+            if emitted >= max_uploads {
+                // The page is full: mark truncated. The Next*Marker pair points
+                // at the LAST emitted upload so the next page resumes strictly
+                // after it (AWS semantics).
+                is_truncated = true;
+                break;
+            }
             uploads_xml.push_str(&format!(
                 "<Upload>\
                  <Key>{}</Key>\
@@ -881,15 +943,59 @@ impl S3Service {
                 upload.initiated.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
                 xml_escape(&upload.storage_class),
             ));
+            next_key_marker = upload.key.clone();
+            next_upload_id_marker = upload.upload_id.clone();
+            emitted += 1;
         }
+
+        let mut markers_xml = String::new();
+        if !key_marker.is_empty() {
+            markers_xml.push_str(&format!(
+                "<KeyMarker>{}</KeyMarker>",
+                xml_escape(&key_marker)
+            ));
+        }
+        if !upload_id_marker.is_empty() {
+            markers_xml.push_str(&format!(
+                "<UploadIdMarker>{}</UploadIdMarker>",
+                xml_escape(&upload_id_marker)
+            ));
+        }
+        if is_truncated {
+            markers_xml.push_str(&format!(
+                "<NextKeyMarker>{}</NextKeyMarker><NextUploadIdMarker>{}</NextUploadIdMarker>",
+                xml_escape(&next_key_marker),
+                xml_escape(&next_upload_id_marker)
+            ));
+        }
+        if !prefix.is_empty() {
+            markers_xml.push_str(&format!("<Prefix>{}</Prefix>", xml_escape(&prefix)));
+        }
+        if !delimiter.is_empty() {
+            markers_xml.push_str(&format!(
+                "<Delimiter>{}</Delimiter>",
+                xml_escape(&delimiter)
+            ));
+        }
+        let common_prefixes_xml: String = common_prefixes
+            .iter()
+            .map(|cp| {
+                format!(
+                    "<CommonPrefixes><Prefix>{}</Prefix></CommonPrefixes>",
+                    xml_escape(cp)
+                )
+            })
+            .collect();
 
         let body = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
              <ListMultipartUploadsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
              <Bucket>{}</Bucket>\
-             <MaxUploads>1000</MaxUploads>\
-             <IsTruncated>false</IsTruncated>\
+             {markers_xml}\
+             <MaxUploads>{max_uploads}</MaxUploads>\
+             <IsTruncated>{is_truncated}</IsTruncated>\
              {uploads_xml}\
+             {common_prefixes_xml}\
              </ListMultipartUploadsResult>",
             xml_escape(bucket),
         );

--- a/crates/fakecloud-s3/src/service/objects/read.rs
+++ b/crates/fakecloud-s3/src/service/objects/read.rs
@@ -272,7 +272,11 @@ impl S3Service {
                 if let Some(pc) = obj.parts_count {
                     headers.insert("x-amz-mp-parts-count", pc.to_string().parse().unwrap());
                 }
-                let part_end = part_start + part_size - 1;
+                // A 0-byte part (the single/last part may legitimately be
+                // empty) makes `part_start + part_size - 1` underflow — a debug
+                // panic / release wrap to a garbage content-range. Saturate so
+                // an empty part reports `bytes 0-0/<total>` with length 0.
+                let part_end = (part_start + part_size).saturating_sub(1);
                 headers.insert(
                     "content-range",
                     format!("bytes {part_start}-{part_end}/{total_size}")
@@ -465,7 +469,11 @@ impl S3Service {
                 if let Some(pc) = obj.parts_count {
                     headers.insert("x-amz-mp-parts-count", pc.to_string().parse().unwrap());
                 }
-                let part_end = part_start + part_size - 1;
+                // A 0-byte part (the single/last part may legitimately be
+                // empty) makes `part_start + part_size - 1` underflow — a debug
+                // panic / release wrap to a garbage content-range. Saturate so
+                // an empty part reports `bytes 0-0/<total>` with length 0.
+                let part_end = (part_start + part_size).saturating_sub(1);
                 headers.insert(
                     "content-range",
                     format!("bytes {part_start}-{part_end}/{total_size}")

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -1198,7 +1198,9 @@ fn list_multipart_uploads_includes_all_in_flight() {
     seed_bucket(&svc, "b");
     let u1 = initiate_mpu(&svc, "b", "a");
     let u2 = initiate_mpu(&svc, "b", "b");
-    let resp = svc.list_multipart_uploads("123456789012", "b").unwrap();
+    let resp = svc
+        .list_multipart_uploads("123456789012", "b", &std::collections::HashMap::new())
+        .unwrap();
     let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
     assert!(body.contains(&u1));
     assert!(body.contains(&u2));
@@ -2610,7 +2612,9 @@ fn list_multipart_uploads() {
     svc.create_multipart_upload("123456789012", &req, "mpl", "f1.bin")
         .unwrap();
 
-    let resp = svc.list_multipart_uploads("123456789012", "mpl").unwrap();
+    let resp = svc
+        .list_multipart_uploads("123456789012", "mpl", &std::collections::HashMap::new())
+        .unwrap();
     let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
     assert!(body.contains("<Upload>"));
     assert!(body.contains("f1.bin"));
@@ -3928,14 +3932,18 @@ fn get_object_retention_bucket_not_found() {
 #[test]
 fn list_multipart_uploads_nonexistent_bucket() {
     let svc = make_service();
-    assert!(svc.list_multipart_uploads("123456789012", "ghost").is_err());
+    assert!(svc
+        .list_multipart_uploads("123456789012", "ghost", &std::collections::HashMap::new())
+        .is_err());
 }
 
 #[test]
 fn list_multipart_uploads_empty() {
     let svc = make_service();
     seed_bucket(&svc, "empmp");
-    let resp = svc.list_multipart_uploads("123456789012", "empmp").unwrap();
+    let resp = svc
+        .list_multipart_uploads("123456789012", "empmp", &std::collections::HashMap::new())
+        .unwrap();
     let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
     assert!(body.contains("<ListMultipartUploadsResult"));
 }


### PR DESCRIPTION
## Summary

Three multipart-upload fixes:

1. **`ListMultipartUploads` ignored every query parameter** — hardcoded `MaxUploads=1000`/`IsTruncated=false` and dumped every upload. Now honors `max-uploads` (clamped 1..=1000), `key-marker`/`upload-id-marker` pagination with real `Next*Marker`, and `prefix`/`delimiter` (CommonPrefixes). (1.18)
2. **`CompleteMultipartUpload` wrote the object to disk twice and held it in RAM twice** — `mpu_complete` streamed parts into the object file, then `put_object` overwrote that same file from a RAM clone. A 5 GB complete held ~10 GB resident and could OOM. Now uses `mpu_complete`'s disk-backed `BodyRef` as the body and drops the redundant clone + second write. (4.1)
3. **`GetObject`/`HeadObject` `?partNumber` on a 0-byte part underflowed** `part_start + part_size - 1` (`0+0-1`) → debug panic / dropped connection, garbage content-range in release. Saturating subtraction now reports `bytes 0-0/<total>`. (2.1)

## Non-code surface
No new API surface — these are correctness/robustness fixes to already-supported operations. No SDK/docs/metadata change applies (checked).

## Test plan
- New E2E `s3_list_multipart_uploads_paginates` (max-uploads + marker resume) and `s3_get_zero_byte_multipart_part_does_not_panic`.
- `cargo test -p fakecloud-s3 --lib` (366) + existing multipart E2E tests pass; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements correct S3 multipart behavior: real pagination/filtering for listing uploads, removes a double write and RAM spike on multipart completion, and fixes 0-byte part reads to avoid panics. Improves correctness for ListMultipartUploads, CompleteMultipartUpload, GetObject, and HeadObject.

- **Bug Fixes**
  - ListMultipartUploads: honors max-uploads (clamped 1..=1000), key-marker/upload-id-marker with real Next*Marker, and prefix/delimiter (CommonPrefixes); returns correct IsTruncated and markers.
  - CompleteMultipartUpload: uses the disk-backed body from mpu_complete instead of rewriting from RAM; removes duplicate write and large memory clone to prevent OOM on big completes.
  - GetObject/HeadObject with ?partNumber on a 0-byte part: saturating content-range; no panic or invalid headers.

<sup>Written for commit 64d4c9b8e03106ae1b6687ec2d6d1a5b306fcb1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

