### PR TITLE
fix(cloudformation): expand SAM Function Policies into a role + non-API events into triggers

### DIFF
--- a/crates/fakecloud-cloudformation/src/template/for_each.rs
+++ b/crates/fakecloud-cloudformation/src/template/for_each.rs
@@ -178,6 +178,15 @@ pub(super) fn expand_sam(value: &Value) -> Value {
                     lambda_props.remove("InlineCode");
                     lambda_props.insert("Code".to_string(), json!({"ZipFile": inline}));
                 }
+                // Expand the function's `Policies` (-> implicit execution role)
+                // and non-API `Events` (-> Events::Rule / EventSourceMapping /
+                // SNS::Subscription + Lambda::Permission). Mutates lambda_props
+                // (sets Role, removes Policies/Events) and returns the extra
+                // native resources to add. Without this SAM functions deploy
+                // with no role and no triggers.
+                let extras =
+                    super::sam_events::expand_function_extras(logical_id, &mut lambda_props);
+
                 let mut lambda_resource = serde_json::Map::new();
                 lambda_resource.insert("Type".to_string(), json!("AWS::Lambda::Function"));
                 lambda_resource.insert("Properties".to_string(), Value::Object(lambda_props));
@@ -187,6 +196,9 @@ pub(super) fn expand_sam(value: &Value) -> Value {
                     }
                 }
                 new_resources.insert(logical_id.clone(), Value::Object(lambda_resource));
+                for (extra_id, extra) in extras {
+                    new_resources.entry(extra_id).or_insert(extra);
+                }
             }
             "AWS::Serverless::Api" => {
                 let mut api_props = merge_global_properties(&global_api, &properties);
@@ -620,7 +632,8 @@ mod tests {
             }
         });
 
-        let props = &expand_sam(&template)["Resources"]["F"]["Properties"];
+        let expanded = expand_sam(&template);
+        let props = &expanded["Resources"]["F"]["Properties"];
         assert_eq!(
             props["Layers"],
             json!([
@@ -628,10 +641,18 @@ mod tests {
                 "arn:aws:lambda:::layer:local:2"
             ])
         );
-        assert_eq!(
-            props["Policies"],
-            json!(["AWSLambdaBasicExecutionRole", "AmazonS3ReadOnlyAccess"])
-        );
+        // `Policies` are now additively merged (Globals ++ resource) and then
+        // consumed into the synthesized execution role's ManagedPolicyArns,
+        // rather than left on the function Properties.
+        assert!(props.get("Policies").is_none());
+        let role_arns = &expanded["Resources"]["FRole"]["Properties"]["ManagedPolicyArns"];
+        let arns = role_arns.as_array().unwrap();
+        assert!(arns
+            .iter()
+            .any(|a| a == "arn:aws:iam::aws:policy/AWSLambdaBasicExecutionRole"));
+        assert!(arns
+            .iter()
+            .any(|a| a == "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"));
     }
 
     // Globals on the non-Function sections (Api/HttpApi/SimpleTable/StateMachine)

--- a/crates/fakecloud-cloudformation/src/template/mod.rs
+++ b/crates/fakecloud-cloudformation/src/template/mod.rs
@@ -2243,6 +2243,7 @@ mod intrinsics;
 mod mappings;
 mod parser;
 mod resolution;
+mod sam_events;
 use conditions::*;
 use for_each::*;
 use intrinsics::*;

