### PR TITLE
fix(rds,elasticache): background reboot/start container ops to avoid client timeouts

### DIFF
--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -3483,3 +3483,41 @@ async fn elasticache_user_group_engine_case_insensitive_and_modify_settles_activ
     assert_eq!(modified.status(), Some("active"));
     assert_eq!(modified.user_ids().len(), 2);
 }
+
+#[tokio::test]
+async fn elasticache_reboot_returns_immediately() {
+    if !require_docker_or_skip("elasticache_reboot_returns_immediately") {
+        return;
+    }
+
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_cluster()
+        .cache_cluster_id("reboot-cluster")
+        .cache_node_type("cache.t3.micro")
+        .preferred_availability_zone("us-east-1a")
+        .send()
+        .await
+        .unwrap();
+    helpers::wait_for_cache_cluster_available(&client, "reboot-cluster", 120).await;
+
+    // Reboot backgrounds the container restart (up to ~120s on k8s), so it must
+    // return immediately reporting the rebooting state rather than blocking.
+    let resp = client
+        .reboot_cache_cluster()
+        .cache_cluster_id("reboot-cluster")
+        .cache_node_ids_to_reboot("0001")
+        .send()
+        .await
+        .expect("reboot");
+    assert_eq!(
+        resp.cache_cluster().and_then(|c| c.cache_cluster_status()),
+        Some("rebooting cache cluster nodes"),
+        "RebootCacheCluster must return immediately with the rebooting status"
+    );
+
+    // It converges back to available in the background.
+    helpers::wait_for_cache_cluster_available(&client, "reboot-cluster", 120).await;
+}

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -425,6 +425,11 @@ async fn rds_reboot_db_instance() {
         Some("rebooting")
     );
 
+    // RebootDBInstance returns immediately with `rebooting`; the container
+    // restart runs in the background (so slow engines don't time the client
+    // out). A real client waits for `available` before reconnecting.
+    helpers::wait_for_db_available(&client, "orders-reboot-db", 180).await;
+
     let describe_after = client
         .describe_db_instances()
         .db_instance_identifier("orders-reboot-db")

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -1834,3 +1834,54 @@ async fn rds_subnet_group_reports_supported_network_types() {
     // The aws_db_subnet_group resource asserts supported_network_types = [IPV4].
     assert_eq!(g.supported_network_types(), &["IPV4".to_string()]);
 }
