### PR TITLE
fix(glue): implement BatchUpdatePartition, DeleteSchemaVersions, UpdateDevEndpoint

### DIFF
--- a/crates/fakecloud-e2e/tests/glue.rs
+++ b/crates/fakecloud-e2e/tests/glue.rs
@@ -979,3 +979,64 @@ async fn dev_endpoint_is_ready_with_default_nodes() {
     assert_eq!(ep.status(), Some("READY"));
     assert_eq!(ep.number_of_nodes(), 5);
 }
+
+#[tokio::test]
+async fn delete_schema_versions_actually_deletes() {
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    glue.create_registry()
+        .registry_name("dsv-registry")
+        .send()
+        .await
+        .expect("create registry");
+    glue.create_schema()
+        .registry_id(
+            aws_sdk_glue::types::RegistryId::builder()
+                .registry_name("dsv-registry")
+                .build(),
+        )
+        .schema_name("dsv-schema")
+        .data_format(aws_sdk_glue::types::DataFormat::Avro)
+        .compatibility(aws_sdk_glue::types::Compatibility::None)
+        .schema_definition(r#"{"type":"record","name":"r","fields":[]}"#)
+        .send()
+        .await
+        .expect("create schema (v1)");
+
+    let schema_id = aws_sdk_glue::types::SchemaId::builder()
+        .registry_name("dsv-registry")
+        .schema_name("dsv-schema")
+        .build();
+
+    // Register a second version.
+    glue.register_schema_version()
+        .schema_id(schema_id.clone())
+        .schema_definition(r#"{"type":"record","name":"r","fields":[{"name":"x","type":"int"}]}"#)
+        .send()
+        .await
+        .expect("register v2");
+
+    // Delete version 2 — must actually remove it.
+    glue.delete_schema_versions()
+        .schema_id(schema_id.clone())
+        .versions("2")
+        .send()
+        .await
+        .expect("delete_schema_versions");
+
+    let v2 = glue
+        .get_schema_version()
+        .schema_id(schema_id)
+        .schema_version_number(
+            aws_sdk_glue::types::SchemaVersionNumber::builder()
+                .version_number(2)
+                .build(),
+        )
+        .send()
+        .await;
+    assert!(
+        v2.is_err(),
+        "version 2 must be gone after delete_schema_versions"
+    );
+}

--- a/crates/fakecloud-glue/src/blueprints.rs
+++ b/crates/fakecloud-glue/src/blueprints.rs
@@ -308,8 +308,55 @@ impl GlueService {
             .dev_endpoints
             .get_mut(&name)
             .ok_or_else(|| entity_not_found(format!("DevEndpoint {name} not found")))?;
-        if let (Some(obj), Some(pk)) = (e.as_object_mut(), body.get("PublicKey")) {
-            obj.insert("PublicKey".into(), pk.clone());
+        if let Some(obj) = e.as_object_mut() {
+            if let Some(pk) = body.get("PublicKey") {
+                obj.insert("PublicKey".into(), pk.clone());
+            }
+            // Previously dropped (bug-hunt 2026-06-24, 1.13): the rest of the
+            // mutable DevEndpoint fields.
+            for scalar in ["CustomLibraries", "Arguments", "RoleArn"] {
+                if let Some(v) = body.get(scalar) {
+                    obj.insert(scalar.into(), v.clone());
+                }
+            }
+            if let Some(add) = body.get("AddPublicKeys").and_then(|v| v.as_array()) {
+                if let Some(keys) = obj
+                    .entry("PublicKeys")
+                    .or_insert_with(|| json!([]))
+                    .as_array_mut()
+                {
+                    for k in add {
+                        if !keys.contains(k) {
+                            keys.push(k.clone());
+                        }
+                    }
+                }
+            }
+            if let Some(del) = body.get("DeletePublicKeys").and_then(|v| v.as_array()) {
+                if let Some(keys) = obj.get_mut("PublicKeys").and_then(|v| v.as_array_mut()) {
+                    keys.retain(|k| !del.contains(k));
+                }
+            }
+            if let Some(add) = body.get("AddArguments").and_then(|v| v.as_object()) {
+                if let Some(args) = obj
+                    .entry("Arguments")
+                    .or_insert_with(|| json!({}))
+                    .as_object_mut()
+                {
+                    for (k, v) in add {
+                        args.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+            if let Some(del) = body.get("DeleteArguments").and_then(|v| v.as_array()) {
+                if let Some(args) = obj.get_mut("Arguments").and_then(|v| v.as_object_mut()) {
+                    for k in del {
+                        if let Some(k) = k.as_str() {
+                            args.remove(k);
+                        }
+                    }
+                }
+            }
         }
         Ok(AwsResponse::ok_json(json!({})))
     }

--- a/crates/fakecloud-glue/src/schema_registry.rs
+++ b/crates/fakecloud-glue/src/schema_registry.rs
@@ -27,6 +27,24 @@ fn registry_name(id: &Value) -> Option<String> {
 /// by `SchemaArn`. The ARN's resource path is `schema/<registry>/<schema>`, so
 /// both the registry and schema name must come out of the ARN — not just the
 /// trailing segment (otherwise a by-ARN lookup keys off the wrong registry).
+/// Parse a Glue `Versions` range string into the set of version numbers it
+/// covers. Accepts comma-separated tokens, each either a single number `N` or
+/// an inclusive range `N-M` (e.g. `"1-3,5"`).
+fn parse_version_range(spec: &str) -> Vec<i64> {
+    let mut out = Vec::new();
+    for token in spec.split(',') {
+        let token = token.trim();
+        if let Some((lo, hi)) = token.split_once('-') {
+            if let (Ok(lo), Ok(hi)) = (lo.trim().parse::<i64>(), hi.trim().parse::<i64>()) {
+                out.extend(lo..=hi);
+            }
+        } else if let Ok(n) = token.parse::<i64>() {
+            out.push(n);
+        }
+    }
+    out
+}
+
 fn schema_key(id: &Value) -> Option<String> {
     if let Some(name) = id.get("SchemaName").and_then(|v| v.as_str()) {
         let reg = id
@@ -436,7 +454,26 @@ impl GlueService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         req_present(&body, "SchemaId")?;
-        req_str(&body, "Versions")?;
+        let versions = req_str(&body, "Versions")?.to_string();
+        // Resolve the schema's (registry, name) and the version numbers to
+        // delete, then actually remove the matching stored versions — the
+        // handler previously validated and returned no errors without deleting
+        // anything, so Get/List kept returning them (bug-hunt 2026-06-24, 1.13).
+        let key = schema_key(&body["SchemaId"])
+            .ok_or_else(|| invalid_input("SchemaId.SchemaName or SchemaId.SchemaArn required"))?;
+        let (reg, name) = key.split_once('\u{1f}').unwrap_or(("", ""));
+        let wanted = parse_version_range(&versions);
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        st.schema_versions.retain(|_id, v| {
+            let same_schema = (v["RegistryName"].as_str() == Some(reg)
+                && v["SchemaName"].as_str() == Some(name))
+                || v["SchemaArn"]
+                    .as_str()
+                    .is_some_and(|a| a.ends_with(&format!("/{reg}/{name}")));
+            let vnum = v["VersionNumber"].as_i64().unwrap_or(0);
+            !(same_schema && wanted.contains(&vnum))
+        });
         Ok(AwsResponse::ok_json(json!({ "SchemaVersionErrors": [] })))
     }
 

--- a/crates/fakecloud-glue/src/service.rs
+++ b/crates/fakecloud-glue/src/service.rs
@@ -759,7 +759,7 @@ fn already_exists(msg: impl Into<String>) -> AwsServiceError {
     )
 }
 
-fn parse_string_map(val: &Value) -> BTreeMap<String, String> {
+pub(crate) fn parse_string_map(val: &Value) -> BTreeMap<String, String> {
     let mut m = BTreeMap::new();
     if let Some(obj) = val.as_object() {
         for (k, v) in obj {
@@ -785,7 +785,7 @@ fn parse_columns(val: &Value) -> Vec<Column> {
         .collect()
 }
 
-fn parse_storage_descriptor(val: &Value) -> Option<StorageDescriptor> {
+pub(crate) fn parse_storage_descriptor(val: &Value) -> Option<StorageDescriptor> {
     if !val.is_object() {
         return None;
     }

--- a/crates/fakecloud-glue/src/tail.rs
+++ b/crates/fakecloud-glue/src/tail.rs
@@ -1056,11 +1056,23 @@ impl GlueService {
                 })
                 .unwrap_or_default();
             let key = crate::service::partition_key(&values);
-            if !tbl.partitions.contains_key(&key) {
+            let Some(part) = tbl.partitions.get_mut(&key) else {
                 errors.push(json!({
                     "PartitionValueList": values,
                     "ErrorDetail": {"ErrorCode": "EntityNotFoundException", "ErrorMessage": "Partition not found"},
                 }));
+                continue;
+            };
+            // Apply the PartitionInput instead of just checking existence —
+            // batch partition edits were a silent no-op (bug-hunt 2026-06-24,
+            // 1.13).
+            let input = &e["PartitionInput"];
+            if input["StorageDescriptor"].is_object() {
+                part.storage_descriptor =
+                    crate::service::parse_storage_descriptor(&input["StorageDescriptor"]);
+            }
+            if input["Parameters"].is_object() {
+                part.parameters = crate::service::parse_string_map(&input["Parameters"]);
             }
         }
         Ok(AwsResponse::ok_json(json!({ "Errors": errors })))


### PR DESCRIPTION
## Summary (1.13)

Three Glue ops validated their input and returned success **without applying it**:
- **BatchUpdatePartition** only checked existence → now applies each entry's `PartitionInput` (StorageDescriptor, Parameters), like single `UpdatePartition`.
- **DeleteSchemaVersions** validated then returned no errors **without deleting** → now resolves the schema and the version-range string (`1`, `1-3`, `1,3`...) and removes the matching stored versions.
- **UpdateDevEndpoint** applied only `PublicKey` → now also `AddPublicKeys`/`DeletePublicKeys`/`AddArguments`/`DeleteArguments`/`CustomLibraries`/`RoleArn`.

## Non-code surface
Round-trip fidelity for already-supported ops; no new API surface. No SDK/docs/metadata change applies (checked).

## Test plan
- E2E `delete_schema_versions_actually_deletes`.
- `cargo test -p fakecloud-glue --lib` (28) passes; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Glue operations that returned success without applying changes. Updates now persist and match AWS behavior; no API surface change.

- **Bug Fixes**
  - BatchUpdatePartition: applies each entry’s PartitionInput (StorageDescriptor, Parameters) instead of only checking existence.
  - DeleteSchemaVersions: resolves the schema from SchemaId/ARN, parses Versions (e.g., "1", "1-3", "1,3"), and deletes matching versions.
  - UpdateDevEndpoint: updates PublicKey plus AddPublicKeys, DeletePublicKeys, AddArguments, DeleteArguments, CustomLibraries, and RoleArn.

<sup>Written for commit e466a9587314612f2cd9be903e3598a5d5c0d4b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

