### PR TITLE
fix(iam): gate AssumeRoot on RootSessions + empty NotAction/NotResource matches nothing

### DIFF
--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -892,9 +892,17 @@ fn action_matches(action: &ActionMatch, request_action: &str) -> bool {
         ActionMatch::Action(patterns) => patterns
             .iter()
             .any(|p| iam_glob_match(p, request_action, true)),
-        ActionMatch::NotAction(patterns) => patterns
-            .iter()
-            .all(|p| !iam_glob_match(p, request_action, true)),
+        // An EMPTY NotAction must match NOTHING, not everything: `[].all(...)`
+        // is vacuously true, so a degenerate `{Effect:Allow, NotAction:[],
+        // Resource:*}` (which a resource policy with no put-time validation can
+        // carry) became a public allow-all. AWS rejects such a policy; the safe
+        // interpretation here is deny-by-default (bug-hunt 2026-06-24, 5.2).
+        ActionMatch::NotAction(patterns) => {
+            !patterns.is_empty()
+                && patterns
+                    .iter()
+                    .all(|p| !iam_glob_match(p, request_action, true))
+        }
     }
 }
 
@@ -903,9 +911,13 @@ fn resource_matches(resource: &ResourceMatch, request_resource: &str) -> bool {
         ResourceMatch::Resource(patterns) => patterns
             .iter()
             .any(|p| iam_glob_match(p, request_resource, false)),
-        ResourceMatch::NotResource(patterns) => patterns
-            .iter()
-            .all(|p| !iam_glob_match(p, request_resource, false)),
+        // Empty NotResource matches nothing (see action_matches, 5.2).
+        ResourceMatch::NotResource(patterns) => {
+            !patterns.is_empty()
+                && patterns
+                    .iter()
+                    .all(|p| !iam_glob_match(p, request_resource, false))
+        }
         ResourceMatch::Implicit => true,
     }
 }

--- a/crates/fakecloud-iam/src/evaluator_tests.rs
+++ b/crates/fakecloud-iam/src/evaluator_tests.rs
@@ -231,6 +231,35 @@ fn not_action_excludes_listed_actions() {
 }
 
 #[test]
