### PR TITLE
test(tfacc): wire elbv2 acceptance suite + target-group protocol/attr fidelity

### DIFF
--- a/crates/fakecloud-e2e/tests/elbv2.rs
+++ b/crates/fakecloud-e2e/tests/elbv2.rs
@@ -7,8 +7,9 @@
 mod helpers;
 
 use aws_sdk_elasticloadbalancingv2::types::{
-    Action, ActionTypeEnum, FixedResponseActionConfig, LoadBalancerAttribute, LoadBalancerTypeEnum,
-    ProtocolEnum,
+    Action, ActionTypeEnum, FixedResponseActionConfig, HostHeaderConditionConfig,
+    LoadBalancerAttribute, LoadBalancerTypeEnum, PathPatternConditionConfig, ProtocolEnum,
+    RuleCondition,
 };
 use aws_sdk_wafv2::types::{DefaultAction, Scope, VisibilityConfig};
 use helpers::TestServer;
@@ -430,5 +431,130 @@ async fn http_target_group_reports_protocol_version_and_attr_defaults() {
     assert_eq!(
         get("load_balancing.algorithm.anomaly_mitigation").as_deref(),
         Some("off")
+    );
+}
+
+#[tokio::test]
+async fn listener_rule_conditions_echo_typed_config() {
+    // A listener rule created with typed condition configs (path-pattern,
+    // host-header) must echo those typed `*Config` sub-objects back on
+    // DescribeRules. AWS always returns them, and terraform-provider-aws
+    // nil-derefs `condition.PathPatternConfig.Values` in resourceListenerRuleRead
+    // if they are absent.
+    let server = TestServer::start().await;
+    let elbv2 = server.elbv2_client().await;
+
+    let lb = elbv2
+        .create_load_balancer()
+        .name("alb-rules")
+        .r#type(LoadBalancerTypeEnum::Application)
+        .send()
+        .await
+        .unwrap();
+    let lb_arn = lb.load_balancers()[0]
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+    let tg = elbv2
+        .create_target_group()
+        .name("tg-rules")
+        .protocol(ProtocolEnum::Http)
+        .port(80)
+        .vpc_id("vpc-12345678")
+        .send()
+        .await
+        .unwrap();
+    let tg_arn = tg.target_groups()[0]
+        .target_group_arn()
+        .unwrap()
+        .to_string();
+    let listener = elbv2
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .protocol(ProtocolEnum::Http)
+        .port(80)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let listener_arn = listener.listeners()[0].listener_arn().unwrap().to_string();
+
+    elbv2
+        .create_rule()
+        .listener_arn(&listener_arn)
+        .priority(100)
+        .conditions(
+            RuleCondition::builder()
+                .field("path-pattern")
+                .path_pattern_config(
+                    PathPatternConditionConfig::builder()
+                        .values("/static/*")
+                        .build(),
+                )
+                .build(),
+        )
+        .conditions(
+            RuleCondition::builder()
+                .field("host-header")
+                .host_header_config(
+                    HostHeaderConditionConfig::builder()
+                        .values("example.com")
+                        .build(),
+                )
+                .build(),
+        )
+        .actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create_rule");
+
+    let rules = elbv2
+        .describe_rules()
+        .listener_arn(&listener_arn)
+        .send()
+        .await
+        .expect("describe_rules");
+    let rule = rules
+        .rules()
+        .iter()
+        .find(|r| r.priority() == Some("100"))
+        .expect("rule with priority 100");
+
+    let path_cond = rule
+        .conditions()
+        .iter()
+        .find(|c| c.field() == Some("path-pattern"))
+        .expect("path-pattern condition");
+    assert_eq!(
+        path_cond
+            .path_pattern_config()
+            .map(|c| c.values())
+            .unwrap_or_default(),
+        &["/static/*"],
+        "path-pattern condition must echo PathPatternConfig.Values"
+    );
+
+    let host_cond = rule
+        .conditions()
+        .iter()
+        .find(|c| c.field() == Some("host-header"))
+        .expect("host-header condition");
+    assert_eq!(
+        host_cond
+            .host_header_config()
+            .map(|c| c.values())
+            .unwrap_or_default(),
+        &["example.com"],
+        "host-header condition must echo HostHeaderConfig.Values"
     );
 }

--- a/crates/fakecloud-e2e/tests/elbv2.rs
+++ b/crates/fakecloud-e2e/tests/elbv2.rs
@@ -380,3 +380,55 @@ async fn associate_web_acl_accepts_listener_arn_against_load_balancer() {
         .unwrap();
     assert!(after.web_acl().is_none());
 }
