### PR TITLE
fix(apigateway): enforce integration timeout on v1 HTTP/HTTP_PROXY/VPC_LINK (504, not hang)

### DIFF
--- a/crates/fakecloud-apigateway/src/data_plane/errors.rs
+++ b/crates/fakecloud-apigateway/src/data_plane/errors.rs
@@ -10,6 +10,16 @@ pub(super) fn bad_gateway(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_GATEWAY, "BadGatewayException", msg.into())
 }
 
+/// API Gateway returns 504 when a backend integration exceeds its timeout
+/// (default 29s for REST APIs).
+pub(super) fn gateway_timeout(msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::GATEWAY_TIMEOUT,
+        "IntegrationTimeoutException",
+        msg.into(),
+    )
+}
+
 pub(super) fn unauthorized(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::UNAUTHORIZED,

--- a/crates/fakecloud-apigateway/src/data_plane/integrations.rs
+++ b/crates/fakecloud-apigateway/src/data_plane/integrations.rs
@@ -21,7 +21,17 @@ pub(super) async fn http_proxy(
         Method::OPTIONS => reqwest::Method::OPTIONS,
         _ => reqwest::Method::GET,
     };
-    let client = reqwest::Client::new();
+    // API Gateway enforces a per-integration timeout (default 29s for REST,
+    // configurable via timeoutInMillis up to that ceiling). Without it a hung
+    // backend would hold the execute-api request open forever.
+    let timeout_ms = integration
+        .timeout_in_millis
+        .filter(|v| *v > 0)
+        .unwrap_or(29_000) as u64;
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(timeout_ms))
+        .build()
+        .map_err(|e| bad_gateway(format!("failed to build HTTP client: {e}")))?;
     let mut builder = client.request(method, url);
     for (k, v) in req.headers.iter() {
         if let Ok(s) = v.to_str() {
@@ -32,10 +42,15 @@ pub(super) async fn http_proxy(
     if !body.is_empty() {
         builder = builder.body(body.clone().to_vec());
     }
-    let resp = builder
-        .send()
-        .await
-        .map_err(|e| bad_gateway(format!("backend HTTP failure: {e}")))?;
+    let resp = builder.send().await.map_err(|e| {
+        if e.is_timeout() {
+            gateway_timeout(format!(
+                "backend integration timed out after {timeout_ms} ms"
+            ))
+        } else {
+            bad_gateway(format!("backend HTTP failure: {e}"))
+        }
+    })?;
     let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
     let mut headers = http::HeaderMap::new();
     for (k, v) in resp.headers().iter() {

--- a/crates/fakecloud-apigateway/src/data_plane/mod.rs
+++ b/crates/fakecloud-apigateway/src/data_plane/mod.rs
@@ -2332,6 +2332,48 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn http_integration_times_out_on_hung_backend() {
+        use tokio::net::TcpListener;
+        // A backend that accepts the connection but never responds.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            loop {
+                if let Ok((stream, _)) = listener.accept().await {
+                    held.push(stream); // hold open, never write a response
+                }
+            }
+        });
+        let integration = Integration {
+            rest_api_id: "api1".to_string(),
+            resource_id: "res1".to_string(),
+            http_method: "GET".to_string(),
+            integration_type: "HTTP_PROXY".to_string(),
+            integration_http_method: Some("GET".to_string()),
+            uri: Some(format!("http://{addr}/items")),
+            credentials: None,
+            request_parameters: BTreeMap::new(),
+            request_templates: BTreeMap::new(),
+            passthrough_behavior: "WHEN_NO_MATCH".to_string(),
+            timeout_in_millis: Some(150),
+            cache_namespace: None,
+            cache_key_parameters: vec![],
+            content_handling: None,
+            connection_type: None,
+            connection_id: None,
+            tls_config: None,
+        };
+        let req = make_request(HeaderMap::new());
+        let err = match http_proxy(&req, &integration, None).await {
+            Err(e) => e,
+            Ok(_) => panic!("hung backend must time out, not return a response"),
+        };
+        // AWS returns 504 (not 502) when the integration exceeds its timeout.
+        assert_eq!(err.status(), StatusCode::GATEWAY_TIMEOUT);
+    }
+
     // ── AWS direct integration tests ──
 
     /// Build an `AWS` (non-proxy) integration with the given


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-25 **Tier-3 HIGH**. The REST (v1) data-plane `http_proxy` built `reqwest::Client::new()` with **no timeout**, so a slow or non-responsive HTTP / HTTP_PROXY / VPC_LINK backend hung the `execute-api` request **indefinitely** and held the request task open forever. The client-configurable `timeoutInMillis` field was ignored. The API Gateway v2 sibling already sets a timeout.

`http_proxy` now:
- builds the client with the integration's `timeoutInMillis` (default 29 000 ms — AWS's REST integration ceiling), and
- maps a reqwest timeout to a **504 `IntegrationTimeoutException`** (matching AWS) instead of hanging or returning 502.

VPC_LINK integrations forward through the same `http_proxy`, so they're covered too.

## Test plan

- Added a behavioral test: a backend that accepts the TCP connection but never responds returns **504** within the configured timeout instead of hanging.
- `cargo test -p fakecloud-apigateway` — 91 passed.
- `cargo clippy -p fakecloud-apigateway --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface check

- No new public API / introspection surface — `timeoutInMillis` is an existing Integration field; this enforces it on the v1 data path.
- No struct/persistence change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces per-integration timeouts for v1 HTTP/HTTP_PROXY/VPC_LINK so non-responsive backends no longer hang requests. Timeouts now return 504 IntegrationTimeoutException, matching AWS behavior.

- **Bug Fixes**
  - Use `timeoutInMillis` (default 29,000 ms) when building the `http_proxy` `reqwest` client.
  - Map client timeouts to 504 `IntegrationTimeoutException` instead of hanging or 502; applies to HTTP/`HTTP_PROXY`/`VPC_LINK`.
  - Added a test to verify a hung backend returns 504 within the configured timeout.

<sup>Written for commit 0aeeaf9e45fc8b85dacfd058149716ab2c1033cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

