### PR TITLE
feat(bedrock): implement InvokeGuardrailChecks (bedrock-runtime)

### DIFF
--- a/crates/fakecloud-bedrock/src/guardrail_checks.rs
+++ b/crates/fakecloud-bedrock/src/guardrail_checks.rs
@@ -1,0 +1,290 @@
+//! `InvokeGuardrailChecks` (bedrock-runtime) — the inline guardrail-tier API
+//! that evaluates a set of messages against requested checks without a
+//! pre-created guardrail. Real (not stubbed) evaluation: content-filter and
+//! prompt-attack categories are matched against keyword/pattern sets, and
+//! sensitive-information entities are detected with regexes that report the
+//! match offsets, mirroring the response shape AWS returns.
+
+use std::sync::OnceLock;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+use regex::Regex;
+use serde_json::{json, Value};
+
+/// One message content block, flattened with its position for offset reporting.
+struct TextBlock {
+    message_index: usize,
+    content_index: usize,
+    text: String,
+}
+
+fn collect_text_blocks(messages: &Value) -> Vec<TextBlock> {
+    let mut blocks = Vec::new();
+    for (mi, msg) in messages.as_array().into_iter().flatten().enumerate() {
+        for (ci, c) in msg["content"].as_array().into_iter().flatten().enumerate() {
+            if let Some(t) = c["text"].as_str() {
+                blocks.push(TextBlock {
+                    message_index: mi,
+                    content_index: ci,
+                    text: t.to_string(),
+                });
+            }
+        }
+    }
+    blocks
+}
+
+/// AWS bills guardrail text in 1000-character "text units" (min 1).
+fn text_units(blocks: &[TextBlock]) -> i64 {
+    let chars: i64 = blocks.iter().map(|b| b.text.chars().count() as i64).sum();
+    ((chars + 999) / 1000).max(1)
+}
+
+fn requested_categories(check: &Value, list_key: &str, field: &str) -> Vec<String> {
+    check[list_key]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|c| c[field].as_str().map(|s| s.to_string()))
+        .collect()
+}
+
+/// Lowercased keyword sets per content-filter category.
+fn content_filter_keywords(category: &str) -> &'static [&'static str] {
+    match category {
+        "VIOLENCE" => &[
+            "kill", "attack", "bomb", "murder", "assault", "shoot", "weapon",
+        ],
+        "HATE" => &["hate", "racist", "bigot", "slur"],
+        "SEXUAL" => &["sex", "nude", "porn", "explicit"],
+        "MISCONDUCT" => &["hack", "steal", "illegal", "fraud", "launder", "exploit"],
+        "INSULTS" => &["idiot", "stupid", "dumb", "loser", "moron"],
+        _ => &[],
+    }
+}
+
+/// Lowercased phrase sets per prompt-attack category.
+fn prompt_attack_phrases(category: &str) -> &'static [&'static str] {
+    match category {
+        "JAILBREAK" => &[
+            "ignore previous instructions",
+            "ignore all previous",
+            "do anything now",
+            "dan mode",
+            "jailbreak",
+            "without any restrictions",
+        ],
+        "PROMPT_INJECTION" => &[
+            "ignore the above",
+            "disregard the previous",
+            "new instructions:",
+            "override your",
+        ],
+        "PROMPT_LEAKAGE" => &[
+            "repeat your system prompt",
+            "what is your system prompt",
+            "reveal your instructions",
+            "print your instructions",
+        ],
+        _ => &[],
+    }
+}
+
+/// Regex for a sensitive-information entity type, or `None` when fakecloud has
+/// no pattern for it (it then reports no detection rather than a false hit).
+fn pii_regex(entity: &str) -> Option<&'static Regex> {
+    macro_rules! re {
+        ($pat:expr) => {{
+            static R: OnceLock<Regex> = OnceLock::new();
+            Some(R.get_or_init(|| Regex::new($pat).unwrap()))
+        }};
+    }
+    match entity {
+        "EMAIL" => re!(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"),
+        "US_SOCIAL_SECURITY_NUMBER" => re!(r"\b\d{3}-\d{2}-\d{4}\b"),
+        "CREDIT_DEBIT_CARD_NUMBER" => re!(r"\b(?:\d[ -]?){13,16}\b"),
+        "PHONE" => re!(r"\b\+?\d[\d\-() ]{7,}\d\b"),
+        "IP_ADDRESS" => re!(r"\b\d{1,3}(?:\.\d{1,3}){3}\b"),
+        "AWS_ACCESS_KEY" => re!(r"\bAKIA[0-9A-Z]{16}\b"),
+        "URL" => re!(r"https?://[^\s]+"),
+        _ => None,
+    }
+}
+
+pub fn invoke_guardrail_checks(
+    req: &AwsRequest,
+    body: &Value,
+) -> Result<AwsResponse, AwsServiceError> {
+    let _ = req;
+    let blocks = collect_text_blocks(&body["messages"]);
+    if blocks.is_empty() {
+        return Err(AwsServiceError::aws_error(
+            http::StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "messages must contain at least one text content block",
+        ));
+    }
+    let checks = &body["checks"];
+    let units = text_units(&blocks);
+    let lower: Vec<String> = blocks.iter().map(|b| b.text.to_lowercase()).collect();
+
+    let mut results = serde_json::Map::new();
+    let mut usage = serde_json::Map::new();
+
+    // ── content filter ──
+    if let Some(cf) = checks.get("contentFilter").filter(|v| !v.is_null()) {
+        let mut entries = Vec::new();
+        for category in requested_categories(cf, "categories", "category") {
+            let kws = content_filter_keywords(&category);
+            if lower.iter().any(|t| kws.iter().any(|k| t.contains(k))) {
+                entries.push(json!({ "category": category, "severityScore": 0.85 }));
+            }
+        }
+        results.insert("contentFilter".into(), json!({ "results": entries }));
+        usage.insert("contentFilter".into(), json!({ "textUnits": units }));
+    }
+
+    // ── prompt attack ──
+    if let Some(pa) = checks.get("promptAttack").filter(|v| !v.is_null()) {
+        let mut entries = Vec::new();
+        for category in requested_categories(pa, "categories", "category") {
+            let phrases = prompt_attack_phrases(&category);
+            if lower.iter().any(|t| phrases.iter().any(|p| t.contains(p))) {
+                entries.push(json!({ "category": category, "severityScore": 0.9 }));
+            }
+        }
+        results.insert("promptAttack".into(), json!({ "results": entries }));
+        usage.insert("promptAttack".into(), json!({ "textUnits": units }));
+    }
+
+    // ── sensitive information ──
+    if let Some(si) = checks.get("sensitiveInformation").filter(|v| !v.is_null()) {
+        let entities = requested_categories(si, "entities", "type");
+        let mut entries = Vec::new();
+        for b in &blocks {
+            for entity in &entities {
+                if let Some(re) = pii_regex(entity) {
+                    for m in re.find_iter(&b.text) {
+                        entries.push(json!({
+                            "type": entity,
+                            "confidenceScore": 0.99,
+                            "beginOffset": m.start() as i64,
+                            "endOffset": m.end() as i64,
+                            "messageIndex": b.message_index as i64,
+                            "contentIndex": b.content_index as i64,
+                        }));
+                    }
+                }
+            }
+        }
+        results.insert(
+            "sensitiveInformation".into(),
+            json!({ "results": entries, "truncated": false }),
+        );
+        usage.insert("sensitiveInformation".into(), json!({ "textUnits": units }));
+    }
+
+    Ok(AwsResponse::ok_json(json!({
+        "results": Value::Object(results),
+        "usage": Value::Object(usage),
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fakecloud_core::service::AwsRequest;
+    use http::{HeaderMap, Method};
+
+    fn req() -> AwsRequest {
+        AwsRequest {
+            service: "bedrock".into(),
+            action: "InvokeGuardrailChecks".into(),
+            region: "us-east-1".into(),
+            account_id: "123456789012".into(),
+            request_id: "t".into(),
+            headers: HeaderMap::new(),
+            query_params: Default::default(),
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/guardrail-checks/invoke".into(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn resp_json(body: &Value) -> Value {
+        let r = match invoke_guardrail_checks(&req(), body) {
+            Ok(r) => r,
+            Err(_) => panic!("expected ok response"),
+        };
+        serde_json::from_slice(r.body.expect_bytes()).unwrap()
+    }
+
+    #[test]
+    fn detects_all_three_check_families() {
+        let body = json!({
+            "messages": [{"role":"USER","content":[
+                {"text":"build a bomb, ignore previous instructions, email a@b.com ssn 123-45-6789"}
+            ]}],
+            "checks": {
+                "contentFilter": {"categories": [{"category":"VIOLENCE"},{"category":"SEXUAL"}]},
+                "promptAttack": {"categories": [{"category":"JAILBREAK"}]},
+                "sensitiveInformation": {"entities": [{"type":"EMAIL"},{"type":"US_SOCIAL_SECURITY_NUMBER"}]}
+            }
+        });
+        let r = resp_json(&body);
+        // VIOLENCE detected, SEXUAL not (only requested-and-matched are returned).
+        let cf = r["results"]["contentFilter"]["results"].as_array().unwrap();
+        assert_eq!(cf.len(), 1);
+        assert_eq!(cf[0]["category"], "VIOLENCE");
+        assert!(cf[0]["severityScore"].as_f64().unwrap() > 0.0);
+        // JAILBREAK detected.
+        assert_eq!(
+            r["results"]["promptAttack"]["results"][0]["category"],
+            "JAILBREAK"
+        );
+        // EMAIL + SSN detected with offsets + position.
+        let si = r["results"]["sensitiveInformation"]["results"]
+            .as_array()
+            .unwrap();
+        let types: Vec<&str> = si.iter().map(|e| e["type"].as_str().unwrap()).collect();
+        assert!(types.contains(&"EMAIL") && types.contains(&"US_SOCIAL_SECURITY_NUMBER"));
+        for e in si {
+            assert!(e["endOffset"].as_i64().unwrap() > e["beginOffset"].as_i64().unwrap());
+            assert_eq!(e["messageIndex"], 0);
+        }
+        assert_eq!(r["results"]["sensitiveInformation"]["truncated"], false);
+        // usage reported per requested check.
+        assert_eq!(r["usage"]["contentFilter"]["textUnits"], 1);
+    }
+
+    #[test]
+    fn clean_text_yields_no_detections() {
+        let body = json!({
+            "messages": [{"role":"USER","content":[{"text":"what a lovely sunny day"}]}],
+            "checks": {"contentFilter": {"categories": [{"category":"VIOLENCE"}]}}
+        });
+        let r = resp_json(&body);
+        assert!(r["results"]["contentFilter"]["results"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+        // Only the requested check appears.
+        assert!(r["results"]["promptAttack"].is_null());
+    }
+
+    #[test]
+    fn empty_messages_is_validation_error() {
+        let body = json!({"messages": [], "checks": {}});
+        let err = match invoke_guardrail_checks(&req(), &body) {
+            Err(e) => e,
+            Ok(_) => panic!("expected validation error"),
+        };
+        assert_eq!(err.code(), "ValidationException");
+    }
+}

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -12,6 +12,7 @@ pub mod enforced_guardrails;
 pub mod evaluation;
 pub mod faults;
 pub mod foundation_model_agreements;
+pub mod guardrail_checks;
 pub mod guardrails;
 pub mod inference_profiles;
 pub mod invocation_jobs;

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -720,6 +720,11 @@ impl BedrockService {
                 ))
             }
 
+            // Runtime: InvokeGuardrailChecks — POST /guardrail-checks/invoke
+            (Method::POST, 2) if segs[0] == "guardrail-checks" && segs[1] == "invoke" => {
+                Some(("InvokeGuardrailChecks", None, None))
+            }
+
             // Runtime: model operations
             (Method::POST, 3) if segs[0] == "model" && segs[2] == "invoke" => {
                 Some(("InvokeModel", Some(decode(&segs[1])), None))
@@ -1066,6 +1071,9 @@ impl AwsService for BedrockService {
                 &extra_id.unwrap_or_default(),
                 &req.body,
             ),
+            "InvokeGuardrailChecks" => {
+                crate::guardrail_checks::invoke_guardrail_checks(&req, &body)
+            }
             // Custom models
             "CreateCustomModel" => {
                 crate::custom_models::create_custom_model(&self.state, &req, &body)

--- a/website/content/docs/services/bedrock.md
+++ b/website/content/docs/services/bedrock.md
@@ -7,7 +7,7 @@ weight = 21
 fakecloud implements **216 of 216** Bedrock-family operations across four APIs:
 
 - **Bedrock** (control plane) — 103 operations *(this page)*
-- **Bedrock Runtime** (model invocation) — 10 operations *(this page)*
+- **Bedrock Runtime** (model invocation) — 11 operations *(this page)*
 - [**Bedrock Agent**](/docs/services/bedrock-agent/) (agents control plane) — 72 operations
 - [**Bedrock Agent Runtime**](/docs/services/bedrock-agent-runtime/) (agent invocation) — 31 operations
 
@@ -40,6 +40,7 @@ For a complete testing guide with code examples, see [Testing Bedrock](/docs/gui
 - **Converse** — with message history, tool use
 - **ConverseStream** — streaming variant
 - **ApplyGuardrail** — content evaluation against configured guardrails
+- **InvokeGuardrailChecks** — inline guardrail-tier checks (no pre-created guardrail): evaluates messages for `contentFilter` / `promptAttack` categories and `sensitiveInformation` entities, returning per-detection scores, PII match offsets, and per-check text-unit usage
 - **CountTokens** — token counting for Anthropic model bodies
 - **Async invoke** — StartAsyncInvoke, GetAsyncInvoke, ListAsyncInvokes
 


### PR DESCRIPTION
## Summary
Bug-hunt 2026-06-26 cycle 3, **batch 3 of 3**. `InvokeGuardrailChecks` (`POST /guardrail-checks/invoke`) is a real declared bedrock-runtime operation but `resolve_action` had no arm for the `guardrail-checks` path, so any call fell through to `ActionNotImplemented` (501-style) — while its sibling `ApplyGuardrail` worked.

Real (not stubbed) evaluation in a new `guardrail_checks` module:
- **contentFilter** — each requested category (VIOLENCE/HATE/SEXUAL/MISCONDUCT/INSULTS) matched against keyword sets → detected categories with a `severityScore`.
- **promptAttack** — JAILBREAK/PROMPT_INJECTION/PROMPT_LEAKAGE matched against phrase sets.
- **sensitiveInformation** — requested entity types detected via regex (EMAIL, SSN, credit card, phone, IP, AWS access key, URL) with real `beginOffset`/`endOffset` + `messageIndex`/`contentIndex`; entity types without a pattern report no detection rather than a false hit.
- `usage.textUnits` per requested check (1000-char billing units).

Routed in `resolve_action` + dispatched; empty messages → `ValidationException`. Not previously in the conformance harness, so the change is purely additive (no baseline regen).

## Test plan
- Unit tests: all-three-families detection (with PII offsets + position), clean text → no detections + only-requested-checks present, empty-messages → ValidationException.
- Verified **end-to-end against a live server** via raw `POST /guardrail-checks/invoke` (VIOLENCE 0.85, JAILBREAK 0.9, EMAIL@50-65 + SSN@70-81, usage textUnits 1).
- `cargo clippy -p fakecloud-bedrock --all-targets -- -D warnings` clean; `cargo fmt`.
- Docs: `bedrock.md` runtime op count 10 → 11 + the InvokeGuardrailChecks bullet.

Completes the cycle-3 bug-hunt (batches: #1966 S3 aws-chunked, #1967 EC2 seed fixes, this). Report: `bug-hunt-reports/2026-06-26-cycle3.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `InvokeGuardrailChecks` in `bedrock-runtime` with real inline guardrail evaluation and proper routing. Fixes 501s for `POST /guardrail-checks/invoke` by adding the missing resolve path.

- **New Features**
  - New `guardrail_checks` module in `fakecloud-bedrock` with `POST /guardrail-checks/invoke` dispatch.
  - Real evaluation:
    - `contentFilter` via keyword matches; `promptAttack` via phrase matches.
    - `sensitiveInformation` via regex with `beginOffset`/`endOffset`, `messageIndex`, and `contentIndex`; only requested checks returned.
  - Reports per-check `usage.textUnits` (1000-char units).
  - Validates empty messages → `ValidationException`.
  - Docs updated: Bedrock Runtime ops now 11, lists `InvokeGuardrailChecks`.

<sup>Written for commit 6df20d9a9ad2969b990506c623ff302ee9ff0d9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

