### PR TITLE
fix(kinesis): stop persisting ephemeral shard iterators (dead-on-restart)

### DIFF
--- a/crates/fakecloud-kinesis/src/state.rs
+++ b/crates/fakecloud-kinesis/src/state.rs
@@ -19,6 +19,15 @@ pub struct KinesisState {
     pub account_id: String,
     pub region: String,
     pub streams: BTreeMap<String, KinesisStream>,
+    /// Shard-iterator leases are ephemeral (AWS expires them after 5 minutes
+    /// and they never survive a service restart). They were serialized into the
+    /// snapshot with an absolute `expires_at`, so after any restart taking
+    /// longer than 5 minutes every restored iterator was already expired —
+    /// half-done durability that guaranteed `ExpiredIteratorException` on the
+    /// first GetRecords. Skip persisting them; consumers re-acquire via
+    /// GetShardIterator against the (durable) sequence number, exactly as on AWS
+    /// (bug-hunt 2026-06-24, 4.2).
+    #[serde(skip)]
     pub iterators: BTreeMap<String, ShardIteratorLease>,
     pub lambda_checkpoints: BTreeMap<String, usize>,
     pub consumers: BTreeMap<String, KinesisConsumer>,
@@ -192,6 +201,23 @@ mod tests {
         assert!(state.streams.is_empty());
         assert!(state.iterators.is_empty());
         assert_eq!(state.shard_limit, 500);
+    }
+
+    #[test]
+    fn iterators_are_not_persisted_through_snapshot() {
+        let mut state = KinesisState::new("123456789012", "us-east-1");
+        let token = state.insert_iterator("s", "shardId-000000000000", 0);
+        assert!(state.iterators.contains_key(&token));
+
+        // Round-trip through the serde snapshot: the ephemeral iterator lease
+        // must not survive (it would be expired-on-load otherwise, 4.2).
+        let json = serde_json::to_string(&state).unwrap();
+        assert!(
+            !json.contains("expires_at"),
+            "iterator leases must not be serialized: {json}"
+        );
+        let restored: KinesisState = serde_json::from_str(&json).unwrap();
+        assert!(restored.iterators.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The shard-iterator lease map was serialized into the snapshot with an **absolute** `expires_at`. AWS shard iterators expire after 5 minutes and are never durable, so after any restart taking longer than 5 minutes every restored iterator was already expired — half-done durability that guaranteed `ExpiredIteratorException` on the first `GetRecords` for a consumer reusing a persisted token. (4.2)

Marks the `iterators` field `#[serde(skip)]` so leases aren't persisted at all. The durable per-shard `next_sequence_number` still survives, so a checkpointing consumer re-acquires via `GetShardIterator(AT_SEQUENCE_NUMBER)` exactly as on AWS.

## Non-code surface
No new API surface — corrects snapshot contents. No SDK/docs/metadata change applies (checked).

## Test plan
- New unit test `iterators_are_not_persisted_through_snapshot`.
- `cargo test -p fakecloud-kinesis --lib` (118) passes; existing `kinesis_persistence` E2E (re-acquires iterators after restart) still passes; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop persisting Kinesis shard iterator leases in snapshots to prevent expired tokens after restarts. This fixes ExpiredIteratorException on the first GetRecords by re-acquiring iterators from durable sequence numbers.

- **Bug Fixes**
  - Marked `iterators` with `#[serde(skip)]` to avoid serializing ephemeral leases.
  - On restart, consumers re-acquire via GetShardIterator(AT_SEQUENCE_NUMBER) using durable `next_sequence_number`, matching AWS behavior.
  - Added unit test `iterators_are_not_persisted_through_snapshot`.

<sup>Written for commit 237b910718a875490a04ac162e905bafdd942f21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

