### PR TITLE
feat(tfacc): add cloudwatch service; fix DeleteDashboards response shape

### DIFF
--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -1389,7 +1389,18 @@ impl CloudWatchService {
         for n in names {
             acct.dashboards.remove(&n);
         }
-        Ok(empty_metadata_response("DeleteDashboards", &req.request_id))
+        // DeleteDashboards returns an (empty) DeleteDashboardsResult element;
+        // the AWS SDK fails to deserialize the response if the result node is
+        // absent ("DeleteDashboardsResult node not found").
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <DeleteDashboardsResponse xmlns=\"{NS}\">\
+             <DeleteDashboardsResult/>\
+             <ResponseMetadata><RequestId>{}</RequestId></ResponseMetadata>\
+             </DeleteDashboardsResponse>",
+            req.request_id
+        );
+        Ok(AwsResponse::xml(StatusCode::OK, body))
     }
 
     fn list_dashboards(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {

--- a/crates/fakecloud-e2e/tests/cloudwatch.rs
+++ b/crates/fakecloud-e2e/tests/cloudwatch.rs
@@ -245,3 +245,40 @@ async fn list_metrics_filters_by_dimension() {
         .expect("list filtered");
     assert_eq!(listed.metrics().len(), 1);
 }
+
+#[tokio::test]
+async fn dashboard_put_get_delete_roundtrip() {
+    // DeleteDashboards must return a parseable response (an empty
+    // DeleteDashboardsResult element) — the SDK errors if that node is absent.
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+
+    let body = r#"{"widgets":[{"type":"text","x":0,"y":0,"width":6,"height":3,"properties":{"markdown":"hi"}}]}"#;
+    cw.put_dashboard()
+        .dashboard_name("dash1")
+        .dashboard_body(body)
+        .send()
+        .await
+        .expect("put dashboard");
+
+    let got = cw
+        .get_dashboard()
+        .dashboard_name("dash1")
+        .send()
+        .await
+        .expect("get dashboard");
+    assert!(got.dashboard_body().unwrap().contains("markdown"));
+
+    // Delete must succeed (response deserializes thanks to the result node).
+    cw.delete_dashboards()
+        .dashboard_names("dash1")
+        .send()
+        .await
+        .expect("delete dashboards");
+
+    let listed = cw.list_dashboards().send().await.expect("list");
+    assert!(listed
+        .dashboard_entries()
+        .iter()
+        .all(|e| e.dashboard_name() != Some("dash1")));
+}

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -644,6 +644,22 @@ pub const SERVICES: &[Service] = &[
         run_regex: "^TestAccFirehoseDeliveryStream(_basic|DataSource_basic)$",
         deny: &[],
     },
+    Service {
+        name: "cloudwatch",
+        // CloudWatch: the `_basic` smoke for composite alarms, dashboards, metric
+        // alarms, metric streams, and contributor-insight rules. Fix:
+        // DeleteDashboards returns an (empty) DeleteDashboardsResult element so
+        // the SDK can deserialize the response.
+        run_regex: "^TestAccCloudWatch[A-Za-z0-9]+_basic$",
+        deny: &[
+            // --- gap: managed contributor-insight rules are AWS-vendor-published
+            //     rule templates (per service namespace); fakecloud does not
+            //     model the managed-rule catalogue the resource + data source
+            //     enumerate. ---
+            "TestAccCloudWatchContributorManagedInsightRule_basic",
+            "TestAccCloudWatchContributorManagedInsightRulesDataSource_basic",
+        ],
+    },
 ];
 
 /// CI matrix shards. One GitHub Actions job per entry.
@@ -962,6 +978,12 @@ pub const SHARDS: &[Shard] = &[
         name: "firehose",
         service: "firehose",
         run_regex: "^TestAccFirehoseDeliveryStream(_basic|DataSource_basic)$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "cloudwatch",
+        service: "cloudwatch",
+        run_regex: "^TestAccCloudWatch[A-Za-z0-9]+_basic$",
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -310,4 +310,5 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_SCHEDULER", "scheduler"),
     ("AWS_ENDPOINT_URL_WAFV2", "wafv2"),
     ("AWS_ENDPOINT_URL_FIREHOSE", "firehose"),
+    ("AWS_ENDPOINT_URL_CLOUDWATCH", "monitoring"),
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -211,3 +211,8 @@ async fn wafv2_acceptance() {
 async fn firehose_acceptance() {
     run_shard("firehose").await;
 }
+
+#[tokio::test]
+async fn cloudwatch_acceptance() {
+    run_shard("cloudwatch").await;
+}


### PR DESCRIPTION
## Summary

Fifth of the new-service tfacc expansion: wire **CloudWatch** into the harness (new `Service` + `Shard` + `acc.rs` fn + `AWS_ENDPOINT_URL_CLOUDWATCH` endpoint var). The `_basic` smoke for composite alarms, dashboards, metric alarms, metric streams, and contributor insight rules now runs -- 5 of 7 pass.

**Fix:** `DeleteDashboards` returns an (empty) `DeleteDashboardsResult` element. The generic metadata-only response omitted it, so the AWS SDK failed to deserialize ("DeleteDashboardsResult node not found") and the dashboard resource's destroy errored.

Managed contributor-insight rules (`ContributorManagedInsightRule` + its data source) stay denied: they are AWS-vendor-published rule templates per service namespace, and fakecloud does not model the managed-rule catalogue the resource + data source enumerate.

No new public API surface (response-shape fix on an existing operation).

## Test plan
- New e2e `dashboard_put_get_delete_roundtrip` -- pass.
- Local tfacc: `cloudwatch` shard green (CompositeAlarm, Dashboard, MetricAlarm, MetricStream, ContributorInsightRule), minus the 2 managed-rule denies.
- `cargo test -p fakecloud-cloudwatch` (19), `cargo clippy --all-targets -D warnings`, `cargo fmt`, `check-doc-counts.sh` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired CloudWatch into `fakecloud-tfacc` and fixed the `DeleteDashboards` response shape. `_basic` CloudWatch tests now run, and dashboard deletes deserialize correctly in the AWS SDK.

- **New Features**
  - Added CloudWatch service, shard, and acceptance test entry to `fakecloud-tfacc`.
  - Mapped `AWS_ENDPOINT_URL_CLOUDWATCH` to "monitoring".
  - Enabled `_basic` tests for composite alarms, dashboards, metric alarms, metric streams, and contributor insight rules; two managed-rule variants remain denied.

- **Bug Fixes**
  - `DeleteDashboards` now returns an empty `DeleteDashboardsResult`, enabling AWS SDK deserialization and successful destroy.
  - Added `dashboard_put_get_delete_roundtrip` e2e test in `fakecloud-e2e`.

<sup>Written for commit ce67f7dbd26f37ef09cb732a28b2d63cb831a923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

