### PR TITLE
test(tfacc): wire RDS option groups + fix DescribeOptionGroups read shape

### DIFF
--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -850,7 +850,7 @@ impl RdsService {
                 let name = get_param(req, "OptionGroupName").or_else(|| get_param(req, "TargetOptionGroupIdentifier"))
                     .ok_or_else(|| missing("OptionGroupName"))?;
                 let arn = Arn::new("rds", region, &aid, &format!("og:{name}")).to_string();
-                let entry = json!({"OptionGroupName": name, "OptionGroupArn": arn, "EngineName": get_param(req, "EngineName").unwrap_or_else(|| "mysql".to_string()), "MajorEngineVersion": get_param(req, "MajorEngineVersion").unwrap_or_else(|| "8.0".to_string())});
+                let entry = json!({"OptionGroupName": name, "OptionGroupArn": arn, "EngineName": get_param(req, "EngineName").unwrap_or_else(|| "mysql".to_string()), "MajorEngineVersion": get_param(req, "MajorEngineVersion").unwrap_or_else(|| "8.0".to_string()), "OptionGroupDescription": get_param(req, "OptionGroupDescription").unwrap_or_default()});
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
                 store(&mut state.extras, "option_groups").insert(name.clone(), entry.clone());
@@ -891,7 +891,51 @@ impl RdsService {
                 if let Some(m) = state.extras.get_mut("option_groups") { m.remove(&name); }
                 xml_empty_action(&action, &rid)
             }
-            "DescribeOptionGroups" => list_extras_xml(self, &aid, "option_groups", "OptionGroupsList", "DescribeOptionGroups", option_group_xml, &rid),
+            "DescribeOptionGroups" => {
+                // RDS wraps each list element in its named member tag
+                // (`<OptionGroup>`), not the generic `<member>`; the SDK
+                // unmarshals an empty list otherwise. AWS also filters by name
+                // and raises OptionGroupNotFoundFault for an unknown group.
+                let wanted = get_param(req, "OptionGroupName");
+                let accounts = self.state_handle().read();
+                let groups: Vec<Value> = accounts
+                    .get(&aid)
+                    .and_then(|s| s.extras.get("option_groups"))
+                    .map(|m| m.values().cloned().collect())
+                    .unwrap_or_default();
+                if let Some(name) = &wanted {
+                    let found = groups
+                        .iter()
+                        .any(|g| g["OptionGroupName"].as_str() == Some(name.as_str()));
+                    if !found {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "OptionGroupNotFoundFault",
+                            format!("Specified OptionGroup: {name} not found."),
+                        ));
+                    }
+                }
+                let members = groups
+                    .iter()
+                    .filter(|g| {
+                        wanted
+                            .as_deref()
+                            .is_none_or(|n| g["OptionGroupName"].as_str() == Some(n))
+                    })
+                    .map(|g| {
+                        format!(
+                            "        <OptionGroup>\n{}\n        </OptionGroup>",
+                            option_group_xml(g)
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Ok(xml_response(
+                    "DescribeOptionGroups",
+                    format!("    <OptionGroupsList>\n{members}\n    </OptionGroupsList>"),
+                    &rid,
+                ))
+            }
             "DescribeOptionGroupOptions" => Ok(xml_response("DescribeOptionGroupOptions", "    <OptionGroupOptions/>".to_string(), &rid)),
 
             // ── Event subscriptions ──

--- a/crates/fakecloud-rds/src/extras/xml_renderers.rs
+++ b/crates/fakecloud-rds/src/extras/xml_renderers.rs
@@ -323,11 +323,12 @@ pub(super) fn security_group_xml(v: &Value) -> String {
 
 pub(super) fn option_group_xml(v: &Value) -> String {
     format!(
-        "          <OptionGroupName>{}</OptionGroupName>\n          <OptionGroupArn>{}</OptionGroupArn>\n          <EngineName>{}</EngineName>\n          <MajorEngineVersion>{}</MajorEngineVersion>",
+        "          <OptionGroupName>{}</OptionGroupName>\n          <OptionGroupArn>{}</OptionGroupArn>\n          <EngineName>{}</EngineName>\n          <MajorEngineVersion>{}</MajorEngineVersion>\n          <OptionGroupDescription>{}</OptionGroupDescription>\n          <AllowsVpcAndNonVpcInstanceMemberships>true</AllowsVpcAndNonVpcInstanceMemberships>\n          <Options/>",
         xml_escape(v["OptionGroupName"].as_str().unwrap_or("")),
         xml_escape(v["OptionGroupArn"].as_str().unwrap_or("")),
         xml_escape(v["EngineName"].as_str().unwrap_or("")),
         xml_escape(v["MajorEngineVersion"].as_str().unwrap_or("")),
+        xml_escape(v["OptionGroupDescription"].as_str().unwrap_or("")),
     )
 }
 

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -549,10 +549,10 @@ pub const SERVICES: &[Service] = &[
         name: "rds",
         // RDS control-plane resources that need no DB engine container. The DB
         // subnet group reports `supported_network_types = [IPV4]` and a
-        // `Complete` status. DB and cluster parameter groups now round-trip
-        // correctly and run in the `rds-param-groups` shard below. Option
-        // groups remain deferred; DB instances/clusters need Docker and stay
-        // out.
+        // `Complete` status. DB/cluster parameter groups and option groups now
+        // round-trip correctly and run in the `rds-param-groups` /
+        // `rds-option-groups` shards below. DB instances/clusters need Docker
+        // and stay out.
         run_regex: "^TestAccRDSSubnetGroup_basic$",
         deny: &[],
     },
@@ -1068,6 +1068,15 @@ pub const SHARDS: &[Shard] = &[
         name: "rds-param-groups",
         service: "rds",
         run_regex: "^TestAccRDS(ParameterGroup|ClusterParameterGroup)_basic$",
+        extra_deny: &[],
+    },
+    // DB option groups. DescribeOptionGroups now emits the named
+    // <OptionGroup> member tag (not <member>) so the SDK reads it back, plus
+    // the OptionGroupDescription/VPC-membership fields the provider asserts.
+    Shard {
+        name: "rds-option-groups",
+        service: "rds",
+        run_regex: "^TestAccRDSOptionGroup_basic$",
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -113,6 +113,11 @@ async fn rds_param_groups_acceptance() {
 }
 
 #[tokio::test]
+async fn rds_option_groups_acceptance() {
+    run_shard("rds-option-groups").await;
+}
+
+#[tokio::test]
 async fn cloudfront_acceptance() {
     run_shard("cloudfront").await;
 }


### PR DESCRIPTION
## Summary

Third batch of the RDS acceptance-tree expansion. Un-defers RDS **option groups** (the last of the param/option/cluster-param trio that was held out of tfacc).

New `rds-option-groups` shard running `TestAccRDSOptionGroup_basic`.

Fidelity fix: `DescribeOptionGroups` wrapped each list element in the generic `<member>` tag, so the AWS SDK unmarshaled an empty list and the provider failed apply with `reading RDS DB Option Group (...): empty result`. It now:
- uses the named `<OptionGroup>` member tag (matching the working DB-subnet / DB-parameter-group paths),
- honors the `OptionGroupName` filter and raises `OptionGroupNotFoundFault` for an unknown group,
- renders `OptionGroupDescription`, `AllowsVpcAndNonVpcInstanceMemberships`, and an empty `<Options/>` list that the provider reads back, and
- `CreateOptionGroup` persists the supplied `OptionGroupDescription`.

This is the same wire-shape class fixed for cluster parameter groups in the previous batch.

## Test plan

- `TestAccRDSOptionGroup_basic` PASS (was: "empty result" on read), locally and end-to-end through the harness shard (`cargo test -p fakecloud-tfacc --test acc rds_option_groups_acceptance` — 1 passed, 116s).
- `cargo test -p fakecloud-rds` — 222 passed.
- `cargo clippy -p fakecloud-rds -p fakecloud-tfacc --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface check

- No new public API / introspection surface — existing RDS query-protocol response fields; no first-party SDK change.
- No struct/persistence change (option groups stored in the existing JSON extras map).
- tfacc service list in `docs/about/conformance.md` unchanged: `rds` already listed; this deepens coverage within it.

## Follow-on

RDS event subscriptions and global clusters both panic the provider on read (a missing response field nil-derefs) and need field-level investigation; then the Lambda tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired RDS option groups into `fakecloud-tfacc` and fixed the `DescribeOptionGroups` response so Terraform reads option groups correctly.

- **New Features**
  - Added `rds-option-groups` shard running `TestAccRDSOptionGroup_basic`.
  - `CreateOptionGroup` now persists `OptionGroupDescription`.

- **Bug Fixes**
  - `DescribeOptionGroups` now emits `<OptionGroup>` members (not `<member>`), honors the `OptionGroupName` filter, and returns `OptionGroupNotFoundFault` for unknown groups.
  - Response now includes `OptionGroupDescription`, `AllowsVpcAndNonVpcInstanceMemberships`, and an empty `<Options/>` list.

<sup>Written for commit 4d093f2e7c378267a2168ee7d335e41272d0a6bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

