### PR TITLE
fix(lambda): return X-Amz-Log-Result for buffered Invoke with LogType=Tail

### DIFF
--- a/crates/fakecloud-e2e/src/bin/e2e_nextest_partitions.rs
+++ b/crates/fakecloud-e2e/src/bin/e2e_nextest_partitions.rs
@@ -26,7 +26,8 @@ const LAMBDA_RUNTIME_PYTHON_FILTER: &str = concat!(
     "test(test_invoke_warm_start) | ",
     "test(test_invoke_with_payload) | ",
     "test(test_invoke_with_environment) | ",
-    "test(test_invoke_no_code)",
+    "test(test_invoke_no_code) | ",
+    "test(invoke_with_log_type_tail_returns_log_result)",
     ")"
 );
 const LAMBDA_RUNTIME_NODEJS_FILTER: &str = concat!(

--- a/crates/fakecloud-e2e/tests/lambda_invoke.rs
+++ b/crates/fakecloud-e2e/tests/lambda_invoke.rs
@@ -763,3 +763,52 @@ exports.handler = async (event) => {
     }
     assert!(saw_error_complete, "missing InvokeComplete with error");
 }
+
+#[tokio::test]
+async fn invoke_with_log_type_tail_returns_log_result() {
+    use aws_sdk_lambda::types::LogType;
+    use base64::Engine as _;
+
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    // A handler that prints a unique marker to stdout (-> container logs).
+    let handler_src = "\
+def handler(event, context):
+    print('LOGMARKER_ALPHA_9F3X')
+    return {'ok': True}
+";
+    let zip = make_zip(&[("lambda_function.py", handler_src.as_bytes())]);
+    client
+        .create_function()
+        .function_name("logtail-fn")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("lambda_function.handler")
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .invoke()
+        .function_name("logtail-fn")
+        .log_type(LogType::Tail)
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await
+        .unwrap();
+
+    // X-Amz-Log-Result must be present and decode to the function's logs.
+    let log_result = resp
+        .log_result()
+        .expect("LogType=Tail must return a LogResult");
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(log_result)
+        .expect("LogResult must be valid base64");
+    let logs = String::from_utf8_lossy(&decoded);
+    assert!(
+        logs.contains("LOGMARKER_ALPHA_9F3X"),
+        "LogResult should contain the function's stdout: {logs}"
+    );
+}

--- a/crates/fakecloud-lambda/src/runtime/backend.rs
+++ b/crates/fakecloud-lambda/src/runtime/backend.rs
@@ -114,4 +114,11 @@ pub trait LambdaBackend: Send + Sync + 'static {
     async fn prepull_image(&self, _image: &str) -> Result<(), RuntimeError> {
         Ok(())
     }
+
+    /// Fetch the recent stdout/stderr of a running instance, used to build the
+    /// `X-Amz-Log-Result` tail an `Invoke` with `LogType=Tail` returns. Default
+    /// `None` (no logs available); the container backends override it.
+    async fn instance_logs(&self, _handle: &BackendHandle) -> Option<String> {
+        None
+    }
 }

--- a/crates/fakecloud-lambda/src/runtime/docker.rs
+++ b/crates/fakecloud-lambda/src/runtime/docker.rs
@@ -468,6 +468,27 @@ impl LambdaBackend for DockerBackend {
         }
     }
 
