### PR TITLE
chore(release): bump workspace to v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3820,7 +3820,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4000,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4123,7 +4123,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4242,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4268,7 +4268,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -113,175 +113,175 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.24.0"
+version = "0.25.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.24.0")
+    testImplementation("dev.fakecloud:fakecloud:0.25.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.24.0"
+version = "0.25.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.24.0"
+version = "0.25.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Release v0.25.0. Cycle 3 of the autonomous loop.

**New features (minor bump):**
- **EC2 public AMI catalogue** (#1964/#1965): every account is seeded with public Amazon Linux / Ubuntu / Windows AMIs; `DescribeImages` honours `Owner` + glob `name` filters, so Terraform `data "aws_ami"` resolves (and the ELBv2 `TargetGroupAttachment` acceptance test now passes against real terraform-provider-aws).
- **bedrock-runtime `InvokeGuardrailChecks`** (#1968): real inline guardrail-tier evaluation (contentFilter / promptAttack / sensitiveInformation with PII offsets).

**Bug-hunt fixes (2026-06-26 cycle 3):**
- **S3 aws-chunked** (#1966): default boto3 ≥ 1.36 / aws-crt PutObject was silently corrupted — the aws-chunked framing was stored as object bytes. Now decoded.
- **EC2 seed correctness** (#1967): seeded AMIs are read-only (deregister/modify → AuthFailure), the catalogue survives upgrade+restart, ReplaceImageCriteria round-trips, lazy read fallback.

Also fc-next-step's demand-mining methodology was upgraded (rival trackers + paywall + unimplemented surface + tfacc + forums).

## Test plan
Version bump only (Cargo.toml + Cargo.lock + TS/Python/Java SDK manifests). No new crate (guardrail_checks is a new .rs in the existing fakecloud-bedrock crate). CI green gates the tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.25.0 across the Rust workspace and SDKs. This minor release adds the EC2 public AMI catalog and `bedrock-runtime` `InvokeGuardrailChecks`, and fixes S3 aws-chunked uploads and EC2 seed immutability.

- **Dependencies**
  - Bump versions to 0.25.0 in `Cargo.toml`, `Cargo.lock`, and SDK manifests (`sdks/java`, `sdks/python`, `sdks/typescript`).

<sup>Written for commit 0b3b6bc629c5d744a8b1b0adf7fd00cfb9ddf25c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

