### PR TITLE
fix(ec2,iam,glue): persist Modify/Update fields that were silently dropped

### DIFF
--- a/crates/fakecloud-e2e/tests/glue.rs
+++ b/crates/fakecloud-e2e/tests/glue.rs
@@ -1040,3 +1040,41 @@ async fn delete_schema_versions_actually_deletes() {
         "version 2 must be gone after delete_schema_versions"
     );
 }
+
+#[tokio::test]
+async fn update_crawler_schedule_persists_expression() {
+    use aws_sdk_glue::types::{CrawlerTargets, S3Target};
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    glue.create_crawler()
+        .name("sched-crawler")
+        .role("arn:aws:iam::123456789012:role/glue")
+        .database_name("analytics")
+        .targets(
+            CrawlerTargets::builder()
+                .s3_targets(S3Target::builder().path("s3://b/a").build())
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create crawler");
+
+    // The Schedule cron expression was previously dropped; GetCrawler must
+    // reflect it after UpdateCrawlerSchedule.
+    glue.update_crawler_schedule()
+        .crawler_name("sched-crawler")
+        .schedule("cron(0 12 * * ? *)")
+        .send()
+        .await
+        .expect("update schedule");
+
+    let got = glue
+        .get_crawler()
+        .name("sched-crawler")
+        .send()
+        .await
+        .expect("get crawler");
+    let sched = got.crawler().and_then(|c| c.schedule()).expect("schedule");
+    assert_eq!(sched.schedule_expression(), Some("cron(0 12 * * ? *)"));
+}

--- a/crates/fakecloud-ec2/src/service/eni.rs
+++ b/crates/fakecloud-ec2/src/service/eni.rs
@@ -331,10 +331,19 @@ pub(crate) fn modify_network_interface_attribute(
 }
 
 pub(crate) fn reset_network_interface_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "NetworkInterfaceId")?;
+    let eni_id = require(&req.query_params, "NetworkInterfaceId")?;
+    // The only resettable attribute is sourceDestCheck (back to the default
+    // true). Previously this validated then persisted nothing.
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        if let Some(eni) = state.network_interfaces.get_mut(&eni_id) {
+            eni.source_dest_check = true;
+        }
+    }
     Ok(Ec2Service::respond(
         "ResetNetworkInterfaceAttribute",
         &req.request_id,
@@ -343,7 +352,7 @@ pub(crate) fn reset_network_interface_attribute(
 }
 
 pub(crate) fn describe_network_interface_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "NetworkInterfaceId")?;
@@ -363,14 +372,40 @@ pub(crate) fn describe_network_interface_attribute(
             "associatePublicIpAddress",
         ],
     )?;
