### PR TITLE
fix(cloudformation): synthesize implicit API from SAM Function Api/HttpApi events

### DIFF
--- a/crates/fakecloud-cloudformation/src/template/for_each.rs
+++ b/crates/fakecloud-cloudformation/src/template/for_each.rs
@@ -139,6 +139,9 @@ pub(super) fn expand_sam(value: &Value) -> Value {
     };
 
     let mut new_resources = serde_json::Map::new();
+    // Api/HttpApi routes collected from every function's Events, synthesized
+    // into the implicit API after the loop.
+    let mut sam_api_routes: Vec<super::sam_events::ApiRoute> = Vec::new();
     for (logical_id, resource) in resources_map.iter() {
         let Some(resource_obj) = resource.as_object() else {
             new_resources.insert(logical_id.clone(), resource.clone());
@@ -184,8 +187,11 @@ pub(super) fn expand_sam(value: &Value) -> Value {
                 // (sets Role, removes Policies/Events) and returns the extra
                 // native resources to add. Without this SAM functions deploy
                 // with no role and no triggers.
-                let extras =
-                    super::sam_events::expand_function_extras(logical_id, &mut lambda_props);
+                let extras = super::sam_events::expand_function_extras(
+                    logical_id,
+                    &mut lambda_props,
+                    &mut sam_api_routes,
+                );
 
                 let mut lambda_resource = serde_json::Map::new();
                 lambda_resource.insert("Type".to_string(), json!("AWS::Lambda::Function"));
@@ -360,6 +366,12 @@ pub(super) fn expand_sam(value: &Value) -> Value {
                 new_resources.insert(logical_id.clone(), resource.clone());
             }
         }
+    }
+
+    // Synthesize the implicit API resources from the collected Api/HttpApi
+    // routes (one RestApi/HttpApi shared across all functions).
+    for (id, res) in super::sam_events::synthesize_api_resources(&sam_api_routes) {
+        new_resources.entry(id).or_insert(res);
     }
 
     resources_map.clear();

--- a/crates/fakecloud-cloudformation/src/template/sam_events.rs
+++ b/crates/fakecloud-cloudformation/src/template/sam_events.rs
@@ -13,14 +13,31 @@
 
 use serde_json::{json, Map, Value};
 
-/// Expand a Serverless::Function's `Policies` and non-API `Events`.
+/// One HTTP route a function exposes via an `Api`/`HttpApi` event, collected
+/// during the function pass and turned into native API resources afterward by
+/// [`synthesize_api_resources`].
+pub(super) struct ApiRoute {
+    pub function_id: String,
+    /// Explicit `RestApiId`/`ApiId` (a `Ref`/string), or `None` for the
+    /// implicit API SAM creates per protocol.
+    pub explicit_api: Option<Value>,
+    pub path: String,
+    /// Upper-case HTTP method, or `ANY`.
+    pub method: String,
+    /// `true` = `HttpApi` (API Gateway v2), `false` = `Api` (REST v1).
+    pub http_api: bool,
+}
+
+/// Expand a Serverless::Function's `Policies` and `Events`.
 ///
 /// Mutates `lambda_props` in place (removes `Policies`/`Events`, sets `Role`
-/// to the synthesized role when no explicit `Role` was given) and returns the
-/// extra native resources to add to the template, keyed by logical id.
+/// to the synthesized role when no explicit `Role` was given), returns the
+/// extra native resources to add, and pushes any `Api`/`HttpApi` routes onto
+/// `api_routes` for the post-pass implicit-API synthesis.
 pub(super) fn expand_function_extras(
     function_id: &str,
     lambda_props: &mut Map<String, Value>,
+    api_routes: &mut Vec<ApiRoute>,
 ) -> Vec<(String, Value)> {
     let mut extras: Vec<(String, Value)> = Vec::new();
 
@@ -76,7 +93,32 @@ pub(super) fn expand_function_extras(
             "EventBridgeRule" | "CloudWatchEvent" => {
                 extras.extend(eventbridge_event(function_id, &id_base, &props));
             }
-            // Api / HttpApi: handled by the implicit-API synthesis pass.
+            "Api" | "HttpApi" => {
+                // Collect the route; the API resources are synthesized in a
+                // post-pass so all functions sharing the implicit API land in
+                // one RestApi/HttpApi.
+                let http_api = event_type == "HttpApi";
+                let path = props
+                    .get("Path")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("/")
+                    .to_string();
+                let method = props
+                    .get("Method")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("ANY")
+                    .to_uppercase();
+                let explicit_api = props
+                    .get(if http_api { "ApiId" } else { "RestApiId" })
+                    .cloned();
+                api_routes.push(ApiRoute {
+                    function_id: function_id.to_string(),
+                    explicit_api,
+                    path,
+                    method,
+                    http_api,
+                });
+            }
             // S3 / Cognito / etc.: left for a dedicated pass.
             _ => {}
         }
@@ -298,6 +340,211 @@ fn lambda_permission(function_id: &str, principal: &str, source_arn: Value) -> V
     })
 }
 
