### PR TITLE
feat(tfacc): add wafv2 service; REGIONAL ARN scope + CAPTCHA URL fixes

### DIFF
--- a/crates/fakecloud-e2e/tests/wafv2.rs
+++ b/crates/fakecloud-e2e/tests/wafv2.rs
@@ -53,6 +53,58 @@ async fn cloudfront_scope_arn_uses_us_east_1_region_segment() {
 }
 
 #[tokio::test]
+async fn regional_scope_arn_uses_regional_path_segment() {
+    // REGIONAL-scope ARNs use the literal `regional` resource-path prefix (not
+    // the region name), e.g. arn:aws:wafv2:us-east-1:acct:regional/ipset/name/id.
+    let server = TestServer::start().await;
+    let waf = server.wafv2_client().await;
+    let summary = waf
+        .create_ip_set()
+        .name("rgn-ipset")
+        .scope(Scope::Regional)
+        .ip_address_version(aws_sdk_wafv2::types::IpAddressVersion::Ipv4)
+        .addresses("10.0.0.0/8")
+        .send()
+        .await
+        .expect("create")
+        .summary
+        .expect("summary");
+    let arn = summary.arn().expect("arn");
+    assert!(
+        arn.contains(":regional/ipset/rgn-ipset/"),
+        "REGIONAL ARN must use the `regional` path segment, got: {arn}"
+    );
+}
+
+#[tokio::test]
+async fn web_acl_without_token_domains_has_no_integration_url() {
+    // GetWebACL reports ApplicationIntegrationURL only when the ACL declares
+    // token domains; a basic ACL has none, so the field is absent.
+    let server = TestServer::start().await;
+    let waf = server.wafv2_client().await;
+    waf.create_web_acl()
+        .name("no-captcha")
+        .scope(Scope::Regional)
+        .default_action(allow_default())
+        .visibility_config(vis("no-captcha"))
+        .send()
+        .await
+        .expect("create");
+    let got = waf
+        .get_web_acl()
+        .name("no-captcha")
+        .scope(Scope::Regional)
+        .send()
+        .await
+        .expect("get");
+    assert!(
+        got.application_integration_url().is_none(),
+        "no token domains -> no ApplicationIntegrationURL, got: {:?}",
+        got.application_integration_url()
+    );
+}
+
+#[tokio::test]
 async fn web_acl_create_get_update_delete_lifecycle() {
     let server = TestServer::start().await;
     let waf = server.wafv2_client().await;

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -616,6 +616,24 @@ pub const SERVICES: &[Service] = &[
         run_regex: "^TestAccSESV2[A-Za-z0-9]+_basic$",
         deny: &[],
     },
+    Service {
+        name: "wafv2",
+        // WAF v2: the `_basic` smoke for IP sets, regex pattern sets, rule groups,
+        // and web ACLs (+ their data sources / association). Fixes: REGIONAL-scope
+        // ARNs use the literal `regional` resource-path prefix (was the region
+        // name), and GetWebACL only reports ApplicationIntegrationURL when the ACL
+        // declares token domains (the provider always sends a default CaptchaConfig
+        // even for a basic ACL, so the CAPTCHA endpoint must gate on token domains).
+        run_regex: "^TestAccWAFV2[A-Za-z0-9]+_basic$",
+        deny: &[
+            // --- gap: the logging-configuration test provisions a Firehose
+            //     delivery stream as the log destination, which drifts on
+            //     Firehose's extended_s3_configuration computed defaults
+            //     (custom_time_zone, s3_backup_mode) — a Firehose-fidelity gap,
+            //     not a WAF one. ---
+            "TestAccWAFV2WebACLLoggingConfiguration_basic",
+        ],
+    },
 ];
 
 /// CI matrix shards. One GitHub Actions job per entry.