+    // Read the real stored ENI so a Modify is reflected on read-back. Previously
+    // every attribute returned a hardcoded constant (description="eni", empty
+    // groupSet, sourceDestCheck=true) regardless of stored state.
+    let accounts = svc.state.read();
+    let eni = accounts
+        .get(&req.account_id)
+        .and_then(|a| a.network_interfaces.get(&id));
     let attr_xml = match attribute.as_str() {
-        "description" => "<description><value>eni</value></description>".to_string(),
-        "groupSet" => ec2_list("groupSet", &[]),
-        "attachment" => String::new(),
+        "description" => format!(
+            "<description><value>{}</value></description>",
+            eni.map(|e| e.description.as_str()).unwrap_or("")
+        ),
+        "groupSet" => {
+            let groups: Vec<String> = eni
+                .map(|e| {
+                    e.group_ids
+                        .iter()
+                        .map(|g| format!("{}{}", ec2_elem("groupId", g), ec2_elem("groupName", g)))
+                        .collect()
+                })
+                .unwrap_or_default();
+            ec2_list("groupSet", &groups)
+        }
+        "attachment" => eni
+            .and_then(|e| e.attachment.as_ref())
+            .map(|a| format!("<attachment>{}</attachment>", attachment_inner(a)))
+            .unwrap_or_default(),
         "associatePublicIpAddress" => {
             "<associatePublicIpAddress>false</associatePublicIpAddress>".to_string()
         }
-        _ => "<sourceDestCheck><value>true</value></sourceDestCheck>".to_string(),
+        _ => format!(
+            "<sourceDestCheck><value>{}</value></sourceDestCheck>",
+            eni.map(|e| e.source_dest_check).unwrap_or(true)
+        ),
     };
     let body = format!("{}{}", ec2_elem("networkInterfaceId", &id), attr_xml);
     Ok(Ec2Service::respond(
@@ -634,5 +669,79 @@ mod tests {
         assert!(!eni.source_dest_check, "SourceDestCheck must persist");
         assert_eq!(eni.description, "new-desc");
         assert_eq!(eni.group_ids, vec!["sg-a".to_string(), "sg-b".to_string()]);
+    }
+
+    fn seed_eni(svc: &Ec2Service) {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create("000000000000");
+        state.network_interfaces.insert(
+            "eni-1".to_string(),
+            NetworkInterface {
+                network_interface_id: "eni-1".into(),
+                subnet_id: "subnet-1".into(),
+                vpc_id: "vpc-1".into(),
+                availability_zone: "us-east-1a".into(),
+                description: "old".into(),
+                mac_address: "02:00:00:00:00:01".into(),
+                private_ip_address: "10.0.0.5".into(),
+                status: "available".into(),
+                interface_type: "interface".into(),
+                source_dest_check: true,
+                group_ids: vec!["sg-old".into()],
+                private_ips: vec![],
+                ipv6_addresses: vec![],
+                attachment: None,
+            },
+        );
+    }
+
+    fn describe_attr(svc: &Ec2Service, attr: &str) -> String {
+        let resp = describe_network_interface_attribute(
+            svc,
+            &req(&[("NetworkInterfaceId", "eni-1"), ("Attribute", attr)]),
+        )
+        .unwrap();
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn describe_network_interface_attribute_reads_state() {
+        let svc = Ec2Service::new();
+        seed_eni(&svc);
+        modify_network_interface_attribute(
+            &svc,
+            &req(&[
+                ("NetworkInterfaceId", "eni-1"),
+                ("SourceDestCheck.Value", "false"),
+                ("Description.Value", "new-desc"),
+                ("SecurityGroupId.1", "sg-a"),
+            ]),
+        )
+        .unwrap();
+
+        assert!(describe_attr(&svc, "sourceDestCheck")
+            .contains("<sourceDestCheck><value>false</value></sourceDestCheck>"));
+        assert!(describe_attr(&svc, "description")
+            .contains("<description><value>new-desc</value></description>"));
+        assert!(describe_attr(&svc, "groupSet").contains("<groupId>sg-a</groupId>"));
+    }
+
+    #[test]
+    fn reset_network_interface_attribute_resets_source_dest_check() {
+        let svc = Ec2Service::new();
+        seed_eni(&svc);
+        modify_network_interface_attribute(
+            &svc,
+            &req(&[
+                ("NetworkInterfaceId", "eni-1"),
+                ("SourceDestCheck.Value", "false"),
+            ]),
+        )
+        .unwrap();
+        reset_network_interface_attribute(&svc, &req(&[("NetworkInterfaceId", "eni-1")])).unwrap();
+        let accounts = svc.state.read();
+        assert!(
+            accounts.get("000000000000").unwrap().network_interfaces["eni-1"].source_dest_check
+        );
     }
 }

--- a/crates/fakecloud-glue/src/crawlers.rs
+++ b/crates/fakecloud-glue/src/crawlers.rs
@@ -234,12 +234,31 @@ impl GlueService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let name = req_str(&body, "CrawlerName")?.to_string();
+        let schedule = body
+            .get("Schedule")
+            .and_then(|v| v.as_str())
+            .map(String::from);
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id, &req.region);
-        state
+        let crawler = state
             .crawlers
-            .get(&name)
+            .get_mut(&name)
             .ok_or_else(|| entity_not_found(format!("Crawler {name} not found")))?;
+        // The Schedule cron expression was previously dropped on the floor, so
+        // GetCrawler kept showing the old/empty schedule.
+        if let Some(obj) = crawler.as_object_mut() {
+            match schedule {
+                Some(expr) => {
+                    obj.insert(
+                        "Schedule".into(),
+                        json!({"ScheduleExpression": expr, "State": "SCHEDULED"}),
+                    );
+                }
+                None => {
+                    obj.insert("Schedule".into(), json!({"State": "NOT_SCHEDULED"}));
+                }
+            }
+        }
         Ok(AwsResponse::ok_json(json!({})))
     }
 

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -445,6 +445,30 @@ fn login_profile_lifecycle() {
 }
 
 #[test]
