### PR TITLE
fix(application-autoscaling): persist state across restart; fix example compose healthcheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,6 +3153,7 @@ dependencies = [
  "chrono-tz",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
  "serde",

--- a/crates/fakecloud-application-autoscaling/Cargo.toml
+++ b/crates/fakecloud-application-autoscaling/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }

--- a/crates/fakecloud-application-autoscaling/src/lib.rs
+++ b/crates/fakecloud-application-autoscaling/src/lib.rs
@@ -6,10 +6,11 @@ pub mod ticker;
 
 pub use hooks::{DynamoDbCapacityHook, EcsServiceHook, MetricReader};
 pub use scheduled_executor::ScheduledActionExecutor;
-pub use service::ApplicationAutoScalingService;
+pub use service::{save_application_autoscaling_snapshot, ApplicationAutoScalingService};
 pub use state::{
-    AccountState, Alarm, ApplicationAutoScalingAccounts, NotScaledReason, PolicyKey,
-    ScalableTarget, ScalableTargetAction, ScalingActivity, ScalingPolicy, ScheduledAction,
-    ScheduledKey, SharedApplicationAutoScalingState, SuspendedState, TargetKey,
+    AccountState, Alarm, ApplicationAutoScalingAccounts, ApplicationAutoScalingSnapshot,
+    NotScaledReason, PolicyKey, ScalableTarget, ScalableTargetAction, ScalingActivity,
+    ScalingPolicy, ScheduledAction, ScheduledKey, SharedApplicationAutoScalingState,
+    SuspendedState, TargetKey, APPLICATION_AUTOSCALING_SNAPSHOT_SCHEMA_VERSION,
 };
 pub use ticker::ScalingWatcher;

--- a/crates/fakecloud-application-autoscaling/src/service.rs
+++ b/crates/fakecloud-application-autoscaling/src/service.rs
@@ -9,14 +9,18 @@ use parking_lot::RwLock;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use tokio::sync::Mutex as AsyncMutex;
+
 use fakecloud_aws::arn::{partition_for, Arn};
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::{SnapshotHook, SnapshotStore};
 
 use crate::state::{
-    AccountState, ApplicationAutoScalingAccounts, NotScaledReason, ScalableTarget,
-    ScalableTargetAction, ScalingActivity, ScalingPolicy, ScheduledAction,
+    AccountState, ApplicationAutoScalingAccounts, ApplicationAutoScalingSnapshot, NotScaledReason,
+    ScalableTarget, ScalableTargetAction, ScalingActivity, ScalingPolicy, ScheduledAction,
     SharedApplicationAutoScalingState, SuspendedState,
+    APPLICATION_AUTOSCALING_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const SUPPORTED_ACTIONS: &[&str] = &[
@@ -38,15 +42,78 @@ const SUPPORTED_ACTIONS: &[&str] = &[
 
 pub struct ApplicationAutoScalingService {
     state: SharedApplicationAutoScalingState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
 }
 
 impl ApplicationAutoScalingService {
     pub fn new(state: SharedApplicationAutoScalingState) -> Self {
-        Self { state }
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
     }
 
     pub fn shared_state(&self) -> SharedApplicationAutoScalingState {
         Arc::clone(&self.state)
+    }
+
+    async fn save_snapshot(&self) {
+        save_application_autoscaling_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await;
+    }
+
+    /// CloudFormation persist hook routing through the same serialize path.
+    pub fn snapshot_hook(&self) -> Option<SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                save_application_autoscaling_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
+    }
+}
+
+/// Persist the current state as a snapshot; noop in memory mode. Offloads
+/// serde + the blocking file write to the Tokio blocking pool.
+pub async fn save_application_autoscaling_snapshot(
+    state: &SharedApplicationAutoScalingState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: &AsyncMutex<()>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = ApplicationAutoScalingSnapshot {
+        schema_version: APPLICATION_AUTOSCALING_SNAPSHOT_SCHEMA_VERSION,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write application-autoscaling snapshot"),
+        Err(err) => tracing::error!(%err, "application-autoscaling snapshot task panicked"),
     }
 }
 
@@ -67,7 +134,18 @@ impl AwsService for ApplicationAutoScalingService {
     }
 
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        match req.action.as_str() {
+        let mutates = matches!(
+            req.action.as_str(),
+            "RegisterScalableTarget"
+                | "DeregisterScalableTarget"
+                | "PutScalingPolicy"
+                | "DeleteScalingPolicy"
+                | "PutScheduledAction"
+                | "DeleteScheduledAction"
+                | "TagResource"
+                | "UntagResource"
+        );
+        let result = match req.action.as_str() {
             "RegisterScalableTarget" => self.register_scalable_target(&req),
             "DescribeScalableTargets" => self.describe_scalable_targets(&req),
             "DeregisterScalableTarget" => self.deregister_scalable_target(&req),
@@ -86,7 +164,11 @@ impl AwsService for ApplicationAutoScalingService {
                 "application-autoscaling",
                 other,
             )),
+        };
+        if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
+            self.save_snapshot().await;
         }
+        result
     }
 }
 
