### PR TITLE
fix(route53,cloudfront): honor List pagination params instead of ignoring them

### DIFF
--- a/crates/fakecloud-cloudfront/src/service.rs
+++ b/crates/fakecloud-cloudfront/src/service.rs
@@ -1036,7 +1036,7 @@ impl CloudFrontService {
         Ok(empty_response(StatusCode::NO_CONTENT))
     }
 
-    fn list_distributions(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    fn list_distributions(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let state = self.state.read();
         let mut dists: Vec<StoredDistribution> = state
             .accounts
@@ -1045,7 +1045,40 @@ impl CloudFrontService {
             .collect();
         dists.sort_by_key(|a| a.last_modified_time);
         drop(state);
-        let body = build_distribution_list_xml(&dists, "DistributionList");
+
+        // CloudFront paginates with Marker (the next distribution Id) + MaxItems.
+        let max_items = req
+            .query_params
+            .get("MaxItems")
+            .or_else(|| req.query_params.get("maxitems"))
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(100);
+        let marker = req
+            .query_params
+            .get("Marker")
+            .or_else(|| req.query_params.get("marker"));
+        let start_idx = match marker {
+            Some(m) if !m.is_empty() => {
+                dists.iter().position(|d| &d.id == m).unwrap_or(dists.len())
+            }
+            _ => 0,
+        };
+        let page: Vec<StoredDistribution> = dists
+            .iter()
+            .skip(start_idx)
+            .take(max_items)
+            .cloned()
+            .collect();
+        let next_marker = dists.get(start_idx + page.len()).map(|d| d.id.clone());
+
+        let body = build_distribution_list_xml(
+            &page,
+            "DistributionList",
+            marker.map(String::as_str).unwrap_or(""),
+            max_items,
+            next_marker.as_deref(),
+        );
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
     }
 
@@ -1624,13 +1657,25 @@ pub(crate) fn build_distribution_xml(dist: &StoredDistribution) -> String {
     out
 }
 
-fn build_distribution_list_xml(dists: &[StoredDistribution], root: &str) -> String {
+fn build_distribution_list_xml(
+    dists: &[StoredDistribution],
+    root: &str,
+    marker: &str,
+    max_items: usize,
+    next_marker: Option<&str>,
+) -> String {
     let mut out = String::with_capacity(2048);
     out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
     out.push_str(&format!("<{root} xmlns=\"{ns}\">", ns = crate::NAMESPACE));
-    out.push_str("<Marker></Marker>");
-    out.push_str(&format!("<MaxItems>{}</MaxItems>", dists.len().max(100)));
-    out.push_str("<IsTruncated>false</IsTruncated>");
+    out.push_str(&format!("<Marker>{}</Marker>", esc(marker)));
+    if let Some(nm) = next_marker {
+        out.push_str(&format!("<NextMarker>{}</NextMarker>", esc(nm)));
+    }
+    out.push_str(&format!("<MaxItems>{max_items}</MaxItems>"));
+    out.push_str(&format!(
+        "<IsTruncated>{}</IsTruncated>",
+        next_marker.is_some()
+    ));
     out.push_str(&format!("<Quantity>{}</Quantity>", dists.len()));
     if dists.is_empty() {
         out.push_str(&format!("</{root}>"));
@@ -2005,6 +2050,22 @@ fn parse_query_value(query: &str, key: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn distribution_list_xml_renders_pagination_fields() {
+        // Truncated page: echoes the request marker, the requested MaxItems,
+        // IsTruncated=true, and the NextMarker cursor.
+        let xml =
+            build_distribution_list_xml(&[], "DistributionList", "EDFDVBD6", 2, Some("E2NEXT"));
+        assert!(xml.contains("<Marker>EDFDVBD6</Marker>"));
+        assert!(xml.contains("<MaxItems>2</MaxItems>"));
+        assert!(xml.contains("<IsTruncated>true</IsTruncated>"));
+        assert!(xml.contains("<NextMarker>E2NEXT</NextMarker>"));
+        // Final page: no NextMarker, IsTruncated=false.
+        let xml = build_distribution_list_xml(&[], "DistributionList", "", 100, None);
+        assert!(xml.contains("<IsTruncated>false</IsTruncated>"));
+        assert!(!xml.contains("<NextMarker>"));
+    }
 
     #[test]
     fn placeholder_label_detects_braces_and_percent_encoding() {

--- a/crates/fakecloud-route53/src/service/hosted_zones.rs
+++ b/crates/fakecloud-route53/src/service/hosted_zones.rs
@@ -225,16 +225,39 @@ impl Route53Service {
             .unwrap_or_default();
         drop(state);
         zones.sort_by(|a, b| a.id.cmp(&b.id));
+
+        // Paginate on marker (the next zone id) + maxitems.
+        let max_items = req
+            .query_params
+            .get("maxitems")
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(100);
+        let start_idx = match req.query_params.get("marker") {
+            Some(m) if !m.is_empty() => {
+                zones.iter().position(|z| &z.id == m).unwrap_or(zones.len())
+            }
+            _ => 0,
+        };
+        let page: Vec<&StoredHostedZone> = zones.iter().skip(start_idx).take(max_items).collect();
+        let next_marker = zones.get(start_idx + page.len()).map(|z| z.id.clone());
+
         let mut body = String::with_capacity(1024);
         body.push_str(XML_DECL);
         body.push_str(&format!("<ListHostedZonesResponse xmlns=\"{NS}\">"));
         body.push_str("<HostedZones>");
-        for z in &zones {
+        for z in &page {
             push_hosted_zone(&mut body, z);
         }
         body.push_str("</HostedZones>");
-        body.push_str("<MaxItems>100</MaxItems>");
-        body.push_str("<IsTruncated>false</IsTruncated>");
+        body.push_str(&format!("<MaxItems>{max_items}</MaxItems>"));
+        body.push_str(&format!(
+            "<IsTruncated>{}</IsTruncated>",
+            next_marker.is_some()
+        ));
+        if let Some(m) = next_marker {
+            body.push_str(&format!("<NextMarker>{m}</NextMarker>"));
+        }
         body.push_str("</ListHostedZonesResponse>");
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
     }

--- a/crates/fakecloud-route53/src/service/records.rs
+++ b/crates/fakecloud-route53/src/service/records.rs
@@ -96,7 +96,7 @@ impl Route53Service {
 
     pub(super) fn list_resource_record_sets(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         route: &Route,
     ) -> Result<AwsResponse, AwsServiceError> {
         let id = require_id(route)?;
@@ -108,16 +108,81 @@ impl Route53Service {
             .and_then(|a| a.hosted_zones.get(&id).cloned())
             .ok_or_else(|| no_such_hosted_zone(&id))?;
         drop(state);
+
+        // Route 53 returns record sets ordered by (name, type) and paginates
+        // with maxitems + the StartRecordName/Type/Identifier cursor. Names,
+        // record types, and set identifiers are XML-safe DNS/enum values.
+        let max_items = req
+            .query_params
+            .get("maxitems")
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(100);
+        let start_name = req.query_params.get("name").map(|s| s.to_ascii_lowercase());
+        let start_type = req.query_params.get("type").cloned();
+        let start_ident = req.query_params.get("identifier").cloned();
+
+        let mut sorted: Vec<&crate::model::ResourceRecordSet> =
+            zone.resource_record_sets.iter().collect();
+        sorted.sort_by(|a, b| {
+            a.name
+                .to_ascii_lowercase()
+                .cmp(&b.name.to_ascii_lowercase())
+                .then(a.record_type.cmp(&b.record_type))
+                .then(a.set_identifier.cmp(&b.set_identifier))
+        });
+
+        let start_idx = match &start_name {
+            None => 0,
+            Some(sn) => sorted
+                .iter()
+                .position(|r| match r.name.to_ascii_lowercase().cmp(sn) {
+                    std::cmp::Ordering::Greater => true,
+                    std::cmp::Ordering::Less => false,
+                    std::cmp::Ordering::Equal => match &start_type {
+                        None => true,
+                        Some(st) => match r.record_type.cmp(st) {
+                            std::cmp::Ordering::Greater => true,
+                            std::cmp::Ordering::Less => false,
+                            std::cmp::Ordering::Equal => start_ident
+                                .as_deref()
+                                .is_none_or(|si| r.set_identifier.as_deref().unwrap_or("") >= si),
+                        },
+                    },
+                })
+                .unwrap_or(sorted.len()),
+        };
+
+        let page: Vec<&crate::model::ResourceRecordSet> = sorted
+            .iter()
+            .skip(start_idx)
+            .take(max_items)
+            .copied()
+            .collect();
+        let next = sorted.get(start_idx + page.len()).copied();
+
         let mut body = String::with_capacity(1024);
         body.push_str(XML_DECL);
         body.push_str(&format!("<ListResourceRecordSetsResponse xmlns=\"{NS}\">"));
         body.push_str("<ResourceRecordSets>");
-        for r in &zone.resource_record_sets {
+        for r in &page {
             push_rrset(&mut body, r);
         }
         body.push_str("</ResourceRecordSets>");
-        body.push_str("<IsTruncated>false</IsTruncated>");
-        body.push_str("<MaxItems>100</MaxItems>");
+        body.push_str(&format!("<IsTruncated>{}</IsTruncated>", next.is_some()));
+        if let Some(n) = next {
+            body.push_str(&format!("<NextRecordName>{}</NextRecordName>", n.name));
+            body.push_str(&format!(
+                "<NextRecordType>{}</NextRecordType>",
+                n.record_type
+            ));
+            if let Some(si) = &n.set_identifier {
+                body.push_str(&format!(
+                    "<NextRecordIdentifier>{si}</NextRecordIdentifier>"
+                ));
+            }
+        }
+        body.push_str(&format!("<MaxItems>{max_items}</MaxItems>"));
         body.push_str("</ListResourceRecordSetsResponse>");
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
     }


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-25 Tier-1 — three `List*` handlers validated (or bound) their pagination params then **ignored the values**, always returning every item with a hardcoded `IsTruncated=false`. Breaks clients paginating accounts with >100 records/zones/distributions.

- **Route53 `ListResourceRecordSets`** (MEDIUM) — was bound to `_req` and ignored everything. Now orders record sets by (name, type, set-identifier), honors `maxitems` + the `StartRecordName`/`Type`/`Identifier` cursor, and emits `IsTruncated` + `NextRecordName`/`NextRecordType`/`NextRecordIdentifier`.
- **Route53 `ListHostedZones`** (LOW) — honors `marker` (next zone id) + `maxitems`; emits real `MaxItems`/`IsTruncated`/`NextMarker` instead of hardcoded `100`/`false`.
- **CloudFront `ListDistributions`** (LOW) — honors `Marker` (next distribution id) + `MaxItems`; emits `Marker`/`NextMarker`/`MaxItems`/`IsTruncated` computed from the page.

## Test plan

- Added a CloudFront list-builder pagination unit test (Marker/NextMarker/MaxItems/IsTruncated).
- `cargo test -p fakecloud-route53 -p fakecloud-cloudfront` — passes.
- Route53 + CloudFront conformance suites green (20 tests) with the server bin built.
- `cargo clippy` clean; `cargo fmt` applied.

## Surface check

- No new public API / introspection surface — existing query-protocol/REST response fields (`NextMarker`, `NextRecord*`, `IsTruncated`).
- No struct/persistence change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pagination in `fakecloud-route53` and `fakecloud-cloudfront` list APIs to honor request cursors and limits and return correct truncation fields. Clients can now paginate zones, record sets, and distributions reliably on large accounts.

- **Bug Fixes**
  - Route53 `ListResourceRecordSets` — orders by name/type/set-identifier; respects `maxitems` and `name`/`type`/`identifier` cursors; returns `IsTruncated` plus `NextRecordName`/`NextRecordType`/`NextRecordIdentifier`.
  - Route53 `ListHostedZones` — respects `marker` and `maxitems`; returns real `MaxItems`, `IsTruncated`, and `NextMarker`.
  - CloudFront `ListDistributions` — respects `Marker` and `MaxItems`; echoes `Marker`; computes `NextMarker`, `IsTruncated`, and `MaxItems`.

<sup>Written for commit 11c26b02e2087101d270eda9e127928cb8607df7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

