### PR TITLE
fix(cloudformation): apply UpdateStack property changes to SQS queues and SNS topics

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1323,7 +1323,9 @@ impl ResourceProvisioner {
             "AWS::StepFunctions::StateMachine" => {
                 Some(self.update_sfn_state_machine(existing, new_def)?)
             }
+            "AWS::SQS::Queue" => Some(self.update_sqs_queue(existing, new_def)?),
             "AWS::SQS::QueuePolicy" => Some(self.update_sqs_queue_policy(existing, new_def)?),
+            "AWS::SNS::Topic" => Some(self.update_sns_topic(existing, new_def)?),
             "AWS::SNS::TopicPolicy" => Some(self.update_sns_topic_policy(existing, new_def)?),
             "AWS::S3::BucketPolicy" => Some(self.update_s3_bucket_policy(existing, new_def)?),
             _ => None,
@@ -6079,6 +6081,72 @@ mod tests {
             resource_type: resource_type.to_string(),
             properties: props,
         }
+    }
+
+    #[test]
+    fn update_stack_applies_sqs_queue_property_change() {
+        let prov = make_provisioner();
+        let created = prov
+            .create_resource(&make_resource(
+                "AWS::SQS::Queue",
+                "Q",
+                serde_json::json!({ "QueueName": "q1", "VisibilityTimeout": "30" }),
+            ))
+            .expect("queue provisions");
+        // UpdateStack changes a property; previously a no-op (`_ => None`).
+        let updated = prov
+            .update_resource(
+                &created,
+                &make_resource(
+                    "AWS::SQS::Queue",
+                    "Q",
+                    serde_json::json!({ "QueueName": "q1", "VisibilityTimeout": "120" }),
+                ),
+            )
+            .expect("update succeeds")
+            .expect("SQS::Queue is an updatable type");
+        assert_eq!(updated.physical_id, created.physical_id);
+        let sqs = prov.sqs_state.read();
+        let acct = sqs.get("123456789012").unwrap();
+        let queue = acct.queues.get(&created.physical_id).unwrap();
+        assert_eq!(
+            queue
+                .attributes
+                .get("VisibilityTimeout")
+                .map(String::as_str),
+            Some("120")
+        );
+    }
+
+    #[test]
+    fn update_stack_applies_sns_topic_property_change() {
+        let prov = make_provisioner();
+        let created = prov
+            .create_resource(&make_resource(
+                "AWS::SNS::Topic",
+                "T",
+                serde_json::json!({ "TopicName": "t1", "DisplayName": "before" }),
+            ))
+            .expect("topic provisions");
+        let updated = prov
+            .update_resource(
+                &created,
+                &make_resource(
+                    "AWS::SNS::Topic",
+                    "T",
+                    serde_json::json!({ "TopicName": "t1", "DisplayName": "after" }),
+                ),
+            )
+            .expect("update succeeds")
+            .expect("SNS::Topic is an updatable type");
+        assert_eq!(updated.physical_id, created.physical_id);
+        let sns = prov.sns_state.read();
+        let acct = sns.get("123456789012").unwrap();
+        let topic = acct.topics.get(&created.physical_id).unwrap();
+        assert_eq!(
+            topic.attributes.get("DisplayName").map(String::as_str),
+            Some("after")
+        );
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
@@ -19,6 +19,46 @@ impl ResourceProvisioner {
 
     // --- SNS ---
 
+    /// Apply a CFN property update to an existing SNS topic in place,
+    /// preserving its subscriptions/tags. Mirrors the attribute extraction in
+    /// `create_sns_topic` so a stack update re-applies DisplayName / KMS /
+    /// FIFO config instead of being silently dropped.
+    pub(super) fn update_sns_topic(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let arn = &existing.physical_id;
+        let mut __sns_mas = self.sns_state.write();
+        let state = __sns_mas.get_or_create(&self.account_id);
+        let topic = state
+            .topics
+            .get_mut(arn)
+            .ok_or_else(|| format!("SNS topic {arn} not yet provisioned"))?;
+        for key in [
+            "DisplayName",
+            "KmsMasterKeyId",
+            "SignatureVersion",
+            "TracingConfig",
+            "ArchivePolicy",
+            "FifoThroughputScope",
+        ] {
+            if let Some(s) = props.get(key).and_then(|v| v.as_str()) {
+                topic.attributes.insert(key.to_string(), s.to_string());
+            }
+        }
+        for key in ["FifoTopic", "ContentBasedDeduplication"] {
+            if let Some(b) = props
+                .get(key)
+                .and_then(|v| v.as_bool().or_else(|| v.as_str().map(|s| s == "true")))
+            {
+                topic.attributes.insert(key.to_string(), b.to_string());
+            }
+        }
+        Ok(ProvisionResult::new(arn.clone()))
+    }
+
     pub(super) fn create_sns_topic(
         &self,
         resource: &ResourceDefinition,

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sqs.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sqs.rs
@@ -20,6 +20,51 @@ impl ResourceProvisioner {
 
     // --- SQS ---
 
+    /// Apply a CFN property update to an existing queue in place, preserving
+    /// its enqueued messages. Re-applies the same property-to-attribute
+    /// mapping `create_sqs_queue` uses so a stack update isn't a no-op.
+    pub(super) fn update_sqs_queue(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let url = &existing.physical_id;
+        let mut __sqs_mas = self.sqs_state.write();
+        let state = __sqs_mas.get_or_create(&self.account_id);
+        let queue = state
+            .queues
+            .get_mut(url)
+            .ok_or_else(|| format!("Queue {url} not yet provisioned"))?;
+        if let Some(obj) = props.as_object() {
+            for (k, v) in obj {
+                if k == "QueueName" || k == "Tags" {
+                    continue;
+                }
+                let value = match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Bool(b) => b.to_string(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
+                        serde_json::to_string(v).unwrap_or_default()
+                    }
+                    serde_json::Value::Null => continue,
+                };
+                queue.attributes.insert(k.clone(), value);
+            }
+        }
+        if queue
+            .attributes
+            .get("KmsMasterKeyId")
+            .is_some_and(|k| !k.is_empty())
+        {
+            queue
+                .attributes
+                .insert("SqsManagedSseEnabled".to_string(), "false".to_string());
+        }
+        Ok(ProvisionResult::new(url.clone()))
+    }
+
     pub(super) fn create_sqs_queue(
         &self,
         resource: &ResourceDefinition,


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-25 Tier-1 (finding 1.9, part 1). `update_resource` hit the `_ => None` arm for `AWS::SQS::Queue` and `AWS::SNS::Topic`, so a CloudFormation **UpdateStack** that changed a queue or topic property reported success but **mutated nothing**.

Added `update_sqs_queue` and `update_sns_topic`, which apply the changed properties to the existing resource **in place** (preserving enqueued messages / subscriptions), mirroring the property-to-attribute mapping each create path uses, and wired both arms into `update_resource`.

## Test plan

- Added two tests: an UpdateStack changing `VisibilityTimeout` on an existing queue and `DisplayName` on an existing topic now actually applies (was a no-op).
- `cargo test -p fakecloud-cloudformation` — 244 passed.
- `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface check

- No new public API / introspection surface — internal CFN provisioner update path.
- No struct/persistence change.

## Follow-on (rest of finding 1.9 + 1.10/1.11)

- IAM Role/Policy/ManagedPolicy UpdateStack arms.
- `AWS::EC2::*` create provisioner (1.10).
- GetAtt completeness for non-eagerly-captured attributes (1.11).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a CloudFormation bug where UpdateStack changes to SQS queues and SNS topics were no-ops. Updates now apply in place and preserve messages and subscriptions.

- **Bug Fixes**
  - Added update paths for `AWS::SQS::Queue` and `AWS::SNS::Topic`; wired into `update_resource`.
  - Reapply CFN properties to existing resources (same mapping as create).
  - Tests cover `VisibilityTimeout` (SQS) and `DisplayName` (SNS); both now update correctly.
  - No public API or storage changes.

<sup>Written for commit 0a12514ae6ac7348a04c5319ea09276b7719b2d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

