### PR TITLE
fix(elasticache,ecs,ecr): persist dropped Update/Delete fields (1.13)

### DIFF
--- a/crates/fakecloud-e2e/tests/ecr.rs
+++ b/crates/fakecloud-e2e/tests/ecr.rs
@@ -66,6 +66,68 @@ async fn create_describe_list_delete_repository() {
 }
 
 #[tokio::test]
+async fn delete_repository_with_images_requires_force() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+
+    client
+        .create_repository()
+        .repository_name("nonempty-repo")
+        .send()
+        .await
+        .expect("create_repository");
+
+    let manifest = r#"{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"mediaType":"application/vnd.docker.container.image.v1+json","size":7023,"digest":"sha256:dummy"},"layers":[]}"#;
+    client
+        .put_image()
+        .repository_name("nonempty-repo")
+        .image_manifest(manifest)
+        .image_tag("v1")
+        .send()
+        .await
+        .expect("put_image");
+
+    // Without force, a repository holding images must not delete (bug-hunt
+    // 2026-06-24, 1.13 — force was accepted but ignored).
+    let err = client
+        .delete_repository()
+        .repository_name("nonempty-repo")
+        .send()
+        .await
+        .expect_err("delete without force should fail");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("RepositoryNotEmpty"),
+        "unexpected error: {msg}"
+    );
+
+    // The repository must still exist.
+    let still = client
+        .describe_repositories()
+        .repository_names("nonempty-repo")
+        .send()
+        .await
+        .expect("repo still present");
+    assert_eq!(still.repositories().len(), 1);
+
+    // With force=true the delete succeeds.
+    client
+        .delete_repository()
+        .repository_name("nonempty-repo")
+        .force(true)
+        .send()
+        .await
+        .expect("force delete");
+    let err = client
+        .describe_repositories()
+        .repository_names("nonempty-repo")
+        .send()
+        .await
+        .expect_err("gone after force delete");
+    assert!(format!("{err:?}").contains("RepositoryNotFound"));
+}
+
+#[tokio::test]
 async fn create_repository_with_options() {
     let server = TestServer::start().await;
     let client = server.ecr_client().await;

--- a/crates/fakecloud-e2e/tests/ecs.rs
+++ b/crates/fakecloud-e2e/tests/ecs.rs
@@ -862,6 +862,60 @@ async fn update_service_scales_up_and_down() {
 }
 
 #[tokio::test]
+async fn update_service_applies_az_rebalancing_and_volume_configs() {
+    if !require_docker_or_skip("update_service_applies_az_rebalancing_and_volume_configs") {
+        return;
+    }
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap_service_fixtures(&client, "azr-cluster", "azr-td").await;
+    client
+        .create_service()
+        .cluster("azr-cluster")
+        .service_name("web")
+        .task_definition("azr-td")
+        .desired_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    use aws_sdk_ecs::types::{AvailabilityZoneRebalancing, ServiceVolumeConfiguration};
+    // UpdateService previously dropped availabilityZoneRebalancing +
+    // volumeConfigurations (bug-hunt 2026-06-24, 1.13).
+    let updated = client
+        .update_service()
+        .cluster("azr-cluster")
+        .service("web")
+        .availability_zone_rebalancing(AvailabilityZoneRebalancing::Enabled)
+        .volume_configurations(
+            ServiceVolumeConfiguration::builder()
+                .name("data")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("update_service");
+    assert_eq!(
+        updated.service().unwrap().availability_zone_rebalancing(),
+        Some(&AvailabilityZoneRebalancing::Enabled)
+    );
+
+    // Read back via Describe to confirm it persisted.
+    let desc = client
+        .describe_services()
+        .cluster("azr-cluster")
+        .services("web")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        desc.services()[0].availability_zone_rebalancing(),
+        Some(&AvailabilityZoneRebalancing::Enabled)
+    );
+}
+
+#[tokio::test]
 async fn update_service_new_task_definition_triggers_rolling_deployment() {
     let server = TestServer::start().await;
     let client = server.ecs_client().await;

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -89,6 +89,66 @@ async fn elasticache_create_cache_cluster_and_describe() {
 }
 
 #[tokio::test]
+async fn elasticache_modify_cache_cluster_applies_fields() {
+    if !require_docker_or_skip("elasticache_modify_cache_cluster_applies_fields") {
+        return;
+    }
+
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_cluster()
+        .cache_cluster_id("modify-cluster")
+        .cache_node_type("cache.t3.micro")
+        .engine("redis")
+        .send()
+        .await
+        .unwrap();
+    helpers::wait_for_cache_cluster_available(&client, "modify-cluster", 120).await;
+
+    // ModifyCacheCluster must persist the full set of mutable fields, not just
+    // node count / type (bug-hunt 2026-06-24, 1.13).
+    let resp = client
+        .modify_cache_cluster()
+        .cache_cluster_id("modify-cluster")
+        .engine_version("7.0")
+        .preferred_maintenance_window("sun:23:00-mon:01:30")
+        .notification_topic_arn("arn:aws:sns:us-east-1:123456789012:cache-events")
+        .snapshot_retention_limit(5)
+        .snapshot_window("05:00-06:00")
+        .auto_minor_version_upgrade(false)
+        .apply_immediately(true)
+        .send()
+        .await
+        .unwrap();
+    let c = resp.cache_cluster().expect("cache cluster");
+    assert_eq!(c.engine_version(), Some("7.0"));
+    assert_eq!(
+        c.preferred_maintenance_window(),
+        Some("sun:23:00-mon:01:30")
+    );
+    assert_eq!(c.snapshot_retention_limit(), Some(5));
+    assert_eq!(c.snapshot_window(), Some("05:00-06:00"));
+    assert_eq!(c.auto_minor_version_upgrade(), Some(false));
+
+    // Read back to confirm it persisted, not just echoed.
+    let describe = client
+        .describe_cache_clusters()
+        .cache_cluster_id("modify-cluster")
+        .send()
+        .await
+        .unwrap();
+    let c = &describe.cache_clusters()[0];
+    assert_eq!(c.engine_version(), Some("7.0"));
+    assert_eq!(c.snapshot_retention_limit(), Some(5));
+    assert_eq!(
+        c.notification_configuration().and_then(|n| n.topic_arn()),
+        Some("arn:aws:sns:us-east-1:123456789012:cache-events")
+    );
+}
+
+#[tokio::test]
 async fn elasticache_describe_cache_clusters_paginates() {
     if !require_docker_or_skip("elasticache_describe_cache_clusters_paginates") {
         return;

--- a/crates/fakecloud-ecr/src/service/repositories.rs
+++ b/crates/fakecloud-ecr/src/service/repositories.rs
@@ -76,9 +76,18 @@ impl EcrService {
             .repositories
             .get(&name)
             .ok_or_else(|| repository_not_found(&name))?;
-        // Repository-image state lands in Batch 2; until then, nothing
-        // to block the delete, so `force` is accepted but noop-ish.
-        let _ = force;
+        // AWS refuses to delete a repository that still holds images unless
+        // `force` is set, returning RepositoryNotEmptyException.
+        if !force && !repo.images.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "RepositoryNotEmptyException",
+                format!(
+                    "The repository with name '{name}' in registry with id '{account}' \
+                     cannot be deleted because it still contains images",
+                ),
+            ));
+        }
         let snapshot = repository_to_json(repo);
         state.repositories.remove(&name);
         Ok(AwsResponse::ok_json(json!({ "repository": snapshot })))

--- a/crates/fakecloud-ecs/src/service_services_resource.rs
+++ b/crates/fakecloud-ecs/src/service_services_resource.rs
@@ -458,6 +458,12 @@ impl EcsService {
                 if let Some(a) = body.get("serviceRegistries").and_then(|v| v.as_array()) {
                     svc.service_registries = a.clone();
                 }
+                if let Some(s) = opt_str(&body, "availabilityZoneRebalancing") {
+                    svc.availability_zone_rebalancing = Some(s.to_string());
+                }
+                if let Some(a) = body.get("volumeConfigurations").and_then(|v| v.as_array()) {
+                    svc.volume_configurations = a.clone();
+                }
 
                 if let Some(n) = new_desired {
                     let n = n.max(0) as i32;

--- a/crates/fakecloud-elasticache/src/service/clusters.rs
+++ b/crates/fakecloud-elasticache/src/service/clusters.rs
@@ -483,6 +483,36 @@ impl ElastiCacheService {
         if let Some(t) = new_node_type {
             cluster.cache_node_type = t;
         }
+        if let Some(v) = optional_query_param(request, "EngineVersion") {
+            cluster.engine_version = v;
+        }
+        if let Some(v) = optional_query_param(request, "CacheParameterGroupName") {
+            cluster.cache_parameter_group_name = Some(v);
+        }
+        if let Some(v) = optional_query_param(request, "PreferredMaintenanceWindow") {
+            cluster.preferred_maintenance_window = Some(v);
+        }
+        if let Some(v) = optional_query_param(request, "NotificationTopicArn") {
+            cluster.notification_topic_arn = Some(v);
+        }
+        if let Some(v) = optional_query_param(request, "SnapshotRetentionLimit")
+            .and_then(|v| v.parse::<i32>().ok())
+        {
+            cluster.snapshot_retention_limit = v;
+        }
+        if let Some(v) = optional_query_param(request, "SnapshotWindow") {
+            cluster.snapshot_window = Some(v);
+        }
+        if let Some(v) = parse_optional_bool(
+            optional_query_param(request, "AutoMinorVersionUpgrade").as_deref(),
+        )? {
+            cluster.auto_minor_version_upgrade = v;
+        }
+        // Replace the security-group set only when the caller supplies one.
+        let sg_ids = parse_query_list_param(request, "SecurityGroupIds", "SecurityGroupId");
+        if !sg_ids.is_empty() {
+            cluster.security_group_ids = sg_ids;
+        }
         cluster.cache_cluster_status = "modifying".to_string();
         let xml = cache_cluster_xml(cluster, true);
         Ok(AwsResponse::xml(


### PR DESCRIPTION
## Summary

Three MED round-trip-drop fixes from the 2026-06-24 bug hunt (finding 1.13 — write succeeds, read-back shows the default):

- **ElastiCache `ModifyCacheCluster`** applied only `NumCacheNodes`/`CacheNodeType` and dropped ~8 other mutable fields. Now also applies `EngineVersion`, `CacheParameterGroupName`, `PreferredMaintenanceWindow`, `NotificationTopicArn`, `SnapshotRetentionLimit`, `SnapshotWindow`, `AutoMinorVersionUpgrade`, and `SecurityGroupIds` (replaced only when supplied).
- **ECS `UpdateService`** dropped `availabilityZoneRebalancing` and `volumeConfigurations`. Both now applied and rendered by DescribeServices.
- **ECR `DeleteRepository`** accepted `force` but ignored it. Now returns `RepositoryNotEmptyException` when the repo still holds images and `force` is unset; `force=true` deletes regardless.

## Test plan

- `elasticache_modify_cache_cluster_applies_fields` — sets the full field set, asserts both the Modify response and a follow-up Describe.
- `update_service_applies_az_rebalancing_and_volume_configs` — asserts AZ rebalancing round-trips through Update + Describe.
- `delete_repository_with_images_requires_force` — non-force delete of a repo with an image errors and leaves it intact; force delete removes it. (Passes locally, no docker needed.)
- `cargo clippy`/`fmt` clean on all three crates.

## Surface

No new API surface or fields beyond what AWS already declares for these ops; no SDK/docs/website changes (existing ops gaining fidelity).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes round-trip drops in ElastiCache ModifyCacheCluster, ECS UpdateService, and ECR DeleteRepository. Updates now persist correctly and deletes respect force semantics.

- **Bug Fixes**
  - ElastiCache ModifyCacheCluster now persists: EngineVersion, CacheParameterGroupName, PreferredMaintenanceWindow, NotificationTopicArn, SnapshotRetentionLimit, SnapshotWindow, AutoMinorVersionUpgrade, and SecurityGroupIds.
  - ECS UpdateService now persists availabilityZoneRebalancing and volumeConfigurations, and DescribeServices returns them.
  - ECR DeleteRepository returns RepositoryNotEmptyException when images exist and force is unset; force=true deletes anyway.
  - Added end-to-end tests for each case.

<sup>Written for commit bfa5548730e96bd6df0f7484378643151a830ec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

