### PR TITLE
fix(ec2): guard seeded AMIs, reseed on restore, persist image criteria, lazy read

### DIFF
--- a/crates/fakecloud-e2e/tests/ec2_ami_catalogue.rs
+++ b/crates/fakecloud-e2e/tests/ec2_ami_catalogue.rs
@@ -1,0 +1,146 @@
+//! Seeded public AMI catalogue behavior: the amazon/Canonical-owned seeds are
+//! read-only (DeregisterImage / ModifyImageAttribute on them is AuthFailure, as
+//! in real AWS), the catalogue survives an upgrade-then-restart in persistent
+//! mode, and ReplaceImageCriteriaInAllowedImagesSettings round-trips.
+
+mod helpers;
+
+use helpers::TestServer;
+
+async fn an_amazon_ami(c: &aws_sdk_ec2::Client) -> String {
+    c.describe_images()
+        .owners("amazon")
+        .send()
+        .await
+        .unwrap()
+        .images()
+        .first()
+        .expect("seeded amazon AMI present")
+        .image_id()
+        .unwrap()
+        .to_string()
+}
+
+#[tokio::test]
+async fn seeded_public_amis_are_read_only() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    let seed = an_amazon_ami(&c).await;
+
+    // Deregister of an amazon-owned seed must be rejected (AuthFailure).
+    let err = c
+        .deregister_image()
+        .image_id(&seed)
+        .send()
+        .await
+        .expect_err("deregister of amazon AMI should fail");
+    assert!(
+        format!("{err:?}").contains("AuthFailure"),
+        "expected AuthFailure, got {err:?}"
+    );
+
+    // ModifyImageAttribute on a seed must also be rejected.
+    let err = c
+        .modify_image_attribute()
+        .image_id(&seed)
+        .description(
+            aws_sdk_ec2::types::AttributeValue::builder()
+                .value("hijack")
+                .build(),
+        )
+        .send()
+        .await
+        .expect_err("modify of amazon AMI should fail");
+    assert!(format!("{err:?}").contains("AuthFailure"), "got {err:?}");
+
+    // The seed is still present + unmodified.
+    let still = c.describe_images().image_ids(&seed).send().await.unwrap();
+    assert_eq!(
+        still.images().len(),
+        1,
+        "seed must survive the rejected ops"
+    );
+
+    // A user-registered AMI (owned by the caller) CAN be deregistered.
+    let mine = c
+        .register_image()
+        .name("my-own-ami")
+        .send()
+        .await
+        .unwrap()
+        .image_id()
+        .unwrap()
+        .to_string();
+    c.deregister_image()
+        .image_id(&mine)
+        .send()
+        .await
+        .expect("deregister of own AMI should succeed");
+}
+
+#[tokio::test]
+async fn replace_image_criteria_round_trips() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+
+    c.replace_image_criteria_in_allowed_images_settings()
+        .image_criteria(
+            aws_sdk_ec2::types::ImageCriterionRequest::builder()
+                .image_providers("amazon")
+                .image_providers("123456789012")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("replace criteria");
+
+    let got = c
+        .get_allowed_images_settings()
+        .send()
+        .await
+        .expect("get settings");
+    let criteria = got.image_criteria();
+    assert_eq!(criteria.len(), 1, "one criterion persisted");
+    let providers = criteria[0].image_providers();
+    assert!(
+        providers.contains(&"amazon".to_string())
+            && providers.contains(&"123456789012".to_string()),
+        "providers round-trip: {providers:?}"
+    );
+}
+
+#[tokio::test]
+async fn ami_catalogue_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut s = TestServer::start_persistent(tmp.path()).await;
+
+    // Touch EC2 so the account is persisted.
+    let c = s.ec2_client().await;
+    c.create_vpc()
+        .cidr_block("10.9.0.0/16")
+        .send()
+        .await
+        .unwrap();
+    let before = c
+        .describe_images()
+        .owners("amazon")
+        .send()
+        .await
+        .unwrap()
+        .images()
+        .len();
+    assert!(before >= 4, "seeds present before restart: {before}");
+
+    s.restart().await;
+
+    let c2 = s.ec2_client().await;
+    let after = c2
+        .describe_images()
+        .owners("amazon")
+        .send()
+        .await
+        .unwrap()
+        .images()
+        .len();
+    assert_eq!(after, before, "amazon AMI catalogue must survive restart");
+}

--- a/crates/fakecloud-ec2/src/service/image.rs
+++ b/crates/fakecloud-ec2/src/service/image.rs
@@ -175,6 +175,22 @@ pub(crate) fn register_image(
     ))
 }
 
