### PR TITLE
feat(tfacc): add apigateway (v1) service; SDK/export disposition + validator bool

### DIFF
--- a/crates/fakecloud-apigateway/src/service_extras.rs
+++ b/crates/fakecloud-apigateway/src/service_extras.rs
@@ -390,11 +390,24 @@ impl ApiGatewayService {
             })
             .to_string()
         };
+        // AWS returns the export as a downloadable attachment; the
+        // Content-Disposition header is surfaced by the `aws_api_gateway_export`
+        // data source as `content_disposition`.
+        let export_type = params
+            .get("exportType")
+            .cloned()
+            .unwrap_or_else(|| "oas30".to_string());
+        let mut headers = http::HeaderMap::new();
+        if let Ok(v) = http::HeaderValue::from_str(&format!(
+            "attachment; filename=\"{api_id}-{export_type}.json\""
+        )) {
+            headers.insert(http::header::CONTENT_DISPOSITION, v);
+        }
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/json".to_string(),
             body: bytes::Bytes::from(body.into_bytes()).into(),
-            headers: http::HeaderMap::new(),
+            headers,
         })
     }
 
@@ -408,11 +421,19 @@ impl ApiGatewayService {
         // returns a deterministic dummy zip header — enough for SDK
         // tests that just want to verify the endpoint exists.
         let body = format!("PK\x03\x04fakecloud-{sdk_type}-stub-zip\x00\x00\x00",);
+        // The `aws_api_gateway_sdk` data source reads `content_disposition` from
+        // the attachment header AWS returns.
+        let mut headers = http::HeaderMap::new();
+        if let Ok(v) =
+            http::HeaderValue::from_str(&format!("attachment; filename=\"{sdk_type}.zip\""))
+        {
+            headers.insert(http::header::CONTENT_DISPOSITION, v);
+        }
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/octet-stream".to_string(),
             body: bytes::Bytes::from(body.into_bytes()).into(),
-            headers: http::HeaderMap::new(),
+            headers,
         })
     }
 

