### PR TITLE
feat(tfacc): add ses (v1) service; identity ARN/token/omit-absent + reputation fixes

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ses.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ses.rs
@@ -321,6 +321,7 @@ impl ResourceProvisioner {
             bounce_topic: None,
             complaint_topic: None,
             delivery_topic: None,
+            verification_token: None,
         };
         let mut accounts = self.ses_state.write();
         let state = accounts.get_or_create(&self.account_id);

--- a/crates/fakecloud-e2e/tests/ses_v1.rs
+++ b/crates/fakecloud-e2e/tests/ses_v1.rs
@@ -798,3 +798,49 @@ async fn test_get_account_sending_enabled() {
 
     assert!(resp.enabled());
 }
+
+#[tokio::test]
+async fn verification_token_is_stable_and_identity_accepts_arn() {
+    // The domain-verification token returned by VerifyDomainIdentity matches the
+    // one GetIdentityVerificationAttributes reports (deterministic + stored).
+    // GetIdentityVerificationAttributes omits unknown identities entirely, and
+    // SetIdentityNotificationTopic accepts the identity ARN form.
+    let server = TestServer::start().await;
+    let client = server.ses_client().await;
+
+    let verify = client
+        .verify_domain_identity()
+        .domain("stable.example.com")
+        .send()
+        .await
+        .expect("verify");
+    let token = verify.verification_token().to_string();
+    assert!(!token.is_empty());
+
+    let attrs = client
+        .get_identity_verification_attributes()
+        .identities("stable.example.com")
+        .identities("missing.example.com")
+        .send()
+        .await
+        .expect("get attrs");
+    let map = attrs.verification_attributes();
+    // Known identity present with the same token; unknown one omitted.
+    assert_eq!(
+        map.get("stable.example.com")
+            .and_then(|a| a.verification_token()),
+        Some(token.as_str())
+    );
+    assert!(!map.contains_key("missing.example.com"));
+
+    // SetIdentityNotificationTopic resolves the ARN form to the identity.
+    let arn = "arn:aws:ses:us-east-1:123456789012:identity/stable.example.com";
+    client
+        .set_identity_notification_topic()
+        .identity(arn)
+        .notification_type(aws_sdk_ses::types::NotificationType::Bounce)
+        .sns_topic("arn:aws:sns:us-east-1:123456789012:t")
+        .send()
+        .await
+        .expect("set notification topic via ARN");
+}

--- a/crates/fakecloud-e2e/tests/ses_v1.rs
+++ b/crates/fakecloud-e2e/tests/ses_v1.rs
@@ -129,11 +129,10 @@ async fn test_get_identity_verification_attributes() {
         aws_sdk_ses::types::VerificationStatus::Success
     );
 
-    let unknown = attrs.get("unknown@example.com").expect("unknown entry");
-    assert_eq!(
-        *unknown.verification_status(),
-        aws_sdk_ses::types::VerificationStatus::NotStarted
-    );
+    // AWS omits unknown identities from the VerificationAttributes map entirely
+    // (the Terraform provider relies on absent-from-map == NotFound for its
+    // CheckDestroy), so the unknown identity is not present in the response.
+    assert!(!attrs.contains_key("unknown@example.com"));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -857,6 +857,7 @@ mod tests {
             bounce_topic: None,
             complaint_topic: None,
             delivery_topic: None,
+            verification_token: None,
         }
     }
 

