### PR TITLE
test(tfacc): wire bedrockagent + real action-group/collaborator/version fidelity

### DIFF
--- a/crates/fakecloud-bedrock-agent/src/service/agents.rs
+++ b/crates/fakecloud-bedrock-agent/src/service/agents.rs
@@ -29,6 +29,8 @@ impl BedrockAgentService {
             customer_encryption_key_arn: opt_str(&body, "customerEncryptionKeyArn"),
             prompt_override_configuration: opt_json(&body, "promptOverrideConfiguration"),
             guardrail_configuration: opt_json(&body, "guardrailConfiguration"),
+            agent_collaboration: opt_str(&body, "agentCollaboration")
+                .unwrap_or_else(|| "DISABLED".to_string()),
             agent_status: "NOT_PREPARED".to_string(),
             prepared_at: None,
             created_at: now_dt,
@@ -110,6 +112,9 @@ impl BedrockAgentService {
         if body.get("guardrailConfiguration").is_some() {
             a.guardrail_configuration = opt_json(&body, "guardrailConfiguration");
         }
+        if let Some(c) = opt_str(&body, "agentCollaboration") {
+            a.agent_collaboration = c;
+        }
         Ok(AwsResponse::ok_json(json!({ "agent": agent_json(a) })))
     }
 
@@ -125,6 +130,7 @@ impl BedrockAgentService {
         state.agent_versions.remove(&id);
         state.agent_knowledge_bases.remove(&id);
         state.agent_collaborators.remove(&id);
+        state.agent_action_groups.retain(|_, ag| ag.agent_id != id);
         Ok(AwsResponse::ok_json(json!({})))
     }
 
@@ -140,11 +146,34 @@ impl BedrockAgentService {
         a.agent_status = "PREPARED".to_string();
         a.prepared_at = Some(now());
         a.updated_at = now();
+        let snapshot = a.clone();
+        // PrepareAgent cuts a new numbered agent version from the current DRAFT
+        // (real ECS-style: version 1 on first prepare, then incrementing). The
+        // versions are what ListAgentVersions / the versions data source read.
+        let versions = state.agent_versions.entry(id.clone()).or_default();
+        let next = versions
+            .iter()
+            .filter_map(|v| v.agent_version.parse::<u32>().ok())
+            .max()
+            .map(|n| n + 1)
+            .unwrap_or(1);
+        versions.push(AgentVersion {
+            agent_version: next.to_string(),
+            agent_id: id.clone(),
+            agent_name: snapshot.agent_name.clone(),
+            description: snapshot.description.clone(),
+            created_at: now(),
+            updated_at: now(),
+            instruction: snapshot.instruction.clone(),
+            foundation_model: snapshot.foundation_model.clone(),
+            guardrail_configuration: snapshot.guardrail_configuration.clone(),
+            prompt_override_configuration: snapshot.prompt_override_configuration.clone(),
+        });
         Ok(AwsResponse::ok_json(json!({
             "agentId": id,
             "agentStatus": "PREPARED",
             "agentVersion": "DRAFT",
-            "preparedAt": a.prepared_at.as_ref().unwrap().to_rfc3339(),
+            "preparedAt": snapshot.prepared_at.as_ref().unwrap().to_rfc3339(),
         })))
     }
 
@@ -162,12 +191,29 @@ impl BedrockAgentService {
         if !state.agents.contains_key(&agent_id) {
             return Err(not_found(format!("Agent {agent_id} not found")));
         }
+        // Creating an alias without an explicit routingConfiguration makes AWS
+        // cut a new agent version and route 100% of traffic to it, so the alias
+        // always reads back exactly one routing-configuration entry. Mirror that
+        // by defaulting to the latest prepared version (or "1").
+        let mut routing_configuration = opt_array(&body, "routingConfiguration");
+        if routing_configuration.is_empty() {
+            let version = state
+                .agent_versions
+                .get(&agent_id)
+                .and_then(|vs| {
+                    vs.iter()
+                        .filter_map(|v| v.agent_version.parse::<u32>().ok())
+                        .max()
+                })
+                .unwrap_or(1);
+            routing_configuration = vec![json!({ "agentVersion": version.to_string() })];
+        }
         let alias = AgentAlias {
             alias_id: alias_id.clone(),
             alias_name: name.clone(),
             agent_id: agent_id.clone(),
             agent_version: opt_str(&body, "agentVersion").unwrap_or_else(|| "DRAFT".to_string()),
-            routing_configuration: opt_array(&body, "routingConfiguration"),
+            routing_configuration,
             description: opt_str(&body, "description"),
             alias_arn: format!(
                 "arn:aws:bedrock:{}:{}:agent-alias/{}/{}",
@@ -472,9 +518,12 @@ impl BedrockAgentService {
         }
         let coll = AgentCollaborator {
             agent_id: agent_id.clone(),
+            agent_version: opt_str(&body, "agentVersion").unwrap_or_else(|| "DRAFT".to_string()),
             collaborator_id: collaborator_id.clone(),
             collaborator_name: req_str(&body, "collaboratorName")?,
-            collaborator_alias_arn: opt_str(&body, "collaboratorAliasArn").unwrap_or_default(),
+            agent_descriptor: opt_json(&body, "agentDescriptor"),
+            collaboration_instruction: opt_str(&body, "collaborationInstruction")
+                .unwrap_or_default(),
             relay_conversation_history: opt_str(&body, "relayConversationHistory")
                 .unwrap_or_else(|| "DISABLED".to_string()),
             created_at: now_dt,
@@ -485,13 +534,10 @@ impl BedrockAgentService {
             .entry(agent_id.clone())
             .or_default()
             .push(coll);
-        Ok(AwsResponse::ok_json(json!({
-            "agentCollaborator": {
-                "agentId": agent_id,
-                "collaboratorId": collaborator_id,
-                "createdAt": now_dt.to_rfc3339(),
-            }
-        })))
+        let coll = state.agent_collaborators[&agent_id].last().unwrap();
+        Ok(AwsResponse::ok_json(
+            json!({ "agentCollaborator": agent_collaborator_json(coll) }),
+        ))
     }
 
     pub(super) fn disassociate_agent_collaborator(
@@ -574,8 +620,11 @@ impl BedrockAgentService {
         if let Some(n) = opt_str(&body, "collaboratorName") {
             c.collaborator_name = n;
         }
-        if let Some(a) = opt_str(&body, "collaboratorAliasArn") {
-            c.collaborator_alias_arn = a;
+        if body.get("agentDescriptor").is_some() {
+            c.agent_descriptor = opt_json(&body, "agentDescriptor");
+        }
+        if let Some(i) = opt_str(&body, "collaborationInstruction") {
+            c.collaboration_instruction = i;
         }
         if let Some(r) = opt_str(&body, "relayConversationHistory") {
             c.relay_conversation_history = r;
@@ -598,14 +647,30 @@ impl BedrockAgentService {
         if !state.agents.contains_key(&agent_id) {
             return Err(not_found(format!("Agent {agent_id} not found")));
         }
-        Ok(AwsResponse::ok_json(json!({
-            "agentActionGroup": {
-                "actionGroupId": action_group_id,
-                "agentId": agent_id,
-                "actionGroupName": req_str(&body, "actionGroupName")?,
-                "createdAt": now_dt.to_rfc3339(),
-            }
-        })))
+        let ag = AgentActionGroup {
+            action_group_id: action_group_id.clone(),
+            agent_id: agent_id.clone(),
+            agent_version: opt_str(&body, "agentVersion").unwrap_or_else(|| "DRAFT".to_string()),
+            action_group_name: req_str(&body, "actionGroupName")?.to_string(),
+            description: opt_str(&body, "description"),
+            // AWS defaults a new action group to ENABLED when the caller omits
+            // actionGroupState.
+            action_group_state: opt_str(&body, "actionGroupState")
+                .unwrap_or_else(|| "ENABLED".to_string()),
+            action_group_executor: opt_json(&body, "actionGroupExecutor"),
+            api_schema: opt_json(&body, "apiSchema"),
+            function_schema: opt_json(&body, "functionSchema"),
+            parent_action_group_signature: opt_str(&body, "parentActionGroupSignature"),
+            created_at: now_dt,
+            updated_at: now_dt,
+        };
+        state
+            .agent_action_groups
+            .insert(action_group_id.clone(), ag);
+        let ag = state.agent_action_groups.get(&action_group_id).unwrap();
+        Ok(AwsResponse::ok_json(
+            json!({ "agentActionGroup": action_group_json(ag) }),
+        ))
     }
 
     pub(super) fn get_agent_action_group(
@@ -619,17 +684,14 @@ impl BedrockAgentService {
         let state = accts
             .get(&req.account_id)
             .ok_or_else(|| not_found(format!("Action group {action_group_id} not found")))?;
-        if !state.agents.contains_key(&agent_id) {
-            return Err(not_found(format!("Agent {agent_id} not found")));
-        }
-        Ok(AwsResponse::ok_json(json!({
-            "agentActionGroup": {
-                "actionGroupId": action_group_id,
-                "agentId": agent_id,
-                "actionGroupName": action_group_id,
-                "createdAt": now().to_rfc3339(),
-            }
-        })))
+        let ag = state
+            .agent_action_groups
+            .get(&action_group_id)
+            .filter(|ag| ag.agent_id == agent_id)
+            .ok_or_else(|| not_found(format!("Action group {action_group_id} not found")))?;
+        Ok(AwsResponse::ok_json(
+            json!({ "agentActionGroup": action_group_json(ag) }),
+        ))
     }
 
     pub(super) fn list_agent_action_groups(
@@ -645,7 +707,15 @@ impl BedrockAgentService {
         if !state.agents.contains_key(&agent_id) {
             return Err(not_found(format!("Agent {agent_id} not found")));
         }
-        Ok(AwsResponse::ok_json(json!({ "actionGroupSummaries": [] })))
+        let list: Vec<Value> = state
+            .agent_action_groups
+            .values()
+            .filter(|ag| ag.agent_id == agent_id)
+            .map(action_group_summary_json)
+            .collect();
+        Ok(AwsResponse::ok_json(
+            json!({ "actionGroupSummaries": list }),
+        ))
     }
 
     pub(super) fn update_agent_action_group(
@@ -657,16 +727,36 @@ impl BedrockAgentService {
         let action_group_id = req_str(&body, "actionGroupId")?;
         let mut accts = self.state.write();
         let state = accts.get_or_create(&req.account_id, &req.region);
-        if !state.agents.contains_key(&agent_id) {
-            return Err(not_found(format!("Agent {agent_id} not found")));
+        let ag = state
+            .agent_action_groups
+            .get_mut(&action_group_id)
+            .filter(|ag| ag.agent_id == agent_id)
+            .ok_or_else(|| not_found(format!("Action group {action_group_id} not found")))?;
+        if let Some(n) = opt_str(&body, "actionGroupName") {
+            ag.action_group_name = n;
         }
-        Ok(AwsResponse::ok_json(json!({
-            "agentActionGroup": {
-                "actionGroupId": action_group_id,
-                "agentId": agent_id,
-                "updatedAt": now().to_rfc3339(),
-            }
-        })))
+        if let Some(v) = opt_str(&body, "agentVersion") {
+            ag.agent_version = v;
+        }
+        if let Some(d) = opt_str(&body, "description") {
+            ag.description = Some(d);
+        }
+        if let Some(s) = opt_str(&body, "actionGroupState") {
+            ag.action_group_state = s;
+        }
+        if body.get("actionGroupExecutor").is_some() {
+            ag.action_group_executor = opt_json(&body, "actionGroupExecutor");
+        }
+        if body.get("apiSchema").is_some() {
+            ag.api_schema = opt_json(&body, "apiSchema");
+        }
+        if body.get("functionSchema").is_some() {
+            ag.function_schema = opt_json(&body, "functionSchema");
+        }
+        ag.updated_at = now();
+        Ok(AwsResponse::ok_json(
+            json!({ "agentActionGroup": action_group_json(ag) }),
+        ))
     }
 
     pub(super) fn delete_agent_action_group(
@@ -675,11 +765,18 @@ impl BedrockAgentService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let agent_id = req_str(&body, "agentId")?;
-        let _action_group_id = req_str(&body, "actionGroupId")?;
+        let action_group_id = req_str(&body, "actionGroupId")?;
         let mut accts = self.state.write();
         let state = accts.get_or_create(&req.account_id, &req.region);
-        if !state.agents.contains_key(&agent_id) {
-            return Err(not_found(format!("Agent {agent_id} not found")));
+        match state.agent_action_groups.get(&action_group_id) {
+            Some(ag) if ag.agent_id == agent_id => {
+                state.agent_action_groups.remove(&action_group_id);
+            }
+            _ => {
+                return Err(not_found(format!(
+                    "Action group {action_group_id} not found"
+                )))
+            }
         }
         Ok(AwsResponse::ok_json(json!({})))
     }

--- a/crates/fakecloud-bedrock-agent/src/service/mod.rs
+++ b/crates/fakecloud-bedrock-agent/src/service/mod.rs
@@ -13,9 +13,10 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    Agent, AgentAlias, AgentCollaborator, AgentKnowledgeBase, AgentVersion, BedrockAgentAccounts,
-    BedrockAgentSnapshot, DataSource, Flow, FlowAlias, FlowVersion, IngestionJob, KnowledgeBase,
-    Prompt, PromptVersion, SharedBedrockAgentState, BEDROCK_AGENT_SNAPSHOT_SCHEMA_VERSION,
+    Agent, AgentActionGroup, AgentAlias, AgentCollaborator, AgentKnowledgeBase, AgentVersion,
+    BedrockAgentAccounts, BedrockAgentSnapshot, DataSource, Flow, FlowAlias, FlowVersion,
+    IngestionJob, KnowledgeBase, Prompt, PromptVersion, SharedBedrockAgentState,
+    BEDROCK_AGENT_SNAPSHOT_SCHEMA_VERSION,
 };
 
 /// Bedrock Agent read actions all start with `Get`, `List`, or `Validate`;
@@ -1054,14 +1055,90 @@ fn agent_json(a: &Agent) -> Value {
     if let Some(ref k) = a.customer_encryption_key_arn {
         o["customerEncryptionKeyArn"] = json!(k);
     }
-    if let Some(ref p) = a.prompt_override_configuration {
-        o["promptOverrideConfiguration"] = p.clone();
-    }
+    // AWS always returns a promptOverrideConfiguration: when the caller did
+    // not override any prompts it still reports the four default prompt
+    // configurations (promptCreationMode=DEFAULT). The terraform-provider-aws
+    // agent reader dereferences `PromptOverrideConfiguration.PromptConfigurations`
+    // unconditionally (removeDefaultPrompts), so the field must never be null.
+    o["promptOverrideConfiguration"] = a
+        .prompt_override_configuration
+        .clone()
+        .unwrap_or_else(default_prompt_override_configuration);
+    // AWS always reports agentCollaboration; default DISABLED when unset.
+    o["agentCollaboration"] = json!(if a.agent_collaboration.is_empty() {
+        "DISABLED"
+    } else {
+        a.agent_collaboration.as_str()
+    });
     if let Some(ref g) = a.guardrail_configuration {
         o["guardrailConfiguration"] = g.clone();
     }
     if let Some(ref p) = a.prepared_at {
         o["preparedAt"] = json!(p.to_rfc3339());
+    }
+    o
+}
+
+/// The default `promptOverrideConfiguration` AWS reports for an agent whose
+/// caller overrode no prompts: one entry per prompt type, each in DEFAULT
+/// creation mode. The terraform provider keeps only OVERRIDDEN entries, so
+/// these are filtered out client-side and produce no diff.
+fn default_prompt_override_configuration() -> Value {
+    let default_prompt = |prompt_type: &str, enabled: bool| {
+        json!({
+            "promptType": prompt_type,
+            "promptCreationMode": "DEFAULT",
+            "promptState": if enabled { "ENABLED" } else { "DISABLED" },
+            "parserMode": "DEFAULT",
+        })
+    };
+    json!({
+        "promptConfigurations": [
+            default_prompt("PRE_PROCESSING", true),
+            default_prompt("ORCHESTRATION", true),
+            default_prompt("KNOWLEDGE_BASE_RESPONSE_GENERATION", true),
+            default_prompt("POST_PROCESSING", false),
+        ],
+    })
+}
+
+fn action_group_json(ag: &AgentActionGroup) -> Value {
+    let mut o = json!({
+        "actionGroupId": ag.action_group_id,
+        "agentId": ag.agent_id,
+        "agentVersion": ag.agent_version,
+        "actionGroupName": ag.action_group_name,
+        "actionGroupState": ag.action_group_state,
+        "createdAt": ag.created_at.to_rfc3339(),
+        "updatedAt": ag.updated_at.to_rfc3339(),
+    });
+    if let Some(ref d) = ag.description {
+        o["description"] = json!(d);
+    }
+    if let Some(ref e) = ag.action_group_executor {
+        o["actionGroupExecutor"] = e.clone();
+    }
+    if let Some(ref s) = ag.api_schema {
+        o["apiSchema"] = s.clone();
+    }
+    if let Some(ref s) = ag.function_schema {
+        o["functionSchema"] = s.clone();
+    }
+    if let Some(ref s) = ag.parent_action_group_signature {
+        o["parentActionGroupSignature"] = json!(s);
+    }
+    o
+}
+
+fn action_group_summary_json(ag: &AgentActionGroup) -> Value {
+    let mut o = json!({
+        "actionGroupId": ag.action_group_id,
+        "actionGroupName": ag.action_group_name,
+        "actionGroupState": ag.action_group_state,
+        "updatedAt": ag.updated_at.to_rfc3339(),
+    });
+    if let Some(ref d) = ag.description {
+        o["description"] = json!(d);
     }
     o
 }
@@ -1335,15 +1412,20 @@ fn agent_kb_json(a: &AgentKnowledgeBase) -> Value {
 }
 
 fn agent_collaborator_json(c: &AgentCollaborator) -> Value {
-    json!({
+    let mut o = json!({
         "agentId": c.agent_id,
+        "agentVersion": if c.agent_version.is_empty() { "DRAFT" } else { c.agent_version.as_str() },
         "collaboratorId": c.collaborator_id,
         "collaboratorName": c.collaborator_name,
-        "collaboratorAliasArn": c.collaborator_alias_arn,
+        "collaborationInstruction": c.collaboration_instruction,
         "relayConversationHistory": c.relay_conversation_history,
         "createdAt": c.created_at.to_rfc3339(),
-        "updatedAt": c.updated_at.to_rfc3339(),
-    })
+        "lastUpdatedAt": c.updated_at.to_rfc3339(),
+    });
+    if let Some(ref d) = c.agent_descriptor {
+        o["agentDescriptor"] = d.clone();
+    }
+    o
 }
 
 impl BedrockAgentService {}

--- a/crates/fakecloud-bedrock-agent/src/state.rs
+++ b/crates/fakecloud-bedrock-agent/src/state.rs
@@ -50,6 +50,8 @@ pub struct BedrockAgentState {
     pub agents: BTreeMap<String, Agent>,
     pub agent_aliases: BTreeMap<String, AgentAlias>,
     pub agent_versions: BTreeMap<String, Vec<AgentVersion>>,
+    #[serde(default)]
+    pub agent_action_groups: BTreeMap<String, AgentActionGroup>,
     pub knowledge_bases: BTreeMap<String, KnowledgeBase>,
     pub data_sources: BTreeMap<String, DataSource>,
     pub agent_knowledge_bases: BTreeMap<String, Vec<AgentKnowledgeBase>>,
@@ -71,6 +73,7 @@ impl BedrockAgentState {
             agents: BTreeMap::new(),
             agent_aliases: BTreeMap::new(),
             agent_versions: BTreeMap::new(),
+            agent_action_groups: BTreeMap::new(),
             knowledge_bases: BTreeMap::new(),
             data_sources: BTreeMap::new(),
             agent_knowledge_bases: BTreeMap::new(),
@@ -100,6 +103,9 @@ pub struct Agent {
     pub customer_encryption_key_arn: Option<String>,
     pub prompt_override_configuration: Option<serde_json::Value>,
     pub guardrail_configuration: Option<serde_json::Value>,
+    /// `DISABLED` | `SUPERVISOR` | `SUPERVISOR_ROUTER`. AWS always reports it.
+    #[serde(default)]
+    pub agent_collaboration: String,
     pub agent_status: String,
     pub prepared_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
@@ -119,6 +125,22 @@ pub struct AgentAlias {
     pub alias_arn: String,
     pub agent_alias_status: String,
     pub failure_reasons: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentActionGroup {
+    pub action_group_id: String,
+    pub agent_id: String,
+    pub agent_version: String,
+    pub action_group_name: String,
+    pub description: Option<String>,
+    pub action_group_state: String,
+    pub action_group_executor: Option<serde_json::Value>,
+    pub api_schema: Option<serde_json::Value>,
+    pub function_schema: Option<serde_json::Value>,
+    pub parent_action_group_signature: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -178,9 +200,16 @@ pub struct AgentKnowledgeBase {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentCollaborator {
     pub agent_id: String,
+    #[serde(default)]
+    pub agent_version: String,
     pub collaborator_id: String,
     pub collaborator_name: String,
-    pub collaborator_alias_arn: String,
+    /// The collaborator target, an `{ "aliasArn": ... }` object. AWS reads it
+    /// back as `agent_descriptor.0.alias_arn`.
+    #[serde(default)]
+    pub agent_descriptor: Option<serde_json::Value>,
+    #[serde(default)]
+    pub collaboration_instruction: String,
     pub relay_conversation_history: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -7838,10 +7838,22 @@ async fn main() {
                                 .map(|cs| cs.iter().map(|c| serde_json::json!({
                                     "collaboratorId": c.collaborator_id,
                                     "collaboratorName": c.collaborator_name,
-                                    "collaboratorAliasArn": c.collaborator_alias_arn,
+                                    "agentDescriptor": c.agent_descriptor,
+                                    "collaborationInstruction": c.collaboration_instruction,
                                     "relayConversationHistory": c.relay_conversation_history,
                                 })).collect())
                                 .unwrap_or_default();
+                            let action_groups: Vec<serde_json::Value> = state
+                                .agent_action_groups
+                                .values()
+                                .filter(|ag| ag.agent_id == *agent_id)
+                                .map(|ag| serde_json::json!({
+                                    "actionGroupId": ag.action_group_id,
+                                    "actionGroupName": ag.action_group_name,
+                                    "actionGroupState": ag.action_group_state,
+                                    "description": ag.description,
+                                }))
+                                .collect();
                             out.push(serde_json::json!({
                                 "agentId": agent.agent_id,
                                 "agentName": agent.agent_name,
@@ -7850,10 +7862,7 @@ async fn main() {
                                 "foundationModel": agent.foundation_model,
                                 "instruction": agent.instruction,
                                 "knowledgeBases": kbs,
-                                // Action groups are not persisted in state today
-                                // (CreateAgentActionGroup returns a stub id); the
-                                // field is exposed for forward compatibility.
-                                "actionGroups": Vec::<serde_json::Value>::new(),
+                                "actionGroups": action_groups,
                                 "collaborators": collaborators,
                                 "aliases": aliases,
                                 "versions": versions,

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -749,6 +749,22 @@ pub const SERVICES: &[Service] = &[
             "TestAccELBV2TargetGroupAttachment_basic",
         ],
     },
+    Service {
+        name: "bedrockagent",
+        // Bedrock Agent control plane: the `_basic` smoke for agents, agent
+        // action groups, agent aliases, agent collaborators, and the
+        // agent-versions data source.
+        run_regex: "^TestAccBedrockAgent[A-Za-z0-9]+_basic$",
+        deny: &[
+            // --- gap: a knowledge-base association requires a real Bedrock
+            //     knowledge base, which in turn provisions an Aurora
+            //     PostgreSQL (pgvector) cluster as its vector store and runs
+            //     embedding ingestion. fakecloud models neither the vector
+            //     store nor KB ingestion, so the dependency chain cannot be
+            //     stood up. ---
+            "TestAccBedrockAgentAgentKnowledgeBaseAssociation_basic",
+        ],
+    },
 ];
 
 /// CI matrix shards. One GitHub Actions job per entry.
@@ -1091,6 +1107,12 @@ pub const SHARDS: &[Shard] = &[
         name: "elbv2",
         service: "elbv2",
         run_regex: "^TestAccELBV2[A-Za-z0-9]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "bedrockagent",
+        service: "bedrockagent",
+        run_regex: "^TestAccBedrockAgent[A-Za-z0-9]+_basic$",
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -316,4 +316,5 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
         "AWS_ENDPOINT_URL_ELASTIC_LOAD_BALANCING_V2",
         "elasticloadbalancingv2",
     ),
+    ("AWS_ENDPOINT_URL_BEDROCK_AGENT", "bedrock-agent"),
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -208,6 +208,11 @@ async fn elbv2_acceptance() {
 }
 
 #[tokio::test]
+async fn bedrockagent_acceptance() {
+    run_shard("bedrockagent").await;
+}
+
+#[tokio::test]
 async fn scheduler_acceptance() {
     run_shard("scheduler").await;
 }


### PR DESCRIPTION
## Summary

Wires **Bedrock Agent** into the `fakecloud-tfacc` terraform-provider-aws acceptance harness and replaces the stubbed agent sub-resource handlers with real, round-tripping control-plane state.

### tfacc wiring
- Add `bedrockagent` to the allowlist + CI shard (`TestAccBedrockAgent*_basic`) and the `AWS_ENDPOINT_URL_BEDROCK_AGENT` endpoint var; add `bedrockagent_acceptance`.
- **Deny** `AgentKnowledgeBaseAssociation_basic`: it needs a real Bedrock knowledge base, which provisions an Aurora-PostgreSQL (pgvector) vector store and runs embedding ingestion — fakecloud models neither, so the dependency chain can't stand up. Documented inline.

### Agent fidelity fixes the suite exposed
- **CreateAgent/GetAgent always return `promptOverrideConfiguration`** (the four default prompt configs when none are overridden). The provider unconditionally dereferences `PromptOverrideConfiguration.PromptConfigurations` in `resourceAgentRead`/`removeDefaultPrompts`, so a null field SIGSEGVs it.
- Agents store + echo **`agentCollaboration`** (default `DISABLED`) so a `SUPERVISOR` agent round-trips (was: inconsistent-result-after-apply).
- **PrepareAgent now cuts a numbered `AgentVersion`** from the DRAFT, so `ListAgentVersions` / the versions data source return summaries.
- **CreateAgentAlias defaults `routingConfiguration`** to the latest version when omitted (AWS auto-routes to a new version) → `routing_configuration.# == 1`.
- **Action groups get real CRUD** (new `AgentActionGroup` state struct + create/get/list/update/delete), echoing `actionGroupState` (default ENABLED), executor, and api/function schema (were stubs returning fake data).
- **Agent collaborators store + echo `agentDescriptor` + `collaborationInstruction` + `agentVersion`** (previously dropped → non-empty refresh plan).
- Introspection `/_fakecloud` agent dump updated to the new collaborator fields and now lists real action groups.

## Test plan
- `bedrockagent` tfacc shard — Agent / ActionGroup / Alias / Collaborator / Versions `_basic` all pass (verified locally against the real terraform-provider-aws suite); KB-association denied.
- `bedrock_agent` conformance 4/4 pass; `cargo clippy`/`cargo fmt` clean.

## Surface
tfacc wiring is internal CI infra and the agent fixes are behavioral (no new public API surface, fields, or endpoints), so no docs/SDK/website/metadata changes are required. The introspection JSON gained richer agent fields (additive).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired Bedrock Agent into the `fakecloud-tfacc` acceptance harness and replaced stubbed sub-resources with real, persistent state. Aligns agent, alias, collaborator, and action-group behavior with AWS to remove refresh diffs and crashes.

- **New Features**
  - Added Bedrock Agent to `fakecloud-tfacc` (allowlist, new `bedrockagent` CI shard, `AWS_ENDPOINT_URL_BEDROCK_AGENT`); runs Agent/ActionGroup/Alias/Collaborator/Versions basics. Denied KB association test due to unmodeled Bedrock KB + Aurora pgvector deps.
  - `PrepareAgent` now creates numbered `AgentVersion`s; `ListAgentVersions` returns summaries. `CreateAgentAlias` defaults `routingConfiguration` to the latest version when omitted.
  - Implemented real Action Group CRUD with persisted state (state defaults to ENABLED) plus executor and API/function schema; `/_fakecloud` now lists real action groups.
  - Collaborators store and return `agentDescriptor`, `collaborationInstruction`, and `agentVersion`.

- **Bug Fixes**
  - `CreateAgent`/`GetAgent` always return `promptOverrideConfiguration` (four default prompts) to avoid provider nil-deref.
  - Agents persist and echo `agentCollaboration` (default `DISABLED`) so SUPERVISOR/SUPERVISOR_ROUTER round-trip correctly.

<sup>Written for commit be4a633575b84cf4bd1fc4e27fee9f896b8709a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

