### PR TITLE
fix(apigateway,apigatewayv2): cover dropped fields in Update* patch arms

### DIFF
--- a/crates/fakecloud-apigateway/src/helpers.rs
+++ b/crates/fakecloud-apigateway/src/helpers.rs
@@ -370,7 +370,7 @@ pub(crate) fn apply_rest_api_patch(api: &mut RestApi, op: &str, path: &str, valu
 }
 
 pub(crate) fn apply_method_patch(m: &mut ApiMethod, op: &str, path: &str, value: &Value) {
-    if op != "replace" && op != "add" {
+    if op != "replace" && op != "add" && op != "remove" {
         return;
     }
     match path {
@@ -386,6 +386,42 @@ pub(crate) fn apply_method_patch(m: &mut ApiMethod, op: &str, path: &str, value:
             }
         }
         "/operationName" => m.operation_name = value.as_str().map(String::from),
+        // Previously dropped (bug-hunt 2026-06-24, 1.11): request validation +
+        // Cognito authorization scopes. AWS patches map members at
+        // `/requestParameters/<name>` (bool) and `/requestModels/<contentType>`
+        // (model name).
+        "/requestValidatorId" => m.request_validator_id = value.as_str().map(String::from),
+        _ if path.starts_with("/requestParameters/") => {
+            let key = path.trim_start_matches("/requestParameters/").to_string();
+            if op == "remove" {
+                m.request_parameters.remove(&key);
+            } else {
+                let required = value
+                    .as_bool()
+                    .or_else(|| value.as_str().map(|s| s == "true"))
+                    .unwrap_or(false);
+                m.request_parameters.insert(key, required);
+            }
+        }
+        _ if path.starts_with("/requestModels/") => {
+            let key = path.trim_start_matches("/requestModels/").to_string();
+            if op == "remove" {
+                m.request_models.remove(&key);
+            } else if let Some(v) = value.as_str() {
+                m.request_models.insert(key, v.to_string());
+            }
+        }
+        "/authorizationScopes" if op == "add" => {
+            if let Some(s) = value.as_str() {
+                if !m.authorization_scopes.iter().any(|x| x == s) {
+                    m.authorization_scopes.push(s.to_string());
+                }
+            }
+        }
+        _ if path.starts_with("/authorizationScopes/") && op == "remove" => {
+            let target = path.trim_start_matches("/authorizationScopes/");
+            m.authorization_scopes.retain(|x| x != target);
+        }
         _ => {}
     }
 }