+/// Strip a path/method into a logical-id-safe token (alphanumeric only).
+fn sanitize(s: &str) -> String {
+    s.chars().filter(|c| c.is_ascii_alphanumeric()).collect()
+}
+
+/// The AWS_PROXY integration URI for a Lambda, resolved at provision time via
+/// `Fn::Sub` over the function's ARN.
+fn lambda_integration_uri(function_id: &str) -> Value {
+    json!({
+        "Fn::Sub": format!(
+            "arn:aws:apigateway:${{AWS::Region}}:lambda:path/2015-03-31/functions/${{{function_id}.Arn}}/invocations"
+        )
+    })
+}
+
+/// Turn the collected `Api`/`HttpApi` routes into native API resources. All
+/// routes without an explicit API id share one implicit API per protocol
+/// (`ServerlessRestApi` / `ServerlessHttpApi`), matching SAM. Returns the extra
+/// resources keyed by logical id. Without this a SAM function with an Api event
+/// deployed with no routes — every call 404'd (bug-hunt 2026-06-24, 1.1).
+pub(super) fn synthesize_api_resources(routes: &[ApiRoute]) -> Vec<(String, Value)> {
+    let mut out: Vec<(String, Value)> = Vec::new();
+    if routes.is_empty() {
+        return out;
+    }
+
+    // --- REST (v1) routes sharing the implicit ServerlessRestApi ---
+    let rest: Vec<&ApiRoute> = routes
+        .iter()
+        .filter(|r| !r.http_api && r.explicit_api.is_none())
+        .collect();
+    if !rest.is_empty() {
+        let api_id = "ServerlessRestApi";
+        out.push((
+            api_id.to_string(),
+            json!({
+                "Type": "AWS::ApiGateway::RestApi",
+                "Properties": { "Name": "ServerlessRestApi", "EndpointConfiguration": { "Types": ["REGIONAL"] } }
+            }),
+        ));
+        // Build the resource tree, deduping by full path prefix.
+        let mut resource_for_path: std::collections::BTreeMap<String, String> =
+            std::collections::BTreeMap::new();
+        let mut method_ids: Vec<String> = Vec::new();
+        for route in &rest {
+            // Resolve (creating as needed) the Resource for this path, then a
+            // Method + Permission targeting the function.
+            let mut parent_ref = json!({ "Fn::GetAtt": [api_id, "RootResourceId"] });
+            let mut prefix = String::new();
+            for segment in route.path.split('/').filter(|s| !s.is_empty()) {
+                prefix.push('/');
+                prefix.push_str(segment);
+                let res_id = format!("{api_id}Resource{}", sanitize(&prefix));
+                if !resource_for_path.contains_key(&prefix) {
+                    out.push((
+                        res_id.clone(),
+                        json!({
+                            "Type": "AWS::ApiGateway::Resource",
+                            "Properties": {
+                                "RestApiId": { "Ref": api_id },
+                                "ParentId": parent_ref,
+                                "PathPart": segment,
+                            }
+                        }),
+                    ));
+                    resource_for_path.insert(prefix.clone(), res_id.clone());
+                }
+                let id = resource_for_path.get(&prefix).cloned().unwrap();
+                parent_ref = json!({ "Fn::GetAtt": [id, "ResourceId"] });
+            }
+            // Root path "/" maps to the RestApi's root resource id directly.
+            let resource_ref = if route.path.trim_matches('/').is_empty() {
+                json!({ "Fn::GetAtt": [api_id, "RootResourceId"] })
+            } else {
+                json!({ "Ref": resource_for_path.get(&prefix).cloned().unwrap() })
+            };
+            let http_method = if route.method == "ANY" {
+                "ANY".to_string()
+            } else {
+                route.method.clone()
+            };
+            let method_id = format!(
+                "{api_id}Method{}{}{}",
+                sanitize(&route.function_id),
+                sanitize(&route.path),
+                sanitize(&http_method)
+            );
+            out.push((
+                method_id.clone(),
+                json!({
+                    "Type": "AWS::ApiGateway::Method",
+                    "Properties": {
+                        "RestApiId": { "Ref": api_id },
+                        "ResourceId": resource_ref,
+                        "HttpMethod": http_method,
+                        "AuthorizationType": "NONE",
+                        "Integration": {
+                            "Type": "AWS_PROXY",
+                            "IntegrationHttpMethod": "POST",
+                            "Uri": lambda_integration_uri(&route.function_id),
+                        }
+                    }
+                }),
+            ));
+            method_ids.push(method_id);
+            out.push((
+                format!("{api_id}Perm{}", sanitize(&route.function_id)),
+                lambda_permission(
+                    &route.function_id,
+                    "apigateway.amazonaws.com",
+                    json!({ "Fn::Sub": format!("arn:aws:execute-api:${{AWS::Region}}:${{AWS::AccountId}}:${{{api_id}}}/*") }),
+                ),
+            ));
+        }
+        // One Deployment (after all methods) + Stage.
+        out.push((
+            format!("{api_id}Deployment"),
+            json!({
+                "Type": "AWS::ApiGateway::Deployment",
+                "DependsOn": method_ids,
+                "Properties": { "RestApiId": { "Ref": api_id } }
+            }),
+        ));
+        out.push((
+            format!("{api_id}ProdStage"),
+            json!({
+                "Type": "AWS::ApiGateway::Stage",
+                "Properties": {
+                    "RestApiId": { "Ref": api_id },
+                    "DeploymentId": { "Ref": format!("{api_id}Deployment") },
+                    "StageName": "Prod",
+                }
+            }),
+        ));
+    }
+
+    // --- HTTP (v2) routes sharing the implicit ServerlessHttpApi ---
+    let http: Vec<&ApiRoute> = routes
+        .iter()
+        .filter(|r| r.http_api && r.explicit_api.is_none())
+        .collect();
+    if !http.is_empty() {
+        let api_id = "ServerlessHttpApi";
+        out.push((
+            api_id.to_string(),
+            json!({
+                "Type": "AWS::ApiGatewayV2::Api",
+                "Properties": { "Name": "ServerlessHttpApi", "ProtocolType": "HTTP" }
+            }),
+        ));
+        for route in &http {
+            let integ_id = format!("{api_id}Integ{}", sanitize(&route.function_id));
+            out.push((
+                integ_id.clone(),
+                json!({
+                    "Type": "AWS::ApiGatewayV2::Integration",
+                    "Properties": {
+                        "ApiId": { "Ref": api_id },
+                        "IntegrationType": "AWS_PROXY",
+                        "IntegrationUri": { "Fn::GetAtt": [route.function_id.clone(), "Arn"] },
+                        "PayloadFormatVersion": "2.0",
+                    }
+                }),
+            ));
+            let route_key = if route.method == "ANY" {
+                format!("ANY {}", route.path)
+            } else {
+                format!("{} {}", route.method, route.path)
+            };
+            out.push((
+                format!(
+                    "{api_id}Route{}{}",
+                    sanitize(&route.function_id),
+                    sanitize(&route.path)
+                ),
+                json!({
+                    "Type": "AWS::ApiGatewayV2::Route",
+                    "Properties": {
+                        "ApiId": { "Ref": api_id },
+                        "RouteKey": route_key,
+                        "Target": { "Fn::Sub": format!("integrations/${{{integ_id}}}") },
+                    }
+                }),
+            ));
+            out.push((
+                format!("{api_id}Perm{}", sanitize(&route.function_id)),
+                lambda_permission(
+                    &route.function_id,
+                    "apigateway.amazonaws.com",
+                    json!({ "Fn::Sub": format!("arn:aws:execute-api:${{AWS::Region}}:${{AWS::AccountId}}:${{{api_id}}}/*") }),
+                ),
+            ));
+        }
+        out.push((
+            format!("{api_id}DefaultStage"),
+            json!({
+                "Type": "AWS::ApiGatewayV2::Stage",
+                "Properties": { "ApiId": { "Ref": api_id }, "StageName": "$default", "AutoDeploy": true }
+            }),
+        ));
+    }
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -309,7 +556,7 @@ mod tests {
             "Policies": ["AmazonS3ReadOnlyAccess", {"Statement": [{"Effect":"Allow","Action":"logs:PutLogEvents","Resource":"*"}]}]
         }))
         .unwrap();