+
+#[tokio::test]
+async fn http_target_group_reports_protocol_version_and_attr_defaults() {
+    // An HTTP target group reports its default ProtocolVersion (HTTP1), and
+    // DescribeTargetGroupAttributes returns the cross-zone + anomaly-mitigation
+    // defaults the aws_lb_target_group data source reads.
+    let server = TestServer::start().await;
+    let elbv2 = server.elbv2_client().await;
+
+    let tg = elbv2
+        .create_target_group()
+        .name("tg-pv")
+        .protocol(ProtocolEnum::Http)
+        .port(80)
+        .vpc_id("vpc-12345678")
+        .target_type(aws_sdk_elasticloadbalancingv2::types::TargetTypeEnum::Instance)
+        .send()
+        .await
+        .expect("create_target_group");
+    let arn = tg.target_groups()[0]
+        .target_group_arn()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        tg.target_groups()[0].protocol_version(),
+        Some("HTTP1"),
+        "HTTP target group must report HTTP1 protocol version"
+    );
+
+    let attrs = elbv2
+        .describe_target_group_attributes()
+        .target_group_arn(&arn)
+        .send()
+        .await
+        .expect("describe attributes");
+    let get = |k: &str| {
+        attrs
+            .attributes()
+            .iter()
+            .find(|a| a.key() == Some(k))
+            .and_then(|a| a.value())
+            .map(str::to_string)
+    };
+    assert_eq!(
+        get("load_balancing.cross_zone.enabled").as_deref(),
+        Some("use_load_balancer_configuration")
+    );
+    assert_eq!(
+        get("load_balancing.algorithm.anomaly_mitigation").as_deref(),
+        Some("off")
+    );
+}

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -932,7 +932,15 @@ impl Elbv2Service {
         let vpc_id = optional_query_param(req, "VpcId");
         let ip_address_type =
             optional_query_param(req, "IpAddressType").unwrap_or_else(|| "ipv4".into());
-        let protocol_version = optional_query_param(req, "ProtocolVersion");
+        // AWS defaults ProtocolVersion to HTTP1 for HTTP/HTTPS target groups and
+        // always reports it; TCP/UDP/TLS/GENEVE groups have no protocol version.
+        // The aws_lb_target_group resource reads `protocol_version` for
+        // application-protocol groups, so it must be present.
+        let protocol_version =
+            optional_query_param(req, "ProtocolVersion").or_else(|| match protocol.as_deref() {
+                Some("HTTP") | Some("HTTPS") => Some("HTTP1".to_string()),
+                _ => None,
+            });
         let health_check_protocol =
             optional_query_param(req, "HealthCheckProtocol").or_else(|| protocol.clone());
         let health_check_port =

--- a/crates/fakecloud-elbv2/src/service_helpers.rs
+++ b/crates/fakecloud-elbv2/src/service_helpers.rs
@@ -1134,6 +1134,19 @@ pub(crate) fn default_target_group_attributes() -> BTreeMap<String, String> {
         "load_balancing.algorithm.type".to_string(),
         "round_robin".to_string(),
     );
+    // AWS always reports cross-zone load balancing; an ALB target group inherits
+    // the load balancer's setting by default. The aws_lb_target_group data
+    // source reads `load_balancing_cross_zone_enabled` from this attribute.
+    m.insert(
+        "load_balancing.cross_zone.enabled".to_string(),
+        "use_load_balancer_configuration".to_string(),
+    );
+    // Anomaly mitigation defaults off; the data source reads it as
+    // `load_balancing_anomaly_mitigation`.
+    m.insert(
+        "load_balancing.algorithm.anomaly_mitigation".to_string(),
+        "off".to_string(),
+    );
     m.insert("slow_start.duration_seconds".to_string(), "0".to_string());
     m
 }