@@ -1278,6 +1360,51 @@ mod tests {
             access_key_id: None,
             principal: None,
         }
+    }
+
+    #[tokio::test]
+    async fn register_scalable_target_persists_to_snapshot() {
+        use std::sync::Mutex;
+        #[derive(Default)]
+        struct MemStore(Mutex<Option<Vec<u8>>>);
+        impl SnapshotStore for MemStore {
+            fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+                Ok(self.0.lock().unwrap().clone())
+            }
+            fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+                *self.0.lock().unwrap() = Some(bytes.to_vec());
+                Ok(())
+            }
+        }
+        let store = Arc::new(MemStore::default());
+        let svc = ApplicationAutoScalingService::new(Arc::new(RwLock::new(
+            ApplicationAutoScalingAccounts::new(),
+        )))
+        .with_snapshot_store(store.clone());
+        let req = make_req(
+            "RegisterScalableTarget",
+            json!({
+                "ServiceNamespace": "ecs",
+                "ResourceId": "service/cluster1/svc1",
+                "ScalableDimension": "ecs:service:DesiredCount",
+                "MinCapacity": 1,
+                "MaxCapacity": 5,
+            }),
+        );
+        svc.handle(req).await.unwrap();
+        // The mutating action wrote a snapshot; it round-trips the target.
+        let bytes = store
+            .0
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("RegisterScalableTarget must persist a snapshot");
+        let snap: ApplicationAutoScalingSnapshot = serde_json::from_slice(&bytes).unwrap();
+        let accounts = snap.accounts.expect("snapshot carries accounts");
+        assert!(accounts
+            .accounts
+            .values()
+            .any(|a| !a.scalable_targets.is_empty()));
     }
 
     #[test]

--- a/crates/fakecloud-application-autoscaling/src/state.rs
+++ b/crates/fakecloud-application-autoscaling/src/state.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 pub type SharedApplicationAutoScalingState = Arc<RwLock<ApplicationAutoScalingAccounts>>;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ApplicationAutoScalingAccounts {
     pub accounts: BTreeMap<String, AccountState>,
 }
@@ -20,18 +20,59 @@ impl ApplicationAutoScalingAccounts {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+/// Versioned on-disk persistence snapshot for Application Auto Scaling.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApplicationAutoScalingSnapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<ApplicationAutoScalingAccounts>,
+}
+
+pub const APPLICATION_AUTOSCALING_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AccountState {
     /// Keyed by (ServiceNamespace, ResourceId, ScalableDimension).
+    #[serde(with = "map_as_pairs")]
     pub scalable_targets: BTreeMap<TargetKey, ScalableTarget>,
     /// Keyed by (ServiceNamespace, ResourceId, ScalableDimension, PolicyName).
+    #[serde(with = "map_as_pairs")]
     pub scaling_policies: BTreeMap<PolicyKey, ScalingPolicy>,
     /// Keyed by (ServiceNamespace, ResourceId, ScalableDimension, ScheduledActionName).
+    #[serde(with = "map_as_pairs")]
     pub scheduled_actions: BTreeMap<ScheduledKey, ScheduledAction>,
     /// Scaling activities, newest first.
     pub scaling_activities: Vec<ScalingActivity>,
     /// Tags keyed by ARN.
     pub tags: BTreeMap<String, BTreeMap<String, String>>,
+}
+
+/// Serialize a `BTreeMap` with a non-string (tuple) key as a sequence of
+/// `[key, value]` pairs. JSON object keys must be strings, so the tuple-keyed
+/// maps above can't serialize directly — this round-trips them via a list,
+/// which is what the persistence snapshot needs.
+mod map_as_pairs {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::collections::BTreeMap;
+
+    pub fn serialize<K, V, S>(map: &BTreeMap<K, V>, ser: S) -> Result<S::Ok, S::Error>
+    where
+        K: Serialize + Ord,
+        V: Serialize,
+        S: Serializer,
+    {
+        ser.collect_seq(map.iter())
+    }
+
+    pub fn deserialize<'de, K, V, D>(de: D) -> Result<BTreeMap<K, V>, D::Error>
+    where
+        K: Deserialize<'de> + Ord,
+        V: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        let pairs: Vec<(K, V)> = Vec::deserialize(de)?;
+        Ok(pairs.into_iter().collect())
+    }
 }
 
 pub type TargetKey = (String, String, String);

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2921,10 +2921,70 @@ async fn main() {
         cfn_snapshot_hooks.insert("cloudwatch", h);
     }
     registry.register(Arc::new(cloudwatch_service));