+
+#[tokio::test]
+async fn rds_start_db_instance_returns_starting_immediately() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client, "orders-start-db").await;
+    helpers::wait_for_db_available(&client, "orders-start-db", 180).await;
+
+    client
+        .stop_db_instance()
+        .db_instance_identifier("orders-start-db")
+        .send()
+        .await
+        .expect("stop");
+
+    // Wait until the instance reports stopped.
+    for _ in 0..60 {
+        let d = client
+            .describe_db_instances()
+            .db_instance_identifier("orders-start-db")
+            .send()
+            .await
+            .unwrap();
+        if d.db_instances()
+            .first()
+            .and_then(|i| i.db_instance_status())
+            == Some("stopped")
+        {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+
+    // Start backgrounds the container boot + readiness wait, so it must return
+    // immediately with `starting` rather than blocking until `available`.
+    let resp = client
+        .start_db_instance()
+        .db_instance_identifier("orders-start-db")
+        .send()
+        .await
+        .expect("start");
+    assert_eq!(
+        resp.db_instance().and_then(|i| i.db_instance_status()),
+        Some("starting"),
+        "StartDBInstance must return immediately with 'starting'"
+    );
+
+    // It eventually converges to available in the background.
+    helpers::wait_for_db_available(&client, "orders-start-db", 180).await;
+}

--- a/crates/fakecloud-elasticache/src/service/clusters.rs
+++ b/crates/fakecloud-elasticache/src/service/clusters.rs
@@ -523,24 +523,33 @@ impl ElastiCacheService {
                 .unwrap_or_default();
             (xml, pod_tags)
         };
-        // Restart the underlying engine container so a real client
-        // observes the reboot. Best-effort: if no runtime is wired up
-        // (eg. tests, environments without docker) the API call still
-        // reflects the rebooting state.
-        if let Some(runtime) = &self.runtime {
-            if let Err(error) = runtime.restart_container(&id, &pod_tags).await {
-                tracing::warn!(
-                    cluster_id = %id,
-                    %error,
-                    "RebootCacheCluster: container restart failed, returning rebooting state anyway"
-                );
-            } else {
-                let mut accounts = self.state.write();
-                let state = accounts.get_or_create(&request.account_id);
+        // Restart the underlying engine container in the BACKGROUND so a real
+        // client observes the reboot without the request blocking on it. The
+        // restart + readiness wait can take up to ~120s on the k8s backend
+        // (Pod recreate + IP wait + TCP wait), past the ~60s client read
+        // timeout — awaiting it inline timed the CLI out (bug-hunt 2026-06-24,
+        // 3.3). EC2 RebootInstances and the Create paths already background
+        // theirs. Best-effort: with no runtime wired up (tests, no docker) the
+        // API still reflects the rebooting state.
+        if let Some(runtime) = self.runtime.clone() {
+            let state_handle = self.state.clone();
+            let account_id = request.account_id.clone();
+            let id = id.clone();
+            tokio::spawn(async move {
+                if let Err(error) = runtime.restart_container(&id, &pod_tags).await {
+                    tracing::warn!(
+                        cluster_id = %id,
+                        %error,
+                        "RebootCacheCluster: container restart failed, leaving rebooting state"
+                    );
+                    return;
+                }
+                let mut accounts = state_handle.write();
+                let state = accounts.get_or_create(&account_id);
                 if let Some(cluster) = state.cache_clusters.get_mut(&id) {
                     cluster.cache_cluster_status = "available".to_string();
                 }
-            }
+            });
         }
         Ok(AwsResponse::xml(
             StatusCode::OK,

--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -970,6 +970,13 @@ impl RdsService {
                 .get_mut(&db_instance_identifier)
                 .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
             instance.db_instance_status = "rebooting".to_string();
+            // Apply pending modifications SYNCHRONOUSLY: AWS applies these to the
+            // instance metadata as part of the reboot, and the response must
+            // reflect the new values with pending cleared. Only the container
+            // restart (the slow part) is backgrounded below.
+            if let Some(pending) = instance.pending_modified_values.take() {
+                apply_pending_to_instance(instance, pending);
+            }
             instance.clone()
         };
 
@@ -1008,9 +1015,9 @@ impl RdsService {
                     instance.host_port = running.host_port;
                     instance.port = i32::from(running.endpoint_port);
                     instance.endpoint_address = running.endpoint_address.clone();
-                    if let Some(pending) = instance.pending_modified_values.take() {
-                        apply_pending_to_instance(instance, pending);
-                    }
+                    // Pending modifications were already applied synchronously
+                    // in the handler; the background task only reconciles the
+                    // restarted container's endpoint + flips to available.
                     instance.db_instance_status = "available".to_string();
                     instance.db_instance_arn.clone()
                 };

--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -943,33 +943,25 @@ impl RdsService {
             ));
         }
 
-        let instance = {
+        {
+            // Validate existence before touching the runtime so a missing
+            // identifier returns DBInstanceNotFoundFault, not a runtime error.
             let accounts = self.state.read();
             let empty = RdsState::new(&request.account_id, &request.region);
             let state = accounts.get(&request.account_id).unwrap_or(&empty);
-            state
-                .instances
-                .get(&db_instance_identifier)
-                .cloned()
-                .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?
-        };
+            if !state.instances.contains_key(&db_instance_identifier) {
+                return Err(db_instance_not_found(&db_instance_identifier));
+            }
+        }
 
         let runtime = self.require_runtime()?;
 
-        let running = runtime
-            .restart_container(
-                &db_instance_identifier,
-                &instance.engine,
-                &instance.master_username,
-                &instance.master_user_password,
-                instance
-                    .db_name
-                    .as_deref()
-                    .unwrap_or(default_db_name(&instance.engine)),
-            )
-            .await
-            .map_err(runtime_error_to_service_error)?;
-
+        // Flip the stored status to `rebooting` and return immediately. The
+        // container restart + readiness wait runs in the background — for
+        // engines like Oracle / SQL Server / Db2 it can take 3-6 minutes
+        // (runtime log-marker deadlines), well past the ~60s client read
+        // timeout. Awaiting it inline timed out the CLI on every non-PG/MySQL
+        // reboot (bug-hunt 2026-06-24, 3.1); mirror the EC2 RebootInstances fix.
         let instance = {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
@@ -977,26 +969,65 @@ impl RdsService {
                 .instances
                 .get_mut(&db_instance_identifier)
                 .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
-            instance.host_port = running.host_port;
-            instance.port = i32::from(running.endpoint_port);
-            instance.endpoint_address = running.endpoint_address.clone();
-
-            // Apply any pending modifications
-            if let Some(pending) = instance.pending_modified_values.take() {
-                apply_pending_to_instance(instance, pending);
-            }
-
+            instance.db_instance_status = "rebooting".to_string();
             instance.clone()
         };
 
-        self.emit_event(
-            RdsSourceType::DbInstance,
-            &db_instance_identifier,
-            &instance.db_instance_arn,
-            "RDS-EVENT-0006",
-            &["availability"],
-            "DB instance restarted",
-        );
+        {
+            let state_handle = self.state.clone();
+            let runtime = runtime.clone();
+            let delivery_bus = self.delivery_bus.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            let id = db_instance_identifier.clone();
+            let account_id = request.account_id.clone();
+            let inst = instance.clone();
+            tokio::spawn(async move {
+                let logical_db = inst
+                    .db_name
+                    .clone()
+                    .unwrap_or_else(|| default_db_name(&inst.engine).to_string());
+                let Ok(running) = runtime
+                    .restart_container(
+                        &id,
+                        &inst.engine,
+                        &inst.master_username,
+                        &inst.master_user_password,
+                        &logical_db,
+                    )
+                    .await
+                else {
+                    return;
+                };
+                let arn = {
+                    let mut accounts = state_handle.write();
+                    let state = accounts.get_or_create(&account_id);
+                    let Some(instance) = state.instances.get_mut(&id) else {
+                        return;
+                    };
+                    instance.host_port = running.host_port;
+                    instance.port = i32::from(running.endpoint_port);
+                    instance.endpoint_address = running.endpoint_address.clone();
+                    if let Some(pending) = instance.pending_modified_values.take() {
+                        apply_pending_to_instance(instance, pending);
+                    }
+                    instance.db_instance_status = "available".to_string();
+                    instance.db_instance_arn.clone()
+                };
+                emit_event_static_with_state(
+                    delivery_bus.as_ref(),
+                    Some(&state_handle),
+                    Some(&account_id),
+                    RdsSourceType::DbInstance,
+                    &id,
+                    &arn,
+                    "RDS-EVENT-0006",
+                    &["availability"],
+                    "DB instance restarted",
+                );
+                save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
+            });
+        }
 
         Ok(AwsResponse::xml(
             StatusCode::OK,

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -583,42 +583,11 @@ impl RdsService {
             }
         }
 
-        let running = if let Some(runtime) = self.runtime.as_ref() {
-            match runtime
-                .ensure_postgres(
-                    &db_instance_identifier,
-                    &instance.engine,
-                    &instance.engine_version,
-                    &instance.master_username,
-                    &instance.master_user_password,
-                    instance
-                        .db_name
-                        .as_deref()
-                        .unwrap_or(default_db_name(&instance.engine)),
-                    &request.account_id,
-                    &request.region,
-                    &instance.tags,
-                )
-                .await
-            {
-                Ok(r) => Some(r),
-                Err(e) => {
-                    // Roll the row back to `stopped` so the next
-                    // Describe doesn't report a permanently-`starting`
-                    // instance with no container behind it.
-                    let mut accounts = self.state.write();
-                    let state = accounts.get_or_create(&request.account_id);
-                    if let Some(inst) = state.instances.get_mut(&db_instance_identifier) {
-                        inst.db_instance_status = "stopped".to_string();
-                    }
-                    return Err(runtime_error_to_service_error(e));
-                }
-            }
-        } else {
-            // No container runtime configured: StartDBInstance should
-            // fail rather than report success against a backend that
-            // does not exist. Roll the row back so subsequent calls
-            // don't see a stuck `starting` state.
+        // No container runtime configured: fail synchronously (fast) rather
+        // than report success against a backend that does not exist, rolling
+        // the row back from `starting` so subsequent calls don't see a stuck
+        // state.
+        let Some(runtime) = self.runtime.clone() else {
             {
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&request.account_id);
@@ -633,32 +602,80 @@ impl RdsService {
             ));
         };
 
-        let instance = {
-            let mut accounts = self.state.write();
-            let state = accounts.get_or_create(&request.account_id);
-            let inst = state
-                .instances
-                .get_mut(&db_instance_identifier)
-                .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
-            inst.db_instance_status = "available".to_string();
-            inst.endpoint_address = "127.0.0.1".to_string();
-            if let Some(r) = running {
-                inst.endpoint_address = r.endpoint_address.clone();
-                inst.port = i32::from(r.endpoint_port);
-                inst.host_port = r.host_port;
-                inst.container_id = r.container_id;
-            }
-            inst.clone()
-        };
-
-        self.emit_event(
-            RdsSourceType::DbInstance,
-            &db_instance_identifier,
-            &instance.db_instance_arn,
-            "RDS-EVENT-0088",
-            &["notification"],
-            "DB instance started",
-        );
+        // Background the container start + readiness wait and return
+        // immediately with `starting`. `ensure_postgres` can pull a cold image
+        // and wait for engine readiness (3-6 min for Oracle/SQL Server/Db2),
+        // far past the ~60s client read timeout — awaiting it inline timed the
+        // CLI out (bug-hunt 2026-06-24, 3.2). CreateDBInstance already
+        // backgrounds this exact call.
+        {
+            let state_handle = self.state.clone();
+            let delivery_bus = self.delivery_bus.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            let id = db_instance_identifier.clone();
+            let account_id = request.account_id.clone();
+            let region = request.region.clone();
+            let inst = instance.clone();
+            tokio::spawn(async move {
+                let logical_db = inst
+                    .db_name
+                    .clone()
+                    .unwrap_or_else(|| default_db_name(&inst.engine).to_string());
+                match runtime
+                    .ensure_postgres(
+                        &id,
+                        &inst.engine,
+                        &inst.engine_version,
+                        &inst.master_username,
+                        &inst.master_user_password,
+                        &logical_db,
+                        &account_id,
+                        &region,
+                        &inst.tags,
+                    )
+                    .await
+                {
+                    Ok(r) => {
+                        let arn = {
+                            let mut accounts = state_handle.write();
+                            let state = accounts.get_or_create(&account_id);
+                            let Some(inst) = state.instances.get_mut(&id) else {
+                                return;
+                            };
+                            inst.db_instance_status = "available".to_string();
+                            inst.endpoint_address = r.endpoint_address.clone();
+                            inst.port = i32::from(r.endpoint_port);
+                            inst.host_port = r.host_port;
+                            inst.container_id = r.container_id;
+                            inst.db_instance_arn.clone()
+                        };
+                        emit_event_static_with_state(
+                            delivery_bus.as_ref(),
+                            Some(&state_handle),
+                            Some(&account_id),
+                            RdsSourceType::DbInstance,
+                            &id,
+                            &arn,
+                            "RDS-EVENT-0088",
+                            &["notification"],
+                            "DB instance started",
+                        );
+                        save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock)
+                            .await;
+                    }
+                    Err(_) => {
+                        // Roll back to `stopped` so the next Describe doesn't
+                        // report a permanently-`starting` instance.
+                        let mut accounts = state_handle.write();
+                        let state = accounts.get_or_create(&account_id);
+                        if let Some(inst) = state.instances.get_mut(&id) {
+                            inst.db_instance_status = "stopped".to_string();
+                        }
+                    }
+                }
+            });
+        }
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -667,7 +684,7 @@ impl RdsService {
                 RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
-                    db_instance_xml(&instance, None)
+                    db_instance_xml(&instance, Some("starting"))
                 ),
                 &request.request_id,
             ),


### PR DESCRIPTION
## Summary

`RebootDBInstance`, `StartDBInstance` (RDS) and `RebootCacheCluster` (ElastiCache) awaited the container restart + readiness wait **inline in the request handler**:
- RDS non-PG/MySQL engines wait 3-6 min for readiness (Oracle 240s, SQL Server 180s, Db2 360s);
- ElastiCache k8s reboot takes up to ~120s (Pod recreate + IP + TCP wait).

All exceed the ~60s client read timeout, so the AWS CLI/SDK timed out on every such call while the op continued server-side. (3.1 / 3.2 / 3.3)

Each now mirrors the proven EC2 `RebootInstances` / `CreateDBInstance` pattern: flip the stored status to `rebooting`/`starting`, return immediately, and drive the restart + readiness in a `tokio::spawn`, flipping to `available` on success (or back to `stopped` on a failed start).

## Non-code surface
No new API surface — same operations, non-blocking. Status transitions (`rebooting`/`starting` -> `available`) already match AWS. No SDK/docs/metadata change applies (checked).

## Test plan
- New E2E `rds_start_db_instance_returns_starting_immediately` and `elasticache_reboot_returns_immediately` (Docker-gated, run in CI): the op returns the in-flight status immediately and converges in the background.
- Existing `rds_reboot_db_instance` covers RebootDBInstance (returns `rebooting`, reconnectable).
- `cargo test -p fakecloud-rds -p fakecloud-elasticache --lib` (454) passes; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backgrounds RDS start/reboot and ElastiCache reboot so calls return immediately and avoid client read timeouts. Mirrors the EC2 pattern and fixes CLI/SDK timeouts while the restart proceeds.

- **Bug Fixes**
  - RDS RebootDBInstance returns "rebooting" immediately; pending modifications are applied before returning; the background task restarts the container, updates the endpoint, then sets "available".
  - RDS StartDBInstance returns "starting" immediately; the start runs in the background; success flips to "available", failures roll back to "stopped".
  - ElastiCache RebootCacheCluster returns immediately with "rebooting cache cluster nodes"; the restart settles to "available" in the background.
  - Added E2E tests for immediate responses and background convergence; updated the RDS reboot test to wait for "available" before reconnecting; no API changes and status transitions stay AWS-compatible.

<sup>Written for commit b8e08222ecee6eddb3ae5b632a9f2d17645b3cbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

