### PR TITLE
test(tfacc): wire RDS DB + cluster parameter groups + fix round-trip fidelity

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
@@ -96,6 +96,7 @@ impl ResourceProvisioner {
             db_parameter_group_family: family,
             description,
             parameters,
+            parameter_apply_methods: std::collections::BTreeMap::new(),
             tags,
         };
         state.parameter_groups.insert(name.clone(), group);

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -351,11 +351,12 @@ impl RdsService {
                     .ok_or_else(|| missing("DBClusterParameterGroupName"))?;
                 let arn = Arn::new("rds", region, &aid, &format!("cluster-pg:{name}")).to_string();
                 let family = get_param(req, "DBParameterGroupFamily").unwrap_or_else(|| "aurora-postgresql15".to_string());
-                let entry = json!({"DBClusterParameterGroupName": name, "DBClusterParameterGroupArn": arn, "DBParameterGroupFamily": family, "Description": get_param(req, "Description").unwrap_or_default()});
+                let description = get_param(req, "Description").unwrap_or_default();
+                let entry = json!({"DBClusterParameterGroupName": name, "DBClusterParameterGroupArn": arn, "DBParameterGroupFamily": family, "Description": description});
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
                 store(&mut state.extras, "cluster_param_groups").insert(name.clone(), entry);
-                Ok(xml_response(action.as_str(), cluster_pg_xml(&name, &arn, &family), &rid))
+                Ok(xml_response(action.as_str(), cluster_pg_xml(&name, &arn, &family, &description), &rid))
             }
             "ModifyDBClusterParameterGroup" => {
                 let name = get_param(req, "DBClusterParameterGroupName").ok_or_else(|| missing("DBClusterParameterGroupName"))?;
@@ -368,9 +369,27 @@ impl RdsService {
                             if !obj.contains_key("Parameters") {
                                 obj.insert("Parameters".to_string(), json!({}));
                             }
+                            if !obj.contains_key("ParameterApplyMethods") {
+                                obj.insert("ParameterApplyMethods".to_string(), json!({}));
+                            }
+                            // Capture values and apply methods separately so the
+                            // existing string-valued `Parameters` map shape stays
+                            // backward compatible with older persisted snapshots.
+                            let apply_methods: Vec<(String, String)> = parsed
+                                .iter()
+                                .map(|p| (p.name.clone(), p.apply_method.clone()))
+                                .collect();
                             if let Some(p) = obj.get_mut("Parameters").and_then(|p| p.as_object_mut()) {
-                                for (n, v) in parsed {
-                                    p.insert(n, json!(v));
+                                for param in &parsed {
+                                    p.insert(param.name.clone(), json!(param.value));
+                                }
+                            }
+                            if let Some(m) = obj
+                                .get_mut("ParameterApplyMethods")
+                                .and_then(|m| m.as_object_mut())
+                            {
+                                for (n, am) in apply_methods {
+                                    m.insert(n, json!(am));
                                 }
                             }
                         }
@@ -380,6 +399,35 @@ impl RdsService {
             }
             "ResetDBClusterParameterGroup" => {
                 let name = get_param(req, "DBClusterParameterGroupName").ok_or_else(|| missing("DBClusterParameterGroupName"))?;
+                let reset_all = get_param(req, "ResetAllParameters")
+                    .map(|v| v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false);
+                let named: Vec<String> = crate::service::parse_db_parameter_members(req)
+                    .into_iter()
+                    .map(|p| p.name)
+                    .collect();
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    if let Some(entry) = state
+                        .extras
+                        .get_mut("cluster_param_groups")
+                        .and_then(|m| m.get_mut(&name))
+                        .and_then(|e| e.as_object_mut())
+                    {
+                        for key in ["Parameters", "ParameterApplyMethods"] {
+                            if let Some(obj) = entry.get_mut(key).and_then(|p| p.as_object_mut()) {
+                                if reset_all || named.is_empty() {
+                                    obj.clear();
+                                } else {
+                                    for n in &named {
+                                        obj.remove(n);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 Ok(xml_response("ResetDBClusterParameterGroup", format!("    <DBClusterParameterGroupName>{}</DBClusterParameterGroupName>", xml_escape(&name)), &rid))
             }
             "DeleteDBClusterParameterGroup" => {
@@ -389,7 +437,52 @@ impl RdsService {
                 if let Some(m) = state.extras.get_mut("cluster_param_groups") { m.remove(&name); }
                 xml_empty_action(&action, &rid)
             }
-            "DescribeDBClusterParameterGroups" => list_extras_xml(self, &aid, "cluster_param_groups", "DBClusterParameterGroups", "DescribeDBClusterParameterGroups", cluster_pg_member_xml, &rid),
+            "DescribeDBClusterParameterGroups" => {
+                // RDS query lists wrap each element in its named member tag
+                // (`<DBClusterParameterGroup>`), not the generic `<member>`;
+                // the AWS SDK unmarshaler returns an empty list otherwise.
+                // AWS also filters by name and raises NotFound for an unknown
+                // group rather than returning everything.
+                let wanted = get_param(req, "DBClusterParameterGroupName");
+                let accounts = self.state_handle().read();
+                let groups: Vec<Value> = accounts
+                    .get(&aid)
+                    .and_then(|s| s.extras.get("cluster_param_groups"))
+                    .map(|m| m.values().cloned().collect())
+                    .unwrap_or_default();
+                if let Some(name) = &wanted {
+                    let found = groups.iter().any(|g| {
+                        g["DBClusterParameterGroupName"].as_str() == Some(name.as_str())
+                    });
+                    if !found {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "DBParameterGroupNotFound",
+                            format!("DBClusterParameterGroup not found: {name}"),
+                        ));
+                    }
+                }
+                let members = groups
+                    .iter()
+                    .filter(|g| {
+                        wanted.as_deref().is_none_or(|n| {
+                            g["DBClusterParameterGroupName"].as_str() == Some(n)
+                        })
+                    })
+                    .map(|g| {
+                        format!(
+                            "        <DBClusterParameterGroup>\n{}\n        </DBClusterParameterGroup>",
+                            cluster_pg_member_xml(g)
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Ok(xml_response(
+                    "DescribeDBClusterParameterGroups",
+                    format!("    <DBClusterParameterGroups>\n{members}\n    </DBClusterParameterGroups>"),
+                    &rid,
+                ))
+            }
             "DescribeDBClusterParameters" => {
                 let name = get_param(req, "DBClusterParameterGroupName").ok_or_else(|| missing("DBClusterParameterGroupName"))?;
                 let source_filter = get_param(req, "Source");
@@ -411,10 +504,16 @@ impl RdsService {
                     .and_then(|p| p.as_object())
                     .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string())).collect())
                     .unwrap_or_default();
+                let apply_methods: BTreeMap<String, String> = entry
+                    .and_then(|e| e.get("ParameterApplyMethods"))
+                    .and_then(|p| p.as_object())
+                    .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string())).collect())
+                    .unwrap_or_default();
                 let mut members = String::new();
                 if include_user {
                     for (n, v) in &user_params {
-                        members.push_str(&crate::service::render_user_parameter_xml(n, v));
+                        let apply_method = apply_methods.get(n).map(String::as_str).unwrap_or("immediate");
+                        members.push_str(&crate::service::render_user_parameter_xml(n, v, apply_method));
                     }
                 }
                 if include_engine_default {
@@ -1239,6 +1338,32 @@ impl RdsService {
             "DescribeDBParameters" => Ok(xml_response("DescribeDBParameters", "    <Parameters/>".to_string(), &rid)),
             "ResetDBParameterGroup" => {
                 let name = get_param(req, "DBParameterGroupName").ok_or_else(|| missing("DBParameterGroupName"))?;
+                // Resetting a parameter flips its source back from `user` to
+                // `engine-default`, so we drop it from the user-set map. With
+                // `ResetAllParameters=true` (or no explicit list) every user
+                // value is cleared; otherwise only the named parameters are.
+                let reset_all = get_param(req, "ResetAllParameters")
+                    .map(|v| v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false);
+                let named: Vec<String> = crate::service::parse_db_parameter_members(req)
+                    .into_iter()
+                    .map(|p| p.name)
+                    .collect();
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    if let Some(group) = state.parameter_groups.get_mut(&name) {
+                        if reset_all || named.is_empty() {
+                            group.parameters.clear();
+                            group.parameter_apply_methods.clear();
+                        } else {
+                            for n in &named {
+                                group.parameters.remove(n);
+                                group.parameter_apply_methods.remove(n);
+                            }
+                        }
+                    }
+                }
                 Ok(xml_response("ResetDBParameterGroup", format!("    <DBParameterGroupName>{}</DBParameterGroupName>", xml_escape(&name)), &rid))
             }
             "DescribeEngineDefaultParameters" => {

--- a/crates/fakecloud-rds/src/extras/xml_renderers.rs
+++ b/crates/fakecloud-rds/src/extras/xml_renderers.rs
@@ -274,19 +274,20 @@ pub(super) fn cluster_snapshot_member_xml(v: &Value) -> String {
     )
 }
 
-pub(super) fn cluster_pg_xml(name: &str, arn: &str, family: &str) -> String {
+pub(super) fn cluster_pg_xml(name: &str, arn: &str, family: &str, description: &str) -> String {
     format!(
-        "    <DBClusterParameterGroup>\n      <DBClusterParameterGroupName>{}</DBClusterParameterGroupName>\n      <DBClusterParameterGroupArn>{}</DBClusterParameterGroupArn>\n      <DBParameterGroupFamily>{}</DBParameterGroupFamily>\n    </DBClusterParameterGroup>",
-        xml_escape(name), xml_escape(arn), xml_escape(family),
+        "    <DBClusterParameterGroup>\n      <DBClusterParameterGroupName>{}</DBClusterParameterGroupName>\n      <DBClusterParameterGroupArn>{}</DBClusterParameterGroupArn>\n      <DBParameterGroupFamily>{}</DBParameterGroupFamily>\n      <Description>{}</Description>\n    </DBClusterParameterGroup>",
+        xml_escape(name), xml_escape(arn), xml_escape(family), xml_escape(description),
     )
 }
 
 pub(super) fn cluster_pg_member_xml(v: &Value) -> String {
     format!(
-        "          <DBClusterParameterGroupName>{}</DBClusterParameterGroupName>\n          <DBClusterParameterGroupArn>{}</DBClusterParameterGroupArn>\n          <DBParameterGroupFamily>{}</DBParameterGroupFamily>",
+        "          <DBClusterParameterGroupName>{}</DBClusterParameterGroupName>\n          <DBClusterParameterGroupArn>{}</DBClusterParameterGroupArn>\n          <DBParameterGroupFamily>{}</DBParameterGroupFamily>\n          <Description>{}</Description>",
         xml_escape(v["DBClusterParameterGroupName"].as_str().unwrap_or("")),
         xml_escape(v["DBClusterParameterGroupArn"].as_str().unwrap_or("")),
         xml_escape(v["DBParameterGroupFamily"].as_str().unwrap_or("")),
+        xml_escape(v["Description"].as_str().unwrap_or("")),
     )
 }
 

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -860,11 +860,12 @@ impl RdsService {}
 /// Render a single user-set parameter as the XML shape AWS emits inside
 /// `DescribeDB(Cluster)Parameters` responses. We don't store metadata
 /// alongside user values so we report `dynamic`/`string` defaults.
-pub(crate) fn render_user_parameter_xml(name: &str, value: &str) -> String {
+pub(crate) fn render_user_parameter_xml(name: &str, value: &str, apply_method: &str) -> String {
     format!(
-        "      <Parameter>\n        <ParameterName>{}</ParameterName>\n        <ParameterValue>{}</ParameterValue>\n        <Source>user</Source>\n        <ApplyType>dynamic</ApplyType>\n        <DataType>string</DataType>\n        <IsModifiable>true</IsModifiable>\n      </Parameter>\n",
+        "      <Parameter>\n        <ParameterName>{}</ParameterName>\n        <ParameterValue>{}</ParameterValue>\n        <Source>user</Source>\n        <ApplyType>dynamic</ApplyType>\n        <ApplyMethod>{}</ApplyMethod>\n        <DataType>string</DataType>\n        <IsModifiable>true</IsModifiable>\n      </Parameter>\n",
         xml_escape(name),
         xml_escape(value),
+        xml_escape(apply_method),
     )
 }
 
@@ -890,15 +891,24 @@ pub(crate) fn render_engine_default_parameter_xml(
 /// (the `Parameter` list location name from the Smithy model); we also
 /// accept the generic `Parameters.member.N` form so hand-built clients
 /// using the default Query list shape keep working. Skips members
-/// missing a name or value; ApplyMethod is accepted but ignored
-/// (single-state model).
-pub(crate) fn parse_db_parameter_members(request: &AwsRequest) -> Vec<(String, String)> {
+/// missing a name or value. `ApplyMethod` defaults to `immediate` (AWS's
+/// default) and is preserved so a `Describe` round-trip echoes it back —
+/// the Terraform provider sets `apply_method = "immediate"` by default and
+/// drifts if the read-back omits it.
+pub(crate) struct DbParameterInput {
+    pub name: String,
+    pub value: String,
+    pub apply_method: String,
+}
+
+pub(crate) fn parse_db_parameter_members(request: &AwsRequest) -> Vec<DbParameterInput> {
     let mut out = Vec::new();
     for prefix in ["Parameters.Parameter", "Parameters.member"] {
         let mut index = 1;
         loop {
             let name_key = format!("{prefix}.{index}.ParameterName");
             let value_key = format!("{prefix}.{index}.ParameterValue");
+            let apply_key = format!("{prefix}.{index}.ApplyMethod");
             let name = optional_query_param(request, &name_key);
             let value = optional_query_param(request, &value_key);
             if name.is_none() && value.is_none() {
@@ -906,7 +916,14 @@ pub(crate) fn parse_db_parameter_members(request: &AwsRequest) -> Vec<(String, S
             }
             if let (Some(n), Some(v)) = (name, value) {
                 if !n.is_empty() {
-                    out.push((n, v));
+                    let apply_method = optional_query_param(request, &apply_key)
+                        .filter(|m| !m.is_empty())
+                        .unwrap_or_else(|| "immediate".to_string());
+                    out.push(DbParameterInput {
+                        name: n,
+                        value: v,
+                        apply_method,
+                    });
                 }
             }
             index += 1;

--- a/crates/fakecloud-rds/src/service/parameter_groups.rs
+++ b/crates/fakecloud-rds/src/service/parameter_groups.rs
@@ -53,6 +53,7 @@ impl RdsService {
             db_parameter_group_family,
             description,
             parameters: std::collections::BTreeMap::new(),
+            parameter_apply_methods: std::collections::BTreeMap::new(),
             tags,
         };
 
@@ -238,8 +239,13 @@ impl RdsService {
             parameter_group.description = new_description;
         }
 
-        for (name, value) in parsed_params {
-            parameter_group.parameters.insert(name, value);
+        for param in parsed_params {
+            parameter_group
+                .parameters
+                .insert(param.name.clone(), param.value);
+            parameter_group
+                .parameter_apply_methods
+                .insert(param.name, param.apply_method);
         }
 
         let parameter_group_clone = parameter_group.clone();
@@ -311,7 +317,12 @@ impl RdsService {
         let mut members_xml = String::new();
         if include_user {
             for (name, value) in &parameter_group.parameters {
-                members_xml.push_str(&render_user_parameter_xml(name, value));
+                let apply_method = parameter_group
+                    .parameter_apply_methods
+                    .get(name)
+                    .map(String::as_str)
+                    .unwrap_or("immediate");
+                members_xml.push_str(&render_user_parameter_xml(name, value, apply_method));
             }
         }
         if include_engine_default {

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -413,6 +413,11 @@ pub struct DbParameterGroup {
     pub db_parameter_group_family: String,
     pub description: String,
     pub parameters: BTreeMap<String, String>,
+    /// Per-parameter `ApplyMethod` (`immediate` | `pending-reboot`),
+    /// keyed by parameter name. Defaulted for snapshots written before
+    /// this field existed; a missing entry reads back as `immediate`.
+    #[serde(default)]
+    pub parameter_apply_methods: BTreeMap<String, String>,
     pub tags: Vec<RdsTag>,
 }
 
@@ -867,6 +872,7 @@ pub fn default_parameter_groups(
             db_parameter_group_family: family.to_string(),
             description: description.to_string(),
             parameters: BTreeMap::new(),
+            parameter_apply_methods: BTreeMap::new(),
             tags: Vec::new(),
         };
         groups.insert(group_name, group);

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -548,12 +548,11 @@ pub const SERVICES: &[Service] = &[
     Service {
         name: "rds",
         // RDS control-plane resources that need no DB engine container. The DB
-        // subnet group now reports `supported_network_types = [IPV4]` and a
-        // `Complete` status. Parameter/option/cluster-parameter groups are
-        // deferred: their go-acceptance Modify-then-Describe round-trip returns
-        // empty parameters/groups even though the same calls succeed via the
-        // AWS CLI (a request-handling discrepancy still under investigation).
-        // DB instances/clusters need Docker and stay out.
+        // subnet group reports `supported_network_types = [IPV4]` and a
+        // `Complete` status. DB and cluster parameter groups now round-trip
+        // correctly and run in the `rds-param-groups` shard below. Option
+        // groups remain deferred; DB instances/clusters need Docker and stay
+        // out.
         run_regex: "^TestAccRDSSubnetGroup_basic$",
         deny: &[],
     },
@@ -1058,6 +1057,17 @@ pub const SHARDS: &[Shard] = &[
         name: "rds",
         service: "rds",
         run_regex: "^TestAccRDSSubnetGroup_basic$",
+        extra_deny: &[],
+    },
+    // DB and DB-cluster parameter groups. Both need no engine container:
+    // the create/modify/reset/describe round-trip now preserves each
+    // parameter's ApplyMethod, resets cleanly back to engine-default, and
+    // (for cluster groups) emits the named member tag + Description that
+    // the provider reads back.
+    Shard {
+        name: "rds-param-groups",
+        service: "rds",
+        run_regex: "^TestAccRDS(ParameterGroup|ClusterParameterGroup)_basic$",
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -108,6 +108,11 @@ async fn rds_acceptance() {
 }
 
 #[tokio::test]
+async fn rds_param_groups_acceptance() {
+    run_shard("rds-param-groups").await;
+}
+
+#[tokio::test]
 async fn cloudfront_acceptance() {
     run_shard("cloudfront").await;
 }


### PR DESCRIPTION
## Summary

Second batch of the RDS acceptance-tree expansion. Un-defers RDS **parameter groups**, which were explicitly held out of tfacc with a note about a "Modify-then-Describe round-trip [that] returns empty parameters/groups." This roots out that discrepancy and the related ones the upstream suite surfaces.

New `rds-param-groups` shard running `_basic` for:
- `TestAccRDSParameterGroup`
- `TestAccRDSClusterParameterGroup`

Fidelity fixes:

- **ApplyMethod round-trip.** DB and cluster parameters now preserve and return each parameter's `ApplyMethod` (`immediate` / `pending-reboot`). The Terraform provider defaults `apply_method = "immediate"` and produced a perpetual plan diff because `DescribeDB(Cluster)Parameters` omitted the field. Stored per-parameter via a backward-compatible `#[serde(default)]` map (DB groups) and a sibling JSON map (cluster groups).
- **Reset actually resets.** `ResetDBParameterGroup` / `ResetDBClusterParameterGroup` were no-ops. They now drop the named parameters — or all of them with `ResetAllParameters=true` — from the user-set map, so a parameter removed from config flips its source back to `engine-default`. Previously the "parameter no longer user defined" check failed after a parameter was removed.
- **Cluster describe wire shape.** `DescribeDBClusterParameterGroups` wrapped elements in the generic `<member>` tag, which made the AWS SDK unmarshal an empty list ("empty result" on read). It now uses the named `<DBClusterParameterGroup>` member tag (matching the working DB-subnet/DB-parameter-group paths), honors the `DBClusterParameterGroupName` filter, returns `DBParameterGroupNotFound` for an unknown group, and includes `<Description>`.

The stale deferral comment on the `rds` Service entry is updated to reflect that parameter groups are now wired (option groups remain deferred; DB instances/clusters still need Docker).

## Test plan

- Both families pass locally against a fresh fakecloud server, and end-to-end through the harness shard (`cargo test -p fakecloud-tfacc --test acc rds_param_groups_acceptance` — 1 passed, 127s):
  - `TestAccRDSParameterGroup_basic` PASS (was: perpetual diff, then reset check)
  - `TestAccRDSClusterParameterGroup_basic` PASS (was: empty-result on read)
- `cargo test -p fakecloud-rds` — 222 passed
- `cargo clippy -p fakecloud-rds -p fakecloud-tfacc --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface check

- No new public API / introspection endpoint — these are existing RDS query-protocol response fields, so no first-party SDK change.
- `DbParameterGroup` gained a `#[serde(default)]` `parameter_apply_methods` map; cluster groups store apply methods in a sibling JSON key — both back-compatible with older persisted snapshots. CFN provisioner ctor updated for the new field.
- tfacc service list in `docs/about/conformance.md` unchanged: `rds` already listed; this deepens resource coverage within it.

## Follow-on batches

RDS option groups (separate failure), event subscriptions and global clusters (provider panic on read — need their own investigation), then the Lambda tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables RDS DB and cluster parameter groups in `fakecloud-tfacc` and fixes the Modify/Describe round-trip so Terraform no longer drifts. ApplyMethod now round-trips, resets work, and cluster group listing matches AWS.

- **New Features**
  - Add `rds-param-groups` shard to run `TestAccRDSParameterGroup_basic` and `TestAccRDSClusterParameterGroup_basic`.

- **Bug Fixes**
  - Preserve `ApplyMethod` for DB and cluster parameters; `DescribeDB(Cluster)Parameters` now includes it.
  - Make `ResetDB(Cluster)ParameterGroup` clear named or all parameters (and apply methods) to restore `engine-default`.
  - Fix `DescribeDBClusterParameterGroups` to use the `<DBClusterParameterGroup>` member tag, honor name filtering, include `<Description>`, and return `DBParameterGroupNotFound` for unknown groups.

<sup>Written for commit 300f7882bc5f893b0460d769cf8592e6546a3913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

