### PR TITLE
chore(release): bump workspace to v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3983,7 +3983,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4324,7 +4324,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -112,175 +112,175 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.22.0"
+version = "0.23.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.22.0")
+    testImplementation("dev.fakecloud:fakecloud:0.23.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.22.0</version>
+    <version>0.23.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.22.0"
+version = "0.23.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.22.0"
+version = "0.23.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release v0.23.0. Bumps the workspace + all `fakecloud-*` dep pins + the TypeScript/Python/Java SDK versions from 0.22.0 to 0.23.0, and regenerates `Cargo.lock`.

Minor bump — new capability since v0.22.0:
- **CloudFormation**: provision `AWS::EC2::*` resources (VPC/Subnet/SecurityGroup/RouteTable/InternetGateway) through the real EC2 handlers; UpdateStack now applies SQS/SNS/IAM property changes; GetAtt Outputs resolve live attributes (new public `Ec2Service::provision_sync`).
- **Application Auto Scaling**: state now persists across restart.
- **API Gateway v1**: enforces integration timeout (504, no hang).
- **RDS**: option-group Options / event-sub source ids / global-cluster + integration + proxy-target round-trips.
- **Route53 / CloudFront**: List pagination honored.
- tfacc acceptance breadth (EC2 VPC families + full RDS control-plane tree) + weekly aws-models refresh.

No new crates (no release.yml publish-list change); `fakecloud-ec2` already publishes before `fakecloud-cloudformation` (the one new inter-crate dep).

## Test plan

- `cargo update --workspace` regenerated the lock; no `0.22.0` remains in any bumped manifest or in `fakecloud-*` lock entries.
- All 46 publishable crates verified present in `release.yml`.
- Tag `v0.23.0` on the merge commit triggers the publish workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.23.0: bump all `fakecloud-*` crates and SDKs to 0.23.0 and regenerate `Cargo.lock`. Adds CloudFormation EC2 provisioning and several small improvements.

- **New Features**
  - CloudFormation: provision `AWS::EC2::*` (VPC/Subnet/SecurityGroup/RouteTable/InternetGateway) via real EC2 handlers; live `GetAtt`; `UpdateStack` applies SQS/SNS/IAM changes; new `Ec2Service::provision_sync`.
  - Application Auto Scaling: state persists across restart.
  - API Gateway v1: enforce integration timeout (504).
  - RDS: option-group Options, event-sub source IDs, global-cluster; integration and proxy-target round-trips.
  - Route53/CloudFront: list pagination honored.

- **Dependencies**
  - Bump workspace and all `fakecloud-*` crate versions to 0.23.0.
  - Update SDKs: Java, Python, and TypeScript to 0.23.0.
  - Regenerate `Cargo.lock`. No new crates; `release.yml` publish list unchanged.

<sup>Written for commit 2ae857b7e3d845c894d5ffa257fb83161b37d338. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