-        let extras = expand_function_extras("MyFn", &mut props);
+        let extras = expand_function_extras("MyFn", &mut props, &mut Vec::new());
         // Role injected as GetAtt.
         assert_eq!(props["Role"], json!({"Fn::GetAtt": ["MyFnRole", "Arn"]}));
         assert!(props.get("Policies").is_none());
@@ -329,7 +576,7 @@ mod tests {
             "Policies": ["AmazonS3ReadOnlyAccess"]
         }))
         .unwrap();
-        let extras = expand_function_extras("MyFn", &mut props);
+        let extras = expand_function_extras("MyFn", &mut props, &mut Vec::new());
         assert_eq!(
             props["Role"],
             json!("arn:aws:iam::123456789012:role/explicit")
@@ -343,7 +590,7 @@ mod tests {
             "Events": { "Cron": { "Type": "Schedule", "Properties": { "Schedule": "rate(5 minutes)" } } }
         }))
         .unwrap();
-        let extras = expand_function_extras("MyFn", &mut props);
+        let extras = expand_function_extras("MyFn", &mut props, &mut Vec::new());
         let (_, rule) = extras.iter().find(|(id, _)| id == "MyFnCronRule").unwrap();
         assert_eq!(rule["Type"], "AWS::Events::Rule");
         assert_eq!(rule["Properties"]["ScheduleExpression"], "rate(5 minutes)");