+fn update_login_profile_rotates_password() {
+    let svc = make_service();
+    svc.handle_sync("CreateUser", vec![("UserName", "rotuser")]);
+    svc.handle_sync(
+        "CreateLoginProfile",
+        vec![("UserName", "rotuser"), ("Password", "OldP@ss1")],
+    );
+    svc.handle_sync(
+        "UpdateLoginProfile",
+        vec![("UserName", "rotuser"), ("Password", "NewP@ss2")],
+    );
+    // The Password param must actually update the stored profile (previously
+    // dropped, so a rotate silently kept the old password).
+    let accounts = svc.state.read();
+    let stored = accounts
+        .get("123456789012")
+        .unwrap()
+        .login_profiles
+        .get("rotuser")
+        .unwrap();
+    assert_eq!(stored.password, "NewP@ss2");
+}
+
+#[test]
 fn create_login_profile_duplicate_fails() {
     let svc = make_service();
     svc.handle_sync("CreateUser", vec![("UserName", "dupuser")]);

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -862,6 +862,12 @@ impl IamService {
             )
         })?;
 
+        // The Password parameter was previously ignored, so rotating a console
+        // password via UpdateLoginProfile returned 200 but silently kept the old
+        // password.
+        if let Some(password) = req.query_params.get("Password") {
+            profile.password = password.clone();
+        }
         if let Some(v) = req.query_params.get("PasswordResetRequired") {
             profile.password_reset_required = v == "true";
         }


### PR DESCRIPTION
## Summary
Cycle-4 bug-hunt Tier-1 write/read-asymmetry stubs (findings 1.2, 1.3, 1.4) — an Update/Modify returned 200 but the read-back showed the old value.

- **EC2 `DescribeNetworkInterfaceAttribute`** returned hardcoded constants (`description="eni"`, empty groupSet, sourceDestCheck=true) instead of reading the stored ENI, so a NAT-instance `SourceDestCheck` disable was invisible on read-back. `ResetNetworkInterfaceAttribute` now actually resets `source_dest_check` to true (was a no-op).
- **IAM `UpdateLoginProfile`** dropped the `Password` parameter, so a console-password rotation returned 200 but silently kept the old password.
- **Glue `UpdateCrawlerSchedule`** dropped the `Schedule` cron expression, so `GetCrawler` kept showing the old/empty schedule.

## Test plan
- EC2: `describe_network_interface_attribute_reads_state` + `reset_network_interface_attribute_resets_source_dest_check` unit tests.
- IAM: `update_login_profile_rotates_password` unit test.
- Glue: `update_crawler_schedule_persists_expression` e2e (UpdateCrawlerSchedule → GetCrawler reflects the cron). All pass.
- `cargo clippy -p fakecloud-ec2 -p fakecloud-iam -p fakecloud-glue --all-targets -- -D warnings` clean.

## Surface
Behavior fixes to existing ops; no new public API/SDK surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes write/read asymmetry so updates persist and reads reflect new values across EC2 ENI attributes, IAM login profile password, and Glue crawler schedule. Prevents 200 OK responses that left old state visible.

- **Bug Fixes**
  - `fakecloud-ec2`: DescribeNetworkInterfaceAttribute now reads stored ENI (description, groupSet, sourceDestCheck). ResetNetworkInterfaceAttribute actually resets source_dest_check to true.
  - `fakecloud-iam`: UpdateLoginProfile now persists the `Password` parameter, enabling password rotation.
  - `fakecloud-glue`: UpdateCrawlerSchedule now stores the `Schedule` cron as {ScheduleExpression, State}, so GetCrawler returns the updated schedule.

<sup>Written for commit e55747162cb31364e8609884edefa8325427273b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

