### PR TITLE
fix(cognito,wafv2,ses): persist dropped Update/Create fields (1.13)

### DIFF
--- a/crates/fakecloud-cognito/src/service/auth/signup.rs
+++ b/crates/fakecloud-cognito/src/service/auth/signup.rs
@@ -92,6 +92,7 @@ impl CognitoService {
                 totp_verified: false,
                 devices: BTreeMap::new(),
                 linked_providers: Vec::new(),
+                mfa_options: Vec::new(),
             };
 
             pool_users.insert(username.to_string(), user.clone());

--- a/crates/fakecloud-cognito/src/service/legacy.rs
+++ b/crates/fakecloud-cognito/src/service/legacy.rs
@@ -3,11 +3,27 @@ use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
-use crate::state::LinkedProvider;
-
 use crate::state::CognitoState;
+use crate::state::LinkedProvider;
+use crate::state::MfaOption;
 
 use super::{require_str, CognitoService};
+
+/// Parse the legacy `MFAOptions` list shape
+/// (`[{DeliveryMedium, AttributeName}]`) into stored options.
+fn parse_mfa_options(value: &Value) -> Vec<MfaOption> {
+    value
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .map(|o| MfaOption {
+                    delivery_medium: o["DeliveryMedium"].as_str().unwrap_or_default().to_string(),
+                    attribute_name: o["AttributeName"].as_str().unwrap_or_default().to_string(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
 
 impl CognitoService {
     // ── Legacy MFA Settings ────────────────────────────────────────────
@@ -18,16 +34,15 @@ impl CognitoService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let pool_id = require_str(&body, "UserPoolId")?;
-        let username = require_str(&body, "Username")?;
-        let _mfa_options = body["MFAOptions"].as_array();
+        let pool_id = require_str(&body, "UserPoolId")?.to_string();
+        let username = require_str(&body, "Username")?.to_string();
+        let mfa_options = parse_mfa_options(&body["MFAOptions"]);
 
-        let accounts = self.state.read();
-        let empty = CognitoState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
         // Validate pool and user exist
-        let users = state.users.get(pool_id).ok_or_else(|| {
+        let users = state.users.get_mut(&pool_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ResourceNotFoundException",
@@ -35,15 +50,17 @@ impl CognitoService {
             )
         })?;
 
-        if !users.contains_key(username) {
-            return Err(AwsServiceError::aws_error(
+        let user = users.get_mut(&username).ok_or_else(|| {
+            AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "UserNotFoundException",
                 format!("User {username} does not exist."),
-            ));
-        }
+            )
+        })?;
 
-        // Legacy operation — accept but don't change behavior (maps to AdminSetUserMFAPreference)
+        // Legacy operation — persist the MFA options so GetUser echoes them
+        // (maps loosely to AdminSetUserMFAPreference).
+        user.mfa_options = mfa_options;
         Ok(AwsResponse::ok_json(json!({})))
     }
 
@@ -53,34 +70,36 @@ impl CognitoService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let access_token = require_str(&body, "AccessToken")?;
-        let _mfa_options = body["MFAOptions"].as_array();
+        let access_token = require_str(&body, "AccessToken")?.to_string();
+        let mfa_options = parse_mfa_options(&body["MFAOptions"]);
 
-        let accounts = self.state.read();
-        let empty = CognitoState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.access_tokens.get(access_token).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotAuthorizedException",
-                "Invalid access token.",
-            )
-        })?;
+        let (pool_id, username) = {
+            let token_data = state.access_tokens.get(&access_token).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid access token.",
+                )
+            })?;
+            (token_data.user_pool_id.clone(), token_data.username.clone())
+        };
 
-        // Validate user exists
-        if !state
+        let user = state
             .users
-            .get(&token_data.user_pool_id)
-            .is_some_and(|u| u.contains_key(&token_data.username))
-        {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ResourceNotFoundException",
-                "User not found.",
-            ));
-        }
+            .get_mut(&pool_id)
+            .and_then(|u| u.get_mut(&username))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    "User not found.",
+                )
+            })?;
 
