### PR TITLE
fix(cognito): SRP temp-password reset, client_id binding, DoS + timing hardening

### DIFF
--- a/crates/fakecloud-cognito/src/service/auth/challenges.rs
+++ b/crates/fakecloud-cognito/src/service/auth/challenges.rs
@@ -120,6 +120,54 @@ impl CognitoService {
         }
     }
 
+    /// If the user still owes a forced password reset, return a
+    /// `NEW_PASSWORD_REQUIRED` challenge instead of minting tokens. The SRP /
+    /// SELECT_CHALLENGE success path only proves the user's *current* (possibly
+    /// temporary) password; an admin-created user with a temporary password
+    /// must still set a permanent one, exactly as the `USER_PASSWORD_AUTH`
+    /// (initiate.rs) and `AdminInitiateAuth` (admin.rs) paths require. Returns
+    /// `Some(challenge)` when a reset is owed, `None` to proceed to tokens.
+    fn maybe_force_new_password(
+        &self,
+        pool_id: &str,
+        client_id: &str,
+        username: &str,
+        req: &AwsRequest,
+    ) -> Option<AwsResponse> {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let needs_reset = state
+            .users
+            .get(pool_id)
+            .and_then(|users| users.get(username))
+            .map(|u| u.user_status == user_status::FORCE_CHANGE_PASSWORD)
+            .unwrap_or(false);
+        if !needs_reset {
+            return None;
+        }
+        let session = Uuid::new_v4().to_string();
+        state.sessions.insert(
+            session.clone(),
+            SessionData {
+                user_pool_id: pool_id.to_string(),
+                username: username.to_string(),
+                client_id: client_id.to_string(),
+                challenge_name: "NEW_PASSWORD_REQUIRED".to_string(),
+                challenge_results: vec![],
+                challenge_metadata: None,
+            },
+        );
+        Some(AwsResponse::ok_json(json!({
+            "ChallengeName": "NEW_PASSWORD_REQUIRED",
+            "Session": session,
+            "ChallengeParameters": {
+                "USER_ID_FOR_SRP": username,
+                "requiredAttributes": "[]",
+                "userAttributes": "{}"
+            }
+        })))
+    }
+
     /// `RespondToAuthChallenge(ChallengeName=PASSWORD_VERIFIER)`: verify the
     /// client's SRP6a proof against the handshake stashed at InitiateAuth time
     /// and, on success, mint real tokens. Reuses the shared token issuer.
@@ -166,7 +214,7 @@ impl CognitoService {
                     "Invalid session for the user, session is expired.",
                 )
             })?;
