### PR TITLE
test(tfacc): wire application-autoscaling + fix ECS service/cluster delete fidelity

### DIFF
--- a/crates/fakecloud-e2e/tests/ecs.rs
+++ b/crates/fakecloud-e2e/tests/ecs.rs
@@ -1004,6 +1004,13 @@ async fn delete_service_requires_zero_desired_unless_force() {
         .expect("force delete");
     assert_eq!(forced.service().unwrap().service_name(), Some("web"));
 
+    // AWS does NOT drop a deleted service immediately: it stays describable
+    // (DRAINING while tasks stop, then INACTIVE) instead of returning MISSING.
+    // It is excluded from ListServices either way. (The exact DRAINING vs
+    // INACTIVE status depends on whether the drained tasks have stopped yet,
+    // which is non-deterministic when a real container runtime is present;
+    // `deleted_service_with_no_tasks_becomes_inactive` covers the terminal
+    // transition deterministically.)
     let after = client
         .describe_services()
         .cluster("del-cluster")
@@ -1011,9 +1018,78 @@ async fn delete_service_requires_zero_desired_unless_force() {
         .send()
         .await
         .unwrap();
-    assert!(after.services().is_empty());
-    assert_eq!(after.failures().len(), 1);
-    assert_eq!(after.failures()[0].reason(), Some("MISSING"));
+    assert_eq!(after.services().len(), 1);
+    assert!(
+        matches!(
+            after.services()[0].status(),
+            Some("DRAINING") | Some("INACTIVE")
+        ),
+        "deleted service must remain describable as DRAINING/INACTIVE, got {:?}",
+        after.services()[0].status()
+    );
+    assert!(after.failures().is_empty());
+
+    let listed = client
+        .list_services()
+        .cluster("del-cluster")
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        listed.service_arns().is_empty(),
+        "deleted service must not appear in ListServices"
+    );
+}
+
+#[tokio::test]
+async fn deleted_service_with_no_tasks_becomes_inactive() {
+    // A service with no running tasks (desiredCount=0) deletes cleanly: AWS
+    // keeps it describable as INACTIVE (the terraform-provider-aws delete
+    // waiter polls DescribeServices until it observes INACTIVE), and excludes
+    // it from ListServices.
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap_service_fixtures(&client, "drain-cluster", "drain-td").await;
+    client
+        .create_service()
+        .cluster("drain-cluster")
+        .service_name("idle")
+        .task_definition("drain-td")
+        .desired_count(0)
+        .send()
+        .await
+        .unwrap();
+
+    let deleted = client
+        .delete_service()
+        .cluster("drain-cluster")
+        .service("idle")
+        .send()
+        .await
+        .expect("delete idle service");
+    assert_eq!(deleted.service().unwrap().service_name(), Some("idle"));
+
+    let after = client
+        .describe_services()
+        .cluster("drain-cluster")
+        .services("idle")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(after.services().len(), 1);
+    assert_eq!(after.services()[0].status(), Some("INACTIVE"));
+    assert!(after.failures().is_empty());
+
+    let listed = client
+        .list_services()
+        .cluster("drain-cluster")
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        listed.service_arns().is_empty(),
+        "INACTIVE service must not appear in ListServices"
+    );
 }
 
 // -- Phase O1: multi-container task launch --------------------------

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -1094,6 +1094,45 @@ pub(crate) fn recompute_service_counts(
     }
 }
 
+/// True while a service still owns any task that has not reached STOPPED
+/// (RUNNING / PENDING / PROVISIONING). Used to decide when a DRAINING
+/// (deleted) service has fully drained and may transition to INACTIVE.
+pub(crate) fn service_has_live_tasks(
+    state: &EcsState,
+    service_name: &str,
+    cluster_name: &str,
+) -> bool {
+    let service_tag = format!("ecs-svc/{}", service_name);
+    state.tasks.values().any(|t| {
+        t.started_by.as_deref() == Some(service_tag.as_str())
+            && t.cluster_name == cluster_name
+            && matches!(
+                t.last_status.as_str(),
+                "RUNNING" | "PENDING" | "PROVISIONING"
+            )
+    })
+}
+
+/// Count tasks in a cluster that have not yet reached STOPPED. Authoritative
+/// for DeleteCluster's ClusterContainsTasksException check: the cached
+/// running/pending counters on the cluster can drift under rapid task churn
+/// (e.g. a container that exits immediately may transition PENDING -> STOPPED
+/// without a clean RUNNING decrement), so the gate scans live task records
+/// instead. STOPPED tasks linger as history and never block cluster deletion.
+pub(crate) fn cluster_active_task_count(state: &EcsState, cluster_name: &str) -> usize {
+    state
+        .tasks
+        .values()
+        .filter(|t| {
+            t.cluster_name == cluster_name
+                && matches!(
+                    t.last_status.as_str(),
+                    "RUNNING" | "PENDING" | "PROVISIONING"
+                )
+        })
+        .count()
+}
+
 pub(crate) fn inject_service_task_sets(
     state: &EcsState,
     service_name: &str,

--- a/crates/fakecloud-ecs/src/service_clusters.rs
+++ b/crates/fakecloud-ecs/src/service_clusters.rs
@@ -120,16 +120,25 @@ impl EcsService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&account);
+        let active_services = state
+            .clusters
+            .get(&name)
+            .ok_or_else(|| cluster_not_found(&name))?
+            .active_services_count;
+        if active_services > 0 {
+            return Err(cluster_contains_services());
+        }
+        // Scan live task records rather than the cluster's cached running/
+        // pending counters, which can drift under rapid task churn (a
+        // container that exits immediately may skip a clean RUNNING->STOPPED
+        // counter decrement). STOPPED tasks are history and don't block delete.
+        if cluster_active_task_count(state, &name) > 0 {
+            return Err(cluster_contains_tasks());
+        }
         let cluster = state
             .clusters
             .get_mut(&name)
             .ok_or_else(|| cluster_not_found(&name))?;
