### PR TITLE
fix(rds): patch Oracle Linux base CVEs in mysql image via microdnf update

### DIFF
--- a/crates/fakecloud-rds/assets/mysql/Dockerfile
+++ b/crates/fakecloud-rds/assets/mysql/Dockerfile
@@ -45,8 +45,15 @@ RUN set -eux; \
 # vendored inline in fakecloud_udf.c (the upstream mysql:8.0 image
 # strips its community release repo so `mysql-community-devel` is not
 # installable, and adding it back hard-codes a brittle URL).
+#
+# `microdnf update` patches the Oracle Linux base packages (krb5-libs,
+# libcap, ...) to their latest el9 builds, mirroring the `apt-get
+# upgrade` the Debian branch already runs. Without it the Trivy scan in
+# docker-rds-images.yml fails on fixed-status HIGH OS CVEs that ship in
+# the pinned mysql:8.0 base layer.
 RUN set -eux; \
     if command -v microdnf >/dev/null 2>&1; then \
+        microdnf update -y; \
         microdnf install -y \
             gcc make libcurl-devel glibc-devel; \
         microdnf clean all; \


### PR DESCRIPTION
## Summary

The `RDS support images` workflow's `scan (mysql, 8.0)` job failed on the `v0.25.0` tag ([run](https://github.com/faiscadev/fakecloud/actions/runs/28247138847/job/83689566924)). Trivy reported 3 fixed-status HIGH OS CVEs in the published `fakecloud-mysql:8.0` image, all shipped by the pinned `mysql:8.0` Oracle Linux base layer:

- `krb5-libs` CVE-2026-40355, CVE-2026-40356 (fixed in `1.21.1-10.0.1.el9_8`)
- `libcap` CVE-2026-4878 (fixed in `2.48-10.el9_8.1`)

Root cause: the mysql Dockerfile's `microdnf` branch installs build deps but never upgrades the base OS packages. The Debian-based postgres/mariadb images already run `apt-get upgrade -y`, which is why only mysql tripped the scan.

Fix: add `microdnf update -y` to the `microdnf` branch so the Oracle Linux base packages are patched to their latest el9 builds before the image is published, mirroring the existing Debian `apt-get upgrade`.

## Test plan

- PR triggers the `build` dry-run (paths filter matches `crates/fakecloud-rds/assets/mysql/**`), validating the Dockerfile builds for both arches.
- The Trivy `scan` job only runs on tag/dispatch (post-merge); `microdnf update -y` pulls the el9_8 `krb5-libs`/`libcap` builds that carry the fixes for all 3 reported CVEs.

No code/SDK/docs surface affected — image build fix only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `microdnf update -y` in the Oracle Linux branch of the MySQL Dockerfile to patch base OS packages. This clears HIGH CVEs flagged by `Trivy` in the `fakecloud-mysql:8.0` image.

- **Bug Fixes**
  - Add `microdnf update -y` before build deps, mirroring Debian’s `apt-get upgrade -y`.
  - Updates `krb5-libs` and `libcap` to fixed el9 builds, addressing CVE-2026-40355, CVE-2026-40356, and CVE-2026-4878.

<sup>Written for commit 3314eefcd0b52ed10ffec25f914fb86e2c2afbc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