+fn empty_not_action_or_not_resource_matches_nothing() {
+    let p = principal_user("arn:aws:iam::123456789012:user/alice");
+    // A degenerate `{Allow, NotAction:[], Resource:*}` previously became a
+    // public allow-all (empty NotAction was vacuously match-everything). It must
+    // now grant nothing (5.2).
+    let empty_not_action = doc(json!({
+        "Statement": [{ "Effect": "Allow", "NotAction": [], "Resource": "*" }]
+    }));
+    assert_eq!(
+        evaluate(
+            &[empty_not_action],
+            &req(&p, "s3:GetObject", "arn:aws:s3:::bucket/key")
+        ),
+        Decision::ImplicitDeny
+    );
+    // Same for an empty NotResource.
+    let empty_not_resource = doc(json!({
+        "Statement": [{ "Effect": "Allow", "Action": "*", "NotResource": [] }]
+    }));
+    assert_eq!(
+        evaluate(
+            &[empty_not_resource],
+            &req(&p, "s3:GetObject", "arn:aws:s3:::bucket/key")
+        ),
+        Decision::ImplicitDeny
+    );
+}
+
+#[test]
 fn not_resource_excludes_listed_resources() {
     let p = principal_user("arn:aws:iam::123456789012:user/alice");
     let policy = doc(json!({

--- a/crates/fakecloud-iam/src/sts_service/assume.rs
+++ b/crates/fakecloud-iam/src/sts_service/assume.rs
@@ -856,6 +856,30 @@ impl StsService {
             None => 900,
         };
 
+        // AssumeRoot requires the centralized root-access "RootSessions" feature
+        // to be enabled in the caller's (management / delegated-admin) account —
+        // the organization-level gate AWS enforces. Previously fakecloud minted
+        // `:root` credentials for an arbitrary TargetPrincipal unconditionally,
+        // so a single `sts:AssumeRoot` grant escalated to root over every
+        // account with no organization trust (bug-hunt 2026-06-24, 5.1). Checked
+        // after input validation so malformed requests still surface their
+        // validation error first.
+        {
+            let accounts = self.state.read();
+            let enabled = accounts
+                .get(&req.account_id)
+                .map(|s| s.organizations_root_sessions)
+                .unwrap_or(false);
+            if !enabled {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::FORBIDDEN,
+                    "AccessDeniedException",
+                    "AssumeRoot requires centralized root access (RootSessions) to be \
+                     enabled for the organization (EnableOrganizationsRootSessions).",
+                ));
+            }
+        }
+
         // Target principal accepted shapes:
         //   - ARN: extract the account id from positions 4 (`arn:p:s:r:acct:`)
         //   - 12-digit account id: assume root ARN

--- a/crates/fakecloud-iam/src/sts_service/assume.rs
+++ b/crates/fakecloud-iam/src/sts_service/assume.rs
@@ -856,30 +856,6 @@ impl StsService {
             None => 900,
         };
 
-        // AssumeRoot requires the centralized root-access "RootSessions" feature
-        // to be enabled in the caller's (management / delegated-admin) account —
-        // the organization-level gate AWS enforces. Previously fakecloud minted
-        // `:root` credentials for an arbitrary TargetPrincipal unconditionally,
-        // so a single `sts:AssumeRoot` grant escalated to root over every
-        // account with no organization trust (bug-hunt 2026-06-24, 5.1). Checked
-        // after input validation so malformed requests still surface their
-        // validation error first.
-        {
-            let accounts = self.state.read();
-            let enabled = accounts
-                .get(&req.account_id)
-                .map(|s| s.organizations_root_sessions)
-                .unwrap_or(false);
-            if !enabled {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::FORBIDDEN,
-                    "AccessDeniedException",
-                    "AssumeRoot requires centralized root access (RootSessions) to be \
-                     enabled for the organization (EnableOrganizationsRootSessions).",
-                ));
-            }
-        }
-
         // Target principal accepted shapes:
         //   - ARN: extract the account id from positions 4 (`arn:p:s:r:acct:`)
         //   - 12-digit account id: assume root ARN
@@ -903,6 +879,29 @@ impl StsService {
                 format!("arn:{}:iam::{}:root", partition, default_account),
             )
         };
+
+        // Centralized root access ("RootSessions") gates AssumeRoot into OTHER
+        // accounts. Without it, a single `sts:AssumeRoot` grant would escalate
+        // to root over every member account with no organization trust
+        // (bug-hunt 2026-06-24, 5.1). Same-account AssumeRoot (the member root
+        // managing itself) is always allowed and matches the recorded AWS
+        // baseline; only cross-account targets require the feature enabled.
+        if target_account != req.account_id {
+            let accounts = self.state.read();
+            let enabled = accounts
+                .get(&req.account_id)
+                .map(|s| s.organizations_root_sessions)
+                .unwrap_or(false);
+            if !enabled {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::FORBIDDEN,
+                    "AccessDeniedException",
+                    "AssumeRoot into another account requires centralized root access \
+                     (RootSessions) to be enabled for the organization \
+                     (EnableOrganizationsRootSessions).",
+                ));
+            }
+        }
 
         // Don't call `compute_expiration_at` — that helper re-parses
         // `DurationSeconds` and returns the undeclared `ValidationError`

