### PR TITLE
fix(cloudformation): apply UpdateStack changes to IAM roles and customer-managed policies

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/iam.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/iam.rs
@@ -148,6 +148,80 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    /// Apply a CFN property update to an existing role in place: the
+    /// assume-role policy, description, session duration, and permissions
+    /// boundary, plus the inline `Policies` and attached `ManagedPolicyArns`
+    /// (replaced, not appended — the new template is authoritative). Without
+    /// this an UpdateStack that retunes a role's grants is a silent no-op, so a
+    /// workload assuming the role keeps the stale permissions under `--iam`.
+    pub(super) fn update_iam_role(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let arn = &existing.physical_id;
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let role_name = state
+            .roles
+            .iter()
+            .find(|(_, r)| &r.arn == arn)
+            .map(|(name, _)| name.clone())
+            .ok_or_else(|| format!("IAM role {arn} not yet provisioned"))?;
+
+        if let Some(role) = state.roles.get_mut(&role_name) {
+            if let Some(doc) = props.get("AssumeRolePolicyDocument") {
+                role.assume_role_policy_document = if doc.is_string() {
+                    doc.as_str().unwrap_or("").to_string()
+                } else {
+                    serde_json::to_string(doc).unwrap_or_default()
+                };
+            }
+            if let Some(d) = props.get("Description").and_then(|v| v.as_str()) {
+                role.description = Some(d.to_string());
+            }
+            if let Some(m) = props.get("MaxSessionDuration").and_then(|v| v.as_i64()) {
+                role.max_session_duration = m as i32;
+            }
+            if let Some(pb) = props.get("PermissionsBoundary").and_then(|v| v.as_str()) {
+                role.permissions_boundary = Some(pb.to_string());
+            }
+        }
+
+        // Inline policies — replace the whole set with the template's.
+        if let Some(policies) = props.get("Policies").and_then(|v| v.as_array()) {
+            let inline = state
+                .role_inline_policies
+                .entry(role_name.clone())
+                .or_default();
+            inline.clear();
+            for p in policies {
+                if let (Some(n), Some(doc)) = (
+                    p.get("PolicyName").and_then(|v| v.as_str()),
+                    p.get("PolicyDocument"),
+                ) {
+                    let document = if doc.is_string() {
+                        doc.as_str().unwrap_or("").to_string()
+                    } else {
+                        serde_json::to_string(doc).unwrap_or_default()
+                    };
+                    inline.insert(n.to_string(), document);
+                }
+            }
+        }
+        // Attached managed policies — replace the set with the template's.
+        if let Some(arns) = props.get("ManagedPolicyArns").and_then(|v| v.as_array()) {
+            let attached: Vec<String> = arns
+                .iter()
+                .filter_map(|a| a.as_str().map(String::from))
+                .collect();
+            state.role_policies.insert(role_name.clone(), attached);
+        }
+
+        Ok(ProvisionResult::new(arn.clone()).with("Arn", arn.clone()))
+    }
+
     // --- IAM Policy ---
 
     pub(super) fn create_iam_policy(
@@ -219,6 +293,58 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         state.policies.remove(physical_id);
         Ok(())
+    }
+
+    /// Apply a CFN property update to an existing customer-managed policy
+    /// (`AWS::IAM::Policy` / `AWS::IAM::ManagedPolicy`). A changed
+    /// `PolicyDocument` mints a new policy version and makes it the default —
+    /// exactly what real IAM does — so callers reading the policy see the new
+    /// statements instead of the stale create-time version. Description is also
+    /// refreshed. Previously a no-op (`_ => None`).
+    pub(super) fn update_iam_policy(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let arn = &existing.physical_id;
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let policy = state
+            .policies
+            .get_mut(arn)
+            .ok_or_else(|| format!("IAM policy {arn} not yet provisioned"))?;
+
+        if let Some(doc) = props.get("PolicyDocument") {
+            let document = if doc.is_string() {
+                doc.as_str().unwrap_or("").to_string()
+            } else {
+                serde_json::to_string(doc).unwrap_or_default()
+            };
+            let current = policy
+                .versions
+                .iter()
+                .find(|v| v.is_default)
+                .map(|v| v.document.clone());
+            if current.as_deref() != Some(document.as_str()) {
+                for v in policy.versions.iter_mut() {
+                    v.is_default = false;
+                }
+                let version_id = format!("v{}", policy.next_version_num);
+                policy.next_version_num += 1;
+                policy.default_version_id = version_id.clone();
+                policy.versions.push(PolicyVersion {
+                    version_id,
+                    document,
+                    is_default: true,
+                    created_at: policy.created_at,
+                });
+            }
+        }
+        if let Some(d) = props.get("Description").and_then(|v| v.as_str()) {
+            policy.description = d.to_string();
+        }
+        Ok(ProvisionResult::new(arn.clone()).with("Arn", arn.clone()))
     }
 
     pub(super) fn create_iam_user(

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1222,6 +1222,9 @@ impl ResourceProvisioner {
             "AWS::Lambda::Url" => Some(self.update_lambda_url(existing, new_def)?),
             "AWS::Lambda::Alias" => Some(self.update_lambda_alias(existing, new_def)?),
             "AWS::Lambda::Version" => Some(self.update_lambda_version(existing, new_def)?),
+            "AWS::IAM::Role" => Some(self.update_iam_role(existing, new_def)?),
+            "AWS::IAM::Policy" => Some(self.update_iam_policy(existing, new_def)?),
+            "AWS::IAM::ManagedPolicy" => Some(self.update_iam_policy(existing, new_def)?),
             "AWS::ApiGateway::RestApi" => Some(self.update_apigw_rest_api(existing, new_def)?),
             "AWS::ApiGateway::Resource" => Some(self.update_apigw_resource(existing, new_def)?),
             "AWS::ApiGateway::Method" => Some(self.update_apigw_method(existing, new_def)?),
@@ -6079,6 +6082,89 @@ mod tests {
             resource_type: resource_type.to_string(),
             properties: props,
         }
+    }
+
+    #[test]
+    fn update_stack_reconciles_iam_role_policies() {
+        let prov = make_provisioner();
+        let created = prov
+            .create_resource(&make_resource(
+                "AWS::IAM::Role",
+                "R",
+                serde_json::json!({
+                    "RoleName": "r1",
+                    "AssumeRolePolicyDocument": {"Version": "2012-10-17"},
+                    "ManagedPolicyArns": ["arn:aws:iam::aws:policy/ReadOnlyAccess"],
+                }),
+            ))
+            .expect("role provisions");
+        prov.update_resource(
+            &created,
+            &make_resource(
+                "AWS::IAM::Role",
+                "R",
+                serde_json::json!({
+                    "RoleName": "r1",
+                    "AssumeRolePolicyDocument": {"Version": "2012-10-17", "Statement": []},
+                    "Description": "updated",
+                    "ManagedPolicyArns": ["arn:aws:iam::aws:policy/AdministratorAccess"],
+                    "Policies": [{"PolicyName": "inline1", "PolicyDocument": {"k": "v"}}],
+                }),
+            ),
+        )
+        .expect("update succeeds")
+        .expect("IAM::Role is updatable");
+        let iam = prov.iam_state.read();
+        let acct = iam.get("123456789012").unwrap();
+        let role = acct.roles.get("r1").unwrap();
+        assert_eq!(role.description.as_deref(), Some("updated"));
+        assert!(role.assume_role_policy_document.contains("Statement"));
+        // Attached managed policies replaced, not appended.
+        let attached = acct.role_policies.get("r1").unwrap();
+        assert_eq!(
+            attached,
+            &vec!["arn:aws:iam::aws:policy/AdministratorAccess".to_string()]
+        );
+        assert!(acct
+            .role_inline_policies
+            .get("r1")
+            .unwrap()
+            .contains_key("inline1"));
+    }
+
+    #[test]
+    fn update_stack_bumps_managed_policy_version() {
+        let prov = make_provisioner();
+        let created = prov
+            .create_resource(&make_resource(
+                "AWS::IAM::ManagedPolicy",
+                "P",
+                serde_json::json!({
+                    "ManagedPolicyName": "p1",
+                    "PolicyDocument": {"Version": "2012-10-17", "Statement": [{"Effect": "Allow"}]},
+                }),
+            ))
+            .expect("managed policy provisions");
+        prov.update_resource(
+            &created,
+            &make_resource(
+                "AWS::IAM::ManagedPolicy",
+                "P",
+                serde_json::json!({
+                    "ManagedPolicyName": "p1",
+                    "PolicyDocument": {"Version": "2012-10-17", "Statement": [{"Effect": "Deny"}]},
+                }),
+            ),
+        )
+        .expect("update succeeds")
+        .expect("IAM::ManagedPolicy is updatable");
+        let iam = prov.iam_state.read();
+        let acct = iam.get("123456789012").unwrap();
+        let policy = acct.policies.get(&created.physical_id).unwrap();
+        assert_eq!(policy.versions.len(), 2);
+        assert_eq!(policy.default_version_id, "v2");
+        let default = policy.versions.iter().find(|v| v.is_default).unwrap();
+        assert!(default.document.contains("Deny"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-25 Tier-1 (finding 1.9, part 2). `update_resource` hit `_ => None` for `AWS::IAM::Role`, `AWS::IAM::Policy`, and `AWS::IAM::ManagedPolicy`, so a stack update that retuned a role's grants or a policy document reported success but changed nothing — the workload assuming the role kept stale permissions under `--iam` enforcement (now real via the AWS-managed-policy catalog #1880).

- **`update_iam_role`** — applies the assume-role policy, description, max session duration, and permissions boundary in place, and **replaces** the inline `Policies` + attached `ManagedPolicyArns` with the template's set (the new template is authoritative), preserving the role's identity/ARN.
- **`update_iam_policy`** (shared by `AWS::IAM::Policy` and `AWS::IAM::ManagedPolicy`) — a changed `PolicyDocument` mints a new policy version and makes it the default, matching real IAM; description is refreshed.

## Test plan

- An UpdateStack reconciling a role's managed/inline policies + assume-role doc, and one bumping a managed policy to a new default version.
- `cargo test -p fakecloud-cloudformation` — 244 passed.
- `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface check

- No new public API / introspection surface — internal CFN provisioner update path.
- No struct/persistence change.

## Relationship to #1954

Branches off `main` alongside the SQS/SNS UpdateStack PR (#1954); the two add arms in non-adjacent regions of the same `update_resource` match, so they auto-merge.

## Remaining (finding 1.10/1.11)

`AWS::EC2::*` create provisioner (1.10) and GetAtt completeness (1.11) follow in a final PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CloudFormation UpdateStack for IAM roles and customer-managed policies so updates actually change permissions instead of being a no-op. Prevents stale permissions under `--iam` by reconciling role grants and bumping managed policy default versions to match AWS behavior.

- **Bug Fixes**
  - `AWS::IAM::Role`: apply assume-role policy, description, max session duration, and permissions boundary; replace inline `Policies` and `ManagedPolicyArns` with the template’s set; preserve role ARN.
  - `AWS::IAM::Policy` and `AWS::IAM::ManagedPolicy`: when `PolicyDocument` changes, create a new version and set it as default; refresh description.

<sup>Written for commit b2291209f80a399e922beab8966a40175d401369. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

