### PR TITLE
fix(rds): round-trip option-group Options, event-sub source ids, global-cluster/integration/proxy-target modifies

### DIFF
--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -793,7 +793,21 @@ impl RdsService {
                 }
                 Ok(xml_response("DescribeDBProxyTargetGroups", format!("    <TargetGroups>\n{members}    </TargetGroups>"), &rid))
             }
-            "DescribeDBProxyTargets" => Ok(xml_response("DescribeDBProxyTargets", "    <Targets/>".to_string(), &rid)),
+            "DescribeDBProxyTargets" => {
+                let proxy = get_param(req, "DBProxyName").ok_or_else(|| missing("DBProxyName"))?;
+                let group = get_param(req, "TargetGroupName").unwrap_or_else(|| "default".to_string());
+                let key = format!("{proxy}/{group}");
+                let accounts = self.state_handle().read();
+                let targets: Vec<Value> = accounts
+                    .get(&aid)
+                    .and_then(|s| s.extras.get("proxy_targets"))
+                    .and_then(|m| m.get(&key))
+                    .and_then(|v| v.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                let members: String = targets.iter().map(db_proxy_target_xml).collect();
+                Ok(xml_response("DescribeDBProxyTargets", format!("    <Targets>{members}</Targets>"), &rid))
+            }
             "ModifyDBProxyTargetGroup" => {
                 let proxy = get_param(req, "DBProxyName").ok_or_else(|| missing("DBProxyName"))?;
                 let group = get_param(req, "TargetGroupName").unwrap_or_else(|| "default".to_string());
@@ -824,8 +838,62 @@ impl RdsService {
                 store(&mut state.extras, "proxy_target_groups").insert(key, entry.clone());
                 Ok(xml_response("ModifyDBProxyTargetGroup", format!("    <DBProxyTargetGroup>\n      <DBProxyName>{}</DBProxyName>\n      <TargetGroupName>{}</TargetGroupName>\n    </DBProxyTargetGroup>", xml_escape(&proxy), xml_escape(&group)), &rid))
             }
-            "RegisterDBProxyTargets" => Ok(xml_response("RegisterDBProxyTargets", "    <DBProxyTargets/>".to_string(), &rid)),
-            "DeregisterDBProxyTargets" => xml_empty_action(&action, &rid),
+            "RegisterDBProxyTargets" => {
+                let proxy = get_param(req, "DBProxyName").ok_or_else(|| missing("DBProxyName"))?;
+                let group = get_param(req, "TargetGroupName").unwrap_or_else(|| "default".to_string());
+                let key = format!("{proxy}/{group}");
+                let instances = parse_member_list(req, "DBInstanceIdentifiers");
+                let clusters = parse_member_list(req, "DBClusterIdentifiers");
+                let new_targets: Vec<Value> = instances
+                    .iter()
+                    .map(|id| json!({"RdsResourceId": id, "Type": "RDS_INSTANCE", "Port": 3306, "Endpoint": format!("{id}.{region}.rds.amazonaws.com")}))
+                    .chain(clusters.iter().map(|id| {
+                        json!({"RdsResourceId": id, "Type": "TRACKED_CLUSTER", "Port": 3306, "Endpoint": format!("{id}.cluster-{region}.rds.amazonaws.com")})
+                    }))
+                    .collect();
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let map = store(&mut state.extras, "proxy_targets");
+                    let existing = map.entry(key).or_insert_with(|| json!([]));
+                    if let Some(arr) = existing.as_array_mut() {
+                        for t in &new_targets {
+                            let rid_val = t["RdsResourceId"].as_str();
+                            arr.retain(|e| e["RdsResourceId"].as_str() != rid_val);
+                            arr.push(t.clone());
+                        }
+                    }
+                }
+                let members: String = new_targets.iter().map(db_proxy_target_xml).collect();
+                Ok(xml_response("RegisterDBProxyTargets", format!("    <DBProxyTargets>{members}</DBProxyTargets>"), &rid))
+            }
+            "DeregisterDBProxyTargets" => {
+                let proxy = get_param(req, "DBProxyName").ok_or_else(|| missing("DBProxyName"))?;
+                let group = get_param(req, "TargetGroupName").unwrap_or_else(|| "default".to_string());
+                let key = format!("{proxy}/{group}");
+                let remove: Vec<String> = parse_member_list(req, "DBInstanceIdentifiers")
+                    .into_iter()
+                    .chain(parse_member_list(req, "DBClusterIdentifiers"))
+                    .collect();
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    if let Some(arr) = state
+                        .extras
+                        .get_mut("proxy_targets")
+                        .and_then(|m| m.get_mut(&key))
+                        .and_then(|v| v.as_array_mut())
+                    {
+                        arr.retain(|e| {
+                            e["RdsResourceId"]
+                                .as_str()
+                                .map(|r| !remove.iter().any(|x| x == r))
+                                .unwrap_or(true)
+                        });
+                    }
+                }
+                xml_empty_action(&action, &rid)
+            }
 
             // ── Security groups (legacy) ──
             "CreateDBSecurityGroup" | "AuthorizeDBSecurityGroupIngress" | "RevokeDBSecurityGroupIngress" => {
@@ -874,12 +942,28 @@ impl RdsService {
                         )
                     })?;
                 if let Some(obj) = entry.as_object_mut() {
-                    if !to_include.is_empty() {
-                        obj.insert("OptionsToInclude".to_string(), json!(to_include));
+                    // Maintain the effective Options list so DescribeOptionGroups
+                    // reflects what was added/removed: upsert each included option
+                    // by OptionName, then drop any names in OptionsToRemove.
+                    let mut options = obj
+                        .get("Options")
+                        .and_then(|o| o.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    for inc in &to_include {
+                        let name = inc["OptionName"].as_str().unwrap_or_default().to_string();
+                        options.retain(|o| o["OptionName"].as_str() != Some(name.as_str()));
+                        options.push(inc.clone());
                     }
                     if !to_remove.is_empty() {
-                        obj.insert("OptionsToRemove".to_string(), json!(to_remove));
+                        options.retain(|o| {
+                            o["OptionName"]
+                                .as_str()
+                                .map(|n| !to_remove.iter().any(|r| r == n))
+                                .unwrap_or(true)
+                        });
                     }
+                    obj.insert("Options".to_string(), json!(options));
                 }
                 let updated = entry.clone();
                 Ok(xml_response("ModifyOptionGroup", format!("    <OptionGroup>\n{}\n    </OptionGroup>", option_group_xml(&updated)), &rid))
@@ -942,7 +1026,9 @@ impl RdsService {
             "CreateEventSubscription" => {
                 let name = get_param(req, "SubscriptionName").ok_or_else(|| missing("SubscriptionName"))?;
                 let arn = Arn::new("rds", region, &aid, &format!("es:{name}")).to_string();
-                let entry = json!({"CustSubscriptionId": name, "CustomerAwsId": aid, "EventSubscriptionArn": arn, "SnsTopicArn": get_param(req, "SnsTopicArn").unwrap_or_default(), "SourceType": get_param(req, "SourceType").unwrap_or_default(), "Status": "active", "Enabled": true});
+                let source_ids = parse_member_list(req, "SourceIds");
+                let event_categories = parse_member_list(req, "EventCategories");
+                let entry = json!({"CustSubscriptionId": name, "CustomerAwsId": aid, "EventSubscriptionArn": arn, "SnsTopicArn": get_param(req, "SnsTopicArn").unwrap_or_default(), "SourceType": get_param(req, "SourceType").unwrap_or_default(), "Status": "active", "Enabled": true, "SourceIdsList": source_ids, "EventCategoriesList": event_categories});
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
                 store(&mut state.extras, "event_subscriptions").insert(name.clone(), entry.clone());
@@ -988,7 +1074,37 @@ impl RdsService {
                 let wanted = get_param(req, "SubscriptionName");
                 list_extras_named_xml(self, &aid, "event_subscriptions", "EventSubscriptionsList", "EventSubscription", "DescribeEventSubscriptions", event_sub_xml, wanted.as_deref(), "CustSubscriptionId", "SubscriptionNotFound", &rid)
             }
-            "AddSourceIdentifierToSubscription" | "RemoveSourceIdentifierFromSubscription" => Ok(xml_response(action.as_str(), "    <EventSubscription/>".to_string(), &rid)),
+            "AddSourceIdentifierToSubscription" | "RemoveSourceIdentifierFromSubscription" => {
+                let name = get_param(req, "SubscriptionName").ok_or_else(|| missing("SubscriptionName"))?;
+                let source_id = get_param(req, "SourceIdentifier");
+                let adding = action.as_str() == "AddSourceIdentifierToSubscription";
+                let mut accounts = write_state!();
+                let state = accounts.get_or_create(&aid);
+                let entry = state
+                    .extras
+                    .get_mut("event_subscriptions")
+                    .and_then(|m| m.get_mut(&name))
+                    .ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "SubscriptionNotFound",
+                            format!("Subscription {name} not found."),
+                        )
+                    })?;
+                if let (Some(obj), Some(sid)) = (entry.as_object_mut(), source_id) {
+                    let list = obj
+                        .entry("SourceIdsList".to_string())
+                        .or_insert_with(|| json!([]));
+                    if let Some(arr) = list.as_array_mut() {
+                        arr.retain(|v| v.as_str() != Some(sid.as_str()));
+                        if adding {
+                            arr.push(json!(sid));
+                        }
+                    }
+                }
+                let updated = entry.clone();
+                Ok(xml_response(action.as_str(), format!("    <EventSubscription>\n{}\n    </EventSubscription>", event_sub_xml(&updated)), &rid))
+            }
 
             // ── Global clusters ──
             "CreateGlobalCluster" => {
@@ -1012,7 +1128,58 @@ impl RdsService {
                 store(&mut state.extras, "global_clusters").insert(id.clone(), entry.clone());
                 Ok(xml_response("CreateGlobalCluster", format!("    <GlobalCluster>\n{}\n    </GlobalCluster>", global_cluster_xml(&entry)), &rid))
             }
-            "ModifyGlobalCluster" | "FailoverGlobalCluster" | "SwitchoverGlobalCluster" | "RemoveFromGlobalCluster" => Ok(xml_response(action.as_str(), "    <GlobalCluster/>".to_string(), &rid)),
+            "ModifyGlobalCluster" | "FailoverGlobalCluster" | "SwitchoverGlobalCluster" | "RemoveFromGlobalCluster" => {
+                let id = get_param(req, "GlobalClusterIdentifier").ok_or_else(|| missing("GlobalClusterIdentifier"))?;
+                let new_id = get_param(req, "NewGlobalClusterIdentifier");
+                let deletion_protection = get_param(req, "DeletionProtection")
+                    .map(|v| v.eq_ignore_ascii_case("true"));
+                let engine_version = get_param(req, "EngineVersion");
+                let updated = {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let map = state
+                        .extras
+                        .get_mut("global_clusters")
+                        .ok_or_else(|| {
+                            AwsServiceError::aws_error(
+                                StatusCode::NOT_FOUND,
+                                "GlobalClusterNotFoundFault",
+                                format!("{id} not found."),
+                            )
+                        })?;
+                    let mut entry = map.get(&id).cloned().ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "GlobalClusterNotFoundFault",
+                            format!("{id} not found."),
+                        )
+                    })?;
+                    if let Some(obj) = entry.as_object_mut() {
+                        if action.as_str() == "ModifyGlobalCluster" {
+                            if let Some(dp) = deletion_protection {
+                                obj.insert("DeletionProtection".to_string(), json!(dp));
+                            }
+                            if let Some(ev) = &engine_version {
+                                obj.insert("EngineVersion".to_string(), json!(ev));
+                            }
+                            if let Some(nid) = &new_id {
+                                obj.insert("GlobalClusterIdentifier".to_string(), json!(nid));
+                            }
+                        }
+                    }
+                    // A rename re-keys the stored map entry.
+                    if action.as_str() == "ModifyGlobalCluster" {
+                        if let Some(nid) = &new_id {
+                            map.remove(&id);
+                            map.insert(nid.clone(), entry.clone());
+                        } else {
+                            map.insert(id.clone(), entry.clone());
+                        }
+                    }
+                    entry
+                };
+                Ok(xml_response(action.as_str(), format!("    <GlobalCluster>\n{}\n    </GlobalCluster>", global_cluster_xml(&updated)), &rid))
+            }
             "DeleteGlobalCluster" => {
                 let id = get_param(req, "GlobalClusterIdentifier").ok_or_else(|| missing("GlobalClusterIdentifier"))?;
                 let mut accounts = write_state!();
@@ -1038,7 +1205,54 @@ impl RdsService {
                 store(&mut state.extras, "integrations").insert(name.clone(), entry.clone());
                 Ok(xml_response("CreateIntegration", integration_xml(&entry), &rid))
             }
-            "ModifyIntegration" => Ok(xml_response("ModifyIntegration", "    <Integration/>".to_string(), &rid)),
+            "ModifyIntegration" => {
+                let ident = get_param(req, "IntegrationIdentifier")
+                    .or_else(|| get_param(req, "IntegrationName"))
+                    .ok_or_else(|| missing("IntegrationIdentifier"))?;
+                let data_filter = get_param(req, "DataFilter");
+                let description = get_param(req, "Description");
+                let new_name = get_param(req, "IntegrationName");
+                let updated = {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let map = state.extras.get_mut("integrations").ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "IntegrationNotFoundFault",
+                            format!("Integration {ident} not found."),
+                        )
+                    })?;
+                    // The identifier may be the integration name or its ARN.
+                    let key = map
+                        .iter()
+                        .find(|(k, v)| {
+                            k.as_str() == ident || v["IntegrationArn"].as_str() == Some(ident.as_str())
+                        })
+                        .map(|(k, _)| k.clone())
+                        .ok_or_else(|| {
+                            AwsServiceError::aws_error(
+                                StatusCode::NOT_FOUND,
+                                "IntegrationNotFoundFault",
+                                format!("Integration {ident} not found."),
+                            )
+                        })?;
+                    let mut entry = map.get(&key).cloned().unwrap_or(json!({}));
+                    if let Some(obj) = entry.as_object_mut() {
+                        if let Some(v) = &data_filter {
+                            obj.insert("DataFilter".to_string(), json!(v));
+                        }
+                        if let Some(v) = &description {
+                            obj.insert("Description".to_string(), json!(v));
+                        }
+                        if let Some(v) = &new_name {
+                            obj.insert("IntegrationName".to_string(), json!(v));
+                        }
+                    }
+                    map.insert(key, entry.clone());
+                    entry
+                };
+                Ok(xml_response("ModifyIntegration", format!("    <Integration>\n{}\n    </Integration>", integration_xml(&updated)), &rid))
+            }
             "DeleteIntegration" => {
                 let name = get_param(req, "IntegrationIdentifier").or_else(|| get_param(req, "IntegrationName")).ok_or_else(|| missing("IntegrationIdentifier"))?;
                 let mut accounts = write_state!();

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -312,10 +312,24 @@ fn endpoints_proxies_secgroups() {
     );
     ok_on(&svc, "DescribeDBProxyEndpoints", &[]);
     ok_on(&svc, "DescribeDBProxyTargetGroups", &[]);
-    ok_on(&svc, "DescribeDBProxyTargets", &[]);
+    ok_on(&svc, "DescribeDBProxyTargets", &[("DBProxyName", "p1")]);
     ok_on(&svc, "ModifyDBProxyTargetGroup", &[("DBProxyName", "p1")]);
-    ok_on(&svc, "RegisterDBProxyTargets", &[]);
-    ok_on(&svc, "DeregisterDBProxyTargets", &[]);
+    ok_on(
+        &svc,
+        "RegisterDBProxyTargets",
+        &[
+            ("DBProxyName", "p1"),
+            ("DBInstanceIdentifiers.member.1", "db1"),
+        ],
+    );
+    ok_on(
+        &svc,
+        "DeregisterDBProxyTargets",
+        &[
+            ("DBProxyName", "p1"),
+            ("DBInstanceIdentifiers.member.1", "db1"),
+        ],
+    );
     ok_on(
         &svc,
         "DeleteDBProxyEndpoint",
@@ -369,8 +383,16 @@ fn option_groups_event_subs_global_clusters() {
         "ModifyEventSubscription",
         &[("SubscriptionName", "es1")],
     );
-    ok_on(&svc, "AddSourceIdentifierToSubscription", &[]);
-    ok_on(&svc, "RemoveSourceIdentifierFromSubscription", &[]);
+    ok_on(
+        &svc,
+        "AddSourceIdentifierToSubscription",
+        &[("SubscriptionName", "es1"), ("SourceIdentifier", "db1")],
+    );
+    ok_on(
+        &svc,
+        "RemoveSourceIdentifierFromSubscription",
+        &[("SubscriptionName", "es1"), ("SourceIdentifier", "db1")],
+    );
     ok_on(&svc, "DescribeEventSubscriptions", &[]);
     ok_on(
         &svc,
@@ -382,10 +404,26 @@ fn option_groups_event_subs_global_clusters() {
         "CreateGlobalCluster",
         &[("GlobalClusterIdentifier", "gc1")],
     );
-    ok_on(&svc, "ModifyGlobalCluster", &[]);
-    ok_on(&svc, "FailoverGlobalCluster", &[]);
-    ok_on(&svc, "SwitchoverGlobalCluster", &[]);
-    ok_on(&svc, "RemoveFromGlobalCluster", &[]);
+    ok_on(
+        &svc,
+        "ModifyGlobalCluster",
+        &[("GlobalClusterIdentifier", "gc1")],
+    );
+    ok_on(
+        &svc,
+        "FailoverGlobalCluster",
+        &[("GlobalClusterIdentifier", "gc1")],
+    );
+    ok_on(
+        &svc,
+        "SwitchoverGlobalCluster",
+        &[("GlobalClusterIdentifier", "gc1")],
+    );
+    ok_on(
+        &svc,
+        "RemoveFromGlobalCluster",
+        &[("GlobalClusterIdentifier", "gc1")],
+    );
     ok_on(&svc, "DescribeGlobalClusters", &[]);
     ok_on(
         &svc,
@@ -398,7 +436,11 @@ fn option_groups_event_subs_global_clusters() {
 fn integrations_blue_green_shard_groups_tenant_dbs() {
     let svc = svc();
     ok_on(&svc, "CreateIntegration", &[("IntegrationName", "i1")]);
-    ok_on(&svc, "ModifyIntegration", &[]);
+    ok_on(
+        &svc,
+        "ModifyIntegration",
+        &[("IntegrationIdentifier", "i1")],
+    );
     ok_on(&svc, "DescribeIntegrations", &[]);
     ok_on(
         &svc,
@@ -1853,12 +1895,109 @@ fn modify_option_group_persists_options_to_include_and_remove() {
         ],
     );
     let v = extras_value(&svc, "option_groups", "og1");
-    assert_eq!(v["OptionsToInclude"][0]["OptionName"].as_str(), Some("OEM"));
-    assert_eq!(v["OptionsToInclude"][0]["Port"].as_str(), Some("1158"));
-    assert_eq!(
-        v["OptionsToRemove"][0].as_str(),
-        Some("Native Network Encryption")
+    // The effective Options list reflects the included option; the removed
+    // name was never present, so it stays absent. DescribeOptionGroups now
+    // renders this set instead of an empty <Options/>.
+    assert_eq!(v["Options"][0]["OptionName"].as_str(), Some("OEM"));
+    assert_eq!(v["Options"][0]["Port"].as_str(), Some("1158"));
+    assert!(!v["Options"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|o| o["OptionName"].as_str() == Some("Native Network Encryption")));
+}
+
+#[test]
+fn event_subscription_round_trips_source_ids_and_categories() {
+    let svc = svc();
+    ok_on(
+        &svc,
+        "CreateEventSubscription",
+        &[
+            ("SubscriptionName", "es1"),
+            ("SnsTopicArn", "arn:aws:sns:us-east-1:000000000000:t"),
+            ("SourceIds.member.1", "db1"),
+            ("SourceIds.member.2", "db2"),
+            ("EventCategories.member.1", "creation"),
+        ],
     );
+    let v = extras_value(&svc, "event_subscriptions", "es1");
+    assert_eq!(v["SourceIdsList"][0].as_str(), Some("db1"));
+    assert_eq!(v["SourceIdsList"][1].as_str(), Some("db2"));
+    assert_eq!(v["EventCategoriesList"][0].as_str(), Some("creation"));
+    // Add/remove a source identifier mutates the persisted list.
+    ok_on(
+        &svc,
+        "AddSourceIdentifierToSubscription",
+        &[("SubscriptionName", "es1"), ("SourceIdentifier", "db3")],
+    );
+    let v = extras_value(&svc, "event_subscriptions", "es1");
+    assert!(v["SourceIdsList"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|x| x.as_str() == Some("db3")));
+    ok_on(
+        &svc,
+        "RemoveSourceIdentifierFromSubscription",
+        &[("SubscriptionName", "es1"), ("SourceIdentifier", "db1")],
+    );
+    let v = extras_value(&svc, "event_subscriptions", "es1");
+    assert!(!v["SourceIdsList"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|x| x.as_str() == Some("db1")));
+}
+
+#[test]
+fn register_db_proxy_targets_round_trips() {
+    let svc = svc();
+    ok_on(&svc, "CreateDBProxy", &[("DBProxyName", "p1")]);
+    ok_on(
+        &svc,
+        "RegisterDBProxyTargets",
+        &[
+            ("DBProxyName", "p1"),
+            ("DBInstanceIdentifiers.member.1", "db1"),
+        ],
+    );
+    let v = extras_value(&svc, "proxy_targets", "p1/default");
+    assert_eq!(v[0]["RdsResourceId"].as_str(), Some("db1"));
+    assert_eq!(v[0]["Type"].as_str(), Some("RDS_INSTANCE"));
+    ok_on(
+        &svc,
+        "DeregisterDBProxyTargets",
+        &[
+            ("DBProxyName", "p1"),
+            ("DBInstanceIdentifiers.member.1", "db1"),
+        ],
+    );
+    let v = extras_value(&svc, "proxy_targets", "p1/default");
+    assert_eq!(v.as_array().map(|a| a.len()), Some(0));
+}
+
+#[test]
+fn modify_global_cluster_persists_deletion_protection() {
+    let svc = svc();
+    ok_on(
+        &svc,
+        "CreateGlobalCluster",
+        &[
+            ("GlobalClusterIdentifier", "gc1"),
+            ("Engine", "aurora-postgresql"),
+        ],
+    );
+    ok_on(
+        &svc,
+        "ModifyGlobalCluster",
+        &[
+            ("GlobalClusterIdentifier", "gc1"),
+            ("DeletionProtection", "true"),
+        ],
+    );
+    let v = extras_value(&svc, "global_clusters", "gc1");
+    assert_eq!(v["DeletionProtection"].as_bool(), Some(true));
 }
 
 #[test]

--- a/crates/fakecloud-rds/src/extras/xml_renderers.rs
+++ b/crates/fakecloud-rds/src/extras/xml_renderers.rs
@@ -2,6 +2,23 @@
 
 use super::*;
 
+/// Render a JSON string array as an AWS query `<Wrapper><member>..</member></Wrapper>`
+/// list, or a self-closing `<Wrapper/>` when empty/absent.
+pub(super) fn json_str_array_xml(v: &Value, wrapper: &str) -> String {
+    let members: Vec<&str> = v
+        .as_array()
+        .map(|a| a.iter().filter_map(|x| x.as_str()).collect())
+        .unwrap_or_default();
+    if members.is_empty() {
+        return format!("<{wrapper}/>");
+    }
+    let body: String = members
+        .iter()
+        .map(|m| format!("<member>{}</member>", xml_escape(m)))
+        .collect();
+    format!("<{wrapper}>{body}</{wrapper}>")
+}
+
 pub(super) fn db_cluster_member_xml(v: &Value) -> String {
     let mut out = String::new();
     out.push_str(&format!(
@@ -322,19 +339,52 @@ pub(super) fn security_group_xml(v: &Value) -> String {
 }
 
 pub(super) fn option_group_xml(v: &Value) -> String {
+    let options = v["Options"]
+        .as_array()
+        .map(|opts| {
+            opts.iter()
+                .map(|o| {
+                    let mut inner = format!(
+                        "<OptionName>{}</OptionName>",
+                        xml_escape(o["OptionName"].as_str().unwrap_or(""))
+                    );
+                    let port = o.get("Port").and_then(|p| {
+                        p.as_i64()
+                            .or_else(|| p.as_str().and_then(|s| s.parse().ok()))
+                    });
+                    if let Some(p) = port {
+                        inner.push_str(&format!("<Port>{p}</Port>"));
+                    }
+                    if let Some(ver) = o.get("OptionVersion").and_then(|x| x.as_str()) {
+                        inner.push_str(&format!(
+                            "<OptionVersion>{}</OptionVersion>",
+                            xml_escape(ver)
+                        ));
+                    }
+                    format!("<Option>{inner}</Option>")
+                })
+                .collect::<String>()
+        })
+        .unwrap_or_default();
+    let options_xml = if options.is_empty() {
+        "<Options/>".to_string()
+    } else {
+        format!("<Options>{options}</Options>")
+    };
     format!(
-        "          <OptionGroupName>{}</OptionGroupName>\n          <OptionGroupArn>{}</OptionGroupArn>\n          <EngineName>{}</EngineName>\n          <MajorEngineVersion>{}</MajorEngineVersion>\n          <OptionGroupDescription>{}</OptionGroupDescription>\n          <AllowsVpcAndNonVpcInstanceMemberships>true</AllowsVpcAndNonVpcInstanceMemberships>\n          <Options/>",
+        "          <OptionGroupName>{}</OptionGroupName>\n          <OptionGroupArn>{}</OptionGroupArn>\n          <EngineName>{}</EngineName>\n          <MajorEngineVersion>{}</MajorEngineVersion>\n          <OptionGroupDescription>{}</OptionGroupDescription>\n          <AllowsVpcAndNonVpcInstanceMemberships>true</AllowsVpcAndNonVpcInstanceMemberships>\n          {}",
         xml_escape(v["OptionGroupName"].as_str().unwrap_or("")),
         xml_escape(v["OptionGroupArn"].as_str().unwrap_or("")),
         xml_escape(v["EngineName"].as_str().unwrap_or("")),
         xml_escape(v["MajorEngineVersion"].as_str().unwrap_or("")),
         xml_escape(v["OptionGroupDescription"].as_str().unwrap_or("")),
+        options_xml,
     )
 }
 
 pub(super) fn event_sub_xml(v: &Value) -> String {
     format!(
-        "          <CustSubscriptionId>{}</CustSubscriptionId>\n          <CustomerAwsId>{}</CustomerAwsId>\n          <EventSubscriptionArn>{}</EventSubscriptionArn>\n          <SnsTopicArn>{}</SnsTopicArn>\n          <SourceType>{}</SourceType>\n          <Status>{}</Status>\n          <Enabled>{}</Enabled>\n          <EventCategoriesList/>\n          <SourceIdsList/>",
+        "          <CustSubscriptionId>{}</CustSubscriptionId>\n          <CustomerAwsId>{}</CustomerAwsId>\n          <EventSubscriptionArn>{}</EventSubscriptionArn>\n          <SnsTopicArn>{}</SnsTopicArn>\n          <SourceType>{}</SourceType>\n          <Status>{}</Status>\n          <Enabled>{}</Enabled>\n          {}\n          {}",
         xml_escape(v["CustSubscriptionId"].as_str().unwrap_or("")),
         xml_escape(v["CustomerAwsId"].as_str().unwrap_or("")),
         xml_escape(v["EventSubscriptionArn"].as_str().unwrap_or("")),
@@ -342,6 +392,8 @@ pub(super) fn event_sub_xml(v: &Value) -> String {
         xml_escape(v["SourceType"].as_str().unwrap_or("")),
         xml_escape(v["Status"].as_str().unwrap_or("active")),
         v["Enabled"].as_bool().unwrap_or(true),
+        json_str_array_xml(&v["EventCategoriesList"], "EventCategoriesList"),
+        json_str_array_xml(&v["SourceIdsList"], "SourceIdsList"),
     )
 }
 
@@ -359,6 +411,16 @@ pub(super) fn global_cluster_xml(v: &Value) -> String {
         xml_escape(v["DatabaseName"].as_str().unwrap_or("")),
         v["DeletionProtection"].as_bool().unwrap_or(false),
         v["StorageEncrypted"].as_bool().unwrap_or(false),
+    )
+}
+
+pub(super) fn db_proxy_target_xml(v: &Value) -> String {
+    format!(
+        "<member><RdsResourceId>{}</RdsResourceId><Type>{}</Type><Port>{}</Port><Endpoint>{}</Endpoint><TargetHealth><State>AVAILABLE</State></TargetHealth></member>",
+        xml_escape(v["RdsResourceId"].as_str().unwrap_or("")),
+        xml_escape(v["Type"].as_str().unwrap_or("RDS_INSTANCE")),
+        v["Port"].as_i64().unwrap_or(3306),
+        xml_escape(v["Endpoint"].as_str().unwrap_or("")),
     )
 }
 


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-25 Tier-1 — the **RDS extras round-trip cluster**. Several Modify/Register ops parsed their input but returned/persisted nothing, so read-back showed the default (write-succeeds / read-shows-default stubs). Surfaced on the surface the recent tfacc batches (#1947-#1949) deepened.

- **ModifyOptionGroup Options** (MEDIUM) — now maintains an effective `Options` list (upsert `OptionsToInclude` by name, drop `OptionsToRemove`) and renders it; previously the Modify response and every `DescribeOptionGroups` hardcoded empty `<Options/>`.
- **Event-subscription SourceIds / EventCategories** (MEDIUM) — `CreateEventSubscription` now captures them and renders `SourceIdsList` / `EventCategoriesList`; `AddSourceIdentifierToSubscription` / `RemoveSourceIdentifierFromSubscription` mutate the persisted list and return the subscription. Fixes a perpetual diff for Terraform `aws_db_event_subscription` with `source_ids` / `event_categories`.
- **ModifyGlobalCluster / Failover / Switchover / RemoveFromGlobalCluster** (LOW) — load, apply `DeletionProtection` / `EngineVersion` / rename, persist, return the wrapped `GlobalCluster` (were no-op empty `<GlobalCluster/>`).
- **ModifyIntegration** (LOW) — load by name or ARN, apply changes, persist, return (was no-op empty `<Integration/>`).
- **RegisterDBProxyTargets / DescribeDBProxyTargets / DeregisterDBProxyTargets** (LOW) — persist registered `RDS_INSTANCE` / `TRACKED_CLUSTER` targets and reflect them on Describe (were register-succeeds / describe-empty stubs).

## Test plan

- Updated the extras unit tests that encoded the old stub shapes (now pass the AWS-mandated params + assert the round-trips).
- Added focused round-trip tests: event-sub source ids add/remove, proxy-target register/deregister, global-cluster deletion-protection persist.
- `cargo test -p fakecloud-rds` — 225 passed.
- `cargo clippy -p fakecloud-rds --all-targets -- -D warnings` clean; `cargo fmt` applied.
- All three RDS tfacc shards still pass end-to-end: `rds-param-groups`, `rds-option-groups`, `rds-event-global` (1 passed each via the harness).

## Surface check

- No new public API / introspection surface — existing RDS query-protocol response fields.
- No struct/persistence schema change (all stored in the existing JSON extras maps; new fields are additive).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RDS extras round‑trip behavior by persisting and returning data for Option Groups, Event Subscriptions, Global Clusters, Integrations, and DB Proxy targets so reads match writes. Removes empty responses and resolves Terraform diffs for `aws_db_event_subscription` and proxy targets.

- **Bug Fixes**
  - Option groups: `ModifyOptionGroup` now maintains an `Options` list (upsert includes, drop removes) and `DescribeOptionGroups` renders it.
  - Event subscriptions: `CreateEventSubscription` saves `SourceIdsList` and `EventCategoriesList`; add/remove source ID updates the list and returns the subscription (fixes Terraform diff).
  - Global clusters: `Modify`/`Failover`/`Switchover`/`RemoveFromGlobalCluster` load, apply `DeletionProtection`/`EngineVersion`/rename, persist, and return the updated `GlobalCluster`.
  - Integrations: `ModifyIntegration` loads by name or ARN, applies `DataFilter`/`Description`/rename, persists, and returns the updated `Integration`.
  - DB Proxy targets: `Register`/`Deregister` now persist `RDS_INSTANCE`/`TRACKED_CLUSTER` targets and `DescribeDBProxyTargets` returns them.

<sup>Written for commit d5cfb84017d7d4a67767dcdbbef330fa1b972875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