+/// An AMI the caller does not own. The seeded public catalogue is owned by
+/// amazon/Canonical (`owner_id` set to a foreign account); a user-registered
+/// AMI has `owner_id == None` (owned by the requesting account). AWS rejects
+/// DeregisterImage / ModifyImageAttribute on an AMI you don't own.
+fn owned_by_other(img: &Image, account: &str) -> bool {
+    img.owner_id.as_deref().is_some_and(|o| o != account)
+}
+
+fn ami_auth_failure(id: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        http::StatusCode::BAD_REQUEST,
+        "AuthFailure",
+        format!("Not authorized for image: {id}"),
+    )
+}
+
 pub(crate) fn deregister_image(
     svc: &Ec2Service,
     req: &AwsRequest,
@@ -182,6 +198,14 @@ pub(crate) fn deregister_image(
     let id = require(&req.query_params, "ImageId")?;
     let mut accounts = svc.state.write();
     let state = accounts.get_or_create(&req.account_id);
+    // Reject deregistering a public AMI owned by amazon/Canonical (the seeded
+    // catalogue) — AWS returns AuthFailure, and removing a seed would silently
+    // break `data.aws_ami { owners=["amazon"] }` for this account.
+    if let Some(img) = state.images.get(&id) {
+        if owned_by_other(img, &req.account_id) {
+            return Err(ami_auth_failure(&id));
+        }
+    }
     state.images.remove(&id);
     state.tags.remove(&id);
     Ok(Ec2Service::respond(
@@ -205,8 +229,17 @@ pub(crate) fn describe_images(
     // resolve the seeded public catalogue instead of every image in the account.
     let owners = indexed_list(&req.query_params, "Owner");
     let accounts = svc.state.read();
-    let empty = Ec2State::new(&req.account_id, &req.region);
-    let state = accounts.get(&req.account_id).unwrap_or(&empty);
+    // Lazily build the seeded fallback ONLY for a not-yet-created account, so
+    // the common existing-account path doesn't construct-and-discard a fresh
+    // (default-network + AMI-catalogue) state on every DescribeImages.
+    let empty;
+    let state = match accounts.get(&req.account_id) {
+        Some(s) => s,
+        None => {
+            empty = Ec2State::new(&req.account_id, &req.region);
+            &empty
+        }
+    };
     let mut items: Vec<String> = state
         .images
         .values()
@@ -477,6 +510,12 @@ pub(crate) fn modify_image_attribute(
         .images
         .get_mut(&id)
         .ok_or_else(|| crate::service_helpers::not_found("InvalidAMIID.NotFound", &id))?;
+
+    // AWS rejects modifying an AMI you don't own (the seeded amazon/Canonical
+    // public catalogue) with AuthFailure.
+    if owned_by_other(img, &req.account_id) {
+        return Err(ami_auth_failure(&id));
+    }
 
     // The `Attribute` form (Attribute + Value + OperationType) and the
     // structured `LaunchPermission`/`Description` forms are mutually
@@ -843,10 +882,24 @@ pub(crate) fn get_allowed_images_settings(
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| "disabled".to_string())
     };
+    let criteria = {
+        let accounts = svc.state.read();
+        accounts
+            .get(&req.account_id)
+            .map(|s| s.allowed_image_criteria.clone())
+            .unwrap_or_default()
+    };
+    let criterion_items: Vec<String> = criteria
+        .iter()
+        // `ec2_list` wraps each element in `<item>`, which is the
+        // ImageProviderList member name the SDK reads — so pass the raw
+        // provider strings, not pre-wrapped elements.
+        .map(|providers| ec2_list("imageProviderSet", providers))
+        .collect();
     let body = format!(
         "{}{}",
         ec2_elem("state", &st),
-        ec2_list("imageCriterionSet", &[])
+        ec2_list("imageCriterionSet", &criterion_items)
     );
     Ok(Ec2Service::respond(
         "GetAllowedImagesSettings",
@@ -856,9 +909,36 @@ pub(crate) fn get_allowed_images_settings(
 }
 
 pub(crate) fn replace_image_criteria_in_allowed_images_settings(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    // Parse `ImageCriterion.N.ImageProvider.M` into a list-of-provider-lists and
+    // persist it so GetAllowedImagesSettings round-trips (was a no-op stub).
+    let mut criteria: Vec<Vec<String>> = Vec::new();
+    let mut n = 1;
+    loop {
+        let providers = indexed_list(
+            &req.query_params,
+            &format!("ImageCriterion.{n}.ImageProvider"),
+        );
+        // A criterion with no ImageProvider.M still counts if its prefix exists.
+        let has_criterion = providers.is_empty()
+            && req
+                .query_params
+                .keys()
+                .any(|k| k.starts_with(&format!("ImageCriterion.{n}.")));
+        if providers.is_empty() && !has_criterion {
+            break;
+        }
+        criteria.push(providers);
+        n += 1;
+    }
+    {
+        let mut accounts = svc.state.write();
+        accounts
+            .get_or_create(&req.account_id)
+            .allowed_image_criteria = criteria;
+    }
     Ok(Ec2Service::respond(
         "ReplaceImageCriteriaInAllowedImagesSettings",
         &req.request_id,

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -1117,6 +1117,11 @@ pub struct Ec2State {
     /// Account-level allowed-images settings state.
     #[serde(default)]
     pub allowed_images_settings: String,
+    /// Allowed-images `imageCriterionSet`: each criterion is its list of
+    /// `ImageProvider`s, persisted by ReplaceImageCriteriaInAllowedImagesSettings
+    /// and reported by GetAllowedImagesSettings.
+    #[serde(default)]
+    pub allowed_image_criteria: Vec<Vec<String>>,
     #[serde(default)]
     pub network_acls: BTreeMap<String, NetworkAcl>,
     #[serde(default)]
@@ -1306,6 +1311,15 @@ impl Ec2State {
         // Amazon/Canonical-owned public images.
         crate::defaults::seed_public_images(&mut state);
         state
+    }
+
+    /// Idempotently (re)seed the public AMI catalogue into this account. Used on
+    /// snapshot restore so accounts persisted by a binary that predated the
+    /// catalogue (#1964) still get it after an upgrade+restart — without it,
+    /// `aws_ami { owners=["amazon"] }` returns empty for legacy accounts. Seeds
+    /// have deterministic ids, so re-seeding an already-seeded account is a no-op.
+    pub fn ensure_public_images_seeded(&mut self) {
+        crate::defaults::seed_public_images(self);
     }
 
     /// Replace the tag set for `resource_id` with `tags` merged over any

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1726,6 +1726,17 @@ async fn main() {
                             if let Some(accounts) = snapshot.accounts {
                                 let account_count = accounts.account_count();
                                 *ec2_state.write() = accounts;
+                                // Backfill the public AMI catalogue into any
+                                // restored account that predates it (legacy
+                                // snapshot from before #1964). Idempotent —
+                                // seeds have deterministic ids, so already-seeded
+                                // accounts are unchanged.
+                                {
+                                    let mut guard = ec2_state.write();
+                                    for (_, st) in guard.iter_mut() {
+                                        st.ensure_public_images_seeded();
+                                    }
+                                }
                                 tracing::info!(
                                     accounts = account_count,
                                     "loaded ec2 persistence snapshot"


### PR DESCRIPTION
## Summary
Bug-hunt 2026-06-26 cycle 3, **batch 2 of 3** — fixes three regressions the cycle-3 AMI-seed work (#1964/#1965) introduced, plus a pre-existing stub.

- **#2 (MEDIUM):** `DeregisterImage` / `ModifyImageAttribute` had no owner guard, so a caller could remove or mutate the seeded amazon/Canonical-owned public AMIs in its own account — permanently breaking `data.aws_ami { owners=["amazon"] }` (the exact thing the catalogue exists for). Now reject ops on an AMI owned by another owner with `AuthFailure`, matching AWS. User-registered AMIs (owner_id == None) are still freely deregistered/modified.
- **#5 (LOW):** a snapshot written by a pre-#1964 binary restored an account whose images map lacked the seeds, and the read-path fallback only seeds ABSENT accounts → after upgrade+restart `aws_ami` returned empty. On restore, idempotently reseed the public catalogue into every restored account (deterministic ids → no-op for already-seeded).
- **#4 (LOW):** `ReplaceImageCriteriaInAllowedImagesSettings` was a write-succeeds/read-default stub. Now persists the `ImageCriterion` `ImageProviders` and emits them from `GetAllowedImagesSettings`.
- **#6 (LOW):** `DescribeImages` eagerly built the (now seed-heavier) throwaway `Ec2State` on every read; use a deferred fallback so it's constructed only for a not-yet-created account.

## Test plan
- New e2e `ec2_ami_catalogue`: seeded-AMI deregister/modify rejected (AuthFailure) + user AMI deregister OK; `ReplaceImageCriteria` → `GetAllowedImagesSettings` round-trip (verified the real wire shape `ImageCriterion.N.ImageProvider.M` via the aws CLI against a live server); catalogue survives `start_persistent` → restart.
- ec2 image conformance (register/modify/deregister/get-allowed-images/replace) — 5/5 green.
- `cargo clippy -p fakecloud-ec2 --all-targets -- -D warnings` clean; `cargo fmt`.

Batch 1 = #1966 (S3 aws-chunked). Batch 3 = bedrock InvokeGuardrailChecks. Report: `bug-hunt-reports/2026-06-26-cycle3.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block DeregisterImage/ModifyImageAttribute on seeded amazon/Canonical AMIs and reseed the public AMI catalogue on snapshot restore. Persist allowed-image criteria and make DescribeImages lazy to reduce read overhead.

- **Bug Fixes**
  - Reject deregister/modify on AMIs owned by other accounts with AuthFailure; user-registered AMIs still allowed.
  - On snapshot restore, reseed the public AMI catalogue for each account; deterministic ids make this idempotent.
  - Persist ImageCriterion providers from ReplaceImageCriteriaInAllowedImagesSettings and return them via GetAllowedImagesSettings.

- **Performance**
  - DescribeImages now builds the default seeded state only when the account doesn’t exist, reducing work on reads.

<sup>Written for commit 473935ed54fef17662e272efcedbf8f070b2a2ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

