### PR TITLE
chore(release): bump workspace to v0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3845,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4137,7 +4137,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4244,7 +4244,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4373,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -113,179 +113,179 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.25.0"
+version = "0.26.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.25.0")
+    testImplementation("dev.fakecloud:fakecloud:0.26.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.25.0</version>
+    <version>0.26.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.25.0"
+version = "0.26.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.25.0"
+version = "0.26.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Release v0.26.0. Headline: new **EC2 Auto Scaling** service (`autoscaling` — Auto Scaling Groups + Launch Configurations launching real container-backed EC2 instances, CFN-provisionable) plus a full cycle-4 bug-hunt sweep (#1975-#1982).

Version bump across Cargo.toml (workspace + all fakecloud-* dep pins), Cargo.lock, and the TypeScript/Python/Java SDKs. First release containing `fakecloud-autoscaling` (already in the release.yml publish list, topo-ordered after fakecloud-ec2).

## Test plan
- Tag-driven publish runs on merge + `v0.26.0` tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.26.0 adds EC2 Auto Scaling via `fakecloud-autoscaling` (Auto Scaling Groups + Launch Configurations for container-backed EC2, CloudFormation-provisionable) and includes a cycle-4 bug-fix sweep. Also bumps workspace and SDK versions for publish.

- **Dependencies**
  - Bumped all `fakecloud-*` crates and workspace to `0.26.0` (`Cargo.toml` and `Cargo.lock`).
  - Updated SDK versions to `0.26.0`: TypeScript `fakecloud` (`package.json`), Python `fakecloud` (`pyproject.toml`), and Java `fakecloud` (`build.gradle.kts` + README coordinates).

<sup>Written for commit d42dee1d6e2e374d0fb5a600d933332305ed2b67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

