### PR TITLE
fix(cloudformation): persist live GetAtt attributes so Outputs resolve them

### DIFF
--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -199,7 +199,7 @@ pub(crate) fn provision_stack_resources(
             })?;
 
             match provisioner.create_resource(&resolved_def) {
-                Ok(stack_resource) => {
+                Ok(mut stack_resource) => {
                     physical_ids.insert(
                         stack_resource.logical_id.clone(),
                         stack_resource.physical_id.clone(),
@@ -217,7 +217,12 @@ pub(crate) fn provision_stack_resources(
                             attr_map.insert((*attr).to_string(), v);
                         }
                     }
-                    attributes.insert(stack_resource.logical_id.clone(), attr_map);
+                    attributes.insert(stack_resource.logical_id.clone(), attr_map.clone());
+                    // Persist the live-resolved attributes onto the stored
+                    // resource so later readers — notably resolve_template_outputs,
+                    // which reads StackResource.attributes directly without the
+                    // overlay — see the full GetAtt set, not just the eager subset.
+                    stack_resource.attributes = attr_map;
                     resources.push(stack_resource);
                     made_progress = true;
                 }
@@ -2670,6 +2675,56 @@ mod tests {
             .unwrap();
         assert_eq!(stack.resources.len(), 1);
         assert_eq!(stack.resources[0].resource_type, "Custom::Thing");
+    }
+
+    #[tokio::test]
+    async fn output_getatt_resolves_well_known_attribute() {
+        // An Output that GetAtts a well-known attribute the create handler does
+        // not eagerly capture (SQS QueueUrl) must resolve to the live value, not
+        // a `Queue.QueueUrl` placeholder. Regression for bug-hunt 2026-06-25 1.11:
+        // resolve_template_outputs reads StackResource.attributes, which now
+        // carries the live get_att overlay applied during provisioning.
+        let svc = make_service();
+        let template = r#"{
+            "Resources": {
+                "Queue": { "Type": "AWS::SQS::Queue", "Properties": { "QueueName": "out-q" } }
+            },
+            "Outputs": {
+                "Url": { "Value": { "Fn::GetAtt": ["Queue", "QueueUrl"] } }
+            }
+        }"#;
+        let mut params = HashMap::new();
+        params.insert("StackName".to_string(), "out-stack".to_string());
+        params.insert("TemplateBody".to_string(), template.to_string());
+        svc.create_stack(&make_request("CreateStack", params))
+            .await
+            .expect("create returns StackId");
+
+        let mut url = String::new();
+        for _ in 0..200 {
+            {
+                let accounts = svc.state.read();
+                if let Some(stack) = accounts
+                    .get("123456789012")
+                    .and_then(|s| s.stacks.get("out-stack"))
+                {
+                    if stack.status != "CREATE_IN_PROGRESS" {
+                        url = stack
+                            .outputs
+                            .iter()
+                            .find(|o| o.key == "Url")
+                            .map(|o| o.value.clone())
+                            .unwrap_or_default();
+                        break;
+                    }
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            url.contains("out-q") && url != "Queue.QueueUrl",
+            "GetAtt QueueUrl output should resolve to the live url, got {url:?}"
+        );
     }
 
     // ── Service error paths ──


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-25 Tier-1 (finding 1.11). During provisioning the create loop overlays each resource's well-known `GetAtt` attributes (resolved live via the provisioner) onto a local map used for property resolution, but pushed the **original** `StackResource` whose `attributes` only held the eager subset. `resolve_template_outputs` reads `StackResource.attributes` directly, so an Output GetAtt-ing a well-known attribute the create handler didn't eagerly capture (e.g. SQS `QueueUrl`) resolved to a `Queue.QueueUrl` **placeholder** instead of the live value.

The enriched attribute map is now persisted back onto the stored `StackResource`, so Outputs (and any other `StackResource.attributes` reader) see the full set.

## Test plan

- Added a test: a stack whose Output GetAtts SQS `QueueUrl` now resolves to the real queue url (confirmed `create_sqs_queue` does not eagerly capture `QueueUrl`, so the test exercises the fix).
- `cargo test -p fakecloud-cloudformation` — 245 passed.
- `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface check

- No new public API / introspection surface — internal CFN attribute-resolution path.
- No struct/persistence schema change (`StackResource.attributes` already serialized; this populates it more completely).

## Remaining (finding 1.10)

`AWS::EC2::*` create provisioner — requires adding EC2 state to the provisioner (a struct-field sweep) + per-type create arms; follows as the final bug-hunt PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist live `GetAtt` attributes onto `StackResource.attributes` during provisioning so Outputs resolve real values instead of placeholders (e.g., SQS `QueueUrl`). This fixes missing well-known attributes when `resolve_template_outputs` reads stored resources.

- **Bug Fixes**
  - Write the overlayed attribute map back to `StackResource` before storing it, so all readers see the full `GetAtt` set.
  - Added a regression test verifying an Output for SQS `QueueUrl` returns the real URL; `fakecloud-cloudformation` tests pass.

<sup>Written for commit 10680e2e1d8a5cc3fa34608da9d1cc33faf5ea27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

