### PR TITLE
feat(ec2,tfacc): align seeded AMIs to standard acctest helper, unblock ELBv2 target-group attachment

### DIFF
--- a/crates/fakecloud-ec2/src/defaults.rs
+++ b/crates/fakecloud-ec2/src/defaults.rs
@@ -126,11 +126,29 @@ pub(crate) fn seed_public_images(state: &mut Ec2State) {
     const CANONICAL: &str = "099720109477";
     const AMAZON_WINDOWS: &str = "801119661308";
     let seeds: &[AmiSeed] = &[
+        // Amazon Linux 2 (x86_64 + arm64). The `amzn2-ami-minimal-hvm-*` name +
+        // `root-device-type = ebs` shape is exactly what the standard
+        // terraform-provider-aws acctest helper
+        // `ConfigLatestAmazonLinux2HVMEBSX8664AMI()` / `…ARM64AMI()` filters on,
+        // so every acceptance test that launches an instance via that helper
+        // (aws_instance, the ELBv2 target-group attachment, autoscaling, …)
+        // resolves a real AMI from this catalogue.
         (
             "ami-0a1b2c3d4e5f60001",
-            "amzn2-ami-hvm-2.0.20240306.2-x86_64-gp2",
-            "Amazon Linux 2 AMI 2.0.20240306.2 x86_64 HVM gp2",
+            "amzn2-ami-minimal-hvm-2.0.20240306.2-x86_64-ebs",
+            "Amazon Linux 2 AMI 2.0.20240306.2 x86_64 Minimal HVM ebs",
             "x86_64",
+            AMAZON,
+            Some("amazon"),
+            "2024-03-06T12:00:00.000Z",
+            "/dev/xvda",
+            None,
+        ),
+        (
+            "ami-0a1b2c3d4e5f60007",
+            "amzn2-ami-minimal-hvm-2.0.20240306.2-arm64-ebs",
+            "Amazon Linux 2 AMI 2.0.20240306.2 arm64 Minimal HVM ebs",
+            "arm64",
             AMAZON,
             Some("amazon"),
             "2024-03-06T12:00:00.000Z",
@@ -178,6 +196,20 @@ pub(crate) fn seed_public_images(state: &mut Ec2State) {
             CANONICAL,
             None,
             "2024-04-23T06:00:00.000Z",
+            "/dev/sda1",
+            None,
+        ),
+        // Canonical instance-store Ubuntu (the `ubuntu/images/hvm-instance/*`
+        // shape the `aws_ami_ids` acctest filters on, distinct from the EBS
+        // `hvm-ssd*` images above).
+        (
+            "ami-0a1b2c3d4e5f60008",
+            "ubuntu/images/hvm-instance/ubuntu-jammy-22.04-amd64-server-20240319",
+            "Canonical, Ubuntu, 22.04 LTS, amd64 jammy instance-store image build on 2024-03-19",
+            "x86_64",
+            CANONICAL,
+            None,
+            "2024-03-19T05:00:00.000Z",
             "/dev/sda1",
             None,
         ),

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -739,14 +739,12 @@ pub const SERVICES: &[Service] = &[
         // cross-zone (`use_load_balancer_configuration`) and anomaly-mitigation
         // (`off`) defaults the data source reads. (DeleteLoadBalancer already
         // returns its result node as of the prior fix.)
+        // TargetGroupAttachment now runs: its config launches a real EC2
+        // instance from `ConfigLatestAmazonLinux2HVMEBSX8664AMI()`, which the
+        // seeded public AMI catalogue (named to match that helper's
+        // `amzn2-ami-minimal-hvm-*` + `root-device-type = ebs` filter) resolves.
         run_regex: "^TestAccELBV2[A-Za-z0-9]+_basic$",
-        deny: &[
-            // --- gap: the target-group attachment registers a real EC2 instance
-            //     as a target; its pre-apply config resolves an EC2 data source
-            //     (AMI / instance) that returns no results without a populated
-            //     EC2 image catalogue, so the attachment cannot be planned. ---
-            "TestAccELBV2TargetGroupAttachment_basic",
-        ],
+        deny: &[],
     },
     Service {
         name: "bedrockagent",


### PR DESCRIPTION
## Summary
Batch 2 of the re-scoped EC2 next-step (after #1964 seeded the catalogue). Real terraform-provider-aws acceptance tests resolve an AMI through the shared helper `ConfigLatestAmazonLinux2HVMEBSX8664AMI()` / `…ARM64AMI()`, which filters `owners=["amazon"]` + `name="amzn2-ami-minimal-hvm-*"` + `root-device-type=ebs` + `architecture`. Batch 1's seeds used arbitrary names, so any instance-launching test still couldn't plan.

- **Rename the Amazon Linux 2 seed** to `amzn2-ami-minimal-hvm-2.0.20240306.2-x86_64-ebs` + add the **arm64** variant, so both helper arches resolve. Add a Canonical `ubuntu/images/hvm-instance/*` instance-store seed.
- **Remove the ELBv2 `TestAccELBV2TargetGroupAttachment_basic` tfacc deny** — its config launches a real EC2 instance via that helper, which the catalogue now resolves end-to-end (plan → apply → register target → destroy).

## Test plan
- **Verified against real `terraform-provider-aws` v5.97.0 locally**: `go test ./internal/service/elbv2/ -run '^TestAccELBV2TargetGroupAttachment_basic$'` → `ok 32.6s` (was the deny-listed gap, allowlist.rs:744-748).
- `cargo nextest run -p fakecloud-ec2` green (seed-filtering unit tests updated names).
- `cargo clippy -p fakecloud-ec2 -p fakecloud-tfacc --all-targets -- -D warnings` clean; `cargo fmt`.

## Deliberately NOT bundled (next increment, per the decision report's trimmed scope — avoiding the read-shape grind the adversarial disconfirm flagged as diluting filler)
- `aws_instance` / instance-data-source tests need a seeded **DescribeInstanceTypes** catalogue (`reading EC2 Instance Type (t2.small): empty result`).
- `aws_ebs_volume` needs gp2 `iops` read-shape fidelity (expected 100, got 3000).

Both are clean high-leverage atoms for a future fc-next-step, not part of the AMI-catalogue winner.

Decision report: `next-step-reports/2026-06-26-cycle3.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned EC2 AMI seeds to match the `terraform-provider-aws` acctest helper filters and enabled the ELBv2 target-group attachment test.

- **New Features**
  - Renamed Amazon Linux 2 AMI to `amzn2-ami-minimal-hvm-2.0.20240306.2-x86_64-ebs` and added `…-arm64-ebs` to satisfy `owners=["amazon"]`, `root-device-type=ebs`, and arch filters.
  - Seeded Canonical instance-store Ubuntu `ubuntu/images/hvm-instance/*` for `aws_ami_ids` coverage.

- **Bug Fixes**
  - Removed the deny for `TestAccELBV2TargetGroupAttachment_basic` in `fakecloud-tfacc` so it plans and applies with the new seeds.

<sup>Written for commit f7a65b4202950d41c48e4d1f01ebba50bd7156e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

