### PR TITLE
test(tfacc): wire RDS event subscriptions + global clusters; fix read panics

### DIFF
--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -941,11 +941,12 @@ impl RdsService {
             // ── Event subscriptions ──
             "CreateEventSubscription" => {
                 let name = get_param(req, "SubscriptionName").ok_or_else(|| missing("SubscriptionName"))?;
-                let entry = json!({"CustSubscriptionId": name, "SnsTopicArn": get_param(req, "SnsTopicArn").unwrap_or_default(), "Status": "active", "Enabled": true});
+                let arn = Arn::new("rds", region, &aid, &format!("es:{name}")).to_string();
+                let entry = json!({"CustSubscriptionId": name, "CustomerAwsId": aid, "EventSubscriptionArn": arn, "SnsTopicArn": get_param(req, "SnsTopicArn").unwrap_or_default(), "SourceType": get_param(req, "SourceType").unwrap_or_default(), "Status": "active", "Enabled": true});
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
                 store(&mut state.extras, "event_subscriptions").insert(name.clone(), entry.clone());
-                Ok(xml_response("CreateEventSubscription", event_sub_xml(&entry), &rid))
+                Ok(xml_response("CreateEventSubscription", format!("    <EventSubscription>\n{}\n    </EventSubscription>", event_sub_xml(&entry)), &rid))
             }
             "ModifyEventSubscription" => {
                 let name = get_param(req, "SubscriptionName").ok_or_else(|| missing("SubscriptionName"))?;
@@ -983,18 +984,33 @@ impl RdsService {
                 if let Some(m) = state.extras.get_mut("event_subscriptions") { m.remove(&name); }
                 Ok(xml_response("DeleteEventSubscription", "    <EventSubscription/>".to_string(), &rid))
             }
-            "DescribeEventSubscriptions" => list_extras_xml(self, &aid, "event_subscriptions", "EventSubscriptionsList", "DescribeEventSubscriptions", event_sub_xml, &rid),
+            "DescribeEventSubscriptions" => {
+                let wanted = get_param(req, "SubscriptionName");
+                list_extras_named_xml(self, &aid, "event_subscriptions", "EventSubscriptionsList", "EventSubscription", "DescribeEventSubscriptions", event_sub_xml, wanted.as_deref(), "CustSubscriptionId", "SubscriptionNotFound", &rid)
+            }
             "AddSourceIdentifierToSubscription" | "RemoveSourceIdentifierFromSubscription" => Ok(xml_response(action.as_str(), "    <EventSubscription/>".to_string(), &rid)),
 
             // ── Global clusters ──
             "CreateGlobalCluster" => {
                 let id = get_param(req, "GlobalClusterIdentifier").ok_or_else(|| missing("GlobalClusterIdentifier"))?;
                 let arn = Arn::global("rds", &aid, &format!("global-cluster:{id}")).to_string();
-                let entry = json!({"GlobalClusterIdentifier": id, "GlobalClusterArn": arn, "Status": "available"});
+                let entry = json!({
+                    "GlobalClusterIdentifier": id,
+                    "GlobalClusterArn": arn,
+                    "GlobalClusterResourceId": new_cluster_resource_id(),
+                    "Endpoint": format!("{id}.global.{region}.rds.amazonaws.com"),
+                    "Status": "available",
+                    "Engine": get_param(req, "Engine").unwrap_or_else(|| "aurora-postgresql".to_string()),
+                    "EngineVersion": get_param(req, "EngineVersion").unwrap_or_else(|| "16.4".to_string()),
+                    "EngineLifecycleSupport": get_param(req, "EngineLifecycleSupport").unwrap_or_else(|| "open-source-rds-extended-support".to_string()),
+                    "DatabaseName": get_param(req, "DatabaseName").unwrap_or_default(),
+                    "DeletionProtection": get_param(req, "DeletionProtection").map(|v| v.eq_ignore_ascii_case("true")).unwrap_or(false),
+                    "StorageEncrypted": get_param(req, "StorageEncrypted").map(|v| v.eq_ignore_ascii_case("true")).unwrap_or(false),
+                });
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
                 store(&mut state.extras, "global_clusters").insert(id.clone(), entry.clone());
-                Ok(xml_response("CreateGlobalCluster", global_cluster_xml(&entry), &rid))
+                Ok(xml_response("CreateGlobalCluster", format!("    <GlobalCluster>\n{}\n    </GlobalCluster>", global_cluster_xml(&entry)), &rid))
             }
             "ModifyGlobalCluster" | "FailoverGlobalCluster" | "SwitchoverGlobalCluster" | "RemoveFromGlobalCluster" => Ok(xml_response(action.as_str(), "    <GlobalCluster/>".to_string(), &rid)),
             "DeleteGlobalCluster" => {
@@ -1004,7 +1020,13 @@ impl RdsService {
                 if let Some(m) = state.extras.get_mut("global_clusters") { m.remove(&id); }
                 Ok(xml_response("DeleteGlobalCluster", "    <GlobalCluster/>".to_string(), &rid))
             }
-            "DescribeGlobalClusters" => list_extras_xml(self, &aid, "global_clusters", "GlobalClusters", "DescribeGlobalClusters", global_cluster_xml, &rid),
+            "DescribeGlobalClusters" => {
+                let wanted = get_param(req, "GlobalClusterIdentifier");
+                // RDS names this list's member `<GlobalClusterMember>`, not the
+                // usual singular-of-wrapper (`<GlobalCluster>`); the SDK
+                // unmarshals an empty list with any other tag.
+                list_extras_named_xml(self, &aid, "global_clusters", "GlobalClusters", "GlobalClusterMember", "DescribeGlobalClusters", global_cluster_xml, wanted.as_deref(), "GlobalClusterIdentifier", "GlobalClusterNotFoundFault", &rid)
+            }
 
             // ── Integrations ──
             "CreateIntegration" => {

--- a/crates/fakecloud-rds/src/extras/parse.rs
+++ b/crates/fakecloud-rds/src/extras/parse.rs
@@ -170,3 +170,56 @@ pub(super) fn list_extras_xml(
     );
     Ok(xml_response(action, inner, rid))
 }
+
+/// Like [`list_extras_xml`] but wraps each element in the list's *named*
+/// member tag (e.g. `<GlobalCluster>`) instead of the generic `<member>`.
+/// RDS query-protocol Describe lists use the named member tag, and the AWS
+/// SDK unmarshals an empty list when it sees `<member>` — which makes the
+/// Terraform provider nil-deref on read. Also filters by a single id field
+/// and raises `not_found_code` when a requested id is absent, matching AWS.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn list_extras_named_xml(
+    svc: &RdsService,
+    aid: &str,
+    category: &str,
+    wrapper: &str,
+    member_tag: &str,
+    action: &str,
+    render: impl Fn(&Value) -> String,
+    wanted: Option<&str>,
+    id_field: &str,
+    not_found_code: &str,
+    rid: &str,
+) -> Result<AwsResponse, AwsServiceError> {
+    let accounts = svc.state_handle().read();
+    let items: Vec<Value> = accounts
+        .get(aid)
+        .and_then(|s| s.extras.get(category))
+        .map(|m| m.values().cloned().collect())
+        .unwrap_or_default();
+    if let Some(w) = wanted {
+        if !items.iter().any(|v| v[id_field].as_str() == Some(w)) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                not_found_code,
+                format!("{w} not found."),
+            ));
+        }
+    }
+    let body = items
+        .iter()
+        .filter(|v| wanted.is_none_or(|w| v[id_field].as_str() == Some(w)))
+        .map(|v| {
+            format!(
+                "        <{member_tag}>\n{}\n        </{member_tag}>",
+                render(v)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(xml_response(
+        action,
+        format!("    <{wrapper}>\n{body}\n    </{wrapper}>"),
+        rid,
+    ))
+}

--- a/crates/fakecloud-rds/src/extras/xml_renderers.rs
+++ b/crates/fakecloud-rds/src/extras/xml_renderers.rs
@@ -334,9 +334,12 @@ pub(super) fn option_group_xml(v: &Value) -> String {
 
 pub(super) fn event_sub_xml(v: &Value) -> String {
     format!(
-        "          <CustSubscriptionId>{}</CustSubscriptionId>\n          <SnsTopicArn>{}</SnsTopicArn>\n          <Status>{}</Status>\n          <Enabled>{}</Enabled>",
+        "          <CustSubscriptionId>{}</CustSubscriptionId>\n          <CustomerAwsId>{}</CustomerAwsId>\n          <EventSubscriptionArn>{}</EventSubscriptionArn>\n          <SnsTopicArn>{}</SnsTopicArn>\n          <SourceType>{}</SourceType>\n          <Status>{}</Status>\n          <Enabled>{}</Enabled>\n          <EventCategoriesList/>\n          <SourceIdsList/>",
         xml_escape(v["CustSubscriptionId"].as_str().unwrap_or("")),
+        xml_escape(v["CustomerAwsId"].as_str().unwrap_or("")),
+        xml_escape(v["EventSubscriptionArn"].as_str().unwrap_or("")),
         xml_escape(v["SnsTopicArn"].as_str().unwrap_or("")),
+        xml_escape(v["SourceType"].as_str().unwrap_or("")),
         xml_escape(v["Status"].as_str().unwrap_or("active")),
         v["Enabled"].as_bool().unwrap_or(true),
     )
@@ -344,10 +347,18 @@ pub(super) fn event_sub_xml(v: &Value) -> String {
 
 pub(super) fn global_cluster_xml(v: &Value) -> String {
     format!(
-        "          <GlobalClusterIdentifier>{}</GlobalClusterIdentifier>\n          <GlobalClusterArn>{}</GlobalClusterArn>\n          <Status>{}</Status>",
+        "          <GlobalClusterIdentifier>{}</GlobalClusterIdentifier>\n          <GlobalClusterArn>{}</GlobalClusterArn>\n          <GlobalClusterResourceId>{}</GlobalClusterResourceId>\n          <Endpoint>{}</Endpoint>\n          <Status>{}</Status>\n          <Engine>{}</Engine>\n          <EngineVersion>{}</EngineVersion>\n          <EngineLifecycleSupport>{}</EngineLifecycleSupport>\n          <DatabaseName>{}</DatabaseName>\n          <DeletionProtection>{}</DeletionProtection>\n          <StorageEncrypted>{}</StorageEncrypted>",
         xml_escape(v["GlobalClusterIdentifier"].as_str().unwrap_or("")),
         xml_escape(v["GlobalClusterArn"].as_str().unwrap_or("")),
+        xml_escape(v["GlobalClusterResourceId"].as_str().unwrap_or("")),
+        xml_escape(v["Endpoint"].as_str().unwrap_or("")),
         xml_escape(v["Status"].as_str().unwrap_or("available")),
+        xml_escape(v["Engine"].as_str().unwrap_or("aurora-postgresql")),
+        xml_escape(v["EngineVersion"].as_str().unwrap_or("")),
+        xml_escape(v["EngineLifecycleSupport"].as_str().unwrap_or("open-source-rds-extended-support")),
+        xml_escape(v["DatabaseName"].as_str().unwrap_or("")),
+        v["DeletionProtection"].as_bool().unwrap_or(false),
+        v["StorageEncrypted"].as_bool().unwrap_or(false),
     )
 }
 

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -1079,6 +1079,16 @@ pub const SHARDS: &[Shard] = &[
         run_regex: "^TestAccRDSOptionGroup_basic$",
         extra_deny: &[],
     },
+    // Event subscriptions and global clusters. Both Describe lists now use
+    // their named member tags (<EventSubscription> / <GlobalClusterMember>)
+    // and the Create responses wrap the resource element, so the provider
+    // no longer nil-derefs reading them back.
+    Shard {
+        name: "rds-event-global",
+        service: "rds",
+        run_regex: "^TestAccRDS(EventSubscription|GlobalCluster)_basic$",
+        extra_deny: &[],
+    },
     Shard {
         name: "elasticache",
         service: "elasticache",

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -118,6 +118,11 @@ async fn rds_option_groups_acceptance() {
 }
 
 #[tokio::test]
+async fn rds_event_global_acceptance() {
+    run_shard("rds-event-global").await;
+}
+
+#[tokio::test]
 async fn cloudfront_acceptance() {
     run_shard("cloudfront").await;
 }


### PR DESCRIPTION
## Summary

Fourth batch of the RDS acceptance-tree expansion. Wires RDS **event subscriptions** and **global clusters**, both of which previously **panicked the Terraform provider on read** (nil pointer dereference).

New `rds-event-global` shard running `TestAccRDSEventSubscription_basic` and `TestAccRDSGlobalCluster_basic`.

Two root causes (both in the RDS query-protocol response shape):

1. **Describe list member tag.** `DescribeEventSubscriptions` / `DescribeGlobalClusters` wrapped each element in the generic `<member>` tag, so the AWS SDK unmarshaled an empty list and the provider nil-derefed. Added a reusable `list_extras_named_xml` helper that wraps each element in the list's *named* member tag, filters by id, and raises the resource's NotFound fault. Event subscriptions use `<EventSubscription>`; global clusters use `<GlobalClusterMember>` (an RDS quirk — not the singular of the `<GlobalClusters>` wrapper, confirmed against the AWS SDK Go deserializer).

2. **Create response wrapper.** `CreateEventSubscription` / `CreateGlobalCluster` returned the resource's fields without the wrapping `<EventSubscription>` / `<GlobalCluster>` element, so `output.EventSubscription` / `output.GlobalCluster` was nil and the provider panicked at `d.SetId(...)`. Both Create responses now wrap the element.

Plus the response fields the provider reads back:
- **Event subscription:** `CustomerAwsId`, `EventSubscriptionArn`, `SourceType`, empty `EventCategoriesList` / `SourceIdsList`.
- **Global cluster:** `Engine`, `EngineVersion`, `EngineLifecycleSupport`, `DatabaseName`, `DeletionProtection`, `StorageEncrypted`, `GlobalClusterResourceId`, `Endpoint`.

## Test plan

- Both families pass locally and end-to-end through the harness shard (`cargo test -p fakecloud-tfacc --test acc rds_event_global_acceptance` — 1 passed, 177s):
  - `TestAccRDSEventSubscription_basic` PASS (was: provider panic)
  - `TestAccRDSGlobalCluster_basic` PASS (was: provider panic, then resource-id/endpoint asserts)
- `cargo test -p fakecloud-rds` — 222 passed.
- `cargo clippy -p fakecloud-rds -p fakecloud-tfacc --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface check

- No new public API / introspection surface — existing RDS response fields; no first-party SDK change.
- No struct/persistence change (both stored in the existing JSON extras maps).
- `list_extras_named_xml` is reusable for the remaining RDS extras lists (snapshots, proxies, endpoints, integrations, etc.), which share the same latent `<member>` shape and can migrate as they're wired.
- tfacc service list in `docs/about/conformance.md` unchanged: `rds` already listed.

## Follow-on

Remaining RDS extras lists share the `<member>` shape (latent until wired); then the Lambda tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RDS event subscriptions and global clusters to `fakecloud-rds`/`fakecloud-tfacc`, fixing Terraform read panics by matching AWS XML response shapes and returning required fields.

- **Bug Fixes**
  - Describe lists now use named member tags (`<EventSubscription>`, `<GlobalClusterMember>`). Introduces `list_extras_named_xml` to render named members, filter by id, and raise NotFound faults.
  - Create responses wrap the resource element (`<EventSubscription>`, `<GlobalCluster>`) to avoid nil outputs.
  - Populates fields read by the provider:
    - Event subscription: `CustomerAwsId`, `EventSubscriptionArn`, `SourceType`, empty `EventCategoriesList`/`SourceIdsList`.
    - Global cluster: `Engine`, `EngineVersion`, `EngineLifecycleSupport`, `DatabaseName`, `DeletionProtection`, `StorageEncrypted`, `GlobalClusterResourceId`, `Endpoint`.

- **Tests**
  - Adds `rds-event-global` shard to `fakecloud-tfacc` running `TestAccRDSEventSubscription_basic` and `TestAccRDSGlobalCluster_basic`.

<sup>Written for commit cea4300491ea497009b658ed4a0a09ced0bfe194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

