### PR TITLE
fix(s3): abort-incomplete-MPU lifecycle, ListObjectVersions encoding-type, conditional precedence

### DIFF
--- a/crates/fakecloud-e2e/tests/s3_conditional_and_listing.rs
+++ b/crates/fakecloud-e2e/tests/s3_conditional_and_listing.rs
@@ -1,0 +1,81 @@
+//! RFC 7232 conditional-header precedence (If-Modified-Since ignored when
+//! If-None-Match is present) and ListObjectVersions encoding-type=url.
+
+mod helpers;
+
+use aws_sdk_s3::primitives::ByteStream;
+use helpers::TestServer;
+
+#[tokio::test]
+async fn if_modified_since_ignored_when_if_none_match_present() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket().bucket("cond").send().await.unwrap();
+    let put = s3
+        .put_object()
+        .bucket("cond")
+        .key("k")
+        .body(ByteStream::from_static(b"v"))
+        .send()
+        .await
+        .unwrap();
+    let etag = put.e_tag().unwrap().to_string();
+
+    // Non-matching If-None-Match + a future If-Modified-Since. RFC 7232 §3.3:
+    // If-Modified-Since must be ignored -> 200, not 304.
+    let resp = s3
+        .get_object()
+        .bucket("cond")
+        .key("k")
+        .if_none_match("\"does-not-match\"")
+        .if_modified_since(aws_sdk_s3::primitives::DateTime::from_secs(4102444800)) // year 2100
+        .send()
+        .await;
+    assert!(resp.is_ok(), "should return 200, not 304: {resp:?}");
+
+    // Matching If-None-Match still 304 regardless of If-Modified-Since.
+    let not_mod = s3
+        .get_object()
+        .bucket("cond")
+        .key("k")
+        .if_none_match(&etag)
+        .send()
+        .await;
+    assert!(not_mod.is_err(), "matching If-None-Match must be 304");
+}
+
+#[tokio::test]
+async fn list_object_versions_honors_encoding_type_url() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket().bucket("vers").send().await.unwrap();
+    // A key with characters that url-encoding changes.
+    s3.put_object()
+        .bucket("vers")
+        .key("a b/c+d")
+        .body(ByteStream::from_static(b"x"))
+        .send()
+        .await
+        .unwrap();
+
+    let listed = s3
+        .list_object_versions()
+        .bucket("vers")
+        .encoding_type(aws_sdk_s3::types::EncodingType::Url)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        listed.encoding_type(),
+        Some(&aws_sdk_s3::types::EncodingType::Url)
+    );
+    // The key is url-encoded in the response (space -> %20, + -> %2B); the
+    // Rust SDK surfaces it verbatim. Previously the param was ignored and the
+    // key came back raw / XML-escaped.
+    let v = listed.versions();
+    assert!(
+        v.iter().any(|ver| ver.key() == Some("a%20b/c%2Bd")),
+        "key should be url-encoded: {v:?}"
+    );
+}

--- a/crates/fakecloud-s3/src/lifecycle.rs
+++ b/crates/fakecloud-s3/src/lifecycle.rs
@@ -170,6 +170,38 @@ impl LifecycleProcessor {
                 }
             }
         }
+
+        // Abort multipart uploads older than DaysAfterInitiation. Without this
+        // sweep, abandoned uploads (started but never completed/aborted) leaked
+        // forever in memory + on disk, and configuring the rule had no effect.
+        if let Some(days) = rule.abort_incomplete_mpu_days {
+            let stale: Vec<String> = bucket
+                .multipart_uploads
+                .iter()
+                .filter(|(_, mpu)| {
+                    // The prefix filter (if any) scopes the rule to matching keys.
+                    rule.prefix
+                        .as_ref()
+                        .map(|p| p.is_empty() || mpu.key.starts_with(p))
+                        .unwrap_or(true)
+                        && today
+                            .signed_duration_since(mpu.initiated.date_naive())
+                            .num_days()
+                            >= days as i64
+                })
+                .map(|(id, _)| id.clone())
+                .collect();
+            if !stale.is_empty() {
+                tracing::info!(
+                    bucket = %bucket_name,
+                    count = stale.len(),
+                    "S3 lifecycle: aborting incomplete multipart uploads"
+                );
+                for id in &stale {
+                    bucket.multipart_uploads.remove(id);
+                }
+            }
+        }
     }
 }
 
