### PR TITLE
fix(dynamodb): comparison-vs-missing-attribute, numeric equality, SET arithmetic

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
@@ -277,9 +277,20 @@ pub(crate) fn key_cond_simple_comparison(
         let actual = actual_owned.as_ref();
         let expected = expr_attr_values.get(right);
 
+        // A comparison whose left attribute path does not resolve is false for
+        // EVERY operator in DynamoDB (use attribute_exists/attribute_not_exists
+        // to test presence). Previously `<>`/`<`/`<=` against a missing
+        // attribute wrongly matched (bug-audit 2026-06-26, 1.5): `attr <> :v`
+        // gave `None != Some(v)` -> true and `attr < :v` gave Less -> true, so
+        // "not in terminal state" filters and `version <> :v` write guards
+        // silently passed.
+        if actual.is_none() {
+            return false;
+        }
+
         return match *op {
-            "=" => actual == expected,
-            "<>" => actual != expected,
+            "=" => values_equal(actual, expected),
+            "<>" => !values_equal(actual, expected),
             "<" => compare_attribute_values(actual, expected) == std::cmp::Ordering::Less,
             ">" => compare_attribute_values(actual, expected) == std::cmp::Ordering::Greater,
             "<=" => {

--- a/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
@@ -556,9 +556,10 @@ pub(crate) fn evaluate_list_append_rhs(
     Some(json!({ "L": merged }))
 }
 
-/// `<arith_left> +/- <arith_right>` — both operands must resolve to N values
-/// (or the LHS may be missing, in which case it's treated as 0). Anything
-/// else is rejected with the same `ValidationException` AWS returns.
+/// `<arith_left> +/- <arith_right>` — both operands must resolve to N values.
+/// A missing operand is rejected with the same `ValidationException` AWS
+/// returns (SET arithmetic does NOT zero-default a missing attribute — that's
+/// what `if_not_exists` is for; the ADD action has its own zero-default path).
 pub(crate) fn evaluate_arithmetic_rhs(
     arith_left: &str,
     arith_right: &str,
@@ -571,17 +572,13 @@ pub(crate) fn evaluate_arithmetic_rhs(
     let right_val =
         resolve_ref_or_path(arith_right.trim(), item, expr_attr_names, expr_attr_values);
 
-    let left_num = match extract_number(&left_val) {
-        Some(n) => n,
-        None if left_val.is_some() => {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationException",
-                "An operand in the update expression has an incorrect data type",
-            ));
-        }
-        None => 0.0,
-    };
+    let left_num = extract_number(&left_val).ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "An operand in the update expression has an incorrect data type",
+        )
+    })?;
     let right_num = extract_number(&right_val).ok_or_else(|| {
         AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -128,6 +128,28 @@ pub(crate) fn compare_attribute_values(a: Option<&Value>, b: Option<&Value>) -> 
     }
 }
 
