### PR TITLE
fix(release,cloudformation): restore app-autoscaling version pin + persist CFN-provisioned autoscaling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,7 @@ version = "0.25.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
+version = "0.25.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"

--- a/crates/fakecloud-autoscaling/src/service.rs
+++ b/crates/fakecloud-autoscaling/src/service.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use fakecloud_core::query::{optional_query_param, query_response_xml, required_query_param};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
-use fakecloud_persistence::SnapshotStore;
+use fakecloud_persistence::{SnapshotHook, SnapshotStore};
 
 use crate::state::{
     AccountState, AsgInstance, AsgTag, AutoScalingGroup, AutoScalingSnapshot, LaunchConfiguration,
@@ -141,6 +141,32 @@ impl AutoScalingService {
             serde_json::to_vec(&snap).unwrap_or_default()
         };
         let _ = tokio::task::spawn_blocking(move || store.save(&bytes)).await;
+    }
+
+    /// CloudFormation write-through hook. The CFN provisioner mutates
+    /// `autoscaling_state` directly (not through this service's handlers), so
+    /// without this hook a CFN-provisioned ASG / launch configuration would
+    /// never hit the snapshot and would vanish on restart (#1766 class).
+    pub fn snapshot_hook(&self) -> Option<SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let store = store.clone();
+            let state = state.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                let _guard = lock.lock().await;
+                let bytes = {
+                    let snap = AutoScalingSnapshot {
+                        schema_version: AUTOSCALING_SNAPSHOT_SCHEMA_VERSION,
+                        accounts: Some(state.read().clone()),
+                    };
+                    serde_json::to_vec(&snap).unwrap_or_default()
+                };
+                let _ = tokio::task::spawn_blocking(move || store.save(&bytes)).await;
+            })
+        }))
     }
 }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_autoscaling_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_autoscaling_persistence.rs
@@ -1,0 +1,58 @@
+//! A CloudFormation-provisioned AWS::AutoScaling::* stack survives a restart in
+//! persistent mode. Regression for the #1766-class gap where the CFN provisioner
+//! wrote straight into `autoscaling_state` but no `cfn_snapshot_hooks` entry for
+//! "autoscaling" was registered, so the ASG vanished on restart.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "Resources": {
+    "LC": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": { "ImageId": "ami-0a1b2c3d4e5f60001", "InstanceType": "t3.micro" }
+    },
+    "ASG": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "Properties": {
+        "MinSize": "1", "MaxSize": "3", "DesiredCapacity": "2",
+        "LaunchConfigurationName": { "Ref": "LC" },
+        "AvailabilityZones": ["us-east-1a"]
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisioned_asg_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let cfn = server.cloudformation_client().await;
+
+    cfn.create_stack()
+        .stack_name("asg-persist")
+        .template_body(TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    server.restart().await;
+    let asg = aws_sdk_autoscaling::Client::new(&server.aws_config().await);
+
+    // The group provisioned by CFN is still present after restart.
+    let groups = asg.describe_auto_scaling_groups().send().await.unwrap();
+    let g = groups
+        .auto_scaling_groups()
+        .iter()
+        .find(|g| g.desired_capacity() == Some(2))
+        .expect("CFN-provisioned ASG should survive restart");
+    assert_eq!(g.instances().len(), 2, "ASG capacity persisted");
+
+    // The launch configuration survives too.
+    let lcs = asg.describe_launch_configurations().send().await.unwrap();
+    assert!(
+        !lcs.launch_configurations().is_empty(),
+        "CFN launch configuration should survive restart"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3060,6 +3060,9 @@ async fn main() {
     if let Some(store) = autoscaling_snapshot_store.clone() {
         autoscaling_service = autoscaling_service.with_snapshot_store(store);
     }
+    if let Some(h) = autoscaling_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("autoscaling", h);
+    }
     registry.register(Arc::new(autoscaling_service));
     let wafv2_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {


### PR DESCRIPTION
## Summary
Two Tier-0 regressions that came in with the EC2 Auto Scaling feature, caught by the cycle-4 bug hunt as a pre-release flight:

1. **Release-blocking** — `[workspace.dependencies.fakecloud-application-autoscaling]` lost its `version = "0.25.0"` pin (dropped in 65a0aa62). It is the only internal workspace dep missing it. On the next release tag, `cargo publish -p fakecloud-cloudformation` / `-p fakecloud` emit a version-less registry dependency and cargo hard-errors `all dependencies must have a version specified when publishing`, aborting the publish pipeline after ~36 crates are already on crates.io.
2. **Restart-breaking (#1766 class)** — the CFN `AWS::AutoScaling::*` provisioner mutates `autoscaling_state` directly; `service_key_for_type` maps `"AutoScaling" => "autoscaling"` but no `cfn_snapshot_hooks.insert("autoscaling", …)` was registered, so `persist_touched_services` silently no-ops and a CFN-provisioned ASG vanished on restart in persistent mode. Adds `AutoScalingService::snapshot_hook()` and registers it.

## Test plan
- New e2e `cloudformation_autoscaling_persistence.rs`: create a CFN ASG+LaunchConfiguration stack, `restart()` the persistent server, assert both survive. PASS.
- `cargo clippy -p fakecloud-autoscaling --all-targets -- -D warnings` clean.
- Existing `cloudformation_autoscaling.rs` (same-session create/delete) still passes.

## Surface
Release-pipeline + persistence fix; no new public API/SDK surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `fakecloud-application-autoscaling` version pin to unblock publishing and persists CloudFormation-provisioned Auto Scaling resources across restarts by adding a snapshot hook.

- **Bug Fixes**
  - Persist `AWS::AutoScaling::*` created by CloudFormation across server restarts by adding `AutoScalingService::snapshot_hook()` and registering `autoscaling` in CFN snapshot hooks; adds an e2e test that verifies the ASG and LaunchConfiguration survive a restart.

- **Dependencies**
  - Re-pin `workspace.dependencies.fakecloud-application-autoscaling` to `0.25.0` so `cargo publish` succeeds for `fakecloud-cloudformation` and `fakecloud`.

<sup>Written for commit 21929ca47b5d2d96163b38e91fb6625d3158c91f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

