### PR TITLE
fix(ses): emit result node in SES v1 Query-protocol write responses

### DIFF
--- a/crates/fakecloud-ses/src/v1.rs
+++ b/crates/fakecloud-ses/src/v1.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use http::StatusCode;
 use std::collections::HashMap;
 
-use fakecloud_core::query::{query_metadata_only_xml, query_response_xml};
+use fakecloud_core::query::query_response_xml;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -1,8 +1,12 @@
 use super::*;
 
-/// Response with only metadata (no result body).
+/// Response with an empty result body. The SES v1 Query protocol always wraps
+/// the response in a `<{Action}Result>` element (empty for actions with no
+/// output members); omitting it makes the AWS SDK fail to deserialize with
+/// "{Action}Result node not found". Use this for write actions that return no
+/// data of their own.
 pub(crate) fn xml_metadata_only(action: &str, request_id: &str) -> AwsResponse {
-    let xml = query_metadata_only_xml(action, SES_NS, request_id);
+    let xml = query_response_xml(action, SES_NS, "", request_id);
     AwsResponse::xml(StatusCode::OK, xml)
 }
 

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -1871,3 +1871,26 @@ fn set_and_get_identity_notification_topic() {
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
     assert!(!body.contains("<BounceTopic>"), "cleared: {body}");
 }
+
+#[test]
+fn v1_write_action_response_includes_result_node() {
+    // The SES v1 Query protocol always wraps the response in a
+    // `<{Action}Result>` element; the AWS SDK fails to deserialize without it
+    // ("{Action}Result node not found"). A no-output write action like
+    // CreateConfigurationSet must still emit an empty result node.
+    let state = make_state();
+    let resp = handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSet",
+            vec![("ConfigurationSet.Name", "cs1")],
+        ),
+    )
+    .unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(
+        body.contains("<CreateConfigurationSetResult"),
+        "response must carry the result node: {body}"
+    );
+    assert!(body.contains("<CreateConfigurationSetResponse"));
+}


### PR DESCRIPTION
## Summary

The SES v1 (Query/XML) protocol always wraps a response in a `<{Action}Result>` element -- empty for actions with no output members. The `xml_metadata_only` helper emitted only `<{Action}Response>` + `<ResponseMetadata>` with **no result node**, so the AWS SDK failed to deserialize every no-output SES v1 write action with "{Action}Result node not found" (e.g. `CreateConfigurationSet`, the verify/delete/set identity actions).

This emits an empty `<{Action}Result/>` node (via `query_response_xml` with an empty body) so the response matches the protocol shape. It unblocks the apply path for the SES v1 acceptance tests, which previously errored at the very first create.

The remaining per-resource SES v1 gaps -- deterministic verification tokens, the v1 identity delete/notification state model, receipt-rule wiring, configuration-set `last_fresh_start` / reputation options -- are separate follow-ups, so **SES v1 is not yet wired into the tfacc harness** (it would be red). This PR is the foundational correctness fix that every SES v1 write action needed.

No new public API surface (response-shape correctness fix).

## Test plan
- New unit test `v1_write_action_response_includes_result_node` asserts the result node is present.
- `cargo test -p fakecloud-ses` (251 pass), `cargo clippy --all-targets -D warnings`, `cargo fmt` clean.
- Confirmed locally: with the fix, the SES v1 acceptance tests progress past create (real multi-second apply durations) instead of failing instantly on the malformed response.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure SES v1 Query responses include an empty <{Action}Result> node for no-output write actions. This fixes AWS SDK deserialization errors and lets actions like CreateConfigurationSet proceed.

- **Bug Fixes**
  - Updated `xml_metadata_only` to use `query_response_xml` with an empty body, emitting `<{Action}Result/>` as required by the protocol.
  - Added unit test `v1_write_action_response_includes_result_node` to verify the result node is present.

<sup>Written for commit 780fdd6b20687992ab7fb97199085f3364c0a8c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