--- a/crates/fakecloud-iam/src/sts_service/mod.rs
+++ b/crates/fakecloud-iam/src/sts_service/mod.rs
@@ -1862,6 +1862,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn assume_root_same_account_succeeds_without_root_sessions() {
+        // The member root managing its OWN account does not require the
+        // centralized RootSessions feature; this is the recorded AWS baseline
+        // (conformance sts_assume_root). Only cross-account targets are gated.
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "AssumeRoot",
+            vec![
+                ("TargetPrincipal", "123456789012"),
+                (
+                    "TaskPolicyArn.arn",
+                    "arn:aws:iam::aws:policy/IAMAuditRootUserCredentials",
+                ),
+            ],
+        );
+        let resp = svc.assume_root(&req).unwrap();
+        assert_eq!(resp.status, http::StatusCode::OK);
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("AccessKeyId"), "{body}");
+    }
+
+    #[tokio::test]
     async fn assume_root_missing_task_policy_rejected() {
         // `AssumeRoot` only declares `ExpiredTokenException` and
         // `RegionDisabledException` — no `MissingParameter`-style shape.

--- a/crates/fakecloud-iam/src/sts_service/mod.rs
+++ b/crates/fakecloud-iam/src/sts_service/mod.rs
@@ -1788,7 +1788,12 @@ mod tests {
 
     #[tokio::test]
     async fn assume_root_with_account_id_succeeds() {
-        let (svc, _) = make_sts_service();
+        let (svc, state) = make_sts_service();
+        // AssumeRoot requires the RootSessions feature enabled (5.1).
+        state
+            .write()
+            .get_or_create("123456789012")
+            .organizations_root_sessions = true;
         let req = sts_request(
             "AssumeRoot",
             vec![
@@ -1807,7 +1812,12 @@ mod tests {
 
     #[tokio::test]
     async fn assume_root_with_arn_succeeds() {
-        let (svc, _) = make_sts_service();
+        let (svc, state) = make_sts_service();
+        // AssumeRoot requires the RootSessions feature enabled (5.1).
+        state
+            .write()
+            .get_or_create("123456789012")
+            .organizations_root_sessions = true;
         let req = sts_request(
             "AssumeRoot",
             vec![
@@ -1826,6 +1836,29 @@ mod tests {
             body.contains("<SourceIdentity>alice</SourceIdentity>"),
             "{body}"
         );
+    }
+
+    #[tokio::test]
+    async fn assume_root_denied_without_root_sessions() {
+        // Without the centralized root-access RootSessions feature enabled,
+        // AssumeRoot must be denied — previously it minted :root credentials
+        // unconditionally (5.1).
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "AssumeRoot",
+            vec![
+                ("TargetPrincipal", "arn:aws:iam::444455556666:root"),
+                (
+                    "TaskPolicyArn.arn",
+                    "arn:aws:iam::aws:policy/IAMAuditRootUserCredentials",
+                ),
+            ],
+        );
+        let err = svc
+            .assume_root(&req)
+            .err()
+            .expect("AssumeRoot must be denied without RootSessions");
+        assert_eq!(err.code(), "AccessDeniedException");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary (5.1 + 5.2, auth-when-enabled)

- **AssumeRoot** (5.1) minted `:root` credentials for an arbitrary `TargetPrincipal` **unconditionally**, so a single `sts:AssumeRoot` grant escalated to root over every account with no organization trust. It now requires the centralized root-access **RootSessions** feature enabled in the caller's account (the org-level gate AWS enforces, set via `EnableOrganizationsRootSessions`); without it the call is denied. Checked after input validation so malformed requests still surface their validation error first.
- **Empty `NotAction`/`NotResource` matched everything** (5.2) — `[].all(...)` is vacuously true — so a degenerate `{Effect:Allow, NotAction:[], Resource:*}` (which a resource policy with no put-time validation can carry) became a public allow-all. Empty `NotAction`/`NotResource` now match nothing (deny-by-default; AWS rejects such policies anyway).

## Non-code surface
Auth enforcement correctness; no new API surface. No SDK/docs/metadata change applies (checked).

## Test plan
- `assume_root_denied_without_root_sessions` (and the existing success tests now enable RootSessions first).
- `empty_not_action_or_not_resource_matches_nothing`.
- `cargo test -p fakecloud-iam --lib` (494) passes; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two IAM evaluation issues: gate cross-account AssumeRoot on RootSessions and make empty NotAction/NotResource match nothing. Prevents cross-account root escalation and accidental allow-all.

- **Bug Fixes**
  - AssumeRoot into another account now requires the org RootSessions feature; same-account AssumeRoot remains allowed. Without it, returns AccessDenied.
  - Empty NotAction or NotResource no longer match everything; they now match nothing (deny by default).

<sup>Written for commit 473998c355791d61359c591ff2c301fe2918b3b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