@@ -922,6 +940,12 @@ pub const SHARDS: &[Shard] = &[
         name: "sesv2",
         service: "sesv2",
         run_regex: "^TestAccSESV2[A-Za-z0-9]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "wafv2",
+        service: "wafv2",
+        run_regex: "^TestAccWAFV2[A-Za-z0-9]+_basic$",
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -308,4 +308,5 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_ECS", "ecs"),
     ("AWS_ENDPOINT_URL_COGNITO_IDENTITY", "cognito-identity"),
     ("AWS_ENDPOINT_URL_SCHEDULER", "scheduler"),
+    ("AWS_ENDPOINT_URL_WAFV2", "wafv2"),
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -201,3 +201,8 @@ async fn scheduler_acceptance() {
 async fn sesv2_acceptance() {
     run_shard("sesv2").await;
 }
+
+#[tokio::test]
+async fn wafv2_acceptance() {
+    run_shard("wafv2").await;
+}

--- a/crates/fakecloud-wafv2/src/service/mod.rs
+++ b/crates/fakecloud-wafv2/src/service/mod.rs
@@ -594,12 +594,13 @@ fn synth_arn(
         region
     };
     // Real AWS WAF v2 CLOUDFRONT-scope ARNs always use `us-east-1` as the
-    // region segment plus a `global/...` resource path. REGIONAL ARNs use
-    // the caller's region with the region as the resource-path prefix.
+    // region segment plus a `global/...` resource path. REGIONAL ARNs use the
+    // caller's region with the literal `regional` scope prefix in the resource
+    // path (e.g. `arn:aws:wafv2:us-east-1:acct:regional/ipset/name/id`).
     let (region_in_arn, scope_seg) = if scope == "CLOUDFRONT" {
         ("us-east-1", "global")
     } else {
-        (region, region)
+        (region, "regional")
     };
     Arn::new(
         "wafv2",

--- a/crates/fakecloud-wafv2/src/service/web_acls.rs
+++ b/crates/fakecloud-wafv2/src/service/web_acls.rs
@@ -101,15 +101,17 @@ impl Wafv2Service {
                 .get(&(scope, name))
                 .ok_or_else(|| not_found("WebACL"))?
         };
-        let cleared = body
-            .get("ARN")
-            .is_none() // when fetched by name+scope path, AWS may return ApplicationIntegrationURL
-            ;
         let mut response = json!({
             "WebACL": web_acl_detail_json(acl),
             "LockToken": acl.lock_token,
         });
-        if cleared {
+        // AWS only surfaces ApplicationIntegrationURL (the CAPTCHA/Challenge
+        // integration endpoint) for a web ACL that declares token domains. The
+        // provider always sends a default CaptchaConfig (immunity time) even for
+        // a basic ACL, so gating on token domains — not the CAPTCHA config — is
+        // what matches AWS; the Terraform resource asserts the URL is empty when
+        // no token domains are configured.
+        if !acl.token_domains.is_empty() {
             response.as_object_mut().unwrap().insert(
                 "ApplicationIntegrationURL".to_string(),
                 Value::String(format!(


### PR DESCRIPTION
## Summary

Third of the new-service tfacc expansion: wire **WAF v2** into the harness (new `Service` + `Shard` + `acc.rs` fn + `AWS_ENDPOINT_URL_WAFV2` endpoint var). The `_basic` smoke for IP sets, regex pattern sets, rule groups, and web ACLs (+ data sources / association) now runs -- 9 of 10 pass.

**Fixes:**
- REGIONAL-scope resource ARNs use the literal `regional` path prefix (`arn:aws:wafv2:<region>:<acct>:regional/ipset/<name>/<id>`); they previously used the region name as the path segment, so every resource's `arn` failed the provider's `regional/...` pattern assertion. **This single fix unblocked 8 of the 10 wafv2 `_basic` tests.**
- `GetWebACL` only reports `ApplicationIntegrationURL` (the CAPTCHA/Challenge endpoint) when the ACL declares token domains. The provider always sends a default `CaptchaConfig` even for a basic ACL, so the URL must gate on token domains; the resource asserts the attribute is empty otherwise.

`WebACLLoggingConfiguration` stays denied: its test provisions a Firehose delivery stream as the log destination, which drifts on Firehose's `extended_s3_configuration` computed defaults -- a Firehose-fidelity gap, not a WAF one (same root cause denied in the logs DataProtectionPolicyDocument data source).

No new public API surface (ARN-format + response-gating fixes on existing operations).

## Test plan
- New e2e: `regional_scope_arn_uses_regional_path_segment`, `web_acl_without_token_domains_has_no_integration_url` -- pass.
- Local tfacc: full `wafv2` shard green (9 `_basic` tests, minus the Firehose-dependent deny).
- `cargo test -p fakecloud-wafv2` (41), full wafv2 e2e (21) + cfn + persistence -- no regression; `clippy`, `fmt`, `check-doc-counts.sh` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add WAF v2 to the tfacc harness and fix ARN scope and CAPTCHA URL behavior. This enables the provider’s `_basic` wafv2 tests; 9 of 10 now pass.

- **New Features**
  - Wired WAF v2 into tfacc (new Service and Shard, acceptance test entry, `AWS_ENDPOINT_URL_WAFV2`).

- **Bug Fixes**
  - REGIONAL-scope ARNs now use the literal `regional` path segment (e.g., `arn:aws:wafv2:<region>:<acct>:regional/...`).
  - `GetWebACL` returns `ApplicationIntegrationURL` only when token domains are configured.
  - Added e2e tests for both fixes; `WebACLLoggingConfiguration_basic` stays denied due to Firehose default drift.

<sup>Written for commit aaa7310d82b9ea9fab1de52cb4d4e996ceb7b3c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