-    let app_autoscaling_service =
+    let app_autoscaling_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path
+                .join("application-autoscaling")
+                .join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<
+                        fakecloud_application_autoscaling::ApplicationAutoScalingSnapshot,
+                    >(&bytes)
+                    {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_application_autoscaling::APPLICATION_AUTOSCALING_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "application-autoscaling persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_application_autoscaling::APPLICATION_AUTOSCALING_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.accounts.len();
+                                *app_autoscaling_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded application-autoscaling persistence snapshot"
+                                );
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse application-autoscaling persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!(
+                        "no application-autoscaling persistence snapshot found; starting empty"
+                    );
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read application-autoscaling persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut app_autoscaling_service =
         fakecloud_application_autoscaling::ApplicationAutoScalingService::new(
             app_autoscaling_state.clone(),
         );
+    if let Some(store) = app_autoscaling_snapshot_store.clone() {
+        app_autoscaling_service = app_autoscaling_service.with_snapshot_store(store);
+    }
+    if let Some(h) = app_autoscaling_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("application-autoscaling", h);
+    }
     registry.register(Arc::new(app_autoscaling_service));
     let wafv2_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     environment:
       FAKECLOUD_LOG: info
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4566/_fakecloud/health"]
+      # The slim published image ships no curl/wget; use the built-in probe.
+      test: ["CMD", "fakecloud", "healthcheck"]
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-25.

- **Application Auto Scaling persistence** (Tier-4 MEDIUM) — scalable targets, scaling policies, scheduled actions, and tags were **never persisted**: `ApplicationAutoScalingService` had no snapshot store/hook, so everything vanished on restart in persistent mode while its direct-API siblings survived (it was added recently in #1944 and missed the persistence sweep). Added the standard per-service snapshot pattern (mirroring wafv2): a versioned `ApplicationAutoScalingSnapshot`, `with_snapshot_store` / `snapshot_hook` / `save_snapshot`, a central save after any successful mutating action, and load-on-boot + the CFN hook wiring in `main.rs`. The tuple-keyed state maps (`TargetKey`/`PolicyKey`/`ScheduledKey`) can't serialize as JSON object keys, so they round-trip through a `map_as_pairs` serde adapter (the tuple-key serde gotcha from the persistence sweep).
- **Example compose healthcheck** (Tier-5 MEDIUM) — `examples/docker-compose.yml` used `curl`, which the slim published image doesn't ship, so the example container reported unhealthy forever. Switched to the built-in `fakecloud healthcheck` probe (matching the root compose file).

## Test plan

- Added a round-trip test: `RegisterScalableTarget` writes a snapshot that deserializes back with the target present (proves the tuple-key serde adapter + save path).
- `cargo test -p fakecloud-application-autoscaling` — 15 passed.
- Server bin builds; `cargo clippy -p fakecloud-application-autoscaling` and `-p fakecloud --bin fakecloud` clean; `cargo fmt` applied.

## Surface check

- No new public API / introspection surface.
- New persisted snapshot file `application-autoscaling/snapshot.json` follows the existing per-service layout; schema versioned (v1) with forward-compat guard, like the other services.
- `ApplicationAutoScalingAccounts`/`AccountState` gained `Clone` + the `map_as_pairs` serde adapter; backward-compatible (new on-disk file only written in persistent mode).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Application Auto Scaling state across restarts and fix the example compose healthcheck so containers report healthy. This prevents state loss for scalable targets, policies, schedules, and tags in persistent mode.

- **Bug Fixes**
  - Persist `fakecloud-application-autoscaling` state using a versioned snapshot (v1); save after successful mutating actions and load on boot from `application-autoscaling/snapshot.json` (tuple-key maps serialize via `map_as_pairs`).
  - Wire snapshot load and CloudFormation snapshot hook in `fakecloud-server` so CFN-triggered saves also persist.
  - Update `examples/docker-compose.yml` healthcheck to use `fakecloud healthcheck` instead of `curl`.

- **Dependencies**
  - Add `fakecloud-persistence` to `fakecloud-application-autoscaling`.

<sup>Written for commit f654b11748f56e4aa93d94ed01fb6920994e8e34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

