### PR TITLE
test(tfacc): wire EC2 NAT/peering/DHCP-assoc/flow-log + fix peering-options & flow-log fidelity

### DIFF
--- a/crates/fakecloud-ec2/src/service/endpoint.rs
+++ b/crates/fakecloud-ec2/src/service/endpoint.rs
@@ -518,13 +518,15 @@ pub(crate) fn describe_vpc_endpoint_associations(
 
 fn flow_log_xml(f: &FlowLog, tags: &[Tag]) -> String {
     format!(
-        "{}{}{}{}<flowLogStatus>ACTIVE</flowLogStatus><deliverLogsStatus>SUCCESS</deliverLogsStatus>{}{}{}{}",
+        "{}{}{}{}<flowLogStatus>ACTIVE</flowLogStatus><deliverLogsStatus>SUCCESS</deliverLogsStatus>{}{}{}{}{}{}",
         ec2_elem("flowLogId", &f.id),
         ec2_elem("resourceId", &f.resource_id),
         ec2_elem("trafficType", &f.traffic_type),
         ec2_elem("logDestinationType", &f.log_destination_type),
         f.log_group_name.as_ref().map(|n| ec2_elem("logGroupName", n)).unwrap_or_default(),
         f.log_destination.as_ref().map(|d| ec2_elem("logDestination", d)).unwrap_or_default(),
+        f.deliver_logs_permission_arn.as_ref().map(|a| ec2_elem("deliverLogsPermissionArn", a)).unwrap_or_default(),
+        ec2_elem("maxAggregationInterval", &f.max_aggregation_interval.to_string()),
         ec2_elem("creationTime", FIXED_TIME),
         super::tags::tag_set_xml(tags),
     )
@@ -569,6 +571,17 @@ pub(crate) fn create_flow_logs(
         .cloned()
         .unwrap_or_else(|| "cloud-watch-logs".to_string());
     let log_destination = req.query_params.get("LogDestination").cloned();
+    let deliver_logs_permission_arn = req
+        .query_params
+        .get("DeliverLogsPermissionArn")
+        .filter(|v| !v.is_empty())
+        .cloned();
+    // AWS accepts 60 or 600 and defaults to 600 when the field is omitted.
+    let max_aggregation_interval = req
+        .query_params
+        .get("MaxAggregationInterval")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(600);
     let mut ids = Vec::new();
     {
         let mut accounts = svc.state.write();
@@ -591,6 +604,8 @@ pub(crate) fn create_flow_logs(
                     log_destination_type: dest.clone(),
                     log_group_name: req.query_params.get("LogGroupName").cloned(),
                     log_destination: log_destination.clone(),
+                    deliver_logs_permission_arn: deliver_logs_permission_arn.clone(),
+                    max_aggregation_interval,
                 },
             );
             ids.push(id);

--- a/crates/fakecloud-ec2/src/service/nacl.rs
+++ b/crates/fakecloud-ec2/src/service/nacl.rs
@@ -387,17 +387,38 @@ pub(crate) fn replace_network_acl_association(
 // ---- VPC peering ----
 
 fn peering_xml(p: &VpcPeering, tags: &[Tag], owner: &str) -> String {
+    // `<peeringOptions>` carries the three modifiable cross-VPC flags AWS
+    // returns per side. The requester side is present from creation; the
+    // accepter side only materializes once the connection is `active`
+    // (before acceptance the accepter has not been able to set options).
+    let peering_options = |allow_dns: bool| {
+        format!(
+            "<peeringOptions>\
+             <allowDnsResolutionFromRemoteVpc>{allow_dns}</allowDnsResolutionFromRemoteVpc>\
+             <allowEgressFromLocalClassicLinkToRemoteVpc>false</allowEgressFromLocalClassicLinkToRemoteVpc>\
+             <allowEgressFromLocalVpcToRemoteClassicLink>false</allowEgressFromLocalVpcToRemoteClassicLink>\
+             </peeringOptions>"
+        )
+    };
+    let requester_opts = peering_options(p.requester_allow_dns);
+    let accepter_opts = if p.status == "active" {
+        peering_options(p.accepter_allow_dns)
+    } else {
+        String::new()
+    };
     format!(
         "{}<status><code>{}</code><message>{}</message></status>\
-         <requesterVpcInfo>{}{}</requesterVpcInfo>\
-         <accepterVpcInfo>{}{}</accepterVpcInfo>{}",
+         <requesterVpcInfo>{}{}{}</requesterVpcInfo>\
+         <accepterVpcInfo>{}{}{}</accepterVpcInfo>{}",
         ec2_elem("vpcPeeringConnectionId", &p.id),
         p.status,
         p.status,
         ec2_elem("vpcId", &p.requester_vpc_id),
         ec2_elem("ownerId", owner),
+        requester_opts,
         ec2_elem("vpcId", &p.accepter_vpc_id),
         ec2_elem("ownerId", owner),
+        accepter_opts,
         super::tags::tag_set_xml(tags),
     )
 }

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -598,6 +598,18 @@ pub struct FlowLog {
     pub log_group_name: Option<String>,
     /// Destination ARN for `s3` / `kinesis-data-firehose` deliveries.
     pub log_destination: Option<String>,
+    /// IAM role ARN used to deliver logs to CloudWatch Logs
+    /// (`iam_role_arn` on the Terraform resource).
+    #[serde(default)]
+    pub deliver_logs_permission_arn: Option<String>,
+    /// Max log aggregation interval in seconds. AWS accepts 60 or 600 and
+    /// defaults to 600 when unspecified.
+    #[serde(default = "default_max_aggregation_interval")]
+    pub max_aggregation_interval: i64,
+}
+
+fn default_max_aggregation_interval() -> i64 {
+    600
 }
 
 /// A launch template (versions tracked as monotonic counters).

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -1037,6 +1037,23 @@ pub const SHARDS: &[Shard] = &[
         ),
         extra_deny: &[],
     },
+    // NAT gateways, VPC peering connections (+ their modifiable peering
+    // options), DHCP-options-set associations, and flow logs. Split out of
+    // the core `ec2` shard to keep that job's wall time down and isolate
+    // these newer families. All run purely in the control plane (no Docker).
+    Shard {
+        name: "ec2-vpc2",
+        service: "ec2",
+        run_regex: concat!(
+            "^TestAcc(",
+            "VPCNATGateway",
+            "|VPCPeeringConnection|VPCPeeringConnectionOptions",
+            "|VPCDHCPOptionsAssociation",
+            "|VPCFlowLog",
+            ")_basic$",
+        ),
+        extra_deny: &[],
+    },
     Shard {
         name: "rds",
         service: "rds",

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -93,6 +93,11 @@ async fn ec2_acceptance() {
 }
 
 #[tokio::test]
+async fn ec2_vpc2_acceptance() {
+    run_shard("ec2-vpc2").await;
+}
+
+#[tokio::test]
 async fn elasticache_acceptance() {
     run_shard("elasticache").await;
 }


### PR DESCRIPTION
## Summary

First batch of the EC2 acceptance-tree expansion for `fakecloud-tfacc`. The single `ec2` shard previously ran only EIP/KeyPair + core VPC `_basic` families; this wires the next tranche of VPC control-plane resources (all already implemented in `fakecloud-ec2`, just untested against the upstream suite) and fixes the two fidelity gaps they surfaced.

New `ec2-vpc2` shard (split out of `ec2` to keep that job's wall time down and isolate the newer families), covering `_basic` for:

- `VPCNATGateway`
- `VPCPeeringConnection`
- `VPCPeeringConnectionOptions`
- `VPCDHCPOptionsAssociation`
- `VPCFlowLog`

Fidelity fixes the new tests forced:

- **VPC peering options** — `DescribeVpcPeeringConnections` / Create / Accept now emit `<peeringOptions>` (`allowDnsResolutionFromRemoteVpc` plus the two classic-link egress flags) inside both `requesterVpcInfo` and `accepterVpcInfo`. The accepter side appears once the connection is `active`. Previously the options set via `ModifyVpcPeeringConnectionOptions` were persisted but never surfaced on read, so the Terraform provider nil-dereferenced on the missing `PeeringOptions` struct (server-visible as a provider panic).
- **VPC flow logs** — `CreateFlowLogs` now reads and persists `DeliverLogsPermissionArn` and `MaxAggregationInterval` (AWS default 600), and `DescribeFlowLogs` returns `<deliverLogsPermissionArn>` + `<maxAggregationInterval>`. The provider asserts `iam_role_arn` and `max_aggregation_interval` round-trip.

The CI fan-out is auto-generated from `SHARDS` via the `tfacc_shards` bin, so the new shard is picked up automatically; the matching `ec2_vpc2_acceptance` test was added to `tests/acc.rs`. No hardcoded shard count to update.

## Test plan

- All five families pass locally against a fresh fakecloud server:
  - `VPCNATGateway_basic` PASS
  - `VPCPeeringConnection_basic` PASS
  - `VPCPeeringConnectionOptions_basic` PASS (was a provider nil-panic)
  - `VPCDHCPOptionsAssociation_basic` PASS
  - `VPCFlowLog_basic` PASS (was failing on missing `iam_role_arn` / `max_aggregation_interval`)
- `cargo test -p fakecloud-ec2` — 54 passed
- `cargo clippy -p fakecloud-ec2 -p fakecloud-tfacc --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface check

- No new public API / introspection endpoint — these are EC2 response fields the SDKs already model, so no first-party SDK change.
- `FlowLog` struct gained two fields with `#[serde(default)]` (+ a `600` default fn), so persisted snapshots from older versions deserialize fine.
- tfacc service list in `docs/about/conformance.md` is unchanged: `ec2` is already listed; this batch deepens resource coverage within that service rather than adding a service. (Note: that page's "27 services today" line is stale from earlier batches independent of this change.)

## Follow-on batches

EIP association (needs instance launch + `DescribeInstanceTypeOfferings`, Docker), VPC endpoints / managed prefix lists / customer & VPN gateways (a provider panic aborts that group — needs its own investigation), then RDS and Lambda trees.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `ec2-vpc2` acceptance shard to `fakecloud-tfacc` for more EC2 VPC resources, and fixes EC2 peering options and flow log fields to match AWS so provider reads don’t crash and values round-trip.

- **New Features**
  - New `ec2-vpc2` shard covering `_basic`: `VPCNATGateway`, `VPCPeeringConnection`, `VPCPeeringConnectionOptions`, `VPCDHCPOptionsAssociation`, `VPCFlowLog`.
  - Added `ec2_vpc2_acceptance` test; CI picks it up automatically via `tfacc_shards`.

- **Bug Fixes**
  - Peering options: `DescribeVpcPeeringConnections` now includes `<peeringOptions>` in both `requesterVpcInfo` and `accepterVpcInfo` (after active), matching `ModifyVpcPeeringConnectionOptions` and preventing a nil deref.
  - Flow logs: `CreateFlowLogs`/`DescribeFlowLogs` now persist and return `deliverLogsPermissionArn` and `maxAggregationInterval` (defaults to 600).

<sup>Written for commit 4d328be89a9b8b6305f0b7c174ff0b9b35020244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