--- a/crates/fakecloud-elbv2/src/service_helpers.rs
+++ b/crates/fakecloud-elbv2/src/service_helpers.rs
@@ -901,17 +901,7 @@ pub(crate) fn render_rule_xml(r: &crate::state::Rule) -> String {
     let conditions_xml = r
         .conditions
         .iter()
-        .map(|c| {
-            let values = c
-                .values
-                .iter()
-                .map(|v| format!("<member>{}</member>", xml_escape(v)))
-                .collect::<String>();
-            format!(
-                "<member><Field>{}</Field><Values>{values}</Values></member>",
-                xml_escape(&c.field)
-            )
-        })
+        .map(render_rule_condition_xml)
         .collect::<String>();
     let actions_xml = r.actions.iter().map(render_action_xml).collect::<String>();
     format!(
@@ -924,6 +914,94 @@ pub(crate) fn render_rule_xml(r: &crate::state::Rule) -> String {
         priority = xml_escape(&r.priority),
         is_default = r.is_default,
     )
+}
+
+/// Render a single rule condition. AWS returns each condition's typed
+/// `*Config` sub-object (the modern shape the SDK/Terraform read), and for
+/// `host-header`/`path-pattern` also echoes the deprecated top-level
+/// `Values`. Emitting only `<Field>`/`<Values>` makes terraform-provider-aws
+/// nil-deref on `condition.PathPatternConfig.Values` (etc.) in
+/// `resourceListenerRuleRead`, so the typed config must always be present.
+fn render_rule_condition_xml(c: &crate::state::RuleCondition) -> String {
+    let members = |vals: &[String]| {
+        vals.iter()
+            .map(|v| format!("<member>{}</member>", xml_escape(v)))
+            .collect::<String>()
+    };
+    // Typed configs created via the modern `*Config.Values` land in the
+    // type-specific vec; legacy `Values`-only creates land in `c.values`.
+    let typed_or_legacy = |primary: &[String]| -> Vec<String> {
+        if primary.is_empty() {
+            c.values.clone()
+        } else {
+            primary.to_vec()
+        }
+    };
+    let field = xml_escape(&c.field);
+    let config_xml = match c.field.as_str() {
+        "host-header" => {
+            let vals = typed_or_legacy(&c.host_header_values);
+            format!(
+                "<HostHeaderConfig><Values>{}</Values></HostHeaderConfig>",
+                members(&vals)
+            )
+        }
+        "path-pattern" => {
+            let vals = typed_or_legacy(&c.path_pattern_values);
+            format!(
+                "<PathPatternConfig><Values>{}</Values></PathPatternConfig>",
+                members(&vals)
+            )
+        }
+        "http-header" => {
+            let name = c
+                .http_header_name
+                .as_deref()
+                .map(|n| format!("<HttpHeaderName>{}</HttpHeaderName>", xml_escape(n)))
+                .unwrap_or_default();
+            format!(
+                "<HttpHeaderConfig>{name}<Values>{}</Values></HttpHeaderConfig>",
+                members(&c.http_header_values)
+            )
+        }
+        "http-request-method" => format!(
+            "<HttpRequestMethodConfig><Values>{}</Values></HttpRequestMethodConfig>",
+            members(&c.http_request_method_values)
+        ),
+        "source-ip" => format!(
+            "<SourceIpConfig><Values>{}</Values></SourceIpConfig>",
+            members(&c.source_ip_values)
+        ),
+        "query-string" => {
+            let pairs = c
+                .query_string_values
+                .iter()
+                .map(|kv| {
+                    let key = kv
+                        .key
+                        .as_deref()
+                        .map(|k| format!("<Key>{}</Key>", xml_escape(k)))
+                        .unwrap_or_default();
+                    let value = kv
+                        .value
+                        .as_deref()
+                        .map(|v| format!("<Value>{}</Value>", xml_escape(v)))
+                        .unwrap_or_default();
+                    format!("<member>{key}{value}</member>")
+                })
+                .collect::<String>();
+            format!("<QueryStringConfig><Values>{pairs}</Values></QueryStringConfig>")
+        }
+        _ => String::new(),
+    };
+    // AWS echoes the deprecated top-level Values only for host-header and
+    // path-pattern; other fields return it empty.
+    let legacy_values = match c.field.as_str() {
+        "host-header" => members(&typed_or_legacy(&c.host_header_values)),
+        "path-pattern" => members(&typed_or_legacy(&c.path_pattern_values)),
+        _ => String::new(),
+    };
+    format!("<member><Field>{field}</Field><Values>{legacy_values}</Values>{config_xml}</member>")
 }
 
 pub(crate) fn validate_tg_name(name: &str) -> Result<(), AwsServiceError> {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -730,6 +730,25 @@ pub const SERVICES: &[Service] = &[
             "TestAccAPIGatewayVPCLinkDataSource_basic",
         ],
     },
+    Service {
+        name: "elbv2",
+        // ELBv2 (ALB/NLB) control plane: the `_basic` smoke for target groups
+        // (+ data source), listener rules / certificates / data source, trust
+        // stores (+ data source / revocation), hosted-zone-id and load-balancer
+        // data sources. Fixes: an HTTP/HTTPS target group reports its default
+        // ProtocolVersion (HTTP1), and DescribeTargetGroupAttributes returns the
+        // cross-zone (`use_load_balancer_configuration`) and anomaly-mitigation
+        // (`off`) defaults the data source reads. (DeleteLoadBalancer already
+        // returns its result node as of the prior fix.)
+        run_regex: "^TestAccELBV2[A-Za-z0-9]+_basic$",
+        deny: &[
+            // --- gap: the target-group attachment registers a real EC2 instance
+            //     as a target; its pre-apply config resolves an EC2 data source
+            //     (AMI / instance) that returns no results without a populated
+            //     EC2 image catalogue, so the attachment cannot be planned. ---
+            "TestAccELBV2TargetGroupAttachment_basic",
+        ],
+    },
 ];
 
 /// CI matrix shards. One GitHub Actions job per entry.
