### PR TITLE
fix(elbv2): emit result node in Query-protocol metadata-only responses

### DIFF
--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -12,9 +12,7 @@ use http::StatusCode;
 use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::delivery::DeliveryBus;
-use fakecloud_core::query::{
-    optional_query_param, query_metadata_only_xml, query_response_xml, required_query_param,
-};
+use fakecloud_core::query::{optional_query_param, query_response_xml, required_query_param};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_persistence::SnapshotStore;
 

--- a/crates/fakecloud-elbv2/src/service_helpers.rs
+++ b/crates/fakecloud-elbv2/src/service_helpers.rs
@@ -6,7 +6,11 @@ pub(crate) fn xml_resp(action: &str, inner: String, request_id: &str) -> AwsResp
 }
 
 pub(crate) fn xml_metadata_only(action: &str, request_id: &str) -> AwsResponse {
-    let xml = query_metadata_only_xml(action, NS, request_id);
+    // The ELBv2 Query protocol always wraps the response in a `<{Action}Result>`
+    // element (empty for actions with no output members). Omitting it makes the
+    // AWS SDK fail to deserialize with "{Action}Result node not found" -- e.g.
+    // DeleteLoadBalancer, which the Terraform provider's destroy relies on.
+    let xml = query_response_xml(action, NS, "", request_id);
     AwsResponse::xml(StatusCode::OK, xml)
 }
 

--- a/crates/fakecloud-elbv2/src/service_tests.rs
+++ b/crates/fakecloud-elbv2/src/service_tests.rs
@@ -132,10 +132,18 @@ async fn delete_load_balancer_succeeds_when_protection_disabled() {
     let svc = svc();
     let arn = create_lb_and_get_arn(&svc, "unguarded").await;
 
-    svc.handle(req("DeleteLoadBalancer", &[("LoadBalancerArn", &arn)]))
+    let resp = svc
+        .handle(req("DeleteLoadBalancer", &[("LoadBalancerArn", &arn)]))
         .await
         .unwrap();
     assert!(!lb_exists(&svc, &arn), "LB must be removed after delete");
+    // The Query-protocol response must carry the result node so the AWS SDK can
+    // deserialize it ("DeleteLoadBalancerResult node not found" otherwise).
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(
+        body.contains("<DeleteLoadBalancerResult"),
+        "response must include the result node: {body}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

The ELBv2 Query protocol always wraps a response in a `<{Action}Result>` element -- empty for actions with no output members. The `xml_metadata_only` helper emitted only `<{Action}Response>` + `<ResponseMetadata>` with **no result node**, so the AWS SDK failed to deserialize every no-output ELBv2 write action (`DeleteLoadBalancer`, the `Set*`/`Add*`/`Remove*` family) with "{Action}Result node not found".

This emits an empty `<{Action}Result/>` node (via `query_response_xml` with an empty body) so the response matches the protocol shape. **It unblocks the API Gateway VPC link acceptance tests** (`TestAccAPIGatewayVPCLink_basic` + data source), whose destroy deletes the NLB the VPC link targets -- verified passing locally.

Same class of bug as the SES v1 (#1926) and CloudWatch DeleteDashboards (#1921) result-node fixes.

No new public API surface (response-shape correctness fix).

## Test plan
- Owning-crate unit test asserts the `DeleteLoadBalancer` result node is present (48 elbv2 lib tests pass).
- Local tfacc: `TestAccAPIGatewayVPCLink_basic` now passes (was failing on the missing result node during the NLB destroy).
- `cargo clippy -p fakecloud-elbv2 --all-targets -D warnings`, `cargo fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure ELBv2 Query responses include an empty <{Action}Result> node for metadata-only actions, matching the AWS protocol. This fixes SDK deserialization for no-output writes (e.g., DeleteLoadBalancer) and unblocks API Gateway VPC link destroy.

- **Bug Fixes**
  - Update `xml_metadata_only` to use `query_response_xml` with an empty body to emit `<{Action}Result/>` (replaces `query_metadata_only_xml`).
  - Add a unit test verifying `<DeleteLoadBalancerResult>` is present; local `TestAccAPIGatewayVPCLink_basic` now passes.

<sup>Written for commit e0bac43a63e6c924e4ffe563c3670ed51af0fb25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

