### PR TITLE
feat(cognito): USER_AUTH choice-based flow (SELECT_CHALLENGE -> PASSWORD_SRP / PASSWORD)

### DIFF
--- a/crates/fakecloud-cognito/src/service/auth/challenges.rs
+++ b/crates/fakecloud-cognito/src/service/auth/challenges.rs
@@ -107,6 +107,7 @@ impl CognitoService {
                 self.respond_new_password_required(client_id, session, body, req)
             }
             "PASSWORD_VERIFIER" => self.respond_password_verifier(client_id, session, body, req),
+            "SELECT_CHALLENGE" => self.respond_select_challenge(client_id, session, body, req),
             "CUSTOM_CHALLENGE" => {
                 self.respond_custom_challenge(client_id, session, body, req)
                     .await
@@ -249,6 +250,118 @@ impl CognitoService {
         }
 
         self.custom_auth_issue_tokens(&pool_id, client_id, &username, &region, req)
+    }
+
+    /// `RespondToAuthChallenge(ChallengeName=SELECT_CHALLENGE)` for the
+    /// `USER_AUTH` flow: the client's `ANSWER` picks a challenge. `PASSWORD_SRP`
+    /// kicks off the SRP handshake (reusing the shared builder); `PASSWORD`
+    /// verifies the password directly and mints tokens.
+    pub(super) fn respond_select_challenge(
+        &self,
+        client_id: &str,
+        session: &str,
+        body: &Value,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let bad_creds = || {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Incorrect username or password.",
+            )
+        };
+        let responses = body["ChallengeResponses"].as_object().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "ChallengeResponses is required",
+            )
+        })?;
+        let answer = responses
+            .get("ANSWER")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "ANSWER is required in ChallengeResponses",
+                )
+            })?;
+
+        let (pool_id, username, region) = {
+            let accounts = self.state.read();
+            let empty = CognitoState::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+            let sess = state.sessions.get(session).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid session for the user, session is expired.",
+                )
+            })?;
+            if sess.challenge_name != "SELECT_CHALLENGE" {
+                return Err(bad_creds());
+            }
+            (
+                sess.user_pool_id.clone(),
+                sess.username.clone(),
+                state.region.clone(),
+            )
+        };
+        // The SELECT_CHALLENGE session is single-use.
+        {
+            let mut accounts = self.state.write();
+            accounts
+                .get_or_create(&req.account_id)
+                .sessions
+                .remove(session);
+        }
+
+        match answer {
+            "PASSWORD_SRP" => {
+                let srp_a = responses
+                    .get("SRP_A")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidParameterException",
+                            "SRP_A is required for the PASSWORD_SRP challenge",
+                        )
+                    })?;
+                self.build_srp_challenge(&pool_id, client_id, &username, srp_a, req)
+            }
+            "PASSWORD" => {
+                let password = responses
+                    .get("PASSWORD")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(bad_creds)?;
+                let ok = {
+                    let accounts = self.state.read();
+                    let empty = CognitoState::new(&req.account_id, &req.region);
+                    let state = accounts.get(&req.account_id).unwrap_or(&empty);
+                    state
+                        .users
+                        .get(&pool_id)
+                        .and_then(|users| users.get(&username))
+                        .filter(|u| u.enabled)
+                        .map(|u| {
+                            u.password.as_deref() == Some(password)
+                                || u.temporary_password.as_deref() == Some(password)
+                        })
+                        .unwrap_or(false)
+                };
+                if !ok {
+                    return Err(bad_creds());
+                }
+                self.custom_auth_issue_tokens(&pool_id, client_id, &username, &region, req)
+            }
+            other => Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                format!("Unsupported challenge answer: {other}"),
+            )),
+        }
     }
 
     pub(super) fn respond_new_password_required(

--- a/crates/fakecloud-cognito/src/service/auth/initiate.rs
+++ b/crates/fakecloud-cognito/src/service/auth/initiate.rs
@@ -124,6 +124,9 @@ impl CognitoService {
             "USER_SRP_AUTH" => {
                 self.initiate_user_srp_auth(&body, client_id, &pool_id, &explicit_auth_flows, req)
             }
+            "USER_AUTH" => {
+                self.initiate_user_auth(&body, client_id, &pool_id, &explicit_auth_flows, req)
+            }
             "CUSTOM_AUTH" => {
                 self.initiate_custom_auth(&body, client_id, &pool_id, &explicit_auth_flows, req)
                     .await
@@ -181,9 +184,6 @@ impl CognitoService {
         explicit_auth_flows: &[String],
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        use base64::Engine;
-        use rand::RngCore;
-
         if !explicit_auth_flows
             .iter()
             .any(|f| f == "ALLOW_USER_SRP_AUTH")
@@ -223,6 +223,103 @@ impl CognitoService {
                 )
             })?;
         self.require_secret_hash(client_id, username, auth_params.get("SECRET_HASH"))?;
+        self.build_srp_challenge(pool_id, client_id, username, srp_a, req)
+    }
+
+    /// `InitiateAuth(AuthFlow=USER_AUTH)` — the choice-based flow Amplify Gen2
+    /// uses. With a supported `PREFERRED_CHALLENGE` we go straight to it;
+    /// otherwise we return a `SELECT_CHALLENGE` listing the available
+    /// challenges, which the client picks via `RespondToAuthChallenge`.
+    pub(super) fn initiate_user_auth(
+        &self,
+        body: &Value,
+        client_id: &str,
+        pool_id: &str,
+        explicit_auth_flows: &[String],
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        if !explicit_auth_flows.iter().any(|f| f == "ALLOW_USER_AUTH") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "USER_AUTH flow is not enabled for this client.",
+            ));
+        }
+        let auth_params = body["AuthParameters"].as_object().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "AuthParameters is required",
+            )
+        })?;
+        let username = auth_params
+            .get("USERNAME")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "USERNAME is required in AuthParameters",
+                )
+            })?;
+        self.require_secret_hash(client_id, username, auth_params.get("SECRET_HASH"))?;
+
+        let preferred = auth_params
+            .get("PREFERRED_CHALLENGE")
+            .and_then(|v| v.as_str());
+        if preferred == Some("PASSWORD_SRP") {
+            let srp_a = auth_params
+                .get("SRP_A")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterException",
+                        "SRP_A is required for the PASSWORD_SRP challenge",
+                    )
+                })?;
+            return self.build_srp_challenge(pool_id, client_id, username, srp_a, req);
+        }
+
+        // No preferred challenge resolvable inline: present the menu.
+        let session = Uuid::new_v4().to_string();
+        {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            state.sessions.insert(
+                session.clone(),
+                SessionData {
+                    user_pool_id: pool_id.to_string(),
+                    username: username.to_string(),
+                    client_id: client_id.to_string(),
+                    challenge_name: "SELECT_CHALLENGE".to_string(),
+                    challenge_results: vec![],
+                    challenge_metadata: None,
+                },
+            );
+        }
+        Ok(AwsResponse::ok_json(json!({
+            "ChallengeName": "SELECT_CHALLENGE",
+            "Session": session,
+            "AvailableChallenges": ["PASSWORD_SRP", "PASSWORD"],
+            "ChallengeParameters": { "USERNAME": username },
+        })))
+    }
+
+    /// Build the `PASSWORD_VERIFIER` challenge for an SRP handshake: derive the
+    /// user's verifier, pick the server keys, and stash the handshake in the
+    /// session. Shared by `USER_SRP_AUTH` and the `USER_AUTH` `PASSWORD_SRP`
+    /// path. Does not check the auth flow (callers gate that).
+    pub(super) fn build_srp_challenge(
+        &self,
+        pool_id: &str,
+        client_id: &str,
+        username: &str,
+        srp_a: &str,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        use base64::Engine;
+        use rand::RngCore;
 
         let password = {
             let accounts = self.state.read();

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -2475,6 +2475,134 @@ fn user_srp_auth_full_flow() {
     assert_eq!(err.code(), "NotAuthorizedException");
 }
 
+/// USER_AUTH choice-based flow: InitiateAuth returns SELECT_CHALLENGE; the
+/// client selects PASSWORD_SRP (-> SRP handshake -> tokens) or PASSWORD
+/// (-> direct verify -> tokens).
+#[test]
+fn user_auth_select_challenge_flow() {
+    use base64::Engine;
+    let (svc, pool_id) = setup_svc_with_pool();
+
+    let body = json!({
+        "UserPoolId": pool_id,
+        "ClientName": "ua-client",
+        "ExplicitAuthFlows": ["ALLOW_USER_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+    });
+    let client_id = resp_json(
+        &svc.create_user_pool_client(&make_req("CreateUserPoolClient", &body.to_string()))
+            .unwrap(),
+    )["UserPoolClient"]["ClientId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let password = "Ch0ice!Pass";
+    block_on(svc.sign_up(&make_req(
+        "SignUp",
+        &json!({"ClientId": client_id, "Username": "uauser", "Password": password}).to_string(),
+    )))
+    .unwrap();
+    svc.admin_set_user_password(&make_req(
+        "AdminSetUserPassword",
+        &json!({"UserPoolId": pool_id, "Username": "uauser", "Password": password, "Permanent": true})
+            .to_string(),
+    ))
+    .unwrap();
+
+    // --- PASSWORD_SRP path ---
+    let select = resp_json(
+        &block_on(svc.initiate_auth(&make_req(
+            "InitiateAuth",
+            &json!({"ClientId": client_id, "AuthFlow": "USER_AUTH", "AuthParameters": {"USERNAME": "uauser"}}).to_string(),
+        )))
+        .unwrap(),
+    );
+    assert_eq!(select["ChallengeName"], "SELECT_CHALLENGE");
+    assert!(select["AvailableChallenges"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|c| c == "PASSWORD_SRP"));
+    let select_session = select["Session"].as_str().unwrap().to_string();
+
+    let (a_priv, a_pub) = crate::srp::test_client_keypair();
+    let pv = resp_json(
+        &block_on(svc.respond_to_auth_challenge(&make_req(
+            "RespondToAuthChallenge",
+            &json!({
+                "ClientId": client_id,
+                "ChallengeName": "SELECT_CHALLENGE",
+                "Session": select_session,
+                "ChallengeResponses": {"ANSWER": "PASSWORD_SRP", "USERNAME": "uauser", "SRP_A": crate::srp::to_hex(&a_pub)},
+            })
+            .to_string(),
+        )))
+        .unwrap(),
+    );
+    assert_eq!(pv["ChallengeName"], "PASSWORD_VERIFIER");
+    let cp = &pv["ChallengeParameters"];
+    let salt = crate::srp::parse_hex(cp["SALT"].as_str().unwrap()).unwrap();
+    let server_b = crate::srp::parse_hex(cp["SRP_B"].as_str().unwrap()).unwrap();
+    let secret_block_b64 = cp["SECRET_BLOCK"].as_str().unwrap().to_string();
+    let user_id = cp["USER_ID_FOR_SRP"].as_str().unwrap().to_string();
+    let pool_name = crate::srp::pool_short_name(&pool_id).to_string();
+    let secret_block = base64::engine::general_purpose::STANDARD
+        .decode(&secret_block_b64)
+        .unwrap();
+    let ts = "Wed Mar 6 12:34:56 UTC 2024";
+    let sig = crate::srp::test_client_signature(
+        &pool_name,
+        &user_id,
+        password,
+        &salt,
+        &server_b,
+        &a_priv,
+        &secret_block,
+        ts,
+    );
+    let auth = resp_json(
+        &block_on(svc.respond_to_auth_challenge(&make_req(
+            "RespondToAuthChallenge",
+            &json!({
+                "ClientId": client_id,
+                "ChallengeName": "PASSWORD_VERIFIER",
+                "Session": pv["Session"].as_str().unwrap(),
+                "ChallengeResponses": {"USERNAME": "uauser", "PASSWORD_CLAIM_SIGNATURE": sig, "PASSWORD_CLAIM_SECRET_BLOCK": secret_block_b64, "TIMESTAMP": ts},
+            })
+            .to_string(),
+        )))
+        .unwrap(),
+    );
+    assert!(auth["AuthenticationResult"]["AccessToken"]
+        .as_str()
+        .is_some());
+
+    // --- PASSWORD path ---
+    let select2 = resp_json(
+        &block_on(svc.initiate_auth(&make_req(
+            "InitiateAuth",
+            &json!({"ClientId": client_id, "AuthFlow": "USER_AUTH", "AuthParameters": {"USERNAME": "uauser"}}).to_string(),
+        )))
+        .unwrap(),
+    );
+    let pw_auth = resp_json(
+        &block_on(svc.respond_to_auth_challenge(&make_req(
+            "RespondToAuthChallenge",
+            &json!({
+                "ClientId": client_id,
+                "ChallengeName": "SELECT_CHALLENGE",
+                "Session": select2["Session"].as_str().unwrap(),
+                "ChallengeResponses": {"ANSWER": "PASSWORD", "USERNAME": "uauser", "PASSWORD": password},
+            })
+            .to_string(),
+        )))
+        .unwrap(),
+    );
+    assert!(pw_auth["AuthenticationResult"]["AccessToken"]
+        .as_str()
+        .is_some());
+}
+
 /// 1.27: a client WITHOUT a secret must not require SECRET_HASH.
 #[test]
 fn secret_hash_not_required_for_clients_without_secret() {

--- a/website/content/docs/services/cognito.md
+++ b/website/content/docs/services/cognito.md
@@ -18,7 +18,7 @@ fakecloud implements **126 of 126** Cognito User Pools operations at 100% Smithy
 - **Resource servers** — CRUD, custom scopes
 - **Domains** — user pool domains
 - **Multi-region replicas** — `CreateUserPoolReplica` / `DeleteUserPoolReplica` / `ListUserPoolReplicas` / `UpdateUserPoolReplica`. The pool's own region is reported as the `PRIMARY` replica; secondary regions are recorded as control-plane entries (region + status) — fakecloud is single-region, so a replica is a record rather than a real second directory copy
-- **Authentication flows** — USER_PASSWORD_AUTH, USER_SRP_AUTH, REFRESH_TOKEN_AUTH, CUSTOM_AUTH, ADMIN_USER_PASSWORD_AUTH
+- **Authentication flows** — USER_PASSWORD_AUTH, USER_SRP_AUTH (real SRP6a, works with Amplify / amazon-cognito-identity-js), USER_AUTH (choice-based SELECT_CHALLENGE), REFRESH_TOKEN_AUTH, CUSTOM_AUTH, ADMIN_USER_PASSWORD_AUTH
 - **Password management** — ChangePassword, ForgotPassword, ConfirmForgotPassword
 - **Confirmation codes** — email/SMS confirmation flows
 - **Devices** — Confirm, update, forget, track


### PR DESCRIPTION
## Summary

next-step 2026-06-26 batch 2. Implements the modern choice-based **USER_AUTH** flow (Amplify Gen2) on top of batch 1's SRP (#1959).

- **`InitiateAuth(AuthFlow=USER_AUTH)`** returns `ChallengeName=SELECT_CHALLENGE` with `AvailableChallenges` `[PASSWORD_SRP, PASSWORD]` — or goes straight to the SRP handshake when `PREFERRED_CHALLENGE=PASSWORD_SRP` + `SRP_A` is supplied.
- **`RespondToAuthChallenge(SELECT_CHALLENGE)`** routes on the client's `ANSWER`: `PASSWORD_SRP` starts the SRP handshake (reusing the shared `build_srp_challenge` helper extracted from `USER_SRP_AUTH`), `PASSWORD` verifies the password directly and mints tokens. Unknown answers → `InvalidParameterException`.

Refactored `USER_SRP_AUTH`'s challenge construction into `build_srp_challenge` so both flows share one code path (no duplication).

## Test plan

- `user_auth_select_challenge_flow`: drives `InitiateAuth(USER_AUTH)` → `SELECT_CHALLENGE`, then both the **PASSWORD_SRP** answer (full SRP exchange → tokens) and the **PASSWORD** answer (direct verify → tokens).
- `cargo test -p fakecloud-cognito` — passes (incl. batch-1 SRP tests, unchanged).
- `cargo clippy -p fakecloud-cognito --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface check

- No new published crate / introspection endpoint / SDK surface — `USER_AUTH` is a standard Cognito API flow.
- `website/content/docs/services/cognito.md` auth-flow list updated to include `USER_AUTH` (and annotate `USER_SRP_AUTH` as real SRP6a).

## Note on ADMIN_USER_SRP_AUTH

The admin path (`admin_initiate_auth`) authenticates server-side via password (`ADMIN_USER_PASSWORD_AUTH` / `ADMIN_NO_SRP_AUTH`) without an SRP challenge round-trip; `ADMIN_USER_SRP_AUTH` is a rarely-used admin variant that still requires the same client-side SRP proof as `USER_SRP_AUTH`. The user-facing SRP value (Amplify, amazon-cognito-identity-js) is fully delivered by `USER_SRP_AUTH` (#1959) + this `USER_AUTH` flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the choice-based USER_AUTH flow for Cognito: InitiateAuth returns SELECT_CHALLENGE so clients can pick PASSWORD_SRP or PASSWORD, or jump straight to SRP when PREFERRED_CHALLENGE=PASSWORD_SRP. RespondToAuthChallenge handles both paths and mints tokens.

- **New Features**
  - InitiateAuth(USER_AUTH) returns SELECT_CHALLENGE with AvailableChallenges [PASSWORD_SRP, PASSWORD], or goes straight to SRP when PREFERRED_CHALLENGE=PASSWORD_SRP + SRP_A (requires ALLOW_USER_AUTH).
  - RespondToAuthChallenge(SELECT_CHALLENGE): PASSWORD_SRP starts the SRP handshake; PASSWORD verifies the password and issues tokens. Unknown answers return InvalidParameterException.
  - Added an end-to-end test for both paths; docs updated to list USER_AUTH.

- **Refactors**
  - Extracted a shared build_srp_challenge helper from USER_SRP_AUTH and reused it in USER_AUTH.

<sup>Written for commit e560b569f80ec7b67bd0d2aa90cf59a48655d855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

