### PR TITLE
test(tfacc): un-deny wafv2 WebACLLoggingConfiguration (firehose fix lifted it)

### DIFF
--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -325,12 +325,13 @@ pub const SERVICES: &[Service] = &[
         // ListTagsForResource resolves delivery-destination ARNs).
         run_regex: "^TestAccLogs[A-Za-z]+_basic$",
         deny: &[
-            // --- gap: this data source's document GENERATION round-trips, but
-            //     its acceptance config provisions a Firehose delivery stream as
-            //     a findings destination, which drifts on Firehose's
-            //     `extended_s3_configuration` computed defaults (custom_time_zone,
-            //     s3_backup_mode) and the cross-service `LogDeliveryEnabled`
-            //     auto-tag. That is a Firehose-fidelity gap, not a logs one. ---
+            // --- gap: this data source's document GENERATION round-trips, and
+            //     the Firehose extended_s3 default-options drift is now fixed, but
+            //     its config still drifts on the cross-service `LogDeliveryEnabled`
+            //     auto-tag: when a CloudWatch Logs data-protection policy names a
+            //     Firehose stream as a findings destination, AWS tags that stream
+            //     `LogDeliveryEnabled=true`. fakecloud does not perform that
+            //     logs -> firehose cross-service tag write. ---
             "TestAccLogsDataProtectionPolicyDocumentDataSource_basic",
         ],
     },
@@ -624,15 +625,13 @@ pub const SERVICES: &[Service] = &[
         // name), and GetWebACL only reports ApplicationIntegrationURL when the ACL
         // declares token domains (the provider always sends a default CaptchaConfig
         // even for a basic ACL, so the CAPTCHA endpoint must gate on token domains).
+        // (WebACLLoggingConfiguration now passes: it provisions a Firehose
+        //  delivery stream as the log destination, and Firehose's ExtendedS3
+        //  description now reports the default option blocks AWS returns
+        //  (CloudWatchLoggingOptions/CustomTimeZone/S3BackupMode), so the stream
+        //  no longer re-plans.)
         run_regex: "^TestAccWAFV2[A-Za-z0-9]+_basic$",
-        deny: &[
-            // --- gap: the logging-configuration test provisions a Firehose
-            //     delivery stream as the log destination, which drifts on
-            //     Firehose's extended_s3_configuration computed defaults
-            //     (custom_time_zone, s3_backup_mode) — a Firehose-fidelity gap,
-            //     not a WAF one. ---
-            "TestAccWAFV2WebACLLoggingConfiguration_basic",
-        ],
+        deny: &[],
     },
     Service {
         name: "firehose",


### PR DESCRIPTION
## Summary

Follow-up to the firehose tfacc wiring (#1920). The wafv2 `WebACLLoggingConfiguration_basic` test provisions a Firehose delivery stream as the log destination; it was denied because the stream re-planned on Firehose's ExtendedS3 default-options drift. That gap is now fixed (DescribeDeliveryStream reports the default `CloudWatchLoggingOptions` / `CustomTimeZone` / `S3BackupMode` blocks), so the test passes -- un-deny it. The wafv2 shard is now fully green with no remaining denies.

The logs `DataProtectionPolicyDocumentDataSource` deny is **sharpened, not lifted**: its remaining drift is the cross-service `LogDeliveryEnabled` auto-tag (AWS tags a Firehose stream that a CloudWatch Logs data-protection policy names as a findings destination), a separate logs -> firehose tag-write fakecloud does not perform.

No code change (deny-list edit only).

## Test plan
- Local tfacc: `TestAccWAFV2WebACLLoggingConfiguration_basic` passes; full `wafv2` shard green (30s, 0 denies).
- `tfacc_shards` matrix + `check-doc-counts.sh` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Un-denies the WAFv2 WebACL logging-configuration `tfacc` test now that Firehose ExtendedS3 defaults are reported correctly; the test passes and the `wafv2` shard is green. Clarifies that the logs DataProtectionPolicyDocument data source remains denied due to the cross‑service `LogDeliveryEnabled` auto‑tag gap; allowlist-only change.

<sup>Written for commit de7b3274db2d321bab259f6c9896fbeae525b84d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

