### PR TITLE
feat(cloudformation): provision AWS::AutoScaling::* resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3327,6 +3327,7 @@ dependencies = [
  "fakecloud-apigatewayv2",
  "fakecloud-application-autoscaling",
  "fakecloud-athena",
+ "fakecloud-autoscaling",
  "fakecloud-aws",
  "fakecloud-cloudfront",
  "fakecloud-cloudwatch",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -42,6 +42,7 @@ fakecloud-apigateway = { workspace = true }
 fakecloud-apigatewayv2 = { workspace = true }
 fakecloud-ses = { workspace = true }
 fakecloud-application-autoscaling = { workspace = true }
+fakecloud-autoscaling = { workspace = true }
 fakecloud-athena = { workspace = true }
 fakecloud-firehose = { workspace = true }
 fakecloud-glue = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -2534,6 +2534,9 @@ mod tests {
             cognito: shared::<fakecloud_cognito::CognitoState>(),
             rds: shared::<fakecloud_rds::RdsState>(),
             ec2: shared::<fakecloud_ec2::Ec2State>(),
+            autoscaling: Arc::new(parking_lot::RwLock::new(
+                fakecloud_autoscaling::AutoScalingAccounts::new(),
+            )),
             ecs: shared::<fakecloud_ecs::EcsState>(),
             acm: Arc::new(RwLock::new(fakecloud_acm::AcmAccounts::new())),
             elasticache: shared::<fakecloud_elasticache::ElastiCacheState>(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/autoscaling.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/autoscaling.rs
@@ -1,0 +1,188 @@
+//! `AWS::AutoScaling::*` CloudFormation provisioning. Creates Launch
+//! Configurations and Auto Scaling Groups as real records in the `autoscaling`
+//! service state (metadata-only: the group is reconciled to its desired
+//! capacity with placeholder instances, mirroring the service's control plane;
+//! real container instances are a runtime concern, not CFN-time). cycle 4.
+
+use chrono::Utc;
+use fakecloud_autoscaling::state::{AsgInstance, AutoScalingGroup, LaunchConfiguration};
+use serde_json::Value;
+use uuid::Uuid;
+
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+
+fn prop_str<'a>(p: &'a Value, k: &str) -> Option<&'a str> {
+    p.get(k).and_then(|v| v.as_str())
+}
+
+fn prop_i64(p: &Value, k: &str) -> Option<i64> {
+    p.get(k).and_then(|v| {
+        v.as_i64()
+            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+    })
+}
+
+fn str_list(p: &Value, k: &str) -> Vec<String> {
+    p.get(k)
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+impl ResourceProvisioner {
+    fn asg_arn(&self, kind: &str, name: &str) -> String {
+        format!(
+            "arn:aws:autoscaling:{}:{}:{kind}:{}:{kind}Name/{name}",
+            self.region,
+            self.account_id,
+            Uuid::new_v4()
+        )
+    }
+
+    pub(super) fn create_autoscaling_launch_configuration(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = prop_str(props, "LaunchConfigurationName")
+            .map(String::from)
+            .unwrap_or_else(|| resource.logical_id.clone());
+        let image_id = prop_str(props, "ImageId")
+            .ok_or("AWS::AutoScaling::LaunchConfiguration requires ImageId")?
+            .to_string();
+        let instance_type = prop_str(props, "InstanceType")
+            .ok_or("AWS::AutoScaling::LaunchConfiguration requires InstanceType")?
+            .to_string();
+        let lc = LaunchConfiguration {
+            arn: self.asg_arn("launchConfiguration", &name),
+            name: name.clone(),
+            image_id,
+            instance_type,
+            key_name: prop_str(props, "KeyName").map(String::from),
+            security_groups: str_list(props, "SecurityGroups"),
+            user_data: prop_str(props, "UserData").map(String::from),
+            iam_instance_profile: prop_str(props, "IamInstanceProfile").map(String::from),
+            associate_public_ip_address: props
+                .get("AssociatePublicIpAddress")
+                .and_then(|v| v.as_bool()),
+            instance_monitoring: props
+                .get("InstanceMonitoring")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true),
+            ebs_optimized: props
+                .get("EbsOptimized")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            spot_price: prop_str(props, "SpotPrice").map(String::from),
+            placement_tenancy: prop_str(props, "PlacementTenancy").map(String::from),
+            created_time: Utc::now(),
+        };
+        self.autoscaling_state
+            .write()
+            .get_or_create(&self.account_id)
+            .launch_configurations
+            .insert(name.clone(), lc);
+        Ok(ProvisionResult::new(name))
+    }
+
+    pub(super) fn create_autoscaling_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = prop_str(props, "AutoScalingGroupName")
+            .map(String::from)
+            .unwrap_or_else(|| resource.logical_id.clone());
+        let min_size = prop_i64(props, "MinSize").unwrap_or(0);
+        let max_size = prop_i64(props, "MaxSize").unwrap_or(min_size);
+        let desired = prop_i64(props, "DesiredCapacity").unwrap_or(min_size);
+        let mut azs = str_list(props, "AvailabilityZones");
+        if azs.is_empty() {
+            azs.push(format!("{}a", self.region));
+        }
+        let lcn = prop_str(props, "LaunchConfigurationName").map(String::from);
+        let vpc_zone_identifier = props
+            .get("VPCZoneIdentifier")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|x| x.as_str())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            })
+            .or_else(|| prop_str(props, "VPCZoneIdentifier").map(String::from));
+
+        // Placeholder instances to satisfy the desired capacity (the service's
+        // control-plane behavior; runtime launches real ones via the API path).
+        let instances: Vec<AsgInstance> = (0..desired.max(0))
+            .map(|k| {
+                let hex = Uuid::new_v4().simple().to_string();
+                AsgInstance {
+                    instance_id: format!("i-{}", &hex[..17]),
+                    availability_zone: azs[k as usize % azs.len()].clone(),
+                    lifecycle_state: "InService".to_string(),
+                    health_status: "Healthy".to_string(),
+                    launch_configuration_name: lcn.clone(),
+                    protected_from_scale_in: false,
+                }
+            })
+            .collect();
+
+        let arn = self.asg_arn("autoScalingGroup", &name);
+        let group = AutoScalingGroup {
+            arn: arn.clone(),
+            name: name.clone(),
+            launch_configuration_name: lcn,
+            launch_template: None,
+            min_size,
+            max_size,
+            desired_capacity: desired,
+            default_cooldown: prop_i64(props, "Cooldown").unwrap_or(300),
+            availability_zones: azs,
+            vpc_zone_identifier,
+            health_check_type: prop_str(props, "HealthCheckType")
+                .unwrap_or("EC2")
+                .to_string(),
+            health_check_grace_period: prop_i64(props, "HealthCheckGracePeriod").unwrap_or(0),
+            target_group_arns: str_list(props, "TargetGroupARNs"),
+            load_balancer_names: str_list(props, "LoadBalancerNames"),
+            new_instances_protected_from_scale_in: props
+                .get("NewInstancesProtectedFromScaleIn")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            created_time: Utc::now(),
+            instances,
+            tags: Vec::new(),
+            status: None,
+            service_linked_role_arn: format!(
+                "arn:aws:iam::{}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+                self.account_id
+            ),
+        };
+        self.autoscaling_state
+            .write()
+            .get_or_create(&self.account_id)
+            .groups
+            .insert(name.clone(), group);
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    /// Delete an AutoScaling LaunchConfiguration / Group by physical id (name).
+    pub(super) fn delete_autoscaling(&self, resource_type: &str, name: &str) {
+        let mut st = self.autoscaling_state.write();
+        let acct = st.get_or_create(&self.account_id);
+        match resource_type {
+            "AWS::AutoScaling::LaunchConfiguration" => {
+                acct.launch_configurations.remove(name);
+            }
+            "AWS::AutoScaling::AutoScalingGroup" => {
+                acct.groups.remove(name);
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
@@ -90,6 +90,7 @@ impl ResourceProvisioner {
             cognito_state: self.cognito_state.clone(),
             rds_state: self.rds_state.clone(),
             ec2_state: self.ec2_state.clone(),
+            autoscaling_state: self.autoscaling_state.clone(),
             ecs_state: self.ecs_state.clone(),
             acm_state: self.acm_state.clone(),
             elasticache_state: self.elasticache_state.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -880,6 +880,7 @@ pub struct ResourceProvisioner {
     pub cognito_state: SharedCognitoState,
     pub rds_state: SharedRdsState,
     pub ec2_state: fakecloud_ec2::SharedEc2State,
+    pub autoscaling_state: fakecloud_autoscaling::SharedAutoScalingState,
     pub ecs_state: SharedEcsState,
     pub acm_state: SharedAcmState,
     pub elasticache_state: SharedElastiCacheState,
@@ -914,6 +915,7 @@ mod acm;
 mod apigw;
 mod apigwv2;
 mod athena;
+mod autoscaling;
 mod cloudformation;
 mod cloudwatch;
 mod cognito;
@@ -1045,6 +1047,10 @@ impl ResourceProvisioner {
             "AWS::RDS::DBProxy" => self.create_rds_db_proxy(resource),
             "AWS::RDS::DBInstance" => self.create_rds_db_instance(resource),
             "AWS::RDS::DBCluster" => self.create_rds_db_cluster(resource),
+            "AWS::AutoScaling::LaunchConfiguration" => {
+                self.create_autoscaling_launch_configuration(resource)
+            }
+            "AWS::AutoScaling::AutoScalingGroup" => self.create_autoscaling_group(resource),
             "AWS::EC2::VPC" => self.create_ec2_vpc(resource),
             "AWS::EC2::Subnet" => self.create_ec2_subnet(resource),
             "AWS::EC2::SecurityGroup" => self.create_ec2_security_group(resource),
@@ -1619,6 +1625,10 @@ impl ResourceProvisioner {
             | "AWS::EC2::InternetGateway"
             | "AWS::EC2::RouteTable" => {
                 self.delete_ec2_resource(&resource.resource_type, &resource.physical_id)
+            }
+            "AWS::AutoScaling::LaunchConfiguration" | "AWS::AutoScaling::AutoScalingGroup" => {
+                self.delete_autoscaling(&resource.resource_type, &resource.physical_id);
+                Ok(())
             }
             "AWS::ECS::Cluster" => self.delete_ecs_cluster(&resource.physical_id),
             "AWS::ECS::TaskDefinition" => self.delete_ecs_task_definition(&resource.physical_id),
@@ -6031,6 +6041,9 @@ mod tests {
             )),
             ec2_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
+            autoscaling_state: Arc::new(RwLock::new(
+                fakecloud_autoscaling::AutoScalingAccounts::new(),
             )),
             ecs_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -122,6 +122,7 @@ fn service_key_for_type(resource_type: &str) -> Option<&'static str> {
         // vanished on restart (#1766 class). Both have a registered snapshot
         // hook in the server.
         "EC2" => "ec2",
+        "AutoScaling" => "autoscaling",
         "ApplicationAutoScaling" => "application-autoscaling",
         _ => return None,
     })
@@ -296,6 +297,7 @@ pub struct CloudFormationDeps {
     pub cognito: fakecloud_cognito::SharedCognitoState,
     pub rds: fakecloud_rds::SharedRdsState,
     pub ec2: fakecloud_ec2::SharedEc2State,
+    pub autoscaling: fakecloud_autoscaling::SharedAutoScalingState,
     pub ecs: fakecloud_ecs::SharedEcsState,
     pub acm: fakecloud_acm::SharedAcmState,
     pub elasticache: fakecloud_elasticache::SharedElastiCacheState,
@@ -441,6 +443,7 @@ impl CloudFormationService {
             cognito_state: self.deps.cognito.clone(),
             rds_state: self.deps.rds.clone(),
             ec2_state: self.deps.ec2.clone(),
+            autoscaling_state: self.deps.autoscaling.clone(),
             ecs_state: self.deps.ecs.clone(),
             acm_state: self.deps.acm.clone(),
             elasticache_state: self.deps.elasticache.clone(),
@@ -2445,6 +2448,9 @@ mod tests {
                     "us-east-1",
                     "",
                 ),
+            )),
+            autoscaling: Arc::new(RwLock::new(
+                fakecloud_autoscaling::AutoScalingAccounts::new(),
             )),
             ecs: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(

--- a/crates/fakecloud-e2e/tests/cloudformation_autoscaling.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_autoscaling.rs
@@ -1,0 +1,80 @@
+//! CloudFormation provisions AWS::AutoScaling::LaunchConfiguration +
+//! AutoScalingGroup as real records in the `autoscaling` service.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "Resources": {
+    "LC": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": { "ImageId": "ami-0a1b2c3d4e5f60001", "InstanceType": "t3.micro" }
+    },
+    "ASG": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "Properties": {
+        "MinSize": "1", "MaxSize": "3", "DesiredCapacity": "2",
+        "LaunchConfigurationName": { "Ref": "LC" },
+        "AvailabilityZones": ["us-east-1a"]
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_autoscaling_group() {
+    let s = TestServer::start().await;
+    let cfn = s.cloudformation_client().await;
+    let asg = aws_sdk_autoscaling::Client::new(&s.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("asg-stack")
+        .template_body(TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("asg-stack")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described.stacks()[0].stack_status().unwrap().as_str(),
+        "CREATE_COMPLETE"
+    );
+
+    // The launch configuration + group exist in the autoscaling service.
+    let lcs = asg.describe_launch_configurations().send().await.unwrap();
+    assert!(
+        !lcs.launch_configurations().is_empty(),
+        "CFN launch configuration should exist"
+    );
+
+    let groups = asg.describe_auto_scaling_groups().send().await.unwrap();
+    let g = groups
+        .auto_scaling_groups()
+        .iter()
+        .find(|g| g.desired_capacity() == Some(2))
+        .expect("CFN ASG with desired=2");
+    assert_eq!(g.instances().len(), 2, "ASG reconciled to desired capacity");
+
+    // Deleting the stack removes the group.
+    cfn.delete_stack()
+        .stack_name("asg-stack")
+        .send()
+        .await
+        .unwrap();
+    let after = asg.describe_auto_scaling_groups().send().await.unwrap();
+    assert!(
+        after
+            .auto_scaling_groups()
+            .iter()
+            .all(|g| g.desired_capacity() != Some(2)
+                || g.auto_scaling_group_name()
+                    != groups.auto_scaling_groups()[0].auto_scaling_group_name()),
+        "stack delete should remove the ASG"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -920,6 +920,7 @@ async fn main() {
             cognito: cognito_state.clone(),
             rds: rds_state.clone(),
             ec2: ec2_state.clone(),
+            autoscaling: autoscaling_state.clone(),
             ecs: ecs_state.clone(),
             acm: acm_state.clone(),
             elasticache: elasticache_state.clone(),


### PR DESCRIPTION
## Summary
Completes the EC2 Auto Scaling cycle: CloudFormation can now provision
`AWS::AutoScaling::LaunchConfiguration` and `AWS::AutoScaling::AutoScalingGroup`,
writing real records into the `autoscaling` service state (no stubs).

- `resource_provisioner/autoscaling.rs`: `create_autoscaling_launch_configuration`,
  `create_autoscaling_group` (reconciles to `DesiredCapacity` with placeholder
  instances, mirroring the service control plane), `delete_autoscaling`.
- Wired `autoscaling_state` through `CloudFormationDeps` + `ResourceProvisioner`
  (prod ctor, nested child-stack ctor, both test ctors) and `service_key_for_type`.
- Create/delete match arms for both resource types.

## Test plan
- `crates/fakecloud-e2e/tests/cloudformation_autoscaling.rs`: CFN stack creates an
  ASG (`DesiredCapacity=2` -> 2 instances) + a launch configuration, then
  `delete-stack` removes the group. PASS.
- `cargo nextest run -p fakecloud-cloudformation` 248 pass.
- `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` clean.

## Surface
Provisioner-internal change; no new public API/SDK surface. Service docs for EC2
Auto Scaling already shipped with the service crate. CFN-supported-resources is
inferred from provisioner arms, no separate manifest to bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CloudFormation can now provision AWS Auto Scaling resources. It writes real records to the `autoscaling` state and reconciles ASGs to `DesiredCapacity`; stack delete cleans them up.

- **New Features**
  - Support `AWS::AutoScaling::LaunchConfiguration` and `AWS::AutoScaling::AutoScalingGroup` in `fakecloud-cloudformation`.
  - ASGs reconcile to `DesiredCapacity` with placeholder instances (control plane parity).
  - Wire `autoscaling_state` through `CloudFormationDeps` and `ResourceProvisioner`, add delete handlers, and register `AutoScaling` in `service_key_for_type`.
  - Add e2e test that creates LC + ASG (`DesiredCapacity=2`) and verifies deletion removes the group.

- **Dependencies**
  - Add `fakecloud-autoscaling` to `fakecloud-cloudformation`.

<sup>Written for commit 826dec11111bc92d774c1f1bb3f67314fc16ec49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