@@ -181,6 +213,10 @@ struct LifecycleRule {
     expiration_days: Option<u32>,
     expiration_date: Option<NaiveDate>,
     transitions: Vec<Transition>,
+    /// `<AbortIncompleteMultipartUpload><DaysAfterInitiation>` — abort
+    /// multipart uploads older than this many days (the only AWS mechanism to
+    /// auto-clean abandoned MPUs).
+    abort_incomplete_mpu_days: Option<u32>,
 }
 
 struct TagFilter {
@@ -261,6 +297,10 @@ fn parse_lifecycle_rules(xml: &str) -> Option<Vec<LifecycleRule>> {
             }
         }
 
+        let abort_incomplete_mpu_days = extract_block(rule_body, "AbortIncompleteMultipartUpload")
+            .and_then(|b| extract_tag(b, "DaysAfterInitiation"))
+            .and_then(|s| s.parse::<u32>().ok());
+
         rules.push(LifecycleRule {
             status,
             prefix,
@@ -268,6 +308,7 @@ fn parse_lifecycle_rules(xml: &str) -> Option<Vec<LifecycleRule>> {
             expiration_days,
             expiration_date,
             transitions,
+            abort_incomplete_mpu_days,
         });
 
         remaining = &after[rule_end + 7..];
@@ -342,6 +383,21 @@ mod tests {
         assert_eq!(rules[0].status, "Enabled");
         assert_eq!(rules[0].prefix.as_deref(), Some("logs/"));
         assert_eq!(rules[0].expiration_days, Some(30));
+    }
+
+    #[test]
+    fn parse_abort_incomplete_mpu_rule() {
+        let xml = r#"<LifecycleConfiguration>
+            <Rule>
+                <Filter><Prefix>uploads/</Prefix></Filter>
+                <Status>Enabled</Status>
+                <AbortIncompleteMultipartUpload><DaysAfterInitiation>7</DaysAfterInitiation></AbortIncompleteMultipartUpload>
+            </Rule>
+        </LifecycleConfiguration>"#;
+
+        let rules = parse_lifecycle_rules(xml).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].abort_incomplete_mpu_days, Some(7));
     }
 
     #[test]

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -1681,28 +1681,32 @@ pub(crate) fn check_get_conditionals(
         }
     }
 