--- a/crates/fakecloud-ses/src/service/identities.rs
+++ b/crates/fakecloud-ses/src/service/identities.rs
@@ -99,6 +99,7 @@ impl SesV2Service {
             bounce_topic: None,
             complaint_topic: None,
             delivery_topic: None,
+            verification_token: None,
         };
 
         state.identities.insert(identity_name.clone(), identity);

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -65,6 +65,7 @@ fn seed_identity(state: &SharedSesState, name: &str) {
             bounce_topic: None,
             complaint_topic: None,
             delivery_topic: None,
+            verification_token: None,
         },
     );
 }

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -41,6 +41,11 @@ pub struct EmailIdentity {
     pub complaint_topic: Option<String>,
     #[serde(default)]
     pub delivery_topic: Option<String>,
+    /// Domain-verification TXT token. Deterministic per identity and stored so
+    /// VerifyDomainIdentity and GetIdentityVerificationAttributes report the
+    /// same value (the Terraform data source asserts they match).
+    #[serde(default)]
+    pub verification_token: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -10,6 +10,34 @@ pub(crate) fn xml_metadata_only(action: &str, request_id: &str) -> AwsResponse {
     AwsResponse::xml(StatusCode::OK, xml)
 }
 
+/// Normalize an `Identity` parameter to the bare identity name used as the
+/// state map key. SES v1 accepts either the bare email/domain or the identity
+/// ARN (`arn:aws:ses:<region>:<acct>:identity/<name>`); the Terraform provider
+/// passes the ARN to actions like SetIdentityNotificationTopic and
+/// DeleteIdentity, so a lookup keyed on the raw param would miss.
+pub(crate) fn identity_key(identity: &str) -> &str {
+    identity
+        .rsplit_once(":identity/")
+        .map(|(_, name)| name)
+        .unwrap_or(identity)
+}
+
+/// Deterministic 64-hex-char domain-verification token for an identity. Real
+/// SES returns a stable token per identity; deriving it from the name keeps
+/// VerifyDomainIdentity and GetIdentityVerificationAttributes in agreement
+/// across calls and process restarts.
+pub(crate) fn verification_token_for(name: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(b"fakecloud-ses-verification:");
+    hasher.update(name.as_bytes());
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
 /// Dispatch a v1 Query protocol action.
 pub fn handle_v1_action(
     state: &SharedSesState,
@@ -692,6 +720,7 @@ pub(crate) fn verify_email_identity(
             bounce_topic: None,
             complaint_topic: None,
             delivery_topic: None,
+            verification_token: None,
         });
     Ok(xml_metadata_only("VerifyEmailIdentity", &req.request_id))
 }
@@ -727,6 +756,7 @@ pub(crate) fn verify_email_address(
             bounce_topic: None,
             complaint_topic: None,
             delivery_topic: None,
+            verification_token: None,
         });
     Ok(xml_metadata_only("VerifyEmailAddress", &req.request_id))
 }
@@ -786,6 +816,7 @@ pub(crate) fn verify_domain_identity(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let domain = required_param(&req.query_params, "Domain")?;
+    let token = verification_token_for(domain);
     let mut accounts = state.write();
     let st = accounts.get_or_create(&req.account_id);
     st.identities
@@ -809,9 +840,8 @@ pub(crate) fn verify_domain_identity(
             bounce_topic: None,
             complaint_topic: None,
             delivery_topic: None,
+            verification_token: Some(token.clone()),
         });
-    // Return a verification token
-    let token = format!("{:x}{:x}{:x}", rand_u64(), rand_u64(), rand_u64());
     let inner = format!("<VerificationToken>{token}</VerificationToken>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
@@ -849,6 +879,7 @@ pub(crate) fn verify_domain_dkim(
             bounce_topic: None,
             complaint_topic: None,
             delivery_topic: None,
+            verification_token: None,
         });
     // VerifyDomainDkim is the moment SES tells you "ok, I generated DKIM
     // keys, here are the CNAMEs you must publish". Lazily create the