@@ -364,7 +611,7 @@ mod tests {
             "Events": { "Q": { "Type": "SQS", "Properties": { "Queue": "arn:aws:sqs:us-east-1:000000000000:q", "BatchSize": 10 } } }
         }))
         .unwrap();
-        let extras = expand_function_extras("MyFn", &mut props);
+        let extras = expand_function_extras("MyFn", &mut props, &mut Vec::new());
         let (_, esm) = extras
             .iter()
             .find(|(id, _)| id == "MyFnQEventSourceMapping")

--- a/crates/fakecloud-e2e/tests/cloudformation_sam_api.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_sam_api.rs
@@ -1,0 +1,105 @@
+//! SAM `AWS::Serverless::Function` `Api`/`HttpApi` events expand into a working
+//! implicit API: a function with an Api event previously deployed with no
+//! routes (every call 404'd). The transform now synthesizes the implicit
+//! RestApi (resources + methods + deployment + stage) and HttpApi (integration
+//! + route + stage) so the routes exist.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::Capability;
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  Api:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: sam-api-fn
+      Runtime: python3.12
+      Handler: index.handler
+      InlineCode: |
+        def handler(event, context):
+            return {"statusCode": 200, "body": "ok"}
+      Events:
+        Hello:
+          Type: Api
+          Properties:
+            Path: /hello
+            Method: get
+"#;
+
+#[tokio::test]
+async fn sam_function_api_event_creates_implicit_rest_api() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+
+    cfn.create_stack()
+        .stack_name("sam-api")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityNamedIam)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("sam-api")
+        .send()
+        .await
+        .expect("describe_stacks");
+    assert_eq!(
+        described
+            .stacks()
+            .first()
+            .unwrap()
+            .stack_status()
+            .unwrap()
+            .as_str(),
+        "CREATE_COMPLETE"
+    );
+
+    // The implicit ServerlessRestApi must exist with a /hello resource and a GET
+    // method wired to the function via an AWS_PROXY integration.
+    let apigw = server.apigateway_client().await;
+    let apis = apigw.get_rest_apis().send().await.expect("get_rest_apis");
+    let api = apis
+        .items()
+        .iter()
+        .find(|a| a.name() == Some("ServerlessRestApi"))
+        .expect("implicit ServerlessRestApi created");
+    let api_id = api.id().unwrap();
+
+    let resources = apigw
+        .get_resources()
+        .rest_api_id(api_id)
+        .send()
+        .await
+        .expect("get_resources");
+    let hello = resources
+        .items()
+        .iter()
+        .find(|r| r.path() == Some("/hello"))
+        .expect("/hello resource synthesized");
+    assert!(
+        hello
+            .resource_methods()
+            .map(|m| m.contains_key("GET"))
+            .unwrap_or(false),
+        "GET method on /hello: {:?}",
+        hello.resource_methods()
+    );
+
+    // A deployed stage must exist so the route is reachable.
+    let stages = apigw
+        .get_stages()
+        .rest_api_id(api_id)
+        .send()
+        .await
+        .expect("get_stages");
+    assert!(
+        !stages.item().is_empty(),
+        "a stage must be deployed for the implicit API"
+    );
+}


