### PR TITLE
chore(release): bump workspace to v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4085,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4238,7 +4238,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -112,175 +112,175 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.21.0"
+version = "0.21.1"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.21.0")
+    testImplementation("dev.fakecloud:fakecloud:0.21.1")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.21.0</version>
+    <version>0.21.1</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.21.0"
+version = "0.21.1"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.21.0"
+version = "0.21.1"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release **v0.21.0 -> v0.21.1**. Bug fixes only (no new services/ops/SDK methods), so a patch bump.

Includes the 12 bug-hunt fixes merged today (#1906-#1917):
- **CFN persist for 9 services** (#1906) — ACM/ELBv2/CloudFront/Route53/Firehose/Glue/WAFv2/Athena/Organizations no longer vanish on restart.
- **CFN provisioner properties** (#1907) — IAM Role policies, Events::Rule Targets, DynamoDB GSI/LSI, SQS RedrivePolicy, SNS inline subs.
- **SQS SendMessageBatch** system attrs + FIFO dedup (#1908).
- **KMS GenerateDataKey EncryptionContext** binding (#1909).
- **SNS PublishBatch** all-protocol fan-out + filter policies + FIFO dedup (#1910).
- **DynamoDB TransactWriteItems** validation (#1911).
- **Kinesis** real MillisBehindLatest (#1912) + stop persisting dead-on-restart iterators (#1917).
- **S3 multipart** — ListMultipartUploads pagination, CompleteMPU double-write OOM, 0-byte partNumber panic (#1913).
- **RDS/ElastiCache** background reboot/start (client timeouts) (#1914).
- **ELBv2 dataplane** sibling_host when containerized (#1915).
- **SecretsManager** RotationRules Duration/ScheduleExpression (#1916).

## Bumped
`Cargo.toml` (workspace + all fakecloud-* pins), `Cargo.lock`, TS/Python/Java SDK versions. No new crates → no release.yml publish-order change.

## Test plan
Version-bump only; CI validates the workspace build. Tag `v0.21.1` after merge triggers the multi-registry publish.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch release: bump workspace and SDKs to v0.21.1 to ship recent bug fixes. No new services, operations, or SDK methods.

- **Dependencies**
  - Bumped all workspace crates to `0.21.1` in `Cargo.toml` and `Cargo.lock`.
  - Updated SDK versions: Java `0.21.1`, Python `0.21.1`, TypeScript `0.21.1`.

<sup>Written for commit 82edd5c337e3448b71982066ee359c7d0093ef28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