@@ -912,24 +943,33 @@ pub(crate) fn get_identity_verification_attributes(
         let key = format!("Identities.member.{i}");
         match req.query_params.get(&key) {
             Some(identity_name) => {
+                // AWS omits unknown identities from the VerificationAttributes
+                // map entirely; the Terraform provider treats absent-from-map as
+                // NotFound (its CheckDestroy relies on this). Emitting a
+                // NotStarted entry for a deleted identity would read as "still
+                // exists", so only emit an entry when the identity is in state.
+                let Some(identity) = st.identities.get(identity_key(identity_name)) else {
+                    continue;
+                };
                 inner.push_str("<entry>");
                 inner.push_str(&format!("<key>{}</key>", xml_escape(identity_name)));
                 inner.push_str("<value>");
-                if let Some(identity) = st.identities.get(identity_name.as_str()) {
-                    let status = if identity.verified {
-                        "Success"
-                    } else {
-                        "Pending"
-                    };
-                    inner.push_str(&format!(
-                        "<VerificationStatus>{status}</VerificationStatus>"
-                    ));
-                    if identity.identity_type == "Domain" {
-                        let token = format!("{:x}", rand_u64());
-                        inner.push_str(&format!("<VerificationToken>{token}</VerificationToken>"));
-                    }
+                let status = if identity.verified {
+                    "Success"
                 } else {
-                    inner.push_str("<VerificationStatus>NotStarted</VerificationStatus>");
+                    "Pending"
+                };
+                inner.push_str(&format!(
+                    "<VerificationStatus>{status}</VerificationStatus>"
+                ));
+                if identity.identity_type == "Domain" {
+                    // Report the stored deterministic token (falling back to
+                    // deriving it for identities created before the field).
+                    let token = identity
+                        .verification_token
+                        .clone()
+                        .unwrap_or_else(|| verification_token_for(&identity.identity_name));
+                    inner.push_str(&format!("<VerificationToken>{token}</VerificationToken>"));
                 }
                 inner.push_str("</value>");
                 inner.push_str("</entry>");
@@ -964,7 +1004,7 @@ pub(crate) fn get_identity_dkim_attributes(
                 inner.push_str("<entry>");
                 inner.push_str(&format!("<key>{}</key>", xml_escape(identity_name)));
                 inner.push_str("<value>");
-                if let Some(identity) = st.identities.get(identity_name.as_str()) {
+                if let Some(identity) = st.identities.get(identity_key(identity_name)) {
                     let enabled = identity.dkim_signing_enabled;
                     let status = if identity.verified {
                         "Success"
@@ -1008,6 +1048,7 @@ pub(crate) fn delete_identity(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let identity = required_param(&req.query_params, "Identity")?;
+    let identity = identity_key(identity);
     state
         .write()
         .get_or_create(&req.account_id)
@@ -1021,6 +1062,7 @@ pub(crate) fn set_identity_dkim_enabled(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let identity = required_param(&req.query_params, "Identity")?;
+    let identity = identity_key(identity);
     let enabled = required_param(&req.query_params, "DkimEnabled")? == "true";
     let mut accounts = state.write();
     let st = accounts.get_or_create(&req.account_id);
@@ -1059,6 +1101,7 @@ pub(crate) fn set_identity_notification_topic(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let identity = required_param(&req.query_params, "Identity")?;
+    let identity = identity_key(identity);
     let notification_type = required_param(&req.query_params, "NotificationType")?;
     // SnsTopic is optional, and an empty value clears the topic (disables SNS
     // notifications for that type), matching AWS.
@@ -1100,6 +1143,7 @@ pub(crate) fn set_identity_feedback_forwarding_enabled(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let identity = required_param(&req.query_params, "Identity")?;
+    let identity = identity_key(identity);
     let enabled = required_param(&req.query_params, "ForwardingEnabled")? == "true";
     let mut accounts = state.write();
     let st = accounts.get_or_create(&req.account_id);
@@ -1133,7 +1177,7 @@ pub(crate) fn get_identity_notification_attributes(
                 inner.push_str("<entry>");
                 inner.push_str(&format!("<key>{}</key>", xml_escape(identity_name)));
                 inner.push_str("<value>");
-                if let Some(identity) = st.identities.get(identity_name.as_str()) {
+                if let Some(identity) = st.identities.get(identity_key(identity_name)) {
                     inner.push_str(&format!(
                         "<ForwardingEnabled>{}</ForwardingEnabled>\
                          <HeadersInBounceNotificationsEnabled>false</HeadersInBounceNotificationsEnabled>\
@@ -1193,34 +1237,32 @@ pub(crate) fn get_identity_mail_from_domain_attributes(
         let key = format!("Identities.member.{i}");
         match req.query_params.get(&key) {
             Some(identity_name) => {
+                // AWS omits unknown identities from the map; the provider treats
+                // absent-from-map as NotFound (mail-from CheckDestroy relies on
+                // it). Only emit an entry for an identity that exists.
+                let Some(identity) = st.identities.get_mut(identity_key(identity_name)) else {
+                    continue;
+                };
+                let mail_from = identity.mail_from_domain.clone().unwrap_or_default();
+                if identity.mail_from_domain_status == "Pending" && !mail_from.is_empty() {
+                    identity.mail_from_domain_status = "Success".to_string();
+                }
+                if mail_from.is_empty() {
+                    identity.mail_from_domain_status = "NotStarted".to_string();
+                }
+                let behavior = identity.mail_from_behavior_on_mx_failure.clone();
+                let status = identity.mail_from_domain_status.clone();
                 inner.push_str("<entry>");
                 inner.push_str(&format!("<key>{}</key>", xml_escape(identity_name)));
                 inner.push_str("<value>");
-                if let Some(identity) = st.identities.get_mut(identity_name.as_str()) {
-                    let mail_from = identity.mail_from_domain.clone().unwrap_or_default();
-                    if identity.mail_from_domain_status == "Pending" && !mail_from.is_empty() {
-                        identity.mail_from_domain_status = "Success".to_string();
-                    }
-                    if mail_from.is_empty() {
-                        identity.mail_from_domain_status = "NotStarted".to_string();
-                    }
-                    let behavior = identity.mail_from_behavior_on_mx_failure.clone();
-                    let status = identity.mail_from_domain_status.clone();
-                    inner.push_str(&format!(
-                        "<MailFromDomain>{}</MailFromDomain>\
-                         <MailFromDomainStatus>{}</MailFromDomainStatus>\
-                         <BehaviorOnMXFailure>{}</BehaviorOnMXFailure>",
-                        xml_escape(&mail_from),
-                        xml_escape(&status),
-                        xml_escape(&behavior),
-                    ));
-                } else {
-                    inner.push_str(
-                        "<MailFromDomain/>\
-                         <MailFromDomainStatus>NotStarted</MailFromDomainStatus>\
-                         <BehaviorOnMXFailure>UseDefaultValue</BehaviorOnMXFailure>",
-                    );
-                }
+                inner.push_str(&format!(
+                    "<MailFromDomain>{}</MailFromDomain>\
+                     <MailFromDomainStatus>{}</MailFromDomainStatus>\
+                     <BehaviorOnMXFailure>{}</BehaviorOnMXFailure>",
+                    xml_escape(&mail_from),
+                    xml_escape(&status),
+                    xml_escape(&behavior),
+                ));
                 inner.push_str("</value>");
                 inner.push_str("</entry>");
             }
@@ -1244,6 +1286,7 @@ pub(crate) fn set_identity_mail_from_domain(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let identity = required_param(&req.query_params, "Identity")?;
+    let identity = identity_key(identity);
     let mail_from_domain = req.query_params.get("MailFromDomain").cloned();
     let behavior = req
         .query_params
@@ -1988,6 +2031,21 @@ pub(crate) fn describe_configuration_set(
         "<ConfigurationSet><Name>{}</Name></ConfigurationSet>",
         xml_escape(&cs.name)
     );
+    // ReputationOptions: AWS always reports LastFreshStart (the time reputation
+    // metrics were last reset for the set). The Terraform resource reads
+    // `last_fresh_start` and asserts it is set. We report a stable timestamp so
+    // it is present without re-planning.
+    // The SES v1 DescribeConfigurationSet response nests SendingEnabled inside
+    // ReputationOptions (the resource reads last_fresh_start /
+    // reputation_metrics_enabled / sending_enabled all from this block).
+    inner.push_str(&format!(
+        "<ReputationOptions>\
+         <SendingEnabled>{}</SendingEnabled>\
+         <ReputationMetricsEnabled>{}</ReputationMetricsEnabled>\
+         <LastFreshStart>2024-01-01T00:00:00Z</LastFreshStart>\
+         </ReputationOptions>",
+        cs.sending_enabled, cs.reputation_metrics_enabled
+    ));
     // Include event destinations if requested
     if let Some(dests) = st.event_destinations.get(name) {
         inner.push_str("<EventDestinations>");

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -45,6 +45,7 @@ fn seed_identity(state: &SharedSesState, name: &str) {
             bounce_topic: None,
             complaint_topic: None,
             delivery_topic: None,
+            verification_token: None,
         },
     );
 }
@@ -872,7 +873,13 @@ fn test_get_identity_verification_attributes() {
     let resp = handle_v1_action(&state, &req).unwrap();
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
     assert!(body.contains("<VerificationStatus>Success</VerificationStatus>"));
-    assert!(body.contains("<VerificationStatus>NotStarted</VerificationStatus>"));
+    // AWS omits unknown identities from the VerificationAttributes map entirely
+    // (the Terraform provider relies on absent-from-map == NotFound), so the
+    // unknown identity must NOT appear in the response.
+    assert!(
+        !body.contains("unknown@test.com"),
+        "unknown identity must be omitted: {body}"
+    );
 }
 
 #[test]

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -659,6 +659,37 @@ pub const SERVICES: &[Service] = &[
             "TestAccCloudWatchContributorManagedInsightRulesDataSource_basic",
         ],
     },
+    Service {
+        name: "ses",
+        // SES v1 (Query/XML protocol): the `_basic` smoke for domain identities
+        // (+ data source / verification), DKIM, mail-from, identity notification
+        // topics, and identity policies. Fixes: identity lookups accept the ARN
+        // form (not just the bare name); the domain-verification token is
+        // deterministic per identity and stored so verify + get-attributes agree;
+        // Get{Verification,MailFrom}Attributes omit unknown identities so the
+        // provider's CheckDestroy reads them as gone; DescribeConfigurationSet
+        // reports the ReputationOptions block (last_fresh_start / sending_enabled
+        // / reputation_metrics_enabled).
+        run_regex: "^TestAccSES[A-Za-z0-9]+_basic$",
+        deny: &[
+            // --- gap: ConfigurationSet and EventDestination pass their apply +
+            //     checks but error in the post-apply destroy when a refresh read
+            //     hits a configuration set the SDK reports as already gone; the
+            //     destroy-time lifecycle for these two still needs work. ---
+            "TestAccSESConfigurationSet_basic",
+            "TestAccSESEventDestination_basic",
+            // --- gap: the template destroy hits the same already-deleted refresh
+            //     path (GetTemplate raising TemplateDoesNotExist during destroy). ---
+            "TestAccSESTemplate_basic",
+            // --- gap: inbound email receipt rules need the SES email-receiving
+            //     feature (active rule sets, rule ordering); the receipt tests'
+            //     shared PreCheck requires a provisioned rule set that fakecloud
+            //     does not model. ---
+            "TestAccSESReceiptFilter_basic",
+            "TestAccSESReceiptRule_basic",
+            "TestAccSESReceiptRuleSet_basic",
+        ],
+    },
 ];
 
 /// CI matrix shards. One GitHub Actions job per entry.
@@ -983,6 +1014,12 @@ pub const SHARDS: &[Shard] = &[
         name: "cloudwatch",
         service: "cloudwatch",
         run_regex: "^TestAccCloudWatch[A-Za-z0-9]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "ses",
+        service: "ses",
+        run_regex: "^TestAccSES[A-Za-z0-9]+_basic$",
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -193,6 +193,11 @@ async fn dynamodb_resources_acceptance() {
 }
 
 #[tokio::test]
+async fn ses_acceptance() {
+    run_shard("ses").await;
+}
+
+#[tokio::test]
 async fn scheduler_acceptance() {
     run_shard("scheduler").await;
 }


### PR DESCRIPTION
## Summary

Wire **SES v1** (Query/XML protocol) into the tfacc harness (new `Service` + `Shard` + `acc.rs` fn; `AWS_ENDPOINT_URL_SES` already present). The `_basic` smoke for domain identities (+ data source / verification), DKIM, mail-from, identity notification topics, and identity policies now runs and passes -- **7 tests**.

**Fixes (all real fakecloud bugs):**
- **Identity ARN resolution**: lookups accept the identity ARN form (`arn:aws:ses:<region>:<acct>:identity/<name>`), not just the bare name. The provider passes the ARN to `SetIdentityNotificationTopic` / `DeleteIdentity` / mail-from / feedback actions, so a raw-keyed lookup missed ("Identity does not exist").
- **Deterministic verification token**: the domain-verification token is now SHA-256-derived from the identity name and stored, so `VerifyDomainIdentity` and `GetIdentityVerificationAttributes` report the same value (the data source asserts they match; it was previously a fresh random each call).
- **Omit unknown identities**: `Get{Verification,MailFrom}Attributes` omit identities not in state (AWS does). Emitting a synthetic entry made the provider's `CheckDestroy` read a deleted identity as still present ("still exists").
- **ReputationOptions**: `DescribeConfigurationSet` reports the block with `SendingEnabled` / `ReputationMetricsEnabled` / `LastFreshStart` (the resource reads `sending_enabled`, `reputation_metrics_enabled`, `last_fresh_start` from it).

**Denied with honest reasons:** `ConfigurationSet` / `EventDestination` / `Template` (apply + checks pass, but their destroy hits an already-deleted refresh path that still needs work) and the three receipt-rule tests (shared PreCheck needs the SES email-receiving feature / a provisioned active rule set fakecloud does not model).

Builds on the SES v1 result-node fix (#1926). No new public API surface.

## Test plan
- New e2e `verification_token_is_stable_and_identity_accepts_arn` (deterministic token, omit-absent, ARN-form lookup) -- pass.
- Local tfacc: `ses` shard green (7 `_basic` tests: DomainIdentity, DomainIdentityDataSource, DomainIdentityVerification, DomainDKIM, DomainMailFrom, IdentityNotificationTopic, IdentityPolicy), minus the documented 6 denies.
- `cargo test -p fakecloud-ses` (251 pass), `cargo clippy --all-targets -D warnings`, `cargo fmt`, `check-doc-counts.sh` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SES v1 (Query/XML) to the `tfacc` acceptance harness and aligns SES identity/reputation behavior with AWS. Seven SES `_basic` acceptance tests now pass (domain identities, verification, DKIM, mail-from, notification topics, identity policies).

- **New Features**
  - Added SES v1 to `tfacc`: new service and shard with `_basic` test regex; `ses` shard enabled.
  - New e2e test and updated existing test for stable verification token, omit-absent behavior, and ARN-form identity resolution.
  - Deny list documents current gaps: ConfigurationSet, EventDestination, Template, and receipt-rule tests.

- **Bug Fixes**
  - Identity lookups accept ARN form (`arn:aws:ses:<region>:<acct>:identity/<name>`) across notification topic, delete, mail-from, and feedback actions.
  - Domain verification token is deterministic per identity (stored) so VerifyDomainIdentity and GetIdentityVerificationAttributes match.
  - Unknown identities are omitted from GetIdentityVerificationAttributes and GetIdentityMailFromDomainAttributes to match AWS and provider expectations.
  - DescribeConfigurationSet now includes ReputationOptions with SendingEnabled, ReputationMetricsEnabled, and LastFreshStart.

<sup>Written for commit 58fc73dceab95f528ca233c4ad0ed6b0b4b23262. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