-            if sess.challenge_name != "PASSWORD_VERIFIER" {
+            if sess.challenge_name != "PASSWORD_VERIFIER" || sess.client_id != client_id {
                 return Err(bad_creds());
             }
             let stash = sess.challenge_metadata.clone().ok_or_else(bad_creds)?;
@@ -224,7 +272,7 @@ impl CognitoService {
         )
         .ok_or_else(bad_creds)?;
 
-        if expected.as_bytes() != client_sig.as_bytes() {
+        if !crate::srp::ct_eq(expected.as_bytes(), client_sig.as_bytes()) {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&req.account_id);
             state.auth_events.push(AuthEvent {
@@ -247,6 +295,11 @@ impl CognitoService {
                 .get_or_create(&req.account_id)
                 .sessions
                 .remove(session);
+        }
+
+        // A valid SRP proof of a *temporary* password still owes a reset.
+        if let Some(resp) = self.maybe_force_new_password(&pool_id, client_id, &username, req) {
+            return Ok(resp);
         }
 
         self.custom_auth_issue_tokens(&pool_id, client_id, &username, &region, req)
@@ -299,7 +352,7 @@ impl CognitoService {
                     "Invalid session for the user, session is expired.",
                 )
             })?;
-            if sess.challenge_name != "SELECT_CHALLENGE" {
+            if sess.challenge_name != "SELECT_CHALLENGE" || sess.client_id != client_id {
                 return Err(bad_creds());
             }
             (
@@ -353,6 +406,12 @@ impl CognitoService {
                 };
                 if !ok {
                     return Err(bad_creds());
+                }
+                // A temporary password still owes a forced reset.
+                if let Some(resp) =
+                    self.maybe_force_new_password(&pool_id, client_id, &username, req)
+                {
+                    return Ok(resp);
                 }
                 self.custom_auth_issue_tokens(&pool_id, client_id, &username, &region, req)
             }

--- a/crates/fakecloud-cognito/src/service/auth/initiate.rs
+++ b/crates/fakecloud-cognito/src/service/auth/initiate.rs
@@ -281,7 +281,28 @@ impl CognitoService {
             return self.build_srp_challenge(pool_id, client_id, username, srp_a, req);
         }
 
-        // No preferred challenge resolvable inline: present the menu.
+        // No preferred challenge resolvable inline: present the menu, filtered
+        // to the factors this app client actually enables. PASSWORD_SRP needs
+        // ALLOW_USER_SRP_AUTH, PASSWORD needs ALLOW_USER_PASSWORD_AUTH. A client
+        // that only opts into ALLOW_USER_AUTH (no specific factor flag) gets
+        // both, matching the permissive default real Cognito applies.
+        let mut available: Vec<&str> = Vec::new();
+        if explicit_auth_flows
+            .iter()
+            .any(|f| f == "ALLOW_USER_SRP_AUTH")
+        {
+            available.push("PASSWORD_SRP");
+        }
+        if explicit_auth_flows
+            .iter()
+            .any(|f| f == "ALLOW_USER_PASSWORD_AUTH")
+        {
+            available.push("PASSWORD");
+        }
+        if available.is_empty() {
+            available = vec!["PASSWORD_SRP", "PASSWORD"];
+        }
+
         let session = Uuid::new_v4().to_string();
         {
             let mut accounts = self.state.write();
@@ -301,7 +322,7 @@ impl CognitoService {
         Ok(AwsResponse::ok_json(json!({
             "ChallengeName": "SELECT_CHALLENGE",
             "Session": session,
-            "AvailableChallenges": ["PASSWORD_SRP", "PASSWORD"],
+            "AvailableChallenges": available,
             "ChallengeParameters": { "USERNAME": username },
         })))
     }
@@ -320,6 +341,18 @@ impl CognitoService {
     ) -> Result<AwsResponse, AwsServiceError> {
         use base64::Engine;
         use rand::RngCore;
+
+        // Reject an oversized SRP_A before stashing it / running modpow: a
+        // legitimate public value is <= the 3072-bit modulus, and an
+        // attacker-sized hex string would only burn CPU on the executor thread
+        // during RespondToAuthChallenge verification (DoS guard).
+        if srp_a.len() > crate::srp::MAX_PUBLIC_HEX_LEN {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "SRP_A is malformed.",
+            ));
+        }
 
         let password = {
             let accounts = self.state.read();

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -2475,6 +2475,255 @@ fn user_srp_auth_full_flow() {
     assert_eq!(err.code(), "NotAuthorizedException");
 }
 
+/// A USER_SRP_AUTH login by an admin-created user whose status is still
+/// FORCE_CHANGE_PASSWORD must, after a valid SRP proof of the *temporary*
+/// password, return a NEW_PASSWORD_REQUIRED challenge rather than minting
+/// tokens (matching real Cognito and the USER_PASSWORD_AUTH path).
+#[test]
+fn user_srp_auth_force_change_password_returns_challenge() {
+    use base64::Engine;
+    let (svc, pool_id) = setup_svc_with_pool();
+
+    let body = json!({
+        "UserPoolId": pool_id,
+        "ClientName": "srp-fcp-client",
+        "ExplicitAuthFlows": ["ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+    });
+    let client_id = resp_json(
+        &svc.create_user_pool_client(&make_req("CreateUserPoolClient", &body.to_string()))
+            .unwrap(),
+    )["UserPoolClient"]["ClientId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Admin-create the user with a temporary password -> FORCE_CHANGE_PASSWORD.
+    let temp_password = "TempP@ss1!";
+    block_on(svc.admin_create_user(&make_req(
+        "AdminCreateUser",
+        &json!({"UserPoolId": pool_id, "Username": "fcpuser", "TemporaryPassword": temp_password})
+            .to_string(),
+    )))
+    .unwrap();
+
+    // SRP handshake using the temporary password.
+    let (a_priv, a_pub) = crate::srp::test_client_keypair();
+    let challenge = resp_json(
+        &block_on(
+            svc.initiate_auth(&make_req(
+                "InitiateAuth",
+                &json!({
+                    "ClientId": client_id,
+                    "AuthFlow": "USER_SRP_AUTH",
+                    "AuthParameters": {"USERNAME": "fcpuser", "SRP_A": crate::srp::to_hex(&a_pub)},
+                })
+                .to_string(),
+            )),
+        )
+        .unwrap(),
+    );
+    assert_eq!(challenge["ChallengeName"], "PASSWORD_VERIFIER");
+    let session = challenge["Session"].as_str().unwrap().to_string();
+    let cp = &challenge["ChallengeParameters"];
+    let salt = crate::srp::parse_hex(cp["SALT"].as_str().unwrap()).unwrap();
+    let server_b = crate::srp::parse_hex(cp["SRP_B"].as_str().unwrap()).unwrap();
+    let secret_block_b64 = cp["SECRET_BLOCK"].as_str().unwrap().to_string();
+    let user_id = cp["USER_ID_FOR_SRP"].as_str().unwrap().to_string();
+    let pool_name = crate::srp::pool_short_name(&pool_id).to_string();
+    let secret_block = base64::engine::general_purpose::STANDARD
+        .decode(&secret_block_b64)
+        .unwrap();
+    let ts = "Wed Mar 6 12:34:56 UTC 2024";
+    let sig = crate::srp::test_client_signature(
+        &pool_name,
+        &user_id,
+        temp_password,
+        &salt,
+        &server_b,
+        &a_priv,
+        &secret_block,
+        ts,
+    );
+
+    // Valid proof of the temporary password -> NEW_PASSWORD_REQUIRED, no tokens.
+    let resp = resp_json(
+        &block_on(svc.respond_to_auth_challenge(&make_req(
+            "RespondToAuthChallenge",
+            &json!({
+                "ClientId": client_id,
+                "ChallengeName": "PASSWORD_VERIFIER",
+                "Session": session,
+                "ChallengeResponses": {"USERNAME": "fcpuser", "PASSWORD_CLAIM_SIGNATURE": sig, "PASSWORD_CLAIM_SECRET_BLOCK": secret_block_b64, "TIMESTAMP": ts},
+            })
+            .to_string(),
+        )))
+        .unwrap(),
+    );
+    assert_eq!(resp["ChallengeName"], "NEW_PASSWORD_REQUIRED");
+    assert!(resp["AuthenticationResult"].is_null());
+    let new_pw_session = resp["Session"].as_str().unwrap().to_string();
+
+    // Completing NEW_PASSWORD_REQUIRED then mints tokens.
+    let final_auth = resp_json(
+        &block_on(
+            svc.respond_to_auth_challenge(&make_req(
+                "RespondToAuthChallenge",
+                &json!({
+                    "ClientId": client_id,
+                    "ChallengeName": "NEW_PASSWORD_REQUIRED",
+                    "Session": new_pw_session,
+                    "ChallengeResponses": {"USERNAME": "fcpuser", "NEW_PASSWORD": "Perm@nent99!"},
+                })
+                .to_string(),
+            )),
+        )
+        .unwrap(),
+    );
+    assert!(final_auth["AuthenticationResult"]["AccessToken"]
+        .as_str()
+        .is_some());
+}
+
+/// A PASSWORD_VERIFIER challenge is bound to the app client that started the
+/// SRP handshake: responding with a different ClientId is rejected even with
+/// an otherwise-valid proof.
+#[test]
+fn user_srp_auth_wrong_client_id_rejected() {
+    use base64::Engine;
+    let (svc, pool_id) = setup_svc_with_pool();
+
+    let mk_client = |name: &str| {
+        resp_json(
+            &svc.create_user_pool_client(&make_req(
+                "CreateUserPoolClient",
+                &json!({
+                    "UserPoolId": pool_id,
+                    "ClientName": name,
+                    "ExplicitAuthFlows": ["ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+                })
+                .to_string(),
+            ))
+            .unwrap(),
+        )["UserPoolClient"]["ClientId"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+    let client_a = mk_client("srp-a");
+    let client_b = mk_client("srp-b");
+
+    let password = "S3cretP@ss!";
+    block_on(svc.sign_up(&make_req(
+        "SignUp",
+        &json!({"ClientId": client_a, "Username": "binduser", "Password": password}).to_string(),
+    )))
+    .unwrap();
+    svc.admin_set_user_password(&make_req(
+        "AdminSetUserPassword",
+        &json!({"UserPoolId": pool_id, "Username": "binduser", "Password": password, "Permanent": true})
+            .to_string(),
+    ))
+    .unwrap();
+
+    let (a_priv, a_pub) = crate::srp::test_client_keypair();
+    let challenge = resp_json(
+        &block_on(
+            svc.initiate_auth(&make_req(
+                "InitiateAuth",
+                &json!({
+                    "ClientId": client_a,
+                    "AuthFlow": "USER_SRP_AUTH",
+                    "AuthParameters": {"USERNAME": "binduser", "SRP_A": crate::srp::to_hex(&a_pub)},
+                })
+                .to_string(),
+            )),
+        )
+        .unwrap(),
+    );
+    let session = challenge["Session"].as_str().unwrap().to_string();
+    let cp = &challenge["ChallengeParameters"];
+    let salt = crate::srp::parse_hex(cp["SALT"].as_str().unwrap()).unwrap();
+    let server_b = crate::srp::parse_hex(cp["SRP_B"].as_str().unwrap()).unwrap();
+    let secret_block_b64 = cp["SECRET_BLOCK"].as_str().unwrap().to_string();
+    let user_id = cp["USER_ID_FOR_SRP"].as_str().unwrap().to_string();
+    let pool_name = crate::srp::pool_short_name(&pool_id).to_string();
+    let secret_block = base64::engine::general_purpose::STANDARD
+        .decode(&secret_block_b64)
+        .unwrap();
+    let ts = "Wed Mar 6 12:34:56 UTC 2024";
+    let sig = crate::srp::test_client_signature(
+        &pool_name,
+        &user_id,
+        password,
+        &salt,
+        &server_b,
+        &a_priv,
+        &secret_block,
+        ts,
+    );
+
+    // Respond with a DIFFERENT client id -> rejected.
+    let err = block_on(svc.respond_to_auth_challenge(&make_req(
+        "RespondToAuthChallenge",
+        &json!({
+            "ClientId": client_b,
+            "ChallengeName": "PASSWORD_VERIFIER",
+            "Session": session,
+            "ChallengeResponses": {"USERNAME": "binduser", "PASSWORD_CLAIM_SIGNATURE": sig, "PASSWORD_CLAIM_SECRET_BLOCK": secret_block_b64, "TIMESTAMP": ts},
+        })
+        .to_string(),
+    )))
+    .err()
+    .expect("wrong client id rejected");
+    assert_eq!(err.code(), "NotAuthorizedException");
+}
+
+/// An oversized SRP_A is rejected up front rather than burning CPU on a
+/// modpow over an attacker-sized public value (DoS guard).
+#[test]
+fn user_srp_auth_rejects_oversized_srp_a() {
+    let (svc, pool_id) = setup_svc_with_pool();
+    let client_id = resp_json(
+        &svc.create_user_pool_client(&make_req(
+            "CreateUserPoolClient",
+            &json!({
+                "UserPoolId": pool_id,
+                "ClientName": "srp-big",
+                "ExplicitAuthFlows": ["ALLOW_USER_SRP_AUTH"]
+            })
+            .to_string(),
+        ))
+        .unwrap(),
+    )["UserPoolClient"]["ClientId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    block_on(
+        svc.sign_up(&make_req(
+            "SignUp",
+            &json!({"ClientId": client_id, "Username": "biguser", "Password": "S3cretP@ss!"})
+                .to_string(),
+        )),
+    )
+    .unwrap();
+
+    let huge = "f".repeat(crate::srp::MAX_PUBLIC_HEX_LEN + 1);
+    let err = block_on(
+        svc.initiate_auth(&make_req(
+            "InitiateAuth",
+            &json!({
+                "ClientId": client_id,
+                "AuthFlow": "USER_SRP_AUTH",
+                "AuthParameters": {"USERNAME": "biguser", "SRP_A": huge},
+            })
+            .to_string(),
+        )),
+    )
+    .err()
+    .expect("oversized SRP_A rejected");
+    assert_eq!(err.code(), "InvalidParameterException");
+}
+
 /// USER_AUTH choice-based flow: InitiateAuth returns SELECT_CHALLENGE; the
 /// client selects PASSWORD_SRP (-> SRP handshake -> tokens) or PASSWORD
 /// (-> direct verify -> tokens).

--- a/crates/fakecloud-cognito/src/srp.rs
+++ b/crates/fakecloud-cognito/src/srp.rs
@@ -17,6 +17,29 @@ use sha2::{Digest, Sha256};
 
 type HmacSha256 = Hmac<Sha256>;
 
+/// Maximum accepted hex length for a client-supplied SRP public value (`SRP_A`).
+/// The 3072-bit modulus is 768 hex chars; a legitimate `A < N` never exceeds
+/// that (plus a small margin). Anything larger is malformed and would only
+/// serve to inflate the cost of the `num-bigint` modpow/multiply that verifies
+/// the proof, so we reject it up front (CPU-DoS guard against an attacker-sized
+/// `A` blocking the executor thread).
+pub const MAX_PUBLIC_HEX_LEN: usize = 1024;
+
+/// Constant-time equality for two equal-length byte slices, used for the SRP
+/// `PASSWORD_CLAIM_SIGNATURE` comparison so the check does not short-circuit on
+/// the first differing byte (no timing side-channel on the proof). The length
+/// branch is not secret: the signature is a fixed-width base64 HMAC-SHA256.
+pub fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 /// The 3072-bit MODP group (RFC 5054) that AWS Cognito uses, g = 2.
 const N_HEX: &str = "\
 FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74\
@@ -153,6 +176,9 @@ pub fn expected_signature(
     timestamp: &str,
 ) -> Option<String> {
     use base64::Engine;
+    if client_a_hex.len() > MAX_PUBLIC_HEX_LEN {
+        return None;
+    }
     let n = modulus();
     let a = from_hex(client_a_hex)?;
     if (&a % &n) == BigUint::from(0u8) {

--- a/website/content/docs/services/cognito.md
+++ b/website/content/docs/services/cognito.md
@@ -18,7 +18,7 @@ fakecloud implements **126 of 126** Cognito User Pools operations at 100% Smithy
 - **Resource servers** — CRUD, custom scopes
 - **Domains** — user pool domains
 - **Multi-region replicas** — `CreateUserPoolReplica` / `DeleteUserPoolReplica` / `ListUserPoolReplicas` / `UpdateUserPoolReplica`. The pool's own region is reported as the `PRIMARY` replica; secondary regions are recorded as control-plane entries (region + status) — fakecloud is single-region, so a replica is a record rather than a real second directory copy
-- **Authentication flows** — USER_PASSWORD_AUTH, USER_SRP_AUTH (real SRP6a, works with Amplify / amazon-cognito-identity-js), USER_AUTH (choice-based SELECT_CHALLENGE), REFRESH_TOKEN_AUTH, CUSTOM_AUTH, ADMIN_USER_PASSWORD_AUTH
+- **Authentication flows** — USER_PASSWORD_AUTH, USER_SRP_AUTH (real SRP6a, works with Amplify / amazon-cognito-identity-js), USER_AUTH (choice-based SELECT_CHALLENGE; the `AvailableChallenges` menu is filtered to the factors the app client enables), REFRESH_TOKEN_AUTH, CUSTOM_AUTH, ADMIN_USER_PASSWORD_AUTH. An admin-created user with a temporary password is challenged with `NEW_PASSWORD_REQUIRED` after a valid SRP/password proof — the forced reset is enforced before tokens are issued, exactly as in real Cognito
 - **Password management** — ChangePassword, ForgotPassword, ConfirmForgotPassword
 - **Confirmation codes** — email/SMS confirmation flows
 - **Devices** — Confirm, update, forget, track


### PR DESCRIPTION
## Summary
Bug-hunt 2026-06-26 (cycle 2) findings against the just-merged Cognito SRP surface (#1959/#1960). All confirmed findings in this crate:

- **H1 (correctness):** `USER_SRP_AUTH` / `USER_AUTH` for an admin-created `FORCE_CHANGE_PASSWORD` user minted full Access/Id/Refresh tokens directly, skipping the forced reset — diverging from the `USER_PASSWORD_AUTH` (initiate.rs) and `AdminInitiateAuth` (admin.rs) paths. Now returns `NEW_PASSWORD_REQUIRED` after a valid SRP/password proof.
- **M1 (blocking/DoS):** `SRP_A` was stashed verbatim and fed to a 3072-bit `num-bigint` modpow + attacker-sized multiply inline on the tokio worker, with no length bound (1 GiB body cap). A 200 MB-hex `SRP_A` measured ~1.8s of pure CPU per request. Now rejected up front when longer than the modulus (+ margin).
- **L1 (fidelity):** `PASSWORD_VERIFIER` / `SELECT_CHALLENGE` sessions weren't bound to the originating app client — a valid proof presented with a *different* `ClientId` minted tokens whose `aud` was the wrong client. Now rejects on `client_id` mismatch (matching the other challenge handlers).
- **L2 (crypto):** `PASSWORD_CLAIM_SIGNATURE` compared with a short-circuiting `!=`. Now a constant-time byte compare.
- **Folded fidelity:** `USER_AUTH` `AvailableChallenges` is now filtered to the client's enabled factors instead of a hardcoded `[PASSWORD_SRP, PASSWORD]`.

Verified-NOT-bugs (cleared, not chased): SRP verifier is genuinely checked; SRP session state persists across restart; session-expiry gap is LOW (single-use sessions, local emulator) and left as a documented realism gap.

## Test plan
- `cargo nextest run -p fakecloud-cognito` — 343 pass (3 new).
- New: `user_srp_auth_force_change_password_returns_challenge`, `user_srp_auth_wrong_client_id_rejected`, `user_srp_auth_rejects_oversized_srp_a`.
- `cargo clippy -p fakecloud-cognito --all-targets -- -D warnings` clean; `cargo fmt`.
- Docs: `website/content/docs/services/cognito.md` auth-flow reference updated. No SDK/endpoint surface change (behavioral fixes).

Report: `bug-hunt-reports/2026-06-26.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cognito SRP auth to match real behavior and hardens it. Enforces forced password reset, binds sessions to the app client, and rejects oversized `SRP_A` to prevent CPU DoS.

- **Bug Fixes**
  - Return NEW_PASSWORD_REQUIRED after a valid SRP/password proof when the user is in FORCE_CHANGE_PASSWORD (no tokens until reset).
  - Bind `PASSWORD_VERIFIER` and `SELECT_CHALLENGE` sessions to the originating `ClientId`; reject mismatches.
  - Compare `PASSWORD_CLAIM_SIGNATURE` in constant time to avoid timing leaks.
  - Reject oversized `SRP_A` early (adds a `MAX_PUBLIC_HEX_LEN` guard) to avoid expensive bigint work.
  - Filter `USER_AUTH` `AvailableChallenges` to the factors enabled on the app client.
  - Tests: 3 new cases covering forced reset, client_id mismatch, and oversized `SRP_A`. Docs updated to reflect the flows.

<sup>Written for commit e1645b0dc2bf66caeb96d04df694d174ca1e9e2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

