### PR TITLE
fix(secretsmanager): persist RotationRules Duration + ScheduleExpression

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/secrets.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/secrets.rs
@@ -148,6 +148,16 @@ impl ResourceProvisioner {
             .get("RotationRules")
             .and_then(|v| v.get("AutomaticallyAfterDays"))
             .and_then(|v| v.as_i64());
+        let rotation_duration = props
+            .get("RotationRules")
+            .and_then(|v| v.get("Duration"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let rotation_schedule_expression = props
+            .get("RotationRules")
+            .and_then(|v| v.get("ScheduleExpression"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
         let mut accounts = self.secretsmanager_state.write();
         let state = accounts.get_or_create(&self.account_id);
         let secret_arn = if state.secrets.contains_key(&secret_id) {
@@ -171,6 +181,8 @@ impl ResourceProvisioner {
         secret.rotation_lambda_arn = rotation_lambda_arn;
         secret.rotation_rules = Some(RotationRules {
             automatically_after_days,
+            duration: rotation_duration,
+            schedule_expression: rotation_schedule_expression,
         });
         secret.last_changed_at = Utc::now();
         Ok(ProvisionResult::new(secret_arn.clone()).with("SecretArn", secret_arn))

--- a/crates/fakecloud-e2e/tests/secretsmanager.rs
+++ b/crates/fakecloud-e2e/tests/secretsmanager.rs
@@ -554,3 +554,43 @@ async fn secretsmanager_rotation_scheduler_tick() {
         Some(1)
     );
 }
+
+#[tokio::test]
+async fn secretsmanager_rotation_rules_schedule_round_trips() {
+    let server = TestServer::start().await;
+    let client = server.secretsmanager_client().await;
+
+    client
+        .create_secret()
+        .name("rotate-sched")
+        .secret_string("v")
+        .send()
+        .await
+        .unwrap();
+
+    // The modern scheduling form (Duration + ScheduleExpression) must survive
+    // the RotateSecret -> DescribeSecret round-trip; previously both were
+    // dropped, surfacing as perpetual Terraform drift.
+    client
+        .rotate_secret()
+        .secret_id("rotate-sched")
+        .rotation_rules(
+            aws_sdk_secretsmanager::types::RotationRulesType::builder()
+                .duration("2h")
+                .schedule_expression("cron(0 8 1 * ? *)")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let desc = client
+        .describe_secret()
+        .secret_id("rotate-sched")
+        .send()
+        .await
+        .unwrap();
+    let rules = desc.rotation_rules().expect("rotation rules present");
+    assert_eq!(rules.duration(), Some("2h"));
+    assert_eq!(rules.schedule_expression(), Some("cron(0 8 1 * ? *)"));
+}

--- a/crates/fakecloud-secretsmanager/src/rotation.rs
+++ b/crates/fakecloud-secretsmanager/src/rotation.rs
@@ -256,6 +256,8 @@ mod tests {
             rotation_lambda_arn: None, // no Lambda for unit tests
             rotation_rules: days.map(|d| RotationRules {
                 automatically_after_days: Some(d),
+                duration: None,
+                schedule_expression: None,
             }),
             last_rotated_at: last_rotated,
             resource_policy: None,

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -871,6 +871,12 @@ impl SecretsManagerService {
             if let Some(days) = rules.automatically_after_days {
                 rules_json["AutomaticallyAfterDays"] = json!(days);
             }
+            if let Some(ref duration) = rules.duration {
+                rules_json["Duration"] = json!(duration);
+            }
+            if let Some(ref expr) = rules.schedule_expression {
+                rules_json["ScheduleExpression"] = json!(expr);
+            }
             response["RotationRules"] = rules_json;
         }
         if let Some(last_rotated) = secret.last_rotated_at {
@@ -1347,6 +1353,14 @@ impl SecretsManagerService {
             let days = rules.get("AutomaticallyAfterDays").and_then(|v| v.as_i64());
             secret.rotation_rules = Some(RotationRules {
                 automatically_after_days: days,
+                duration: rules
+                    .get("Duration")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                schedule_expression: rules
+                    .get("ScheduleExpression")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
             });
         }
 

--- a/crates/fakecloud-secretsmanager/src/state.rs
+++ b/crates/fakecloud-secretsmanager/src/state.rs
@@ -32,6 +32,13 @@ pub struct Secret {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RotationRules {
     pub automatically_after_days: Option<i64>,
+    /// The length of the rotation window, e.g. "2h" / "1d". AWS's modern
+    /// rotation scheduling form alongside ScheduleExpression.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration: Option<String>,
+    /// A cron() or rate() expression for the rotation schedule.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule_expression: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Summary

`RotationRules` only modeled `AutomaticallyAfterDays`, so the modern rotation scheduling form — `Duration` (e.g. `"2h"`) and `ScheduleExpression` (cron/rate) — was silently dropped on `RotateSecret` and never returned by `DescribeSecret`. Terraform/CDK configuring scheduled rotation saw **perpetual drift**. (1.12)

Adds both fields to the struct, parses them in `RotateSecret` and in the CloudFormation `RotationSchedule` provisioner, and renders them in `DescribeSecret`.

## Non-code surface
No new API surface — fills in fields of an already-supported shape. No SDK/docs/metadata change applies (checked).

## Test plan
- New E2E `secretsmanager_rotation_rules_schedule_round_trips`.
- `cargo test -p fakecloud-secretsmanager --lib` (113) passes; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Secrets Manager rotation scheduling by persisting RotationRules Duration and ScheduleExpression across RotateSecret, CloudFormation RotationSchedule, and DescribeSecret. This stops Terraform/CDK from reporting perpetual drift.

- **Bug Fixes**
  - Parse and store Duration and ScheduleExpression on RotateSecret and during CloudFormation provisioning.
  - Return both fields in DescribeSecret responses.
  - Added an E2E test to verify the RotateSecret -> DescribeSecret round-trip.

<sup>Written for commit 1b5ed5491560f6f0cab8bbc59494129beb712aa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

