### PR TITLE
fix(cognito): expire access tokens on first-party operations

### DIFF
--- a/crates/fakecloud-cognito/src/service/auth/signout.rs
+++ b/crates/fakecloud-cognito/src/service/auth/signout.rs
@@ -12,7 +12,7 @@ impl CognitoService {
         let state = accounts.get_or_create(&req.account_id);
 
         // Look up user from access token
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",

--- a/crates/fakecloud-cognito/src/service/branding.rs
+++ b/crates/fakecloud-cognito/src/service/branding.rs
@@ -430,7 +430,7 @@ impl CognitoService {
         let empty = CognitoState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -555,7 +555,7 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -641,7 +641,7 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -688,7 +688,7 @@ impl CognitoService {
         let empty = CognitoState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",

--- a/crates/fakecloud-cognito/src/service/legacy.rs
+++ b/crates/fakecloud-cognito/src/service/legacy.rs
@@ -60,7 +60,7 @@ impl CognitoService {
         let empty = CognitoState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",

--- a/crates/fakecloud-cognito/src/service/mfa.rs
+++ b/crates/fakecloud-cognito/src/service/mfa.rs
@@ -9,7 +9,7 @@ use crate::state::{
     CognitoState, MfaPreferences, SmsConfiguration, SmsMfaConfiguration,
     SoftwareTokenMfaConfiguration,
 };
-// AccessTokenData is used via state.access_tokens.get()
+// AccessTokenData is used via state.valid_access_token()
 
 use super::{ensure_user_pool_exists, generate_totp_secret, require_str, CognitoService};
 
@@ -209,7 +209,7 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -264,7 +264,7 @@ impl CognitoService {
 
         // Identify user from access token or session
         let (pool_id, username) = if let Some(access_token) = body["AccessToken"].as_str() {
-            let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            let token_data = state.valid_access_token(access_token).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "NotAuthorizedException",
@@ -338,7 +338,7 @@ impl CognitoService {
 
         // Identify user from access token or session
         let (pool_id, username) = if let Some(access_token) = body["AccessToken"].as_str() {
-            let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+            let token_data = state.valid_access_token(access_token).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "NotAuthorizedException",
@@ -406,7 +406,7 @@ impl CognitoService {
         let empty = CognitoState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",

--- a/crates/fakecloud-cognito/src/service/misc.rs
+++ b/crates/fakecloud-cognito/src/service/misc.rs
@@ -349,7 +349,7 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -405,7 +405,7 @@ impl CognitoService {
         let state = accounts.get_or_create(&req.account_id);
 
         let (pool_id, username) = if let Some(token) = access_token {
-            let td = state.access_tokens.get(token).ok_or_else(|| {
+            let td = state.valid_access_token(token).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "NotAuthorizedException",
@@ -454,7 +454,7 @@ impl CognitoService {
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         let (pool_id, username) = if let Some(token) = access_token {
-            let td = state.access_tokens.get(token).ok_or_else(|| {
+            let td = state.valid_access_token(token).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "NotAuthorizedException",
@@ -505,7 +505,7 @@ impl CognitoService {
         let empty = CognitoState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -571,7 +571,7 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",

--- a/crates/fakecloud-cognito/src/service/users.rs
+++ b/crates/fakecloud-cognito/src/service/users.rs
@@ -696,7 +696,7 @@ impl CognitoService {
         let empty = CognitoState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -739,7 +739,7 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -800,7 +800,7 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -846,7 +846,7 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -885,7 +885,7 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",
@@ -1015,7 +1015,7 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
+        let token_data = state.valid_access_token(access_token).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "NotAuthorizedException",

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -220,7 +220,28 @@ pub struct LinkedProvider {
     pub provider_attribute_value: Option<String>,
 }
 
+/// Cognito access tokens are valid for 1 hour (the `ExpiresIn: 3600` minted
+/// at sign-in). Used to expire tokens on first-party operations.
+pub const ACCESS_TOKEN_TTL_SECS: i64 = 3600;
+
 impl CognitoState {
+    /// Look up an access token, returning it only if it exists AND has not
+    /// expired. First-party operations (GetUser, ChangePassword, MFA, ...)
+    /// previously validated by a bare map lookup that never checked expiry, so
+    /// an expired-but-not-revoked token kept authorizing indefinitely (bug-hunt
+    /// 2026-06-24, 5.3).
+    pub fn valid_access_token(&self, token: &str) -> Option<&AccessTokenData> {
+        let data = self.access_tokens.get(token)?;
+        let age = Utc::now()
+            .signed_duration_since(data.issued_at)
+            .num_seconds();
+        if age > ACCESS_TOKEN_TTL_SECS {
+            None
+        } else {
+            Some(data)
+        }
+    }
+
     pub fn new(account_id: &str, region: &str) -> Self {
         Self {
             account_id: account_id.to_string(),
@@ -882,6 +903,30 @@ pub fn default_schema_attributes() -> Vec<SchemaAttribute> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn valid_access_token_rejects_expired() {
+        let mut state = CognitoState::new("123456789012", "us-east-1");
+        let mk = |issued_at| AccessTokenData {
+            user_pool_id: "pool".to_string(),
+            username: "u".to_string(),
+            client_id: "c".to_string(),
+            issued_at,
+        };
+        // Fresh token: accepted.
+        state
+            .access_tokens
+            .insert("fresh".to_string(), mk(Utc::now()));
+        assert!(state.valid_access_token("fresh").is_some());
+        // Token issued > 1h ago: rejected (was accepted indefinitely, 5.3).
+        state.access_tokens.insert(
+            "stale".to_string(),
+            mk(Utc::now() - chrono::Duration::seconds(ACCESS_TOKEN_TTL_SECS + 60)),
+        );
+        assert!(state.valid_access_token("stale").is_none());
+        // Unknown token: rejected.
+        assert!(state.valid_access_token("nope").is_none());
+    }
 
     #[test]
     fn new_initializes_empty() {


### PR DESCRIPTION
## Summary (5.3, auth-when-enabled)

GetUser, ChangePassword, the MFA ops, branding, GlobalSignOut and the other first-party Cognito operations validated the bearer token with a bare `access_tokens` map lookup that **never checked expiry** — so an expired-but-not-revoked access token kept authorizing those operations indefinitely. (The API-Gateway authorizer path already fails closed on exp+sig; this was Cognito's own ops.)

Adds `CognitoState::valid_access_token`, which returns the token only if it exists AND was issued within the 1-hour TTL (the `ExpiresIn: 3600` minted at sign-in), and routes all ~22 first-party handler lookups through it.

## Non-code surface
No new API surface — enforcement correctness. No SDK/docs/metadata change applies (checked).

## Test plan
- Unit test `valid_access_token_rejects_expired` (fresh accepted, >1h-old rejected, unknown rejected). Expiry is time-based so a unit test is the right level (an E2E would need a 1-hour wait).
- `cargo test -p fakecloud-cognito --lib` (337) passes; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expire Cognito access tokens for first-party operations. Tokens older than 1 hour are now rejected for GetUser, ChangePassword, MFA, branding, and GlobalSignOut.

- **Bug Fixes**
  - Added CognitoState::valid_access_token with a 1-hour TTL check (`ExpiresIn: 3600`) to replace raw access token lookups.
  - Routed all first-party handlers through the new check, matching API Gateway authorizer behavior.
  - Added a unit test for fresh, expired, and unknown tokens.
  - No API changes.

<sup>Written for commit b526edcc0471be17a487617dbc07e237d3794207. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