--- a/crates/fakecloud-apigateway/src/service_api_keys.rs
+++ b/crates/fakecloud-apigateway/src/service_api_keys.rs
@@ -124,7 +124,7 @@ impl ApiGatewayService {
             .get_mut(&id)
             .ok_or_else(|| not_found("ApiKey not found"))?;
         apply_patch_operations(req, |op, path, value| {
-            if op != "replace" && op != "add" {
+            if op != "replace" && op != "add" && op != "remove" {
                 return;
             }
             match path {
@@ -138,6 +138,19 @@ impl ApiGatewayService {
                     if let Some(b) = value.as_bool() {
                         k.enabled = b;
                     }
+                }
+                // Previously dropped (bug-hunt 2026-06-24, 1.11).
+                "/customerId" => k.customer_id = value.as_str().map(String::from),
+                "/stageKeys" if op == "add" => {
+                    if let Some(s) = value.as_str() {
+                        if !k.stage_keys.iter().any(|x| x == s) {
+                            k.stage_keys.push(s.to_string());
+                        }
+                    }
+                }
+                _ if path.starts_with("/stageKeys/") && op == "remove" => {
+                    let target = path.trim_start_matches("/stageKeys/");
+                    k.stage_keys.retain(|x| x != target);
                 }
                 _ => {}
             }

--- a/crates/fakecloud-apigateway/src/service_authorizers.rs
+++ b/crates/fakecloud-apigateway/src/service_authorizers.rs
@@ -142,7 +142,7 @@ impl ApiGatewayService {
             .get_mut(&id)
             .ok_or_else(|| not_found("Authorizer not found"))?;
         apply_patch_operations(req, |op, path, value| {
-            if op != "replace" && op != "add" {
+            if op != "replace" && op != "add" && op != "remove" {
                 return;
             }
             match path {
@@ -155,6 +155,26 @@ impl ApiGatewayService {
                 "/identitySource" => a.identity_source = value.as_str().map(String::from),
                 "/authorizerResultTtlInSeconds" => {
                     a.authorizer_result_ttl_in_seconds = value.as_i64().map(|v| v as i32);
+                }
+                // Previously dropped: rotating Cognito provider ARNs or updating
+                // the authorizer's IAM credentials / identity validation
+                // silently no-op'd (bug-hunt 2026-06-24, 1.11).
+                "/authorizerCredentials" => {
+                    a.authorizer_credentials = value.as_str().map(String::from)
+                }
+                "/identityValidationExpression" => {
+                    a.identity_validation_expression = value.as_str().map(String::from)
+                }
+                "/providerARNs" if op == "add" => {
+                    if let Some(s) = value.as_str() {
+                        if !a.provider_arns.iter().any(|x| x == s) {
+                            a.provider_arns.push(s.to_string());
+                        }
+                    }
+                }
+                _ if path.starts_with("/providerARNs/") && op == "remove" => {
+                    let target = path.trim_start_matches("/providerARNs/");
+                    a.provider_arns.retain(|x| x != target);
                 }
                 _ => {}
             }

--- a/crates/fakecloud-apigateway/src/service_integrations.rs
+++ b/crates/fakecloud-apigateway/src/service_integrations.rs
@@ -182,6 +182,29 @@ impl ApiGatewayService {
                         integration.request_templates.insert(k, v.to_string());
                     }
                 }
+                // Previously dropped (bug-hunt 2026-06-24, 1.11): VPC-link
+                // connection id, cache namespace/keys, and mTLS backend config.
+                "/connectionId" => integration.connection_id = value.as_str().map(String::from),
+                "/cacheNamespace" => integration.cache_namespace = value.as_str().map(String::from),
+                "/tlsConfig/insecureSkipVerification" => {
+                    let obj = integration
+                        .tls_config
+                        .get_or_insert_with(|| serde_json::json!({}));
+                    if let Some(m) = obj.as_object_mut() {
+                        m.insert("insecureSkipVerification".to_string(), value.clone());
+                    }
+                }
+                "/cacheKeyParameters" if op == "add" => {
+                    if let Some(s) = value.as_str() {
+                        if !integration.cache_key_parameters.iter().any(|x| x == s) {
+                            integration.cache_key_parameters.push(s.to_string());
+                        }
+                    }
+                }
+                _ if path.starts_with("/cacheKeyParameters/") && op == "remove" => {
+                    let target = path.trim_start_matches("/cacheKeyParameters/");
+                    integration.cache_key_parameters.retain(|x| x != target);
+                }
                 _ => {}
             }
         });

--- a/crates/fakecloud-apigateway/src/service_stages.rs
+++ b/crates/fakecloud-apigateway/src/service_stages.rs
@@ -200,6 +200,35 @@ impl ApiGatewayService {
                         s.variables.insert(k, v.to_string());
                     }
                 }
+                // Access-log + canary settings were dropped: their patch arms
+                // fell through, so enabling access logging or a canary
+                // deployment silently no-op'd (bug-hunt 2026-06-24, 1.11).
+                _ if path.starts_with("/accessLogSettings/") => {
+                    let key = path.trim_start_matches("/accessLogSettings/").to_string();
+                    let obj = s
+                        .access_log_settings
+                        .get_or_insert_with(|| serde_json::json!({}));
+                    if let Some(m) = obj.as_object_mut() {
+                        if op == "remove" {
+                            m.remove(&key);
+                        } else {
+                            m.insert(key, value.clone());
+                        }
+                    }
+                }
+                _ if path.starts_with("/canarySettings/") => {
+                    let key = path.trim_start_matches("/canarySettings/").to_string();
+                    let obj = s
+                        .canary_settings
+                        .get_or_insert_with(|| serde_json::json!({}));
+                    if let Some(m) = obj.as_object_mut() {
+                        if op == "remove" {
+                            m.remove(&key);
+                        } else {
+                            m.insert(key, value.clone());
+                        }
+                    }
+                }
                 _ => {}
             }
         });

--- a/crates/fakecloud-apigateway/src/service_usage_plans.rs
+++ b/crates/fakecloud-apigateway/src/service_usage_plans.rs
@@ -124,6 +124,25 @@ impl ApiGatewayService {
                         m.insert(key, value.clone());
                     }
                 }