### PR DESCRIPTION
## Summary (CRITICAL 1.1 — the API half)

A SAM `AWS::Serverless::Function` with an `Api`/`HttpApi` event deployed with **no routes** — every call 404'd. (SAM 2a covered Policies + the non-API event triggers; this covers the API routes.)

The transform now collects every function's `Api`/`HttpApi` routes and, in a post-pass, synthesizes the implicit API resources the native provisioner + data plane already handle:

- **`Api` (REST/v1):** one implicit `ServerlessRestApi`, an `AWS::ApiGateway::Resource` tree built from each route's path (deduped, nested via `ParentId`), an `AWS::ApiGateway::Method` per route with an `AWS_PROXY` integration whose URI resolves the function ARN via `Fn::Sub`, one `Deployment` (`DependsOn` all methods) + a `Prod` `Stage`, and a `Lambda::Permission` per function. The REST data plane routes `/Prod/<path>` to the function.
- **`HttpApi` (v2):** one implicit `ServerlessHttpApi`, an `AWS_PROXY` `Integration` + a `Route` (`RouteKey "METHOD /path"`) per function, a `$default` auto-deploy `Stage`, and a `Lambda::Permission`.

All routes without an explicit `RestApiId`/`ApiId` share one implicit API per protocol, matching SAM.

## Non-code surface
Internal CFN/SAM transform fidelity. No SDK/docs/metadata change applies (checked).

## Test plan
- E2E `sam_function_api_event_creates_implicit_rest_api`: a function with a `Path:/hello Method:get` Api event → implicit `ServerlessRestApi` with a `/hello` resource carrying a `GET` method and a deployed stage.
- Unit tests + `cargo test -p fakecloud-cloudformation --lib` (242) + existing SAM e2e pass; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SAM `AWS::Serverless::Function` `Api`/`HttpApi` events by synthesizing implicit API Gateway resources so routes are created and no longer 404. Routes without an explicit `RestApiId`/`ApiId` now share one implicit API per protocol, matching SAM.

- **Bug Fixes**
  - Collect routes from SAM events during function expansion and synthesize API resources in a post-pass.
  - REST (`Api`): create `ServerlessRestApi`, path resources, `AWS_PROXY` methods, one Deployment, `Prod` Stage, and Lambda permissions.
  - HTTP (`HttpApi`): create `ServerlessHttpApi`, `AWS_PROXY` integrations and routes, `$default` auto-deploy Stage, and permissions.
  - Respect explicit `RestApiId`/`ApiId`; only synthesize for implicit APIs.
  - Added e2e test to verify a `GET /hello` route is created and deployed.

<sup>Written for commit 2a652404c36d8ba2b96374cdb23b75f763d65acb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