--- a/crates/fakecloud-apigateway/src/service_request_validators.rs
+++ b/crates/fakecloud-apigateway/src/service_request_validators.rs
@@ -110,7 +110,24 @@ impl ApiGatewayService {
             .ok_or_else(|| not_found("RequestValidator not found"))?;
         apply_patch_operations(req, |_op, path, value| {
             if let Some(o) = v.as_object_mut() {
-                o.insert(path.trim_start_matches('/').to_string(), value.clone());
+                let key = path.trim_start_matches('/').to_string();
+                // JSON Patch sends scalar values as strings; the boolean
+                // validator flags must be stored as real booleans so
+                // GetRequestValidator returns the type the SDK expects
+                // ("expected Boolean ... got string instead").
+                let coerced = if matches!(
+                    key.as_str(),
+                    "validateRequestBody" | "validateRequestParameters"
+                ) {
+                    match value.as_str() {
+                        Some("true") => serde_json::Value::Bool(true),
+                        Some("false") => serde_json::Value::Bool(false),
+                        _ => value.clone(),
+                    }
+                } else {
+                    value.clone()
+                };
+                o.insert(key, coerced);
             }
         });
         ok(v.clone())

--- a/crates/fakecloud-e2e/tests/apigateway.rs
+++ b/crates/fakecloud-e2e/tests/apigateway.rs
@@ -232,6 +232,11 @@ async fn get_export_returns_openapi_with_real_paths() {
         .send()
         .await
         .expect("get_export");
+    // AWS returns the export as a download attachment; the export data source
+    // reads `content_disposition` from this header.
+    assert!(export
+        .content_disposition()
+        .is_some_and(|d| d.starts_with("attachment;")));
     let body_blob = export.body().expect("export body should be present");
     let body: serde_json::Value =
         serde_json::from_slice(body_blob.as_ref()).expect("export body must be JSON");
@@ -948,4 +953,57 @@ async fn update_usage_plan_adds_api_stage() {
         "apiStage must be attached: {:?}",
         got.api_stages()
     );
+}
+
+#[tokio::test]
+async fn update_request_validator_keeps_boolean_flags() {
+    // UpdateRequestValidator applies JSON-Patch string values; the boolean
+    // validator flags must be stored as real booleans so GetRequestValidator
+    // returns the type the SDK expects (not a string).
+    let server = TestServer::start().await;
+    let client = server.apigateway_client().await;
+
+    let api = client
+        .create_rest_api()
+        .name("rv-api")
+        .send()
+        .await
+        .expect("create_rest_api");
+    let api_id = api.id().unwrap().to_string();
+
+    let rv = client
+        .create_request_validator()
+        .rest_api_id(&api_id)
+        .name("rv")
+        .validate_request_body(false)
+        .validate_request_parameters(false)
+        .send()
+        .await
+        .expect("create_request_validator");
+    let rv_id = rv.id().unwrap().to_string();
+
+    client
+        .update_request_validator()
+        .rest_api_id(&api_id)
+        .request_validator_id(&rv_id)
+        .patch_operations(
+            aws_sdk_apigateway::types::PatchOperation::builder()
+                .op(aws_sdk_apigateway::types::Op::Replace)
+                .path("/validateRequestBody")
+                .value("true")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("update_request_validator");
+
+    // Deserializes only if the flag is stored as a real boolean.
+    let got = client
+        .get_request_validator()
+        .rest_api_id(&api_id)
+        .request_validator_id(&rv_id)
+        .send()
+        .await
+        .expect("get_request_validator");
+    assert_eq!(got.validate_request_body(), true);
 }

--- a/crates/fakecloud-e2e/tests/apigateway.rs
+++ b/crates/fakecloud-e2e/tests/apigateway.rs
@@ -1005,5 +1005,5 @@ async fn update_request_validator_keeps_boolean_flags() {
         .send()
         .await
         .expect("get_request_validator");
-    assert_eq!(got.validate_request_body(), true);
+    assert!(got.validate_request_body());
 }

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -690,6 +690,46 @@ pub const SERVICES: &[Service] = &[
             "TestAccSESReceiptRuleSet_basic",
         ],
     },
+    Service {
+        name: "apigateway",
+        // API Gateway v1 (REST APIs): the `_basic` smoke across ~40 resources and
+        // data sources — REST API, resources, methods, deployments, stages,
+        // models, gateway responses, base-path mappings, documentation, usage
+        // plans, VPC links, and more. Fixes: GetSdk / GetExport set the
+        // Content-Disposition header the SDK/export data sources read as
+        // `content_disposition`; UpdateRequestValidator coerces the JSON-Patch
+        // string flags back to booleans (validateRequestBody /
+        // validateRequestParameters) so GetRequestValidator returns the boolean
+        // type the SDK expects.
+        run_regex: "^TestAccAPIGateway[A-Za-z0-9]+_basic$",
+        deny: &[
+            // --- gap: the api-key / usage-plan-key resources expect their
+            //     generated `value` / `name` surfaced on read in a way the
+            //     resource captures; the create+get responses carry them but the
+            //     attribute still reads empty, which needs a closer look. ---
+            "TestAccAPIGatewayAPIKey_basic",
+            "TestAccAPIGatewayUsagePlanKey_basic",
+            // --- gap: update semantics — the method-response model/parameter
+            //     update, the integration request_templates replacement, and the
+            //     authorizer result-ttl update don't fully apply, leaving drift. ---
+            "TestAccAPIGatewayMethodResponse_basic",
+            "TestAccAPIGatewayIntegration_basic",
+            "TestAccAPIGatewayAuthorizer_basic",
+            // --- gap: the REST API resource policy round-trip mangles the policy
+            //     JSON (a parse error on apply). ---
+            "TestAccAPIGatewayRestAPIPolicy_basic",
+            // --- gap: custom domain names need a certificate upload date and the
+            //     domain-name access-association resource, which are not modelled. ---
+            "TestAccAPIGatewayDomainNameDataSource_basic",
+            "TestAccAPIGatewayDomainNameAccessAssociation_basic",
+            // --- gap: VPC links provision an NLB; the ELBv2 DeleteLoadBalancer
+            //     response omits its result node, so the test's destroy of the
+            //     load balancer fails to deserialize (an ELBv2-fidelity gap, not
+            //     an API Gateway one). ---
+            "TestAccAPIGatewayVPCLink_basic",
+            "TestAccAPIGatewayVPCLinkDataSource_basic",
+        ],
+    },
 ];
 
 /// CI matrix shards. One GitHub Actions job per entry.