+                // apiStages were dropped, so the standard "create plan, then
+                // attach an API stage" flow (Terraform/CDK) silently no-op'd
+                // (bug-hunt 2026-06-24, 1.11). AWS adds a stage via
+                // {op:add, path:/apiStages, value:"<apiId>:<stage>"} and removes
+                // it via {op:remove, path:/apiStages/<apiId>:<stage>}.
+                "/apiStages" if op == "add" => {
+                    if let Some((api_id, stage)) = value.as_str().and_then(|s| s.split_once(':')) {
+                        plan.api_stages
+                            .push(serde_json::json!({"apiId": api_id, "stage": stage}));
+                    }
+                }
+                _ if path.starts_with("/apiStages/") && op == "remove" => {
+                    let target = path.trim_start_matches("/apiStages/");
+                    plan.api_stages.retain(|s| {
+                        let id = s.get("apiId").and_then(|v| v.as_str()).unwrap_or("");
+                        let st = s.get("stage").and_then(|v| v.as_str()).unwrap_or("");
+                        format!("{id}:{st}") != target
+                    });
+                }
                 _ => {}
             }
         });

--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -378,6 +378,11 @@ impl ApiGatewayV2Service {
                     entry["DomainNameConfigurations"] =
                         domain_configs_with_status(body.get("DomainNameConfigurations"), name);
                 }
+                // Previously dropped (bug-hunt 2026-06-24, 1.11): the mTLS
+                // truststore config could not be updated.
+                if let Some(mtls) = body.get("MutualTlsAuthentication") {
+                    entry["MutualTlsAuthentication"] = mtls.clone();
+                }
                 ok(entry.clone())
             }
             "DeleteDomainName" => {
@@ -1123,21 +1128,35 @@ impl ApiGatewayV2Service {
                 .map(|s| s.to_string())
                 .ok_or_else(|| missing("ModelId"))?
         };
-        let mut entry = json!({
-            "ModelId": id,
-            "Name": body["Name"].as_str().unwrap_or(""),
-            "Schema": body["Schema"].as_str().unwrap_or("{}"),
-            "ContentType": body["ContentType"].as_str().unwrap_or("application/json"),
-        });
-        if let Some(desc) = body["Description"].as_str() {
-            entry["Description"] = json!(desc);
-        }
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
         let bucket = state.models.entry(api).or_default();
         if !is_create && !bucket.contains_key(&id) {
             return Err(not_found("Model", &id));
         }
+        // On update, start from the existing entry and overlay only the fields
+        // the request actually sent. Rebuilding from defaults clobbered Name to
+        // "" and ContentType to the default whenever the caller patched only
+        // Schema — true data loss (bug-hunt 2026-06-24, 1.11).
+        let mut entry = if is_create {
+            json!({
+                "ModelId": id,
+                "Name": body["Name"].as_str().unwrap_or(""),
+                "Schema": body["Schema"].as_str().unwrap_or("{}"),
+                "ContentType": body["ContentType"].as_str().unwrap_or("application/json"),
+            })
+        } else {
+            bucket
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| json!({ "ModelId": id }))
+        };
+        for field in ["Name", "Schema", "ContentType", "Description"] {
+            if let Some(v) = body.get(field).filter(|v| !v.is_null()) {
+                entry[field] = v.clone();
+            }
+        }
+        entry["ModelId"] = json!(id);
         bucket.insert(id.clone(), entry.clone());
         ok(entry)
     }

--- a/crates/fakecloud-apigatewayv2/src/service/integrations.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/integrations.rs
@@ -249,6 +249,15 @@ impl ApiGatewayV2Service {
             integration.timeout_in_millis = Some(timeout_in_millis);
         }
 