--- a/crates/fakecloud-cloudformation/src/template/sam_events.rs
+++ b/crates/fakecloud-cloudformation/src/template/sam_events.rs
@@ -1,0 +1,380 @@
+//! SAM (`AWS::Serverless::Function`) `Events` + `Policies` expansion.
+//!
+//! `AWS::Serverless::Function` is sugar: its `Policies` become an implicit
+//! execution role and its `Events` become the native trigger resources
+//! (`Events::Rule`, `Lambda::EventSourceMapping`, `SNS::Subscription`, plus the
+//! `Lambda::Permission` that lets the source invoke the function). The
+//! transform previously dropped both — so a `sam deploy` produced a function
+//! with no role (every IAM-enforced call denied) and no triggers (nothing ever
+//! invoked it). This module synthesizes those native resources; the existing
+//! provisioner arms then create them for real.
+//!
+//! API/HttpApi events are handled separately (implicit-API route synthesis).
+
+use serde_json::{json, Map, Value};
+
+/// Expand a Serverless::Function's `Policies` and non-API `Events`.
+///
+/// Mutates `lambda_props` in place (removes `Policies`/`Events`, sets `Role`
+/// to the synthesized role when no explicit `Role` was given) and returns the
+/// extra native resources to add to the template, keyed by logical id.
+pub(super) fn expand_function_extras(
+    function_id: &str,
+    lambda_props: &mut Map<String, Value>,
+) -> Vec<(String, Value)> {
+    let mut extras: Vec<(String, Value)> = Vec::new();
+
+    // --- Policies -> implicit execution role ---
+    let policies = lambda_props.remove("Policies");
+    let has_explicit_role = lambda_props
+        .get("Role")
+        .map(|r| !r.is_null())
+        .unwrap_or(false);
+    if !has_explicit_role {
+        let role_id = format!("{function_id}Role");
+        let role = build_execution_role(policies.as_ref());
+        extras.push((role_id.clone(), role));
+        lambda_props.insert(
+            "Role".to_string(),
+            json!({ "Fn::GetAtt": [role_id, "Arn"] }),
+        );
+    }
+
+    // --- Events -> native trigger resources ---
+    let Some(events) = lambda_props.remove("Events") else {
+        return extras;
+    };
+    let Some(events) = events.as_object().cloned() else {
+        return extras;
+    };
+    for (event_name, event) in &events {
+        let Some(event_obj) = event.as_object() else {
+            continue;
+        };
+        let event_type = event_obj.get("Type").and_then(|v| v.as_str()).unwrap_or("");
+        let props = event_obj
+            .get("Properties")
+            .and_then(|v| v.as_object())
+            .cloned()
+            .unwrap_or_default();
+        let id_base = format!("{function_id}{event_name}");
+        match event_type {
+            "Schedule" | "ScheduleV2" => {
+                extras.extend(schedule_event(function_id, &id_base, &props));
+            }
+            "SQS" | "DynamoDB" | "Kinesis" | "MSK" | "MQ" => {
+                extras.push(event_source_mapping(
+                    function_id,
+                    &id_base,
+                    event_type,
+                    &props,
+                ));
+            }
+            "SNS" => {
+                extras.extend(sns_event(function_id, &id_base, &props));
+            }
+            "EventBridgeRule" | "CloudWatchEvent" => {
+                extras.extend(eventbridge_event(function_id, &id_base, &props));
+            }
+            // Api / HttpApi: handled by the implicit-API synthesis pass.
+            // S3 / Cognito / etc.: left for a dedicated pass.
+            _ => {}
+        }
+    }
+
+    extras
+}
+
+/// Build an `AWS::IAM::Role` from a function's `Policies`. The trust policy
+/// always allows `lambda.amazonaws.com` to assume it. `Policies` entries that
+/// are managed-policy names/ARNs become `ManagedPolicyArns`; inline statement
+/// documents become inline `Policies`. SAM policy *templates* (object with a
+/// single template key like `DynamoDBCrudPolicy`) are not expanded here — the
+/// role is still created (assume-role works) so the function is no longer
+/// role-less.
+fn build_execution_role(policies: Option<&Value>) -> Value {
+    let mut managed_arns: Vec<Value> = vec![json!(
+        "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    )];
+    let mut inline: Vec<Value> = Vec::new();
+
+    let mut handle = |p: &Value| {
+        if let Some(name) = p.as_str() {
+            managed_arns.push(json!(managed_policy_arn(name)));
+        } else if let Some(obj) = p.as_object() {
+            // An inline statement document: {Statement: [...]} or a full policy.
+            if obj.contains_key("Statement") {
+                inline.push(json!({
+                    "PolicyName": "InlinePolicy",
+                    "PolicyDocument": p.clone(),
+                }));
+            }
+            // Otherwise a SAM policy template — not expanded; role still created.
+        }
+    };
+
+    match policies {
+        Some(Value::Array(arr)) => arr.iter().for_each(&mut handle),
+        Some(p) => handle(p),
+        None => {}
+    }
+
+    let mut props = json!({
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": { "Service": "lambda.amazonaws.com" },
+                "Action": "sts:AssumeRole"
+            }]
+        },
+        "ManagedPolicyArns": managed_arns,
+    });
+    if !inline.is_empty() {
+        props["Policies"] = json!(inline);
+    }
+    json!({ "Type": "AWS::IAM::Role", "Properties": props })
+}
+
+/// Resolve a managed-policy reference to a full ARN. A bare name (e.g.
+/// `AmazonS3ReadOnlyAccess`) becomes the AWS-managed ARN; anything already in
+/// `arn:` form passes through.
+fn managed_policy_arn(name: &str) -> String {
+    if name.starts_with("arn:") {
+        name.to_string()
+    } else {
+        format!("arn:aws:iam::aws:policy/{name}")
+    }
+}
+
+/// `Schedule` event -> `Events::Rule` (ScheduleExpression) targeting the
+/// function + a `Lambda::Permission` allowing EventBridge to invoke it.
+fn schedule_event(
+    function_id: &str,
+    id_base: &str,
+    props: &Map<String, Value>,
+) -> Vec<(String, Value)> {
+    let schedule = props
+        .get("Schedule")
+        .or_else(|| props.get("ScheduleExpression"))
+        .cloned()
+        .unwrap_or(json!("rate(1 day)"));
+    let rule_id = format!("{id_base}Rule");
+    let mut rule_props = json!({
+        "ScheduleExpression": schedule,
+        "State": props.get("Enabled").map(|e| if e.as_bool() == Some(false) { json!("DISABLED") } else { json!("ENABLED") }).unwrap_or(json!("ENABLED")),
+        "Targets": [{
+            "Id": format!("{function_id}Target"),
+            "Arn": { "Fn::GetAtt": [function_id, "Arn"] }
+        }]
+    });
+    if let Some(name) = props.get("Name") {
+        rule_props["Name"] = name.clone();
+    }
+    if let Some(input) = props.get("Input") {
+        rule_props["Targets"][0]["Input"] = input.clone();
+    }
+    vec![
+        (
+            rule_id.clone(),
+            json!({ "Type": "AWS::Events::Rule", "Properties": rule_props }),
+        ),
+        (
+            format!("{id_base}Permission"),
+            lambda_permission(
+                function_id,
+                "events.amazonaws.com",
+                json!({ "Fn::GetAtt": [rule_id, "Arn"] }),
+            ),
+        ),
+    ]
+}
+
+/// SQS / DynamoDB / Kinesis / MSK / MQ event -> `Lambda::EventSourceMapping`.
+fn event_source_mapping(
+    function_id: &str,
+    id_base: &str,
+    event_type: &str,
+    props: &Map<String, Value>,
+) -> (String, Value) {
+    // The source ARN property name varies by event type.
+    let source = props
+        .get("Queue")
+        .or_else(|| props.get("Stream"))
+        .or_else(|| props.get("EventSourceArn"))
+        .or_else(|| props.get("Topics"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let mut esm = json!({
+        "FunctionName": { "Ref": function_id },
+        "EventSourceArn": source,
+    });
+    if let Some(bs) = props.get("BatchSize") {
+        esm["BatchSize"] = bs.clone();
+    }
+    if let Some(en) = props.get("Enabled") {
+        esm["Enabled"] = en.clone();
+    }
+    // Stream sources need a StartingPosition; SAM defaults to TRIM_HORIZON.
+    if matches!(event_type, "DynamoDB" | "Kinesis" | "MSK") {
+        esm["StartingPosition"] = props
+            .get("StartingPosition")
+            .cloned()
+            .unwrap_or(json!("TRIM_HORIZON"));
+    }
+    (
+        format!("{id_base}EventSourceMapping"),
+        json!({ "Type": "AWS::Lambda::EventSourceMapping", "Properties": esm }),
+    )
+}
+
+/// SNS event -> `SNS::Subscription` (protocol lambda) + invoke permission.
+fn sns_event(function_id: &str, id_base: &str, props: &Map<String, Value>) -> Vec<(String, Value)> {
+    let topic = props.get("Topic").cloned().unwrap_or(Value::Null);
+    let sub = json!({
+        "Type": "AWS::SNS::Subscription",
+        "Properties": {
+            "TopicArn": topic.clone(),
+            "Protocol": "lambda",
+            "Endpoint": { "Fn::GetAtt": [function_id, "Arn"] }
+        }
+    });
+    vec![
+        (format!("{id_base}Subscription"), sub),
+        (
+            format!("{id_base}Permission"),
+            lambda_permission(function_id, "sns.amazonaws.com", topic),
+        ),
+    ]
+}
+
+/// EventBridgeRule / CloudWatchEvent event -> `Events::Rule` (EventPattern)
+/// targeting the function + invoke permission.
+fn eventbridge_event(
+    function_id: &str,
+    id_base: &str,
+    props: &Map<String, Value>,
+) -> Vec<(String, Value)> {
+    let rule_id = format!("{id_base}Rule");
+    let mut rule_props = json!({
+        "Targets": [{
+            "Id": format!("{function_id}Target"),
+            "Arn": { "Fn::GetAtt": [function_id, "Arn"] }
+        }]
+    });
+    if let Some(pattern) = props.get("Pattern").or_else(|| props.get("EventPattern")) {
+        rule_props["EventPattern"] = pattern.clone();
+    }
+    if let Some(bus) = props.get("EventBusName") {
+        rule_props["EventBusName"] = bus.clone();
+    }
+    vec![
+        (
+            rule_id.clone(),
+            json!({ "Type": "AWS::Events::Rule", "Properties": rule_props }),
+        ),
+        (
+            format!("{id_base}Permission"),
+            lambda_permission(
+                function_id,
+                "events.amazonaws.com",
+                json!({ "Fn::GetAtt": [rule_id, "Arn"] }),
+            ),
+        ),
+    ]
+}
+
+/// Build an `AWS::Lambda::Permission` granting `principal` invoke on the
+/// function, scoped to `source_arn`.
+fn lambda_permission(function_id: &str, principal: &str, source_arn: Value) -> Value {
+    json!({
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+            "FunctionName": { "Ref": function_id },
+            "Action": "lambda:InvokeFunction",
+            "Principal": principal,
+            "SourceArn": source_arn
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policies_become_execution_role() {
+        let mut props = serde_json::from_value::<Map<String, Value>>(json!({
+            "Handler": "index.handler",
+            "Policies": ["AmazonS3ReadOnlyAccess", {"Statement": [{"Effect":"Allow","Action":"logs:PutLogEvents","Resource":"*"}]}]
+        }))
+        .unwrap();
+        let extras = expand_function_extras("MyFn", &mut props);
+        // Role injected as GetAtt.
+        assert_eq!(props["Role"], json!({"Fn::GetAtt": ["MyFnRole", "Arn"]}));
+        assert!(props.get("Policies").is_none());
+        let (rid, role) = extras.iter().find(|(id, _)| id == "MyFnRole").unwrap();
+        assert_eq!(rid, "MyFnRole");
+        let arns = role["Properties"]["ManagedPolicyArns"].as_array().unwrap();
+        assert!(arns
+            .iter()
+            .any(|a| a == "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"));
+        assert!(role["Properties"]["Policies"].as_array().unwrap().len() == 1);
+    }
+
+    #[test]
+    fn explicit_role_is_kept() {
+        let mut props = serde_json::from_value::<Map<String, Value>>(json!({
+            "Role": "arn:aws:iam::123456789012:role/explicit",
+            "Policies": ["AmazonS3ReadOnlyAccess"]
+        }))
+        .unwrap();
+        let extras = expand_function_extras("MyFn", &mut props);
+        assert_eq!(
+            props["Role"],
+            json!("arn:aws:iam::123456789012:role/explicit")
+        );
+        assert!(!extras.iter().any(|(id, _)| id == "MyFnRole"));
+    }
+
+    #[test]
+    fn schedule_event_makes_rule_and_permission() {
+        let mut props = serde_json::from_value::<Map<String, Value>>(json!({
+            "Events": { "Cron": { "Type": "Schedule", "Properties": { "Schedule": "rate(5 minutes)" } } }
+        }))
+        .unwrap();
+        let extras = expand_function_extras("MyFn", &mut props);
+        let (_, rule) = extras.iter().find(|(id, _)| id == "MyFnCronRule").unwrap();
+        assert_eq!(rule["Type"], "AWS::Events::Rule");
+        assert_eq!(rule["Properties"]["ScheduleExpression"], "rate(5 minutes)");
+        assert_eq!(
+            rule["Properties"]["Targets"][0]["Arn"],
+            json!({"Fn::GetAtt": ["MyFn","Arn"]})
+        );
+        let (_, perm) = extras
+            .iter()
+            .find(|(id, _)| id == "MyFnCronPermission")
+            .unwrap();
+        assert_eq!(perm["Properties"]["Principal"], "events.amazonaws.com");
+    }
+
+    #[test]
+    fn sqs_event_makes_event_source_mapping() {
+        let mut props = serde_json::from_value::<Map<String, Value>>(json!({
+            "Events": { "Q": { "Type": "SQS", "Properties": { "Queue": "arn:aws:sqs:us-east-1:000000000000:q", "BatchSize": 10 } } }
+        }))
+        .unwrap();
+        let extras = expand_function_extras("MyFn", &mut props);
+        let (_, esm) = extras
+            .iter()
+            .find(|(id, _)| id == "MyFnQEventSourceMapping")
+            .unwrap();
+        assert_eq!(esm["Type"], "AWS::Lambda::EventSourceMapping");
+        assert_eq!(
+            esm["Properties"]["EventSourceArn"],
+            "arn:aws:sqs:us-east-1:000000000000:q"
+        );
+        assert_eq!(esm["Properties"]["BatchSize"], 10);
+        assert_eq!(esm["Properties"]["FunctionName"], json!({"Ref": "MyFn"}));
+    }
+}

--- a/crates/fakecloud-e2e/tests/cloudformation_sam_events.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_sam_events.rs
@@ -1,0 +1,142 @@
+//! SAM `AWS::Serverless::Function` `Policies` + `Events` expansion: a function's
+//! Policies become an implicit execution role and its Events become the native
+//! trigger resources (Events::Rule, Lambda::EventSourceMapping) + the
+//! Lambda::Permission that lets the source invoke it. Without this a SAM deploy
+//! produced a role-less, trigger-less function.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::Capability;
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  Worker:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: sam-worker
+      Runtime: python3.12
+      Handler: index.handler
+      InlineCode: |
+        def handler(event, context):
+            return {}
+      Policies:
+        - AmazonS3ReadOnlyAccess
+        - Statement:
+            - Effect: Allow
+              Action: dynamodb:GetItem
+              Resource: '*'
+      Events:
+        Tick:
+          Type: Schedule
+          Properties:
+            Schedule: rate(5 minutes)
+        Jobs:
+          Type: SQS
+          Properties:
+            Queue: arn:aws:sqs:us-east-1:000000000000:jobs
+            BatchSize: 10
+"#;
+
+#[tokio::test]
+async fn sam_function_expands_policies_and_events() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+
+    cfn.create_stack()
+        .stack_name("sam-events")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityNamedIam)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("sam-events")
+        .send()
+        .await
+        .expect("describe_stacks");
+    assert_eq!(
+        described
+            .stacks()
+            .first()
+            .unwrap()
+            .stack_status()
+            .unwrap()
+            .as_str(),
+        "CREATE_COMPLETE"
+    );
+
+    // --- implicit execution role with the managed + inline policies ---
+    let iam = server.iam_client().await;
+    let roles = iam.list_roles().send().await.expect("list_roles");
+    let role = roles
+        .roles()
+        .iter()
+        .find(|r| r.role_name() == "WorkerRole")
+        .expect("WorkerRole synthesized from Policies");
+    let attached = iam
+        .list_attached_role_policies()
+        .role_name(role.role_name())
+        .send()
+        .await
+        .expect("list_attached_role_policies");
+    assert!(
+        attached
+            .attached_policies()
+            .iter()
+            .any(|p| p.policy_arn() == Some("arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess")),
+        "managed policy attached: {:?}",
+        attached.attached_policies()
+    );
+    let inline = iam
+        .list_role_policies()
+        .role_name(role.role_name())
+        .send()
+        .await
+        .expect("list_role_policies");
+    assert!(
+        !inline.policy_names().is_empty(),
+        "inline policy attached: {:?}",
+        inline.policy_names()
+    );
+
+    // --- Schedule event -> Events::Rule targeting the function ---
+    let events = server.eventbridge_client().await;
+    let rules = events.list_rules().send().await.expect("list_rules");
+    let rule = rules
+        .rules()
+        .iter()
+        .find(|r| r.name() == Some("WorkerTickRule"))
+        .expect("WorkerTickRule synthesized from Schedule event");
+    let targets = events
+        .list_targets_by_rule()
+        .rule(rule.name().unwrap())
+        .send()
+        .await
+        .expect("list_targets_by_rule");
+    assert_eq!(
+        targets.targets().len(),
+        1,
+        "schedule rule must target the function"
+    );
+
+    // --- SQS event -> Lambda::EventSourceMapping ---
+    let lambda = server.lambda_client().await;
+    let esms = lambda
+        .list_event_source_mappings()
+        .function_name("sam-worker")
+        .send()
+        .await
+        .expect("list_event_source_mappings");
+    assert!(
+        esms.event_source_mappings()
+            .iter()
+            .any(|m| m.event_source_arn() == Some("arn:aws:sqs:us-east-1:000000000000:jobs")),
+        "SQS event must create an EventSourceMapping: {:?}",
+        esms.event_source_mappings()
+    );
+}


### PR DESCRIPTION
## Summary (part of CRITICAL 1.1/1.2)

A SAM `AWS::Serverless::Function`'s `Policies` and `Events` were dropped by the transform → `sam deploy` produced a function with **no execution role** (every IAM-enforced call denied under #1880) and **no triggers** (nothing invoked it).

The transform now synthesizes the native resources the existing provisioner arms handle:
- **`Policies` → implicit `AWS::IAM::Role`** (`<Fn>Role`, trust = lambda.amazonaws.com); managed names/ARNs → `ManagedPolicyArns`, inline statement docs → inline policies; function `Role` = `GetAtt`. Explicit `Role` kept.
- **`Schedule`/`ScheduleV2` → `Events::Rule`** (+ `Lambda::Permission`).
- **`SQS`/`DynamoDB`/`Kinesis`/`MSK`/`MQ` → `Lambda::EventSourceMapping`**.
- **`SNS` → `SNS::Subscription`** (lambda) + permission.
- **`EventBridgeRule`/`CloudWatchEvent` → `Events::Rule`** (EventPattern) + permission.

**Api/HttpApi events** (implicit-API route synthesis) follow in the next PR. SAM policy *templates* (DynamoDBCrudPolicy etc.) aren't expanded into statements yet — the role is still created so the function is no longer role-less.

## Non-code surface
Internal CFN/SAM transform fidelity; SAM functions/events already documented as supported. No SDK/docs/metadata change applies (checked).

## Test plan
- Unit tests for `expand_function_extras` (Policies→role, explicit-role kept, Schedule→rule, SQS→ESM) + updated the Globals-additive-Policies test (merged list now lands in the role).
- E2E `sam_function_expands_policies_and_events`: deploys a function with Policies + Schedule + SQS events; asserts the role (managed+inline), Events::Rule target, and EventSourceMapping are created.
- `cargo test -p fakecloud-cloudformation --lib` (242) + existing SAM e2e pass; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SAM transform dropping `AWS::Serverless::Function` `Policies` and non-API `Events`. Functions now deploy with a proper execution role and working triggers.

- **Bug Fixes**
  - `Policies` → synthesize `AWS::IAM::Role` (`<Fn>Role`): managed names/ARNs → `ManagedPolicyArns`, inline statements → inline policies; set function `Role` to `GetAtt` of the role; keep explicit `Role` unchanged.
  - Non-API `Events` → native triggers:
    - `Schedule`/`ScheduleV2` → `AWS::Events::Rule` + `AWS::Lambda::Permission`
    - `SQS`/`DynamoDB`/`Kinesis`/`MSK`/`MQ` → `AWS::Lambda::EventSourceMapping`
    - `SNS` → `AWS::SNS::Subscription` (lambda) + permission
    - `EventBridgeRule`/`CloudWatchEvent` → `AWS::Events::Rule` + permission
    - Note: Api/HttpApi events and SAM policy templates are not expanded in this PR.

<sup>Written for commit 44ab1c6a23698f93c2058baddd37bc52de711626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

