### PR TITLE
fix(s3): map ListDirectoryBuckets to s3express, not s3:ListBuckets

### DIFF
--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -1079,7 +1079,7 @@ impl AwsService for S3Service {
         // service prefixes, not `s3:`. Select the right prefix so a policy
         // targeting the real action string actually matches.
         let service = match action {
-            "CreateSession" => "s3express",
+            "CreateSession" | "ListAllMyDirectoryBuckets" => "s3express",
             "WriteGetObjectResponse" => "s3-object-lambda",
             _ => "s3",
         };
@@ -1241,6 +1241,15 @@ fn s3_detect_action(
     // Service root
     if bucket.is_none() {
         return match method {
+            // A directory-bucket listing (`GET /?x-id=ListDirectoryBuckets`) is
+            // authorized under `s3express:ListAllMyDirectoryBuckets`, NOT
+            // `s3:ListBuckets`. Detecting it as ListBuckets let an
+            // `s3:ListBuckets` grant wrongly enumerate directory buckets and
+            // denied a policy that only granted the s3express action (bug-hunt
+            // 2026-06-24, 5.5).
+            "GET" if query.get("x-id").map(|s| s.as_str()) == Some("ListDirectoryBuckets") => {
+                Some("ListAllMyDirectoryBuckets")
+            }
             "GET" => Some("ListBuckets"),
             _ => None,
         };
@@ -2865,6 +2874,16 @@ mod s3_detect_action_tests {
         // POST /WriteGetObjectResponse (no key) — Object Lambda data plane.
         let action = s3_detect_action("POST", Some("WriteGetObjectResponse"), None, &q(&[]));
         assert_eq!(action, Some("WriteGetObjectResponse"));
+    }
+
+    #[test]
+    fn list_directory_buckets_is_distinct_from_list_buckets() {
+        // GET /?x-id=ListDirectoryBuckets -> s3express action, not ListBuckets.
+        let dir = s3_detect_action("GET", None, None, &q(&[("x-id", "ListDirectoryBuckets")]));
+        assert_eq!(dir, Some("ListAllMyDirectoryBuckets"));
+        // Plain GET / is still ListBuckets.
+        let plain = s3_detect_action("GET", None, None, &q(&[]));
+        assert_eq!(plain, Some("ListBuckets"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary (5.5, auth-when-enabled)

A directory-bucket listing (`GET /?x-id=ListDirectoryBuckets`) was detected by the auth action mapper as `s3:ListBuckets`. Under `--iam` that meant a policy granting `s3:ListBuckets` **wrongly permitted directory-bucket enumeration**, and a policy granting only `s3express:ListAllMyDirectoryBuckets` was **wrongly denied**. (The router already dispatched the request correctly to `list_directory_buckets`; only the auth action string was wrong.)

`s3_detect_action` now returns `ListAllMyDirectoryBuckets` for that request, and `iam_action_for` maps it to the `s3express` service prefix.

## Non-code surface
Auth action-mapping correctness; no new API surface. No SDK/docs/metadata change applies (checked).

## Test plan
- Unit test `list_directory_buckets_is_distinct_from_list_buckets` (directory listing → `ListAllMyDirectoryBuckets`; plain `GET /` → `ListBuckets`).
- `cargo test -p fakecloud-s3 --lib` passes; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes S3 auth mapping for directory-bucket listings. `GET /?x-id=ListDirectoryBuckets` now maps to `s3express:ListAllMyDirectoryBuckets` instead of `s3:ListBuckets`, correcting allow/deny behavior under `--iam`.

- **Bug Fixes**
  - Map detected action to `ListAllMyDirectoryBuckets` with the `s3express` prefix.
  - Add unit test to keep `ListDirectoryBuckets` distinct from `ListBuckets`.

<sup>Written for commit ae1933fb65e795a2d1ea0b94f6a5d258dc4f9d42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