+        // Previously dropped (bug-hunt 2026-06-24, 1.11): VPC-link connection
+        // type and the integration-response selection expression.
+        if let Some(connection_type) = body["connectionType"].as_str() {
+            integration.connection_type = connection_type.to_string();
+        }
+        if let Some(expr) = body["integrationResponseSelectionExpression"].as_str() {
+            integration.integration_response_selection_expression = Some(expr.to_string());
+        }
+
         Ok(AwsResponse::ok_json(json!(integration)))
     }
 

--- a/crates/fakecloud-apigatewayv2/src/service/mod.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/mod.rs
@@ -315,6 +315,22 @@ impl ApiGatewayV2Service {
             })?);
         }
 
+        // Previously dropped (bug-hunt 2026-06-24, 1.11): WebSocket route /
+        // API-key selection expressions, IP address type, and the
+        // execute-api-endpoint toggle could not be changed.
+        if let Some(v) = body["routeSelectionExpression"].as_str() {
+            api.route_selection_expression = v.to_string();
+        }
+        if let Some(v) = body["apiKeySelectionExpression"].as_str() {
+            api.api_key_selection_expression = v.to_string();
+        }
+        if let Some(v) = body["ipAddressType"].as_str() {
+            api.ip_address_type = v.to_string();
+        }
+        if let Some(b) = body["disableExecuteApiEndpoint"].as_bool() {
+            api.disable_execute_api_endpoint = b;
+        }
+
         Ok(AwsResponse::ok_json(json!(api)))
     }
 }

--- a/crates/fakecloud-e2e/tests/apigateway.rs
+++ b/crates/fakecloud-e2e/tests/apigateway.rs
@@ -891,3 +891,61 @@ async fn test_invoke_authorizer_honors_identity_source() {
         .expect("test_invoke_authorizer allowed");
     assert_eq!(allowed.client_status(), 200);
 }
+
+#[tokio::test]
+async fn update_usage_plan_adds_api_stage() {
+    use aws_sdk_apigateway::types::{Op, PatchOperation};
+
+    let server = TestServer::start().await;
+    let client = server.apigateway_client().await;
+
+    let api_id = client
+        .create_rest_api()
+        .name("metered")
+        .send()
+        .await
+        .unwrap()
+        .id()
+        .unwrap()
+        .to_string();
+
+    let plan_id = client
+        .create_usage_plan()
+        .name("plan-no-stages")
+        .send()
+        .await
+        .unwrap()
+        .id()
+        .unwrap()
+        .to_string();
+
+    // Attach an API stage via PATCH — previously dropped, so the standard
+    // "create plan then attach stage" flow silently no-op'd.
+    client
+        .update_usage_plan()
+        .usage_plan_id(&plan_id)
+        .patch_operations(
+            PatchOperation::builder()
+                .op(Op::Add)
+                .path("/apiStages")
+                .value(format!("{api_id}:prod"))
+                .build(),
+        )
+        .send()
+        .await
+        .expect("update_usage_plan");
+
+    let got = client
+        .get_usage_plan()
+        .usage_plan_id(&plan_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        got.api_stages()
+            .iter()
+            .any(|s| s.api_id() == Some(api_id.as_str()) && s.stage() == Some("prod")),
+        "apiStage must be attached: {:?}",
+        got.api_stages()
+    );
+}

--- a/crates/fakecloud-e2e/tests/apigatewayv2.rs
+++ b/crates/fakecloud-e2e/tests/apigatewayv2.rs
@@ -1526,3 +1526,87 @@ async fn apigatewayv2_create_api_returns_default_metadata_fields() {
         Some(&aws_sdk_apigatewayv2::types::IpAddressType::Ipv4)
     );
 }
