### PR TITLE
fix(app-autoscaling,eventbridge,ecs,rds): MaxResults caps, EventPattern validation, ECS pending-key, RDS reservation clear

### DIFF
--- a/crates/fakecloud-application-autoscaling/src/service.rs
+++ b/crates/fakecloud-application-autoscaling/src/service.rs
@@ -319,7 +319,7 @@ impl ApplicationAutoScalingService {
         let max_results = body
             .get("MaxResults")
             .and_then(Value::as_u64)
-            .map(|n| n as usize)
+            .map(|n| (n as usize).clamp(1, 50))
             .unwrap_or(50);
         let next_token = body
             .get("NextToken")
@@ -484,8 +484,10 @@ impl ApplicationAutoScalingService {
         let max_results = body
             .get("MaxResults")
             .and_then(Value::as_u64)
-            .map(|n| n as usize)
-            .unwrap_or(50);
+            .map(|n| (n as usize).clamp(1, 10))
+            // DescribeScalingPolicies is uniquely capped at 1-10 (default 10),
+            // unlike the other Describe* ops (1-50). bug-audit 2026-06-26, 1.11.
+            .unwrap_or(10);
         let next_token = body
             .get("NextToken")
             .and_then(Value::as_str)
@@ -654,7 +656,7 @@ impl ApplicationAutoScalingService {
         let max_results = body
             .get("MaxResults")
             .and_then(Value::as_u64)
-            .map(|n| n as usize)
+            .map(|n| (n as usize).clamp(1, 50))
             .unwrap_or(50);
         let next_token = body
             .get("NextToken")
@@ -741,7 +743,7 @@ impl ApplicationAutoScalingService {
         let max_results = body
             .get("MaxResults")
             .and_then(Value::as_u64)
-            .map(|n| n as usize)
+            .map(|n| (n as usize).clamp(1, 50))
             .unwrap_or(50);
         let next_token = body
             .get("NextToken")
@@ -1437,6 +1439,57 @@ mod tests {
         assert_eq!(a.status_code, "Successful");
         assert!(a.description.contains("min capacity to 1"));
         assert!(a.description.contains("max capacity to 5"));
+    }
+
+    #[test]
+    fn describe_scaling_policies_caps_at_ten() {
+        let svc = ApplicationAutoScalingService::default();
+        svc.register_scalable_target(&make_req(
+            "RegisterScalableTarget",
+            json!({
+                "ServiceNamespace": "ecs",
+                "ResourceId": "service/cluster1/svc1",
+                "ScalableDimension": "ecs:service:DesiredCount",
+                "MinCapacity": 1,
+                "MaxCapacity": 5,
+            }),
+        ))
+        .unwrap();
+        for i in 0..11 {
+            svc.put_scaling_policy(&make_req(
+                "PutScalingPolicy",
+                json!({
+                    "PolicyName": format!("p{i}"),
+                    "ServiceNamespace": "ecs",
+                    "ResourceId": "service/cluster1/svc1",
+                    "ScalableDimension": "ecs:service:DesiredCount",
+                    "PolicyType": "StepScaling",
+                    "StepScalingPolicyConfiguration": {
+                        "AdjustmentType": "ChangeInCapacity",
+                        "StepAdjustments": [{"ScalingAdjustment": 1}],
+                    },
+                }),
+            ))
+            .unwrap();
+        }
+        // No MaxResults supplied: AWS defaults DescribeScalingPolicies to 10
+        // (unlike the other Describe* ops' 50) and returns a NextToken.
+        let resp = svc
+            .describe_scaling_policies(&make_req(
+                "DescribeScalingPolicies",
+                json!({"ServiceNamespace": "ecs"}),
+            ))
+            .unwrap();
+        let v: Value = serde_json::from_slice(resp.body.expect_bytes()).expect("json body");
+        assert_eq!(
+            v["ScalingPolicies"].as_array().unwrap().len(),
+            10,
+            "default page must be 10"
+        );
+        assert!(
+            v.get("NextToken").and_then(Value::as_str).is_some(),
+            "truncated result must carry a NextToken"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -315,7 +315,15 @@ impl EcsService {
                         "ecs scheduler: launching tasks to converge to desiredCount",
                     );
                     // Reflect the new PENDING tasks in the stored counts.
-                    if let Some(svc) = state.services.get_mut(&service.service_name) {
+                    // Services are keyed by "cluster/name", not the bare name —
+                    // looking up by service_name returned None, so these counts
+                    // were never updated (stale snapshot until DescribeServices
+                    // recomputed them).
+                    let svc_key = crate::state::EcsState::service_key(
+                        &service.cluster_name,
+                        &service.service_name,
+                    );
+                    if let Some(svc) = state.services.get_mut(&svc_key) {
                         svc.pending_count = svc.pending_count.saturating_add(ids.len() as i32);
                         for d in svc.deployments.iter_mut() {
                             if d.status == "PRIMARY" {

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -631,6 +631,12 @@ impl EventBridgeService {
             256,
         )?;
         validate_optional_string_length_value("EventPattern", &body["EventPattern"], 0, 4096)?;
+        // Reject a syntactically invalid EventPattern at PutRule time, like AWS.
+        // Previously only the length was checked, so an invalid pattern was
+        // stored and PutEvents silently never matched it.
+        if let Some(pattern) = body["EventPattern"].as_str().filter(|s| !s.is_empty()) {
+            validate_event_pattern(pattern)?;
+        }
         validate_optional_enum_value(
             "State",
             &body["State"],

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -2702,6 +2702,29 @@ fn put_rule_rejects_unknown_state() {
     assert!(svc.put_rule(&req).is_err());
 }
 
+#[test]
+fn put_rule_rejects_invalid_event_pattern() {
+    // An EventPattern that isn't valid JSON must be rejected at PutRule time,
+    // not stored and silently never matched.
+    let svc = make_service();
+    let req = make_request(
+        "PutRule",
+        json!({"Name": "r1", "EventPattern": "{not valid json"}),
+    );
+    let err = match svc.put_rule(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("invalid pattern must error"),
+    };
+    assert_eq!(err.code(), "InvalidEventPatternException");
+
+    // A valid pattern still succeeds.
+    let ok = make_request(
+        "PutRule",
+        json!({"Name": "r2", "EventPattern": r#"{"source":["aws.ec2"]}"#}),
+    );
+    assert!(svc.put_rule(&ok).is_ok());
+}
+
 // ── create_connection variants ──
 
 #[test]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2256,6 +2256,13 @@ async fn main() {
                                             "dropped stuck `creating` rds instances after persistence load",
                                         );
                                     }
+                                    // Clear any in-flight identifier reservations a
+                                    // restore/replica op left in the snapshot. The
+                                    // task that held them is dead, so a leftover
+                                    // reservation would otherwise brick that id with
+                                    // DBInstanceAlreadyExists forever (bug-audit
+                                    // 2026-06-26, 4.2).
+                                    state.in_progress_instance_ids.clear();
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
Cycle-4 bug-hunt final cluster (findings 1.11, AA2, 1.12, 4.4, 4.2).

- **application-autoscaling DescribeScalingPolicies** defaults + caps MaxResults at 10 (its unique AWS limit; the other Describe* ops are 1-50), and every Describe* now clamps the user value to its documented max instead of passing it through.
- **EventBridge PutRule** rejects a syntactically invalid EventPattern with `InvalidEventPatternException` at create time instead of storing it so PutEvents silently never matched.
- **ECS scheduler** updates pending/deployment counts under the real `cluster/name` service key (was looking up the bare name → None → counts never updated).
- **RDS** clears `in_progress_instance_ids` on persistence load, so a restore/replica reservation captured mid-flight by the snapshot no longer bricks that identifier with `DBInstanceAlreadyExists` forever.

## Test plan
- Unit: `describe_scaling_policies_caps_at_ten` (app-autoscaling), `put_rule_rejects_invalid_event_pattern` (EventBridge).
- `cargo nextest run -p fakecloud-ecs` 108 pass; app-autoscaling + eventbridge suites pass.
- clippy clean; `cargo build --bin fakecloud --tests` clean.

## Surface
Behavior fixes; no new public API/SDK surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AWS parity bugs across Application Auto Scaling, EventBridge, ECS, and RDS to prevent silent rule mismatches, stale ECS counts, and stuck RDS identifiers. Also clamps `MaxResults` per AWS behavior and validates EventBridge event patterns.

- **Bug Fixes**
  - `fakecloud-application-autoscaling`: Clamp `MaxResults` for all Describe* calls; `DescribeScalingPolicies` defaults to 10 and caps at 10.
  - `fakecloud-eventbridge`: `PutRule` validates `EventPattern` JSON and rejects invalid input with `InvalidEventPatternException`.
  - `fakecloud-ecs`: Scheduler updates pending/deployment counts under the correct `cluster/name` service key.
  - RDS: Clear `in_progress_instance_ids` on persistence load to avoid `DBInstanceAlreadyExists` from stale reservations.

<sup>Written for commit 0db17a3c946764016e723020360bc58ca8e7713a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

