### PR TITLE
test(autoscaling): wire EC2 Auto Scaling tfacc + read-shape fidelity (batch 3)

### DIFF
--- a/crates/fakecloud-autoscaling/src/service.rs
+++ b/crates/fakecloud-autoscaling/src/service.rs
@@ -258,6 +258,15 @@ impl AutoScalingService {
             iam_instance_profile: optional_query_param(req, "IamInstanceProfile"),
             associate_public_ip_address: optional_query_param(req, "AssociatePublicIpAddress")
                 .map(|v| v == "true"),
+            // InstanceMonitoring.Enabled defaults to true (AWS + Terraform).
+            instance_monitoring: optional_query_param(req, "InstanceMonitoring.Enabled")
+                .map(|v| v == "true")
+                .unwrap_or(true),
+            ebs_optimized: optional_query_param(req, "EbsOptimized")
+                .map(|v| v == "true")
+                .unwrap_or(false),
+            spot_price: optional_query_param(req, "SpotPrice"),
+            placement_tenancy: optional_query_param(req, "PlacementTenancy"),
             created_time: Utc::now(),
         };
         {
@@ -283,16 +292,35 @@ impl AutoScalingService {
             .values()
             .filter(|lc| wanted.is_empty() || wanted.contains(&lc.name))
             .map(|lc| {
+                let sgs: String = lc
+                    .security_groups
+                    .iter()
+                    .map(|s| format!("<member>{}</member>", xesc(s)))
+                    .collect();
+                let monitoring = format!(
+                    "<InstanceMonitoring><Enabled>{}</Enabled></InstanceMonitoring>",
+                    lc.instance_monitoring
+                );
                 format!(
-                    "<member>{}{}{}{}{}{}</member>",
+                    "<member>{}{}{}{}{}{}{monitoring}{}{}{}<SecurityGroups>{sgs}</SecurityGroups>{}{}{}{}</member>",
                     el("LaunchConfigurationName", &lc.name),
                     el("LaunchConfigurationARN", &lc.arn),
                     el("ImageId", &lc.image_id),
                     el("InstanceType", &lc.instance_type),
-                    lc.key_name
+                    el("KeyName", lc.key_name.as_deref().unwrap_or("")),
+                    el("IamInstanceProfile", lc.iam_instance_profile.as_deref().unwrap_or("")),
+                    el("EbsOptimized", &lc.ebs_optimized.to_string()),
+                    el(
+                        "AssociatePublicIpAddress",
+                        &lc.associate_public_ip_address.unwrap_or(false).to_string(),
+                    ),
+                    el("SpotPrice", lc.spot_price.as_deref().unwrap_or("")),
+                    el("PlacementTenancy", lc.placement_tenancy.as_deref().unwrap_or("")),
+                    lc.user_data
                         .as_deref()
-                        .map(|k| el("KeyName", k))
+                        .map(|u| el("UserData", u))
                         .unwrap_or_default(),
+                    "<BlockDeviceMappings/>",
                     el("CreatedTime", &iso(lc.created_time)),
                 )
             })
@@ -377,6 +405,13 @@ impl AutoScalingService {
             instances: Vec::new(),
             tags,
             status: None,
+            service_linked_role_arn: optional_query_param(req, "ServiceLinkedRoleARN")
+                .unwrap_or_else(|| {
+                    format!(
+                        "arn:aws:iam::{}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+                        req.account_id
+                    )
+                }),
         };
 
         let _ = azs;
@@ -815,7 +850,7 @@ fn group_xml(g: &AutoScalingGroup) -> String {
     format!(
         "<member>{}{}{}{}{}{}{}{}{}{}{}<AvailabilityZones>{azs}</AvailabilityZones>\
          <Instances>{instances}</Instances><TargetGroupARNs>{tgs}</TargetGroupARNs>\
-         <Tags>{tags}</Tags>{}</member>",
+         <Tags>{tags}</Tags>{}{}{}</member>",
         el("AutoScalingGroupName", &g.name),
         el("AutoScalingGroupARN", &g.arn),
         g.launch_configuration_name
@@ -840,6 +875,8 @@ fn group_xml(g: &AutoScalingGroup) -> String {
             "NewInstancesProtectedFromScaleIn",
             &g.new_instances_protected_from_scale_in.to_string()
         ),
+        el("ServiceLinkedRoleARN", &g.service_linked_role_arn),
+        "<AvailabilityZoneDistribution><CapacityDistributionStrategy>balanced-best-effort</CapacityDistributionStrategy></AvailabilityZoneDistribution>",
     )
 }
 

--- a/crates/fakecloud-autoscaling/src/state.rs
+++ b/crates/fakecloud-autoscaling/src/state.rs
@@ -60,7 +60,20 @@ pub struct LaunchConfiguration {
     pub iam_instance_profile: Option<String>,
     #[serde(default)]
     pub associate_public_ip_address: Option<bool>,
+    /// `InstanceMonitoring.Enabled` — AWS/Terraform default is `true`.
+    #[serde(default = "default_true")]
+    pub instance_monitoring: bool,
+    #[serde(default)]
+    pub ebs_optimized: bool,
+    #[serde(default)]
+    pub spot_price: Option<String>,
+    #[serde(default)]
+    pub placement_tenancy: Option<String>,
     pub created_time: DateTime<Utc>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,6 +112,9 @@ pub struct AutoScalingGroup {
     /// Set during a DeleteAutoScalingGroup that is draining instances.
     #[serde(default)]
     pub status: Option<String>,
+    /// `ServiceLinkedRoleARN` — defaults to the AWSServiceRoleForAutoScaling SLR.
+    #[serde(default)]
+    pub service_linked_role_arn: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -773,6 +773,18 @@ pub const SERVICES: &[Service] = &[
         run_regex: "^TestAccAppAutoScaling[A-Za-z0-9]+_basic$",
         deny: &[],
     },
+    Service {
+        name: "autoscaling",
+        // EC2 Auto Scaling: the `_basic` smoke for an Auto Scaling Group
+        // (`aws_autoscaling_group`) and a Launch Configuration
+        // (`aws_launch_configuration`). The group launches real container-backed
+        // EC2 instances (resolving the launch config's AMI from the seeded
+        // catalogue); the launch configuration round-trips InstanceMonitoring /
+        // ebs_optimized / spot_price / placement_tenancy, and the group reports
+        // ServiceLinkedRoleARN + AvailabilityZoneDistribution the provider reads.
+        run_regex: "^TestAccAutoScaling(Group|LaunchConfiguration)_basic$",
+        deny: &[],
+    },
 ];
 
 /// CI matrix shards. One GitHub Actions job per entry.
@@ -1174,6 +1186,12 @@ pub const SHARDS: &[Shard] = &[
         name: "appautoscaling",
         service: "appautoscaling",
         run_regex: "^TestAccAppAutoScaling[A-Za-z0-9]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "autoscaling",
+        service: "autoscaling",
+        run_regex: "^TestAccAutoScaling(Group|LaunchConfiguration)_basic$",
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -238,6 +238,11 @@ async fn appautoscaling_acceptance() {
 }
 
 #[tokio::test]
+async fn autoscaling_acceptance() {
+    run_shard("autoscaling").await;
+}
+
+#[tokio::test]
 async fn scheduler_acceptance() {
     run_shard("scheduler").await;
 }


### PR DESCRIPTION
## Summary
Batch 3 of the EC2 Auto Scaling winner — wires the `autoscaling` service into the terraform-provider-aws acceptance suite and fixes the read-shape gaps the provider asserts.

- **LaunchConfiguration** now round-trips `InstanceMonitoring.Enabled` (default `true`), `EbsOptimized`, `SpotPrice`, `PlacementTenancy`, and emits `KeyName` / `IamInstanceProfile` / `SecurityGroups` / `AssociatePublicIpAddress` / `BlockDeviceMappings`.
- **AutoScalingGroup** now reports `ServiceLinkedRoleARN` (defaults to the `AWSServiceRoleForAutoScaling` SLR) and `AvailabilityZoneDistribution` (`capacity_distribution_strategy = balanced-best-effort`).
- `allowlist.rs`: new `autoscaling` Service + Shard (`^TestAccAutoScaling(Group|LaunchConfiguration)_basic$`); `acc.rs` `autoscaling_acceptance`.

## Test plan
- **`TestAccAutoScalingGroup_basic` + `TestAccAutoScalingLaunchConfiguration_basic` verified PASS** against the real terraform-provider-aws v5.97.0 locally (`ok`). The group launches real container-backed instances (batch 2), resolving the launch config's AMI from the cycle-3 seeded catalogue. Iteratively triaged each provider read-shape assertion (`enable_monitoring`, `service_linked_role_arn`, `availability_zone_distribution`) to green.
- `cargo nextest run -p fakecloud-autoscaling` green; `cargo clippy -p fakecloud-autoscaling --all-targets -- -D warnings` clean; `cargo fmt`.

Completes the 3-batch EC2 Auto Scaling winner (#1970 control plane, #1972 real instances, this tfacc). A CFN `AWS::AutoScaling::*` provisioner is a clean follow-on. Decision report: `next-step-reports/2026-06-26-cycle4.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires EC2 Auto Scaling into `fakecloud-tfacc` and aligns read shapes with `terraform-provider-aws` so the `_basic` ASG and Launch Configuration tests pass. Adds the autoscaling shard to the acceptance matrix.

- **New Features**
  - LaunchConfiguration: round-trips `InstanceMonitoring.Enabled` (default true), `EbsOptimized`, `SpotPrice`, `PlacementTenancy`, and emits `KeyName`, `IamInstanceProfile`, `SecurityGroups`, `AssociatePublicIpAddress`, `BlockDeviceMappings`.
  - AutoScalingGroup: returns `ServiceLinkedRoleARN` (defaults to the account’s `AWSServiceRoleForAutoScaling`) and `AvailabilityZoneDistribution` with `balanced-best-effort`.
  - `fakecloud-tfacc`: new `autoscaling` service allowlist and shard (`^TestAccAutoScaling(Group|LaunchConfiguration)_basic$`); added `autoscaling_acceptance` test.

<sup>Written for commit 574545207d8c7f4898de9c2843759c2b2eadf0db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