+
+#[tokio::test]
+async fn update_model_partial_preserves_other_fields() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api_id = client
+        .create_api()
+        .name("model-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap()
+        .api_id()
+        .unwrap()
+        .to_string();
+
+    let model_id = client
+        .create_model()
+        .api_id(&api_id)
+        .name("Pet")
+        .content_type("application/json")
+        .schema(r#"{"type":"object"}"#)
+        .send()
+        .await
+        .unwrap()
+        .model_id()
+        .unwrap()
+        .to_string();
+
+    // Update only the Schema — Name and ContentType must be preserved, not
+    // clobbered to defaults.
+    client
+        .update_model()
+        .api_id(&api_id)
+        .model_id(&model_id)
+        .schema(r#"{"type":"object","properties":{}}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let got = client
+        .get_model()
+        .api_id(&api_id)
+        .model_id(&model_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        got.name(),
+        Some("Pet"),
+        "Name must survive a partial update"
+    );
+    assert_eq!(got.content_type(), Some("application/json"));
+}
+
+#[tokio::test]
+async fn update_api_changes_route_selection_expression() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let api_id = client
+        .create_api()
+        .name("ws-api")
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Websocket)
+        .route_selection_expression("$request.body.action")
+        .send()
+        .await
+        .unwrap()
+        .api_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .update_api()
+        .api_id(&api_id)
+        .route_selection_expression("$request.body.kind")
+        .send()
+        .await
+        .unwrap();
+
+    let got = client.get_api().api_id(&api_id).send().await.unwrap();
+    assert_eq!(got.route_selection_expression(), Some("$request.body.kind"));
+}


### PR DESCRIPTION
## Summary (1.11)

The `Update*` handlers' patch-arm lists didn't enumerate every serialized field, so a patch to a missing one returned 200 but **silently no-op'd** — perpetual IaC drift on every Terraform/CDK apply. Filled the gaps across both crates:

**REST (v1):** UsagePlan `/apiStages`; Stage `/accessLogSettings/*` + `/canarySettings/*`; Authorizer credentials/identityValidationExpression/providerARNs; Integration connectionId/cacheNamespace/cacheKeyParameters/tlsConfig; Method requestParameters/requestModels/requestValidatorId/authorizationScopes; ApiKey customerId/stageKeys.

**HTTP/WS (v2):** **UpdateModel now merges onto the existing entry** instead of rebuilding from defaults — a partial update (only Schema) no longer clobbers Name to `""` / ContentType to the default (real data loss); UpdateApi routeSelectionExpression/apiKeySelectionExpression/ipAddressType/disableExecuteApiEndpoint; UpdateIntegration connectionType/integrationResponseSelectionExpression; UpdateDomainName MutualTlsAuthentication.

## Non-code surface
Brings Update* round-trips in line with their Create/Describe; no new API surface. No SDK/docs/metadata change applies (checked).

## Test plan
- E2E: `update_usage_plan_adds_api_stage` (v1), `update_model_partial_preserves_other_fields` + `update_api_changes_route_selection_expression` (v2).
- `cargo test --lib` for both crates (227) + clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped fields in API Gateway Update* handlers so PATCHes apply instead of silently no-op’ing, removing IaC drift. In `fakecloud-apigatewayv2`, `UpdateModel` now merges partial updates to prevent clobbering `Name` and `ContentType`.

- **Bug Fixes**
  - `fakecloud-apigateway` (REST v1): Adds patch support for UsagePlan `"/apiStages"`; Stage `"/accessLogSettings/*"` and `"/canarySettings/*"`; Authorizer `authorizerCredentials`, `identityValidationExpression`, `providerARNs`; Integration `connectionId`, `cacheNamespace`, `cacheKeyParameters`, `tlsConfig`; Method `requestParameters`, `requestModels`, `requestValidatorId`, `authorizationScopes`; ApiKey `customerId`, `stageKeys`.
  - `fakecloud-apigatewayv2` (HTTP/WS): `UpdateModel` merges onto the existing model; `UpdateApi` handles `routeSelectionExpression`, `apiKeySelectionExpression`, `ipAddressType`, `disableExecuteApiEndpoint`; `UpdateIntegration` handles `connectionType`, `integrationResponseSelectionExpression`; `UpdateDomainName` handles `MutualTlsAuthentication`.

<sup>Written for commit 4dec54a67d56626a0a0a42356a0d222bd8db48fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