-    // If-Unmodified-Since
-    if let Some(since) = req
-        .headers
-        .get("if-unmodified-since")
-        .and_then(|v| v.to_str().ok())
-    {
-        if let Some(dt) = parse_http_date(since) {
-            if obj_time > dt {
-                return Err(precondition_failed("If-Unmodified-Since"));
+    // If-Unmodified-Since — RFC 7232 §3.4: ignored when If-Match is present.
+    if req.headers.get("if-match").is_none() {
+        if let Some(since) = req
+            .headers
+            .get("if-unmodified-since")
+            .and_then(|v| v.to_str().ok())
+        {
+            if let Some(dt) = parse_http_date(since) {
+                if obj_time > dt {
+                    return Err(precondition_failed("If-Unmodified-Since"));
+                }
             }
         }
     }
 
-    // If-Modified-Since
-    if let Some(since) = req
-        .headers
-        .get("if-modified-since")
-        .and_then(|v| v.to_str().ok())
-    {
-        if let Some(dt) = parse_http_date(since) {
-            if obj_time <= dt {
-                return Err(not_modified());
+    // If-Modified-Since — RFC 7232 §3.3: ignored when If-None-Match is present.
+    if req.headers.get("if-none-match").is_none() {
+        if let Some(since) = req
+            .headers
+            .get("if-modified-since")
+            .and_then(|v| v.to_str().ok())
+        {
+            if let Some(dt) = parse_http_date(since) {
+                if obj_time <= dt {
+                    return Err(not_modified());
+                }
             }
         }
     }
@@ -1739,32 +1743,36 @@ pub(crate) fn check_head_conditionals(
         }
     }
 
-    // If-Unmodified-Since
-    if let Some(since) = req
-        .headers
-        .get("if-unmodified-since")
-        .and_then(|v| v.to_str().ok())
-    {
-        if let Some(dt) = parse_http_date(since) {
-            if obj_time > dt {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::PRECONDITION_FAILED,
-                    "412",
-                    "Precondition Failed",
-                ));
+    // If-Unmodified-Since — RFC 7232 §3.4: ignored when If-Match is present.
+    if req.headers.get("if-match").is_none() {
+        if let Some(since) = req
+            .headers
+            .get("if-unmodified-since")
+            .and_then(|v| v.to_str().ok())
+        {
+            if let Some(dt) = parse_http_date(since) {
+                if obj_time > dt {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::PRECONDITION_FAILED,
+                        "412",
+                        "Precondition Failed",
+                    ));
+                }
             }
         }
     }
 
-    // If-Modified-Since
-    if let Some(since) = req
-        .headers
-        .get("if-modified-since")
-        .and_then(|v| v.to_str().ok())
-    {
-        if let Some(dt) = parse_http_date(since) {
-            if obj_time <= dt {
-                return Err(not_modified());
+    // If-Modified-Since — RFC 7232 §3.3: ignored when If-None-Match is present.
+    if req.headers.get("if-none-match").is_none() {
+        if let Some(since) = req
+            .headers
+            .get("if-modified-since")
+            .and_then(|v| v.to_str().ok())
+        {
+            if let Some(dt) = parse_http_date(since) {
+                if obj_time <= dt {
+                    return Err(not_modified());
+                }
             }
         }
     }

--- a/crates/fakecloud-s3/src/service/objects/list.rs
+++ b/crates/fakecloud-s3/src/service/objects/list.rs
@@ -527,6 +527,19 @@ impl S3Service {
             None
         };
 
+        // encoding-type=url: AWS url-encodes the key-type fields (Key, Prefix,
+        // KeyMarker, NextKeyMarker, Delimiter, CommonPrefixes.Prefix) so keys
+        // with XML-illegal control characters are still parseable. Unlike
+        // ListObjectsV1/V2, this op previously ignored the parameter.
+        let use_url = req.query_params.get("encoding-type").map(|s| s.as_str()) == Some("url");
+        let enc = |s: &str| {
+            if use_url {
+                url_encode_s3_key(s)
+            } else {
+                xml_escape(s)
+            }
+        };
+
         // Build XML
         let mut versions_xml = String::new();
         for (key, obj, is_latest) in &truncated_entries {
@@ -539,7 +552,7 @@ impl S3Service {
                      <LastModified>{}</LastModified>\
                      <Owner><ID>{owner_id}</ID><DisplayName>{owner_id}</DisplayName></Owner>\
                      </DeleteMarker>",
-                    xml_escape(key),
+                    enc(key),
                     obj.version_id.as_deref().unwrap_or("null"),
                     is_latest,
                     obj.last_modified.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
@@ -556,7 +569,7 @@ impl S3Service {
                      <Owner><ID>{owner_id}</ID><DisplayName>{owner_id}</DisplayName></Owner>\
                      <StorageClass>{}</StorageClass>\
                      </Version>",
-                    xml_escape(key),
+                    enc(key),
                     obj.version_id.as_deref().unwrap_or("null"),
                     is_latest,
                     obj.last_modified.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
@@ -572,7 +585,7 @@ impl S3Service {
         for cp in &common_prefixes {
             cp_xml.push_str(&format!(
                 "<CommonPrefixes><Prefix>{}</Prefix></CommonPrefixes>",
-                xml_escape(cp),
+                enc(cp),
             ));
         }
 
@@ -581,7 +594,7 @@ impl S3Service {
             format!(
                 "<NextKeyMarker>{}</NextKeyMarker>\
                  <NextVersionIdMarker>{}</NextVersionIdMarker>",
-                xml_escape(nk),
+                enc(nk),
                 xml_escape(nv),
             )
         } else {
@@ -590,8 +603,13 @@ impl S3Service {
 
         let delimiter_xml = delimiter
             .as_ref()
-            .map(|d| format!("<Delimiter>{}</Delimiter>", xml_escape(d)))
+            .map(|d| format!("<Delimiter>{}</Delimiter>", enc(d)))
             .unwrap_or_default();
+        let encoding_xml = if use_url {
+            "<EncodingType>url</EncodingType>"
+        } else {
+            ""
+        };
 
         let body = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
@@ -601,14 +619,15 @@ impl S3Service {
              <KeyMarker>{km}</KeyMarker>\
              {delimiter_xml}\
              <MaxKeys>{max_keys}</MaxKeys>\
+             {encoding_xml}\
              <IsTruncated>{is_truncated}</IsTruncated>\
              {marker_xml}\
              {versions_xml}\
              {cp_xml}\
              </ListVersionsResult>",
             name = xml_escape(bucket),
-            pfx = xml_escape(&prefix),
-            km = xml_escape(&key_marker),
+            pfx = enc(&prefix),
+            km = enc(&key_marker),
         );
         Ok(s3_xml(StatusCode::OK, body))
     }


### PR DESCRIPTION
## Summary
Cycle-4 bug-hunt findings 4.3, 1.14, 1.17 (S3).

- **AbortIncompleteMultipartUpload** lifecycle rule (`<DaysAfterInitiation>`) is now parsed and enforced — abandoned multipart uploads older than the configured days are swept. Previously the rule was parsed-then-dropped, so abandoned MPUs leaked forever in memory + on disk and the one AWS auto-cleanup mechanism had no effect.
- **ListObjectVersions** honors `encoding-type=url` (url-encodes Key/Prefix/KeyMarker/NextKeyMarker/Delimiter/CommonPrefixes and emits `<EncodingType>`), so versioned listings of keys with XML-illegal control chars are parseable — V1/V2 already did this.
- **GET/HEAD conditional headers** follow RFC 7232: `If-Modified-Since` ignored when `If-None-Match` present; `If-Unmodified-Since` ignored when `If-Match` present.

## Test plan
- `parse_abort_incomplete_mpu_rule` unit test.
- e2e `s3_conditional_and_listing.rs`: conditional precedence (200 not 304) + encoding-type=url round-trip. Pass.
- `cargo clippy -p fakecloud-s3 --all-targets -- -D warnings` clean.

## Surface
Behavior fixes within S3; no new public API/SDK surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes S3 lifecycle cleanup for abandoned multipart uploads, ListObjectVersions url encoding, and GET/HEAD conditional precedence to match AWS and RFC 7232. Prevents MPU leaks, makes version listings parseable for special keys, and aligns conditional behavior.

- **Bug Fixes**
  - Enforce `<AbortIncompleteMultipartUpload><DaysAfterInitiation>`: sweep abandoned MPUs by age to stop memory/disk leaks.
  - Honor `encoding-type=url` in `ListObjectVersions`: url-encode Key/Prefix/KeyMarker/NextKeyMarker/Delimiter/CommonPrefixes and emit `<EncodingType>url</EncodingType>`.
  - Apply conditional header precedence: ignore `If-Modified-Since` when `If-None-Match` is present, and `If-Unmodified-Since` when `If-Match` is present.

<sup>Written for commit 316034750bef9b42f10da0eabeaaf040cddf092e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

