### PR TITLE
fix(ssm): persist OpsItem timestamps, maint-window-task ServiceRoleArn, shared doc version

### DIFF
--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -921,12 +921,17 @@ async fn ssm_ops_item_crud() {
     let server = TestServer::start().await;
     let client = server.ssm_client().await;
 
+    let planned_start = aws_sdk_ssm::primitives::DateTime::from_secs(1_700_000_000);
+    let planned_end = aws_sdk_ssm::primitives::DateTime::from_secs(1_700_003_600);
+
     // Create
     let create_resp = client
         .create_ops_item()
         .title("E2E Test OpsItem")
         .source("e2e-test")
         .description("A test ops item for E2E tests")
+        .planned_start_time(planned_start)
+        .planned_end_time(planned_end)
         .send()
         .await
         .unwrap();
@@ -945,13 +950,18 @@ async fn ssm_ops_item_crud() {
         item.status(),
         Some(&aws_sdk_ssm::types::OpsItemStatus::Open)
     );
+    // Planned timestamps set on create must round-trip, not be dropped.
+    assert_eq!(item.planned_start_time(), Some(&planned_start));
+    assert_eq!(item.planned_end_time(), Some(&planned_end));
 
     // Update
+    let actual_start = aws_sdk_ssm::primitives::DateTime::from_secs(1_700_001_000);
     client
         .update_ops_item()
         .ops_item_id(&ops_item_id)
         .title("Updated OpsItem")
         .status(aws_sdk_ssm::types::OpsItemStatus::Resolved)
+        .actual_start_time(actual_start)
         .send()
         .await
         .unwrap();
@@ -965,6 +975,9 @@ async fn ssm_ops_item_crud() {
         .unwrap();
     let item = get_resp.ops_item().unwrap();
     assert_eq!(item.title().unwrap(), "Updated OpsItem");
+    assert_eq!(item.actual_start_time(), Some(&actual_start));
+    // Planned times persist across the update that didn't touch them.
+    assert_eq!(item.planned_start_time(), Some(&planned_start));
 
     // Describe
     let desc = client.describe_ops_items().send().await.unwrap();
@@ -1280,10 +1293,16 @@ async fn ssm_maintenance_window_execution() {
         .window_id(&window_id)
         .window_task_id(&task_id)
         .name("updated-task")
+        .service_role_arn("arn:aws:iam::123456789012:role/MaintenanceWindowRole")
         .send()
         .await
         .unwrap();
     assert_eq!(resp.name().unwrap(), "updated-task");
+    // ServiceRoleArn set on update must round-trip, not be dropped.
+    assert_eq!(
+        resp.service_role_arn().unwrap(),
+        "arn:aws:iam::123456789012:role/MaintenanceWindowRole"
+    );
 
     // DescribeMaintenanceWindowExecutions (empty initially)
     let resp = client
@@ -1971,13 +1990,14 @@ async fn ssm_document_permissions() {
         .await
         .unwrap();
 
-    // Add permissions
+    // Add permissions, sharing a specific document version (not the default).
     client
         .modify_document_permission()
         .name("e2e-perm-doc")
         .permission_type(aws_sdk_ssm::types::DocumentPermissionType::Share)
         .account_ids_to_add("111111111111")
         .account_ids_to_add("222222222222")
+        .shared_document_version("$LATEST")
         .send()
         .await
         .unwrap();
@@ -1991,6 +2011,14 @@ async fn ssm_document_permissions() {
         .await
         .unwrap();
     assert_eq!(resp.account_ids().len(), 2);
+    // The shared version set on modify must round-trip, not a hardcoded default.
+    assert!(
+        resp.account_sharing_info_list()
+            .iter()
+            .all(|i| i.shared_document_version() == Some("$LATEST")),
+        "shared version should reflect what was set: {:?}",
+        resp.account_sharing_info_list()
+    );
 
     // Remove one
     client

--- a/crates/fakecloud-ssm/src/service/documents.rs
+++ b/crates/fakecloud-ssm/src/service/documents.rs
@@ -651,12 +651,18 @@ impl SsmService {
         })?;
 
         let account_ids = doc.permissions.get("Share").cloned().unwrap_or_default();
+        let shared_version = doc
+            .permissions
+            .get("__shared_version")
+            .and_then(|v| v.first())
+            .cloned()
+            .unwrap_or_else(|| "$DEFAULT".to_string());
 
         Ok(AwsResponse::ok_json(json!({
             "AccountIds": account_ids,
             "AccountSharingInfoList": account_ids.iter().map(|id| json!({
                 "AccountId": id,
-                "SharedDocumentVersion": "$DEFAULT"
+                "SharedDocumentVersion": shared_version
             })).collect::<Vec<_>>(),
         })))
     }
@@ -765,6 +771,13 @@ impl SsmService {
             if let Some(entry) = doc.permissions.get_mut("Share") {
                 entry.retain(|id| !ids.contains(id));
             }
+        }
+
+        // Persist the shared version so DescribeDocumentPermission reflects it.
+        // Stored under a reserved key separate from the "Share" account list.
+        if let Some(ver) = shared_doc_version {
+            doc.permissions
+                .insert("__shared_version".to_string(), vec![ver.to_string()]);
         }
 
         Ok(AwsResponse::ok_json(json!({})))

--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -746,6 +746,11 @@ impl SsmService {
         if let Some(p) = body["Priority"].as_i64() {
             task.priority = p;
         }
+        // Previously dropped, so the old service role persisted (bug-hunt
+        // 2026-06-24, 1.13).
+        if let Some(role) = body["ServiceRoleArn"].as_str() {
+            task.service_role_arn = Some(role.to_string());
+        }
 
         let mut resp = json!({
             "WindowId": window_id,

--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -772,6 +772,9 @@ impl SsmService {
         if let Some(ref me) = task.max_errors {
             resp["MaxErrors"] = json!(me);
         }
+        if let Some(ref sra) = task.service_role_arn {
+            resp["ServiceRoleArn"] = json!(sra);
+        }
 
         Ok(AwsResponse::ok_json(resp))
     }

--- a/crates/fakecloud-ssm/src/service/ops.rs
+++ b/crates/fakecloud-ssm/src/service/ops.rs
@@ -85,10 +85,12 @@ impl SsmService {
             created_by: Arn::global("iam", &state.account_id, "root").to_string(),
             last_modified_by: Arn::global("iam", &state.account_id, "root").to_string(),
             ops_item_type,
-            planned_start_time: None,
-            planned_end_time: None,
-            actual_start_time: None,
-            actual_end_time: None,
+            // Previously hardcoded None + never rendered, so change-management
+            // SLA timelines were lost on round-trip (bug-hunt 2026-06-24, 1.13).
+            planned_start_time: parse_epoch_ts(&body["PlannedStartTime"]),
+            planned_end_time: parse_epoch_ts(&body["PlannedEndTime"]),
+            actual_start_time: parse_epoch_ts(&body["ActualStartTime"]),
+            actual_end_time: parse_epoch_ts(&body["ActualEndTime"]),
         };
 
         state.ops_items.insert(ops_item_id.clone(), item);
@@ -163,6 +165,16 @@ impl SsmService {
         }
         if let Some(arr) = body["RelatedOpsItems"].as_array() {
             item.related_ops_items = arr.clone();
+        }
+        for (field, target) in [
+            ("PlannedStartTime", &mut item.planned_start_time),
+            ("PlannedEndTime", &mut item.planned_end_time),
+            ("ActualStartTime", &mut item.actual_start_time),
+            ("ActualEndTime", &mut item.actual_end_time),
+        ] {
+            if let Some(ts) = parse_epoch_ts(&body[field]) {
+                *target = Some(ts);
+            }
         }
 
         item.last_modified_time = Utc::now();
@@ -554,8 +566,18 @@ impl SsmService {
     // ── Automation ────────────────────────────────────────────────
 }
 
+/// Parse an epoch-seconds timestamp (float, optional fractional millis) as AWS
+/// encodes SSM timestamps in JSON.
+fn parse_epoch_ts(v: &Value) -> Option<chrono::DateTime<Utc>> {
+    let secs = v.as_f64()?;
+    if !secs.is_finite() || secs < 0.0 {
+        return None;
+    }
+    chrono::DateTime::from_timestamp(secs.trunc() as i64, (secs.fract() * 1e9) as u32)
+}
+
 pub(super) fn ops_item_to_json(item: &SsmOpsItem) -> Value {
-    json!({
+    let mut obj = json!({
         "OpsItemId": item.ops_item_id,
         "Title": item.title,
         "Description": item.description,
@@ -572,5 +594,16 @@ pub(super) fn ops_item_to_json(item: &SsmOpsItem) -> Value {
         "CreatedBy": item.created_by,
         "LastModifiedBy": item.last_modified_by,
         "OpsItemType": item.ops_item_type,
-    })
+    });
+    for (field, ts) in [
+        ("PlannedStartTime", item.planned_start_time),
+        ("PlannedEndTime", item.planned_end_time),
+        ("ActualStartTime", item.actual_start_time),
+        ("ActualEndTime", item.actual_end_time),
+    ] {
+        if let Some(ts) = ts {
+            obj[field] = json!(ts.timestamp_millis() as f64 / 1000.0);
+        }
+    }
+    obj
 }


### PR DESCRIPTION
## Summary

Three SSM MED-stub fixes (write-succeeds / read-back-default) from the 2026-06-24 bug hunt:

- **OpsItem timestamps** — `CreateOpsItem`/`UpdateOpsItem` accepted `PlannedStartTime`, `PlannedEndTime`, `ActualStartTime`, `ActualEndTime` but dropped them; `GetOpsItem` always returned them empty. Now parsed, persisted, and rendered.
- **MaintenanceWindowTask ServiceRoleArn** — `UpdateMaintenanceWindowTask` ignored `ServiceRoleArn`. Now applied and round-trips through `GetMaintenanceWindowTask`.
- **Document shared version** — `ModifyDocumentPermission` validated `SharedDocumentVersion` but discarded it; `DescribeDocumentPermission` hardcoded `$DEFAULT`. Now stored and returned faithfully.

## Test plan

Extended `crates/fakecloud-e2e/tests/ssm.rs`:
- `ssm_ops_item_crud` asserts planned/actual timestamps round-trip on create + update.
- `ssm_document_permissions` asserts the shared version set on modify is returned by describe.
- `ssm_describe_maintenance_window_targets_and_tasks` asserts ServiceRoleArn round-trips on update.

All 3 pass; `cargo test -p fakecloud-ssm --lib` green (225); clippy + fmt clean.

## Surface

No new API surface, env vars, or introspection endpoints — fixes existing op fidelity only, so no SDK/website/docs changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSM stub fidelity so important fields round-trip instead of being dropped. OpsItem timestamps, maintenance window task role, and document shared version now persist and are returned by their read APIs.

- **Bug Fixes**
  - OpsItem: `PlannedStartTime`, `PlannedEndTime`, `ActualStartTime`, `ActualEndTime` are parsed, stored, and returned by `GetOpsItem`.
  - MaintenanceWindowTask: `ServiceRoleArn` is applied in `UpdateMaintenanceWindowTask`, echoed in its response, and returned by `GetMaintenanceWindowTask`.
  - Document permissions: `SharedDocumentVersion` set via `ModifyDocumentPermission` is stored and returned by `DescribeDocumentPermission` (no more hardcoded `$DEFAULT`).

<sup>Written for commit 4e66eb2415d4c04e3047f101042c469a2f1e5a42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