@@ -1020,6 +1060,12 @@ pub const SHARDS: &[Shard] = &[
         name: "ses",
         service: "ses",
         run_regex: "^TestAccSES[A-Za-z0-9]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "apigateway",
+        service: "apigateway",
+        run_regex: "^TestAccAPIGateway[A-Za-z0-9]+_basic$",
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -311,4 +311,5 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_WAFV2", "wafv2"),
     ("AWS_ENDPOINT_URL_FIREHOSE", "firehose"),
     ("AWS_ENDPOINT_URL_CLOUDWATCH", "monitoring"),
+    ("AWS_ENDPOINT_URL_API_GATEWAY", "apigateway"),
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -198,6 +198,11 @@ async fn ses_acceptance() {
 }
 
 #[tokio::test]
+async fn apigateway_acceptance() {
+    run_shard("apigateway").await;
+}
+
+#[tokio::test]
 async fn scheduler_acceptance() {
     run_shard("scheduler").await;
 }


### PR DESCRIPTION
## Summary

Wire **API Gateway v1** (REST APIs) into the tfacc harness (new `Service` + `Shard` + `acc.rs` fn + `AWS_ENDPOINT_URL_API_GATEWAY` endpoint var). The `_basic` smoke across ~40 REST-API resources and data sources now runs -- **43 pass** (full shard green in 246s).

**Fixes:**
- `GetSdk` / `GetExport` set the `Content-Disposition` attachment header, surfaced by the `aws_api_gateway_sdk` / `aws_api_gateway_export` data sources as `content_disposition` (was unset).
- `UpdateRequestValidator` coerces JSON-Patch string flag values back to booleans for `validateRequestBody` / `validateRequestParameters`, so `GetRequestValidator` returns the boolean the SDK expects (it stored the patch string `"true"`, failing deserialization with "expected Boolean ... got string instead").

**Denied with honest reasons (10):** api-key / usage-plan-key `value`/`name` read-surfacing; method-response / integration / authorizer update semantics; REST API resource-policy JSON round-trip; custom domain name cert-upload-date + access-association; and VPC link (provisions an NLB whose ELBv2 `DeleteLoadBalancer` response omits its result node -- an ELBv2-fidelity gap, same class as the SES/cloudwatch result-node fixes, a clear follow-up).

No new public API surface.

## Test plan
- New e2e: export `content_disposition` header + request-validator boolean round-trip -- pass.
- Local tfacc: full `apigateway` shard green (43 `_basic` tests, serial `-p 1 -parallel 1`), minus the 10 documented denies.
- `cargo test -p fakecloud-apigateway` (90), `cargo clippy --all-targets -D warnings`, `cargo fmt`, `check-doc-counts.sh` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds API Gateway v1 (REST) to the tfacc acceptance harness and fixes response fidelity so SDK/data sources behave like AWS. The `_basic` suite now runs for ~40 resources/data sources with 43 passing.

- **New Features**
  - Added `apigateway` to tfacc with a new Service, Shard, and acceptance test.
  - Introduced `AWS_ENDPOINT_URL_API_GATEWAY` endpoint var.
  - Runs `_basic` smoke; 43 pass. Shard excludes 10 known gaps (keys, updates, policy JSON, custom domains, VPC link).

- **Bug Fixes**
  - `GetExport` and `GetSdk` now set `Content-Disposition`, enabling `content_disposition` in `aws_api_gateway_export` and `aws_api_gateway_sdk`.
  - `UpdateRequestValidator` coerces JSON-Patch strings to booleans for `validateRequestBody` and `validateRequestParameters`.
  - Added e2e tests for the header and validator round-trip.

<sup>Written for commit 385e3f0e73635d1e3f8dda8b7dd9900333975827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