-        if cluster.active_services_count > 0 {
-            return Err(cluster_contains_services());
-        }
-        if cluster.running_tasks_count > 0 || cluster.pending_tasks_count > 0 {
-            return Err(cluster_contains_tasks());
-        }
         cluster.status = "INACTIVE".to_string();
         let snapshot = cluster.clone();
         // Real ECS keeps the cluster visible as INACTIVE for about an

--- a/crates/fakecloud-ecs/src/service_services_resource.rs
+++ b/crates/fakecloud-ecs/src/service_services_resource.rs
@@ -914,7 +914,15 @@ impl EcsService {
                     ts.service_name != service_name || ts.cluster_name != cluster_name
                 });
             }
-            state.services.remove(&key);
+            // AWS does NOT drop a deleted service immediately: it transitions
+            // to DRAINING while its tasks stop, then to INACTIVE, and an
+            // INACTIVE service stays describable (DescribeServices) for ~hours
+            // before garbage collection. The terraform-provider-aws delete
+            // waiter polls DescribeServices until it sees status=INACTIVE, so
+            // removing the record here makes that waiter fail with "couldn't
+            // find resource". Keep the service at DRAINING; `describe_services`
+            // flips it to INACTIVE once its tasks have all stopped. It is
+            // excluded from ListServices (only ACTIVE services are listed).
             state.push_event(crate::state::LifecycleEvent {
                 at: Utc::now(),
                 event_type: "ServiceDeleted".into(),
@@ -976,10 +984,13 @@ impl EcsService {
             .collect();
 
         let account = request.account_id.clone();
-        let accounts = self.state.read();
+        // Write lock: a service left at DRAINING by DeleteService transitions to
+        // INACTIVE here once its tasks have all stopped, and we persist that so
+        // the status is stable across subsequent describes and ListServices.
+        let mut accounts = self.state.write();
         let mut found = Vec::new();
         let mut failures = Vec::new();
-        let Some(state) = accounts.get(&account) else {
+        let Some(state) = accounts.get_mut(&account) else {
             for r in &refs {
                 failures.push(json!({"arn": r, "reason": "MISSING"}));
             }
@@ -990,6 +1001,16 @@ impl EcsService {
         for r in &refs {
             let name = service_name_from_ref(r);
             let key = EcsState::service_key(&cluster_name, &name);
+            // A DRAINING (deleted) service whose tasks have all stopped has
+            // reached INACTIVE — flip and persist before serializing so the
+            // delete waiter observes the terminal status.
+            if state.services.get(&key).map(|s| s.status.as_str()) == Some("DRAINING")
+                && !service_has_live_tasks(state, &name, &cluster_name)
+            {
+                if let Some(svc) = state.services.get_mut(&key) {
+                    svc.status = "INACTIVE".into();
+                }
+            }
             match state.services.get(&key) {
                 Some(svc) => {
                     let mut v = service_to_json(svc);
@@ -1037,6 +1058,10 @@ impl EcsService {
             Some(state) => state
                 .services
                 .values()
+                // ListServices returns only live (ACTIVE) services; AWS hides
+                // DRAINING (being deleted) and INACTIVE (deleted) services here,
+                // though they remain visible via DescribeServices.
+                .filter(|s| s.status == "ACTIVE")
                 .filter(|s| s.cluster_name == cluster_name)
                 .filter(|s| launch_type.is_none_or(|lt| s.launch_type == lt))
                 .filter(|s| scheduling.is_none_or(|sc| s.scheduling_strategy == sc))
@@ -1074,6 +1099,7 @@ impl EcsService {
             Some(state) => state
                 .services
                 .values()
+                .filter(|s| s.status == "ACTIVE")
                 .filter(|s| {
                     s.service_registries.iter().any(|r| {
                         r.get("registryArn")

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -765,6 +765,17 @@ pub const SERVICES: &[Service] = &[
             "TestAccBedrockAgentAgentKnowledgeBaseAssociation_basic",
         ],
     },
+    Service {
+        name: "appautoscaling",
+        // Application Auto Scaling: the `_basic` smoke for scalable targets
+        // (`aws_appautoscaling_target`) and scaling policies
+        // (`aws_appautoscaling_policy`). Both register an ECS service as the
+        // scalable dimension (ecs:service:DesiredCount), so they exercise the
+        // ECS control plane on create and the deregister + ECS-service destroy
+        // waiters on teardown.
+        run_regex: "^TestAccAppAutoScaling[A-Za-z0-9]+_basic$",
+        deny: &[],
+    },
 ];
 
 /// CI matrix shards. One GitHub Actions job per entry.
@@ -1113,6 +1124,12 @@ pub const SHARDS: &[Shard] = &[
         name: "bedrockagent",
         service: "bedrockagent",
         run_regex: "^TestAccBedrockAgent[A-Za-z0-9]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "appautoscaling",
+        service: "appautoscaling",
+        run_regex: "^TestAccAppAutoScaling[A-Za-z0-9]+_basic$",
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -317,4 +317,8 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
         "elasticloadbalancingv2",
     ),
     ("AWS_ENDPOINT_URL_BEDROCK_AGENT", "bedrock-agent"),
+    (
+        "AWS_ENDPOINT_URL_APPLICATION_AUTO_SCALING",
+        "application-autoscaling",
+    ),
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -213,6 +213,11 @@ async fn bedrockagent_acceptance() {
 }
 
 #[tokio::test]
+async fn appautoscaling_acceptance() {
+    run_shard("appautoscaling").await;
+}
+
+#[tokio::test]
 async fn scheduler_acceptance() {
     run_shard("scheduler").await;
 }


### PR DESCRIPTION
## Summary

Wires **Application Auto Scaling** into the `fakecloud-tfacc` terraform-provider-aws acceptance harness and fixes the ECS service/cluster delete-lifecycle gaps the suite exposes (both `aws_appautoscaling_target` and `aws_appautoscaling_policy` use an ECS service as the scalable dimension, so they exercise ECS create + the deregister/destroy waiters).

### tfacc wiring
- Add `appautoscaling` to the allowlist + a CI matrix shard running `^TestAccAppAutoScaling[A-Za-z0-9]+_basic$` (Target_basic + Policy_basic), plus the `AWS_ENDPOINT_URL_APPLICATION_AUTO_SCALING` endpoint var and an `appautoscaling_acceptance` test.

### ECS DeleteService fidelity
- AWS does not drop a deleted service immediately: it transitions DRAINING -> INACTIVE and stays describable (DescribeServices) for ~hours. terraform-provider-aws's delete waiter polls DescribeServices until it observes `INACTIVE`, so removing the record made it fail with "couldn't find resource".
- `delete_service` now keeps the service at DRAINING; `describe_services` flips it to INACTIVE once its tasks have all stopped. `ListServices` excludes non-ACTIVE services (AWS hides DRAINING/INACTIVE there, Describe still shows them).

### ECS DeleteCluster fidelity
- The `ClusterContainsTasksException` gate now scans live (non-STOPPED) task records instead of the cached running/pending counters, which drift under rapid task churn (an immediately-exiting container can skip a clean RUNNING->STOPPED counter decrement, leaving the cluster falsely "non-empty" and blocking destroy).

## Test plan
- `appautoscaling` tfacc shard: Target_basic + Policy_basic pass (verified locally against the real terraform-provider-aws suite).
- New E2E: `deleted_service_with_no_tasks_becomes_inactive` (deletes straight to INACTIVE, absent from ListServices); `delete_service_requires_zero_desired_unless_force` updated to assert the deleted service stays describable (DRAINING/INACTIVE) and is not listed.
- ECS conformance: 78/78 pass. `cargo clippy`/`cargo fmt` clean.

## Surface
No public-surface change: tfacc wiring is internal CI infra, and the ECS delete-lifecycle fixes are behavioral (no new API surface, fields, or endpoints), so no docs/SDK/website/metadata updates are needed. The qualitative Terraform-acceptance claims in README/website remain accurate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired Application Auto Scaling into `fakecloud-tfacc` and aligned ECS service/cluster delete behavior with AWS so Terraform delete waiters observe `INACTIVE`. Enables the basic `aws_appautoscaling_target` and `aws_appautoscaling_policy` tests.

- **New Features**
  - Allowlisted `appautoscaling` and added CI shard `^TestAccAppAutoScaling[A-Za-z0-9]+_basic$` (Target_basic + Policy_basic).
  - Added `AWS_ENDPOINT_URL_APPLICATION_AUTO_SCALING`.
  - Added `appautoscaling_acceptance` test.

- **Bug Fixes**
  - ECS DeleteService: keep deleted services describable as `DRAINING`; `DescribeServices` flips to `INACTIVE` once tasks stop. `ListServices` now shows only `ACTIVE`.
  - ECS DeleteCluster: enforce `ClusterContainsTasksException` by scanning live non-`STOPPED` tasks instead of cached counters.
  - New E2E tests cover INACTIVE-after-delete and list filtering, including a no-task service deleting straight to `INACTIVE`.

<sup>Written for commit f7ca1b70376a0fd11306ae5355b3cfc5ed1575fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