@@ -1066,6 +1085,12 @@ pub const SHARDS: &[Shard] = &[
         name: "apigateway",
         service: "apigateway",
         run_regex: "^TestAccAPIGateway[A-Za-z0-9]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "elbv2",
+        service: "elbv2",
+        run_regex: "^TestAccELBV2[A-Za-z0-9]+_basic$",
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -312,4 +312,8 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_FIREHOSE", "firehose"),
     ("AWS_ENDPOINT_URL_CLOUDWATCH", "monitoring"),
     ("AWS_ENDPOINT_URL_API_GATEWAY", "apigateway"),
+    (
+        "AWS_ENDPOINT_URL_ELASTIC_LOAD_BALANCING_V2",
+        "elasticloadbalancingv2",
+    ),
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -203,6 +203,11 @@ async fn apigateway_acceptance() {
 }
 
 #[tokio::test]
+async fn elbv2_acceptance() {
+    run_shard("elbv2").await;
+}
+
+#[tokio::test]
 async fn scheduler_acceptance() {
     run_shard("scheduler").await;
 }


### PR DESCRIPTION
## Summary

Wires ELBv2 (ALB/NLB) into the `fakecloud-tfacc` terraform-provider-aws acceptance harness and fixes the target-group fidelity gaps the real `TestAccELBV2*` corpus surfaces.

- Add `elbv2` to the tfacc allowlist + a CI matrix shard, running `^TestAccELBV2[A-Za-z0-9]+_basic$` (target groups + data source, listener rules/certificates/data source, trust stores + revocation/data source, hosted-zone-id and load-balancer data sources).
  - Deny only `TestAccELBV2TargetGroupAttachment_basic`: its pre-apply config resolves an EC2 AMI/instance data source that returns no results without a populated EC2 image catalogue, so the attachment can't be planned. Documented inline.
- Add `elbv2_acceptance` test + the `AWS_ENDPOINT_URL_ELASTIC_LOAD_BALANCING_V2` endpoint env var.
- **Fidelity fixes** the data sources require:
  - HTTP/HTTPS target groups now default and report `ProtocolVersion=HTTP1` (TCP/UDP/TLS/GENEVE remain none), matching AWS; `aws_lb_target_group` reads `protocol_version`.
  - `DescribeTargetGroupAttributes` returns the cross-zone (`load_balancing.cross_zone.enabled=use_load_balancer_configuration`) and anomaly-mitigation (`load_balancing.algorithm.anomaly_mitigation=off`) defaults the `aws_lb_target_group` data source reads.
- `DeleteLoadBalancer` already returns its result node (`xml_metadata_only`).

## Test plan

- New E2E test `http_target_group_reports_protocol_version_and_attr_defaults` (passes locally) asserts the HTTP1 protocol version + both attribute defaults.
- `elbv2_acceptance` shard runs the real terraform-provider-aws `TestAccELBV2*_basic` suite in CI.
- `cargo clippy -p fakecloud-elbv2 -p fakecloud-tfacc --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface

No public-surface change: tfacc wiring is internal CI test infra, and the target-group fidelity fix is invisible to docs/SDKs. The website/README Terraform-acceptance claims are qualitative ("CI runs the TestAcc* suites") and remain accurate, so no metadata/doc/SDK update is needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ELBv2 (ALB/NLB) to the `fakecloud-tfacc` Terraform acceptance harness. Fixes target group defaults and listener rule condition shapes so `TestAccELBV2*_basic` passes.

- **New Features**
  - Added `elbv2` to the `fakecloud-tfacc` allowlist and a CI shard running `^TestAccELBV2[A-Za-z0-9]+_basic$`.
  - Added `elbv2_acceptance` test and `AWS_ENDPOINT_URL_ELASTIC_LOAD_BALANCING_V2` endpoint env var.
  - Denied only `TestAccELBV2TargetGroupAttachment_basic` (needs a populated EC2 image catalog to plan).

- **Bug Fixes**
  - HTTP/HTTPS target groups now default and report `ProtocolVersion=HTTP1`.
  - `DescribeTargetGroupAttributes` now returns defaults: `load_balancing.cross_zone.enabled=use_load_balancer_configuration` and `load_balancing.algorithm.anomaly_mitigation=off`.
  - `DescribeRules` now emits typed condition configs for listener rules (e.g., PathPatternConfig, HostHeaderConfig) with legacy `Values` echoed only for host-header/path-pattern, preventing a provider nil dereference.

<sup>Written for commit efca4e274b4b66b998246316a52475ffd44b0b00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

