### PR TITLE
fix(cloudformation): provision AWS::EC2::* resources through the real EC2 handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,6 +3287,7 @@ dependencies = [
  "fakecloud-cognito",
  "fakecloud-core",
  "fakecloud-dynamodb",
+ "fakecloud-ec2",
  "fakecloud-ecr",
  "fakecloud-ecs",
  "fakecloud-elasticache",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -29,8 +29,10 @@ fakecloud-elbv2 = { workspace = true }
 fakecloud-organizations = { workspace = true }
 fakecloud-cognito = { workspace = true }
 fakecloud-rds = { workspace = true }
+fakecloud-ec2 = { workspace = true }
 fakecloud-ecs = { workspace = true }
 fakecloud-acm = { workspace = true }
+bytes = { workspace = true }
 fakecloud-elasticache = { workspace = true }
 fakecloud-route53 = { workspace = true }
 fakecloud-cloudfront = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -2533,6 +2533,7 @@ mod tests {
             organizations: Arc::new(RwLock::new(None)),
             cognito: shared::<fakecloud_cognito::CognitoState>(),
             rds: shared::<fakecloud_rds::RdsState>(),
+            ec2: shared::<fakecloud_ec2::Ec2State>(),
             ecs: shared::<fakecloud_ecs::EcsState>(),
             acm: Arc::new(RwLock::new(fakecloud_acm::AcmAccounts::new())),
             elasticache: shared::<fakecloud_elasticache::ElastiCacheState>(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
@@ -89,6 +89,7 @@ impl ResourceProvisioner {
             organizations_state: self.organizations_state.clone(),
             cognito_state: self.cognito_state.clone(),
             rds_state: self.rds_state.clone(),
+            ec2_state: self.ec2_state.clone(),
             ecs_state: self.ecs_state.clone(),
             acm_state: self.acm_state.clone(),
             elasticache_state: self.elasticache_state.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
@@ -1,0 +1,223 @@
+//! `AWS::EC2::*` CloudFormation provisioning. Routes through the real EC2
+//! control-plane handlers (`Ec2Service::provision_sync`) so CFN-created VPCs,
+//! subnets, security groups, route tables, and internet gateways match
+//! API-created ones (default SG/NACL/route-table, id formats, tags) instead of
+//! being recorded as no-op unknown resources. Bug-hunt 2026-06-25 (1.10).
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use fakecloud_core::service::AwsRequest;
+use fakecloud_ec2::Ec2Service;
+use http::{HeaderMap, Method};
+use serde_json::Value;
+
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
+
+/// Pull the text of the first `<tag>...</tag>` element out of an EC2 query
+/// response. The control-plane responses are flat, so a substring scan is
+/// sufficient and avoids a full XML parse.
+fn xml_elem(body: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = body.find(&open)? + open.len();
+    let end = body[start..].find(&close)? + start;
+    Some(body[start..end].to_string())
+}
+
+fn prop_str<'a>(props: &'a Value, key: &str) -> Option<&'a str> {
+    props.get(key).and_then(|v| v.as_str())
+}
+
+impl ResourceProvisioner {
+    fn ec2_request(&self, action: &str, params: HashMap<String, String>) -> AwsRequest {
+        AwsRequest {
+            service: "ec2".to_string(),
+            action: action.to_string(),
+            region: self.region.clone(),
+            account_id: self.account_id.clone(),
+            request_id: "cfn".to_string(),
+            headers: HeaderMap::new(),
+            query_params: params,
+            body: Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    /// Dispatch one EC2 control-plane action through the real handler and
+    /// return the response body as a string for id extraction.
+    fn ec2_dispatch(
+        &self,
+        action: &str,
+        params: HashMap<String, String>,
+    ) -> Result<String, String> {
+        let svc = Ec2Service::with_state(self.ec2_state.clone());
+        let req = self.ec2_request(action, params);
+        let resp = svc
+            .provision_sync(&req)
+            .map_err(|e| format!("EC2 {action} failed: {}", e.message()))?;
+        Ok(String::from_utf8_lossy(resp.body.expect_bytes()).to_string())
+    }
+
+    /// CFN `Tags` -> repeated `TagSpecification.1.Tag.N.{Key,Value}` params so
+    /// the created resource carries its tags, matching a direct CreateTags.
+    fn ec2_tag_params(
+        &self,
+        props: &Value,
+        resource_type: &str,
+        params: &mut HashMap<String, String>,
+    ) {
+        let Some(tags) = props.get("Tags").and_then(|v| v.as_array()) else {
+            return;
+        };
+        params.insert(
+            "TagSpecification.1.ResourceType".to_string(),
+            resource_type.to_string(),
+        );
+        for (i, t) in tags.iter().enumerate() {
+            if let (Some(k), Some(v)) = (
+                t.get("Key").and_then(|v| v.as_str()),
+                t.get("Value").and_then(|v| v.as_str()),
+            ) {
+                let n = i + 1;
+                params.insert(format!("TagSpecification.1.Tag.{n}.Key"), k.to_string());
+                params.insert(format!("TagSpecification.1.Tag.{n}.Value"), v.to_string());
+            }
+        }
+    }
+
+    pub(super) fn create_ec2_vpc(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let mut params = HashMap::new();
+        if let Some(cidr) = prop_str(props, "CidrBlock") {
+            params.insert("CidrBlock".to_string(), cidr.to_string());
+        }
+        if let Some(t) = prop_str(props, "InstanceTenancy") {
+            params.insert("InstanceTenancy".to_string(), t.to_string());
+        }
+        self.ec2_tag_params(props, "vpc", &mut params);
+        let body = self.ec2_dispatch("CreateVpc", params)?;
+        let id = xml_elem(&body, "vpcId").ok_or("CreateVpc returned no vpcId")?;
+        let cidr = xml_elem(&body, "cidrBlock").unwrap_or_default();
+        Ok(ProvisionResult::new(id.clone())
+            .with("VpcId", id)
+            .with("CidrBlock", cidr))
+    }
+
+    pub(super) fn create_ec2_subnet(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let mut params = HashMap::new();
+        let vpc_id = prop_str(props, "VpcId").ok_or("Subnet requires VpcId")?;
+        params.insert("VpcId".to_string(), vpc_id.to_string());
+        if let Some(cidr) = prop_str(props, "CidrBlock") {
+            params.insert("CidrBlock".to_string(), cidr.to_string());
+        }
+        if let Some(az) = prop_str(props, "AvailabilityZone") {
+            params.insert("AvailabilityZone".to_string(), az.to_string());
+        }
+        self.ec2_tag_params(props, "subnet", &mut params);
+        let body = self.ec2_dispatch("CreateSubnet", params)?;
+        let id = xml_elem(&body, "subnetId").ok_or("CreateSubnet returned no subnetId")?;
+        let az = xml_elem(&body, "availabilityZone").unwrap_or_default();
+        Ok(ProvisionResult::new(id.clone())
+            .with("SubnetId", id)
+            .with("AvailabilityZone", az))
+    }
+
+    pub(super) fn create_ec2_security_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let mut params = HashMap::new();
+        let desc = prop_str(props, "GroupDescription").unwrap_or("Managed by CloudFormation");
+        params.insert("GroupDescription".to_string(), desc.to_string());
+        let name = prop_str(props, "GroupName").unwrap_or(&resource.logical_id);
+        params.insert("GroupName".to_string(), name.to_string());
+        if let Some(vpc) = prop_str(props, "VpcId") {
+            params.insert("VpcId".to_string(), vpc.to_string());
+        }
+        self.ec2_tag_params(props, "security-group", &mut params);
+        let body = self.ec2_dispatch("CreateSecurityGroup", params)?;
+        let id = xml_elem(&body, "groupId").ok_or("CreateSecurityGroup returned no groupId")?;
+        Ok(ProvisionResult::new(id.clone())
+            .with("GroupId", id)
+            .with("VpcId", prop_str(props, "VpcId").unwrap_or("").to_string()))
+    }
+
+    pub(super) fn create_ec2_internet_gateway(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let mut params = HashMap::new();
+        self.ec2_tag_params(&resource.properties, "internet-gateway", &mut params);
+        let body = self.ec2_dispatch("CreateInternetGateway", params)?;
+        let id = xml_elem(&body, "internetGatewayId")
+            .ok_or("CreateInternetGateway returned no internetGatewayId")?;
+        Ok(ProvisionResult::new(id.clone()).with("InternetGatewayId", id))
+    }
+
+    pub(super) fn create_ec2_route_table(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let mut params = HashMap::new();
+        let vpc_id = prop_str(props, "VpcId").ok_or("RouteTable requires VpcId")?;
+        params.insert("VpcId".to_string(), vpc_id.to_string());
+        self.ec2_tag_params(props, "route-table", &mut params);
+        let body = self.ec2_dispatch("CreateRouteTable", params)?;
+        let id =
+            xml_elem(&body, "routeTableId").ok_or("CreateRouteTable returned no routeTableId")?;
+        Ok(ProvisionResult::new(id.clone()).with("RouteTableId", id))
+    }
+
+    /// Delete an EC2 resource by its physical id, routing through the real
+    /// handler so dependent default resources are cleaned up correctly.
+    pub(super) fn delete_ec2_resource(
+        &self,
+        resource_type: &str,
+        physical_id: &str,
+    ) -> Result<(), String> {
+        let (action, id_param) = match resource_type {
+            "AWS::EC2::VPC" => ("DeleteVpc", "VpcId"),
+            "AWS::EC2::Subnet" => ("DeleteSubnet", "SubnetId"),
+            "AWS::EC2::SecurityGroup" => ("DeleteSecurityGroup", "GroupId"),
+            "AWS::EC2::InternetGateway" => ("DeleteInternetGateway", "InternetGatewayId"),
+            "AWS::EC2::RouteTable" => ("DeleteRouteTable", "RouteTableId"),
+            _ => return Ok(()),
+        };
+        let mut params = HashMap::new();
+        params.insert(id_param.to_string(), physical_id.to_string());
+        // A delete of an already-gone resource is not a stack failure.
+        let _ = self.ec2_dispatch(action, params);
+        Ok(())
+    }
+
+    /// `Fn::GetAtt` for EC2 resources. The id-style attributes are the physical
+    /// id; the rest were eagerly captured at create time.
+    pub(super) fn get_att_ec2(&self, resource: &StackResource, attribute: &str) -> Option<String> {
+        match (resource.resource_type.as_str(), attribute) {
+            ("AWS::EC2::VPC", "VpcId")
+            | ("AWS::EC2::Subnet", "SubnetId")
+            | ("AWS::EC2::SecurityGroup", "GroupId")
+            | ("AWS::EC2::SecurityGroup", "Id")
+            | ("AWS::EC2::InternetGateway", "InternetGatewayId")
+            | ("AWS::EC2::RouteTable", "RouteTableId") => Some(resource.physical_id.clone()),
+            _ => resource.attributes.get(attribute).cloned(),
+        }
+    }
+}

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -879,6 +879,7 @@ pub struct ResourceProvisioner {
     pub organizations_state: SharedOrganizationsState,
     pub cognito_state: SharedCognitoState,
     pub rds_state: SharedRdsState,
+    pub ec2_state: fakecloud_ec2::SharedEc2State,
     pub ecs_state: SharedEcsState,
     pub acm_state: SharedAcmState,
     pub elasticache_state: SharedElastiCacheState,
@@ -917,6 +918,7 @@ mod cloudformation;
 mod cloudwatch;
 mod cognito;
 mod dynamodb;
+mod ec2;
 mod ecr;
 mod ecs;
 mod eventbridge;
@@ -1043,6 +1045,11 @@ impl ResourceProvisioner {
             "AWS::RDS::DBProxy" => self.create_rds_db_proxy(resource),
             "AWS::RDS::DBInstance" => self.create_rds_db_instance(resource),
             "AWS::RDS::DBCluster" => self.create_rds_db_cluster(resource),
+            "AWS::EC2::VPC" => self.create_ec2_vpc(resource),
+            "AWS::EC2::Subnet" => self.create_ec2_subnet(resource),
+            "AWS::EC2::SecurityGroup" => self.create_ec2_security_group(resource),
+            "AWS::EC2::InternetGateway" => self.create_ec2_internet_gateway(resource),
+            "AWS::EC2::RouteTable" => self.create_ec2_route_table(resource),
             "AWS::ECS::Cluster" => self.create_ecs_cluster(resource),
             "AWS::ECS::TaskDefinition" => self.create_ecs_task_definition(resource),
             "AWS::ECS::Service" => self.create_ecs_service(resource),
@@ -1380,6 +1387,11 @@ impl ResourceProvisioner {
             }
             "AWS::ECS::Cluster" => self.get_att_ecs_cluster(&resource.physical_id, attribute),
             "AWS::ECS::Service" => self.get_att_ecs_service(&resource.physical_id, attribute),
+            "AWS::EC2::VPC"
+            | "AWS::EC2::Subnet"
+            | "AWS::EC2::SecurityGroup"
+            | "AWS::EC2::InternetGateway"
+            | "AWS::EC2::RouteTable" => self.get_att_ec2(resource, attribute),
             "AWS::ECS::CapacityProvider" => {
                 self.get_att_ecs_capacity_provider(&resource.physical_id, attribute)
             }
@@ -1601,6 +1613,13 @@ impl ResourceProvisioner {
             "AWS::RDS::DBProxy" => self.delete_rds_db_proxy(&resource.physical_id),
             "AWS::RDS::DBInstance" => self.delete_rds_db_instance(&resource.physical_id),
             "AWS::RDS::DBCluster" => self.delete_rds_db_cluster(&resource.physical_id),
+            "AWS::EC2::VPC"
+            | "AWS::EC2::Subnet"
+            | "AWS::EC2::SecurityGroup"
+            | "AWS::EC2::InternetGateway"
+            | "AWS::EC2::RouteTable" => {
+                self.delete_ec2_resource(&resource.resource_type, &resource.physical_id)
+            }
             "AWS::ECS::Cluster" => self.delete_ecs_cluster(&resource.physical_id),
             "AWS::ECS::TaskDefinition" => self.delete_ecs_task_definition(&resource.physical_id),
             "AWS::ECS::Service" => self.delete_ecs_service(&resource.physical_id),
@@ -6010,6 +6029,9 @@ mod tests {
             rds_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
+            ec2_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
             ecs_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
@@ -6233,6 +6255,58 @@ mod tests {
             topic.attributes.get("DisplayName").map(String::as_str),
             Some("after")
         );
+    }
+
+    #[test]
+    fn ec2_vpc_subnet_provision_through_real_handlers() {
+        let prov = make_provisioner();
+        let vpc = prov
+            .create_resource(&make_resource(
+                "AWS::EC2::VPC",
+                "Vpc",
+                serde_json::json!({ "CidrBlock": "10.1.0.0/16" }),
+            ))
+            .expect("VPC provisions");
+        assert!(
+            vpc.physical_id.starts_with("vpc-"),
+            "got {}",
+            vpc.physical_id
+        );
+        // The real VPC handler ran: a VPC exists in EC2 state (with the default
+        // SG/route-table/NACL the handler creates), not a recorded no-op.
+        {
+            let ec2 = prov.ec2_state.read();
+            let acct = ec2.get("123456789012").unwrap();
+            assert!(acct.vpcs.contains_key(&vpc.physical_id));
+        }
+        // GetAtt VpcId/CidrBlock resolve; Ref is the vpc id.
+        assert_eq!(
+            prov.get_att(&vpc, "VpcId").as_deref(),
+            Some(vpc.physical_id.as_str())
+        );
+        assert_eq!(
+            prov.get_att(&vpc, "CidrBlock").as_deref(),
+            Some("10.1.0.0/16")
+        );
+
+        // A subnet referencing the VPC (Ref already resolved to the physical id).
+        let subnet = prov
+            .create_resource(&make_resource(
+                "AWS::EC2::Subnet",
+                "Subnet",
+                serde_json::json!({ "VpcId": vpc.physical_id, "CidrBlock": "10.1.1.0/24" }),
+            ))
+            .expect("subnet provisions");
+        assert!(subnet.physical_id.starts_with("subnet-"));
+        {
+            let ec2 = prov.ec2_state.read();
+            let acct = ec2.get("123456789012").unwrap();
+            assert!(acct.subnets.contains_key(&subnet.physical_id));
+        }
+
+        // Delete routes through the real handler.
+        prov.delete_resource(&subnet).expect("subnet deletes");
+        prov.delete_resource(&vpc).expect("vpc deletes");
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -47,6 +47,11 @@ fn well_known_attributes_for(resource_type: &str) -> &'static [&'static str] {
         "AWS::KMS::Key" => &["Arn", "KeyId"],
         "AWS::SecretsManager::Secret" => &["Arn", "Id"],
         "AWS::CloudFront::Distribution" => &["DomainName", "Id"],
+        "AWS::EC2::VPC" => &["VpcId", "CidrBlock"],
+        "AWS::EC2::Subnet" => &["SubnetId", "AvailabilityZone"],
+        "AWS::EC2::SecurityGroup" => &["GroupId", "VpcId"],
+        "AWS::EC2::InternetGateway" => &["InternetGatewayId"],
+        "AWS::EC2::RouteTable" => &["RouteTableId"],
         _ => &[],
     }
 }
@@ -277,6 +282,7 @@ pub struct CloudFormationDeps {
     pub organizations: fakecloud_organizations::SharedOrganizationsState,
     pub cognito: fakecloud_cognito::SharedCognitoState,
     pub rds: fakecloud_rds::SharedRdsState,
+    pub ec2: fakecloud_ec2::SharedEc2State,
     pub ecs: fakecloud_ecs::SharedEcsState,
     pub acm: fakecloud_acm::SharedAcmState,
     pub elasticache: fakecloud_elasticache::SharedElastiCacheState,
@@ -421,6 +427,7 @@ impl CloudFormationService {
             organizations_state: self.deps.organizations.clone(),
             cognito_state: self.deps.cognito.clone(),
             rds_state: self.deps.rds.clone(),
+            ec2_state: self.deps.ec2.clone(),
             ecs_state: self.deps.ecs.clone(),
             acm_state: self.deps.acm.clone(),
             elasticache_state: self.deps.elasticache.clone(),
@@ -2413,6 +2420,13 @@ mod tests {
                 ),
             )),
             rds: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            ec2: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -912,6 +912,28 @@ impl Ec2Service {
         }
     }
 
+    /// Synchronous dispatch for the subset of EC2 control-plane actions the
+    /// CloudFormation provisioner needs (VPC/Subnet/SecurityGroup/RouteTable/
+    /// InternetGateway create + delete). Routing through the real handlers
+    /// keeps CFN-provisioned EC2 resources identical to API-created ones
+    /// (default SG/NACL/route-table, id formats, tags) instead of re-deriving
+    /// them. None of these actions need the container runtime.
+    pub fn provision_sync(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        match request.action.as_str() {
+            "CreateVpc" => vpc::create_vpc(self, request),
+            "DeleteVpc" => vpc::delete_vpc(self, request),
+            "CreateSubnet" => subnet::create_subnet(self, request),
+            "DeleteSubnet" => subnet::delete_subnet(self, request),
+            "CreateSecurityGroup" => sg::create_security_group(self, request),
+            "DeleteSecurityGroup" => sg::delete_security_group(self, request),
+            "CreateRouteTable" => routing::create_route_table(self, request),
+            "DeleteRouteTable" => routing::delete_route_table(self, request),
+            "CreateInternetGateway" => routing::create_internet_gateway(self, request),
+            "DeleteInternetGateway" => routing::delete_internet_gateway(self, request),
+            other => Err(AwsServiceError::action_not_implemented("ec2", other)),
+        }
+    }
+
     /// Attach a container runtime so `RunInstances` boots real containers.
     /// Passing `None` leaves the service in metadata-only mode.
     pub fn with_runtime(mut self, runtime: Option<Arc<Ec2Runtime>>) -> Self {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -916,6 +916,7 @@ async fn main() {
             organizations: organizations_state.clone(),
             cognito: cognito_state.clone(),
             rds: rds_state.clone(),
+            ec2: ec2_state.clone(),
             ecs: ecs_state.clone(),
             acm: acm_state.clone(),
             elasticache: elasticache_state.clone(),


### PR DESCRIPTION
## Summary

Bug-hunt 2026-06-25 Tier-1 (finding 1.10) — the **last** finding. The CFN provisioner had **no `AWS::EC2::*` arm** even though EC2 is a first-class service with a registered CFN snapshot hook, so a template with a VPC/Subnet/SecurityGroup/RouteTable/InternetGateway recorded each as a no-op unknown resource — `CREATE_COMPLETE` with nothing actually created.

- **EC2** — added `Ec2Service::provision_sync`, a public synchronous dispatch for the CFN-relevant control-plane create/delete actions, reusing the real handlers so CFN-created resources match API-created ones (default SG/NACL/route-table, id formats, tags). None of these need the container runtime.
- **CFN** — wired `ec2_state` into the provisioner (`CloudFormationDeps` + both `ResourceProvisioner` ctors + `main.rs` + test ctors) and added create / delete / GetAtt arms for `AWS::EC2::VPC`, `::Subnet`, `::SecurityGroup`, `::InternetGateway`, `::RouteTable`. Each maps CFN properties to query params, dispatches through `provision_sync`, and extracts the real resource id. GetAtt well-known attributes registered so Outputs resolve.

Routing through the real handlers (rather than re-deriving EC2 state) avoids the provisioner-drift anti-pattern the bug-hunt warns about.

## Test plan

- A stack provisioning a VPC + Subnet creates **real** entries in EC2 state (not no-ops); `Ref` / `GetAtt` / delete route through the real handlers.
- `cargo test -p fakecloud-cloudformation` — 247 passed; `cargo test -p fakecloud-ec2` — 54 passed.
- Server bin builds (struct-field sweep across `CloudFormationDeps` + both provisioner ctors + main.rs + 2 test ctors).
- `cargo clippy -p fakecloud-cloudformation -p fakecloud-ec2 --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface check

- New public EC2 API: `Ec2Service::provision_sync` (used by the CFN provisioner). No introspection/SDK surface.
- Struct-field sweep on `ResourceProvisioner` / `CloudFormationDeps` (the known whole-repo ctor sweep); no persistence schema change.

This **completes the 2026-06-25 bug-hunt (16/16 findings)**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CloudFormation now provisions `AWS::EC2::*` through the real EC2 handlers, so VPCs, subnets, security groups, route tables, and internet gateways are actually created and deleted with correct IDs, defaults, and tags. This fixes the prior no-op behavior where stacks reported CREATE_COMPLETE with nothing in EC2.

- **Bug Fixes**
  - Added `Ec2Service::provision_sync` in `fakecloud-ec2` for EC2 create/delete actions and routed `fakecloud-cloudformation` through it.
  - Implemented CFN support for `AWS::EC2::VPC`, `::Subnet`, `::SecurityGroup`, `::InternetGateway`, `::RouteTable` (create, delete, GetAtt).
  - Registered well-known GetAtts so Outputs resolve: VpcId, CidrBlock, SubnetId, AvailabilityZone, GroupId, RouteTableId, InternetGatewayId.
  - Wired `ec2_state` into `CloudFormationDeps`, `ResourceProvisioner`, and server startup to ensure Ref/GetAtt/delete use the real handlers.

<sup>Written for commit c1bbb5308846eb95c0f0ea555a47b02ebd718151. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