+/// Equality for `=` / `<>` that is numeric-aware: two N values are equal when
+/// they are the same decimal regardless of formatting (`3.10` == `3.1`), while
+/// every other type falls back to exact JSON equality (so Maps/Lists/Bool/sets
+/// keep strict equality). Plain `a == b` on the raw JSON wrongly treated
+/// decimally-equal numbers as unequal (bug-audit 2026-06-26, 1.16).
+pub(crate) fn values_equal(a: Option<&Value>, b: Option<&Value>) -> bool {
+    match (a, b) {
+        (Some(av), Some(bv)) => {
+            if let (Some(("N", an)), Some(("N", bn))) =
+                (attribute_type_and_value(av), attribute_type_and_value(bv))
+            {
+                compare_number_strings(an.as_str().unwrap_or("0"), bn.as_str().unwrap_or("0"))
+                    == std::cmp::Ordering::Equal
+            } else {
+                av == bv
+            }
+        }
+        (None, None) => true,
+        _ => false,
+    }
+}
+
 pub(crate) fn execute_partiql_in_state(
     state: &mut crate::state::DynamoDbState,
     statement: &str,

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -1881,9 +1881,10 @@ fn test_evaluate_condition_no_existing_item() {
 
     assert!(evaluate_condition("attribute_not_exists(#s)", None, &names, &values).is_ok());
     assert!(evaluate_condition("attribute_exists(#s)", None, &names, &values).is_err());
-    // Comparison against missing item: None != Some(val) => true for <>
-    assert!(evaluate_condition("#s <> :v", None, &names, &values).is_ok());
-    // None == Some(val) => false for =
+    // A comparison against a missing attribute is false for EVERY operator in
+    // DynamoDB (presence is tested with attribute_exists/not_exists), so both
+    // `<>` and `=` fail the condition here (bug-audit 2026-06-26, 1.5).
+    assert!(evaluate_condition("#s <> :v", None, &names, &values).is_err());
     assert!(evaluate_condition("#s = :v", None, &names, &values).is_err());
 }
 
@@ -5238,4 +5239,64 @@ fn update_table_prunes_attributes_orphaned_by_gsi_delete() {
         .filter_map(|a| a["AttributeName"].as_str())
         .collect();
     assert_eq!(attrs, ["pk"], "orphaned gsiKey attribute should be pruned");
+}
+
+#[test]
+fn filter_comparison_missing_attribute_is_false() {
+    // An item without the `status` attribute. AWS: every comparison against a
+    // missing attribute is false (1.5).
+    let item: HashMap<String, AttributeValue> = [("pk".to_string(), json!({"S": "a"}))]
+        .into_iter()
+        .collect();
+    let names: HashMap<String, String> = HashMap::new();
+    let values: HashMap<String, Value> = [(":s".to_string(), json!({"S": "done"}))]
+        .into_iter()
+        .collect();
+
+    for op in ["status <> :s", "status < :s", "status <= :s", "status = :s"] {
+        assert!(
+            !evaluate_filter_expression(op, &item, &names, &values),
+            "`{op}` must be false when `status` is missing"
+        );
+    }
+}
+
+#[test]
+fn filter_equality_is_numeric_aware() {
+    // 3.10 and 3.1 are the same DynamoDB number; `=` must match and `<>` must
+    // not (1.16).
+    let item: HashMap<String, AttributeValue> = [("n".to_string(), json!({"N": "3.10"}))]
+        .into_iter()
+        .collect();
+    let names: HashMap<String, String> = HashMap::new();
+    let values: HashMap<String, Value> = [(":v".to_string(), json!({"N": "3.1"}))]
+        .into_iter()
+        .collect();
+
+    assert!(evaluate_filter_expression("n = :v", &item, &names, &values));
+    assert!(!evaluate_filter_expression(
+        "n <> :v", &item, &names, &values
+    ));
+}
+
+#[test]
+fn set_arithmetic_on_missing_operand_errors() {
+    // `a = b + :v` where `b` does not exist: AWS rejects with ValidationException
+    // rather than treating the missing operand as 0 (1.10).
+    let item: HashMap<String, AttributeValue> =
+        [("a".to_string(), json!({"N": "1"}))].into_iter().collect();
+    let names: HashMap<String, String> = HashMap::new();
+    let values: HashMap<String, Value> = [(":v".to_string(), json!({"N": "5"}))]
+        .into_iter()
+        .collect();
+
+    let res = evaluate_arithmetic_rhs("b", ":v", true, &item, &names, &values);
+    assert!(
+        res.is_err(),
+        "missing SET operand must error, not zero-default"
+    );
+
+    // Existing operand still works.
+    let ok = evaluate_arithmetic_rhs("a", ":v", true, &item, &names, &values);
+    assert!(ok.is_ok());
 }


### PR DESCRIPTION
## Summary
Cycle-4 bug-hunt Tier-1 DynamoDB expression-semantics cluster (findings 1.5, 1.10, 1.16).

- **Comparison against a missing attribute is now false for every operator** (`=`, `<>`, `<`, `<=`, `>`, `>=`), matching DynamoDB (presence is tested with `attribute_exists`/`attribute_not_exists`). Previously `attr <> :v` → `None != Some(v)` → true and `attr < :v` → Less → true, so "not in terminal state" filters and `version <> :v` write guards silently passed on missing items.
- **`=` / `<>` are numeric-aware**: `3.10` and `3.1` are the same DynamoDB number and now compare equal instead of failing raw JSON string equality.
- **SET arithmetic on a missing operand** (`a = b + :v` with `b` absent) returns `ValidationException` instead of treating the operand as 0 (use `if_not_exists`; the ADD action keeps its own zero-default).

## Test plan
- Updated `test_evaluate_condition_no_existing_item` (it had encoded the buggy `<>`-matches-missing behavior).
- New: `filter_comparison_missing_attribute_is_false`, `filter_equality_is_numeric_aware`, `set_arithmetic_on_missing_operand_errors`.
- `cargo nextest run -p fakecloud-dynamodb` 318 pass; targeted DynamoDB conformance run locally.
- `cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings` clean.

## Surface
Behavior fix within DynamoDB; no new public API/SDK surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `fakecloud-dynamodb` expression semantics with DynamoDB for comparisons, numeric equality, and SET arithmetic. Prevents silent passes in filters/guards and matches AWS validation; addresses findings 1.5, 1.10, 1.16.

- **Bug Fixes**
  - Any comparison against a missing attribute now evaluates to false for all operators (`=`, `<>`, `<`, `<=`, `>`, `>=`). Use `attribute_exists`/`attribute_not_exists` for presence checks.
  - `=` and `<>` are numeric-aware: DynamoDB numbers compare by value (`3.10` equals `3.1`).
  - SET arithmetic now errors on a missing operand (ValidationException) instead of zero-defaulting. Use `if_not_exists` or rely on `ADD` for zero-default behavior.

<sup>Written for commit 0b12a19fe4768c4139cecbe12a0efcbc16ec2b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