+        user.mfa_options = mfa_options;
         Ok(AwsResponse::ok_json(json!({})))
     }
 

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -455,6 +455,7 @@ fn filter_matches_username() {
         totp_verified: false,
         devices: BTreeMap::new(),
         linked_providers: Vec::new(),
+        mfa_options: Vec::new(),
     };
 
     let filter = parse_filter_expression(r#"username = "testuser""#).unwrap();
@@ -489,6 +490,7 @@ fn filter_matches_attribute() {
         totp_verified: false,
         devices: BTreeMap::new(),
         linked_providers: Vec::new(),
+        mfa_options: Vec::new(),
     };
 
     let filter = parse_filter_expression(r#"email = "test@example.com""#).unwrap();
@@ -520,6 +522,7 @@ fn filter_matches_user_status() {
         totp_verified: false,
         devices: BTreeMap::new(),
         linked_providers: Vec::new(),
+        mfa_options: Vec::new(),
     };
 
     let filter =
@@ -5895,6 +5898,16 @@ fn set_user_settings_valid_token() {
     });
     let req = make_req("SetUserSettings", &body.to_string());
     svc.set_user_settings(&req).unwrap();
+
+    // GetUser must echo the MFA options that were just set, not a hardcoded
+    // empty list (bug-hunt 2026-06-24, 1.13).
+    let get_req = make_req("GetUser", &json!({ "AccessToken": token }).to_string());
+    let resp = svc.get_user(&get_req).unwrap();
+    let json: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let opts = json["MFAOptions"].as_array().unwrap();
+    assert_eq!(opts.len(), 1);
+    assert_eq!(opts[0]["DeliveryMedium"], "SMS");
+    assert_eq!(opts[0]["AttributeName"], "phone_number");
 }
 
 #[test]

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -771,6 +771,10 @@ impl CognitoService {
         if let Some(v) = body["EnablePropagateAdditionalUserContextData"].as_bool() {
             client.enable_propagate_additional_user_context_data = v;
         }
+        if body["RefreshTokenRotation"].is_object() {
+            client.refresh_token_rotation =
+                parse_refresh_token_rotation(&body["RefreshTokenRotation"]);
+        }
 
         client.last_modified_date = Utc::now();
 

--- a/crates/fakecloud-cognito/src/service/users.rs
+++ b/crates/fakecloud-cognito/src/service/users.rs
@@ -112,6 +112,7 @@ impl CognitoService {
                 totp_verified: false,
                 devices: BTreeMap::new(),
                 linked_providers: Vec::new(),
+                mfa_options: Vec::new(),
             };
 
             let resp = user_to_json(&user);
@@ -726,7 +727,10 @@ impl CognitoService {
             "UserCreateDate": user.user_create_date.timestamp() as f64,
             "UserLastModifiedDate": user.user_last_modified_date.timestamp() as f64,
             "UserStatus": user.user_status,
-            "MFAOptions": [],
+            "MFAOptions": user.mfa_options.iter().map(|o| json!({
+                "DeliveryMedium": o.delivery_medium,
+                "AttributeName": o.attribute_name,
+            })).collect::<Vec<Value>>(),
         });
 
         Ok(AwsResponse::ok_json(response))

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -608,6 +608,17 @@ pub struct User {
     pub totp_verified: bool,
     pub devices: BTreeMap<String, Device>,
     pub linked_providers: Vec<LinkedProvider>,
+    /// Legacy MFA options set via SetUserSettings/AdminSetUserSettings and
+    /// echoed back by GetUser/AdminGetUser (deprecated in favor of
+    /// mfa_preferences, but still round-tripped for legacy clients).
+    #[serde(default)]
+    pub mfa_options: Vec<MfaOption>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MfaOption {
+    pub delivery_medium: String,
+    pub attribute_name: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/fakecloud-e2e/tests/ses.rs
+++ b/crates/fakecloud-e2e/tests/ses.rs
@@ -618,7 +618,7 @@ async fn ses_contact_list_lifecycle() {
     let server = TestServer::start().await;
     let client = server.sesv2_client().await;
 
-    // Create contact list with topics
+    // Create contact list with topics + tags
     client
         .create_contact_list()
         .contact_list_name("my-list")
@@ -629,6 +629,13 @@ async fn ses_contact_list_lifecycle() {
                 .display_name("Newsletters")
                 .description("Weekly newsletters")
                 .default_subscription_status(SubscriptionStatus::OptIn)
+                .build()
+                .unwrap(),
+        )
+        .tags(
+            aws_sdk_sesv2::types::Tag::builder()
+                .key("team")
+                .value("growth")
                 .build()
                 .unwrap(),
         )
@@ -645,6 +652,11 @@ async fn ses_contact_list_lifecycle() {
         .unwrap();
     assert_eq!(get.contact_list_name(), Some("my-list"));
     assert_eq!(get.description(), Some("A test list"));
+    // Tags set on create must round-trip (bug-hunt 2026-06-24, 1.13).
+    let tags = get.tags();
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].key(), "team");
+    assert_eq!(tags[0].value(), "growth");
     let topics = get.topics();
     assert_eq!(topics.len(), 1);
     assert_eq!(topics[0].topic_name(), "newsletters");

--- a/crates/fakecloud-e2e/tests/wafv2.rs
+++ b/crates/fakecloud-e2e/tests/wafv2.rs
@@ -176,6 +176,77 @@ async fn web_acl_create_get_update_delete_lifecycle() {
 }
 
 #[tokio::test]
+async fn update_web_acl_persists_ddos_and_application_config() {
+    use aws_sdk_wafv2::types::{
+        ApplicationAttribute, ApplicationConfig, LowReputationMode, OnSourceDDoSProtectionConfig,
+    };
+
+    let server = TestServer::start().await;
+    let waf = server.wafv2_client().await;
+
+    let summary = waf
+        .create_web_acl()
+        .name("ddos-acl")
+        .scope(Scope::Regional)
+        .default_action(allow_default())
+        .visibility_config(vis("ddos-acl"))
+        .send()
+        .await
+        .expect("create")
+        .summary
+        .expect("summary");
+    let id = summary.id().expect("id").to_owned();
+    let lock = summary.lock_token().expect("lock").to_owned();
+
+    // UpdateWebACL previously dropped OnSourceDDoSProtectionConfig +
+    // ApplicationConfig (bug-hunt 2026-06-24, 1.13).
+    waf.update_web_acl()
+        .name("ddos-acl")
+        .scope(Scope::Regional)
+        .id(&id)
+        .lock_token(&lock)
+        .default_action(allow_default())
+        .visibility_config(vis("ddos-acl"))
+        .on_source_d_do_s_protection_config(
+            OnSourceDDoSProtectionConfig::builder()
+                .alb_low_reputation_mode(LowReputationMode::ActiveUnderDdos)
+                .build()
+                .unwrap(),
+        )
+        .application_config(
+            ApplicationConfig::builder()
+                .attributes(
+                    ApplicationAttribute::builder()
+                        .name("HostHeader")
+                        .values("example.com")
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("update");
+
+    let got = waf
+        .get_web_acl()
+        .name("ddos-acl")
+        .scope(Scope::Regional)
+        .id(&id)
+        .send()
+        .await
+        .expect("get");
+    let acl = got.web_acl().expect("acl");
+    assert_eq!(
+        acl.on_source_d_do_s_protection_config()
+            .map(|c| c.alb_low_reputation_mode().clone()),
+        Some(LowReputationMode::ActiveUnderDdos)
+    );
+    let app = acl.application_config().expect("application config");
+    assert_eq!(app.attributes().len(), 1);
+    assert_eq!(app.attributes()[0].name(), Some("HostHeader"));
+}
+
+#[tokio::test]
 async fn update_with_stale_lock_token_returns_optimistic_lock_error() {
     let server = TestServer::start().await;
     let waf = server.wafv2_client().await;

--- a/crates/fakecloud-ses/src/service/contact_lists.rs
+++ b/crates/fakecloud-ses/src/service/contact_lists.rs
@@ -52,7 +52,23 @@ impl SesV2Service {
                 last_updated_at: now,
             },
         );
-        state.contacts.insert(name, BTreeMap::new());
+        state.contacts.insert(name.clone(), BTreeMap::new());
+
+        // Persist tags under the contact-list ARN so GetContactList echoes
+        // them (previously dropped).
+        if let Some(tags_arr) = body["Tags"].as_array() {
+            let arn = format!(
+                "arn:aws:ses:{}:{}:contact-list/{}",
+                req.region, req.account_id, name
+            );
+            let mut tag_map = BTreeMap::new();
+            for tag in tags_arr {
+                if let (Some(k), Some(v)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
+                    tag_map.insert(k.to_string(), v.to_string());
+                }
+            }
+            state.tags.insert(arn, tag_map);
+        }
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
@@ -89,13 +105,23 @@ impl SesV2Service {
             })
             .collect();
 
+        let arn = format!(
+            "arn:aws:ses:{}:{}:contact-list/{}",
+            req.region, req.account_id, name
+        );
+        let tags = state
+            .tags
+            .get(&arn)
+            .map(|m| Value::Array(fakecloud_core::tags::tags_to_json(m, "Key", "Value")))
+            .unwrap_or_else(|| Value::Array(Vec::new()));
+
         let response = json!({
             "ContactListName": list.contact_list_name,
             "Description": list.description,
             "Topics": topics,
             "CreatedTimestamp": list.created_at.timestamp() as f64,
             "LastUpdatedTimestamp": list.last_updated_at.timestamp() as f64,
-            "Tags": [],
+            "Tags": tags,
         });
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))

--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -34,6 +34,23 @@ pub(super) fn is_simulator_address(email: &str) -> bool {
     matches!(email.split_once('@'), Some((_, "simulator.amazonses.com")))
 }
 
+/// Parse a SESv2 message-tag list (`[{Name, Value}]`) into name/value pairs.
+fn parse_message_tags(value: &Value) -> Vec<(String, String)> {
+    value
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| {
+                    Some((
+                        t["Name"].as_str()?.to_string(),
+                        t["Value"].as_str()?.to_string(),
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Match an email against verified identities: exact email or matching
 /// verified-domain. Shared between sender + sandbox-recipient gates.
 /// Mailbox-simulator addresses bypass the gate (real SES treats them as
@@ -467,6 +484,9 @@ impl SesV2Service {
             }
         }
 
+        // Tags applied to every entry unless overridden per-entry.
+        let default_tags = parse_message_tags(&body["DefaultEmailTags"]);
+
         let mut results = Vec::new();
 
         for entry in &entries {
@@ -527,6 +547,17 @@ impl SesV2Service {
                 template_data.as_deref(),
             );
 
+            // Per-entry ReplacementTags override the batch default tags by name
+            // (previously dropped, so bulk sends carried no message tags).
+            let mut email_tags = default_tags.clone();
+            for (name, value) in parse_message_tags(&entry["ReplacementTags"]) {
+                if let Some(existing) = email_tags.iter_mut().find(|(n, _)| *n == name) {
+                    existing.1 = value;
+                } else {
+                    email_tags.push((name, value));
+                }
+            }
+
             let sent = SentEmail {
                 message_id: message_id.clone(),
                 from: from.clone(),
@@ -542,7 +573,7 @@ impl SesV2Service {
                 dkim_signature: None,
                 headers: Vec::new(),
                 timestamp: Utc::now(),
-                email_tags: Vec::new(),
+                email_tags,
                 delivery_insights: Vec::new(),
             };
             let signed = self.compute_dkim_signature(&req.account_id, &sent);

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -610,6 +610,62 @@ async fn test_send_bulk_email() {
 }
 
 #[tokio::test]
+async fn test_send_bulk_email_applies_replacement_and_default_tags() {
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
+    let svc = SesV2Service::new(state.clone());
+
+    // DefaultEmailTags apply to every entry; per-entry ReplacementTags add to
+    // or override them by name (previously both were dropped).
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-bulk-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "DefaultEmailTags": [
+                {"Name": "campaign", "Value": "default"},
+                {"Name": "env", "Value": "prod"}
+            ],
+            "DefaultContent": {
+                "Template": {"TemplateName": null, "TemplateData": "{}"}
+            },
+            "BulkEmailEntries": [
+                {
+                    "Destination": {"ToAddresses": ["a@example.com"]},
+                    "ReplacementTags": [
+                        {"Name": "campaign", "Value": "winback"},
+                        {"Name": "segment", "Value": "vip"}
+                    ]
+                },
+                {"Destination": {"ToAddresses": ["b@example.com"]}}
+            ]
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let guard = state.read();
+    let s = guard.default_ref();
+    assert_eq!(s.sent_emails.len(), 2);
+
+    // Entry 0: ReplacementTags override `campaign` and add `segment`; `env`
+    // inherited from the defaults.
+    let t0: std::collections::BTreeMap<_, _> =
+        s.sent_emails[0].email_tags.iter().cloned().collect();
+    assert_eq!(t0.get("campaign").map(String::as_str), Some("winback"));
+    assert_eq!(t0.get("segment").map(String::as_str), Some("vip"));
+    assert_eq!(t0.get("env").map(String::as_str), Some("prod"));
+
+    // Entry 1: no ReplacementTags -> exactly the defaults.
+    let t1: std::collections::BTreeMap<_, _> =
+        s.sent_emails[1].email_tags.iter().cloned().collect();
+    assert_eq!(t1.get("campaign").map(String::as_str), Some("default"));
+    assert_eq!(t1.get("env").map(String::as_str), Some("prod"));
+    assert!(!t1.contains_key("segment"));
+}
+
+#[tokio::test]
 async fn test_send_email_rejects_when_account_paused() {
     let state = make_state();
     {

--- a/crates/fakecloud-wafv2/src/service/web_acls.rs
+++ b/crates/fakecloud-wafv2/src/service/web_acls.rs
@@ -227,6 +227,13 @@ impl Wafv2Service {
         if body.get("DataProtectionConfig").is_some() {
             acl.data_protection_config = body.get("DataProtectionConfig").cloned();
         }
+        if body.get("OnSourceDDoSProtectionConfig").is_some() {
+            acl.on_source_d_do_s_protection_config =
+                body.get("OnSourceDDoSProtectionConfig").cloned();
+        }
+        if body.get("ApplicationConfig").is_some() {
+            acl.application_config = body.get("ApplicationConfig").cloned();
+        }
         acl.lock_token = synth_uuid();
         Ok(AwsResponse::ok_json(
             json!({ "NextLockToken": acl.lock_token }),


### PR DESCRIPTION
## Summary

MED round-trip-drop fixes from the 2026-06-24 bug hunt (finding 1.13):

- **Cognito `UpdateUserPoolClient`** dropped `RefreshTokenRotation` — now applied (create + describe already handled it).
- **Cognito `SetUserSettings`/`AdminSetUserSettings`** dropped `MFAOptions` entirely; `GetUser` hardcoded `[]`. Added a `User.mfa_options` field; both setters persist it and GetUser echoes it.
- **WAFv2 `UpdateWebACL`** dropped `OnSourceDDoSProtectionConfig` and `ApplicationConfig` — now applied (create + GetWebACL already handled them).
- **SES `CreateContactList`** dropped `Tags`; `GetContactList` returned `[]`. Tags now stored under the contact-list ARN and echoed (mirrors the existing delete-removes-tags path).
- **SES `SendBulkEmail`** dropped `DefaultEmailTags` + per-entry `ReplacementTags` — now merged (ReplacementTags override defaults by name) onto each sent message.

## Test plan

- `set_user_settings_valid_token` extended: GetUser echoes the set MFAOptions.
- `test_send_bulk_email_applies_replacement_and_default_tags` (unit): default + replacement tag merge/override.
- `ses_contact_list_lifecycle` extended: tags round-trip.
- `update_web_acl_persists_ddos_and_application_config` (e2e): both configs round-trip via GetWebACL.
- All pass; clippy + fmt clean across cognito/wafv2/ses.

## Surface

No new external API surface (existing op fidelity). New internal `User.mfa_options` field is `#[serde(default)]`, so persistence snapshots remain backward-compatible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix MED round-trip drops across Cognito, WAFv2, and SES so Update/Create inputs persist and show up in Get/Describe. Restores refresh token rotation, legacy MFA options, WAF DDoS/Application config, and SES tags/message tags.

- **Bug Fixes**
  - `fakecloud-cognito`: `UpdateUserPoolClient` applies `RefreshTokenRotation`. `SetUserSettings`/`AdminSetUserSettings` persist `MFAOptions`; `GetUser`/`AdminGetUser` echo them. Adds internal `User.mfa_options` (serde default) for backward-compatible persistence.
  - `fakecloud-wafv2`: `UpdateWebACL` now persists `OnSourceDDoSProtectionConfig` and `ApplicationConfig`; `GetWebACL` returns both.
  - `fakecloud-ses`: `CreateContactList` stores `Tags` (keyed by ARN) and `GetContactList` returns them. `SendBulkEmail` merges `DefaultEmailTags` with per-entry `ReplacementTags`, with name-based overrides per message.

<sup>Written for commit c95a89d17a1c45810585f67581553decfdd26340. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