+    async fn instance_logs(&self, handle: &BackendHandle) -> Option<String> {
+        let BackendHandle::Container { id } = handle else {
+            return None;
+        };
+        // `docker logs` writes the container's stdout to our stdout and stderr
+        // to our stderr; the RIE prints the function's logs there. Tail the
+        // recent lines — the Invoke caller keeps only the last 4 KiB.
+        let output = tokio::process::Command::new(&self.cli)
+            .args(["logs", "--tail", "200", id])
+            .output()
+            .await
+            .ok()?;
+        let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+        if combined.is_empty() {
+            None
+        } else {
+            Some(combined)
+        }
+    }
+
     async fn prepull_image(&self, image: &str) -> Result<(), RuntimeError> {
         // Translate AWS-flavored ECR URIs to fakecloud's local registry so
         // private-ECR `Image` package functions can be warmed too. Falls

--- a/crates/fakecloud-lambda/src/runtime/facade.rs
+++ b/crates/fakecloud-lambda/src/runtime/facade.rs
@@ -214,6 +214,30 @@ impl LambdaRuntime {
         payload: &[u8],
         layers: &[Vec<u8>],
     ) -> Result<Vec<u8>, RuntimeError> {
+        self.invoke_inner(func, payload, layers, false)
+            .await
+            .map(|(bytes, _)| bytes)
+    }
+
+    /// Like [`Self::invoke`] but also returns the instance's recent log tail
+    /// (for `Invoke` with `LogType=Tail` -> `X-Amz-Log-Result`). `None` when the
+    /// backend can't supply logs.
+    pub async fn invoke_with_log_tail(
+        &self,
+        func: &LambdaFunction,
+        payload: &[u8],
+        layers: &[Vec<u8>],
+    ) -> Result<(Vec<u8>, Option<String>), RuntimeError> {
+        self.invoke_inner(func, payload, layers, true).await
+    }
+
+    async fn invoke_inner(
+        &self,
+        func: &LambdaFunction,
+        payload: &[u8],
+        layers: &[Vec<u8>],
+        capture_logs: bool,
+    ) -> Result<(Vec<u8>, Option<String>), RuntimeError> {
         let client = reqwest::Client::builder()
             .connect_timeout(REACHABILITY_PROBE_TIMEOUT)
             .build()
@@ -263,7 +287,18 @@ impl LambdaRuntime {
                     let body = resp.bytes().await;
                     *slot.entry.last_used.write() = Instant::now();
                     return match body {
-                        Ok(b) => Ok(b.to_vec()),
+                        Ok(b) => {
+                            // Capture the instance's log tail while the slot
+                            // (and thus the container/Pod) is still alive.
+                            let logs = if capture_logs {
+                                self.backend
+                                    .instance_logs(&slot.entry.instance.handle)
+                                    .await
+                            } else {
+                                None
+                            };
+                            Ok((b.to_vec(), logs))
+                        }
                         Err(e) => {
                             // Response failed mid-stream — the instance is
                             // suspect. Evict it but don't retry: the

--- a/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
+++ b/crates/fakecloud-lambda/src/runtime/k8s/mod.rs
@@ -206,6 +206,18 @@ impl LambdaBackend for K8sBackend {
         }
     }
 
+    async fn instance_logs(&self, handle: &BackendHandle) -> Option<String> {
+        let BackendHandle::Pod { name, .. } = handle else {
+            return None;
+        };
+        // The function's RIE logs go to the Pod container's stdout/stderr.
+        self.client
+            .pod_logs(name, None)
+            .await
+            .ok()
+            .filter(|s| !s.is_empty())
+    }
+
     /// Sweep Lambda Pods that belong to a previous fakecloud process.
     /// Without this, a fakecloud restart leaks the previous run's Pods
     /// and `Create` collides on function names. Mirrors the docker

--- a/crates/fakecloud-lambda/src/service/invoke.rs
+++ b/crates/fakecloud-lambda/src/service/invoke.rs
@@ -1,5 +1,7 @@
 //! `LambdaService` `invoke` family — extracted from service.rs by audit-2026-05-19.
 
+use base64::Engine as _;
+
 use super::*;
 
 impl LambdaService {
@@ -10,6 +12,7 @@ impl LambdaService {
         account_id: &str,
         invocation_type: InvocationType,
         qualifier: Option<&str>,
+        log_tail: bool,
     ) -> Result<AwsResponse, AwsServiceError> {
         // An unknown alias must 404 like GetFunction does, not silently fall
         // through to $LATEST. resolve_qualifier_to_version returns None for both
@@ -258,8 +261,22 @@ impl LambdaService {
                     Ok(resp)
                 }
                 InvocationType::RequestResponse | InvocationType::DryRun => {
-                    match runtime.invoke(&func, payload, &layer_zips).await {
-                        Ok(response_bytes) => {
+                    // With `LogType=Tail` AWS returns the base64 of the last
+                    // 4 KiB of the invocation's logs in `X-Amz-Log-Result`; the
+                    // buffered path previously never set it (bug-hunt
+                    // 2026-06-24, 1.20).
+                    let invoke_result = if log_tail {
+                        runtime
+                            .invoke_with_log_tail(&func, payload, &layer_zips)
+                            .await
+                    } else {
+                        runtime
+                            .invoke(&func, payload, &layer_zips)
+                            .await
+                            .map(|b| (b, None))
+                    };
+                    match invoke_result.map(|(bytes, logs)| (bytes, logs.filter(|_| log_tail))) {
+                        Ok((response_bytes, log_tail_text)) => {
                             // A handler that throws still returns HTTP 200 with
                             // the error payload in the body; AWS signals it with
                             // the `X-Amz-Function-Error` header (surfaced as
@@ -280,6 +297,19 @@ impl LambdaService {
                                     http::header::HeaderName::from_static("x-amz-function-error"),
                                     http::header::HeaderValue::from_static("Unhandled"),
                                 );
+                            }
+                            // LogType=Tail: base64 of the last 4 KiB of logs.
+                            if let Some(text) = log_tail_text {
+                                let bytes = text.as_bytes();
+                                let tail = &bytes[bytes.len().saturating_sub(4096)..];
+                                let encoded =
+                                    base64::engine::general_purpose::STANDARD.encode(tail);
+                                if let Ok(v) = http::header::HeaderValue::from_str(&encoded) {
+                                    resp.headers.insert(
+                                        http::header::HeaderName::from_static("x-amz-log-result"),
+                                        v,
+                                    );
+                                }
                             }
                             Ok(resp)
                         }

--- a/crates/fakecloud-lambda/src/service/mod.rs
+++ b/crates/fakecloud-lambda/src/service/mod.rs
@@ -1360,6 +1360,11 @@ impl AwsService for LambdaService {
                         .get("x-amz-invocation-type")
                         .and_then(|v| v.to_str().ok()),
                 );
+                let log_tail = req
+                    .headers
+                    .get("x-amz-log-type")
+                    .and_then(|v| v.to_str().ok())
+                    == Some("Tail");
                 // `?Qualifier=` wins; otherwise honor a qualifier embedded in
                 // the function ARN/ref (1.3).
                 let qualifier = req
@@ -1373,6 +1378,7 @@ impl AwsService for LambdaService {
                     aid,
                     invocation_type,
                     qualifier,
+                    log_tail,
                 )
                 .await
             }

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -3322,6 +3322,7 @@ async fn invoke_unknown_alias_returns_not_found() {
             "123456789012",
             InvocationType::RequestResponse,
             Some("no-such-alias"),
+            false,
         )
         .await;
     match result {


### PR DESCRIPTION
## Summary (1.20)

A synchronous `Invoke` with `LogType=Tail` must return the base64 of the last 4 KiB of the invocation's logs in `X-Amz-Log-Result` (the SDK's `LogResult`). The buffered `RequestResponse` path **never set it** — only the streaming eventstream path carried the field, and even there it was always empty. So `aws lambda invoke --log-type Tail` and test harnesses got nothing.

Adds a per-instance log-capture hook to the runtime backend trait (`instance_logs`): the docker/podman backend tails `docker logs`, the k8s backend fetches the Pod's logs via the kube API. `invoke_inner` optionally captures the instance's log tail while the slot is still held; the buffered handler, when `LogType=Tail`, base64s the last 4 KiB into `X-Amz-Log-Result`. The other ~22 `invoke` callers are unchanged (they go through the no-capture wrapper).

## Non-code surface
No new API surface — fills in a documented response header. No SDK/docs/metadata change applies (checked).

## Test plan
- E2E (Docker-gated) `invoke_with_log_type_tail_returns_log_result`: a function prints a marker; `Invoke` with `LogType=Tail` returns a `LogResult` decoding to contain it.
- `cargo test -p fakecloud-lambda --lib` (207) passes; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes buffered Lambda Invoke so `X-Amz-Log-Result` is returned for `LogType=Tail`, base64-encoding the last 4 KiB of the function logs. Works for both Docker and Kubernetes backends via per-instance log capture.

- **Bug Fixes**
  - Return `X-Amz-Log-Result` for synchronous `Invoke` with `LogType=Tail` (last 4 KiB, base64).
  - Add `instance_logs` backend hook; Docker tails `docker logs`, K8s reads Pod logs via the kube API.
  - Add E2E test verifying the log tail and register it in the Python runtime partition filter.

<sup>Written for commit b2e9b6c4e2579b83bba48b28f6182e6e7416af8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

