### PR TITLE
fix(cloudformation): persist + fully provision EC2 / app-autoscaling resources

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
@@ -29,6 +29,74 @@ fn prop_str<'a>(props: &'a Value, key: &str) -> Option<&'a str> {
     props.get(key).and_then(|v| v.as_str())
 }
 
+/// A CloudFormation boolean property may arrive as a JSON bool or as the
+/// string `"true"`/`"false"` (templates often quote them).
+fn prop_bool(props: &Value, key: &str) -> Option<bool> {
+    match props.get(key) {
+        Some(Value::Bool(b)) => Some(*b),
+        Some(Value::String(s)) => match s.as_str() {
+            "true" => Some(true),
+            "false" => Some(false),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// A CFN numeric property may be a JSON number or a quoted string.
+fn num_str(v: &Value) -> Option<String> {
+    match v {
+        Value::Number(n) => Some(n.to_string()),
+        Value::String(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Translate a CFN inline `SecurityGroupIngress` / `SecurityGroupEgress` array
+/// into `IpPermissions.N.*` query params for
+/// `AuthorizeSecurityGroup{Ingress,Egress}`.
+fn sg_rule_params(group_id: &str, rules: &[Value]) -> HashMap<String, String> {
+    let mut p = HashMap::new();
+    p.insert("GroupId".to_string(), group_id.to_string());
+    for (i, r) in rules.iter().enumerate() {
+        let n = i + 1;
+        let proto = prop_str(r, "IpProtocol").unwrap_or("-1");
+        p.insert(format!("IpPermissions.{n}.IpProtocol"), proto.to_string());
+        if let Some(from) = r.get("FromPort").and_then(num_str) {
+            p.insert(format!("IpPermissions.{n}.FromPort"), from);
+        }
+        if let Some(to) = r.get("ToPort").and_then(num_str) {
+            p.insert(format!("IpPermissions.{n}.ToPort"), to);
+        }
+        if let Some(cidr) = prop_str(r, "CidrIp") {
+            p.insert(
+                format!("IpPermissions.{n}.IpRanges.1.CidrIp"),
+                cidr.to_string(),
+            );
+        }
+        if let Some(cidr6) = prop_str(r, "CidrIpv6") {
+            p.insert(
+                format!("IpPermissions.{n}.Ipv6Ranges.1.CidrIpv6"),
+                cidr6.to_string(),
+            );
+        }
+        if let Some(g) = prop_str(r, "SourceSecurityGroupId")
+            .or_else(|| prop_str(r, "DestinationSecurityGroupId"))
+        {
+            p.insert(format!("IpPermissions.{n}.Groups.1.GroupId"), g.to_string());
+        }
+        if let Some(pl) =
+            prop_str(r, "SourcePrefixListId").or_else(|| prop_str(r, "DestinationPrefixListId"))
+        {
+            p.insert(
+                format!("IpPermissions.{n}.PrefixListIds.1.PrefixListId"),
+                pl.to_string(),
+            );
+        }
+    }
+    p
+}
+
 impl ResourceProvisioner {
     fn ec2_request(&self, action: &str, params: HashMap<String, String>) -> AwsRequest {
         AwsRequest {
@@ -109,6 +177,22 @@ impl ResourceProvisioner {
         let body = self.ec2_dispatch("CreateVpc", params)?;
         let id = xml_elem(&body, "vpcId").ok_or("CreateVpc returned no vpcId")?;
         let cidr = xml_elem(&body, "cidrBlock").unwrap_or_default();
+
+        // Apply DNS attributes the template requested (CreateVpc ignores them).
+        let dns_support = prop_bool(props, "EnableDnsSupport");
+        let dns_hostnames = prop_bool(props, "EnableDnsHostnames");
+        if dns_support.is_some() || dns_hostnames.is_some() {
+            let mut mp = HashMap::new();
+            mp.insert("VpcId".to_string(), id.clone());
+            if let Some(v) = dns_support {
+                mp.insert("EnableDnsSupport.Value".to_string(), v.to_string());
+            }
+            if let Some(v) = dns_hostnames {
+                mp.insert("EnableDnsHostnames.Value".to_string(), v.to_string());
+            }
+            self.ec2_dispatch("ModifyVpcAttribute", mp)?;
+        }
+
         Ok(ProvisionResult::new(id.clone())
             .with("VpcId", id)
             .with("CidrBlock", cidr))
@@ -132,9 +216,26 @@ impl ResourceProvisioner {
         let body = self.ec2_dispatch("CreateSubnet", params)?;
         let id = xml_elem(&body, "subnetId").ok_or("CreateSubnet returned no subnetId")?;
         let az = xml_elem(&body, "availabilityZone").unwrap_or_default();
+        let cidr = xml_elem(&body, "cidrBlock")
+            .or_else(|| prop_str(props, "CidrBlock").map(str::to_string))
+            .unwrap_or_default();
+
+        // Apply MapPublicIpOnLaunch the template requested (CreateSubnet
+        // ignores it).
+        if let Some(v) = prop_bool(props, "MapPublicIpOnLaunch") {
+            let mut mp = HashMap::new();
+            mp.insert("SubnetId".to_string(), id.clone());
+            mp.insert("MapPublicIpOnLaunch.Value".to_string(), v.to_string());
+            self.ec2_dispatch("ModifySubnetAttribute", mp)?;
+        }
+
+        // Capture VpcId + CidrBlock so Fn::GetAtt on the subnet resolves them
+        // (real AWS exposes both), not just SubnetId / AvailabilityZone.
         Ok(ProvisionResult::new(id.clone())
             .with("SubnetId", id)
-            .with("AvailabilityZone", az))
+            .with("AvailabilityZone", az)
+            .with("VpcId", vpc_id.to_string())
+            .with("CidrBlock", cidr))
     }
 
     pub(super) fn create_ec2_security_group(
@@ -153,6 +254,21 @@ impl ResourceProvisioner {
         self.ec2_tag_params(props, "security-group", &mut params);
         let body = self.ec2_dispatch("CreateSecurityGroup", params)?;
         let id = xml_elem(&body, "groupId").ok_or("CreateSecurityGroup returned no groupId")?;
+
+        // Apply inline ingress/egress rules (CreateSecurityGroup only creates
+        // the empty group; without this the template's rules are silently
+        // dropped and the SG denies everything).
+        if let Some(rules) = props.get("SecurityGroupIngress").and_then(|v| v.as_array()) {
+            if !rules.is_empty() {
+                self.ec2_dispatch("AuthorizeSecurityGroupIngress", sg_rule_params(&id, rules))?;
+            }
+        }
+        if let Some(rules) = props.get("SecurityGroupEgress").and_then(|v| v.as_array()) {
+            if !rules.is_empty() {
+                self.ec2_dispatch("AuthorizeSecurityGroupEgress", sg_rule_params(&id, rules))?;
+            }
+        }
+
         Ok(ProvisionResult::new(id.clone())
             .with("GroupId", id)
             .with("VpcId", prop_str(props, "VpcId").unwrap_or("").to_string()))

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -48,7 +48,7 @@ fn well_known_attributes_for(resource_type: &str) -> &'static [&'static str] {
         "AWS::SecretsManager::Secret" => &["Arn", "Id"],
         "AWS::CloudFront::Distribution" => &["DomainName", "Id"],
         "AWS::EC2::VPC" => &["VpcId", "CidrBlock"],
-        "AWS::EC2::Subnet" => &["SubnetId", "AvailabilityZone"],
+        "AWS::EC2::Subnet" => &["SubnetId", "AvailabilityZone", "VpcId", "CidrBlock"],
         "AWS::EC2::SecurityGroup" => &["GroupId", "VpcId"],
         "AWS::EC2::InternetGateway" => &["InternetGatewayId"],
         "AWS::EC2::RouteTable" => &["RouteTableId"],
@@ -115,6 +115,14 @@ fn service_key_for_type(resource_type: &str) -> Option<&'static str> {
         "WAFv2" => "wafv2",
         "Athena" => "athena",
         "Organizations" => "organizations",
+        // EC2 and ApplicationAutoScaling were wired into the provisioner after
+        // this table was last audited (EC2: 2026-06-25 #1957;
+        // application-autoscaling: persistence sweep), so their CFN-created VPC
+        // / Subnet / SecurityGroup / scalable-target state mutated in memory and
+        // vanished on restart (#1766 class). Both have a registered snapshot
+        // hook in the server.
+        "EC2" => "ec2",
+        "ApplicationAutoScaling" => "application-autoscaling",
         _ => return None,
     })
 }

--- a/crates/fakecloud-e2e/tests/cfn_provisioner_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cfn_provisioner_persistence.rs
@@ -24,6 +24,10 @@ const CFN_TEMPLATE: &str = r#"{"Resources":{
     "Role":"arn:aws:iam::123456789012:role/r",
     "Code":{"ZipFile":"def handler(event, context):\n    return {}\n"}}},
   "Zone":{"Type":"AWS::Route53::HostedZone","Properties":{"Name":"cfn-zone.example.com."}},
+  "Vpc":{"Type":"AWS::EC2::VPC","Properties":{
+    "CidrBlock":"10.42.0.0/16","Tags":[{"Key":"Name","Value":"cfn-vpc"}]}},
+  "Sg":{"Type":"AWS::EC2::SecurityGroup","Properties":{
+    "GroupName":"cfn-sg","GroupDescription":"cfn sg","VpcId":{"Ref":"Vpc"}}},
   "GlueDb":{"Type":"AWS::Glue::Database","Properties":{
     "CatalogId":"123456789012",
     "DatabaseInput":{"Name":"cfn_glue_db"}}}}}"#;
@@ -106,6 +110,34 @@ async fn glue_database_names(server: &TestServer) -> Vec<String> {
         .database_list()
         .iter()
         .map(|d| d.name().to_string())
+        .collect()
+}
+
+async fn ec2_sg_names(server: &TestServer) -> Vec<String> {
+    server
+        .ec2_client()
+        .await
+        .describe_security_groups()
+        .send()
+        .await
+        .unwrap()
+        .security_groups()
+        .iter()
+        .map(|g| g.group_name().unwrap_or_default().to_string())
+        .collect()
+}
+
+async fn ec2_vpc_cidrs(server: &TestServer) -> Vec<String> {
+    server
+        .ec2_client()
+        .await
+        .describe_vpcs()
+        .send()
+        .await
+        .unwrap()
+        .vpcs()
+        .iter()
+        .map(|v| v.cidr_block().unwrap_or_default().to_string())
         .collect()
 }
 
@@ -252,6 +284,17 @@ async fn cfn_provisioned_resources_survive_restart() {
     assert!(
         glue_dbs.contains(&"cfn_glue_db".to_string()),
         "cfn_glue_db lost: {glue_dbs:?}"
+    );
+
+    // EC2 was wired into the provisioner (2026-06-25 #1957) but missing from
+    // `service_key_for_type`, so CFN-created VPC/SG state vanished on restart
+    // while direct-API EC2 resources persisted (#1766 class).
+    let sgs = ec2_sg_names(&server).await;
+    assert!(sgs.contains(&"cfn-sg".to_string()), "cfn-sg lost: {sgs:?}");
+    let cidrs = ec2_vpc_cidrs(&server).await;
+    assert!(
+        cidrs.contains(&"10.42.0.0/16".to_string()),
+        "cfn-vpc lost: {cidrs:?}"
     );
 }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_ec2.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_ec2.rs
@@ -1,0 +1,152 @@
+//! CloudFormation provisioning fidelity for AWS::EC2::* resources. The 1.10
+//! provisioner created the VPC/Subnet/SecurityGroup but silently dropped inline
+//! SecurityGroup ingress/egress rules, VPC DNS attributes, and subnet
+//! MapPublicIpOnLaunch, and Fn::GetAtt on a Subnet's VpcId/CidrBlock returned
+//! empty. This drives a template that exercises all of them through the real
+//! aws-sdk EC2 client.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::Capability;
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Vpc": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.20.0.0/16",
+        "EnableDnsSupport": true,
+        "EnableDnsHostnames": true,
+        "Tags": [{"Key": "Name", "Value": "cfn-ec2-vpc"}]
+      }
+    },
+    "Subnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {"Ref": "Vpc"},
+        "CidrBlock": "10.20.1.0/24",
+        "AvailabilityZone": "us-east-1a",
+        "MapPublicIpOnLaunch": true
+      }
+    },
+    "Sg": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupName": "cfn-ec2-sg",
+        "GroupDescription": "managed by cfn",
+        "VpcId": {"Ref": "Vpc"},
+        "SecurityGroupIngress": [
+          {"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "CidrIp": "0.0.0.0/0"},
+          {"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "CidrIp": "10.0.0.0/8"}
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "SubnetVpcId": {"Value": {"Fn::GetAtt": ["Subnet", "VpcId"]}},
+    "SubnetCidr": {"Value": {"Fn::GetAtt": ["Subnet", "CidrBlock"]}},
+    "VpcId": {"Value": {"Ref": "Vpc"}},
+    "SgId": {"Value": {"Fn::GetAtt": ["Sg", "GroupId"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_ec2_with_rules_and_attributes() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let ec2 = server.ec2_client().await;
+
+    cfn.create_stack()
+        .stack_name("ec2-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("ec2-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+
+    let vpc_id = *outputs.get("VpcId").expect("VpcId output");
+    let sg_id = *outputs.get("SgId").expect("SgId output");
+
+    // M3: Fn::GetAtt on the subnet resolves VpcId + CidrBlock (was empty).
+    assert_eq!(
+        *outputs.get("SubnetVpcId").expect("SubnetVpcId output"),
+        vpc_id,
+        "Subnet.VpcId GetAtt should equal the VPC id"
+    );
+    assert_eq!(
+        *outputs.get("SubnetCidr").expect("SubnetCidr output"),
+        "10.20.1.0/24"
+    );
+
+    // M2: inline SecurityGroupIngress rules were applied (not dropped).
+    let sgs = ec2
+        .describe_security_groups()
+        .group_ids(sg_id)
+        .send()
+        .await
+        .expect("describe_security_groups");
+    let sg = sgs.security_groups().first().expect("sg present");
+    let ports: Vec<i32> = sg
+        .ip_permissions()
+        .iter()
+        .filter_map(|p| p.from_port())
+        .collect();
+    assert!(ports.contains(&443), "443 ingress missing: {ports:?}");
+    assert!(ports.contains(&22), "22 ingress missing: {ports:?}");
+
+    // L3: VPC DNS attributes were applied.
+    let dns_hostnames = ec2
+        .describe_vpc_attribute()
+        .vpc_id(vpc_id)
+        .attribute(aws_sdk_ec2::types::VpcAttributeName::EnableDnsHostnames)
+        .send()
+        .await
+        .expect("describe_vpc_attribute");
+    assert_eq!(
+        dns_hostnames.enable_dns_hostnames().and_then(|a| a.value()),
+        Some(true),
+        "EnableDnsHostnames should be applied"
+    );
+
+    // L3: subnet MapPublicIpOnLaunch was applied.
+    let subnets = ec2
+        .describe_subnets()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("vpc-id")
+                .values(vpc_id)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("describe_subnets");
+    let subnet = subnets.subnets().first().expect("subnet present");
+    assert_eq!(
+        subnet.map_public_ip_on_launch(),
+        Some(true),
+        "MapPublicIpOnLaunch should be applied"
+    );
+
+    cfn.delete_stack()
+        .stack_name("ec2-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+}

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -930,6 +930,14 @@ impl Ec2Service {
             "DeleteRouteTable" => routing::delete_route_table(self, request),
             "CreateInternetGateway" => routing::create_internet_gateway(self, request),
             "DeleteInternetGateway" => routing::delete_internet_gateway(self, request),
+            // Attribute / rule application the CloudFormation provisioner issues
+            // after a Create so VPC DNS attributes, subnet MapPublicIpOnLaunch,
+            // and inline SecurityGroup ingress/egress rules from a template are
+            // actually applied (not silently dropped).
+            "ModifyVpcAttribute" => vpc::modify_vpc_attribute(self, request),
+            "ModifySubnetAttribute" => subnet::modify_subnet_attribute(self, request),
+            "AuthorizeSecurityGroupIngress" => sg::authorize_security_group_ingress(self, request),
+            "AuthorizeSecurityGroupEgress" => sg::authorize_security_group_egress(self, request),
             other => Err(AwsServiceError::action_not_implemented("ec2", other)),
         }
     }

--- a/website/content/docs/services/cloudformation.md
+++ b/website/content/docs/services/cloudformation.md
@@ -70,6 +70,7 @@ Resources of these types create real backing state in the corresponding fakeclou
 - **CloudWatch** — `Alarm`, `Dashboard`
 - **Cognito** — `UserPool`, `UserPoolClient`, `UserPoolDomain`, `IdentityPool`, `IdentityPoolRoleAttachment`
 - **DynamoDB** — `Table`
+- **EC2** — `VPC`, `Subnet`, `SecurityGroup` (including inline `SecurityGroupIngress` / `SecurityGroupEgress` rules), `InternetGateway`, `RouteTable`. VPC `EnableDnsSupport` / `EnableDnsHostnames` and subnet `MapPublicIpOnLaunch` are applied; `Fn::GetAtt` on a subnet resolves `VpcId` / `CidrBlock`
 - **ECR** — `Repository`, `RepositoryPolicy`, `LifecyclePolicy`, `PullThroughCacheRule`, `RegistryPolicy`, `RegistryScanningConfiguration`, `ReplicationConfiguration`
 - **ECS** — `Cluster`, `Service`, `TaskDefinition`, `CapacityProvider`
 - **ElastiCache** — `CacheCluster`, `ReplicationGroup`, `ParameterGroup`, `SubnetGroup`, `SecurityGroup`, `User`, `UserGroup`
@@ -143,7 +144,7 @@ aws --endpoint-url http://localhost:4566 cloudformation list-exports
 
 ## Gotchas
 
-- **Not every resource type provisions something.** Types in the provisioner list above create real backing state. Anything else (most `AWS::EC2::*`, `AWS::AutoScaling::*`, etc.) is recorded but has no underlying resource, so a follow-up call against that service will 404.
+- **Not every resource type provisions something.** Types in the provisioner list above create real backing state. Anything else (the remaining `AWS::EC2::*` types such as `Instance` / `NatGateway` / `Route`, `AWS::AutoScaling::*`, etc.) is recorded but has no underlying resource, so a follow-up call against that service will 404.
 - **Drift always reports IN_SYNC.** fakecloud is the source of truth for backing state, so real drift never occurs. The drift API still round-trips IDs and statuses for tooling that polls them.
 - **SAM expansion runs at create time.** A re-uploaded template still requires `Capabilities=[CAPABILITY_AUTO_EXPAND]` on operations that touch transforms.
 


### PR DESCRIPTION
## Summary
Bug-hunt 2026-06-26 (cycle 2) findings against the EC2 CloudFormation provisioner (#1957, 1.10):

- **H2 (data-loss, #1766 class):** `service_key_for_type` had no `EC2` / `ApplicationAutoScaling` arm, so `persist_touched_services` never invoked their (registered) snapshot hooks. CFN-created VPC / Subnet / SecurityGroup / scalable-target state mutated in memory and **vanished on restart** while direct-API equivalents persisted. Added both arms (Create/Update/Delete all route through `persist_touched_services`).
- **M2 (stub):** inline `SecurityGroupIngress` / `SecurityGroupEgress` rule arrays were dropped — the SG was created empty (default deny-all). Now applied via `AuthorizeSecurityGroup{Ingress,Egress}`.
- **M3 (correctness):** `Fn::GetAtt` on a Subnet's `VpcId` / `CidrBlock` returned empty. Now captured at provision time and added to the well-known attribute set.
- **L3 (stub):** VPC `EnableDnsSupport` / `EnableDnsHostnames` and Subnet `MapPublicIpOnLaunch` were accepted but never applied. Now applied via `ModifyVpcAttribute` / `ModifySubnetAttribute`.
- Exposed those four actions through `Ec2Service::provision_sync` (they no-op the firewall reconcile when the provisioner's EC2 service has no runtime — safe).
- **L4 (docs):** `cloudformation.md` lists the 5 real-provisioning EC2 types and narrows the stale "most `AWS::EC2::*` recorded but no underlying resource" caveat.

## Test plan
- `cargo nextest run -p fakecloud-cloudformation -p fakecloud-ec2` — 302 pass.
- New e2e `cloudformation_ec2.rs`: asserts SG ingress rules applied, Subnet GetAtt VpcId/CidrBlock resolve, VPC DNS attrs + subnet MapPublicIpOnLaunch applied. PASS.
- Extended `cfn_provisioner_persistence.rs` with an EC2 VPC+SG restart-survival guard (the H2 regression). PASS.
- `cargo clippy -p fakecloud-cloudformation -p fakecloud-ec2 --all-targets -- -D warnings` clean; `cargo fmt`.

Report: `bug-hunt-reports/2026-06-26.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes persistence for CloudFormation-created EC2 and Application Auto Scaling resources and applies missing EC2 rules/attributes during provisioning. Stacks now survive restarts and `Fn::GetAtt` on subnets returns `VpcId` and `CidrBlock`.

- **Bug Fixes**
  - Persist EC2 and ApplicationAutoScaling by wiring `service_key_for_type` so snapshot hooks run; CFN-created VPC/Subnet/SecurityGroup/scalable-targets no longer disappear after restart.
  - Apply inline `SecurityGroupIngress`/`SecurityGroupEgress` via `AuthorizeSecurityGroup{Ingress,Egress}` instead of creating empty groups.
  - Capture Subnet `VpcId` and `CidrBlock` and add them to the well-known attribute set for `Fn::GetAtt`.
  - Apply VPC `EnableDnsSupport`/`EnableDnsHostnames` and Subnet `MapPublicIpOnLaunch` via `ModifyVpcAttribute`/`ModifySubnetAttribute`; actions exposed through `Ec2Service::provision_sync`.
  - Added e2e test (`cloudformation_ec2.rs`) and extended persistence test; updated docs to list provisioned EC2 types and narrow the EC2 caveat.

<sup>Written for commit 869dfdafdb911f169b684bc22fdf26961195c3e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

