### PR TITLE
feat(batch): scaffold AWS Batch service — restJson1 routing + core control plane (batch 0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,7 @@ jobs:
           publish fakecloud-acm
           publish fakecloud-application-autoscaling
           publish fakecloud-autoscaling
+          publish fakecloud-batch
           publish fakecloud-wafv2
           publish fakecloud-cloudwatch
           publish fakecloud-glue

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,6 +3036,7 @@ dependencies = [
  "fakecloud-athena",
  "fakecloud-autoscaling",
  "fakecloud-aws",
+ "fakecloud-batch",
  "fakecloud-bedrock",
  "fakecloud-bedrock-agent",
  "fakecloud-bedrock-agent-runtime",
@@ -3250,6 +3251,23 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "fakecloud-batch"
+version = "0.26.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "fakecloud-aws",
+ "fakecloud-core",
+ "fakecloud-persistence",
+ "http 1.4.0",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "crates/fakecloud-acm", "crates/fakecloud-apigateway", "crates/fakecloud-apigatewayv2", "crates/fakecloud-application-autoscaling", "crates/fakecloud-autoscaling", "crates/fakecloud-athena", "crates/fakecloud-aws", "crates/fakecloud-bedrock", "crates/fakecloud-bedrock-agent", "crates/fakecloud-bedrock-agent-runtime", "crates/fakecloud-cloudformation", "crates/fakecloud-cloudfront", "crates/fakecloud-cloudwatch", "crates/fakecloud-cognito", "crates/fakecloud-conformance", "crates/fakecloud-conformance-macros", "crates/fakecloud-core", "crates/fakecloud-dynamodb", "crates/fakecloud-e2e", "crates/fakecloud-ec2", "crates/fakecloud-ecr", "crates/fakecloud-ecs", "crates/fakecloud-elasticache", "crates/fakecloud-elbv2", "crates/fakecloud-eventbridge", "crates/fakecloud-firehose", "crates/fakecloud-glue", "crates/fakecloud-iam", "crates/fakecloud-kinesis", "crates/fakecloud-kms", "crates/fakecloud-k8s", "crates/fakecloud-lambda", "crates/fakecloud-logs", "crates/fakecloud-organizations", "crates/fakecloud-parity", "crates/fakecloud-persistence", "crates/fakecloud-rds", "crates/fakecloud-route53", "crates/fakecloud-s3", "crates/fakecloud-scheduler", "crates/fakecloud-sdk", "crates/fakecloud-secretsmanager", "crates/fakecloud-server", "crates/fakecloud-ses", "crates/fakecloud-sns", "crates/fakecloud-sqs", "crates/fakecloud-ssm", "crates/fakecloud-stepfunctions", "crates/fakecloud-testkit", "crates/fakecloud-tfacc", "crates/fakecloud-wafv2",]
+members = [ "crates/fakecloud-acm", "crates/fakecloud-apigateway", "crates/fakecloud-apigatewayv2", "crates/fakecloud-application-autoscaling", "crates/fakecloud-autoscaling", "crates/fakecloud-athena", "crates/fakecloud-aws", "crates/fakecloud-batch", "crates/fakecloud-bedrock", "crates/fakecloud-bedrock-agent", "crates/fakecloud-bedrock-agent-runtime", "crates/fakecloud-cloudformation", "crates/fakecloud-cloudfront", "crates/fakecloud-cloudwatch", "crates/fakecloud-cognito", "crates/fakecloud-conformance", "crates/fakecloud-conformance-macros", "crates/fakecloud-core", "crates/fakecloud-dynamodb", "crates/fakecloud-e2e", "crates/fakecloud-ec2", "crates/fakecloud-ecr", "crates/fakecloud-ecs", "crates/fakecloud-elasticache", "crates/fakecloud-elbv2", "crates/fakecloud-eventbridge", "crates/fakecloud-firehose", "crates/fakecloud-glue", "crates/fakecloud-iam", "crates/fakecloud-kinesis", "crates/fakecloud-kms", "crates/fakecloud-k8s", "crates/fakecloud-lambda", "crates/fakecloud-logs", "crates/fakecloud-organizations", "crates/fakecloud-parity", "crates/fakecloud-persistence", "crates/fakecloud-rds", "crates/fakecloud-route53", "crates/fakecloud-s3", "crates/fakecloud-scheduler", "crates/fakecloud-sdk", "crates/fakecloud-secretsmanager", "crates/fakecloud-server", "crates/fakecloud-ses", "crates/fakecloud-sns", "crates/fakecloud-sqs", "crates/fakecloud-ssm", "crates/fakecloud-stepfunctions", "crates/fakecloud-testkit", "crates/fakecloud-tfacc", "crates/fakecloud-wafv2",]
 resolver = "2"
 
 [workspace.package]
@@ -241,6 +241,10 @@ version = "0.26.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
+version = "0.26.0"
+
+[workspace.dependencies.fakecloud-batch]
+path = "crates/fakecloud-batch"
 version = "0.26.0"
 
 [workspace.dependencies.fakecloud-wafv2]

--- a/aws-models/batch.json
+++ b/aws-models/batch.json
@@ -1,0 +1,12328 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.batch#AWSBatchV20160810": {
+      "type": "service",
+      "version": "2016-08-10",
+      "operations": [
+        {
+          "target": "com.amazonaws.batch#CancelJob"
+        },
+        {
+          "target": "com.amazonaws.batch#CreateComputeEnvironment"
+        },
+        {
+          "target": "com.amazonaws.batch#CreateConsumableResource"
+        },
+        {
+          "target": "com.amazonaws.batch#CreateJobQueue"
+        },
+        {
+          "target": "com.amazonaws.batch#CreateQuotaShare"
+        },
+        {
+          "target": "com.amazonaws.batch#CreateSchedulingPolicy"
+        },
+        {
+          "target": "com.amazonaws.batch#CreateServiceEnvironment"
+        },
+        {
+          "target": "com.amazonaws.batch#DeleteComputeEnvironment"
+        },
+        {
+          "target": "com.amazonaws.batch#DeleteConsumableResource"
+        },
+        {
+          "target": "com.amazonaws.batch#DeleteJobQueue"
+        },
+        {
+          "target": "com.amazonaws.batch#DeleteQuotaShare"
+        },
+        {
+          "target": "com.amazonaws.batch#DeleteSchedulingPolicy"
+        },
+        {
+          "target": "com.amazonaws.batch#DeleteServiceEnvironment"
+        },
+        {
+          "target": "com.amazonaws.batch#DeregisterJobDefinition"
+        },
+        {
+          "target": "com.amazonaws.batch#DescribeComputeEnvironments"
+        },
+        {
+          "target": "com.amazonaws.batch#DescribeConsumableResource"
+        },
+        {
+          "target": "com.amazonaws.batch#DescribeJobDefinitions"
+        },
+        {
+          "target": "com.amazonaws.batch#DescribeJobQueues"
+        },
+        {
+          "target": "com.amazonaws.batch#DescribeJobs"
+        },
+        {
+          "target": "com.amazonaws.batch#DescribeQuotaShare"
+        },
+        {
+          "target": "com.amazonaws.batch#DescribeSchedulingPolicies"
+        },
+        {
+          "target": "com.amazonaws.batch#DescribeServiceEnvironments"
+        },
+        {
+          "target": "com.amazonaws.batch#DescribeServiceJob"
+        },
+        {
+          "target": "com.amazonaws.batch#GetJobQueueSnapshot"
+        },
+        {
+          "target": "com.amazonaws.batch#ListConsumableResources"
+        },
+        {
+          "target": "com.amazonaws.batch#ListJobs"
+        },
+        {
+          "target": "com.amazonaws.batch#ListJobsByConsumableResource"
+        },
+        {
+          "target": "com.amazonaws.batch#ListQuotaShares"
+        },
+        {
+          "target": "com.amazonaws.batch#ListSchedulingPolicies"
+        },
+        {
+          "target": "com.amazonaws.batch#ListServiceJobs"
+        },
+        {
+          "target": "com.amazonaws.batch#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.batch#RegisterJobDefinition"
+        },
+        {
+          "target": "com.amazonaws.batch#SubmitJob"
+        },
+        {
+          "target": "com.amazonaws.batch#SubmitServiceJob"
+        },
+        {
+          "target": "com.amazonaws.batch#TagResource"
+        },
+        {
+          "target": "com.amazonaws.batch#TerminateJob"
+        },
+        {
+          "target": "com.amazonaws.batch#TerminateServiceJob"
+        },
+        {
+          "target": "com.amazonaws.batch#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.batch#UpdateComputeEnvironment"
+        },
+        {
+          "target": "com.amazonaws.batch#UpdateConsumableResource"
+        },
+        {
+          "target": "com.amazonaws.batch#UpdateJobQueue"
+        },
+        {
+          "target": "com.amazonaws.batch#UpdateQuotaShare"
+        },
+        {
+          "target": "com.amazonaws.batch#UpdateSchedulingPolicy"
+        },
+        {
+          "target": "com.amazonaws.batch#UpdateServiceEnvironment"
+        },
+        {
+          "target": "com.amazonaws.batch#UpdateServiceJob"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "Batch",
+          "arnNamespace": "batch",
+          "cloudFormationName": "Batch",
+          "cloudTrailEventSource": "batch.amazonaws.com",
+          "endpointPrefix": "batch"
+        },
+        "aws.auth#sigv4": {
+          "name": "batch"
+        },
+        "aws.protocols#restJson1": {},
+        "smithy.api#documentation": "<fullname>Batch</fullname>\n         <p>Using Batch, you can run batch computing workloads on the Amazon Web Services Cloud. Batch computing is a common means for\n   developers, scientists, and engineers to access large amounts of compute resources. Batch uses the advantages of\n   the batch computing to remove the undifferentiated heavy lifting of configuring and managing required infrastructure.\n   At the same time, it also adopts a familiar batch computing software approach. You can use Batch to efficiently\n   provision resources, and work toward eliminating capacity constraints, reducing your overall compute costs, and\n   delivering results more quickly.</p>\n         <p>As a fully managed service, Batch can run batch computing workloads of any scale. Batch automatically\n   provisions compute resources and optimizes workload distribution based on the quantity and scale of your specific\n   workloads. With Batch, there's no need to install or manage batch computing software. This means that you can focus\n   on analyzing results and solving your specific problems instead.</p>",
+        "smithy.api#title": "AWS Batch",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://batch.amazonaws.com/doc/2016-08-10/"
+        },
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws"
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws-us-gov"
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://batch-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://fips.batch.{Region}.amazonaws.com",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://batch.{Region}.amazonaws.com",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://batch-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://batch.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://batch.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 15,
+          "nodes": "/////wAAAAH/////AAAAAAAAAA4AAAADAAAAAQAAAAQF9eENAAAAAgAAAAUF9eENAAAAAwAAAAgAAAAGAAAABAAAAAcF9eEMAAAABQX14QoF9eELAAAABAAAAAwAAAAJAAAABgAAAAoF9eEJAAAABwX14QYAAAALAAAACAX14QcF9eEIAAAABQAAAA0F9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAAPAAAABAX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://batch-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    },
+                                    "aws"
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://fips.batch.{Region}.amazonaws.com",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    },
+                                    "aws-us-gov"
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://batch.{Region}.amazonaws.com",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://batch-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://batch.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://batch.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.af-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "af-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.ap-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.ap-northeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.ap-northeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.ap-northeast-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.ap-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.ap-southeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.ap-southeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.ap-southeast-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.eu-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.eu-north-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.eu-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.eu-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.eu-west-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.me-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "me-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.sa-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "sa-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.batch.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.batch.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.batch.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.batch.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.cn-northwest-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://batch.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.batch#ArrayJobDependency": {
+      "type": "enum",
+      "members": {
+        "N_TO_N": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "N_TO_N"
+          }
+        },
+        "SEQUENTIAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SEQUENTIAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#ArrayJobStatusSummary": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#String"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#Integer"
+      }
+    },
+    "com.amazonaws.batch#ArrayProperties": {
+      "type": "structure",
+      "members": {
+        "size": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The size of the array job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents an Batch array job.</p>"
+      }
+    },
+    "com.amazonaws.batch#ArrayPropertiesDetail": {
+      "type": "structure",
+      "members": {
+        "statusSummary": {
+          "target": "com.amazonaws.batch#ArrayJobStatusSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>A summary of the number of array job children in each available job status. This parameter\n   is returned for parent array jobs.</p>"
+          }
+        },
+        "statusSummaryLastUpdatedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the <code>statusSummary</code> was last updated.</p>"
+          }
+        },
+        "size": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The size of the array job. This parameter is returned for parent array jobs.</p>"
+          }
+        },
+        "index": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The job index within the array that's associated with this job. This parameter is returned\n   for array job children.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the array properties of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#ArrayPropertiesSummary": {
+      "type": "structure",
+      "members": {
+        "size": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The size of the array job. This parameter is returned for parent array jobs.</p>"
+          }
+        },
+        "index": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The job index within the array that's associated with this job. This parameter is returned\n   for children of array jobs.</p>"
+          }
+        },
+        "statusSummary": {
+          "target": "com.amazonaws.batch#ArrayJobStatusSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>A summary of the number of array job children in each available job status. This parameter\n   is returned for parent array jobs.</p>"
+          }
+        },
+        "statusSummaryLastUpdatedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the <code>statusSummary</code> was last updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the array properties of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#AssignPublicIp": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#AttemptContainerDetail": {
+      "type": "structure",
+      "members": {
+        "containerInstanceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon ECS container instance that hosts the job attempt.</p>"
+          }
+        },
+        "taskArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon ECS task that's associated with the job attempt. Each container\n   attempt receives a task ARN when they reach the <code>STARTING</code> status.</p>"
+          }
+        },
+        "exitCode": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The exit code for the job attempt. A non-zero exit code is considered failed.</p>"
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short (255 max characters) human-readable string to provide additional details for a\n   running or stopped container.</p>"
+          }
+        },
+        "logStreamName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the CloudWatch Logs log stream that's associated with the container. The log\n   group for Batch jobs is <code>/aws/batch/job</code>. Each container attempt receives a log\n   stream name when they reach the <code>RUNNING</code> status.</p>"
+          }
+        },
+        "networkInterfaces": {
+          "target": "com.amazonaws.batch#NetworkInterfaceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The network interfaces that are associated with the job attempt.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details of a container that's part of a job attempt.</p>"
+      }
+    },
+    "com.amazonaws.batch#AttemptDetail": {
+      "type": "structure",
+      "members": {
+        "container": {
+          "target": "com.amazonaws.batch#AttemptContainerDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>The details for the container in this job attempt.</p>"
+          }
+        },
+        "startedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the attempt was started (when the attempt\n   transitioned from the <code>STARTING</code> state to the <code>RUNNING</code> state).</p>"
+          }
+        },
+        "stoppedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the attempt was stopped (when the attempt\n   transitioned from the <code>RUNNING</code> state to a terminal state, such as\n    <code>SUCCEEDED</code> or <code>FAILED</code>).</p>"
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short, human-readable string to provide additional details for the current status of the\n   job attempt.</p>"
+          }
+        },
+        "taskProperties": {
+          "target": "com.amazonaws.batch#ListAttemptEcsTaskDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties for a task definition that describes the container and volume definitions of\n   an Amazon ECS task.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents a job attempt.</p>"
+      }
+    },
+    "com.amazonaws.batch#AttemptDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#AttemptDetail"
+      }
+    },
+    "com.amazonaws.batch#AttemptEcsTaskDetails": {
+      "type": "structure",
+      "members": {
+        "containerInstanceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the container instance that hosts the task.</p>"
+          }
+        },
+        "taskArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the Amazon ECS task.</p>"
+          }
+        },
+        "containers": {
+          "target": "com.amazonaws.batch#ListAttemptTaskContainerDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of containers that are included in the <code>taskProperties</code> list.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details of a task.</p>"
+      }
+    },
+    "com.amazonaws.batch#AttemptTaskContainerDetails": {
+      "type": "structure",
+      "members": {
+        "exitCode": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The exit code for the container\u2019s attempt. A non-zero exit code is considered failed.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a container.</p>"
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short (255 max characters) string that's easy to understand and provides additional details for a\n   running or stopped container.</p>"
+          }
+        },
+        "logStreamName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon CloudWatch Logs log stream that's associated with the container. The log\n   group for Batch jobs is <code>/aws/batch/job</code>. Each container attempt receives a log stream name\n   when they reach the <code>RUNNING</code> status.</p>"
+          }
+        },
+        "networkInterfaces": {
+          "target": "com.amazonaws.batch#NetworkInterfaceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The network interfaces that are associated with the job attempt.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details of a container that's part of a job attempt.</p>"
+      }
+    },
+    "com.amazonaws.batch#Boolean": {
+      "type": "boolean"
+    },
+    "com.amazonaws.batch#CEState": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#CEStatus": {
+      "type": "enum",
+      "members": {
+        "CREATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATING"
+          }
+        },
+        "UPDATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATING"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        },
+        "DELETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED"
+          }
+        },
+        "VALID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALID"
+          }
+        },
+        "INVALID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INVALID"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#CEType": {
+      "type": "enum",
+      "members": {
+        "MANAGED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANAGED"
+          }
+        },
+        "UNMANAGED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNMANAGED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#CRAllocationStrategy": {
+      "type": "enum",
+      "members": {
+        "BEST_FIT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BEST_FIT"
+          }
+        },
+        "BEST_FIT_PROGRESSIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BEST_FIT_PROGRESSIVE"
+          }
+        },
+        "BEST_FIT_PROGRESSIVE_ORDERED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BEST_FIT_PROGRESSIVE_ORDERED"
+          }
+        },
+        "SPOT_CAPACITY_OPTIMIZED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPOT_CAPACITY_OPTIMIZED"
+          }
+        },
+        "SPOT_PRICE_CAPACITY_OPTIMIZED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPOT_PRICE_CAPACITY_OPTIMIZED"
+          }
+        },
+        "SPOT_CAPACITY_OPTIMIZED_PRIORITIZED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPOT_CAPACITY_OPTIMIZED_PRIORITIZED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#CRType": {
+      "type": "enum",
+      "members": {
+        "EC2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EC2"
+          }
+        },
+        "SPOT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPOT"
+          }
+        },
+        "FARGATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FARGATE"
+          }
+        },
+        "FARGATE_SPOT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FARGATE_SPOT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#CRUpdateAllocationStrategy": {
+      "type": "enum",
+      "members": {
+        "BEST_FIT_PROGRESSIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BEST_FIT_PROGRESSIVE"
+          }
+        },
+        "BEST_FIT_PROGRESSIVE_ORDERED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BEST_FIT_PROGRESSIVE_ORDERED"
+          }
+        },
+        "SPOT_CAPACITY_OPTIMIZED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPOT_CAPACITY_OPTIMIZED"
+          }
+        },
+        "SPOT_PRICE_CAPACITY_OPTIMIZED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPOT_PRICE_CAPACITY_OPTIMIZED"
+          }
+        },
+        "SPOT_CAPACITY_OPTIMIZED_PRIORITIZED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPOT_CAPACITY_OPTIMIZED_PRIORITIZED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#CancelJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#CancelJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#CancelJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Cancels a job in an Batch job queue. Jobs that are in a <code>SUBMITTED</code>, <code>PENDING</code>, or <code>RUNNABLE</code> state are cancelled and the job status is updated to <code>FAILED</code>.</p>\n         <note>\n            <p>A <code>PENDING</code> job is canceled after all dependency jobs are completed.\n        Therefore, it may take longer than expected to cancel a job in <code>PENDING</code>\n        status.</p>\n            <p>When you try to cancel an array parent job in <code>PENDING</code>, Batch attempts to\n        cancel all child jobs. The array parent job is canceled when all child jobs are\n        completed.</p>\n         </note>\n         <p>Jobs that progressed to the <code>STARTING</code> or\n        <code>RUNNING</code> state aren't canceled. However, the API operation still succeeds, even\n      if no job is canceled. These jobs must be terminated with the <a>TerminateJob</a>\n      operation.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To cancel a job",
+            "documentation": "This example cancels a job with the specified job ID.",
+            "input": {
+              "reason": "Cancelling job.",
+              "jobId": "1d828f65-7a4d-42e8-996d-3b900ed59dc4"
+            },
+            "output": {}
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/canceljob",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#CancelJobRequest": {
+      "type": "structure",
+      "members": {
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Batch job ID of the job to cancel.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A message to attach to the job that explains the reason for canceling it. This message is\n      returned by future <a>DescribeJobs</a> operations on the job. It is also\n      recorded in the Batch activity logs.</p>\n         <p>This parameter has as limit of 1024 characters.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>CancelJob</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#CancelJobResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#CapacityLimit": {
+      "type": "structure",
+      "members": {
+        "maxCapacity": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum capacity available for the service environment. For a quota management enabled service environment, this value represents\n      the maximum quantity of a particular resource type (specified by <code>capacityUnit</code>) that can be allocated to service jobs.\n      For other service environments, this value represents the maximum quantity of all resources that can be allocated to service jobs.</p>\n         <p>For example, if <code>maxCapacity=50</code> and <code>capacityUnit=NUM_INSTANCES</code>, you can run up to 50 instances concurrently.\n      If you run 5 SageMaker Training jobs that each use 10 instances, a subsequent job requiring 10 instances waits in the queue until\n      capacity is available. In a quota management enabled service environment with <code>capacityUnit=ml.m5.large</code>, only\n      <code>ml.m5.large</code> instances count against this limit, and jobs requiring other instance types wait until a matching capacity limit is configured.</p>"
+          }
+        },
+        "capacityUnit": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unit of measure for the capacity limit, which defines how <code>maxCapacity</code> is interpreted. For <code>SAGEMAKER_TRAINING</code> jobs in a quota management\n      enabled service environment, specify the <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ResourceConfig.html#sagemaker-Type-ResourceConfig-InstanceType\">instance type</a>\n      (for example, <code>ml.m5.large</code>). Otherwise, use <code>NUM_INSTANCES</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Defines the type and maximum quantity of resources that can be allocated to service jobs in a service environment.</p>"
+      }
+    },
+    "com.amazonaws.batch#CapacityLimits": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#CapacityLimit"
+      }
+    },
+    "com.amazonaws.batch#ClientException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.batch#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>These errors are usually caused by a client action. One example cause is using an action or resource on behalf\n   of a user that doesn't have permissions to use the action or resource. Another cause is specifying an identifier\n   that's not valid.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.batch#ClientRequestToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        }
+      }
+    },
+    "com.amazonaws.batch#ComputeEnvironmentDetail": {
+      "type": "structure",
+      "members": {
+        "computeEnvironmentName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the compute environment. It can be up to 128 characters long. It can contain uppercase and\n lowercase letters, numbers, hyphens (-), and underscores (_).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "computeEnvironmentArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the compute environment.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "unmanagedvCpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of VCPUs expected to be used for an unmanaged compute environment.</p>"
+          }
+        },
+        "ecsClusterArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the underlying Amazon ECS cluster that the compute environment uses.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags applied to the compute environment.</p>"
+          }
+        },
+        "type": {
+          "target": "com.amazonaws.batch#CEType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the compute environment: <code>MANAGED</code> or <code>UNMANAGED</code>. For\n   more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html\">Compute environments</a> in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#CEState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the compute environment. The valid values are <code>ENABLED</code> or\n    <code>DISABLED</code>.</p>\n         <p>If the state is <code>ENABLED</code>, then the Batch scheduler can attempt to place jobs\n   from an associated job queue on the compute resources within the environment. If the compute\n   environment is managed, then it can scale its instances out or in automatically based on the job\n   queue demand.</p>\n         <p>If the state is <code>DISABLED</code>, then the Batch scheduler doesn't attempt to place\n   jobs within the environment. Jobs in a <code>STARTING</code> or <code>RUNNING</code> state\n   continue to progress normally. Managed compute environments in the <code>DISABLED</code> state\n   don't scale out. </p>\n         <note>\n            <p>Compute environments in a <code>DISABLED</code> state may continue to incur billing\n    charges, for example, if they have running instances due to jobs that are still executing or a non-zero <code>minvCpus</code> setting. To prevent additional charges, disable and delete the compute environment.</p>\n         </note>\n         <p>When an instance is idle, the instance scales down to the <code>minvCpus</code> value.\n   However, the instance size doesn't change. For example, consider a <code>c5.8xlarge</code>\n   instance with a <code>minvCpus</code> value of <code>4</code> and a <code>desiredvCpus</code>\n   value of <code>36</code>. This instance doesn't scale down to a <code>c5.large</code>\n   instance.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#CEStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the compute environment (for example, <code>CREATING</code> or\n    <code>VALID</code>).</p>"
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short, human-readable string to provide additional details for the current status of the\n   compute environment.</p>"
+          }
+        },
+        "computeResources": {
+          "target": "com.amazonaws.batch#ComputeResource",
+          "traits": {
+            "smithy.api#documentation": "<p>The compute resources defined for the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html\">Compute environments</a> in\n   the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "serviceRole": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The service role that's associated with the compute environment that allows Batch to make\n   calls to Amazon Web Services API operations on your behalf. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/service_IAM_role.html\">Batch service IAM role</a> in the\n    <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "updatePolicy": {
+          "target": "com.amazonaws.batch#UpdatePolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the infrastructure update policy for the compute environment. For more information\n   about infrastructure updates, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "eksConfiguration": {
+          "target": "com.amazonaws.batch#EksConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration for the Amazon EKS cluster that supports the Batch compute environment. Only\n   specify this parameter if the <code>containerOrchestrationType</code> is <code>EKS</code>.</p>"
+          }
+        },
+        "containerOrchestrationType": {
+          "target": "com.amazonaws.batch#OrchestrationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The orchestration type of the compute environment. The valid values are <code>ECS</code>\n   (default) or <code>EKS</code>.</p>"
+          }
+        },
+        "uuid": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Unique identifier for the compute environment.</p>"
+          }
+        },
+        "context": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents an Batch compute environment.</p>"
+      }
+    },
+    "com.amazonaws.batch#ComputeEnvironmentDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ComputeEnvironmentDetail"
+      }
+    },
+    "com.amazonaws.batch#ComputeEnvironmentOrder": {
+      "type": "structure",
+      "members": {
+        "order": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The order of the compute environment. Compute environments are tried in ascending order. For\n   example, if two compute environments are associated with a job queue, the compute environment\n   with a lower <code>order</code> integer value is tried for job placement first.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "computeEnvironment": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the compute environment.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The order that compute environments are tried in for job placement within a queue. Compute\n   environments are tried in ascending order. For example, if two compute environments are\n   associated with a job queue, the compute environment with a lower order integer value is tried\n   for job placement first. Compute environments must be in the <code>VALID</code> state before you\n   can associate them with a job queue. All of the compute environments must be either EC2\n    (<code>EC2</code> or <code>SPOT</code>) or Fargate (<code>FARGATE</code> or\n    <code>FARGATE_SPOT</code>); Amazon EC2 and Fargate compute environments can't be mixed.</p>\n         <note>\n            <p>All compute environments that are associated with a job queue must share the same\n    architecture. Batch doesn't support mixing compute environment architecture types in a single\n    job queue.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.batch#ComputeEnvironmentOrders": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ComputeEnvironmentOrder"
+      }
+    },
+    "com.amazonaws.batch#ComputeResource": {
+      "type": "structure",
+      "members": {
+        "type": {
+          "target": "com.amazonaws.batch#CRType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of compute environment: <code>EC2</code>, <code>SPOT</code>, <code>FARGATE</code>,\n   or <code>FARGATE_SPOT</code>. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html\">Compute environments</a> in the\n    <i>Batch User Guide</i>.</p>\n         <p> If you choose <code>SPOT</code>, you must also specify an Amazon EC2 Spot Fleet role with the\n    <code>spotIamFleetRole</code> parameter. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/spot_fleet_IAM_role.html\">Amazon EC2 spot fleet role</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>Multi-node parallel jobs aren't supported on Spot Instances.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "allocationStrategy": {
+          "target": "com.amazonaws.batch#CRAllocationStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The allocation strategy to use for the compute resource if not enough instances of the best\n fitting instance type can be allocated. This might be because of availability of the instance\n type in the Region or <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html\">Amazon EC2 service limits</a>. For more\n information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/allocation-strategies.html\">Allocation strategies</a> in the <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>\n         <note>\n            <p>This parameter is required for Amazon EKS compute environments. For Amazon ECS compute environments,\n     if this parameter isn't specified, the <code>BEST_FIT</code> allocation strategy is used by\n     default.</p>\n         </note>\n         <dl>\n            <dt>BEST_FIT (default)</dt>\n            <dd>\n               <p>Batch selects an instance type that best fits the needs of the jobs with a preference\n      for the lowest-cost instance type. If additional instances of the selected instance type\n      aren't available, Batch waits for the additional instances to be available. If there aren't\n      enough instances available or the user is reaching <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html\">Amazon EC2 service limits</a>,\n      additional jobs aren't run until the currently running jobs are completed. This allocation\n      strategy keeps costs lower but can limit scaling. If you're using Spot Fleets with\n       <code>BEST_FIT</code>, the Spot Fleet IAM Role must be specified. Compute resources that use\n      a <code>BEST_FIT</code> allocation strategy don't support infrastructure updates and can't\n      update some parameters. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in\n      the <i>Batch User Guide</i>.</p>\n            </dd>\n            <dt>BEST_FIT_PROGRESSIVE</dt>\n            <dd>\n               <p>Batch selects additional instance types that are large enough to meet the requirements\n      of the jobs in the queue. Its preference is for instance types with lower cost vCPUs. If\n      additional instances of the previously selected instance types aren't available, Batch\n      selects new instance types.</p>\n            </dd>\n            <dt>BEST_FIT_PROGRESSIVE_ORDERED</dt>\n            <dd>\n               <important>\n                  <p>This is an advanced allocation strategy only for customers who want to control which\n       instance types are preferred during scaling.</p>\n                  <p>Placing large instance types at the top of the list may result in <b>over-provisioning</b> for\n       small jobs. Placing small instance types at the top may cause the compute environment to\n       reach Amazon EC2 instance count limits before reaching <code>maxvCpus</code>.</p>\n               </important>\n               <p>Batch selects instance types in the order they appear in the\n      <code>instanceTypes</code> list. When an instance family is specified, sizes within that\n      family are expanded using <code>BEST_FIT_PROGRESSIVE</code> logic\u2014preferring sizes that\n      best fit the jobs, with larger sizes as fallback. Instance types that cannot meet the resource\n      requirements of the jobs are skipped. This strategy is only available for On-Demand Instance\n      (<code>EC2</code>) compute resources.</p>\n               <p>If an instance family and an explicit instance type from that family both appear in\n      <code>instanceTypes</code>, the explicit type takes its listed position and is excluded from\n      the family expansion. For example, in <code>[\"m7a.4xlarge\", \"m7a\", \"m6a\"]</code>,\n      <code>m7a.4xlarge</code> is always placed first and is excluded from the <code>m7a</code>\n      family expansion.</p>\n            </dd>\n            <dt>SPOT_CAPACITY_OPTIMIZED</dt>\n            <dd>\n               <p>Batch selects one or more instance types that are large enough to meet the requirements\n      of the jobs in the queue. Its preference is for instance types that are less likely to be\n      interrupted. This allocation strategy is only available for Spot Instance compute\n      resources.</p>\n            </dd>\n            <dt>SPOT_PRICE_CAPACITY_OPTIMIZED</dt>\n            <dd>\n               <p>The price and capacity optimized allocation strategy looks at both price and capacity to\n      select the Spot Instance pools that are the least likely to be interrupted and have the lowest\n      possible price. This allocation strategy is only available for Spot Instance compute\n      resources.</p>\n            </dd>\n            <dt>SPOT_CAPACITY_OPTIMIZED_PRIORITIZED</dt>\n            <dd>\n               <important>\n                  <p>This is an advanced allocation strategy for customers who want to influence instance\n       type selection during scaling. This strategy optimizes for <b>capacity\n       first</b>, and honors instance type priorities on a best-effort basis (priorities are\n       honored when they do not significantly reduce available Spot capacity).</p>\n                  <p>Placing large instance types at the top of the list may result in <b>over-provisioning</b> for\n       small jobs. Placing small instance types at the top may cause the compute environment to\n       reach Amazon EC2 instance count limits before reaching <code>maxvCpus</code>.</p>\n               </important>\n               <p>Batch selects instance types in the order they appear in the\n      <code>instanceTypes</code> list, but <b>optimizes for capacity\n      first</b>. The customer-defined priority is honored on a best-effort basis. When Spot\n      Instance capacity pools are similarly available, priority order is respected. When capacity is\n      constrained, Batch selects from the most available pools regardless of priority to minimize\n      the likelihood of Spot Instance interruptions. This strategy is only available for Spot\n      Instance compute resources.</p>\n            </dd>\n         </dl>\n         <p>With any allocation strategy except <code>BEST_FIT</code> using On-Demand\n    (<code>EC2</code>) compute resources, Batch might need to exceed <code>maxvCpus</code> to meet your\n    capacity requirements. In this event, Batch never exceeds <code>maxvCpus</code> by more than\n    a single instance.</p>"
+          }
+        },
+        "minvCpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The minimum number of vCPUs that a compute environment should maintain (even if the compute \n   environment is <code>DISABLED</code>).</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "maxvCpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The maximum number of vCPUs that a compute environment can support.</p>\n         <note>\n            <p>With any allocation strategy except <code>BEST_FIT</code> using On-Demand\n     (<code>EC2</code>) compute resources, Batch might need to exceed <code>maxvCpus</code> to meet your\n     capacity requirements. In this event, Batch never exceeds <code>maxvCpus</code> by more than\n     a single instance.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "desiredvCpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The desired number of vCPUS in the compute environment. Batch modifies this value between \n   the minimum and maximum values based on job queue demand.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "instanceTypes": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The instances types that can be launched. You can specify instance families to launch any\n   instance type within those families (for example, <code>c5</code> or <code>p3</code>), or you can\n   specify specific sizes within a family (such as <code>c5.8xlarge</code>).</p>\n         <p>Batch can select the instance type for you if you choose one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>default_x86_64</code> to choose x86 based instance types (from the <code>m6i</code>,\n     <code>c6i</code>, <code>r6i</code>, and <code>c7i</code> instance families) that matches the resource demands of the job queue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>default_arm64</code> to choose ARM based instance types (from the <code>m6g</code>,\n     <code>c6g</code>, <code>r6g</code>, and <code>c7g</code> instance families) that matches the resource demands of the job queue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>optimal</code> Semantically equivalent to <code>default_x86_64</code>, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/optimal-default-instance-troubleshooting.html\">Optimal instance type configuration to receive automatic instance family\n    updates</a> for details.</p>\n            </li>\n         </ul>\n         <note>\n            <p>Instance family availability varies by Amazon Web Services Region. For example, some Amazon Web Services Regions may not have any fourth generation instance families but have fifth and\n    sixth generation instance families.</p>\n            <p>When using <code>default_x86_64</code> or <code>default_arm64</code> instance bundles,\n    Batch selects instance families based on a balance of cost-effectiveness and performance.\n    While newer generation instances often provide better price-performance, Batch may choose an\n    earlier generation instance family if it provides the optimal combination of availability, cost,\n    and performance for your workload. For example, in an Amazon Web Services Region where both c6i\n    and c7i instances are available, Batch might select c6i instances if they offer better\n    cost-effectiveness for your specific job requirements. For more information on Batch instance\n    types and Amazon Web Services Region availability, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/instance-type-compute-table.html\">Instance\n     type compute table</a> in the <i>Batch User Guide</i>.</p>\n            <p>Batch periodically updates your instances in default bundles to newer,\n    more cost-effective options. Updates happen automatically without requiring any\n    action from you. Your workloads continue running during updates with no interruption\n   </p>\n         </note>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>\n         <note>\n            <p>When you create a compute environment, the instance types that you select for the compute environment must\n    share the same architecture. For example, you can't mix x86 and ARM instances in the same compute\n    environment.</p>\n         </note>"
+          }
+        },
+        "imageId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#deprecated": {
+              "message": "This field is deprecated, use ec2Configuration[].imageIdOverride instead."
+            },
+            "smithy.api#documentation": "<p>The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.\n   This parameter is overridden by the <code>imageIdOverride</code> member of the\n    <code>Ec2Configuration</code> structure.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>\n         <note>\n            <p>The AMI that you choose for a compute environment must match the architecture of the instance types that\n    you intend to use for that compute environment. For example, if your compute environment uses A1 instance types,\n    the compute resource AMI that you choose must support ARM instances. Amazon ECS vends both x86 and ARM versions of the\n    Amazon ECS-optimized Amazon Linux 2023 AMI. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#ecs-optimized-ami-linux-variants.html\">Amazon ECS-optimized\n    Amazon Linux 2023 AMI</a>\n    in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         </note>"
+          }
+        },
+        "subnets": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The VPC subnets where the compute resources are launched. These subnets must be within the\n   same VPC. Fargate compute resources can contain up to 16 subnets. For more information, see\n    <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html\">VPCs and subnets</a>\n   in the <i>Amazon VPC User Guide</i>. This parameter is required for compute\n   environments using <code>EC2</code>, <code>SPOT</code>, <code>FARGATE</code>, or\n   <code>FARGATE_SPOT</code> compute resources.</p>\n         <note>\n            <p>Batch on Amazon EC2 and Batch on Amazon EKS support Local Zones. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-local-zones\"> Local\n     Zones</a> in the <i>Amazon EC2 User Guide for Linux Instances</i>, <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/local-zones.html\">Amazon EKS and Amazon Web Services Local\n     Zones</a> in the <i>Amazon EKS User Guide</i> and <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-regions-zones.html#clusters-local-zones\"> Amazon ECS\n     clusters in Local Zones, Wavelength Zones, and Amazon Web Services Outposts</a> in the <i>Amazon ECS\n     Developer Guide</i>.</p>\n            <p>Batch on Fargate doesn't currently support Local Zones.</p>\n         </note>"
+          }
+        },
+        "securityGroupIds": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 security groups that are associated with instances launched in the compute\n   environment. One or more security groups must be specified, either in\n    <code>securityGroupIds</code> or using a launch template referenced in\n    <code>launchTemplate</code>. This parameter is required for jobs that are running on Fargate\n   resources and must contain at least one security group. Fargate doesn't support launch\n   templates. If security groups are specified using both <code>securityGroupIds</code> and\n    <code>launchTemplate</code>, the values in <code>securityGroupIds</code> are used.</p>"
+          }
+        },
+        "ec2KeyPair": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 key pair that's used for instances launched in the compute environment. You can\n   use this key pair to log in to your instances with SSH.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "instanceRole": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon ECS instance profile applied to Amazon EC2 instances in a compute environment. This\n   parameter is required for Amazon EC2 instances types. You can specify the short name or full Amazon Resource Name (ARN)\n   of an instance profile. For example, <code>\n               <i>ecsInstanceRole</i>\n            </code> or\n     <code>arn:aws:iam::<i><aws_account_id></i>:instance-profile/<i>ecsInstanceRole</i>\n            </code>.\n   For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/instance_IAM_role.html\">Amazon ECS instance role</a> in the <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Key-value pair tags to be applied to Amazon EC2 resources that are launched in the compute\n   environment. For Batch, these take the form of <code>\"String1\": \"String2\"</code>, where\n    <code>String1</code> is the tag key and <code>String2</code> is the tag value (for example,\n    <code>{ \"Name\": \"Batch Instance - C4OnDemand\" }</code>). This is helpful for recognizing your\n   Batch instances in the Amazon EC2 console. Updating these tags requires an infrastructure update to\n   the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>. These tags aren't seen when using the Batch\n    <code>ListTagsForResource</code> API operation.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "placementGroup": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 placement group to associate with your compute resources. If you intend to submit\n   multi-node parallel jobs to your compute environment, you should consider creating a cluster\n   placement group and associate it with your compute resources. This keeps your multi-node parallel\n   job on a logical grouping of instances within a single Availability Zone with high network flow\n   potential. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html\">Placement groups</a> in the\n    <i>Amazon EC2 User Guide for Linux Instances</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "bidPercentage": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum percentage that a Spot Instance price can be when compared with the On-Demand\n   price for that instance type before instances are launched. For example, if your maximum\n   percentage is 20%, then the Spot price must be less than 20% of the current On-Demand price for\n   that Amazon EC2 instance. You always pay the lowest (market) price and never more than your maximum\n   percentage. If you leave this field empty, the default value is 100% of the On-Demand\n   price. For most use cases, we recommend leaving this field empty.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "spotIamFleetRole": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a <code>SPOT</code> compute\n   environment. This role is required if the allocation strategy set to <code>BEST_FIT</code> or if\n   the allocation strategy isn't specified. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/spot_fleet_IAM_role.html\">Amazon EC2 spot fleet role</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>\n         <important>\n            <p>To tag your Spot Instances on creation, the Spot Fleet IAM role specified here must use\n    the newer <b>AmazonEC2SpotFleetTaggingRole</b> managed policy. The\n    previously recommended <b>AmazonEC2SpotFleetRole</b> managed policy\n    doesn't have the required permissions to tag Spot Instances. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/troubleshooting.html#spot-instance-no-tag\">Spot instances\n     not tagged on creation</a> in the <i>Batch User Guide</i>.</p>\n         </important>"
+          }
+        },
+        "launchTemplate": {
+          "target": "com.amazonaws.batch#LaunchTemplateSpecification",
+          "traits": {
+            "smithy.api#documentation": "<p>The launch template to use for your compute resources. Any other compute resource parameters\n   that you specify in a <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_CreateComputeEnvironment.html\">CreateComputeEnvironment</a> API operation override the same parameters in the launch\n   template. You must specify either the launch template ID or launch template name in the request,\n   but not both. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/launch-templates.html\">Launch template support</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "ec2Configuration": {
+          "target": "com.amazonaws.batch#Ec2ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information that's used to select Amazon Machine Images (AMIs) for Amazon EC2 instances\n   in the compute environment. If <code>Ec2Configuration</code> isn't specified, the default is\n    <code>ECS_AL2023</code> for EC2 (ECS) compute environments and <code>EKS_AL2023</code> for EKS compute environments.</p>\n         <p>One or two values can be provided.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "scalingPolicy": {
+          "target": "com.amazonaws.batch#ComputeScalingPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The scaling policy configuration for the compute environment.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents an Batch compute resource. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html\">Compute environments</a> in\n   the <i>Batch User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#ComputeResourceUpdate": {
+      "type": "structure",
+      "members": {
+        "minvCpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The minimum number of vCPUs that an environment should maintain (even if the compute environment \n   is <code>DISABLED</code>).</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "maxvCpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of Amazon EC2 vCPUs that an environment can reach.</p>\n         <note>\n            <p>With any allocation strategy except <code>BEST_FIT</code> using On-Demand\n     (<code>EC2</code>) compute resources, Batch might need to exceed <code>maxvCpus</code> to meet your\n     capacity requirements. In this event, Batch never exceeds <code>maxvCpus</code> by more than\n     a single instance.</p>\n         </note>"
+          }
+        },
+        "desiredvCpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The desired number of vCPUS in the compute environment. Batch modifies this value between \n   the minimum and maximum values based on job queue demand.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>\n         <note>\n            <p>Batch doesn't support changing the desired number of vCPUs of an existing compute\n    environment. Don't specify this parameter for compute environments using Amazon EKS clusters.</p>\n         </note>\n         <note>\n            <p>When you update the <code>desiredvCpus</code> setting, the value must be between the\n     <code>minvCpus</code> and <code>maxvCpus</code> values. </p>\n            <p>Additionally, the updated <code>desiredvCpus</code> value must be greater than or equal to\n    the current <code>desiredvCpus</code> value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/troubleshooting.html#error-desired-vcpus-update\">Troubleshooting\n     Batch</a> in the <i>Batch User Guide</i>.</p>\n         </note>"
+          }
+        },
+        "subnets": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The VPC subnets where the compute resources are launched. Fargate compute resources can\n   contain up to 16 subnets. For Fargate compute resources, providing an empty list will be\n   handled as if this parameter wasn't specified and no change is made. For Amazon EC2 compute resources,\n   providing an empty list removes the VPC subnets from the compute resource. For more information,\n   see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html\">VPCs and\n    subnets</a> in the <i>Amazon VPC User Guide</i>.</p>\n         <p>When updating a compute environment, changing the VPC subnets requires an infrastructure\n   update of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>Batch on Amazon EC2 and Batch on Amazon EKS support Local Zones. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-local-zones\"> Local\n     Zones</a> in the <i>Amazon EC2 User Guide for Linux Instances</i>, <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/local-zones.html\">Amazon EKS and Amazon Web Services Local\n     Zones</a> in the <i>Amazon EKS User Guide</i> and <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-regions-zones.html#clusters-local-zones\"> Amazon ECS\n     clusters in Local Zones, Wavelength Zones, and Amazon Web Services Outposts</a> in the <i>Amazon ECS\n     Developer Guide</i>.</p>\n            <p>Batch on Fargate doesn't currently support Local Zones.</p>\n         </note>"
+          }
+        },
+        "securityGroupIds": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 security groups that are associated with instances launched in the compute\n   environment. This parameter is required for Fargate compute resources, where it can contain up\n   to 5 security groups. For Fargate compute resources, providing an empty list is handled as if\n   this parameter wasn't specified and no change is made. For Amazon EC2 compute resources, providing an\n   empty list removes the security groups from the compute resource.</p>\n         <p>When updating a compute environment, changing the Amazon EC2 security groups requires an\n   infrastructure update of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute\n    environments</a> in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "allocationStrategy": {
+          "target": "com.amazonaws.batch#CRUpdateAllocationStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The allocation strategy to use for the compute resource if there's not enough instances of\n the best fitting instance type that can be allocated. This might be because of availability of\n the instance type in the Region or <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html\">Amazon EC2 service limits</a>. For more\n information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/allocation-strategies.html\">Allocation strategies</a> in the <i>Batch User Guide</i>.</p>\n         <p>When updating a compute environment, changing the allocation strategy requires an\n infrastructure update of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute\n environments</a> in the <i>Batch User Guide</i>. <code>BEST_FIT</code> isn't\n supported when updating a compute environment.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>\n         <dl>\n            <dt>BEST_FIT_PROGRESSIVE</dt>\n            <dd>\n               <p>Batch selects additional instance types that are large enough to meet the requirements\n      of the jobs in the queue. Its preference is for instance types with lower cost vCPUs. If\n      additional instances of the previously selected instance types aren't available, Batch\n      selects new instance types.</p>\n            </dd>\n            <dt>BEST_FIT_PROGRESSIVE_ORDERED</dt>\n            <dd>\n               <important>\n                  <p>This is an advanced allocation strategy only for customers who want to control which\n       instance types are preferred during scaling.</p>\n                  <p>Placing large instance types at the top of the list may result in <b>over-provisioning</b> for\n       small jobs. Placing small instance types at the top may cause the compute environment to\n       reach Amazon EC2 instance count limits before reaching <code>maxvCpus</code>.</p>\n               </important>\n               <p>Batch selects instance types in the order they appear in the\n      <code>instanceTypes</code> list. When an instance family is specified, sizes within that\n      family are expanded using <code>BEST_FIT_PROGRESSIVE</code> logic\u2014preferring sizes that\n      best fit the jobs, with larger sizes as fallback. Instance types that cannot meet the resource\n      requirements of the jobs are skipped. This strategy is only available for On-Demand Instance\n      (<code>EC2</code>) compute resources.</p>\n               <p>If an instance family and an explicit instance type from that family both appear in\n      <code>instanceTypes</code>, the explicit type takes its listed position and is excluded from\n      the family expansion. For example, in <code>[\"m7a.4xlarge\", \"m7a\", \"m6a\"]</code>,\n      <code>m7a.4xlarge</code> is always placed first and is excluded from the <code>m7a</code>\n      family expansion.</p>\n            </dd>\n            <dt>SPOT_CAPACITY_OPTIMIZED</dt>\n            <dd>\n               <p>Batch selects one or more instance types that are large enough to meet the requirements\n      of the jobs in the queue. Its preference is for instance types that are less likely to be\n      interrupted. This allocation strategy is only available for Spot Instance compute\n      resources.</p>\n            </dd>\n            <dt>SPOT_PRICE_CAPACITY_OPTIMIZED</dt>\n            <dd>\n               <p>The price and capacity optimized allocation strategy looks at both price and capacity to\n      select the Spot Instance pools that are the least likely to be interrupted and have the lowest\n      possible price. This allocation strategy is only available for Spot Instance compute\n      resources.</p>\n            </dd>\n            <dt>SPOT_CAPACITY_OPTIMIZED_PRIORITIZED</dt>\n            <dd>\n               <important>\n                  <p>This is an advanced allocation strategy for customers who want to influence instance\n       type selection during scaling. This strategy optimizes for <b>capacity\n       first</b>, and honors instance type priorities on a best-effort basis (priorities are\n       honored when they do not significantly reduce available Spot capacity).</p>\n                  <p>Placing large instance types at the top of the list may result in <b>over-provisioning</b> for\n       small jobs. Placing small instance types at the top may cause the compute environment to\n       reach Amazon EC2 instance count limits before reaching <code>maxvCpus</code>.</p>\n               </important>\n               <p>Batch selects instance types in the order they appear in the\n      <code>instanceTypes</code> list, but <b>optimizes for capacity\n      first</b>. The customer-defined priority is honored on a best-effort basis. When Spot\n      Instance capacity pools are similarly available, priority order is respected. When capacity is\n      constrained, Batch selects from the most available pools regardless of priority to minimize\n      the likelihood of Spot Instance interruptions. This strategy is only available for Spot\n      Instance compute resources.</p>\n            </dd>\n         </dl>\n         <p>With any allocation strategy except <code>BEST_FIT</code> using On-Demand\n    (<code>EC2</code>) compute resources, Batch might need to exceed <code>maxvCpus</code> to meet your\n    capacity requirements. In this event, Batch never exceeds <code>maxvCpus</code> by more than\n    a single instance.</p>"
+          }
+        },
+        "instanceTypes": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The instances types that can be launched. You can specify instance families to launch any\n   instance type within those families (for example, <code>c5</code> or <code>p3</code>), or you can\n   specify specific sizes within a family (such as <code>c5.8xlarge</code>). </p>\n         <p>Batch can select the instance type for you if you choose one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>optimal</code> to select instance types (from the <code>c4</code>, <code>m4</code>,\n    <code>r4</code>, <code>c5</code>, <code>m5</code>, and <code>r5</code>\n    instance families) that match the demand of your job queues. </p>\n            </li>\n            <li>\n               <p>\n                  <code>default_x86_64</code> to choose x86 based instance types (from the <code>m6i</code>,\n     <code>c6i</code>, <code>r6i</code>, and <code>c7i</code> instance families) that matches the resource demands of the job queue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>default_arm64</code> to choose x86 based instance types (from the <code>m6g</code>,\n     <code>c6g</code>, <code>r6g</code>, and <code>c7g</code> instance families) that matches the resource demands of the job queue.</p>\n            </li>\n         </ul>\n         <note>\n            <p>Starting on 11/01/2025 the behavior of <code>optimal</code> is going to be changed to match\n     <code>default_x86_64</code>.  During the change your instance families could be updated to a\n    newer generation. You do not need to perform any actions for the upgrade to happen. For more\n    information about change, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/optimal-default-instance-troubleshooting.html\">Optimal instance type configuration to receive automatic instance family\n    updates</a>.</p>\n         </note>\n         <note>\n            <p>Instance family availability varies by Amazon Web Services Region. For example, some Amazon Web Services Regions may not have any fourth generation instance families but have fifth and\n    sixth generation instance families.</p>\n            <p>When using <code>default_x86_64</code> or <code>default_arm64</code> instance bundles,\n    Batch selects instance families based on a balance of cost-effectiveness and performance.\n    While newer generation instances often provide better price-performance, Batch may choose an\n    earlier generation instance family if it provides the optimal combination of availability, cost,\n    and performance for your workload. For example, in an Amazon Web Services Region where both c6i\n    and c7i instances are available, Batch might select c6i instances if they offer better\n    cost-effectiveness for your specific job requirements. For more information on Batch instance\n    types and Amazon Web Services Region availability, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/instance-type-compute-table.html\">Instance\n     type compute table</a> in the <i>Batch User Guide</i>.</p>\n            <p>Batch periodically updates your instances in default bundles to newer,\n    more cost-effective options. Updates happen automatically without requiring any\n    action from you. Your workloads continue running during updates with no interruption\n   </p>\n         </note>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>\n         <note>\n            <p>When you create a compute environment, the instance types that you select for the compute environment must\n    share the same architecture. For example, you can't mix x86 and ARM instances in the same compute\n    environment.</p>\n         </note>"
+          }
+        },
+        "ec2KeyPair": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 key pair that's used for instances launched in the compute environment. You can\n   use this key pair to log in to your instances with SSH. To remove the Amazon EC2 key pair, set this\n   value to an empty string.</p>\n         <p>When updating a compute environment, changing the Amazon EC2 key pair requires an infrastructure\n   update of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "instanceRole": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon ECS instance profile applied to Amazon EC2 instances in a compute environment.\n   Required for Amazon EC2 instances. You can specify the short name or full Amazon Resource Name (ARN) of an instance\n   profile. For example, <code>\n               <i>ecsInstanceRole</i>\n            </code> or\n     <code>arn:aws:iam::<i><aws_account_id></i>:instance-profile/<i>ecsInstanceRole</i>\n            </code>.\n   For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/instance_IAM_role.html\">Amazon ECS instance role</a> in the <i>Batch User Guide</i>.</p>\n         <p>When updating a compute environment, changing this setting requires an infrastructure update\n   of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Key-value pair tags to be applied to Amazon EC2 resources that are launched in the compute\n   environment. For Batch, these take the form of <code>\"String1\": \"String2\"</code>, where\n    <code>String1</code> is the tag key and <code>String2</code> is the tag value (for example,\n    <code>{ \"Name\": \"Batch Instance - C4OnDemand\" }</code>). This is helpful for recognizing your\n   Batch instances in the Amazon EC2 console. These tags aren't seen when using the Batch\n    <code>ListTagsForResource</code> API operation.</p>\n         <p>When updating a compute environment, changing this setting requires an infrastructure update\n   of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "placementGroup": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 placement group to associate with your compute resources. If you intend to submit\n   multi-node parallel jobs to your compute environment, you should consider creating a cluster\n   placement group and associate it with your compute resources. This keeps your multi-node parallel\n   job on a logical grouping of instances within a single Availability Zone with high network flow\n   potential. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html\">Placement groups</a> in the\n    <i>Amazon EC2 User Guide for Linux Instances</i>.</p>\n         <p>When updating a compute environment, changing the placement group requires an infrastructure\n   update of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "bidPercentage": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum percentage that a Spot Instance price can be when compared with the On-Demand\n   price for that instance type before instances are launched. For example, if your maximum\n   percentage is 20%, the Spot price must be less than 20% of the current On-Demand price for that\n   Amazon EC2 instance. You always pay the lowest (market) price and never more than your maximum\n   percentage. For most use cases, we recommend leaving this field empty.</p>\n         <p>When updating a compute environment, changing the bid percentage requires an infrastructure\n   update of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "launchTemplate": {
+          "target": "com.amazonaws.batch#LaunchTemplateSpecification",
+          "traits": {
+            "smithy.api#documentation": "<p>The updated launch template to use for your compute resources. You must specify either the\n   launch template ID or launch template name in the request, but not both. For more information,\n   see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/launch-templates.html\">Launch template\n    support</a> in the <i>Batch User Guide</i>. To remove the custom launch\n   template and use the default launch template, set <code>launchTemplateId</code> or\n    <code>launchTemplateName</code> member of the launch template specification to an empty string.\n   Removing the launch template from a compute environment will not remove the AMI specified in the\n   launch template. In order to update the AMI specified in a launch template, the\n    <code>updateToLatestImageVersion</code> parameter must be set to <code>true</code>.</p>\n         <p>When updating a compute environment, changing the launch template requires an infrastructure\n   update of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "ec2Configuration": {
+          "target": "com.amazonaws.batch#Ec2ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information used to select Amazon Machine Images (AMIs) for Amazon EC2 instances in the\n   compute environment. If <code>Ec2Configuration</code> isn't specified, the default is\n    <code>ECS_AL2023</code> for EC2 (ECS) compute environments and <code>EKS_AL2023</code> for EKS compute environments.</p>\n         <p>When updating a compute environment, changing this setting requires an infrastructure update\n   of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>. To remove the Amazon EC2 configuration and any custom AMI ID\n   specified in <code>imageIdOverride</code>, set this value to an empty string.</p>\n         <p>One or two values can be provided.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        },
+        "updateToLatestImageVersion": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the AMI ID is updated to the latest one that's supported by Batch when\n   the compute environment has an infrastructure update. The default value is\n   <code>false</code>.</p>\n         <note>\n            <p>An AMI ID can either be specified in the <code>imageId</code> or\n     <code>imageIdOverride</code> parameters or be determined by the launch template that's\n    specified in the <code>launchTemplate</code> parameter. If an AMI ID is specified any of these\n    ways, this parameter is ignored. For more information about to update AMI IDs during an\n    infrastructure update, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html#updating-compute-environments-ami\">Updating\n     the AMI ID</a> in the <i>Batch User Guide</i>.</p>\n         </note>\n         <p>When updating a compute environment, changing this setting requires an infrastructure update\n   of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "type": {
+          "target": "com.amazonaws.batch#CRType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of compute environment: <code>EC2</code>, <code>SPOT</code>, <code>FARGATE</code>,\n   or <code>FARGATE_SPOT</code>. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html\">Compute environments</a> in the\n    <i>Batch User Guide</i>.</p>\n         <p> If you choose <code>SPOT</code>, you must also specify an Amazon EC2 Spot Fleet role with the\n    <code>spotIamFleetRole</code> parameter. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/spot_fleet_IAM_role.html\">Amazon EC2 spot fleet role</a> in the\n    <i>Batch User Guide</i>.</p>\n         <p>When updating a compute environment, changing the type of a compute environment requires an\n   infrastructure update of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute\n    environments</a> in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "imageId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.\n   This parameter is overridden by the <code>imageIdOverride</code> member of the\n    <code>Ec2Configuration</code> structure. To remove the custom AMI ID and use the default AMI ID,\n   set this value to an empty string.</p>\n         <p>When updating a compute environment, changing the AMI ID requires an infrastructure update\n   of the compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>\n         <note>\n            <p>The AMI that you choose for a compute environment must match the architecture of the instance types that\n    you intend to use for that compute environment. For example, if your compute environment uses A1 instance types,\n    the compute resource AMI that you choose must support ARM instances. Amazon ECS vends both x86 and ARM versions of the\n    Amazon ECS-optimized Amazon Linux 2023 AMI. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#ecs-optimized-ami-linux-variants.html\">Amazon ECS-optimized\n    Amazon Linux 2023 AMI</a>\n    in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         </note>"
+          }
+        },
+        "scalingPolicy": {
+          "target": "com.amazonaws.batch#ComputeScalingPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The scaling policy configuration for the compute environment.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't specify it.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the attributes of a compute environment that can be updated. For\n   more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#ComputeScalingPolicy": {
+      "type": "structure",
+      "members": {
+        "minScaleDownDelayMinutes": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The minimum time (in minutes) that Batch keeps instances running in the compute environment \n   after their jobs complete. For each instance, the delay period begins when the last job finishes. \n   If no new jobs are placed on the instance during this delay, Batch terminates the instance once \n   the delay expires.</p>\n         <p>Valid Range: Minimum value of 20. Maximum value of 10080. Use 0 to unset and disable the scale down delay.</p>\n         <note>\n            <p>Idle instances retained during the scale-down delay period are billable at standard EC2 pricing.</p>\n         </note>\n         <note>\n            <p>The scale down delay does not apply to:</p>\n            <ul>\n               <li>\n                  <p>Instances being replaced during infrastructure updates</p>\n               </li>\n               <li>\n                  <p>Newly launched instances that have not yet run any jobs</p>\n               </li>\n               <li>\n                  <p>Spot instances reclaimed due to interruption</p>\n               </li>\n            </ul>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents a scaling policy for a compute environment.</p>"
+      }
+    },
+    "com.amazonaws.batch#ConsumableResourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ConsumableResourceRequirement"
+      }
+    },
+    "com.amazonaws.batch#ConsumableResourceProperties": {
+      "type": "structure",
+      "members": {
+        "consumableResourceList": {
+          "target": "com.amazonaws.batch#ConsumableResourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of consumable resources required by a job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains a list of consumable resources required by a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#ConsumableResourceRequirement": {
+      "type": "structure",
+      "members": {
+        "consumableResource": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name or ARN of the consumable resource.</p>"
+          }
+        },
+        "quantity": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The quantity of the consumable resource that is needed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about a consumable resource required to run a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#ConsumableResourceSummary": {
+      "type": "structure",
+      "members": {
+        "consumableResourceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the consumable resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "consumableResourceName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the consumable resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "totalQuantity": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The total amount of the consumable resource that is available.</p>"
+          }
+        },
+        "inUseQuantity": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The amount of the consumable resource that is currently in use.</p>"
+          }
+        },
+        "resourceType": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the resource is available to be re-used after a job completes. Can be \n            one of: </p>\n         <ul>\n            <li>\n               <p>\n                  <code>REPLENISHABLE</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_REPLENISHABLE</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Current information about a consumable resource.</p>"
+      }
+    },
+    "com.amazonaws.batch#ConsumableResourceSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ConsumableResourceSummary"
+      }
+    },
+    "com.amazonaws.batch#ContainerDetail": {
+      "type": "structure",
+      "members": {
+        "image": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The image used to start the container.</p>"
+          }
+        },
+        "vcpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of vCPUs reserved for the container. For jobs that run on Amazon EC2 resources, you\n   can specify the vCPU requirement for the job using <code>resourceRequirements</code>, but you\n   can't specify the vCPU requirements in both the <code>vcpus</code> and\n    <code>resourceRequirements</code> object. This parameter maps to <code>CpuShares</code> in the\n   <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the\n    <code>--cpu-shares</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. Each\n   vCPU is equivalent to 1,024 CPU shares. You must specify at least one vCPU. This is required but\n   can be specified in several places. It must be specified for each node at least once.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that run on Fargate resources. For jobs that run\n    on Fargate resources, you must specify the vCPU requirement for the job using\n     <code>resourceRequirements</code>.</p>\n         </note>"
+          }
+        },
+        "memory": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>For jobs running on Amazon EC2 resources that didn't specify memory requirements using\n    <code>resourceRequirements</code>, the number of MiB of memory reserved for the job. For other\n   jobs, including all run on Fargate resources, see <code>resourceRequirements</code>.</p>"
+          }
+        },
+        "command": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The command that's passed to the container.</p>"
+          }
+        },
+        "jobRoleArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that's associated with the job when run.</p>"
+          }
+        },
+        "executionRoleArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the execution role that Batch can assume. For more information,\n   see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html\">Batch execution IAM\n    role</a> in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "volumes": {
+          "target": "com.amazonaws.batch#Volumes",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of volumes that are associated with the job.</p>"
+          }
+        },
+        "environment": {
+          "target": "com.amazonaws.batch#EnvironmentVariables",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables to pass to a container.</p>\n         <note>\n            <p>Environment variables cannot start with \"<code>AWS_BATCH</code>\". This naming\n convention is reserved for variables that Batch sets.</p>\n         </note>"
+          }
+        },
+        "mountPoints": {
+          "target": "com.amazonaws.batch#MountPoints",
+          "traits": {
+            "smithy.api#documentation": "<p>The mount points for data volumes in your container.</p>"
+          }
+        },
+        "readonlyRootFilesystem": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is true, the container is given read-only access to its root file\n   system. This parameter maps to <code>ReadonlyRootfs</code> in the\n   <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the\n    <code>--read-only</code> option to <a href=\"https://docs.docker.com/engine/reference/commandline/run/\">\n               <code>docker\n   run</code>\n            </a>.</p>"
+          }
+        },
+        "ulimits": {
+          "target": "com.amazonaws.batch#Ulimits",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ulimit</code> values to set in the container. This parameter maps to\n    <code>Ulimits</code> in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a>\n   and the <code>--ulimit</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker\n   run</a>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources.</p>\n         </note>"
+          }
+        },
+        "privileged": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is true, the container is given elevated permissions on the host\n   container instance (similar to the <code>root</code> user). The default value is\n    <code>false</code>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources and\n    shouldn't be provided, or specified as <code>false</code>.</p>\n         </note>"
+          }
+        },
+        "user": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The user name to use inside the container. This parameter maps to <code>User</code> in the\n   <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the <code>--user</code>\n   option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>.</p>"
+          }
+        },
+        "exitCode": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The exit code returned upon completion.</p>"
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short (255 max characters) human-readable string to provide additional details for a\n   running or stopped container.</p>"
+          }
+        },
+        "containerInstanceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the container instance that the container is running on.</p>"
+          }
+        },
+        "taskArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon ECS task that's associated with the container job. Each container\n   attempt receives a task ARN when they reach the <code>STARTING</code> status.</p>"
+          }
+        },
+        "logStreamName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon CloudWatch Logs log stream that's associated with the container. The log group for\n   Batch jobs is <code>/aws/batch/job</code>. Each container attempt receives a log stream name\n   when they reach the <code>RUNNING</code> status.</p>"
+          }
+        },
+        "instanceType": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The instance type of the underlying host infrastructure of a multi-node parallel job.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources.</p>\n         </note>"
+          }
+        },
+        "networkInterfaces": {
+          "target": "com.amazonaws.batch#NetworkInterfaceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The network interfaces that are associated with the job.</p>"
+          }
+        },
+        "resourceRequirements": {
+          "target": "com.amazonaws.batch#ResourceRequirements",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and amount of resources to assign to a container. The supported resources include\n    <code>GPU</code>, <code>MEMORY</code>, and <code>VCPU</code>.</p>"
+          }
+        },
+        "linuxParameters": {
+          "target": "com.amazonaws.batch#LinuxParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Linux-specific modifications that are applied to the container, such as details for device\n   mappings.</p>"
+          }
+        },
+        "logConfiguration": {
+          "target": "com.amazonaws.batch#LogConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The log configuration specification for the container.</p>\n         <p>This parameter maps to <code>LogConfig</code> in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a>\n   section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the <code>--log-driver</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. By default, containers use the same logging\n   driver that the Docker daemon uses. However, the container might use a different logging driver\n   than the Docker daemon by specifying a log driver with this parameter in the container\n   definition. To use a different logging driver for a container, the log system must be configured\n   properly on the container instance. Or, alternatively, it must be configured on a different log\n   server for remote logging options. For more information on the options for different supported\n   log drivers, see <a href=\"https://docs.docker.com/engine/admin/logging/overview/\">Configure\n    logging drivers</a> in the Docker documentation.</p>\n         <note>\n            <p>Batch currently supports a subset of the logging drivers available to the Docker daemon\n    (shown in the <a href=\"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-logconfiguration.html\">LogConfiguration</a> data type). Additional log drivers might be available in future\n    releases of the Amazon ECS container agent.</p>\n         </note>\n         <p>This parameter requires version 1.18 of the Docker Remote API or greater on your\n container instance. To check the Docker Remote API version on your container instance, log in to your\n container instance and run the following command: <code>sudo docker version | grep \"Server API version\"</code>\n         </p>\n         <note>\n            <p>The Amazon ECS container agent running on a container instance must register the logging drivers\n    available on that instance with the <code>ECS_AVAILABLE_LOGGING_DRIVERS</code> environment\n    variable before containers placed on that instance can use these log configuration options. For\n    more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html\">Amazon ECS container agent\n     configuration</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         </note>"
+          }
+        },
+        "secrets": {
+          "target": "com.amazonaws.batch#SecretList",
+          "traits": {
+            "smithy.api#documentation": "<p>The secrets to pass to the container. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/specifying-sensitive-data.html\">Specifying sensitive data</a> in the\n    <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "networkConfiguration": {
+          "target": "com.amazonaws.batch#NetworkConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The network configuration for jobs that are running on Fargate resources. Jobs that are\n   running on Amazon EC2 resources must not specify this parameter.</p>"
+          }
+        },
+        "fargatePlatformConfiguration": {
+          "target": "com.amazonaws.batch#FargatePlatformConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The platform configuration for jobs that are running on Fargate resources. Jobs that are\n   running on Amazon EC2 resources must not specify this parameter.</p>"
+          }
+        },
+        "ephemeralStorage": {
+          "target": "com.amazonaws.batch#EphemeralStorage",
+          "traits": {
+            "smithy.api#documentation": "<p>The amount of ephemeral storage allocated for the task. This parameter is used to expand the\n   total amount of ephemeral storage available, beyond the default amount, for tasks hosted on\n   Fargate.</p>"
+          }
+        },
+        "runtimePlatform": {
+          "target": "com.amazonaws.batch#RuntimePlatform",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that represents the compute environment architecture for Batch jobs on\n   Fargate.</p>"
+          }
+        },
+        "repositoryCredentials": {
+          "target": "com.amazonaws.batch#RepositoryCredentials",
+          "traits": {
+            "smithy.api#documentation": "<p>The private repository authentication credentials to use.</p>"
+          }
+        },
+        "enableExecuteCommand": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether execute command functionality is turned on for this task. If <code>true</code>, execute\n            command functionality is turned on all the containers in the task.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details of a container that's part of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#ContainerOverrides": {
+      "type": "structure",
+      "members": {
+        "vcpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#deprecated": {
+              "message": "This field is deprecated, use resourceRequirements instead."
+            },
+            "smithy.api#documentation": "<p>This parameter is deprecated, use <code>resourceRequirements</code> to override the\n    <code>vcpus</code> parameter that's set in the job definition. It's not supported for jobs\n   running on Fargate resources. For jobs that run on Amazon EC2 resources, it overrides the\n    <code>vcpus</code> parameter set in the job definition, but doesn't override any vCPU\n   requirement specified in the <code>resourceRequirements</code> structure in the job definition.\n   To override vCPU requirements that are specified in the <code>resourceRequirements</code>\n   structure in the job definition, <code>resourceRequirements</code> must be specified in the\n    <code>SubmitJob</code> request, with <code>type</code> set to <code>VCPU</code> and\n    <code>value</code> set to the new value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/troubleshooting.html#override-resource-requirements\">Can't override job\n    definition resource requirements</a> in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "memory": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#deprecated": {
+              "message": "This field is deprecated, use resourceRequirements instead."
+            },
+            "smithy.api#documentation": "<p>This parameter is deprecated, use <code>resourceRequirements</code> to override the memory\n   requirements specified in the job definition. It's not supported for jobs running on Fargate\n   resources. For jobs that run on Amazon EC2 resources, it overrides the <code>memory</code> parameter\n   set in the job definition, but doesn't override any memory requirement that's specified in the\n    <code>resourceRequirements</code> structure in the job definition. To override memory\n   requirements that are specified in the <code>resourceRequirements</code> structure in the job\n   definition, <code>resourceRequirements</code> must be specified in the <code>SubmitJob</code>\n   request, with <code>type</code> set to <code>MEMORY</code> and <code>value</code> set to the new\n   value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/troubleshooting.html#override-resource-requirements\">Can't override job\n    definition resource requirements</a> in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "command": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The command to send to the container that overrides the default command from the Docker\n   image or the job definition.</p>\n         <note>\n            <p>This parameter can't contain an empty string.</p>\n         </note>"
+          }
+        },
+        "instanceType": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The instance type to use for a multi-node parallel job.</p>\n         <note>\n            <p>This parameter isn't applicable to single-node container jobs or jobs that run on Fargate\n    resources, and shouldn't be provided.</p>\n         </note>"
+          }
+        },
+        "environment": {
+          "target": "com.amazonaws.batch#EnvironmentVariables",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables to send to the container. You can add new environment variables,\n   which are added to the container at launch, or you can override the existing environment\n   variables from the Docker image or the job definition.</p>\n         <note>\n            <p>Environment variables cannot start with \"<code>AWS_BATCH</code>\". This naming\n convention is reserved for variables that Batch sets.</p>\n         </note>"
+          }
+        },
+        "resourceRequirements": {
+          "target": "com.amazonaws.batch#ResourceRequirements",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and amount of resources to assign to a container. This overrides the settings in\n   the job definition. The supported resources include <code>GPU</code>, <code>MEMORY</code>, and\n    <code>VCPU</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The overrides that should be sent to a container.</p>\n         <p>For information about using Batch overrides when you connect event sources to targets, see\n    <a href=\"https://docs.aws.amazon.com/eventbridge/latest/pipes-reference/API_BatchContainerOverrides.html\">BatchContainerOverrides</a>.</p>"
+      }
+    },
+    "com.amazonaws.batch#ContainerProperties": {
+      "type": "structure",
+      "members": {
+        "image": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Required. The image used to start a container. This string is passed directly to the\n   Docker daemon. Images in the Docker Hub registry are available by default. Other repositories are\n   specified with\n     <code>\n               <i>repository-url</i>/<i>image</i>:<i>tag</i>\n            </code>.\n   It can be 255 characters long. It can contain uppercase and lowercase letters, numbers,\n hyphens (-), underscores (_), colons (:), periods (.), forward slashes (/), and number signs (#). This parameter maps to <code>Image</code> in the\n   <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the <code>IMAGE</code>\n   parameter of <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>.</p>\n         <note>\n            <p>Docker image architecture must match the processor architecture of the compute resources\n    that they're scheduled on. For example, ARM-based Docker images can only run on ARM-based\n    compute resources.</p>\n         </note>\n         <ul>\n            <li>\n               <p>Images in Amazon ECR Public repositories use the full <code>registry/repository[:tag]</code> or\n      <code>registry/repository[@digest]</code> naming conventions. For example,\n       <code>public.ecr.aws/<i>registry_alias</i>/<i>my-web-app</i>:<i>latest</i>\n                  </code>.</p>\n            </li>\n            <li>\n               <p>Images in Amazon ECR repositories use the full registry and repository URI (for example,\n      <code>123456789012.dkr.ecr.<region-name>.amazonaws.com/<repository-name></code>).</p>\n            </li>\n            <li>\n               <p>Images in official repositories on Docker Hub use a single name (for example,\n      <code>ubuntu</code> or <code>mongo</code>).</p>\n            </li>\n            <li>\n               <p>Images in other repositories on Docker Hub are qualified with an organization name (for\n     example, <code>amazon/amazon-ecs-agent</code>).</p>\n            </li>\n            <li>\n               <p>Images in other online repositories are qualified further by a domain name (for example,\n      <code>quay.io/assemblyline/ubuntu</code>).</p>\n            </li>\n         </ul>"
+          }
+        },
+        "vcpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#deprecated": {
+              "message": "This field is deprecated, use resourceRequirements instead."
+            },
+            "smithy.api#documentation": "<p>This parameter is deprecated, use <code>resourceRequirements</code> to specify the vCPU\n   requirements for the job definition. It's not supported for jobs running on Fargate resources.\n   For jobs running on Amazon EC2 resources, it specifies the number of vCPUs reserved for the\n   job.</p>\n         <p>Each vCPU is equivalent to 1,024 CPU shares. This parameter maps to <code>CpuShares</code>\n   in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the\n    <code>--cpu-shares</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. The\n   number of vCPUs must be specified but can be specified in several places. You must specify it at\n   least once for each node.</p>"
+          }
+        },
+        "memory": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#deprecated": {
+              "message": "This field is deprecated, use resourceRequirements instead."
+            },
+            "smithy.api#documentation": "<p>This parameter is deprecated, use <code>resourceRequirements</code> to specify the memory\n   requirements for the job definition. It's not supported for jobs running on Fargate resources.\n   For jobs that run on Amazon EC2 resources, it specifies the memory hard limit (in MiB) for a\n   container. If your container attempts to exceed the specified number, it's terminated. You must\n   specify at least 4 MiB of memory for a job using this parameter. The memory hard limit can be\n   specified in several places. It must be specified for each node at least once.</p>"
+          }
+        },
+        "command": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The command that's passed to the container. This parameter maps to <code>Cmd</code> in the\n   <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the <code>COMMAND</code>\n   parameter to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. For more information, see\n    <a href=\"https://docs.docker.com/engine/reference/builder/#cmd\">https://docs.docker.com/engine/reference/builder/#cmd</a>.</p>"
+          }
+        },
+        "jobRoleArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that the container can assume for Amazon Web Services permissions. For more\n   information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html\">IAM roles for tasks</a> in the\n    <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+          }
+        },
+        "executionRoleArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the execution role that Batch can assume. For jobs that run on Fargate\n   resources, you must provide an execution role. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html\">Batch execution IAM role</a>\n   in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "volumes": {
+          "target": "com.amazonaws.batch#Volumes",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of data volumes used in a job.</p>"
+          }
+        },
+        "environment": {
+          "target": "com.amazonaws.batch#EnvironmentVariables",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables to pass to a container. This parameter maps to <code>Env</code> in\n   the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the\n    <code>--env</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>.</p>\n         <important>\n            <p>We don't recommend using plaintext environment variables for sensitive information, such as\n    credential data.</p>\n         </important>\n         <note>\n            <p>Environment variables cannot start with \"<code>AWS_BATCH</code>\". This naming\n convention is reserved for variables that Batch sets.</p>\n         </note>"
+          }
+        },
+        "mountPoints": {
+          "target": "com.amazonaws.batch#MountPoints",
+          "traits": {
+            "smithy.api#documentation": "<p>The mount points for data volumes in your container. This parameter maps to\n    <code>Volumes</code> in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a>\n   and the <code>--volume</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker\n   run</a>.</p>"
+          }
+        },
+        "readonlyRootFilesystem": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is true, the container is given read-only access to its root file\n   system. This parameter maps to <code>ReadonlyRootfs</code> in the\n   <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the\n    <code>--read-only</code> option to <code>docker run</code>.</p>"
+          }
+        },
+        "privileged": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is true, the container is given elevated permissions on the host\n   container instance (similar to the <code>root</code> user). This parameter maps to\n    <code>Privileged</code> in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the\n   <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the <code>--privileged</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. The default value is false.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources and\n    shouldn't be provided, or specified as false.</p>\n         </note>"
+          }
+        },
+        "ulimits": {
+          "target": "com.amazonaws.batch#Ulimits",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ulimits</code> to set in the container. This parameter maps to\n    <code>Ulimits</code> in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a>\n   and the <code>--ulimit</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker\n   run</a>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources and\n    shouldn't be provided.</p>\n         </note>"
+          }
+        },
+        "user": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The user name to use inside the container. This parameter maps to <code>User</code> in the\n   <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the <code>--user</code>\n   option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>.</p>"
+          }
+        },
+        "instanceType": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The instance type to use for a multi-node parallel job. All node groups in a multi-node\n   parallel job must use the same instance type.</p>\n         <note>\n            <p>This parameter isn't applicable to single-node container jobs or jobs that run on Fargate\n    resources, and shouldn't be provided.</p>\n         </note>"
+          }
+        },
+        "resourceRequirements": {
+          "target": "com.amazonaws.batch#ResourceRequirements",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and amount of resources to assign to a container. The supported resources include\n    <code>GPU</code>, <code>MEMORY</code>, and <code>VCPU</code>.</p>"
+          }
+        },
+        "linuxParameters": {
+          "target": "com.amazonaws.batch#LinuxParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Linux-specific modifications that are applied to the container, such as details for device\n   mappings.</p>"
+          }
+        },
+        "logConfiguration": {
+          "target": "com.amazonaws.batch#LogConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The log configuration specification for the container.</p>\n         <p>This parameter maps to <code>LogConfig</code> in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a>\n   section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the <code>--log-driver</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. By default, containers use the same logging\n   driver that the Docker daemon uses. However the container might use a different logging driver\n   than the Docker daemon by specifying a log driver with this parameter in the container\n   definition. To use a different logging driver for a container, the log system must be configured\n   properly on the container instance (or on a different log server for remote logging options). For\n   more information on the options for different supported log drivers, see <a href=\"https://docs.docker.com/engine/admin/logging/overview/\">Configure logging drivers</a>\n   in the Docker documentation.</p>\n         <note>\n            <p>Batch currently supports a subset of the logging drivers available to the Docker daemon\n    (shown in the <a href=\"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-logconfiguration.html\">LogConfiguration</a> data type).</p>\n         </note>\n         <p>This parameter requires version 1.18 of the Docker Remote API or greater on your\n container instance. To check the Docker Remote API version on your container instance, log in to your\n container instance and run the following command: <code>sudo docker version | grep \"Server API version\"</code>\n         </p>\n         <note>\n            <p>The Amazon ECS container agent running on a container instance must register the logging drivers\n    available on that instance with the <code>ECS_AVAILABLE_LOGGING_DRIVERS</code> environment\n    variable before containers placed on that instance can use these log configuration options. For\n    more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html\">Amazon ECS container agent\n     configuration</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         </note>"
+          }
+        },
+        "secrets": {
+          "target": "com.amazonaws.batch#SecretList",
+          "traits": {
+            "smithy.api#documentation": "<p>The secrets for the container. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/specifying-sensitive-data.html\">Specifying sensitive data</a> in the\n    <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "networkConfiguration": {
+          "target": "com.amazonaws.batch#NetworkConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The network configuration for jobs that are running on Fargate resources. Jobs that are\n   running on Amazon EC2 resources must not specify this parameter.</p>"
+          }
+        },
+        "fargatePlatformConfiguration": {
+          "target": "com.amazonaws.batch#FargatePlatformConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The platform configuration for jobs that are running on Fargate resources. Jobs that are\n   running on Amazon EC2 resources must not specify this parameter.</p>"
+          }
+        },
+        "enableExecuteCommand": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether execute command functionality is turned on for this task. If <code>true</code>, execute\n            command functionality is turned on all the containers in the task.</p>"
+          }
+        },
+        "ephemeralStorage": {
+          "target": "com.amazonaws.batch#EphemeralStorage",
+          "traits": {
+            "smithy.api#documentation": "<p>The amount of ephemeral storage to allocate for the task. This parameter is used to expand\n   the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on\n   Fargate.</p>"
+          }
+        },
+        "runtimePlatform": {
+          "target": "com.amazonaws.batch#RuntimePlatform",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that represents the compute environment architecture for Batch jobs on\n   Fargate.</p>"
+          }
+        },
+        "repositoryCredentials": {
+          "target": "com.amazonaws.batch#RepositoryCredentials",
+          "traits": {
+            "smithy.api#documentation": "<p>The private repository authentication credentials to use.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Container properties are used for Amazon ECS based job definitions. These properties to describe the \n   container that's launched as part of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#ContainerSummary": {
+      "type": "structure",
+      "members": {
+        "exitCode": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The exit code to return upon completion.</p>"
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short (255 max characters) human-readable string to provide additional details for a\n   running or stopped container.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents summary details of a container within a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#CreateComputeEnvironment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#CreateComputeEnvironmentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#CreateComputeEnvironmentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an Batch compute environment. You can create <code>MANAGED</code> or\n        <code>UNMANAGED</code> compute environments. <code>MANAGED</code> compute environments can\n      use Amazon EC2 or Fargate resources. <code>UNMANAGED</code> compute environments can only use\n      EC2 resources.</p>\n         <p>In a managed compute environment, Batch manages the capacity and instance types of the\n      compute resources within the environment. This is based on the compute resource specification\n      that you define or the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html\">launch template</a> that you\n      specify when you create the compute environment. Either, you can choose to use EC2 On-Demand\n      Instances and EC2 Spot Instances. Or, you can use Fargate and Fargate Spot capacity in\n      your managed compute environment. You can optionally set a maximum price so that Spot\n      Instances only launch when the Spot Instance price is less than a specified percentage of the\n      On-Demand price.</p>\n         <p>In an unmanaged compute environment, you can manage your own EC2 compute resources and\n      have flexibility with how you configure your compute resources. For example, you can use\n      custom AMIs. However, you must verify that each of your AMIs meet the Amazon ECS container instance\n      AMI specification. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container_instance_AMIs.html\">container instance AMIs</a> in the\n        <i>Amazon Elastic Container Service Developer Guide</i>. After you created your unmanaged compute environment,\n      you can use the <a>DescribeComputeEnvironments</a> operation to find the Amazon ECS\n      cluster that's associated with it. Then, launch your container instances into that Amazon ECS\n      cluster. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html\">Launching an Amazon ECS container\n        instance</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <note>\n            <p>Batch doesn't automatically upgrade the AMIs in a compute environment after it's\n      created. For more information on how to update a compute environment's AMI, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the <i>Batch User Guide</i>.</p>\n         </note>",
+        "smithy.api#examples": [
+          {
+            "title": "To create a managed EC2 compute environment",
+            "documentation": "This example creates a managed compute environment with specific C4 instance types that are launched on demand. The compute environment is called C4OnDemand.",
+            "input": {
+              "computeEnvironmentName": "C4OnDemand",
+              "state": "ENABLED",
+              "type": "MANAGED",
+              "computeResources": {
+                "subnets": [
+                  "subnet-220c0e0a",
+                  "subnet-1a95556d",
+                  "subnet-978f6dce"
+                ],
+                "tags": {
+                  "Name": "Batch Instance - C4OnDemand"
+                },
+                "desiredvCpus": 48,
+                "minvCpus": 0,
+                "instanceTypes": [
+                  "c4.large",
+                  "c4.xlarge",
+                  "c4.2xlarge",
+                  "c4.4xlarge",
+                  "c4.8xlarge"
+                ],
+                "securityGroupIds": [
+                  "sg-cf5093b2"
+                ],
+                "instanceRole": "ecsInstanceRole",
+                "maxvCpus": 128,
+                "type": "EC2",
+                "ec2KeyPair": "id_rsa"
+              },
+              "serviceRole": "arn:aws:iam::012345678910:role/AWSBatchServiceRole"
+            },
+            "output": {
+              "computeEnvironmentName": "C4OnDemand",
+              "computeEnvironmentArn": "arn:aws:batch:us-east-1:012345678910:compute-environment/C4OnDemand"
+            }
+          },
+          {
+            "title": "To create a managed EC2 Spot compute environment",
+            "documentation": "This example creates a managed compute environment with the M4 instance type that is launched when the Spot bid price is at or below 20% of the On-Demand price for the instance type. The compute environment is called M4Spot.",
+            "input": {
+              "computeEnvironmentName": "M4Spot",
+              "state": "ENABLED",
+              "type": "MANAGED",
+              "computeResources": {
+                "subnets": [
+                  "subnet-220c0e0a",
+                  "subnet-1a95556d",
+                  "subnet-978f6dce"
+                ],
+                "type": "SPOT",
+                "spotIamFleetRole": "arn:aws:iam::012345678910:role/aws-ec2-spot-fleet-role",
+                "tags": {
+                  "Name": "Batch Instance - M4Spot"
+                },
+                "desiredvCpus": 4,
+                "minvCpus": 0,
+                "instanceTypes": [
+                  "m4"
+                ],
+                "securityGroupIds": [
+                  "sg-cf5093b2"
+                ],
+                "instanceRole": "ecsInstanceRole",
+                "maxvCpus": 128,
+                "bidPercentage": 20,
+                "ec2KeyPair": "id_rsa"
+              },
+              "serviceRole": "arn:aws:iam::012345678910:role/AWSBatchServiceRole"
+            },
+            "output": {
+              "computeEnvironmentName": "M4Spot",
+              "computeEnvironmentArn": "arn:aws:batch:us-east-1:012345678910:compute-environment/M4Spot"
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/createcomputeenvironment",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#CreateComputeEnvironmentRequest": {
+      "type": "structure",
+      "members": {
+        "computeEnvironmentName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name for your compute environment. It can be up to 128 characters long. It can contain uppercase and\n lowercase letters, numbers, hyphens (-), and underscores (_).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "type": {
+          "target": "com.amazonaws.batch#CEType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of the compute environment: <code>MANAGED</code> or <code>UNMANAGED</code>. For\n      more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html\">Compute Environments</a> in the <i>Batch User Guide</i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#CEState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the compute environment. A compute environment must be created in the\n      <code>ENABLED</code> state.</p>\n         <p>If the state is <code>ENABLED</code>, then the\n      compute environment accepts jobs from a queue and can scale out automatically based on\n      queues.</p>\n         <p>If the state is <code>ENABLED</code>, then the Batch scheduler can attempt to place jobs\n      from an associated job queue on the compute resources within the environment. If the compute\n      environment is managed, then it can scale its instances out or in automatically, based on the\n      job queue demand.</p>\n         <p>If the state is <code>DISABLED</code>, then the Batch scheduler doesn't attempt to place\n      jobs within the environment. Jobs in a <code>STARTING</code> or <code>RUNNING</code> state\n      continue to progress normally. Managed compute environments in the <code>DISABLED</code> state\n      don't scale out. </p>\n         <note>\n            <p>Compute environments in a <code>DISABLED</code> state may continue to incur billing\n        charges, for example, if they have running instances due to jobs that are still executing or a non-zero <code>minvCpus</code> setting. To prevent additional charges, disable and delete the compute environment.</p>\n         </note>\n         <p>When an instance is idle, the instance scales down to the <code>minvCpus</code> value.\n      However, the instance size doesn't change. For example, consider a <code>c5.8xlarge</code>\n      instance with a <code>minvCpus</code> value of <code>4</code> and a <code>desiredvCpus</code>\n      value of <code>36</code>. This instance doesn't scale down to a <code>c5.large</code>\n      instance.</p>"
+          }
+        },
+        "unmanagedvCpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of vCPUs for an unmanaged compute environment. This parameter is only\n      used for fair-share scheduling to reserve vCPU capacity for new share identifiers. If this\n      parameter isn't provided for a fair-share job queue, no vCPU capacity is reserved.</p>\n         <note>\n            <p>This parameter is only supported when the <code>type</code> parameter is set to\n          <code>UNMANAGED</code>.</p>\n         </note>"
+          }
+        },
+        "computeResources": {
+          "target": "com.amazonaws.batch#ComputeResource",
+          "traits": {
+            "smithy.api#documentation": "<p>Details about the compute resources managed by the compute environment. This parameter is\n      required for managed compute environments. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html\">Compute Environments</a>\n      in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "serviceRole": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The full Amazon Resource Name (ARN) of the IAM role that allows Batch to make calls to other Amazon Web Services\n      services on your behalf. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/service_IAM_role.html\">Batch service IAM role</a> in the\n        <i>Batch User Guide</i>.</p>\n         <important>\n            <p>If your account already created the Batch service-linked role, that role is used by\n        default for your compute environment unless you specify a different role here. If the\n        Batch service-linked role doesn't exist in your account, and no role is specified here,\n        the service attempts to create the Batch service-linked role in your account.</p>\n            <p>This automatic service-linked role creation only applies to <code>MANAGED</code> compute\n        environments. For <code>UNMANAGED</code> compute environments, you must explicitly specify a\n        <code>serviceRole</code>.</p>\n         </important>\n         <p>If your specified role has a path other than <code>/</code>, then you must specify either\n      the full role ARN (recommended) or prefix the role name with the path. For example, if a\n      role with the name <code>bar</code> has a path of <code>/foo/</code>, specify\n        <code>/foo/bar</code> as the role name. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-friendly-names\">Friendly\n        names and paths</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>Depending on how you created your Batch service role, its ARN might contain the\n          <code>service-role</code> path prefix. When you only specify the name of the service role,\n        Batch assumes that your ARN doesn't use the <code>service-role</code> path prefix. Because\n        of this, we recommend that you specify the full ARN of your service role when you create\n        compute environments.</p>\n         </note>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the compute environment to help you categorize and organize\n      your resources. Each tag consists of a key and an optional value. For more information, see\n        <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services\n        Resources</a> in <i>Amazon Web Services General Reference</i>.</p>\n         <p>These tags can be updated or removed using the <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_UntagResource.html\">UntagResource</a> API operations. These tags don't propagate to the underlying compute\n      resources.</p>"
+          }
+        },
+        "eksConfiguration": {
+          "target": "com.amazonaws.batch#EksConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The details for the Amazon EKS cluster that supports the compute environment.</p>\n         <note>\n            <p>To create a compute environment that uses EKS resources, the caller must have\n        permissions to call <code>eks:DescribeCluster</code>.</p>\n         </note>"
+          }
+        },
+        "context": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>CreateComputeEnvironment</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#CreateComputeEnvironmentResponse": {
+      "type": "structure",
+      "members": {
+        "computeEnvironmentName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the compute environment. It can be up to 128 characters long. It can contain uppercase and\n lowercase letters, numbers, hyphens (-), and underscores (_).</p>"
+          }
+        },
+        "computeEnvironmentArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the compute environment.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#CreateConsumableResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#CreateConsumableResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#CreateConsumableResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an Batch consumable resource.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To create a consumable resource",
+            "documentation": "Creates a Batch consumable resource.",
+            "input": {
+              "consumableResourceName": "myConsumableResource",
+              "totalQuantity": 123,
+              "resourceType": "REPLENISHABLE",
+              "tags": {
+                "Department": "Engineering",
+                "User": "JaneDoe"
+              }
+            },
+            "output": {
+              "consumableResourceName": "myConsumableResource",
+              "consumableResourceArn": "arn:aws:batch:us-east-1:012345678910:consumable-resource/myConsumableResource"
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/createconsumableresource",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#CreateConsumableResourceRequest": {
+      "type": "structure",
+      "members": {
+        "consumableResourceName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the consumable resource. Must be unique.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "totalQuantity": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The total amount of the consumable resource that is available. Must be non-negative.</p>"
+          }
+        },
+        "resourceType": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the resource is available to be re-used after a job completes. Can be \n            one of: </p>\n         <ul>\n            <li>\n               <p>\n                  <code>REPLENISHABLE</code> (default)</p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_REPLENISHABLE</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the consumable resource to help you categorize and organize your\n            resources. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using-tags.html\">Tagging your Batch resources</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#CreateConsumableResourceResponse": {
+      "type": "structure",
+      "members": {
+        "consumableResourceName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the consumable resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "consumableResourceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the consumable resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#CreateJobQueue": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#CreateJobQueueRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#CreateJobQueueResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an Batch job queue. When you create a job queue, you associate one or more\n      compute environments to the queue and assign an order of preference for the compute\n      environments.</p>\n         <p>You also set a priority to the job queue that determines the order that the Batch\n      scheduler places jobs onto its associated compute environments. For example, if a compute\n      environment is associated with more than one job queue, the job queue with a higher priority\n      is given preference for scheduling jobs to that compute environment.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To create a job queue with a single compute environment",
+            "documentation": "This example creates a job queue called LowPriority that uses the M4Spot compute environment.",
+            "input": {
+              "priority": 1,
+              "state": "ENABLED",
+              "computeEnvironmentOrder": [
+                {
+                  "computeEnvironment": "M4Spot",
+                  "order": 1
+                }
+              ],
+              "jobQueueName": "LowPriority"
+            },
+            "output": {
+              "jobQueueName": "LowPriority",
+              "jobQueueArn": "arn:aws:batch:us-east-1:012345678910:job-queue/LowPriority"
+            }
+          },
+          {
+            "title": "To create a job queue with multiple compute environments",
+            "documentation": "This example creates a job queue called HighPriority that uses the C4OnDemand compute environment with an order of 1 and the M4Spot compute environment with an order of 2.",
+            "input": {
+              "priority": 10,
+              "state": "ENABLED",
+              "computeEnvironmentOrder": [
+                {
+                  "computeEnvironment": "C4OnDemand",
+                  "order": 1
+                },
+                {
+                  "computeEnvironment": "M4Spot",
+                  "order": 2
+                }
+              ],
+              "jobQueueName": "HighPriority"
+            },
+            "output": {
+              "jobQueueName": "HighPriority",
+              "jobQueueArn": "arn:aws:batch:us-east-1:012345678910:job-queue/HighPriority"
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/createjobqueue",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#CreateJobQueueRequest": {
+      "type": "structure",
+      "members": {
+        "jobQueueName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the job queue. It can be up to 128 letters long. It can contain uppercase and\n      lowercase letters, numbers, hyphens (-), and underscores (_).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#JQState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the job queue. If the job queue state is <code>ENABLED</code>, it is able to\n      accept jobs. If the job queue state is <code>DISABLED</code>, new jobs can't be added to the\n      queue, but jobs already in the queue can finish.</p>"
+          }
+        },
+        "schedulingPolicyArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the fair-share scheduling policy. Job queues that don't have a fair-share scheduling policy are scheduled in a first-in, first-out (FIFO) model.  After a job queue has a fair-share scheduling policy, it can be replaced but can't be removed.</p>\n         <p>The format is\n          <code>aws:<i>Partition</i>:batch:<i>Region</i>:<i>Account</i>:scheduling-policy/<i>Name</i>\n            </code>.</p>\n         <p>An example is\n        <code>aws:aws:batch:us-west-2:123456789012:scheduling-policy/MySchedulingPolicy</code>.</p>\n         <p>A job queue without a fair-share scheduling policy is scheduled as a FIFO job queue and can't have a fair-share scheduling policy added. Jobs queues with a fair-share scheduling policy can have a maximum of 500 active share identifiers. When the limit has been reached, submissions of any jobs that add a new share identifier fail.</p>"
+          }
+        },
+        "priority": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The priority of the job queue. Job queues with a higher priority (or a higher integer\n      value for the <code>priority</code> parameter) are evaluated first when associated with the\n      same compute environment. Priority is determined in descending order. For example, a job queue\n      with a priority value of <code>10</code> is given scheduling preference over a job queue with\n      a priority value of <code>1</code>. All of the compute environments must be either EC2\n        (<code>EC2</code> or <code>SPOT</code>) or Fargate (<code>FARGATE</code> or\n        <code>FARGATE_SPOT</code>); EC2 and Fargate compute environments can't be mixed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "computeEnvironmentOrder": {
+          "target": "com.amazonaws.batch#ComputeEnvironmentOrders",
+          "traits": {
+            "smithy.api#documentation": "<p>The set of compute environments mapped to a job queue and their order relative to each\n      other. The job scheduler uses this parameter to determine which compute environment runs a\n      specific job. Compute environments must be in the <code>VALID</code> state before you can\n      associate them with a job queue. You can associate up to three compute environments with a job\n      queue. All of the compute environments must be either EC2 (<code>EC2</code> or\n        <code>SPOT</code>) or Fargate (<code>FARGATE</code> or <code>FARGATE_SPOT</code>); EC2 and\n      Fargate compute environments can't be mixed.</p>\n         <note>\n            <p>All compute environments that are associated with a job queue must share the same\n        architecture. Batch doesn't support mixing compute environment architecture types in a\n        single job queue.</p>\n         </note>"
+          }
+        },
+        "serviceEnvironmentOrder": {
+          "target": "com.amazonaws.batch#ServiceEnvironmentOrders",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of service environments that this job queue can use to allocate jobs. All serviceEnvironments must have the same type. A job queue can't have both a serviceEnvironmentOrder and a computeEnvironmentOrder field.</p>"
+          }
+        },
+        "jobQueueType": {
+          "target": "com.amazonaws.batch#JobQueueType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of job queue. For service jobs that run on SageMaker Training, this value is <code>SAGEMAKER_TRAINING</code>. For regular container jobs, this value is <code>EKS</code>, <code>ECS</code>, or <code>ECS_FARGATE</code> depending on the compute environment.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the job queue to help you categorize and organize your\n      resources. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using-tags.html\">Tagging your Batch resources</a>\n      in <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "jobStateTimeLimitActions": {
+          "target": "com.amazonaws.batch#JobStateTimeLimitActions",
+          "traits": {
+            "smithy.api#documentation": "<p>The set of actions that Batch performs on jobs that remain at the head of the job queue in the specified state longer than specified times. Batch will perform each action after <code>maxTimeSeconds</code> has passed. (<b>Note</b>: The minimum value for maxTimeSeconds is 600 (10 minutes) and its maximum value is 86,400 (24 hours).)</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>CreateJobQueue</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#CreateJobQueueResponse": {
+      "type": "structure",
+      "members": {
+        "jobQueueName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the job queue.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobQueueArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job queue.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#CreateQuotaShare": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#CreateQuotaShareRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#CreateQuotaShareResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an Batch quota share. Each quota share operates as a virtual queue with a configured compute capacity, resource sharing strategy, and borrow limits. </p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/createquotashare",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#CreateQuotaShareRequest": {
+      "type": "structure",
+      "members": {
+        "quotaShareName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the quota share. It can be up to 128 characters long. It can contain uppercase and\n      lowercase letters, numbers, hyphens (-), and underscores (_).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Batch job queue associated with the quota share. This can be the job queue name or ARN.\n    A job queue must be in the <code>VALID</code> state before you can associate it with a quota share.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "capacityLimits": {
+          "target": "com.amazonaws.batch#QuotaShareCapacityLimits",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list that specifies the quantity and type of compute capacity allocated to the quota share. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "resourceSharingConfiguration": {
+          "target": "com.amazonaws.batch#QuotaShareResourceSharingConfiguration",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies whether a quota share reserves, lends, or both lends and borrows idle compute capacity.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "preemptionConfiguration": {
+          "target": "com.amazonaws.batch#QuotaSharePreemptionConfiguration",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the preemption behavior for jobs in a quota share.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#QuotaShareState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the quota share. If the quota share is <code>ENABLED</code>, it is able to accept jobs.\n    If the quota share is <code>DISABLED</code>, new jobs won't be accepted but jobs already submitted can finish.\n    The default state is <code>ENABLED</code>.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the quota share to help you categorize and organize your\n      resources. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using-tags.html\">Tagging your Batch resources</a>\n      in <i>Batch User Guide</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#CreateQuotaShareResponse": {
+      "type": "structure",
+      "members": {
+        "quotaShareName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the quota share.</p>"
+          }
+        },
+        "quotaShareArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the quota share.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#CreateSchedulingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#CreateSchedulingPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#CreateSchedulingPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an Batch scheduling policy.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/createschedulingpolicy",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#CreateSchedulingPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the fair-share scheduling policy. It can be up to 128 letters long. It can contain\n      uppercase and lowercase letters, numbers, hyphens (-), and underscores (_).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "quotaSharePolicy": {
+          "target": "com.amazonaws.batch#QuotaSharePolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The quota share scheduling policy details. Only one of fairsharePolicy or quotaSharePolicy can be set.\n        Once set, this policy type cannot be removed or changed to a fairSharePolicy.</p>"
+          }
+        },
+        "fairsharePolicy": {
+          "target": "com.amazonaws.batch#FairsharePolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The fair-share scheduling policy details. Only one of fairsharePolicy or quotaSharePolicy can be set.\n    Once set, this policy type cannot be removed or changed to a quotaSharePolicy.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the scheduling policy to help you categorize and organize your\n      resources. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services\n        Resources</a> in <i>Amazon Web Services General Reference</i>.</p>\n         <p>These tags can be updated or removed using the <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_UntagResource.html\">UntagResource</a> API operations.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>CreateSchedulingPolicy</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#CreateSchedulingPolicyResponse": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the scheduling policy.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "arn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the scheduling policy. The format is\n          <code>aws:<i>Partition</i>:batch:<i>Region</i>:<i>Account</i>:scheduling-policy/<i>Name</i>\n            </code>.\n      For example,\n        <code>aws:aws:batch:us-west-2:123456789012:scheduling-policy/MySchedulingPolicy</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#CreateServiceEnvironment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#CreateServiceEnvironmentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#CreateServiceEnvironmentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a service environment for running service jobs. Service environments define capacity limits for specific service types such as SageMaker Training jobs.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/createserviceenvironment",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#CreateServiceEnvironmentRequest": {
+      "type": "structure",
+      "members": {
+        "serviceEnvironmentName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name for the service environment. It can be up to 128 characters long and can contain letters, numbers, hyphens (-), and underscores (_).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceEnvironmentType": {
+          "target": "com.amazonaws.batch#ServiceEnvironmentType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of service environment. For SageMaker Training jobs, specify <code>SAGEMAKER_TRAINING</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#ServiceEnvironmentState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the service environment. Valid values are <code>ENABLED</code> and <code>DISABLED</code>. The default value is <code>ENABLED</code>.</p>"
+          }
+        },
+        "capacityLimits": {
+          "target": "com.amazonaws.batch#CapacityLimits",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The capacity limits for the service environment. The number of instances a job consumes is the total number of instances requested in the submit training job request resource configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the service environment to help you categorize and organize your resources. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using-tags.html\">Tagging your Batch resources</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#CreateServiceEnvironmentResponse": {
+      "type": "structure",
+      "members": {
+        "serviceEnvironmentName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the service environment.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceEnvironmentArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the service environment.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteComputeEnvironment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DeleteComputeEnvironmentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DeleteComputeEnvironmentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an Batch compute environment.</p>\n         <p>Before you can delete a compute environment, you must set its state to\n        <code>DISABLED</code> with the <a>UpdateComputeEnvironment</a> API operation and\n      disassociate it from any job queues with the <a>UpdateJobQueue</a> API operation.\n      Compute environments that use Fargate resources must terminate all active jobs on that\n      compute environment before deleting the compute environment. If this isn't done, the compute\n      environment enters an invalid state.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To delete a compute environment",
+            "documentation": "This example deletes the P2OnDemand compute environment.",
+            "input": {
+              "computeEnvironment": "P2OnDemand"
+            },
+            "output": {}
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/deletecomputeenvironment",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DeleteComputeEnvironmentRequest": {
+      "type": "structure",
+      "members": {
+        "computeEnvironment": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or Amazon Resource Name (ARN) of the compute environment to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>DeleteComputeEnvironment</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteComputeEnvironmentResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteConsumableResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DeleteConsumableResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DeleteConsumableResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified consumable resource.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To delete a consumable resource",
+            "documentation": "Deletes the specified consumable resource.",
+            "input": {
+              "consumableResource": "myConsumableResource"
+            },
+            "output": {}
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/deleteconsumableresource",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DeleteConsumableResourceRequest": {
+      "type": "structure",
+      "members": {
+        "consumableResource": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or ARN of the consumable resource that will be deleted.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteConsumableResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteJobQueue": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DeleteJobQueueRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DeleteJobQueueResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified job queue. You must first disable submissions for a queue with the\n        <a>UpdateJobQueue</a> operation. All jobs in the queue are eventually terminated\n      when you delete a job queue.</p>\n         <p>It's not necessary to disassociate compute environments from a queue before submitting a\n        <code>DeleteJobQueue</code> request.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To delete a job queue",
+            "documentation": "This example deletes the GPGPU job queue.",
+            "input": {
+              "jobQueue": "GPGPU"
+            },
+            "output": {}
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/deletejobqueue",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DeleteJobQueueRequest": {
+      "type": "structure",
+      "members": {
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The short name or full Amazon Resource Name (ARN) of the queue to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>DeleteJobQueue</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteJobQueueResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteQuotaShare": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DeleteQuotaShareRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DeleteQuotaShareResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified quota share. You must first disable submissions for the share by\n      updating the state to <code>DISABLED</code> using the <a>UpdateQuotaShare</a> operation.\n      All jobs in the share are eventually terminated when you delete a quota share.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/deletequotashare",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DeleteQuotaShareRequest": {
+      "type": "structure",
+      "members": {
+        "quotaShareArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the quota share.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteQuotaShareResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteSchedulingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DeleteSchedulingPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DeleteSchedulingPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified scheduling policy.</p>\n         <p>You can't delete a scheduling policy that's used in any job queues.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/deleteschedulingpolicy",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DeleteSchedulingPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "arn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the scheduling policy to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>DeleteSchedulingPolicy</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteSchedulingPolicyResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteServiceEnvironment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DeleteServiceEnvironmentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DeleteServiceEnvironmentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a Service environment. Before you can delete a service environment, you must first set its state to <code>DISABLED</code> with the <code>UpdateServiceEnvironment</code> API operation and disassociate it from any job queues with the <code>UpdateJobQueue</code> API operation.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/deleteserviceenvironment",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DeleteServiceEnvironmentRequest": {
+      "type": "structure",
+      "members": {
+        "serviceEnvironment": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or ARN of the service environment to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DeleteServiceEnvironmentResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DeregisterJobDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DeregisterJobDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DeregisterJobDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deregisters an Batch job definition. Job definitions are permanently deleted after 180\n      days.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To deregister a job definition",
+            "documentation": "This example deregisters a job definition called sleep10.",
+            "input": {
+              "jobDefinition": "sleep10"
+            },
+            "output": {}
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/deregisterjobdefinition",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DeregisterJobDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "jobDefinition": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name and revision (<code>name:revision</code>) or full Amazon Resource Name (ARN) of the job definition\n      to deregister.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DeregisterJobDefinitionResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeComputeEnvironments": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DescribeComputeEnvironmentsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DescribeComputeEnvironmentsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Describes one or more of your compute environments.</p>\n         <p>If you're using an unmanaged compute environment, you can use the\n        <code>DescribeComputeEnvironment</code> operation to determine the\n        <code>ecsClusterArn</code> that you launch your Amazon ECS container instances into.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To describe a compute environment",
+            "documentation": "This example describes the P2OnDemand compute environment.",
+            "input": {
+              "computeEnvironments": [
+                "P2OnDemand"
+              ]
+            },
+            "output": {
+              "computeEnvironments": [
+                {
+                  "computeEnvironmentName": "P2OnDemand",
+                  "computeEnvironmentArn": "arn:aws:batch:us-east-1:012345678910:compute-environment/P2OnDemand",
+                  "ecsClusterArn": "arn:aws:ecs:us-east-1:012345678910:cluster/P2OnDemand_Batch_2c06f29d-d1fe-3a49-879d-42394c86effc",
+                  "type": "MANAGED",
+                  "state": "ENABLED",
+                  "status": "VALID",
+                  "statusReason": "ComputeEnvironment Healthy",
+                  "computeResources": {
+                    "type": "EC2",
+                    "minvCpus": 0,
+                    "maxvCpus": 128,
+                    "desiredvCpus": 48,
+                    "instanceTypes": [
+                      "p2"
+                    ],
+                    "subnets": [
+                      "subnet-220c0e0a",
+                      "subnet-1a95556d",
+                      "subnet-978f6dce"
+                    ],
+                    "securityGroupIds": [
+                      "sg-cf5093b2"
+                    ],
+                    "ec2KeyPair": "id_rsa",
+                    "instanceRole": "ecsInstanceRole",
+                    "tags": {
+                      "Name": "Batch Instance - P2OnDemand"
+                    }
+                  },
+                  "serviceRole": "arn:aws:iam::012345678910:role/AWSBatchServiceRole"
+                }
+              ]
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/describecomputeenvironments",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "computeEnvironments",
+          "pageSize": "maxResults"
+        },
+        "smithy.test#smokeTests": [
+          {
+            "id": "DescribeComputeEnvironmentsSuccess",
+            "params": {},
+            "vendorParams": {
+              "region": "us-west-2"
+            },
+            "vendorParamsShape": "aws.test#AwsVendorParams",
+            "expect": {
+              "success": {}
+            }
+          }
+        ]
+      }
+    },
+    "com.amazonaws.batch#DescribeComputeEnvironmentsRequest": {
+      "type": "structure",
+      "members": {
+        "computeEnvironments": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of up to 100 compute environment names or full Amazon Resource Name (ARN) entries.</p>"
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of cluster results returned by <code>DescribeComputeEnvironments</code>\n      in paginated output. When this parameter is used, <code>DescribeComputeEnvironments</code>\n      only returns <code>maxResults</code> results in a single page along with a\n        <code>nextToken</code> response element. The remaining results of the initial request can be\n      seen by sending another <code>DescribeComputeEnvironments</code> request with the returned\n        <code>nextToken</code> value. This value can be between 1 and\n      100. If this parameter isn't used, then <code>DescribeComputeEnvironments</code>\n      returns up to 100 results and a <code>nextToken</code> value if\n      applicable.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value returned from a previous paginated\n        <code>DescribeComputeEnvironments</code> request where <code>maxResults</code> was used and\n      the results exceeded the value of that parameter. Pagination continues from the end of the\n      previous results that returned the <code>nextToken</code> value. This value is\n        <code>null</code> when there are no more results to return.</p>\n         <note>\n            <p>Treat this token as an opaque identifier that's only used to\n retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>DescribeComputeEnvironments</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeComputeEnvironmentsResponse": {
+      "type": "structure",
+      "members": {
+        "computeEnvironments": {
+          "target": "com.amazonaws.batch#ComputeEnvironmentDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of compute environments.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future\n        <code>DescribeComputeEnvironments</code> request. When the results of a\n        <code>DescribeComputeEnvironments</code> request exceed <code>maxResults</code>, this value\n      can be used to retrieve the next page of results. This value is <code>null</code> when there\n      are no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeConsumableResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DescribeConsumableResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DescribeConsumableResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a description of the specified consumable resource.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To get a description of a consumable resource",
+            "documentation": "Returns a description of the specified consumable resource.",
+            "input": {
+              "consumableResource": "myConsumableResource"
+            },
+            "output": {
+              "consumableResourceName": "myConsumableResource",
+              "consumableResourceArn": "arn:aws:batch:us-east-1:012345678910:consumable-resource/myConsumableResource",
+              "totalQuantity": 123,
+              "inUseQuantity": 123,
+              "availableQuantity": 123,
+              "resourceType": "REPLENISHABLE",
+              "createdAt": 123,
+              "tags": {
+                "Department": "Engineering",
+                "User": "JaneDoe"
+              }
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/describeconsumableresource",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DescribeConsumableResourceRequest": {
+      "type": "structure",
+      "members": {
+        "consumableResource": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or ARN of the consumable resource whose description will be returned.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeConsumableResourceResponse": {
+      "type": "structure",
+      "members": {
+        "consumableResourceName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the consumable resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "consumableResourceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the consumable resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "totalQuantity": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The total amount of the consumable resource that is available.</p>"
+          }
+        },
+        "inUseQuantity": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The amount of the consumable resource that is currently in use.</p>"
+          }
+        },
+        "availableQuantity": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The amount of the consumable resource that is currently available to use.</p>"
+          }
+        },
+        "resourceType": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the resource is available to be re-used after a job completes. Can be \n            one of: </p>\n         <ul>\n            <li>\n               <p>\n                  <code>REPLENISHABLE</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>NON_REPLENISHABLE</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "createdAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the consumable resource was created.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the consumable resource to help you categorize and organize your\n            resources. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using-tags.html\">Tagging your Batch resources</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeJobDefinitions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DescribeJobDefinitionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DescribeJobDefinitionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Describes a list of job definitions. You can specify a <code>status</code> (such as\n        <code>ACTIVE</code>) to only return job definitions that match that status.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To describe active job definitions",
+            "documentation": "This example describes all of your active job definitions.",
+            "input": {
+              "status": "ACTIVE"
+            },
+            "output": {
+              "jobDefinitions": [
+                {
+                  "jobDefinitionName": "sleep60",
+                  "jobDefinitionArn": "arn:aws:batch:us-east-1:012345678910:job-definition/sleep60:1",
+                  "revision": 1,
+                  "status": "ACTIVE",
+                  "type": "container",
+                  "containerProperties": {
+                    "image": "busybox",
+                    "resourceRequirements": [
+                      {
+                        "type": "MEMORY",
+                        "value": "128"
+                      },
+                      {
+                        "type": "VCPU",
+                        "value": "1"
+                      }
+                    ],
+                    "command": [
+                      "sleep",
+                      "60"
+                    ],
+                    "volumes": [],
+                    "environment": [],
+                    "mountPoints": [],
+                    "ulimits": []
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/describejobdefinitions",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "jobDefinitions",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.batch#DescribeJobDefinitionsRequest": {
+      "type": "structure",
+      "members": {
+        "jobDefinitions": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of up to 100 job definitions. Each entry in the list can either be an ARN in the\n      format\n        <code>arn:aws:batch:${Region}:${Account}:job-definition/${JobDefinitionName}:${Revision}</code>\n      or a short version using the form <code>${JobDefinitionName}:${Revision}</code>. This\n      parameter can't be used with other parameters.</p>"
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results returned by <code>DescribeJobDefinitions</code> in paginated\n      output. When this parameter is used, <code>DescribeJobDefinitions</code> only returns\n        <code>maxResults</code> results in a single page and a <code>nextToken</code> response\n      element. The remaining results of the initial request can be seen by sending another\n        <code>DescribeJobDefinitions</code> request with the returned <code>nextToken</code> value.\n      This value can be between 1 and 100. If this parameter isn't\n      used, then <code>DescribeJobDefinitions</code> returns up to 100 results and\n      a <code>nextToken</code> value if applicable.</p>"
+          }
+        },
+        "jobDefinitionName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the job definition to describe.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The status used to filter job definitions.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value returned from a previous paginated\n        <code>DescribeJobDefinitions</code> request where <code>maxResults</code> was used and the\n      results exceeded the value of that parameter. Pagination continues from the end of the\n      previous results that returned the <code>nextToken</code> value. This value is\n        <code>null</code> when there are no more results to return.</p>\n         <note>\n            <p>Treat this token as an opaque identifier that's only used to\n retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>DescribeJobDefinitions</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeJobDefinitionsResponse": {
+      "type": "structure",
+      "members": {
+        "jobDefinitions": {
+          "target": "com.amazonaws.batch#JobDefinitionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of job definitions.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future\n        <code>DescribeJobDefinitions</code> request. When the results of a\n        <code>DescribeJobDefinitions</code> request exceed <code>maxResults</code>, this value can\n      be used to retrieve the next page of results. This value is <code>null</code> when there are\n      no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeJobQueues": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DescribeJobQueuesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DescribeJobQueuesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Describes one or more of your job queues.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To describe a job queue",
+            "documentation": "This example describes the HighPriority job queue.",
+            "input": {
+              "jobQueues": [
+                "HighPriority"
+              ]
+            },
+            "output": {
+              "jobQueues": [
+                {
+                  "jobQueueName": "HighPriority",
+                  "jobQueueArn": "arn:aws:batch:us-east-1:012345678910:job-queue/HighPriority",
+                  "state": "ENABLED",
+                  "status": "VALID",
+                  "statusReason": "JobQueue Healthy",
+                  "priority": 1,
+                  "computeEnvironmentOrder": [
+                    {
+                      "order": 1,
+                      "computeEnvironment": "arn:aws:batch:us-east-1:012345678910:compute-environment/C4OnDemand"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/describejobqueues",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "jobQueues",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.batch#DescribeJobQueuesRequest": {
+      "type": "structure",
+      "members": {
+        "jobQueues": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of up to 100 queue names or full queue Amazon Resource Name (ARN) entries.</p>"
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results returned by <code>DescribeJobQueues</code> in paginated\n      output. When this parameter is used, <code>DescribeJobQueues</code> only returns\n        <code>maxResults</code> results in a single page and a <code>nextToken</code> response\n      element. The remaining results of the initial request can be seen by sending another\n        <code>DescribeJobQueues</code> request with the returned <code>nextToken</code> value. This\n      value can be between 1 and 100. If this parameter isn't used,\n      then <code>DescribeJobQueues</code> returns up to 100 results and a\n        <code>nextToken</code> value if applicable.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value returned from a previous paginated\n        <code>DescribeJobQueues</code> request where <code>maxResults</code> was used and the\n      results exceeded the value of that parameter. Pagination continues from the end of the\n      previous results that returned the <code>nextToken</code> value. This value is\n        <code>null</code> when there are no more results to return.</p>\n         <note>\n            <p>Treat this token as an opaque identifier that's only used to\n retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>DescribeJobQueues</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeJobQueuesResponse": {
+      "type": "structure",
+      "members": {
+        "jobQueues": {
+          "target": "com.amazonaws.batch#JobQueueDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of job queues.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future <code>DescribeJobQueues</code>\n      request. When the results of a <code>DescribeJobQueues</code> request exceed\n        <code>maxResults</code>, this value can be used to retrieve the next page of results. This\n      value is <code>null</code> when there are no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DescribeJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DescribeJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Describes a list of Batch jobs.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To describe a specific job",
+            "documentation": "This example describes a job with the specified job ID.",
+            "input": {
+              "jobs": [
+                "24fa2d7a-64c4-49d2-8b47-f8da4fbde8e9"
+              ]
+            },
+            "output": {
+              "jobs": [
+                {
+                  "jobName": "example",
+                  "jobId": "24fa2d7a-64c4-49d2-8b47-f8da4fbde8e9",
+                  "jobQueue": "arn:aws:batch:us-east-1:012345678910:job-queue/HighPriority",
+                  "status": "SUCCEEDED",
+                  "createdAt": 1480460782010,
+                  "startedAt": 1480460816500,
+                  "stoppedAt": 1480460880699,
+                  "dependsOn": [],
+                  "jobDefinition": "sleep60",
+                  "parameters": {},
+                  "container": {
+                    "image": "busybox",
+                    "vcpus": 1,
+                    "memory": 128,
+                    "command": [
+                      "sleep",
+                      "60"
+                    ],
+                    "volumes": [],
+                    "environment": [],
+                    "mountPoints": [],
+                    "ulimits": [],
+                    "exitCode": 0,
+                    "containerInstanceArn": "arn:aws:ecs:us-east-1:012345678910:container-instance/5406d7cd-58bd-4b8f-9936-48d7c6b1526c"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/describejobs",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DescribeJobsRequest": {
+      "type": "structure",
+      "members": {
+        "jobs": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of up to 100 job IDs.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>DescribeJobs</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeJobsResponse": {
+      "type": "structure",
+      "members": {
+        "jobs": {
+          "target": "com.amazonaws.batch#JobDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of jobs.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeQuotaShare": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DescribeQuotaShareRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DescribeQuotaShareResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a description of the specified quota share.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/describequotashare",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DescribeQuotaShareRequest": {
+      "type": "structure",
+      "members": {
+        "quotaShareArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the quota share.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeQuotaShareResponse": {
+      "type": "structure",
+      "members": {
+        "quotaShareName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the quota share.</p>"
+          }
+        },
+        "quotaShareArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the quota share.</p>"
+          }
+        },
+        "jobQueueArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the job queue associated with the quota share.</p>"
+          }
+        },
+        "capacityLimits": {
+          "target": "com.amazonaws.batch#QuotaShareCapacityLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that specifies the quantity and type of compute capacity allocated to the quota share.</p>"
+          }
+        },
+        "resourceSharingConfiguration": {
+          "target": "com.amazonaws.batch#QuotaShareResourceSharingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a quota share reserves, lends, or both lends and borrows idle compute capacity.</p>"
+          }
+        },
+        "preemptionConfiguration": {
+          "target": "com.amazonaws.batch#QuotaSharePreemptionConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the preemption behavior for jobs in a quota share.</p>"
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#QuotaShareState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the quota share.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#QuotaShareStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the quota share.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags applied to the quota share.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeSchedulingPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DescribeSchedulingPoliciesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DescribeSchedulingPoliciesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Describes one or more of your scheduling policies.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/describeschedulingpolicies",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DescribeSchedulingPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "arns": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of up to 100 scheduling policy Amazon Resource Name (ARN) entries.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>DescribeSchedulingPolicies</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeSchedulingPoliciesResponse": {
+      "type": "structure",
+      "members": {
+        "schedulingPolicies": {
+          "target": "com.amazonaws.batch#SchedulingPolicyDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of scheduling policies.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeServiceEnvironments": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DescribeServiceEnvironmentsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DescribeServiceEnvironmentsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Describes one or more of your service environments.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/describeserviceenvironments",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "serviceEnvironments",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.batch#DescribeServiceEnvironmentsRequest": {
+      "type": "structure",
+      "members": {
+        "serviceEnvironments": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of service environment names or ARN entries.</p>"
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results returned by <code>DescribeServiceEnvironments</code> in paginated output. When this parameter is used, <code>DescribeServiceEnvironments</code> only returns <code>maxResults</code> results in a single page and a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>DescribeServiceEnvironments</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter isn't used, then <code>DescribeServiceEnvironments</code> returns up to 100 results and a <code>nextToken</code> value if applicable.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value returned from a previous paginated <code>DescribeServiceEnvironments</code> request where <code>maxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>nextToken</code> value. This value is <code>null</code> when there are no more results to return.</p>\n         <note>\n            <p>Treat this token as an opaque identifier that's only used to\n retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeServiceEnvironmentsResponse": {
+      "type": "structure",
+      "members": {
+        "serviceEnvironments": {
+          "target": "com.amazonaws.batch#ServiceEnvironmentDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of service environments that match the request.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future <code>DescribeServiceEnvironments</code> request. When the results of a <code>DescribeServiceEnvironments</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeServiceJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#DescribeServiceJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#DescribeServiceJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>The details of a service job.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/describeservicejob",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#DescribeServiceJobRequest": {
+      "type": "structure",
+      "members": {
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job ID for the service job to describe.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#DescribeServiceJobResponse": {
+      "type": "structure",
+      "members": {
+        "attempts": {
+          "target": "com.amazonaws.batch#ServiceJobAttemptDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of job attempts associated with the service job.</p>"
+          }
+        },
+        "capacityUsage": {
+          "target": "com.amazonaws.batch#ServiceJobCapacityUsageDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>The configured capacity for the service job, such as the number of instances. The\n            number of instances should be the same value as the\n                <code>serviceRequestPayload.InstanceCount</code> field.</p>"
+          }
+        },
+        "createdAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job was created.</p>"
+          }
+        },
+        "isTerminated": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the service job has been terminated.</p>"
+          }
+        },
+        "jobArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the service job.</p>"
+          }
+        },
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job ID for the service job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the service job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ARN of the job queue that the service job is associated with.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "latestAttempt": {
+          "target": "com.amazonaws.batch#LatestServiceJobAttempt",
+          "traits": {
+            "smithy.api#documentation": "<p>The latest attempt associated with the service job.</p>"
+          }
+        },
+        "retryStrategy": {
+          "target": "com.amazonaws.batch#ServiceJobRetryStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The retry strategy to use for failed service jobs that are submitted with this service job.</p>"
+          }
+        },
+        "scheduledAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job was scheduled. This\n            represents when the service job was dispatched to SageMaker and the service job transitioned to the\n                <code>SCHEDULED</code> state.</p>"
+          }
+        },
+        "schedulingPriority": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The scheduling priority of the service job. </p>"
+          }
+        },
+        "serviceRequestPayload": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The request, in JSON, for the service that the <code>SubmitServiceJob</code> operation is queueing. </p>"
+          }
+        },
+        "serviceJobType": {
+          "target": "com.amazonaws.batch#ServiceJobType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of service job. For SageMaker Training jobs, this value is <code>SAGEMAKER_TRAINING</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "shareIdentifier": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The share identifier for the service job. This is used for fair-share scheduling.</p>"
+          }
+        },
+        "quotaShareName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the quota share that the service job is associated with.</p>"
+          }
+        },
+        "preemptionConfiguration": {
+          "target": "com.amazonaws.batch#ServiceJobPreemptionConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the service job behavior when preempted.</p>"
+          }
+        },
+        "preemptionSummary": {
+          "target": "com.amazonaws.batch#ServiceJobPreemptionSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>Summarizes the preemptions of the service job. This field appears on a service job\n        when it has been preempted.</p>"
+          }
+        },
+        "startedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job was started.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#ServiceJobStatus",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The current status of the service job. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short, human-readable string to provide more details for the current status of the service job.</p>"
+          }
+        },
+        "stoppedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job stopped running.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that are associated with the service job. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using-tags.html\">Tagging your Batch resources</a>.</p>"
+          }
+        },
+        "timeoutConfig": {
+          "target": "com.amazonaws.batch#ServiceJobTimeout",
+          "traits": {
+            "smithy.api#documentation": "<p>The timeout configuration for the service job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#Device": {
+      "type": "structure",
+      "members": {
+        "hostPath": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The path for the device on the host container instance.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "containerPath": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The path inside the container that's used to expose the host device. By default, the\n    <code>hostPath</code> value is used.</p>"
+          }
+        },
+        "permissions": {
+          "target": "com.amazonaws.batch#DeviceCgroupPermissions",
+          "traits": {
+            "smithy.api#documentation": "<p>The explicit permissions to provide to the container for the device. By default, the\n   container has permissions for <code>read</code>, <code>write</code>, and <code>mknod</code> for\n   the device.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents a container instance host device.</p>\n         <note>\n            <p>This object isn't applicable to jobs that are running on Fargate resources and shouldn't\n    be provided.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.batch#DeviceCgroupPermission": {
+      "type": "enum",
+      "members": {
+        "READ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "READ"
+          }
+        },
+        "WRITE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WRITE"
+          }
+        },
+        "MKNOD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MKNOD"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#DeviceCgroupPermissions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#DeviceCgroupPermission"
+      }
+    },
+    "com.amazonaws.batch#DevicesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#Device"
+      }
+    },
+    "com.amazonaws.batch#Double": {
+      "type": "double"
+    },
+    "com.amazonaws.batch#EFSAuthorizationConfig": {
+      "type": "structure",
+      "members": {
+        "accessPointId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EFS access point ID to use. If an access point is specified, the root directory value\n   specified in the <code>EFSVolumeConfiguration</code> must either be omitted or set to\n    <code>/</code> which enforces the path set on the EFS access point. If an access point is used,\n   transit encryption must be enabled in the <code>EFSVolumeConfiguration</code>. For more\n   information, see <a href=\"https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html\">Working\n    with Amazon EFS access points</a> in the <i>Amazon Elastic File System User Guide</i>.</p>"
+          }
+        },
+        "iam": {
+          "target": "com.amazonaws.batch#EFSAuthorizationConfigIAM",
+          "traits": {
+            "smithy.api#documentation": "<p>Whether or not to use the Batch job IAM role defined in a job definition when mounting the\n   Amazon EFS file system. If enabled, transit encryption must be enabled in the\n    <code>EFSVolumeConfiguration</code>. If this parameter is omitted, the default value of\n    <code>DISABLED</code> is used. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/efs-volumes.html#efs-volume-accesspoints\">Using Amazon EFS access points</a> in\n   the <i>Batch User Guide</i>. EFS IAM authorization requires that\n    <code>TransitEncryption</code> be <code>ENABLED</code> and that a <code>JobRoleArn</code> is\n   specified.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The authorization configuration details for the Amazon EFS file system.</p>"
+      }
+    },
+    "com.amazonaws.batch#EFSAuthorizationConfigIAM": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#EFSTransitEncryption": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#EFSVolumeConfiguration": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon EFS file system ID to use.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "rootDirectory": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The directory within the Amazon EFS file system to mount as the root directory inside the host.\n   If this parameter is omitted, the root of the Amazon EFS volume is used instead. Specifying\n    <code>/</code> has the same effect as omitting this parameter. The maximum length is 4,096\n   characters.</p>\n         <important>\n            <p>If an EFS access point is specified in the <code>authorizationConfig</code>, the root\n    directory parameter must either be omitted or set to <code>/</code>, which enforces the path set\n    on the Amazon EFS access point.</p>\n         </important>"
+          }
+        },
+        "transitEncryption": {
+          "target": "com.amazonaws.batch#EFSTransitEncryption",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether to enable encryption for Amazon EFS data in transit between the Amazon ECS host and\n   the Amazon EFS server. Transit encryption must be enabled if Amazon EFS IAM authorization is used. If\n   this parameter is omitted, the default value of <code>DISABLED</code> is used. For more\n   information, see <a href=\"https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html\">Encrypting data in transit</a> in the <i>Amazon Elastic File System User Guide</i>.</p>"
+          }
+        },
+        "transitEncryptionPort": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The port to use when sending encrypted data between the Amazon ECS host and the Amazon EFS server. If\n   you don't specify a transit encryption port, it uses the port selection strategy that the Amazon EFS\n   mount helper uses. The value must be between 0 and 65,535. For more information, see <a href=\"https://docs.aws.amazon.com/efs/latest/ug/efs-mount-helper.html\">EFS mount helper</a> in the\n    <i>Amazon Elastic File System User Guide</i>.</p>"
+          }
+        },
+        "authorizationConfig": {
+          "target": "com.amazonaws.batch#EFSAuthorizationConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization configuration details for the Amazon EFS file system.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This is used when you're using an Amazon Elastic File System file system for job storage. For more\n   information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/efs-volumes.html\">Amazon EFS\n    Volumes</a> in the <i>Batch User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#Ec2Configuration": {
+      "type": "structure",
+      "members": {
+        "imageType": {
+          "target": "com.amazonaws.batch#ImageType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The image type to match with the instance type to select an AMI. The supported values are\n   different for <code>ECS</code> and <code>EKS</code> resources.</p>\n         <dl>\n            <dt>ECS</dt>\n            <dd>\n               <p>If the <code>imageIdOverride</code> parameter isn't specified, then a recent <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html\">Amazon ECS-optimized Amazon Linux 2023 AMI</a> (<code>ECS_AL2023</code>) is used. If a new image type is\n      specified in an update, but neither an <code>imageId</code> nor a <code>imageIdOverride</code>\n      parameter is specified, then the latest Amazon ECS optimized AMI for that image type that's\n      supported by Batch is used.</p>\n               <important>\n                  <p>Amazon Web Services is ending support for Amazon ECS Amazon Linux 2-optimized and accelerated AMIs on June 30,\n       2026. On January 12, 2026, Batch changed the default AMI for new Amazon ECS compute environments\n       from Amazon Linux 2 to Amazon Linux 2023. Effective June 30, 2026, Batch will block creation\n       of new Amazon ECS compute environments using Batch-provided Amazon Linux 2 AMIs. We strongly recommend\n       migrating your existing Batch Amazon ECS compute environments to Amazon Linux 2023 prior to June 30,\n       2026. For more information on upgrading from AL2 to AL2023, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/ecs-migration-2023.html\">How to migrate\n        from ECS AL2 to ECS AL2023</a> in the <i>Batch User Guide</i>.</p>\n               </important>\n               <dl>\n                  <dt>ECS_AL2</dt>\n                  <dd>\n                     <p>\n                        <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html\">Amazon Linux\n         2</a>: Used for non-GPU instance families.</p>\n                  </dd>\n                  <dt>ECS_AL2_NVIDIA</dt>\n                  <dd>\n                     <p>\n                        <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#gpuami\">Amazon Linux 2\n          (GPU)</a>: Used for GPU instance families (for example <code>P4</code> and\n          <code>G4</code>) and non Amazon Web Services Graviton-based instance types.</p>\n                  </dd>\n                  <dt>ECS_AL2023</dt>\n                  <dd>\n                     <p>\n                        <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html\">Amazon Linux 2023</a>: Default \n         for all non-GPU instance families.</p>\n                     <note>\n                        <p>Amazon Linux 2023 does not support <code>A1</code> instances.</p>\n                     </note>\n                  </dd>\n                  <dt>ECS_AL2023_NVIDIA</dt>\n                  <dd>\n                     <p>\n                        <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#gpuami\">Amazon Linux 2023\n          (GPU)</a>: Default for all GPU instance families and can be used for all non Amazon Web Services Graviton-based instance types.</p>\n                     <note>\n                        <p>ECS_AL2023_NVIDIA doesn't support <code>p3</code> and <code>g3</code> instance types.</p>\n                     </note>\n                  </dd>\n               </dl>\n            </dd>\n            <dt>EKS</dt>\n            <dd>\n               <p>If the <code>imageIdOverride</code> parameter isn't specified, then a recent <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\">Amazon EKS-optimized Amazon Linux 2023\n       AMI</a> (<code>EKS_AL2023</code>) is used. If a new image type is specified in an update,\n      but neither an <code>imageId</code> nor a <code>imageIdOverride</code> parameter is specified,\n      then the latest Amazon EKS optimized AMI for that image type that Batch supports is used.</p>\n               <important>\n                  <p>Amazon Linux 2023 AMIs are the\n       default on Batch for Amazon EKS.</p>\n                  <p>Amazon Web Services ended support for Amazon EKS AL2-optimized and AL2-accelerated AMIs on November 26,\n       2025. Batch Amazon EKS compute environments using Amazon Linux 2 will no longer receive software\n       updates, security patches, or bug fixes from Amazon Web Services. We recommend migrating to Amazon Linux\n       2023. For more information on upgrading from AL2 to AL2023, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/eks-migration-2023.html\">How to upgrade from EKS AL2 to EKS AL2023</a> in the <i>Batch User Guide</i>.</p>\n               </important>\n               <dl>\n                  <dt>EKS_AL2</dt>\n                  <dd>\n                     <p>\n                        <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\">Amazon\n          Linux 2</a>: Used for non-GPU instance families.</p>\n                  </dd>\n                  <dt>EKS_AL2_NVIDIA</dt>\n                  <dd>\n                     <p>\n                        <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\">Amazon\n          Linux 2 (accelerated)</a>: Used for GPU instance families (for example,\n          <code>P4</code> and <code>G4</code>) and can be used for all non Amazon Web Services Graviton-based\n         instance types.</p>\n                  </dd>\n                  <dt>EKS_AL2023</dt>\n                  <dd>\n                     <p>\n                        <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\">Amazon\n         Linux 2023</a>: Default for non-GPU instance families.</p>\n                     <note>\n                        <p>Amazon Linux 2023 does not support <code>A1</code> instances.</p>\n                     </note>\n                  </dd>\n                  <dt>EKS_AL2023_NVIDIA</dt>\n                  <dd>\n                     <p>\n                        <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\">Amazon\n          Linux 2023 (accelerated)</a>: Default for GPU instance families and can be used for all non Amazon Web Services\n         Graviton-based instance types.</p>\n                  </dd>\n               </dl>\n            </dd>\n         </dl>",
+            "smithy.api#required": {}
+          }
+        },
+        "imageIdOverride": {
+          "target": "com.amazonaws.batch#ImageIdOverride",
+          "traits": {
+            "smithy.api#documentation": "<p>The AMI ID used for instances launched in the compute environment that match the image type.\n   This setting overrides the <code>imageId</code> set in the <code>computeResource</code>\n   object.</p>\n         <note>\n            <p>The AMI that you choose for a compute environment must match the architecture of the instance types that\n    you intend to use for that compute environment. For example, if your compute environment uses A1 instance types,\n    the compute resource AMI that you choose must support ARM instances. Amazon ECS vends both x86 and ARM versions of the\n    Amazon ECS-optimized Amazon Linux 2023 AMI. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#ecs-optimized-ami-linux-variants.html\">Amazon ECS-optimized\n    Amazon Linux 2023 AMI</a>\n    in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         </note>"
+          }
+        },
+        "batchImageStatus": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the Batch-provided default AMIs associated with the <code>imageType</code>.</p>\n         <p>The field only appears after the compute environment has begun scaling instances using the <code>imageType</code>. The field is not present when an image is specified in\n            <code>ComputeResources.imageId</code> (deprecated), the default launch template, or\n            <code>Ec2Configuration.imageIdOverride</code>. The field is also not present when the compute environment has a launch template override.\n            \n            \n            For more information on image selection, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/ami-selection-order.html\">AMI selection order</a>.</p>\n         <note>\n            <p>This field is read-only and only appears in the <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_DescribeComputeEnvironments.html\">DescribeComputeEnvironments</a> response.</p>\n         </note>\n         <ul>\n            <li>\n               <p>\n                  <code>LATEST</code> \u2212 Using the most recent AMI supported</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_AVAILABLE</code> \u2212 An updated AMI is available</p>\n               <ul>\n                  <li>\n                     <p>If a compute environment has multiple AMIs for the <code>imageType</code> and any one AMI has <code>UPDATE_AVAILABLE</code>, the status shows <code>UPDATE_AVAILABLE</code>.</p>\n                  </li>\n                  <li>\n                     <p>For compute environments that use <code>BEST_FIT</code> as their allocation strategy,\n                    you can perform a <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/blue-green-updates.html\">blue/green update</a> to update the AMI.</p>\n                  </li>\n                  <li>\n                     <p>For all other compute environments, you can perform an\n                    <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/managing-ami-versions.html#updating-ami-versions\">AMI version update</a> to update the AMI to the latest version.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>"
+          }
+        },
+        "imageKubernetesVersion": {
+          "target": "com.amazonaws.batch#KubernetesVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>The Kubernetes version for the compute environment. If you don't specify a value, the latest\n   version that Batch supports is used.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information used to select Amazon Machine Images (AMIs) for instances in the\n   compute environment. If <code>Ec2Configuration</code> isn't specified, the default is\n    <code>ECS_AL2023</code> (<a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html\">Amazon ECS-optimized Amazon Linux 2023</a>) for EC2 (ECS) compute environments and <code>EKS_AL2023</code> (<a href=\"https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\">Amazon EKS-optimized Amazon Linux 2023\n    AMI</a>) for EKS compute environments.</p>\n         <note>\n            <p>This object isn't applicable to jobs that are running on Fargate resources.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.batch#Ec2ConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#Ec2Configuration"
+      }
+    },
+    "com.amazonaws.batch#EcsProperties": {
+      "type": "structure",
+      "members": {
+        "taskProperties": {
+          "target": "com.amazonaws.batch#ListEcsTaskProperties",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>An object that contains the properties for the Amazon ECS task definition of a job.</p>\n         <note>\n            <p>This object is currently limited to one task element. However, the task element can run up to 10 containers.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains the properties for the Amazon ECS resources of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#EcsPropertiesDetail": {
+      "type": "structure",
+      "members": {
+        "taskProperties": {
+          "target": "com.amazonaws.batch#ListEcsTaskDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties for the Amazon ECS task definition of a job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains the details for the Amazon ECS resources of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#EcsPropertiesOverride": {
+      "type": "structure",
+      "members": {
+        "taskProperties": {
+          "target": "com.amazonaws.batch#ListTaskPropertiesOverride",
+          "traits": {
+            "smithy.api#documentation": "<p>The overrides for the Amazon ECS task definition of a job.</p>\n         <note>\n            <p>This object is currently limited to one element.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains overrides for the Amazon ECS task definition of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#EcsTaskDetails": {
+      "type": "structure",
+      "members": {
+        "containers": {
+          "target": "com.amazonaws.batch#ListTaskContainerDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of containers that are included in the <code>taskProperties</code> list.</p>"
+          }
+        },
+        "containerInstanceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the container instance that hosts the task.</p>"
+          }
+        },
+        "taskArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the Amazon ECS task.</p>"
+          }
+        },
+        "ephemeralStorage": {
+          "target": "com.amazonaws.batch#EphemeralStorage",
+          "traits": {
+            "smithy.api#documentation": "<p>The amount of ephemeral storage allocated for the task.</p>"
+          }
+        },
+        "executionRoleArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the execution role that Batch can assume. For more information, see\n    <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html\">Batch execution IAM\n    role</a> in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "platformVersion": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Fargate platform version where the jobs are running.</p>"
+          }
+        },
+        "ipcMode": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The IPC resource namespace to use for the containers in the task. The valid values are\n   <code>host</code>, <code>task</code>, or <code>none</code>. For more information see <code>ipcMode</code> in <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_EcsTaskProperties.html\">EcsTaskProperties</a>.</p>"
+          }
+        },
+        "taskRoleArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that the container can assume for Amazon Web Services permissions. For more\n   information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html\">IAM roles for tasks</a> in the\n    <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <note>\n            <p>This is object is comparable to <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerProperties.html\">ContainerProperties:jobRoleArn</a>.</p>\n         </note>"
+          }
+        },
+        "pidMode": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The process namespace to use for the containers in the task. The valid values are\n   <code>host</code>, or <code>task</code>. For more information see <code>pidMode</code> in <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_EcsTaskProperties.html\">EcsTaskProperties</a>.</p>"
+          }
+        },
+        "networkConfiguration": {
+          "target": "com.amazonaws.batch#NetworkConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The network configuration for jobs that are running on Fargate resources. Jobs that are\n   running on Amazon EC2 resources must not specify this parameter.</p>"
+          }
+        },
+        "runtimePlatform": {
+          "target": "com.amazonaws.batch#RuntimePlatform",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that represents the compute environment architecture for Batch jobs on\n   Fargate.</p>"
+          }
+        },
+        "volumes": {
+          "target": "com.amazonaws.batch#Volumes",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of data volumes used in a job.</p>"
+          }
+        },
+        "enableExecuteCommand": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether execute command functionality is turned on for this task. If <code>true</code>, execute\n            command functionality is turned on all the containers in the task.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details of a task definition that describes the container and volume definitions of an\n   Amazon ECS task.</p>"
+      }
+    },
+    "com.amazonaws.batch#EcsTaskProperties": {
+      "type": "structure",
+      "members": {
+        "containers": {
+          "target": "com.amazonaws.batch#ListTaskContainerProperties",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>This object is a list of containers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ephemeralStorage": {
+          "target": "com.amazonaws.batch#EphemeralStorage",
+          "traits": {
+            "smithy.api#documentation": "<p>The amount of ephemeral storage to allocate for the task. This parameter is used to expand\n   the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on\n   Fargate.</p>"
+          }
+        },
+        "executionRoleArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the execution role that Batch can assume. For jobs that run on Fargate\n   resources, you must provide an execution role. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html\">Batch execution IAM role</a>\n   in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "platformVersion": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Fargate platform version where the jobs are running. A platform version is specified\n   only for jobs that are running on Fargate resources. If one isn't specified, the\n    <code>LATEST</code> platform version is used by default. This uses a recent, approved version of\n   the Fargate platform for compute resources. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html\">Fargate\n    platform versions</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+          }
+        },
+        "ipcMode": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The IPC resource namespace to use for the containers in the task. The valid values are\n    <code>host</code>, <code>task</code>, or <code>none</code>.</p>\n         <p>If <code>host</code> is specified, all containers within the tasks that specified the\n    <code>host</code> IPC mode on the same container instance share the same IPC resources with the\n   host Amazon EC2 instance.</p>\n         <p>If <code>task</code> is specified, all containers within the specified <code>task</code>\n   share the same IPC resources.</p>\n         <p>If <code>none</code> is specified, the IPC resources within the containers of a task are\n   private, and are not shared with other containers in a task or on the container instance. </p>\n         <p>If no value is specified, then the IPC resource namespace sharing depends on the Docker\n   daemon setting on the container instance. For more information, see <a href=\"https://docs.docker.com/engine/reference/run/#ipc-settings---ipc\">IPC settings</a> in\n   the Docker run reference.</p>"
+          }
+        },
+        "taskRoleArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that's associated with the Amazon ECS task.</p>\n         <note>\n            <p>This is object is comparable to <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerProperties.html\">ContainerProperties:jobRoleArn</a>.</p>\n         </note>"
+          }
+        },
+        "pidMode": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The process namespace to use for the containers in the task. The valid values are\n    <code>host</code> or <code>task</code>. For example, monitoring sidecars might need\n    <code>pidMode</code> to access information about other containers running in the same\n   task.</p>\n         <p>If <code>host</code> is specified, all containers within the tasks that specified the\n    <code>host</code> PID mode on the same container instance share the process namespace with the\n   host Amazon EC2 instance.</p>\n         <p>If <code>task</code> is specified, all containers within the specified task share the same\n   process namespace.</p>\n         <p>If no value is specified, the default is a private namespace for each container. For more\n   information, see <a href=\"https://docs.docker.com/engine/reference/run/#pid-settings---pid\">PID settings</a> in the Docker run reference.</p>"
+          }
+        },
+        "networkConfiguration": {
+          "target": "com.amazonaws.batch#NetworkConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The network configuration for jobs that are running on Fargate resources. Jobs that are\n   running on Amazon EC2 resources must not specify this parameter.</p>"
+          }
+        },
+        "runtimePlatform": {
+          "target": "com.amazonaws.batch#RuntimePlatform",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that represents the compute environment architecture for Batch jobs on\n   Fargate.</p>"
+          }
+        },
+        "volumes": {
+          "target": "com.amazonaws.batch#Volumes",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of volumes that are associated with the job.</p>"
+          }
+        },
+        "enableExecuteCommand": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether execute command functionality is turned on for this task. If <code>true</code>, execute\n            command functionality is turned on all the containers in the task.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The properties for a task definition that describes the container and volume definitions of\n   an Amazon ECS task. You can specify which Docker images to use, the required resources, and other\n   configurations related to launching the task definition through an Amazon ECS service or task.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksAnnotationsMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#String"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#String"
+      }
+    },
+    "com.amazonaws.batch#EksAttemptContainerDetail": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a container.</p>"
+          }
+        },
+        "containerID": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for the container.</p>"
+          }
+        },
+        "exitCode": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The exit code returned for the job attempt. A non-zero exit code is considered\n   failed.</p>"
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short (255 max characters) human-readable string to provide additional details for a\n   running or stopped container.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details for an attempt for a job attempt that an Amazon EKS\n   container runs.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksAttemptContainerDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EksAttemptContainerDetail"
+      }
+    },
+    "com.amazonaws.batch#EksAttemptDetail": {
+      "type": "structure",
+      "members": {
+        "containers": {
+          "target": "com.amazonaws.batch#EksAttemptContainerDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>The details for the final status of the containers for this job attempt.</p>"
+          }
+        },
+        "initContainers": {
+          "target": "com.amazonaws.batch#EksAttemptContainerDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>The details for the init containers.</p>"
+          }
+        },
+        "eksClusterArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon EKS cluster.</p>"
+          }
+        },
+        "podName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the pod for this job attempt.</p>"
+          }
+        },
+        "podNamespace": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The namespace of the Amazon EKS cluster that the pod exists in.</p>"
+          }
+        },
+        "nodeName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the node for this job attempt.</p>"
+          }
+        },
+        "startedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the attempt was started (when the attempt\n   transitioned from the <code>STARTING</code> state to the <code>RUNNING</code> state).</p>"
+          }
+        },
+        "stoppedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the attempt was stopped. This happens when the\n   attempt transitioned from the <code>RUNNING</code> state to a terminal state, such as\n    <code>SUCCEEDED</code> or <code>FAILED</code>.</p>"
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short, human-readable string to provide additional details for the current status of the\n   job attempt.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details of a job attempt for a job attempt by an Amazon EKS\n   container.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksAttemptDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EksAttemptDetail"
+      }
+    },
+    "com.amazonaws.batch#EksConfiguration": {
+      "type": "structure",
+      "members": {
+        "eksClusterArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon EKS cluster. An example is\n     <code>arn:<i>aws</i>:eks:<i>us-east-1</i>:<i>123456789012</i>:cluster/<i>ClusterForBatch</i>\n            </code>.\n  </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "kubernetesNamespace": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The namespace of the Amazon EKS cluster. Batch manages pods in this namespace. The value\n   can't left empty or null. It must be fewer than 64 characters long, can't be set to\n    <code>default</code>, can't start with \"<code>kube-</code>,\" and must match this regular\n   expression: <code>^[a-z0-9]([-a-z0-9]*[a-z0-9])?$</code>. For more information, see <a href=\"https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/\">Namespaces</a> in the Kubernetes documentation.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration for the Amazon EKS cluster that supports the Batch compute environment. The\n   cluster must exist before the compute environment can be created.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksContainer": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the container. If the name isn't specified, the default name\n    \"<code>Default</code>\" is used. Each container in a pod must have a unique name.</p>"
+          }
+        },
+        "image": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Docker image used to start the container.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "imagePullPolicy": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The image pull policy for the container. Supported values are <code>Always</code>,\n    <code>IfNotPresent</code>, and <code>Never</code>. This parameter defaults to\n    <code>IfNotPresent</code>. However, if the <code>:latest</code> tag is specified, it defaults to\n    <code>Always</code>. For more information, see <a href=\"https://kubernetes.io/docs/concepts/containers/images/#updating-images\">Updating\n    images</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "command": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The entrypoint for the container. This isn't run within a shell. If this isn't specified,\n   the <code>ENTRYPOINT</code> of the container image is used. Environment variable references are\n   expanded using the container's environment.</p>\n         <p>If the referenced environment variable doesn't exist, the reference in the command isn't\n   changed. For example, if the reference is to \"<code>$(NAME1)</code>\" and the <code>NAME1</code>\n   environment variable doesn't exist, the command string will remain \"<code>$(NAME1)</code>.\"\n    <code>$$</code> is replaced with <code>$</code> and the resulting string isn't expanded. For\n   example, <code>$$(VAR_NAME)</code> will be passed as <code>$(VAR_NAME)</code> whether or not the\n    <code>VAR_NAME</code> environment variable exists. The entrypoint can't be updated. For more\n   information, see <a href=\"https://docs.docker.com/engine/reference/builder/#entrypoint\">ENTRYPOINT</a> in the <i>Dockerfile reference</i> and <a href=\"https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/\">Define a command and arguments for a container</a> and <a href=\"https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#entrypoint\">Entrypoint</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "args": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of arguments to the entrypoint. If this isn't specified, the <code>CMD</code> of\n   the container image is used. This corresponds to the <code>args</code> member in the <a href=\"https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#entrypoint\">Entrypoint</a> portion of the <a href=\"https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/\">Pod</a>\n   in Kubernetes. Environment variable references are expanded using the container's environment.</p>\n         <p>If the referenced environment variable doesn't exist, the reference in the command isn't\n   changed. For example, if the reference is to \"<code>$(NAME1)</code>\" and the <code>NAME1</code>\n   environment variable doesn't exist, the command string will remain \"<code>$(NAME1)</code>.\"\n    <code>$$</code> is replaced with <code>$</code>, and the resulting string isn't expanded. For\n   example, <code>$$(VAR_NAME)</code> is passed as <code>$(VAR_NAME)</code> whether or not the\n    <code>VAR_NAME</code> environment variable exists. For more information, see <a href=\"https://docs.docker.com/engine/reference/builder/#cmd\">Dockerfile reference: CMD</a>\n   and <a href=\"https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/\">Define a command and arguments for a pod</a> in the <i>Kubernetes\n    documentation</i>.</p>"
+          }
+        },
+        "env": {
+          "target": "com.amazonaws.batch#EksContainerEnvironmentVariables",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables to pass to a container.</p>\n         <note>\n            <p>Environment variables cannot start with \"<code>AWS_BATCH</code>\". This naming\n convention is reserved for variables that Batch sets.</p>\n         </note>"
+          }
+        },
+        "resources": {
+          "target": "com.amazonaws.batch#EksContainerResourceRequirements",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and amount of resources to assign to a container. The supported resources include\n    <code>memory</code>, <code>cpu</code>, and <code>nvidia.com/gpu</code>. For more information,\n   see <a href=\"https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\">Resource management for pods and containers</a> in the <i>Kubernetes\n    documentation</i>.</p>"
+          }
+        },
+        "volumeMounts": {
+          "target": "com.amazonaws.batch#EksContainerVolumeMounts",
+          "traits": {
+            "smithy.api#documentation": "<p>The volume mounts for the container. Batch supports <code>emptyDir</code>,\n    <code>hostPath</code>, and <code>secret</code> volume types. For more information about volumes\n   and volume mounts in Kubernetes, see <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/\">Volumes</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "securityContext": {
+          "target": "com.amazonaws.batch#EksContainerSecurityContext",
+          "traits": {
+            "smithy.api#documentation": "<p>The security context for a job. For more information, see <a href=\"https://kubernetes.io/docs/tasks/configure-pod-container/security-context/\">Configure a\n    security context for a pod or container</a> in the <i>Kubernetes\n    documentation</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>EKS container properties are used in job definitions for Amazon EKS based job definitions to\n   describe the properties for a container node in the pod that's launched as part of a job. This\n   can't be specified for Amazon ECS based job definitions.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksContainerDetail": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the container. If the name isn't specified, the default name\n    \"<code>Default</code>\" is used. Each container in a pod must have a unique name.</p>"
+          }
+        },
+        "image": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Docker image used to start the container.</p>"
+          }
+        },
+        "imagePullPolicy": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The image pull policy for the container. Supported values are <code>Always</code>,\n    <code>IfNotPresent</code>, and <code>Never</code>. This parameter defaults to\n    <code>Always</code> if the <code>:latest</code> tag is specified, <code>IfNotPresent</code>\n   otherwise. For more information, see <a href=\"https://kubernetes.io/docs/concepts/containers/images/#updating-images\">Updating\n    images</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "command": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The entrypoint for the container. For more information, see <a href=\"https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#entrypoint\">Entrypoint</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "args": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of arguments to the entrypoint. If this isn't specified, the <code>CMD</code> of\n   the container image is used. This corresponds to the <code>args</code> member in the <a href=\"https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#entrypoint\">Entrypoint</a> portion of the <a href=\"https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/\">Pod</a>\n   in Kubernetes. Environment variable references are expanded using the container's environment.</p>\n         <p>If the referenced environment variable doesn't exist, the reference in the command isn't\n   changed. For example, if the reference is to \"<code>$(NAME1)</code>\" and the <code>NAME1</code>\n   environment variable doesn't exist, the command string will remain \"<code>$(NAME1)</code>\".\n    <code>$$</code> is replaced with <code>$</code> and the resulting string isn't expanded. For\n   example, <code>$$(VAR_NAME)</code> is passed as <code>$(VAR_NAME)</code> whether or not the\n    <code>VAR_NAME</code> environment variable exists. For more information, see <a href=\"https://docs.docker.com/engine/reference/builder/#cmd\">Dockerfile reference: CMD</a>\n   and <a href=\"https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/\">Define a command and arguments for a pod</a> in the <i>Kubernetes\n    documentation</i>.</p>"
+          }
+        },
+        "env": {
+          "target": "com.amazonaws.batch#EksContainerEnvironmentVariables",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables to pass to a container.</p>\n         <note>\n            <p>Environment variables cannot start with \"<code>AWS_BATCH</code>\". This naming\n convention is reserved for variables that Batch sets.</p>\n         </note>"
+          }
+        },
+        "resources": {
+          "target": "com.amazonaws.batch#EksContainerResourceRequirements",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and amount of resources to assign to a container. The supported resources include\n    <code>memory</code>, <code>cpu</code>, and <code>nvidia.com/gpu</code>. For more information,\n   see <a href=\"https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\">Resource management for pods and containers</a> in the <i>Kubernetes\n    documentation</i>.</p>"
+          }
+        },
+        "exitCode": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The exit code returned for the job attempt. A non-zero exit code is considered\n   failed.</p>"
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short human-readable string to provide additional details for a running or stopped\n   container. It can be up to 255 characters long.</p>"
+          }
+        },
+        "volumeMounts": {
+          "target": "com.amazonaws.batch#EksContainerVolumeMounts",
+          "traits": {
+            "smithy.api#documentation": "<p>The volume mounts for the container. Batch supports <code>emptyDir</code>,\n    <code>hostPath</code>, and <code>secret</code> volume types. For more information about volumes\n   and volume mounts in Kubernetes, see <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/\">Volumes</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "securityContext": {
+          "target": "com.amazonaws.batch#EksContainerSecurityContext",
+          "traits": {
+            "smithy.api#documentation": "<p>The security context for a job. For more information, see <a href=\"https://kubernetes.io/docs/tasks/configure-pod-container/security-context/\">Configure a\n    security context for a pod or container</a> in the <i>Kubernetes\n    documentation</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details for container properties that are returned by <code>DescribeJobs</code> for jobs\n   that use Amazon EKS.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksContainerDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EksContainerDetail"
+      }
+    },
+    "com.amazonaws.batch#EksContainerEnvironmentVariable": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the environment variable.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "value": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the environment variable.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An environment variable.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksContainerEnvironmentVariables": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EksContainerEnvironmentVariable"
+      }
+    },
+    "com.amazonaws.batch#EksContainerOverride": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A pointer to the container that you want to override. The name must match a unique container\n   name that you wish to override.</p>"
+          }
+        },
+        "image": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The override of the Docker image that's used to start the container.</p>"
+          }
+        },
+        "command": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The command to send to the container that overrides the default command from the Docker\n   image or the job definition.</p>"
+          }
+        },
+        "args": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The arguments to the entrypoint to send to the container that overrides the default\n   arguments from the Docker image or the job definition. For more information, see <a href=\"https://docs.docker.com/engine/reference/builder/#cmd\">Dockerfile reference: CMD</a>\n   and <a href=\"https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/\">Define a command an arguments for a pod</a> in the <i>Kubernetes\n    documentation</i>.</p>"
+          }
+        },
+        "env": {
+          "target": "com.amazonaws.batch#EksContainerEnvironmentVariables",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables to send to the container. You can add new environment variables,\n   which are added to the container at launch. Or, you can override the existing environment\n   variables from the Docker image or the job definition.</p>\n         <note>\n            <p>Environment variables cannot start with \"<code>AWS_BATCH</code>\". This naming\n convention is reserved for variables that Batch sets.</p>\n         </note>"
+          }
+        },
+        "resources": {
+          "target": "com.amazonaws.batch#EksContainerResourceRequirements",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and amount of resources to assign to a container. These override the settings in\n   the job definition. The supported resources include <code>memory</code>, <code>cpu</code>, and\n    <code>nvidia.com/gpu</code>. For more information, see <a href=\"https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\">Resource\n    management for pods and containers</a> in the <i>Kubernetes\n   documentation</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Object representing any Kubernetes overrides to a job definition that's used in a <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html\">SubmitJob</a> API\n   operation.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksContainerOverrideList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EksContainerOverride"
+      }
+    },
+    "com.amazonaws.batch#EksContainerResourceRequirements": {
+      "type": "structure",
+      "members": {
+        "limits": {
+          "target": "com.amazonaws.batch#EksLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and quantity of the resources to reserve for the container. The values vary based\n   on the <code>name</code> that's specified. Resources can be requested using either the\n    <code>limits</code> or the <code>requests</code> objects.</p>\n         <dl>\n            <dt>memory</dt>\n            <dd>\n               <p>The memory hard limit (in MiB) for the container, using whole integers, with a \"Mi\"\n      suffix. If your container attempts to exceed the memory specified, the container is\n      terminated. You must specify at least 4 MiB of memory for a job. <code>memory</code> can be\n      specified in <code>limits</code>, <code>requests</code>, or both. If <code>memory</code> is\n      specified in both places, then the value that's specified in <code>limits</code> must be equal\n      to the value that's specified in <code>requests</code>.</p>\n               <note>\n                  <p>To maximize your resource utilization, provide your jobs with as much memory as possible\n       for the specific instance type that you are using. To learn how, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/memory-management.html\">Memory management</a> in the\n        <i>Batch User Guide</i>.</p>\n               </note>\n            </dd>\n            <dt>cpu</dt>\n            <dd>\n               <p>The number of CPUs that's reserved for the container. Values must be an even multiple of\n       <code>0.25</code>. <code>cpu</code> can be specified in <code>limits</code>,\n       <code>requests</code>, or both. If <code>cpu</code> is specified in both places, then the\n      value that's specified in <code>limits</code> must be at least as large as the value that's\n      specified in <code>requests</code>.</p>\n            </dd>\n            <dt>nvidia.com/gpu</dt>\n            <dd>\n               <p>The number of GPUs that's reserved for the container. Values must be a whole integer.\n       <code>memory</code> can be specified in <code>limits</code>, <code>requests</code>, or both.\n      If <code>memory</code> is specified in both places, then the value that's specified in\n       <code>limits</code> must be equal to the value that's specified in\n      <code>requests</code>.</p>\n            </dd>\n         </dl>"
+          }
+        },
+        "requests": {
+          "target": "com.amazonaws.batch#EksRequests",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and quantity of the resources to request for the container. The values vary based\n   on the <code>name</code> that's specified. Resources can be requested by using either the\n    <code>limits</code> or the <code>requests</code> objects.</p>\n         <dl>\n            <dt>memory</dt>\n            <dd>\n               <p>The memory hard limit (in MiB) for the container, using whole integers, with a \"Mi\"\n      suffix. If your container attempts to exceed the memory specified, the container is\n      terminated. You must specify at least 4 MiB of memory for a job. <code>memory</code> can be\n      specified in <code>limits</code>, <code>requests</code>, or both. If <code>memory</code> is\n      specified in both, then the value that's specified in <code>limits</code> must be equal to the\n      value that's specified in <code>requests</code>.</p>\n               <note>\n                  <p>If you're trying to maximize your resource utilization by providing your jobs as much\n       memory as possible for a particular instance type, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/memory-management.html\">Memory management</a> in the\n        <i>Batch User Guide</i>.</p>\n               </note>\n            </dd>\n            <dt>cpu</dt>\n            <dd>\n               <p>The number of CPUs that are reserved for the container. Values must be an even multiple\n      of <code>0.25</code>. <code>cpu</code> can be specified in <code>limits</code>,\n       <code>requests</code>, or both. If <code>cpu</code> is specified in both, then the value\n      that's specified in <code>limits</code> must be at least as large as the value that's\n      specified in <code>requests</code>.</p>\n            </dd>\n            <dt>nvidia.com/gpu</dt>\n            <dd>\n               <p>The number of GPUs that are reserved for the container. Values must be a whole integer.\n       <code>nvidia.com/gpu</code> can be specified in <code>limits</code>, <code>requests</code>,\n      or both. If <code>nvidia.com/gpu</code> is specified in both, then the value that's specified\n      in <code>limits</code> must be equal to the value that's specified in\n      <code>requests</code>.</p>\n            </dd>\n         </dl>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type and amount of resources to assign to a container. The supported resources include\n    <code>memory</code>, <code>cpu</code>, and <code>nvidia.com/gpu</code>. For more information,\n   see <a href=\"https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\">Resource management for pods and containers</a> in the <i>Kubernetes\n    documentation</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksContainerSecurityContext": {
+      "type": "structure",
+      "members": {
+        "runAsUser": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is specified, the container is run as the specified user ID\n    (<code>uid</code>). If this parameter isn't specified, the default is the user that's specified\n   in the image metadata. This parameter maps to <code>RunAsUser</code> and <code>MustRanAs</code>\n   policy in the <a href=\"https://kubernetes.io/docs/concepts/security/pod-security-policy/#users-and-groups\">Users\n    and groups pod security policies</a> in the <i>Kubernetes\n   documentation</i>.</p>"
+          }
+        },
+        "runAsGroup": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is specified, the container is run as the specified group ID\n    (<code>gid</code>). If this parameter isn't specified, the default is the group that's specified\n   in the image metadata. This parameter maps to <code>RunAsGroup</code> and <code>MustRunAs</code>\n   policy in the <a href=\"https://kubernetes.io/docs/concepts/security/pod-security-policy/#users-and-groups\">Users\n    and groups pod security policies</a> in the <i>Kubernetes\n   documentation</i>.</p>"
+          }
+        },
+        "privileged": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is <code>true</code>, the container is given elevated permissions on the\n   host container instance. The level of permissions are similar to the <code>root</code> user\n   permissions. The default value is <code>false</code>. This parameter maps to\n    <code>privileged</code> policy in the <a href=\"https://kubernetes.io/docs/concepts/security/pod-security-policy/#privileged\">Privileged\n    pod security policies</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "allowPrivilegeEscalation": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Whether or not a container or a Kubernetes pod is allowed to gain more privileges than its parent\n   process. The default value is <code>false</code>.</p>"
+          }
+        },
+        "readOnlyRootFilesystem": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is <code>true</code>, the container is given read-only access to its\n   root file system. The default value is <code>false</code>. This parameter maps to\n    <code>ReadOnlyRootFilesystem</code> policy in the <a href=\"https://kubernetes.io/docs/concepts/security/pod-security-policy/#volumes-and-file-systems\">Volumes and file systems pod security policies</a> in the <i>Kubernetes\n    documentation</i>.</p>"
+          }
+        },
+        "runAsNonRoot": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is specified, the container is run as a user with a <code>uid</code>\n   other than 0. If this parameter isn't specified, so such rule is enforced. This parameter maps to\n    <code>RunAsUser</code> and <code>MustRunAsNonRoot</code> policy in the <a href=\"https://kubernetes.io/docs/concepts/security/pod-security-policy/#users-and-groups\">Users\n    and groups pod security policies</a> in the <i>Kubernetes\n   documentation</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The security context for a job. For more information, see <a href=\"https://kubernetes.io/docs/tasks/configure-pod-container/security-context/\">Configure a\n    security context for a pod or container</a> in the <i>Kubernetes\n    documentation</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksContainerVolumeMount": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name the volume mount. This must match the name of one of the volumes in the\n   pod.</p>"
+          }
+        },
+        "mountPath": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The path on the container where the volume is mounted.</p>"
+          }
+        },
+        "subPath": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A sub-path inside the referenced volume instead of its root.</p>"
+          }
+        },
+        "readOnly": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>If this value is <code>true</code>, the container has read-only access to the volume.\n   Otherwise, the container can write to the volume. The default value is <code>false</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The volume mounts for a container for an Amazon EKS job. For more information about volumes and\n   volume mounts in Kubernetes, see <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/\">Volumes</a> in the <i>Kubernetes documentation</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksContainerVolumeMounts": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EksContainerVolumeMount"
+      }
+    },
+    "com.amazonaws.batch#EksContainers": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EksContainer"
+      }
+    },
+    "com.amazonaws.batch#EksEmptyDir": {
+      "type": "structure",
+      "members": {
+        "medium": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The medium to store the volume. The default value is an empty string, which uses the storage\n   of the node.</p>\n         <dl>\n            <dt>\"\"</dt>\n            <dd>\n               <p>\n                  <b>(Default)</b> Use the disk storage of the node.</p>\n            </dd>\n            <dt>\"Memory\"</dt>\n            <dd>\n               <p>Use the <code>tmpfs</code> volume that's backed by the RAM of the node. Contents of the\n      volume are lost when the node reboots, and any storage on the volume counts against the\n      container's memory limit.</p>\n            </dd>\n         </dl>"
+          }
+        },
+        "sizeLimit": {
+          "target": "com.amazonaws.batch#Quantity",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum size of the volume. By default, there's no maximum size defined.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the configuration of a Kubernetes <code>emptyDir</code> volume. An\n    <code>emptyDir</code> volume is first created when a pod is assigned to a node. It exists as\n   long as that pod is running on that node. The <code>emptyDir</code> volume is initially empty.\n   All containers in the pod can read and write the files in the <code>emptyDir</code> volume.\n   However, the <code>emptyDir</code> volume can be mounted at the same or different paths in each\n   container. When a pod is removed from a node for any reason, the data in the\n    <code>emptyDir</code> is deleted permanently. For more information, see <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/#emptydir\">emptyDir</a> in the\n    <i>Kubernetes documentation</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksHostPath": {
+      "type": "structure",
+      "members": {
+        "path": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The path of the file or directory on the host to mount into containers on the pod.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the configuration of a Kubernetes <code>hostPath</code> volume. A <code>hostPath</code>\n   volume mounts an existing file or directory from the host node's filesystem into your pod. For\n   more information, see <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/#hostpath\">hostPath</a> in the <i>Kubernetes documentation</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksLabelsMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#String"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#String"
+      }
+    },
+    "com.amazonaws.batch#EksLimits": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#String"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#Quantity"
+      }
+    },
+    "com.amazonaws.batch#EksMetadata": {
+      "type": "structure",
+      "members": {
+        "labels": {
+          "target": "com.amazonaws.batch#EksLabelsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Key-value pairs used to identify, sort, and organize cube resources. Can contain up to 63\n   uppercase letters, lowercase letters, numbers, hyphens (-), and underscores (_). Labels can be\n   added or modified at any time. Each resource can have multiple labels, but each key must be\n   unique for a given object.</p>"
+          }
+        },
+        "annotations": {
+          "target": "com.amazonaws.batch#EksAnnotationsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Key-value pairs used to attach arbitrary, non-identifying metadata to Kubernetes objects. \n        Valid annotation keys have two segments: an optional prefix and a name, separated by a \n        slash (/). </p>\n         <ul>\n            <li>\n               <p>The prefix is optional and must be 253 characters or less. If specified, the prefix \n                must be a DNS subdomain\u2212 a series of DNS labels separated by dots (.), and it must \n                end with a slash (/).</p>\n            </li>\n            <li>\n               <p>The name segment is required and must be 63 characters or less. It can include alphanumeric \n                characters ([a-z0-9A-Z]), dashes (-), underscores (_), and dots (.), but must begin and end \n                with an alphanumeric character.</p>\n            </li>\n         </ul>\n         <note>\n            <p>Annotation values must be 255 characters or less.</p>\n         </note>\n         <p>Annotations can be added or modified at any time. Each resource can have multiple annotations. </p>"
+          }
+        },
+        "namespace": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The namespace of the Amazon EKS cluster. In Kubernetes, namespaces provide a mechanism for isolating \n      groups of resources within a single cluster. Names of resources need to be unique within a namespace, \n      but not across namespaces. Batch places Batch Job pods in this namespace. If this field is provided, \n      the value can't be empty or null. It must meet the following requirements:</p>\n         <ul>\n            <li>\n               <p>1-63 characters long</p>\n            </li>\n            <li>\n               <p>Can't be set to default</p>\n            </li>\n            <li>\n               <p>Can't start with <code>kube</code>\n               </p>\n            </li>\n            <li>\n               <p>Must match the following regular expression:\n  <code>^[a-z0-9]([-a-z0-9]*[a-z0-9])?$</code>\n               </p>\n            </li>\n         </ul>\n         <p>\n   For more information, see \n   <a href=\"https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/\">Namespaces</a> in the <i>Kubernetes documentation</i>. This namespace can be \n   different from the <code>kubernetesNamespace</code> set in the compute environment's \n   <code>EksConfiguration</code>, but must have identical role-based access control (RBAC) roles as \n   the compute environment's <code>kubernetesNamespace</code>. For multi-node parallel jobs,\n   the same value must be provided across all the node ranges.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes and uniquely identifies Kubernetes resources. For example, the compute environment that\n   a pod runs in or the <code>jobID</code> for a job running in the pod. For more information, see\n   <a href=\"https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/\">\n   Understanding Kubernetes Objects</a> in the <i>Kubernetes documentation</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksPersistentVolumeClaim": {
+      "type": "structure",
+      "members": {
+        "claimName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the <code>persistentVolumeClaim</code> bounded to a <code>persistentVolume</code>. \n         For more information, see <a href=\"https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims\">\n         Persistent Volume Claims</a> in the <i>Kubernetes documentation</i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "readOnly": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>An optional boolean value indicating if the mount is read only. Default is false. For more\n         information, see <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/#read-only-mounts\">\n         Read Only Mounts</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>persistentVolumeClaim</code> volume is used to mount a <a href=\"https://kubernetes.io/docs/concepts/storage/persistent-volumes/\">PersistentVolume</a>\n         into a Pod. PersistentVolumeClaims are a way for users to \"claim\" durable storage without knowing \n         the details of the particular cloud environment. See the information about <a href=\"https://kubernetes.io/docs/concepts/storage/persistent-volumes/\">PersistentVolumes</a>\n         in the <i>Kubernetes documentation</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksPodProperties": {
+      "type": "structure",
+      "members": {
+        "serviceAccountName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the service account that's used to run the pod. For more information, see\n    <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html\">Kubernetes service\n    accounts</a> and <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html\">Configure a Kubernetes service account\n    to assume an IAM role</a> in the <i>Amazon EKS User Guide</i> and <a href=\"https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/\">Configure service accounts for pods</a> in the <i>Kubernetes\n   documentation</i>.</p>"
+          }
+        },
+        "hostNetwork": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates if the pod uses the hosts' network IP address. The default value is\n    <code>true</code>. Setting this to <code>false</code> enables the Kubernetes pod networking model.\n   Most Batch workloads are egress-only and don't require the overhead of IP allocation for each\n   pod for incoming connections. For more information, see <a href=\"https://kubernetes.io/docs/concepts/security/pod-security-policy/#host-namespaces\">Host\n    namespaces</a> and <a href=\"https://kubernetes.io/docs/concepts/workloads/pods/#pod-networking\">Pod networking</a>\n   in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "dnsPolicy": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The DNS policy for the pod. The default value is <code>ClusterFirst</code>. If the\n    <code>hostNetwork</code> parameter is not specified, the default is\n    <code>ClusterFirstWithHostNet</code>. <code>ClusterFirst</code> indicates that any DNS query\n   that does not match the configured cluster domain suffix is forwarded to the upstream nameserver\n   inherited from the node. For more information, see <a href=\"https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy\">Pod's DNS policy</a> in the <i>Kubernetes documentation</i>.</p>\n         <p>Valid values: <code>Default</code> | <code>ClusterFirst</code> |\n    <code>ClusterFirstWithHostNet</code>\n         </p>"
+          }
+        },
+        "imagePullSecrets": {
+          "target": "com.amazonaws.batch#ImagePullSecrets",
+          "traits": {
+            "smithy.api#documentation": "<p>References a Kubernetes secret resource. It holds a list of secrets. These secrets help to gain\n   access to pull an images from a private registry.</p>\n         <p>\n            <code>ImagePullSecret$name</code> is required when this object is used.</p>"
+          }
+        },
+        "containers": {
+          "target": "com.amazonaws.batch#EksContainers",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties of the container that's used on the Amazon EKS pod.</p>\n         <note>\n            <p>This object is limited to 10 elements.</p>\n         </note>"
+          }
+        },
+        "initContainers": {
+          "target": "com.amazonaws.batch#EksContainers",
+          "traits": {
+            "smithy.api#documentation": "<p>These containers run before application containers, always runs to completion, and must\n   complete successfully before the next container starts. These containers are registered with the\n   Amazon EKS Connector agent and persists the registration information in the Kubernetes backend data store.\n   For more information, see <a href=\"https://kubernetes.io/docs/concepts/workloads/pods/init-containers/\">Init\n    Containers</a> in the <i>Kubernetes documentation</i>.</p>\n         <note>\n            <p>This object is limited to 10 elements.</p>\n         </note>"
+          }
+        },
+        "volumes": {
+          "target": "com.amazonaws.batch#EksVolumes",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the volumes for a job definition that uses Amazon EKS resources.</p>"
+          }
+        },
+        "metadata": {
+          "target": "com.amazonaws.batch#EksMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Metadata about the Kubernetes pod. For more information, see <a href=\"https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/\">Understanding Kubernetes Objects</a> in the <i>Kubernetes\n   documentation</i>.</p>"
+          }
+        },
+        "shareProcessNamespace": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates if the processes in a container are shared, or visible, to other containers in the\n   same pod. For more information, see <a href=\"https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/\">Share\n    Process Namespace between Containers in a Pod</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The properties for the pod.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksPodPropertiesDetail": {
+      "type": "structure",
+      "members": {
+        "serviceAccountName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the service account that's used to run the pod. For more information, see\n    <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html\">Kubernetes service\n    accounts</a> and <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html\">Configure a Kubernetes service account\n    to assume an IAM role</a> in the <i>Amazon EKS User Guide</i> and <a href=\"https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/\">Configure service accounts for pods</a> in the <i>Kubernetes\n   documentation</i>.</p>"
+          }
+        },
+        "hostNetwork": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates if the pod uses the hosts' network IP address. The default value is\n    <code>true</code>. Setting this to <code>false</code> enables the Kubernetes pod networking model.\n   Most Batch workloads are egress-only and don't require the overhead of IP allocation for each\n   pod for incoming connections. For more information, see <a href=\"https://kubernetes.io/docs/concepts/security/pod-security-policy/#host-namespaces\">Host\n    namespaces</a> and <a href=\"https://kubernetes.io/docs/concepts/workloads/pods/#pod-networking\">Pod networking</a>\n   in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "dnsPolicy": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The DNS policy for the pod. The default value is <code>ClusterFirst</code>. If the\n    <code>hostNetwork</code> parameter is not specified, the default is\n    <code>ClusterFirstWithHostNet</code>. <code>ClusterFirst</code> indicates that any DNS query\n   that does not match the configured cluster domain suffix is forwarded to the upstream nameserver\n   inherited from the node. If no value was specified for <code>dnsPolicy</code> in the <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_RegisterJobDefinition.html\">RegisterJobDefinition</a> API operation, then no value will be returned for\n    <code>dnsPolicy</code> by either of <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_DescribeJobDefinitions.html\">DescribeJobDefinitions</a>\n   or <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_DescribeJobs.html\">DescribeJobs</a> API operations. The pod spec setting will contain either\n    <code>ClusterFirst</code> or <code>ClusterFirstWithHostNet</code>, depending on the value of the\n    <code>hostNetwork</code> parameter. For more information, see <a href=\"https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy\">Pod's DNS policy</a> in the <i>Kubernetes documentation</i>.</p>\n         <p>Valid values: <code>Default</code> | <code>ClusterFirst</code> |\n    <code>ClusterFirstWithHostNet</code>\n         </p>"
+          }
+        },
+        "imagePullSecrets": {
+          "target": "com.amazonaws.batch#ImagePullSecrets",
+          "traits": {
+            "smithy.api#documentation": "<p>Displays the reference pointer to the Kubernetes secret resource. These secrets help to gain\n   access to pull an images from a private registry.</p>"
+          }
+        },
+        "containers": {
+          "target": "com.amazonaws.batch#EksContainerDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties of the container that's used on the Amazon EKS pod.</p>"
+          }
+        },
+        "initContainers": {
+          "target": "com.amazonaws.batch#EksContainerDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>The container registered with the Amazon EKS Connector agent and persists the registration\n   information in the Kubernetes backend data store.</p>"
+          }
+        },
+        "volumes": {
+          "target": "com.amazonaws.batch#EksVolumes",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the volumes for a job definition using Amazon EKS resources.</p>"
+          }
+        },
+        "podName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the pod for this job.</p>"
+          }
+        },
+        "nodeName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the node for this job.</p>"
+          }
+        },
+        "metadata": {
+          "target": "com.amazonaws.batch#EksMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes and uniquely identifies Kubernetes resources. For example, the compute environment that\n   a pod runs in or the <code>jobID</code> for a job running in the pod. For more information, see\n    <a href=\"https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/\">Understanding Kubernetes Objects</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "shareProcessNamespace": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates if the processes in a container are shared, or visible, to other containers in the\n   same pod. For more information, see <a href=\"https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/\">Share\n    Process Namespace between Containers in a Pod</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details for the pod.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksPodPropertiesOverride": {
+      "type": "structure",
+      "members": {
+        "containers": {
+          "target": "com.amazonaws.batch#EksContainerOverrideList",
+          "traits": {
+            "smithy.api#documentation": "<p>The overrides for the container that's used on the Amazon EKS pod.</p>"
+          }
+        },
+        "initContainers": {
+          "target": "com.amazonaws.batch#EksContainerOverrideList",
+          "traits": {
+            "smithy.api#documentation": "<p>The overrides for the <code>initContainers</code> defined in the Amazon EKS pod. These containers run before\n   application containers, always run to completion, and must complete successfully before the next\n   container starts. These containers are registered with the Amazon EKS Connector agent and persists the\n   registration information in the Kubernetes backend data store. For more information, see <a href=\"https://kubernetes.io/docs/concepts/workloads/pods/init-containers/\">Init\n    Containers</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "metadata": {
+          "target": "com.amazonaws.batch#EksMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Metadata about the overrides for the container that's used on the Amazon EKS pod.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains overrides for the Kubernetes pod properties of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksProperties": {
+      "type": "structure",
+      "members": {
+        "podProperties": {
+          "target": "com.amazonaws.batch#EksPodProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties for the Kubernetes pod resources of a job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains the properties for the Kubernetes resources of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksPropertiesDetail": {
+      "type": "structure",
+      "members": {
+        "podProperties": {
+          "target": "com.amazonaws.batch#EksPodPropertiesDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties for the Kubernetes pod resources of a job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains the details for the Kubernetes resources of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksPropertiesOverride": {
+      "type": "structure",
+      "members": {
+        "podProperties": {
+          "target": "com.amazonaws.batch#EksPodPropertiesOverride",
+          "traits": {
+            "smithy.api#documentation": "<p>The overrides for the Kubernetes pod resources of a job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains overrides for the Kubernetes resources of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksRequests": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#String"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#Quantity"
+      }
+    },
+    "com.amazonaws.batch#EksSecret": {
+      "type": "structure",
+      "members": {
+        "secretName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the secret. The name must be allowed as a DNS subdomain name. For more\n   information, see <a href=\"https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names\">DNS subdomain names</a> in the <i>Kubernetes documentation</i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "optional": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the secret or the secret's keys must be defined.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the configuration of a Kubernetes <code>secret</code> volume. For more information, see\n    <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/#secret\">secret</a> in the\n    <i>Kubernetes documentation</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksVolume": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the volume. The name must be allowed as a DNS subdomain name. For more\n   information, see <a href=\"https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names\">DNS subdomain names</a> in the <i>Kubernetes documentation</i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "hostPath": {
+          "target": "com.amazonaws.batch#EksHostPath",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the configuration of a Kubernetes <code>hostPath</code> volume. For more information,\n   see <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/#hostpath\">hostPath</a>\n   in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "emptyDir": {
+          "target": "com.amazonaws.batch#EksEmptyDir",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the configuration of a Kubernetes <code>emptyDir</code> volume. For more information,\n   see <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/#emptydir\">emptyDir</a>\n   in the <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "secret": {
+          "target": "com.amazonaws.batch#EksSecret",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the configuration of a Kubernetes <code>secret</code> volume. For more information, see\n    <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/#secret\">secret</a> in the\n    <i>Kubernetes documentation</i>.</p>"
+          }
+        },
+        "persistentVolumeClaim": {
+          "target": "com.amazonaws.batch#EksPersistentVolumeClaim",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the configuration of a Kubernetes <code>persistentVolumeClaim</code> bounded to a \n        <code>persistentVolume</code>. For more information, see <a href=\"https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims\">\n        Persistent Volume Claims</a> in the <i>Kubernetes documentation</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies an Amazon EKS volume for a job definition.</p>"
+      }
+    },
+    "com.amazonaws.batch#EksVolumes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EksVolume"
+      }
+    },
+    "com.amazonaws.batch#EnvironmentVariables": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#KeyValuePair"
+      }
+    },
+    "com.amazonaws.batch#EphemeralStorage": {
+      "type": "structure",
+      "members": {
+        "sizeInGiB": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The total amount, in GiB, of ephemeral storage to set for the task. The minimum supported\n   value is <code>21</code> GiB and the maximum supported value is <code>200</code> GiB.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The amount of ephemeral storage to allocate for the task. This parameter is used to expand\n   the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on\n   Fargate.</p>"
+      }
+    },
+    "com.amazonaws.batch#EvaluateOnExit": {
+      "type": "structure",
+      "members": {
+        "onStatusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains a glob pattern to match against the <code>StatusReason</code> returned for a job.\n   The pattern can contain up to 512 characters. It can contain letters, numbers, periods (.),\n   colons (:), and white spaces (including spaces or tabs). It can optionally end with an asterisk (*) \n   so that only the start of the string needs to be an exact match.</p>"
+          }
+        },
+        "onReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains a glob pattern to match against the <code>Reason</code> returned for a job. The\n   pattern can contain up to 512 characters. It can contain letters, numbers, periods (.), colons\n   (:), and white space (including spaces and tabs). It can optionally end with an asterisk (*) so\n   that only the start of the string needs to be an exact match.</p>"
+          }
+        },
+        "onExitCode": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains a glob pattern to match against the decimal representation of the\n    <code>ExitCode</code> returned for a job. The pattern can be up to 512 characters long. It can\n   contain only numbers, and can end with an asterisk (*) so that only the start of the string needs\n   to be an exact match.</p>\n         <p>The string can contain up to 512 characters.</p>"
+          }
+        },
+        "action": {
+          "target": "com.amazonaws.batch#RetryAction",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the action to take if all of the specified conditions\n   (<code>onStatusReason</code>, <code>onReason</code>, and <code>onExitCode</code>) are met. The\n   values aren't case sensitive.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies an array of up to 5 conditions to be met, and an action to take\n    (<code>RETRY</code> or <code>EXIT</code>) if all conditions are met. If none of the\n    <code>EvaluateOnExit</code> conditions in a <code>RetryStrategy</code> match, then the job is\n   retried.</p>"
+      }
+    },
+    "com.amazonaws.batch#EvaluateOnExitList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EvaluateOnExit"
+      }
+    },
+    "com.amazonaws.batch#FairshareCapacityUsage": {
+      "type": "structure",
+      "members": {
+        "capacityUnit": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unit of measure for the capacity usage. For compute jobs, this is\n                <code>VCPU</code> for Amazon EC2 and <code>cpu</code> for Amazon EKS. For service jobs, this is the instance type.</p>"
+          }
+        },
+        "quantity": {
+          "target": "com.amazonaws.batch#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>The quantity of capacity being used, measured in the units specified by\n                <code>capacityUnit</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The capacity usage for a fairshare scheduling job queue.</p>"
+      }
+    },
+    "com.amazonaws.batch#FairshareCapacityUsageList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#FairshareCapacityUsage"
+      }
+    },
+    "com.amazonaws.batch#FairshareCapacityUtilization": {
+      "type": "structure",
+      "members": {
+        "shareIdentifier": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The share identifier for the fairshare scheduling job queue.</p>"
+          }
+        },
+        "capacityUsage": {
+          "target": "com.amazonaws.batch#FairshareCapacityUsageList",
+          "traits": {
+            "smithy.api#documentation": "<p>The capacity usage information for this share, including the unit of measure and\n            quantity being used. This is\n            <code>VCPU</code> for Amazon EC2 and <code>cpu</code> for Amazon EKS.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The capacity utilization for a specific share in a fairshare scheduling job queue, including the share identifier and its current usage.</p>"
+      }
+    },
+    "com.amazonaws.batch#FairshareCapacityUtilizationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#FairshareCapacityUtilization"
+      }
+    },
+    "com.amazonaws.batch#FairsharePolicy": {
+      "type": "structure",
+      "members": {
+        "shareDecaySeconds": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The amount of time (in seconds) to use to calculate a fair-share percentage for each \n   share identifier in use. A value of zero (0) indicates the default minimum time window (600 seconds).\n   The maximum supported value is 604800 (1 week).</p>\n         <p>The decay allows for more recently run jobs to have more weight than jobs that ran earlier. \n   Consider adjusting this number if you have jobs that (on average) run longer than ten minutes, \n   or a large difference in job count or job run times between share identifiers, and the allocation\n   of resources doesn't meet your needs.</p>"
+          }
+        },
+        "computeReservation": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>A value used to reserve some of the available maximum vCPU for share identifiers that\n   aren't already used.</p>\n         <p>The reserved ratio is\n     <code>(<i>computeReservation</i>/100)^<i>ActiveFairShares</i>\n            </code>\n   where <code>\n               <i>ActiveFairShares</i>\n            </code> is the number of active share\n   identifiers.</p>\n         <p>For example, a <code>computeReservation</code> value of 50 indicates that Batch reserves\n   50% of the maximum available vCPU if there's only one share identifier. It reserves 25% if\n   there are two share identifiers. It reserves 12.5% if there are three share\n   identifiers. A <code>computeReservation</code> value of 25 indicates that Batch should reserve\n   25% of the maximum available vCPU if there's only one share identifier, 6.25% if there are\n   two fair share identifiers, and 1.56% if there are three share identifiers.</p>\n         <p>The minimum value is 0 and the maximum value is 99.</p>"
+          }
+        },
+        "shareDistribution": {
+          "target": "com.amazonaws.batch#ShareAttributesList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of <code>SharedIdentifier</code> objects that contain the weights for the \n   share identifiers for the fair-share policy. Share identifiers that aren't included have a\n   default weight of <code>1.0</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The fair-share scheduling policy details.</p>"
+      }
+    },
+    "com.amazonaws.batch#FairshareUtilizationDetail": {
+      "type": "structure",
+      "members": {
+        "activeShareCount": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The total number of active shares in the fairshare scheduling job queue that are\n            currently utilizing capacity.</p>"
+          }
+        },
+        "topCapacityUtilization": {
+          "target": "com.amazonaws.batch#FairshareCapacityUtilizationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the top 20 shares with the highest capacity utilization, ordered by usage\n            amount.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The fairshare utilization for a job queue, including the number\n            of active shares and top capacity utilization.</p>"
+      }
+    },
+    "com.amazonaws.batch#FargatePlatformConfiguration": {
+      "type": "structure",
+      "members": {
+        "platformVersion": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Fargate platform version where the jobs are running. A platform version is\n   specified only for jobs that are running on Fargate resources. If one isn't specified, the\n    <code>LATEST</code> platform version is used by default. This uses a recent, approved version of\n   the Fargate platform for compute resources. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html\">Fargate\n    platform versions</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The platform configuration for jobs that are running on Fargate resources. Jobs that run\n   on Amazon EC2 resources must not specify this parameter.</p>"
+      }
+    },
+    "com.amazonaws.batch#FirelensConfiguration": {
+      "type": "structure",
+      "members": {
+        "type": {
+          "target": "com.amazonaws.batch#FirelensConfigurationType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The log router to use. The valid values are <code>fluentd</code> or <code>fluentbit</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "options": {
+          "target": "com.amazonaws.batch#FirelensConfigurationOptionsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The options to use when configuring the log router. This field is optional and can be\n            used to specify a custom configuration file or to add additional metadata, such as the\n            task, task definition, cluster, and container instance details to the log event. If\n            specified, the syntax to use is\n            <code>\"options\":{\"enable-ecs-log-metadata\":\"true|false\",\"config-file-type:\"s3|file\",\"config-file-value\":\"arn:aws:s3:::mybucket/fluent.conf|filepath\"}</code>.\n            For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html#firelens-taskdef\">Creating a task definition that uses a FireLens configuration</a>\n            in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The FireLens configuration for the container. This is used to specify and configure a\n            log router for container logs. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html\">Custom log</a> routing in the <i>Amazon Elastic Container Service Developer\n            Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#FirelensConfigurationOptionsMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#String"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#String"
+      }
+    },
+    "com.amazonaws.batch#FirelensConfigurationType": {
+      "type": "enum",
+      "members": {
+        "FLUENTD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fluentd"
+          }
+        },
+        "FLUENTBIT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fluentbit"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#Float": {
+      "type": "float"
+    },
+    "com.amazonaws.batch#FrontOfQueueDetail": {
+      "type": "structure",
+      "members": {
+        "jobs": {
+          "target": "com.amazonaws.batch#FrontOfQueueJobSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Names (ARNs) of the first 100 <code>RUNNABLE</code> jobs in a named job queue. For first-in-first-out (FIFO) job queues, jobs are ordered based on their submission time. For fair-share scheduling (FSS) job queues, jobs are ordered based on their job priority and share usage.</p>"
+          }
+        },
+        "lastUpdatedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when each of the first 100 <code>RUNNABLE</code> jobs were last updated. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains a list of the first 100 <code>RUNNABLE</code> jobs associated to a single job queue.</p>"
+      }
+    },
+    "com.amazonaws.batch#FrontOfQueueJobSummary": {
+      "type": "structure",
+      "members": {
+        "jobArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN for a job in a named job queue.</p>"
+          }
+        },
+        "earliestTimeAtPosition": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the job transitioned to its current position in the job queue.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents summary details for the first 100 <code>RUNNABLE</code> jobs in a job queue.</p>"
+      }
+    },
+    "com.amazonaws.batch#FrontOfQueueJobSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#FrontOfQueueJobSummary"
+      }
+    },
+    "com.amazonaws.batch#FrontOfQuotaShareJobSummary": {
+      "type": "structure",
+      "members": {
+        "jobArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN for a job in a named quota share.</p>"
+          }
+        },
+        "earliestTimeAtPosition": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the job transitioned to its current position in the quota share.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents summary details for the first <code>RUNNABLE</code> job in a quota share.</p>"
+      }
+    },
+    "com.amazonaws.batch#FrontOfQuotaShareJobSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#FrontOfQuotaShareJobSummary"
+      }
+    },
+    "com.amazonaws.batch#FrontOfQuotaSharesDetail": {
+      "type": "structure",
+      "members": {
+        "quotaShares": {
+          "target": "com.amazonaws.batch#FrontOfQuotaSharesJobSummaryMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains a list of the first <code>RUNNABLE</code> job in each named quota share.</p>"
+          }
+        },
+        "lastUpdatedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the first <code>RUNNABLE</code> job per quota share were all last updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details of the first <code>RUNNABLE</code> job in each named quota share associated with a single job queue.</p>"
+      }
+    },
+    "com.amazonaws.batch#FrontOfQuotaSharesJobSummaryMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#String"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#FrontOfQuotaShareJobSummaryList"
+      }
+    },
+    "com.amazonaws.batch#GetJobQueueSnapshot": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#GetJobQueueSnapshotRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#GetJobQueueSnapshotResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a snapshot of job queue state, including ordering of <code>RUNNABLE</code> jobs, as well as capacity utilization for already dispatched jobs.\n    The first 100 <code>RUNNABLE</code> jobs in the job queue are listed in order of dispatch. For job queues with an attached\n    quota-share policy, the first <code>RUNNABLE</code> job in each quota share is also listed. Capacity utilization for the job queue is provided, as well as\n    break downs by share for job queues with attached fair-share or quota-share scheduling policies.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/getjobqueuesnapshot",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#GetJobQueueSnapshotRequest": {
+      "type": "structure",
+      "members": {
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job queue\u2019s name or full queue Amazon Resource Name (ARN).</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#GetJobQueueSnapshotResponse": {
+      "type": "structure",
+      "members": {
+        "frontOfQueue": {
+          "target": "com.amazonaws.batch#FrontOfQueueDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of the first 100 <code>RUNNABLE</code> jobs in each job queue. For\n      first-in-first-out (FIFO) job queues, jobs are ordered based on their submission time. For job queues with an attached\n      fair-share scheduling (FSS) or quota-share policy, jobs are ordered based on their job priority and share\n      usage.</p>"
+          }
+        },
+        "frontOfQuotaShares": {
+          "target": "com.amazonaws.batch#FrontOfQuotaSharesDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>The first <code>RUNNABLE</code> job in each quota share. Jobs are ordered based on their job priority and share usage.</p>"
+          }
+        },
+        "queueUtilization": {
+          "target": "com.amazonaws.batch#QueueSnapshotUtilizationDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>The job queue's capacity utilization, including total usage and\n            breakdown per given share.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#Host": {
+      "type": "structure",
+      "members": {
+        "sourcePath": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The path on the host container instance that's presented to the container. If this parameter\n   is empty, then the Docker daemon has assigned a host path for you. If this parameter contains a\n   file location, then the data volume persists at the specified location on the host container\n   instance until you delete it manually. If the source path location doesn't exist on the host\n   container instance, the Docker daemon creates it. If the location does exist, the contents of the\n   source path folder are exported.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that run on Fargate resources. Don't provide this\n    for these jobs.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Determine whether your data volume persists on the host container instance and where it's\n   stored. If this parameter is empty, then the Docker daemon assigns a host path for your data\n   volume. However, the data isn't guaranteed to persist after the containers that are associated\n   with it stop running.</p>"
+      }
+    },
+    "com.amazonaws.batch#ImageIdOverride": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.batch#ImagePullSecret": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Provides a unique identifier for the <code>ImagePullSecret</code>. This object is required\n   when <code>EksPodProperties$imagePullSecrets</code> is used.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>References a Kubernetes secret resource. This name of the secret must start and end with an\n   alphanumeric character, is required to be lowercase, can include periods (.) and hyphens (-), and\n   can't contain more than 253 characters.</p>"
+      }
+    },
+    "com.amazonaws.batch#ImagePullSecrets": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ImagePullSecret"
+      }
+    },
+    "com.amazonaws.batch#ImageType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.batch#Integer": {
+      "type": "integer"
+    },
+    "com.amazonaws.batch#JQState": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#JQStatus": {
+      "type": "enum",
+      "members": {
+        "CREATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATING"
+          }
+        },
+        "UPDATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATING"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        },
+        "DELETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED"
+          }
+        },
+        "VALID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALID"
+          }
+        },
+        "INVALID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INVALID"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#JobCapacityUsageSummary": {
+      "type": "structure",
+      "members": {
+        "capacityUnit": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unit of measure for the capacity usage. This is\n            <code>VCPU</code> for Amazon EC2 and <code>cpu</code> for Amazon EKS.</p>"
+          }
+        },
+        "quantity": {
+          "target": "com.amazonaws.batch#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>The quantity of capacity being used by the job, measured in the units specified by\n                <code>capacityUnit</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The capacity usage for a job, including the unit of measure\n            and quantity of resources being used.</p>"
+      }
+    },
+    "com.amazonaws.batch#JobCapacityUsageSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#JobCapacityUsageSummary"
+      }
+    },
+    "com.amazonaws.batch#JobDefinition": {
+      "type": "structure",
+      "members": {
+        "jobDefinitionName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the job definition.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobDefinitionArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the job definition.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "revision": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The revision of the job definition.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job definition.</p>"
+          }
+        },
+        "type": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of job definition. It's either <code>container</code> or <code>multinode</code>. If\n   the job is run on Fargate resources, then <code>multinode</code> isn't supported. For more\n   information about multi-node parallel jobs, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/multi-node-job-def.html\">Creating a multi-node parallel job definition</a> in\n   the <i>Batch User Guide</i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "schedulingPriority": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The scheduling priority of the job definition. This only affects jobs in job queues with a\n   fair-share policy. Jobs with a higher scheduling priority are scheduled before jobs with a lower\n   scheduling priority.</p>"
+          }
+        },
+        "parameters": {
+          "target": "com.amazonaws.batch#ParametersMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Default parameters or parameter substitution placeholders that are set in the job\n   definition. Parameters are specified as a key-value pair mapping. Parameters in a\n    <code>SubmitJob</code> request override any corresponding parameter defaults from the job\n   definition. For more information about specifying parameters, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html\">Job definition parameters</a> in the\n    <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "retryStrategy": {
+          "target": "com.amazonaws.batch#RetryStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The retry strategy to use for failed jobs that are submitted with this job\n   definition.</p>"
+          }
+        },
+        "containerProperties": {
+          "target": "com.amazonaws.batch#ContainerProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object with properties specific to Amazon ECS-based jobs. When\n    <code>containerProperties</code> is used in the job definition, it can't be used in addition to\n    <code>eksProperties</code>, <code>ecsProperties</code>, or <code>nodeProperties</code>.</p>"
+          }
+        },
+        "timeout": {
+          "target": "com.amazonaws.batch#JobTimeout",
+          "traits": {
+            "smithy.api#documentation": "<p>The timeout time for jobs that are submitted with this job definition. After the amount of\n   time you specify passes, Batch terminates your jobs if they aren't finished.</p>"
+          }
+        },
+        "nodeProperties": {
+          "target": "com.amazonaws.batch#NodeProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object with properties that are specific to multi-node parallel jobs. When\n    <code>nodeProperties</code> is used in the job definition, it can't be used in addition to\n    <code>containerProperties</code>, <code>ecsProperties</code>, or\n   <code>eksProperties</code>.</p>\n         <note>\n            <p>If the job runs on Fargate resources, don't specify <code>nodeProperties</code>. Use\n     <code>containerProperties</code> instead.</p>\n         </note>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that are applied to the job definition.</p>"
+          }
+        },
+        "propagateTags": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether to propagate the tags from the job or job definition to the corresponding\n   Amazon ECS task. If no value is specified, the tags aren't propagated. Tags can only be propagated to\n   the tasks when the tasks are created. For tags with the same name, job tags are given priority\n   over job definitions tags. If the total number of combined tags from the job and job definition\n   is over 50, the job is moved to the <code>FAILED</code> state.</p>"
+          }
+        },
+        "platformCapabilities": {
+          "target": "com.amazonaws.batch#PlatformCapabilityList",
+          "traits": {
+            "smithy.api#documentation": "<p>The platform capabilities required by the job definition. If no value is specified, it\n   defaults to <code>EC2</code>. Jobs run on Fargate resources specify\n   <code>FARGATE</code>.</p>"
+          }
+        },
+        "ecsProperties": {
+          "target": "com.amazonaws.batch#EcsProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties for the Amazon ECS resources of a job.When\n    <code>ecsProperties</code> is used in the job definition, it can't be used in addition to\n    <code>containerProperties</code>, <code>eksProperties</code>, or\n   <code>nodeProperties</code>.</p>"
+          }
+        },
+        "eksProperties": {
+          "target": "com.amazonaws.batch#EksProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object with properties that are specific to Amazon EKS-based jobs. When\n    <code>eksProperties</code> is used in the job definition, it can't be used in addition to\n    <code>containerProperties</code>, <code>ecsProperties</code>, or\n   <code>nodeProperties</code>.</p>"
+          }
+        },
+        "containerOrchestrationType": {
+          "target": "com.amazonaws.batch#OrchestrationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The orchestration type of the compute environment. The valid values are <code>ECS</code>\n   (default) or <code>EKS</code>.</p>"
+          }
+        },
+        "consumableResourceProperties": {
+          "target": "com.amazonaws.batch#ConsumableResourceProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains a list of consumable resources required by the job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents an Batch job definition.</p>"
+      }
+    },
+    "com.amazonaws.batch#JobDefinitionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#JobDefinition"
+      }
+    },
+    "com.amazonaws.batch#JobDefinitionType": {
+      "type": "enum",
+      "members": {
+        "Container": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "container"
+          }
+        },
+        "Multinode": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "multinode"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#JobDependency": {
+      "type": "structure",
+      "members": {
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The job ID of the Batch job that's associated with this dependency.</p>"
+          }
+        },
+        "type": {
+          "target": "com.amazonaws.batch#ArrayJobDependency",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the job dependency.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents an Batch job dependency.</p>"
+      }
+    },
+    "com.amazonaws.batch#JobDependencyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#JobDependency"
+      }
+    },
+    "com.amazonaws.batch#JobDetail": {
+      "type": "structure",
+      "members": {
+        "jobArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job.</p>"
+          }
+        },
+        "jobName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job name.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job queue that the job is associated with.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#JobStatus",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The current status for the job.</p>\n         <note>\n            <p>If your jobs don't progress to <code>STARTING</code>, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/troubleshooting.html#job_stuck_in_runnable\">Jobs stuck in RUNNABLE\n     status</a> in the troubleshooting section of the\n    <i>Batch User Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "shareIdentifier": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The share identifier for the job.</p>"
+          }
+        },
+        "schedulingPriority": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The scheduling policy of the job definition. This only affects jobs in job queues with a\n   fair-share policy. Jobs with a higher scheduling priority are scheduled before jobs with a lower\n   scheduling priority.</p>"
+          }
+        },
+        "attempts": {
+          "target": "com.amazonaws.batch#AttemptDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of job attempts that are associated with this job.</p>"
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short, human-readable string to provide more details for the current status of the\n   job.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CAPACITY:INSUFFICIENT_INSTANCE_CAPACITY</code> - All compute environments have\n     insufficient capacity to service the job.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MISCONFIGURATION:COMPUTE_ENVIRONMENT_MAX_RESOURCE</code> - All compute environments\n     have a <code>maxVcpu</code> setting that is smaller than the job requirements.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MISCONFIGURATION:JOB_RESOURCE_REQUIREMENT</code> - All compute environments have no\n     connected instances that meet the job requirements.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MISCONFIGURATION:SERVICE_ROLE_PERMISSIONS</code> - All compute environments have\n     problems with the service role permissions.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "createdAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the job was created. For non-array jobs and\n   parent array jobs, this is when the job entered the <code>SUBMITTED</code> state. This is\n   specifically at the time <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html\">SubmitJob</a> was called. For array child\n   jobs, this is when the child job was spawned by its parent and entered the <code>PENDING</code>\n   state.</p>"
+          }
+        },
+        "retryStrategy": {
+          "target": "com.amazonaws.batch#RetryStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The retry strategy to use for this job if an attempt fails.</p>"
+          }
+        },
+        "startedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the job was started. More specifically, it's\n   when the job transitioned from the <code>STARTING</code> state to the <code>RUNNING</code> state.\n  </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "stoppedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the job was stopped. More specifically, it's\n   when the job transitioned from the <code>RUNNING</code> state to a terminal state, such as\n    <code>SUCCEEDED</code> or <code>FAILED</code>.</p>"
+          }
+        },
+        "dependsOn": {
+          "target": "com.amazonaws.batch#JobDependencyList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of job IDs that this job depends on.</p>"
+          }
+        },
+        "jobDefinition": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job definition that this job uses.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "parameters": {
+          "target": "com.amazonaws.batch#ParametersMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional parameters that are passed to the job that replace parameter substitution\n   placeholders or override any corresponding parameter defaults from the job definition.</p>"
+          }
+        },
+        "container": {
+          "target": "com.amazonaws.batch#ContainerDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that represents the details for the container that's associated with the job. If\n   the details are for a multiple-container job, this object will be empty. </p>"
+          }
+        },
+        "nodeDetails": {
+          "target": "com.amazonaws.batch#NodeDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that represents the details of a node that's associated with a multi-node parallel\n   job.</p>"
+          }
+        },
+        "nodeProperties": {
+          "target": "com.amazonaws.batch#NodeProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that represents the node properties of a multi-node parallel job.</p>\n         <note>\n            <p>This isn't applicable to jobs that are running on Fargate resources.</p>\n         </note>"
+          }
+        },
+        "arrayProperties": {
+          "target": "com.amazonaws.batch#ArrayPropertiesDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>The array properties of the job, if it's an array job.</p>"
+          }
+        },
+        "timeout": {
+          "target": "com.amazonaws.batch#JobTimeout",
+          "traits": {
+            "smithy.api#documentation": "<p>The timeout configuration for the job.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that are applied to the job.</p>"
+          }
+        },
+        "propagateTags": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether to propagate the tags from the job or job definition to the corresponding\n   Amazon ECS task. If no value is specified, the tags aren't propagated. Tags can only be propagated to\n   the tasks when the tasks are created. For tags with the same name, job tags are given priority\n   over job definitions tags. If the total number of combined tags from the job and job definition\n   is over 50, the job is moved to the <code>FAILED</code> state.</p>"
+          }
+        },
+        "platformCapabilities": {
+          "target": "com.amazonaws.batch#PlatformCapabilityList",
+          "traits": {
+            "smithy.api#documentation": "<p>The platform capabilities required by the job definition. If no value is specified, it\n   defaults to <code>EC2</code>. Jobs run on Fargate resources specify\n   <code>FARGATE</code>.</p>"
+          }
+        },
+        "eksProperties": {
+          "target": "com.amazonaws.batch#EksPropertiesDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>An object with various properties that are specific to Amazon EKS based jobs. </p>"
+          }
+        },
+        "eksAttempts": {
+          "target": "com.amazonaws.batch#EksAttemptDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of job attempts that are associated with this job.</p>"
+          }
+        },
+        "ecsProperties": {
+          "target": "com.amazonaws.batch#EcsPropertiesDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>An object with properties that are specific to Amazon ECS-based jobs. </p>"
+          }
+        },
+        "isCancelled": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the job is canceled.</p>"
+          }
+        },
+        "isTerminated": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the job is terminated.</p>"
+          }
+        },
+        "consumableResourceProperties": {
+          "target": "com.amazonaws.batch#ConsumableResourceProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains a list of consumable resources required by the job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents an Batch job.</p>"
+      }
+    },
+    "com.amazonaws.batch#JobDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#JobDetail"
+      }
+    },
+    "com.amazonaws.batch#JobExecutionTimeoutMinutes": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 7200
+        }
+      }
+    },
+    "com.amazonaws.batch#JobQueueDetail": {
+      "type": "structure",
+      "members": {
+        "jobQueueName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job queue name.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobQueueArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job queue.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#JQState",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Describes the ability of the queue to accept new jobs. If the job queue state is\n    <code>ENABLED</code>, it can accept jobs. If the job queue state is <code>DISABLED</code>, new\n   jobs can't be added to the queue, but jobs already in the queue can finish.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "schedulingPolicyArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the scheduling policy. The format is\n     <code>aws:<i>Partition</i>:batch:<i>Region</i>:<i>Account</i>:scheduling-policy/<i>Name</i>\n            </code>.\n   For example,\n    <code>aws:aws:batch:us-west-2:123456789012:scheduling-policy/MySchedulingPolicy</code>.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#JQStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job queue (for example, <code>CREATING</code> or\n   <code>VALID</code>).</p>"
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short, human-readable string to provide additional details for the current status of the\n   job queue.</p>"
+          }
+        },
+        "priority": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The priority of the job queue. Job queue priority determines the order \n   that job queues are evaluated when multiple queues dispatch jobs within a \n   shared compute environment. A higher value for <code>priority</code> indicates\n   a higher priority. Queues are evaluated in cycles, in descending order by\n   priority. For example, a job queue with a priority value of <code>10</code> is \n   evaluated before a queue with a priority value of <code>1</code>. All of the \n   compute environments must be either Amazon EC2 (<code>EC2</code> or <code>SPOT</code>)\n   or Fargate (<code>FARGATE</code> or <code>FARGATE_SPOT</code>). Amazon EC2 and \n   Fargate compute environments can't be mixed.</p>\n         <note>\n            <p>Job queue priority doesn't guarantee that a particular job executes before \n    a job in a lower priority queue. Jobs added to higher priority queues during the \n    queue evaluation cycle might not be evaluated until the next cycle. A job is \n    dispatched from a queue only if resources are available when the queue is evaluated. \n    If there are insufficient resources available at that time, the cycle proceeds to the \n    next queue. This means that jobs added to higher priority queues might have to wait \n    for jobs in multiple lower priority queues to complete before they are dispatched. \n    You can use job dependencies to control the order for jobs from queues with different \n    priorities. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/job_dependencies.html\">Job Dependencies</a>\n    in the <i>Batch User Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "computeEnvironmentOrder": {
+          "target": "com.amazonaws.batch#ComputeEnvironmentOrders",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The compute environments that are attached to the job queue and the order that job placement\n   is preferred. Compute environments are selected for job placement in ascending order.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceEnvironmentOrder": {
+          "target": "com.amazonaws.batch#ServiceEnvironmentOrders",
+          "traits": {
+            "smithy.api#documentation": "<p>The order of the service environment associated with the job queue. Job queues with a higher priority are evaluated first when associated with the same service environment.</p>"
+          }
+        },
+        "jobQueueType": {
+          "target": "com.amazonaws.batch#JobQueueType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of job queue. For service jobs that run on SageMaker Training, this value is <code>SAGEMAKER_TRAINING</code>. For regular container jobs, this value is <code>EKS</code>, <code>ECS</code>, or <code>ECS_FARGATE</code> depending on the compute environment.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that are applied to the job queue. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using-tags.html\">Tagging your Batch resources</a> in\n    <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "jobStateTimeLimitActions": {
+          "target": "com.amazonaws.batch#JobStateTimeLimitActions",
+          "traits": {
+            "smithy.api#documentation": "<p>The set of actions that Batch perform on jobs that remain at the head of the job queue in the specified state longer than specified times. Batch will perform each action after <code>maxTimeSeconds</code> has passed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details for an Batch job queue.</p>"
+      }
+    },
+    "com.amazonaws.batch#JobQueueDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#JobQueueDetail"
+      }
+    },
+    "com.amazonaws.batch#JobQueueType": {
+      "type": "enum",
+      "members": {
+        "EKS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EKS"
+          }
+        },
+        "ECS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ECS"
+          }
+        },
+        "ECS_FARGATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ECS_FARGATE"
+          }
+        },
+        "SAGEMAKER_TRAINING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SAGEMAKER_TRAINING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#JobStateTimeLimitAction": {
+      "type": "structure",
+      "members": {
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The reason to log for the action being taken.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#JobStateTimeLimitActionsState",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The state of the job needed to trigger the action. The only supported value is <code>RUNNABLE</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "maxTimeSeconds": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The approximate amount of time, in seconds, that must pass with the job in the specified state before the action\n   is taken. The minimum value is 600 (10 minutes) and the maximum value is 86,400 (24 hours).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "action": {
+          "target": "com.amazonaws.batch#JobStateTimeLimitActionsAction",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The action to take when a job is at the head of the job queue in the specified state for the specified period of\n   time. For job queues connected to a <code>ECS</code>, <code>FARGATE</code> or <code>EKS</code> compute environment, the only supported value is <code>CANCEL</code>, which will cancel the job. \n   For job queues connected to a <code>SAGEMAKER_TRAINING</code> service environment, the only supported value is <code>TERMINATE</code>, which will terminate the job.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies an action that Batch will take after the job has remained at the head of the queue in the specified state for longer than the specified time.</p>"
+      }
+    },
+    "com.amazonaws.batch#JobStateTimeLimitActions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#JobStateTimeLimitAction"
+      }
+    },
+    "com.amazonaws.batch#JobStateTimeLimitActionsAction": {
+      "type": "enum",
+      "members": {
+        "CANCEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CANCEL"
+          }
+        },
+        "TERMINATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#JobStateTimeLimitActionsState": {
+      "type": "enum",
+      "members": {
+        "RUNNABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNABLE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#JobStatus": {
+      "type": "enum",
+      "members": {
+        "SUBMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUBMITTED"
+          }
+        },
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "RUNNABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNABLE"
+          }
+        },
+        "STARTING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STARTING"
+          }
+        },
+        "RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNING"
+          }
+        },
+        "SUCCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCEEDED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#JobSummary": {
+      "type": "structure",
+      "members": {
+        "jobArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job.</p>"
+          }
+        },
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job name.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "capacityUsage": {
+          "target": "com.amazonaws.batch#JobCapacityUsageSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The configured capacity usage information for this job, including the unit of measure and\n            quantity of resources.</p>"
+          }
+        },
+        "createdAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the job was created. For non-array jobs and\n   parent array jobs, this is when the job entered the <code>SUBMITTED</code> state (at the time\n    <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html\">SubmitJob</a>\n   was called). For array child jobs, this is when the child job was spawned by its parent and\n   entered the <code>PENDING</code> state.</p>"
+          }
+        },
+        "scheduledAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the job was scheduled for\n            execution. For more information on job statues, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/service-job-status.html\">Service job status</a> in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "shareIdentifier": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The share identifier for the fairshare scheduling queue that this job is\n            associated with.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status for the job.</p>"
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short, human-readable string to provide more details for the current status of the\n   job.</p>"
+          }
+        },
+        "startedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp for when the job was started. More specifically, it's when the job\n   transitioned from the <code>STARTING</code> state to the <code>RUNNING</code> state.</p>"
+          }
+        },
+        "stoppedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp for when the job was stopped. More specifically, it's when the job\n   transitioned from the <code>RUNNING</code> state to a terminal state, such as\n    <code>SUCCEEDED</code> or <code>FAILED</code>.</p>"
+          }
+        },
+        "container": {
+          "target": "com.amazonaws.batch#ContainerSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that represents the details of the container that's associated with the\n   job.</p>"
+          }
+        },
+        "arrayProperties": {
+          "target": "com.amazonaws.batch#ArrayPropertiesSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>The array properties of the job, if it's an array job.</p>"
+          }
+        },
+        "nodeProperties": {
+          "target": "com.amazonaws.batch#NodePropertiesSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>The node properties for a single node in a job summary list.</p>\n         <note>\n            <p>This isn't applicable to jobs that are running on Fargate resources.</p>\n         </note>"
+          }
+        },
+        "jobDefinition": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job definition.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents summary details of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#JobSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#JobSummary"
+      }
+    },
+    "com.amazonaws.batch#JobTimeout": {
+      "type": "structure",
+      "members": {
+        "attemptDurationSeconds": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The job timeout time (in seconds) that's measured from the job attempt's\n    <code>startedAt</code> timestamp. After this time passes, Batch terminates your jobs if they\n   aren't finished. The minimum value for the timeout is 60 seconds.</p>\n         <p>For array jobs, the timeout applies to the child jobs, not to the parent array job.</p>\n         <p>For multi-node parallel (MNP) jobs, the timeout applies to the whole job, not to the\n   individual nodes.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents a job timeout configuration.</p>"
+      }
+    },
+    "com.amazonaws.batch#KeyValuePair": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the key-value pair. For environment variables, this is the name of the\n   environment variable.</p>"
+          }
+        },
+        "value": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the key-value pair. For environment variables, this is the value of the\n   environment variable.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A key-value pair object.</p>"
+      }
+    },
+    "com.amazonaws.batch#KeyValuesPair": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the filter. Filter names are case sensitive.</p>"
+          }
+        },
+        "values": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The filter values.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A filter name and value pair that's used to return a more specific list of results from a\n    <code>ListJobs</code> or <code>ListJobsByConsumableResource</code> API operation.</p>"
+      }
+    },
+    "com.amazonaws.batch#KubernetesVersion": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.batch#LatestServiceJobAttempt": {
+      "type": "structure",
+      "members": {
+        "serviceResourceId": {
+          "target": "com.amazonaws.batch#ServiceResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The service resource identifier associated with the service job attempt.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the latest attempt of a service job. A Service job can transition from <code>SCHEDULED</code> back to <code>RUNNABLE</code> state when they encounter capacity constraints.</p>"
+      }
+    },
+    "com.amazonaws.batch#LaunchTemplateSpecification": {
+      "type": "structure",
+      "members": {
+        "launchTemplateId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the launch template.</p>"
+          }
+        },
+        "launchTemplateName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the launch template.</p>"
+          }
+        },
+        "version": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The version number of the launch template, \n   <code>$Default</code>, or <code>$Latest</code>.</p>\n         <p>If the value is <code>$Default</code>, the default version of the launch template is used. If the value is <code>$Latest</code>, the latest version of the launch template is used. </p>\n         <important>\n            <p>If the AMI ID that's used in a compute environment is from the launch template, the AMI\n    isn't changed when the compute environment is updated. It's only changed if the\n     <code>updateToLatestImageVersion</code> parameter for the compute environment is set to\n     <code>true</code>. During an infrastructure update, if either <code>$Default</code> or\n     <code>$Latest</code> is specified, Batch re-evaluates the launch template version, and it\n    might use a different version of the launch template. This is the case even if the launch\n    template isn't specified in the update. When updating a compute environment, changing the launch\n    template requires an infrastructure update of the compute environment. For more information, see\n     <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute\n     environments</a> in the <i>Batch User Guide</i>.</p>\n         </important>\n         <p>Default: <code>$Default</code>\n         </p>\n         <p>Latest: <code>$Latest</code>\n         </p>"
+          }
+        },
+        "overrides": {
+          "target": "com.amazonaws.batch#LaunchTemplateSpecificationOverrideList",
+          "traits": {
+            "smithy.api#documentation": "<p>A launch template to use in place of the default launch template. You must specify either the launch template ID or launch template name in the request, but not both.</p>\n         <p>You can specify up to ten (10) launch template overrides that are associated to unique instance types or families for each compute environment.</p>\n         <note>\n            <p>To unset all override templates for a compute environment, you can pass an empty array to the <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_UpdateComputeEnvironment.html\">UpdateComputeEnvironment.overrides</a> parameter, or not include the <code>overrides</code> parameter when submitting the <code>UpdateComputeEnvironment</code> API operation.</p>\n         </note>"
+          }
+        },
+        "userdataType": {
+          "target": "com.amazonaws.batch#UserdataType",
+          "traits": {
+            "smithy.api#documentation": "<p>The EKS node initialization process to use. You only need to specify this value if you are\n   using a custom AMI. The default value is <code>EKS_BOOTSTRAP_SH</code>. If\n    <i>imageType</i> is a custom AMI based on EKS_AL2023 or EKS_AL2023_NVIDIA then you\n   must choose <code>EKS_NODEADM</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents a launch template that's associated with a compute resource. You\n   must specify either the launch template ID or launch template name in the request, but not\n   both.</p>\n         <p>If security groups are specified using both the <code>securityGroupIds</code> parameter of\n    <code>CreateComputeEnvironment</code> and the launch template, the values in the\n    <code>securityGroupIds</code> parameter of <code>CreateComputeEnvironment</code> will be\n   used.</p>\n         <note>\n            <p>This object isn't applicable to jobs that are running on Fargate resources.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.batch#LaunchTemplateSpecificationOverride": {
+      "type": "structure",
+      "members": {
+        "launchTemplateId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the launch template.</p>\n         <p>\n            <b>Note:</b> If you specify the <code>launchTemplateId</code> you can't specify the <code>launchTemplateName</code> as well.</p>"
+          }
+        },
+        "launchTemplateName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the launch template.</p>\n         <p>\n            <b>Note:</b> If you specify the <code>launchTemplateName</code> you can't specify the <code>launchTemplateId</code> as well.</p>"
+          }
+        },
+        "version": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The version number of the launch template, \n   <code>$Default</code>, or <code>$Latest</code>.</p>\n         <p>If the value is <code>$Default</code>, the default version of the launch template is used. If the value is <code>$Latest</code>, the latest version of the launch template is used. </p>\n         <important>\n            <p>If the AMI ID that's used in a compute environment is from the launch template, the AMI\n    isn't changed when the compute environment is updated. It's only changed if the\n     <code>updateToLatestImageVersion</code> parameter for the compute environment is set to\n     <code>true</code>. During an infrastructure update, if either <code>$Default</code> or <code>$Latest</code> is specified, Batch re-evaluates the launch template version, and it\n    might use a different version of the launch template. This is the case even if the launch\n    template isn't specified in the update. When updating a compute environment, changing the launch\n    template requires an infrastructure update of the compute environment. For more information, see\n     <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute\n     environments</a> in the <i>Batch User Guide</i>.</p>\n         </important>\n         <p>Default: <code>$Default</code>\n         </p>\n         <p>Latest: <code>$Latest</code>\n         </p>"
+          }
+        },
+        "targetInstanceTypes": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The instance type or family that this override launch template should be applied to.</p>\n         <p>This parameter is required when defining a launch template override.</p>\n         <p>Information included in this parameter must meet the following requirements:</p>\n         <ul>\n            <li>\n               <p>Must be a valid Amazon EC2 instance type or family.</p>\n            </li>\n            <li>\n               <p>The following Batch <code>InstanceTypes</code> are not allowed: <code>optimal</code>, <code>default_x86_64</code>, and <code>default_arm64</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>targetInstanceTypes</code> can target only instance types and families that are included within the <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_ComputeResource.html#Batch-Type-ComputeResource-instanceTypes\">\n                     <code>ComputeResource.instanceTypes</code>\n                  </a> set. <code>targetInstanceTypes</code> doesn't need to include all of the instances from the <code>instanceType</code> set, but at least a subset. For example, if <code>ComputeResource.instanceTypes</code> includes <code>[m5, g5]</code>, <code>targetInstanceTypes</code> can include <code>[m5.2xlarge]</code> and <code>[m5.large]</code> but not <code>[c5.large]</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>targetInstanceTypes</code> included within the same launch template override or across launch template overrides can't overlap for the same compute environment. For example, you can't define one launch template override to target an instance family and another define an instance type within this same family.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "userdataType": {
+          "target": "com.amazonaws.batch#UserdataType",
+          "traits": {
+            "smithy.api#documentation": "<p>The EKS node initialization process to use. You only need to specify this value if you are\n   using a custom AMI. The default value is <code>EKS_BOOTSTRAP_SH</code>. If\n    <i>imageType</i> is a custom AMI based on EKS_AL2023 or EKS_AL2023_NVIDIA then you\n   must choose <code>EKS_NODEADM</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents a launch template to use in place of the default launch template. You must specify either the launch template ID or launch template name in the request, but not\n   both.</p>\n         <p>If security groups are specified using both the <code>securityGroupIds</code> parameter of\n    <code>CreateComputeEnvironment</code> and the launch template, the values in the\n    <code>securityGroupIds</code> parameter of <code>CreateComputeEnvironment</code> will be\n   used.</p>\n         <p>You can define up to ten (10) overrides for each compute environment.</p>\n         <note>\n            <p>This object isn't applicable to jobs that are running on Fargate resources.</p>\n         </note>\n         <note>\n            <p>To unset all override templates for a compute environment, you can pass an empty array to the <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_UpdateComputeEnvironment.html\">UpdateComputeEnvironment.overrides</a> parameter, or not include the <code>overrides</code> parameter when submitting the <code>UpdateComputeEnvironment</code> API operation.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.batch#LaunchTemplateSpecificationOverrideList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#LaunchTemplateSpecificationOverride"
+      }
+    },
+    "com.amazonaws.batch#LinuxParameters": {
+      "type": "structure",
+      "members": {
+        "devices": {
+          "target": "com.amazonaws.batch#DevicesList",
+          "traits": {
+            "smithy.api#documentation": "<p>Any of the host devices to expose to the container. This parameter maps to\n    <code>Devices</code> in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a>\n   and the <code>--device</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker\n   run</a>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't\n    provide it for these jobs.</p>\n         </note>"
+          }
+        },
+        "initProcessEnabled": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>If true, run an <code>init</code> process inside the container that forwards signals and\n   reaps processes. This parameter maps to the <code>--init</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. This parameter requires version 1.25 of the Docker Remote API or greater on your\n container instance. To check the Docker Remote API version on your container instance, log in to your\n container instance and run the following command: <code>sudo docker version | grep \"Server API version\"</code>\n         </p>"
+          }
+        },
+        "sharedMemorySize": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The value for the size (in MiB) of the <code>/dev/shm</code> volume. This parameter maps to\n   the <code>--shm-size</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker\n   run</a>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't\n    provide it for these jobs.</p>\n         </note>"
+          }
+        },
+        "tmpfs": {
+          "target": "com.amazonaws.batch#TmpfsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The container path, mount options, and size (in MiB) of the <code>tmpfs</code> mount. This\n   parameter maps to the <code>--tmpfs</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker\n    run</a>.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't\n    provide this parameter for this resource type.</p>\n         </note>"
+          }
+        },
+        "maxSwap": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The total amount of swap memory (in MiB) a container can use. This parameter is translated\n   to the <code>--memory-swap</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker\n    run</a> where the value is the sum of the container memory plus the <code>maxSwap</code>\n   value. For more information, see <a href=\"https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details\">\n               <code>--memory-swap</code> details</a> in the Docker documentation.</p>\n         <p>If a <code>maxSwap</code> value of <code>0</code> is specified, the container doesn't use\n   swap. Accepted values are <code>0</code> or any positive integer. If the <code>maxSwap</code>\n   parameter is omitted, the container doesn't use the swap configuration for the container instance\n   on which it runs. A <code>maxSwap</code> value must be set for the <code>swappiness</code>\n   parameter to be used.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't\n    provide it for these jobs.</p>\n         </note>"
+          }
+        },
+        "swappiness": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>You can use this parameter to tune a container's memory swappiness behavior. A\n    <code>swappiness</code> value of <code>0</code> causes swapping to not occur unless absolutely\n   necessary. A <code>swappiness</code> value of <code>100</code> causes pages to be swapped\n   aggressively. Valid values are whole numbers between <code>0</code> and <code>100</code>. If the\n    <code>swappiness</code> parameter isn't specified, a default value of <code>60</code> is used.\n   If a value isn't specified for <code>maxSwap</code>, then this parameter is ignored. If\n    <code>maxSwap</code> is set to 0, the container doesn't use swap. This parameter maps to the\n    <code>--memory-swappiness</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker\n    run</a>.</p>\n         <p>Consider the following when you use a per-container swap configuration.</p>\n         <ul>\n            <li>\n               <p>Swap space must be enabled and allocated on the container instance for the containers to\n     use.</p>\n               <note>\n                  <p>By default, the Amazon ECS optimized AMIs don't have swap enabled. You must enable swap on the\n      instance to use this feature. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-swap-volumes.html\">Instance store swap\n       volumes</a> in the <i>Amazon EC2 User Guide for Linux Instances</i> or <a href=\"http://aws.amazon.com/premiumsupport/knowledge-center/ec2-memory-swap-file/\">How do I\n       allocate memory to work as swap space in an Amazon EC2 instance by using a swap\n      file?</a>\n                  </p>\n               </note>\n            </li>\n            <li>\n               <p>The swap space parameters are only supported for job definitions using EC2\n     resources.</p>\n            </li>\n            <li>\n               <p>If the <code>maxSwap</code> and <code>swappiness</code> parameters are omitted from a job\n     definition, each container has a default <code>swappiness</code> value of 60. Moreover, the\n     total swap usage is limited to two times the memory reservation of the container.</p>\n            </li>\n         </ul>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't\n    provide it for these jobs.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Linux-specific modifications that are applied to the container, such as details for device\n   mappings.</p>"
+      }
+    },
+    "com.amazonaws.batch#ListAttemptEcsTaskDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#AttemptEcsTaskDetails"
+      }
+    },
+    "com.amazonaws.batch#ListAttemptTaskContainerDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#AttemptTaskContainerDetails"
+      }
+    },
+    "com.amazonaws.batch#ListConsumableResources": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#ListConsumableResourcesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#ListConsumableResourcesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of Batch consumable resources.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To get a list of a consumable resources",
+            "documentation": "Returns a list of the consumable resources for your account.",
+            "input": {
+              "filters": [
+                {
+                  "name": "CONSUMABLE_RESOURCE_NAME",
+                  "values": [
+                    "my*"
+                  ]
+                }
+              ],
+              "maxResults": 123
+            },
+            "output": {
+              "consumableResources": [
+                {
+                  "consumableResourceArn": "arn:aws:batch:us-east-1:012345678910:consumable-resource/myConsumableResource",
+                  "consumableResourceName": "myConsumableResource",
+                  "inUseQuantity": 12,
+                  "resourceType": "REPLENISHABLE",
+                  "totalQuantity": 123
+                }
+              ]
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/listconsumableresources",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "consumableResources",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.batch#ListConsumableResourcesFilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#KeyValuesPair"
+      }
+    },
+    "com.amazonaws.batch#ListConsumableResourcesRequest": {
+      "type": "structure",
+      "members": {
+        "filters": {
+          "target": "com.amazonaws.batch#ListConsumableResourcesFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The filters to apply to the consumable resource list query. If used, only those consumable \n            resources that match the filter are listed. Filter names and values can be:</p>\n         <ul>\n            <li>\n               <p>name: <code>CONSUMABLE_RESOURCE_NAME </code>\n               </p>\n               <p>values: case-insensitive matches for the consumable resource name. If a filter \n                    value ends with an asterisk (*), it matches any consumable resource name that begins \n                    with the string before the '*'.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results returned by <code>ListConsumableResources</code> in paginated\n            output. When this parameter is used, <code>ListConsumableResources</code> only returns\n            <code>maxResults</code> results in a single page and a <code>nextToken</code> response\n            element. The remaining results of the initial request can be seen by sending another\n            <code>ListConsumableResources</code> request with the returned <code>nextToken</code> value.\n            This value can be between 1 and 100. If this parameter isn't\n            used, then <code>ListConsumableResources</code> returns up to 100 results and\n            a <code>nextToken</code> value if applicable.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value returned from a previous paginated \n            <code>ListConsumableResources</code> request where <code>maxResults</code> was used and the \n            results exceeded the value of that parameter. Pagination continues from the end of the previous \n            results that returned the <code>nextToken</code> value. This value is <code>null</code> when \n            there are no more results to return.</p>\n         <note>\n            <p>Treat this token as an opaque identifier that's only used to\n retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#ListConsumableResourcesResponse": {
+      "type": "structure",
+      "members": {
+        "consumableResources": {
+          "target": "com.amazonaws.batch#ConsumableResourceSummaryList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of consumable resources that match the request.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListConsumableResources</code> \n            request. When the results of a <code>ListConsumableResources</code> request exceed <code>maxResults</code>, \n            this value can be used to retrieve the next page of results. This value is <code>null</code> \n            when there are no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#ListEcsTaskDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EcsTaskDetails"
+      }
+    },
+    "com.amazonaws.batch#ListEcsTaskProperties": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#EcsTaskProperties"
+      }
+    },
+    "com.amazonaws.batch#ListJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#ListJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#ListJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of Batch jobs.</p>\n         <p>You must specify only one of the following items:</p>\n         <ul>\n            <li>\n               <p>A job queue ID to return a list of jobs in that job queue</p>\n            </li>\n            <li>\n               <p>A multi-node parallel job ID to return a list of nodes for that job</p>\n            </li>\n            <li>\n               <p>An array job ID to return a list of the children for that job</p>\n            </li>\n         </ul>",
+        "smithy.api#examples": [
+          {
+            "title": "To list running jobs",
+            "documentation": "This example lists the running jobs in the HighPriority job queue.",
+            "input": {
+              "jobQueue": "HighPriority"
+            },
+            "output": {
+              "jobSummaryList": [
+                {
+                  "jobId": "e66ff5fd-a1ff-4640-b1a2-0b0a142f49bb",
+                  "jobName": "example"
+                }
+              ]
+            }
+          },
+          {
+            "title": "To list submitted jobs",
+            "documentation": "This example lists jobs in the HighPriority job queue that are in the SUBMITTED job status.",
+            "input": {
+              "jobQueue": "HighPriority",
+              "jobStatus": "SUBMITTED"
+            },
+            "output": {
+              "jobSummaryList": [
+                {
+                  "jobId": "68f0c163-fbd4-44e6-9fd1-25b14a434786",
+                  "jobName": "example"
+                }
+              ]
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/listjobs",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "jobSummaryList",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.batch#ListJobsByConsumableResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#ListJobsByConsumableResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#ListJobsByConsumableResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of Batch jobs that require a specific consumable resource.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To get a list of Batch jobs by consumable resource",
+            "documentation": "Returns a list of Batch jobs that require a specific consumable resource.",
+            "input": {
+              "consumableResource": "myConsumableResource",
+              "filters": [
+                {
+                  "name": "CONSUMABLE_RESOURCE_NAME",
+                  "values": [
+                    "my*"
+                  ]
+                }
+              ],
+              "maxResults": 123
+            },
+            "output": {
+              "jobs": [
+                {
+                  "consumableResourceProperties": {
+                    "consumableResourceList": [
+                      {
+                        "consumableResource": "myConsumableResource",
+                        "quantity": 123
+                      }
+                    ]
+                  },
+                  "createdAt": 1480460782010,
+                  "jobArn": "arn:aws:batch:us-east-1:012345678910:job/myJob",
+                  "jobDefinitionArn": "arn:aws:batch:us-east-1:012345678910:job-definition/myJobDef",
+                  "jobName": "myJob",
+                  "jobQueueArn": "arn:aws:batch:us-east-1:012345678910:job-queue/myJobQueue",
+                  "jobStatus": "PENDING",
+                  "quantity": 123
+                }
+              ]
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/listjobsbyconsumableresource",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "jobs",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.batch#ListJobsByConsumableResourceFilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#KeyValuesPair"
+      }
+    },
+    "com.amazonaws.batch#ListJobsByConsumableResourceRequest": {
+      "type": "structure",
+      "members": {
+        "consumableResource": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or ARN of the consumable resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "filters": {
+          "target": "com.amazonaws.batch#ListJobsByConsumableResourceFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The filters to apply to the job list query. If used, only those jobs requiring the specified \n            consumable resource (<code>consumableResource</code>) and that match the value of the filters\n            are listed. The filter names and values can be:</p>\n         <ul>\n            <li>\n               <p>name: <code>JOB_STATUS</code>\n               </p>\n               <p>values: <code>SUBMITTED | PENDING | RUNNABLE | STARTING | RUNNING | SUCCEEDED | FAILED</code>\n               </p>\n            </li>\n            <li>\n               <p>name: <code>JOB_NAME </code>\n               </p>\n               <p>The values are case-insensitive matches for the job name. If a filter value ends \n                    with an asterisk (*), it matches any job name that begins with the string before \n                    the '*'.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results returned by <code>ListJobsByConsumableResource</code> in paginated\n            output. When this parameter is used, <code>ListJobsByConsumableResource</code> only returns\n            <code>maxResults</code> results in a single page and a <code>nextToken</code> response\n            element. The remaining results of the initial request can be seen by sending another\n            <code>ListJobsByConsumableResource</code> request with the returned <code>nextToken</code> value.\n            This value can be between 1 and 100. If this parameter isn't\n            used, then <code>ListJobsByConsumableResource</code> returns up to 100 results \n            and a <code>nextToken</code> value if applicable.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value returned from a previous paginated \n            <code>ListJobsByConsumableResource</code> request where <code>maxResults</code> was used and the \n            results exceeded the value of that parameter. Pagination continues from the end of the previous \n            results that returned the <code>nextToken</code> value. This value is <code>null</code> when \n            there are no more results to return.</p>\n         <note>\n            <p>Treat this token as an opaque identifier that's only used to\n retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#ListJobsByConsumableResourceResponse": {
+      "type": "structure",
+      "members": {
+        "jobs": {
+          "target": "com.amazonaws.batch#ListJobsByConsumableResourceSummaryList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The list of jobs that require the specified consumable resources.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListJobsByConsumableResource</code> \n            request. When the results of a <code>ListJobsByConsumableResource</code> request exceed \n            <code>maxResults</code>, this value can be used to retrieve the next page of results. This \n            value is <code>null</code> when there are no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#ListJobsByConsumableResourceSummary": {
+      "type": "structure",
+      "members": {
+        "jobArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobQueueArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job queue.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobDefinitionArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job definition.</p>"
+          }
+        },
+        "shareIdentifier": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The fair-share scheduling identifier for the job.</p>"
+          }
+        },
+        "jobStatus": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The status of the job. Can be one of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SUBMITTED</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>PENDING</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RUNNABLE</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>STARTING</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RUNNING</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>SUCCEEDED</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code>\n               </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "quantity": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The total amount of the consumable resource that is available.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short, human-readable string to provide more details for the current status of the job.</p>"
+          }
+        },
+        "startedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp for when the job was started. More specifically, it's when the job transitioned \n            from the <code>STARTING</code> state to the <code>RUNNING</code> state.</p>"
+          }
+        },
+        "createdAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the consumable resource was created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "consumableResourceProperties": {
+          "target": "com.amazonaws.batch#ConsumableResourceProperties",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Contains a list of consumable resources required by the job.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Current information about a consumable resource required by a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#ListJobsByConsumableResourceSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ListJobsByConsumableResourceSummary"
+      }
+    },
+    "com.amazonaws.batch#ListJobsFilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#KeyValuesPair"
+      }
+    },
+    "com.amazonaws.batch#ListJobsRequest": {
+      "type": "structure",
+      "members": {
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name or full Amazon Resource Name (ARN) of the job queue used to list jobs.</p>"
+          }
+        },
+        "arrayJobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The job ID for an array job. Specifying an array job ID with this parameter lists all\n      child jobs from within the specified array.</p>"
+          }
+        },
+        "multiNodeJobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The job ID for a multi-node parallel job. Specifying a multi-node parallel job ID with\n      this parameter lists all nodes that are associated with the specified job.</p>"
+          }
+        },
+        "jobStatus": {
+          "target": "com.amazonaws.batch#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The job status used to filter jobs in the specified queue. If the <code>filters</code>\n      parameter is specified, the <code>jobStatus</code> parameter is ignored and jobs with any\n      status are returned. The exception is the <code>SHARE_IDENTIFIER</code> filter and <code>jobStatus</code> can be used together. If you don't specify a status, only <code>RUNNING</code> jobs are\n      returned.</p>\n         <note>\n            <p>Array job parents are updated to <code>PENDING</code> when any child job is updated to <code>RUNNABLE</code> and remain in <code>PENDING</code> status while child jobs are running. To view these jobs, filter by <code>PENDING</code> status until all child jobs reach a terminal state.</p>\n         </note>"
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results returned by <code>ListJobs</code> in a paginated output. When this parameter is used, <code>ListJobs</code> returns up to <code>maxResults</code> results in a single page and a <code>nextToken</code> response element, if applicable. The remaining results of the initial request can be seen by sending another <code>ListJobs</code> request with the returned <code>nextToken</code> value.</p>\n         <p>The following outlines key parameters and limitations:</p>\n         <ul>\n            <li>\n               <p>The minimum value is 1. </p>\n            </li>\n            <li>\n               <p>When <code>--job-status</code> is used, Batch returns up to 1000 values. </p>\n            </li>\n            <li>\n               <p>When <code>--filters</code> is used, Batch returns up to 100 values.</p>\n            </li>\n            <li>\n               <p>If neither parameter is used, then <code>ListJobs</code> returns up to\n      1000 results (jobs that are in the <code>RUNNING</code> status) and a <code>nextToken</code> value, if applicable.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value returned from a previous paginated <code>ListJobs</code>\n      request where <code>maxResults</code> was used and the results exceeded the value of that\n      parameter. Pagination continues from the end of the previous results that returned the\n        <code>nextToken</code> value. This value is <code>null</code> when there are no more results\n      to return.</p>\n         <note>\n            <p>Treat this token as an opaque identifier that's only used to\n retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
+          }
+        },
+        "filters": {
+          "target": "com.amazonaws.batch#ListJobsFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The filter to apply to the query. Only one filter can be used at a time. When the filter\n      is used, <code>jobStatus</code> is ignored with the exception that <code>SHARE_IDENTIFIER</code> and <code>jobStatus</code> can be used together. The filter doesn't apply to child jobs in an array\n      or multi-node parallel (MNP) jobs. The results are sorted by the <code>createdAt</code> field,\n      with the most recent jobs being first.</p>\n         <note>\n            <p>The <code>SHARE_IDENTIFIER</code> filter and the <code>jobStatus</code> field can be used together to filter results.</p>\n         </note>\n         <dl>\n            <dt>JOB_NAME</dt>\n            <dd>\n               <p>The value of the filter is a case-insensitive match for the job name. If the value\n            ends with an asterisk (*), the filter matches any job name that begins with the string\n            before the '*'. This corresponds to the <code>jobName</code> value. For example,\n              <code>test1</code> matches both <code>Test1</code> and <code>test1</code>, and\n              <code>test1*</code> matches both <code>test1</code> and <code>Test10</code>. When the\n              <code>JOB_NAME</code> filter is used, the results are grouped by the job name and\n            version.</p>\n            </dd>\n            <dt>JOB_DEFINITION</dt>\n            <dd>\n               <p>The value for the filter is the name or Amazon Resource Name (ARN) of the job definition. This\n            corresponds to the <code>jobDefinition</code> value. The value is case sensitive. When\n            the value for the filter is the job definition name, the results include all the jobs\n            that used any revision of that job definition name. If the value ends with an asterisk\n            (*), the filter matches any job definition name that begins with the string before the\n            '*'. For example, <code>jd1</code> matches only <code>jd1</code>, and <code>jd1*</code>\n            matches both <code>jd1</code> and <code>jd1A</code>. The version of the job definition\n            that's used doesn't affect the sort order. When the <code>JOB_DEFINITION</code> filter\n            is used and the ARN is used (which is in the form\n              <code>arn:${Partition}:batch:${Region}:${Account}:job-definition/${JobDefinitionName}:${Revision}</code>),\n            the results include jobs that used the specified revision of the job definition.\n            Asterisk (*) isn't supported when the ARN is used.</p>\n            </dd>\n            <dt>BEFORE_CREATED_AT</dt>\n            <dd>\n               <p>The value for the filter is the time that's before the job was created. This\n            corresponds to the <code>createdAt</code> value. The value is a string representation of\n            the number of milliseconds since 00:00:00 UTC (midnight) on January 1, 1970.</p>\n            </dd>\n            <dt>AFTER_CREATED_AT</dt>\n            <dd>\n               <p>The value for the filter is the time that's after the job was created. This\n            corresponds to the <code>createdAt</code> value. The value is a string representation of\n            the number of milliseconds since 00:00:00 UTC (midnight) on January 1, 1970.</p>\n            </dd>\n            <dt>SHARE_IDENTIFIER</dt>\n            <dd>\n               <p>The value for the filter is the fairshare scheduling share identifier.</p>\n            </dd>\n         </dl>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>ListJobs</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#ListJobsResponse": {
+      "type": "structure",
+      "members": {
+        "jobSummaryList": {
+          "target": "com.amazonaws.batch#JobSummaryList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of job summaries that match the request.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListJobs</code> request.\n      When the results of a <code>ListJobs</code> request exceed <code>maxResults</code>, this value\n      can be used to retrieve the next page of results. This value is <code>null</code> when there\n      are no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#ListQuotaShares": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#ListQuotaSharesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#ListQuotaSharesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of Batch quota shares associated with a job queue.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/listquotashares",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "quotaShares",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.batch#ListQuotaSharesRequest": {
+      "type": "structure",
+      "members": {
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or full Amazon Resource Name (ARN) of the job queue used to list quota shares.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results returned by <code>ListQuotaShares</code> in\n      paginated output. When this parameter is used, <code>ListQuotaShares</code> only\n      returns <code>maxResults</code> results in a single page and a <code>nextToken</code> response\n      element. You can see the remaining results of the initial request by sending another\n        <code>ListQuotaShares</code> request with the returned <code>nextToken</code> value.\n      This value can be between 1 and 100. If this parameter isn't\n      used, <code>ListQuotaShares</code> returns up to 100 results and a\n        <code>nextToken</code> value if applicable.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value that's returned from a previous paginated\n        <code>ListQuotaShares</code> request where <code>maxResults</code> was used and the\n      results exceeded the value of that parameter. Pagination continues from the end of the\n      previous results that returned the <code>nextToken</code> value. This value is\n        <code>null</code> when there are no more results to return.</p>\n         <note>\n            <p>Treat this token as an opaque identifier that's only used to\n retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#ListQuotaSharesResponse": {
+      "type": "structure",
+      "members": {
+        "quotaShares": {
+          "target": "com.amazonaws.batch#QuotaShareList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of quota shares that match the request.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future\n        <code>ListQuotaShares</code> request. When the results of a\n        <code>ListQuotaShares</code> request exceed <code>maxResults</code>, this value can\n      be used to retrieve the next page of results. This value is <code>null</code> when there are\n      no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#ListSchedulingPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#ListSchedulingPoliciesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#ListSchedulingPoliciesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of Batch scheduling policies.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/listschedulingpolicies",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "schedulingPolicies",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.batch#ListSchedulingPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "maxResults": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results that's returned by <code>ListSchedulingPolicies</code> in\n      paginated output. When this parameter is used, <code>ListSchedulingPolicies</code> only\n      returns <code>maxResults</code> results in a single page and a <code>nextToken</code> response\n      element. You can see the remaining results of the initial request by sending another\n        <code>ListSchedulingPolicies</code> request with the returned <code>nextToken</code> value.\n      This value can be between 1 and 100. If this parameter isn't\n      used, <code>ListSchedulingPolicies</code> returns up to 100 results and a\n        <code>nextToken</code> value if applicable.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value that's returned from a previous paginated\n        <code>ListSchedulingPolicies</code> request where <code>maxResults</code> was used and the\n      results exceeded the value of that parameter. Pagination continues from the end of the\n      previous results that returned the <code>nextToken</code> value. This value is\n        <code>null</code> when there are no more results to return.</p>\n         <note>\n            <p>Treat this token as an opaque identifier that's only used to\n retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>ListSchedulingPolicies</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#ListSchedulingPoliciesResponse": {
+      "type": "structure",
+      "members": {
+        "schedulingPolicies": {
+          "target": "com.amazonaws.batch#SchedulingPolicyListingDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of scheduling policies that match the request.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future\n        <code>ListSchedulingPolicies</code> request. When the results of a\n        <code>ListSchedulingPolicies</code> request exceed <code>maxResults</code>, this value can\n      be used to retrieve the next page of results. This value is <code>null</code> when there are\n      no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#ListServiceJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#ListServiceJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#ListServiceJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of service jobs for a specified job queue.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/listservicejobs",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "jobSummaryList",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.batch#ListServiceJobsRequest": {
+      "type": "structure",
+      "members": {
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name or ARN of the job queue with which to list service jobs.</p>"
+          }
+        },
+        "jobStatus": {
+          "target": "com.amazonaws.batch#ServiceJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The job status used to filter service jobs in the specified queue. If the <code>filters</code>\n\t            parameter is specified, the <code>jobStatus</code> parameter is ignored and jobs with any\n\t            status are returned. The exceptions are the <code>SHARE_IDENTIFIER</code> filter and <code>QUOTA_SHARE_NAME</code> filter, which\n                can be used with <code>jobStatus</code>. If you don't specify a status, only <code>RUNNING</code> jobs are\n\t            returned.</p>\n         <note>\n            <p>The <code>SHARE_IDENTIFIER</code> filter or <code>QUOTA_SHARE_NAME</code> filter can be used with the <code>jobStatus</code> field to filter results.</p>\n         </note>"
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results returned by <code>ListServiceJobs</code> in paginated output. When this parameter is used, <code>ListServiceJobs</code> only returns <code>maxResults</code> results in a single page and a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>ListServiceJobs</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter isn't used, then <code>ListServiceJobs</code> returns up to 100 results and a <code>nextToken</code> value if applicable.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value returned from a previous paginated <code>ListServiceJobs</code> request where <code>maxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>nextToken</code> value. This value is <code>null</code> when there are no more results to return.</p>\n         <note>\n            <p>Treat this token as an opaque identifier that's only used to\n retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
+          }
+        },
+        "filters": {
+          "target": "com.amazonaws.batch#ListJobsFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The filter to apply to the query. Only one filter can be used at a time. When the\n\t            filter is used, <code>jobStatus</code> is ignored with the exception that <code>SHARE_IDENTIFIER</code> or <code>QUOTA_SHARE_NAME</code> and <code>jobStatus</code> can be used together. The results are sorted by the\n\t                <code>createdAt</code> field, with the most recent jobs being first.</p>\n         <note>\n            <p>The <code>SHARE_IDENTIFIER</code> or <code>QUOTA_SHARE_NAME</code> filter and the <code>jobStatus</code> field can be used together to filter results.</p>\n         </note>\n         <dl>\n            <dt>JOB_NAME</dt>\n            <dd>\n               <p>The value of the filter is a case-insensitive match for the job name. If the value\n                       ends with an asterisk (*), the filter matches any job name that begins with the string\n                       before the '*'. This corresponds to the <code>jobName</code> value. For example,\n                       <code>test1</code> matches both <code>Test1</code> and <code>test1</code>, and\n                       <code>test1*</code> matches both <code>test1</code> and <code>Test10</code>. When the\n                       <code>JOB_NAME</code> filter is used, the results are grouped by the job name and\n                       version.</p>\n            </dd>\n            <dt>BEFORE_CREATED_AT</dt>\n            <dd>\n               <p>The value for the filter is the time that's before the job was created. This\n                       corresponds to the <code>createdAt</code> value. The value is a string representation of\n                       the number of milliseconds since 00:00:00 UTC (midnight) on January 1, 1970.</p>\n            </dd>\n            <dt>AFTER_CREATED_AT</dt>\n            <dd>\n               <p>The value for the filter is the time that's after the job was created. This\n                       corresponds to the <code>createdAt</code> value. The value is a string representation of\n                       the number of milliseconds since 00:00:00 UTC (midnight) on January 1, 1970.</p>\n            </dd>\n            <dt>SHARE_IDENTIFIER</dt>\n            <dd>\n               <p>The value for the filter is the fairshare scheduling share identifier.</p>\n            </dd>\n            <dt>QUOTA_SHARE_NAME</dt>\n            <dd>\n               <p>The value for the filter is the quota management share name.</p>\n            </dd>\n         </dl>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#ListServiceJobsResponse": {
+      "type": "structure",
+      "members": {
+        "jobSummaryList": {
+          "target": "com.amazonaws.batch#ServiceJobSummaryList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of service job summaries.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListServiceJobs</code> request. When the results of a <code>ListServiceJobs</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the tags for an Batch resource. Batch resources that support tags are compute environments, jobs, job definitions, job queues,\n and scheduling policies. ARNs for child jobs of array and multi-node parallel (MNP) jobs aren't supported.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "ListTagsForResource Example",
+            "documentation": "This demonstrates calling the ListTagsForResource action.",
+            "input": {
+              "resourceArn": "arn:aws:batch:us-east-1:123456789012:job-definition/sleep30:1"
+            },
+            "output": {
+              "tags": {
+                "Stage": "Alpha",
+                "Department": "Engineering",
+                "User": "JaneDoe"
+              }
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v1/tags/{resourceArn}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "resourceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the resource that tags are listed for. Batch resources that support tags are compute environments, jobs, job definitions, job queues,\n and scheduling policies. ARNs for child jobs of array and multi-node parallel (MNP) jobs aren't supported.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>ListTagsForResource</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags for the resource.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#ListTaskContainerDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#TaskContainerDetails"
+      }
+    },
+    "com.amazonaws.batch#ListTaskContainerOverrides": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#TaskContainerOverrides"
+      }
+    },
+    "com.amazonaws.batch#ListTaskContainerProperties": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#TaskContainerProperties"
+      }
+    },
+    "com.amazonaws.batch#ListTaskPropertiesOverride": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#TaskPropertiesOverride"
+      }
+    },
+    "com.amazonaws.batch#LogConfiguration": {
+      "type": "structure",
+      "members": {
+        "logDriver": {
+          "target": "com.amazonaws.batch#LogDriver",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The log driver to use for the container. The valid values that are listed for this parameter\n   are log drivers that the Amazon ECS container agent can communicate with by default.</p>\n         <p>The supported log drivers are <code>awsfirelens</code>, <code>awslogs</code>, <code>fluentd</code>, <code>gelf</code>,\n    <code>json-file</code>, <code>journald</code>, <code>logentries</code>, <code>syslog</code>, and\n    <code>splunk</code>.</p>\n         <note>\n            <p>Jobs that are running on Fargate resources are restricted to the <code>awslogs</code> and\n     <code>splunk</code> log drivers.</p>\n         </note>\n         <dl>\n            <dt>awsfirelens</dt>\n            <dd>\n               <p>Specifies the firelens logging driver. For more information on configuring Firelens, see\n       <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html\">Send\n       Amazon ECS logs to an Amazon Web Services service or Amazon Web Services Partner</a> in the\n       <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n            </dd>\n            <dt>awslogs</dt>\n            <dd>\n               <p>Specifies the Amazon CloudWatch Logs logging driver. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using_awslogs.html\">Using the awslogs log driver</a>\n      in the <i>Batch User Guide</i> and <a href=\"https://docs.docker.com/config/containers/logging/awslogs/\">Amazon CloudWatch Logs logging\n       driver</a> in the Docker documentation.</p>\n            </dd>\n            <dt>fluentd</dt>\n            <dd>\n               <p>Specifies the Fluentd logging driver. For more information including usage and options,\n      see <a href=\"https://docs.docker.com/config/containers/logging/fluentd/\">Fluentd logging\n       driver</a> in the <i>Docker documentation</i>.</p>\n            </dd>\n            <dt>gelf</dt>\n            <dd>\n               <p>Specifies the Graylog Extended Format (GELF) logging driver. For more information\n      including usage and options, see <a href=\"https://docs.docker.com/config/containers/logging/gelf/\">Graylog Extended Format logging\n       driver</a> in the <i>Docker documentation</i>.</p>\n            </dd>\n            <dt>journald</dt>\n            <dd>\n               <p>Specifies the journald logging driver. For more information including usage and options,\n      see <a href=\"https://docs.docker.com/config/containers/logging/journald/\">Journald logging\n       driver</a> in the <i>Docker documentation</i>.</p>\n            </dd>\n            <dt>json-file</dt>\n            <dd>\n               <p>Specifies the JSON file logging driver. For more information including usage and options,\n      see <a href=\"https://docs.docker.com/config/containers/logging/json-file/\">JSON File\n       logging driver</a> in the <i>Docker documentation</i>.</p>\n            </dd>\n            <dt>splunk</dt>\n            <dd>\n               <p>Specifies the Splunk logging driver. For more information including usage and options,\n      see <a href=\"https://docs.docker.com/config/containers/logging/splunk/\">Splunk logging\n       driver</a> in the <i>Docker documentation</i>.</p>\n            </dd>\n            <dt>syslog</dt>\n            <dd>\n               <p>Specifies the syslog logging driver. For more information including usage and options,\n      see <a href=\"https://docs.docker.com/config/containers/logging/syslog/\">Syslog logging\n       driver</a> in the <i>Docker documentation</i>.</p>\n            </dd>\n         </dl>\n         <note>\n            <p>If you have a custom driver that's not listed earlier that you want to work with the Amazon ECS\n    container agent, you can fork the Amazon ECS container agent project that's <a href=\"https://github.com/aws/amazon-ecs-agent\">available on GitHub</a> and customize it to\n    work with that driver. We encourage you to submit pull requests for changes that you want to\n    have included. However, Amazon Web Services doesn't currently support running modified copies of this\n    software.</p>\n         </note>\n         <p>This parameter requires version 1.18 of the Docker Remote API or greater on your\n container instance. To check the Docker Remote API version on your container instance, log in to your\n container instance and run the following command: <code>sudo docker version | grep \"Server API version\"</code>\n         </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "options": {
+          "target": "com.amazonaws.batch#LogConfigurationOptionsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration options to send to the log driver. This parameter requires version 1.19 of the Docker Remote API or greater on your\n container instance. To check the Docker Remote API version on your container instance, log in to your\n container instance and run the following command: <code>sudo docker version | grep \"Server API version\"</code>\n         </p>"
+          }
+        },
+        "secretOptions": {
+          "target": "com.amazonaws.batch#SecretList",
+          "traits": {
+            "smithy.api#documentation": "<p>The secrets to pass to the log configuration. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/specifying-sensitive-data.html\">Specifying sensitive\n    data</a> in the <i>Batch User Guide</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Log configuration options to send to a custom log driver for the container.</p>"
+      }
+    },
+    "com.amazonaws.batch#LogConfigurationOptionsMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#String"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#String"
+      }
+    },
+    "com.amazonaws.batch#LogDriver": {
+      "type": "enum",
+      "members": {
+        "JSON_FILE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "json-file"
+          }
+        },
+        "SYSLOG": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "syslog"
+          }
+        },
+        "JOURNALD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "journald"
+          }
+        },
+        "GELF": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "gelf"
+          }
+        },
+        "FLUENTD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fluentd"
+          }
+        },
+        "AWSLOGS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "awslogs"
+          }
+        },
+        "SPLUNK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "splunk"
+          }
+        },
+        "AWSFIRELENS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "awsfirelens"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#Long": {
+      "type": "long"
+    },
+    "com.amazonaws.batch#MountPoint": {
+      "type": "structure",
+      "members": {
+        "containerPath": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The path on the container where the host volume is mounted.</p>"
+          }
+        },
+        "readOnly": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>If this value is <code>true</code>, the container has read-only access to the volume.\n   Otherwise, the container can write to the volume. The default value is <code>false</code>.</p>"
+          }
+        },
+        "sourceVolume": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the volume to mount.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details for a Docker volume mount point that's used in a job's container properties. This\n   parameter maps to <code>Volumes</code> in the <a href=\"https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerCreate\">Create a\n    container</a> section of the <i>Docker Remote API</i> and the\n    <code>--volume</code> option to docker run.</p>"
+      }
+    },
+    "com.amazonaws.batch#MountPoints": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#MountPoint"
+      }
+    },
+    "com.amazonaws.batch#NetworkConfiguration": {
+      "type": "structure",
+      "members": {
+        "assignPublicIp": {
+          "target": "com.amazonaws.batch#AssignPublicIp",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the job has a public IP address. For a job that's running on Fargate\n   resources in a private subnet to send outbound traffic to the internet (for example, to pull\n   container images), the private subnet requires a NAT gateway be attached to route requests to the\n   internet. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html\">Amazon ECS task networking</a> in the\n    <i>Amazon Elastic Container Service Developer Guide</i>. The default value is \"<code>DISABLED</code>\".</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The network configuration for jobs that are running on Fargate resources. Jobs that are\n   running on Amazon EC2 resources must not specify this parameter.</p>"
+      }
+    },
+    "com.amazonaws.batch#NetworkInterface": {
+      "type": "structure",
+      "members": {
+        "attachmentId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The attachment ID for the network interface.</p>"
+          }
+        },
+        "ipv6Address": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The private IPv6 address for the network interface.</p>"
+          }
+        },
+        "privateIpv4Address": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The private IPv4 address for the network interface.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the elastic network interface for a multi-node parallel job\n   node.</p>"
+      }
+    },
+    "com.amazonaws.batch#NetworkInterfaceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#NetworkInterface"
+      }
+    },
+    "com.amazonaws.batch#NodeDetails": {
+      "type": "structure",
+      "members": {
+        "nodeIndex": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The node index for the node. Node index numbering starts at zero. This index is also\n   available on the node with the <code>AWS_BATCH_JOB_NODE_INDEX</code> environment variable.</p>"
+          }
+        },
+        "isMainNode": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the current node is the main node for a multi-node parallel job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details of a multi-node parallel job node.</p>"
+      }
+    },
+    "com.amazonaws.batch#NodeOverrides": {
+      "type": "structure",
+      "members": {
+        "numNodes": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of nodes to use with a multi-node parallel job. This value overrides the number\n   of nodes that are specified in the job definition. To use this override, you must meet the\n   following conditions:</p>\n         <ul>\n            <li>\n               <p>There must be at least one node range in your job definition that has an open upper\n     boundary, such as <code>:</code> or <code>n:</code>.</p>\n            </li>\n            <li>\n               <p>The lower boundary of the node range that's specified in the job definition must be fewer\n     than the number of nodes specified in the override.</p>\n            </li>\n            <li>\n               <p>The main node index that's specified in the job definition must be fewer than the number\n     of nodes specified in the override.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "nodePropertyOverrides": {
+          "target": "com.amazonaws.batch#NodePropertyOverrides",
+          "traits": {
+            "smithy.api#documentation": "<p>The node property overrides for the job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents any node overrides to a job definition that's used in a <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html\">SubmitJob</a> API\n   operation.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources. Don't\n    provide it for these jobs. Rather, use <code>containerOverrides</code> instead.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.batch#NodeProperties": {
+      "type": "structure",
+      "members": {
+        "numNodes": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The number of nodes that are associated with a multi-node parallel job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "mainNode": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the node index for the main node of a multi-node parallel job. This node index\n   value must be fewer than the number of nodes.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nodeRangeProperties": {
+          "target": "com.amazonaws.batch#NodeRangeProperties",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of node ranges and their properties that are associated with a multi-node parallel\n   job.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the node properties of a multi-node parallel job.</p>\n         <note>\n            <p>Node properties can't be specified for Amazon EKS based job definitions.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.batch#NodePropertiesSummary": {
+      "type": "structure",
+      "members": {
+        "isMainNode": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the current node is the main node for a multi-node parallel job.</p>"
+          }
+        },
+        "numNodes": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of nodes that are associated with a multi-node parallel job.</p>"
+          }
+        },
+        "nodeIndex": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The node index for the node. Node index numbering begins at zero. This index is also\n   available on the node with the <code>AWS_BATCH_JOB_NODE_INDEX</code> environment variable.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the properties of a node that's associated with a multi-node\n   parallel job.</p>"
+      }
+    },
+    "com.amazonaws.batch#NodePropertyOverride": {
+      "type": "structure",
+      "members": {
+        "targetNodes": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The range of nodes, using node index values, that's used to override. A range of\n    <code>0:3</code> indicates nodes with index values of <code>0</code> through <code>3</code>. If\n   the starting range value is omitted (<code>:n</code>), then <code>0</code> is used to start the\n   range. If the ending range value is omitted (<code>n:</code>), then the highest possible node\n   index is used to end the range.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "containerOverrides": {
+          "target": "com.amazonaws.batch#ContainerOverrides",
+          "traits": {
+            "smithy.api#documentation": "<p>The overrides that are sent to a node range.</p>"
+          }
+        },
+        "ecsPropertiesOverride": {
+          "target": "com.amazonaws.batch#EcsPropertiesOverride",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties that you want to replace for the existing Amazon ECS\n   resources of a job.</p>"
+          }
+        },
+        "instanceTypes": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the instance types that you want to replace for the existing\n   resources of a job.</p>"
+          }
+        },
+        "eksPropertiesOverride": {
+          "target": "com.amazonaws.batch#EksPropertiesOverride",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties that you want to replace for the existing Amazon EKS resources of a job.</p>"
+          }
+        },
+        "consumableResourcePropertiesOverride": {
+          "target": "com.amazonaws.batch#ConsumableResourceProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains overrides for the consumable resources of a job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The object that represents any node overrides to a job definition that's used in a <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html\">SubmitJob</a> API\n   operation.</p>"
+      }
+    },
+    "com.amazonaws.batch#NodePropertyOverrides": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#NodePropertyOverride"
+      }
+    },
+    "com.amazonaws.batch#NodeRangeProperties": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#NodeRangeProperty"
+      }
+    },
+    "com.amazonaws.batch#NodeRangeProperty": {
+      "type": "structure",
+      "members": {
+        "targetNodes": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The range of nodes, using node index values. A range of <code>0:3</code> indicates nodes\n   with index values of <code>0</code> through <code>3</code>. If the starting range value is\n   omitted (<code>:n</code>), then <code>0</code> is used to start the range. If the ending range\n   value is omitted (<code>n:</code>), then the highest possible node index is used to end the\n   range. Your accumulative node ranges must account for all nodes (<code>0:n</code>). You can nest\n   node ranges (for example, <code>0:10</code> and <code>4:5</code>). In this case, the\n    <code>4:5</code> range properties override the <code>0:10</code> properties.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "container": {
+          "target": "com.amazonaws.batch#ContainerProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The container details for the node range.</p>"
+          }
+        },
+        "instanceTypes": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The instance types of the underlying host infrastructure of a multi-node parallel\n   job.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources.</p>\n            <p>In addition, this list object is currently limited to one element.</p>\n         </note>"
+          }
+        },
+        "ecsProperties": {
+          "target": "com.amazonaws.batch#EcsProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>This is an object that represents the properties of the node range for a multi-node parallel\n   job.</p>"
+          }
+        },
+        "eksProperties": {
+          "target": "com.amazonaws.batch#EksProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>This is an object that represents the properties of the node range for a multi-node parallel job.</p>"
+          }
+        },
+        "consumableResourceProperties": {
+          "target": "com.amazonaws.batch#ConsumableResourceProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains a list of consumable resources required by a job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This is an object that represents the properties of the node range for a multi-node parallel\n   job.</p>"
+      }
+    },
+    "com.amazonaws.batch#OrchestrationType": {
+      "type": "enum",
+      "members": {
+        "ECS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ECS"
+          }
+        },
+        "EKS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EKS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#ParametersMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#String"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#String"
+      }
+    },
+    "com.amazonaws.batch#PlatformCapability": {
+      "type": "enum",
+      "members": {
+        "EC2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EC2"
+          }
+        },
+        "FARGATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FARGATE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#PlatformCapabilityList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#PlatformCapability"
+      }
+    },
+    "com.amazonaws.batch#Quantity": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.batch#QueueSnapshotCapacityUsage": {
+      "type": "structure",
+      "members": {
+        "capacityUnit": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unit of measure for the capacity usage. For compute jobs, this is\n            <code>VCPU</code> for Amazon EC2 and <code>cpu</code> for Amazon EKS. For service jobs, this is the instance type.</p>"
+          }
+        },
+        "quantity": {
+          "target": "com.amazonaws.batch#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>The quantity of capacity being used in the queue snapshot, measured in the units\n            specified by <code>capacityUnit</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configured capacity usage for a job queue snapshot, including the unit of\n            measure and quantity of resources being used.</p>"
+      }
+    },
+    "com.amazonaws.batch#QueueSnapshotCapacityUsageList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#QueueSnapshotCapacityUsage"
+      }
+    },
+    "com.amazonaws.batch#QueueSnapshotUtilizationDetail": {
+      "type": "structure",
+      "members": {
+        "totalCapacityUsage": {
+          "target": "com.amazonaws.batch#QueueSnapshotCapacityUsageList",
+          "traits": {
+            "smithy.api#documentation": "<p>The total capacity usage for the entire job queue.</p>"
+          }
+        },
+        "fairshareUtilization": {
+          "target": "com.amazonaws.batch#FairshareUtilizationDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>The utilization information for a fairshare scheduling job queues, including\n            active share count and top capacity utilization by share.</p>"
+          }
+        },
+        "quotaShareUtilization": {
+          "target": "com.amazonaws.batch#QuotaShareUtilizationDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>The utilization information for a job queue with a quota share scheduling policy.</p>"
+          }
+        },
+        "lastUpdatedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the queue utilization information was\n            last updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The job queue utilization at a specific point in time,\n            including total capacity usage, and quota share or fairshare utilization breakdown\n            depending on the job queue scheduling policy.</p>"
+      }
+    },
+    "com.amazonaws.batch#QuotaShareCapacityLimit": {
+      "type": "structure",
+      "members": {
+        "maxCapacity": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The maximum capacity available for the quota share. This value represents the maximum quantity of a resource that can be allocated to jobs in the quota share\n       without borrowing.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "capacityUnit": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unit of compute capacity for the capacityLimit. For example, <code>ml.m5.large</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Defines the capacity limit for a quota share, or the type and maximum quantity of a particular resource that can be allocated to jobs in the quota share\n       without borrowing. </p>"
+      }
+    },
+    "com.amazonaws.batch#QuotaShareCapacityLimits": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#QuotaShareCapacityLimit"
+      }
+    },
+    "com.amazonaws.batch#QuotaShareCapacityUsage": {
+      "type": "structure",
+      "members": {
+        "capacityUnit": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unit of compute capacity for the capacity usage.</p>"
+          }
+        },
+        "quantity": {
+          "target": "com.amazonaws.batch#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>The quantity of capacity being used.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The capacity usage for a quota share, including units of compute capacity and quantity of resources being used.</p>"
+      }
+    },
+    "com.amazonaws.batch#QuotaShareCapacityUsageList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#QuotaShareCapacityUsage"
+      }
+    },
+    "com.amazonaws.batch#QuotaShareCapacityUtilization": {
+      "type": "structure",
+      "members": {
+        "quotaShareName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the quota share.</p>"
+          }
+        },
+        "capacityUsage": {
+          "target": "com.amazonaws.batch#QuotaShareCapacityUsageList",
+          "traits": {
+            "smithy.api#documentation": "<p>The capacity usage information for this quota share, including the units of compute capacity and quantity being used.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The capacity utilization for a specific quota share, including the quota share name and its current usage.</p>"
+      }
+    },
+    "com.amazonaws.batch#QuotaShareCapacityUtilizationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#QuotaShareCapacityUtilization"
+      }
+    },
+    "com.amazonaws.batch#QuotaShareDetail": {
+      "type": "structure",
+      "members": {
+        "quotaShareName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the quota share.</p>"
+          }
+        },
+        "quotaShareArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the quota share.</p>"
+          }
+        },
+        "jobQueueArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job queue associated with the quota share.</p>"
+          }
+        },
+        "capacityLimits": {
+          "target": "com.amazonaws.batch#QuotaShareCapacityLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that specifies the quantity and type of compute capacity allocated to the quota share.</p>"
+          }
+        },
+        "resourceSharingConfiguration": {
+          "target": "com.amazonaws.batch#QuotaShareResourceSharingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a quota share reserves, lends, or both lends and borrows idle compute capacity.</p>"
+          }
+        },
+        "preemptionConfiguration": {
+          "target": "com.amazonaws.batch#QuotaSharePreemptionConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the preemption behavior for jobs in a quota share.</p>"
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#QuotaShareState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the quota share.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#QuotaShareStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the quota share.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about a quota share, including its configuration, state, and capacity limits.</p>"
+      }
+    },
+    "com.amazonaws.batch#QuotaShareIdleResourceAssignmentStrategy": {
+      "type": "enum",
+      "members": {
+        "FIFO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FIFO"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#QuotaShareInSharePreemptionState": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#QuotaShareList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#QuotaShareDetail"
+      }
+    },
+    "com.amazonaws.batch#QuotaSharePolicy": {
+      "type": "structure",
+      "members": {
+        "idleResourceAssignmentStrategy": {
+          "target": "com.amazonaws.batch#QuotaShareIdleResourceAssignmentStrategy",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The strategy that determines how idle resources are assigned to quota shares\n       that are borrowing capacity. Currently, only <code>FIFO</code> is supported.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The quota share scheduling policy details for a job queue.</p>"
+      }
+    },
+    "com.amazonaws.batch#QuotaSharePreemptionConfiguration": {
+      "type": "structure",
+      "members": {
+        "inSharePreemption": {
+          "target": "com.amazonaws.batch#QuotaShareInSharePreemptionState",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies whether jobs within a quota share can be preempted by another, higher priority job in the same quota share.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the preemption behavior for jobs in a quota share.</p>"
+      }
+    },
+    "com.amazonaws.batch#QuotaShareResourceSharingConfiguration": {
+      "type": "structure",
+      "members": {
+        "strategy": {
+          "target": "com.amazonaws.batch#QuotaShareResourceSharingStrategy",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The resource sharing strategy for the quota share. The <code>RESERVE</code> strategy allows a quota share to reserve idle capacity for itself.\n      <code>LEND</code> configures the share to lend its idle capacity to another share in need of capacity.\n      The <code>LEND_AND_BORROW</code> strategy configures the share to borrow idle capacity from an underutilized share, as well as lend to another share.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "borrowLimit": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum percentage of additional capacity that the quota share can borrow from other shares. <code>borrowLimit</code> can only be applied to quota shares with a strategy of <code>LEND_AND_BORROW</code>.\n        This value is expressed as a percentage of the quota share's configured <a href=\"https://docs.aws.amazon.com/batch/latest/APIReference/API_QuotaShareCapacityLimit.html\">CapacityLimits</a>.</p>\n         <p>The <code>borrowLimit</code> is applied uniformly across all capacity units. \n        For example, if the <code>borrowLimit</code> is 200, the quota \n        share can borrow up to 200% of its configured <code>maxCapacity</code> for each capacity unit. The default <code>borrowLimit</code> is -1, which indicates unlimited borrowing.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies whether a quota share reserves, lends, or both lends and borrows idle compute capacity.</p>"
+      }
+    },
+    "com.amazonaws.batch#QuotaShareResourceSharingStrategy": {
+      "type": "enum",
+      "members": {
+        "RESERVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RESERVE"
+          }
+        },
+        "LEND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LEND"
+          }
+        },
+        "LEND_AND_BORROW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LEND_AND_BORROW"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#QuotaShareState": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#QuotaShareStatus": {
+      "type": "enum",
+      "members": {
+        "CREATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATING"
+          }
+        },
+        "VALID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALID"
+          }
+        },
+        "INVALID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INVALID"
+          }
+        },
+        "UPDATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATING"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#QuotaShareUtilizationDetail": {
+      "type": "structure",
+      "members": {
+        "topCapacityUtilization": {
+          "target": "com.amazonaws.batch#QuotaShareCapacityUtilizationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the top capacity utilizations across quota shares associated with a job queue.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the capacity utilization details of all quota shares associated with a single job queue.</p>"
+      }
+    },
+    "com.amazonaws.batch#RegisterJobDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#RegisterJobDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#RegisterJobDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Registers an Batch job definition.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "RegisterJobDefinition with tags",
+            "documentation": "This demonstrates calling the RegisterJobDefinition action, including tags.",
+            "input": {
+              "jobDefinitionName": "sleep30",
+              "type": "container",
+              "containerProperties": {
+                "image": "busybox",
+                "command": [
+                  "sleep",
+                  "30"
+                ],
+                "resourceRequirements": [
+                  {
+                    "type": "MEMORY",
+                    "value": "128"
+                  },
+                  {
+                    "type": "VCPU",
+                    "value": "1"
+                  }
+                ]
+              },
+              "tags": {
+                "Department": "Engineering",
+                "User": "JaneDoe"
+              }
+            },
+            "output": {
+              "jobDefinitionName": "sleep30",
+              "jobDefinitionArn": "arn:aws:batch:us-east-1:012345678910:job-definition/sleep30:1",
+              "revision": 1
+            }
+          },
+          {
+            "title": "To register a job definition",
+            "documentation": "This example registers a job definition for a simple container job.",
+            "input": {
+              "containerProperties": {
+                "image": "busybox",
+                "command": [
+                  "sleep",
+                  "10"
+                ],
+                "resourceRequirements": [
+                  {
+                    "type": "MEMORY",
+                    "value": "128"
+                  },
+                  {
+                    "type": "VCPU",
+                    "value": "1"
+                  }
+                ]
+              },
+              "type": "container",
+              "jobDefinitionName": "sleep10"
+            },
+            "output": {
+              "jobDefinitionName": "sleep10",
+              "jobDefinitionArn": "arn:aws:batch:us-east-1:012345678910:job-definition/sleep10:1",
+              "revision": 1
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/registerjobdefinition",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#RegisterJobDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "jobDefinitionName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the job definition to register. It can be up to 128 letters long. It can\n      contain uppercase and lowercase letters, numbers, hyphens (-), and underscores (_).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "type": {
+          "target": "com.amazonaws.batch#JobDefinitionType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of job definition. For more information about multi-node parallel jobs, see\n        <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/multi-node-job-def.html\">Creating a multi-node\n        parallel job definition</a> in the <i>Batch User Guide</i>.</p>\n         <ul>\n            <li>\n               <p>If the value is <code>container</code>, then one of the following is required: <code>containerProperties</code>, <code>ecsProperties</code>, or <code>eksProperties</code>.</p>\n            </li>\n            <li>\n               <p>If the value is <code>multinode</code>, then <code>nodeProperties</code> is required.</p>\n            </li>\n         </ul>\n         <note>\n            <p>If the job is run on Fargate resources, then <code>multinode</code> isn't supported.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "parameters": {
+          "target": "com.amazonaws.batch#ParametersMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Default parameter substitution placeholders to set in the job definition. Parameters are\n      specified as a key-value pair mapping. Parameters in a <code>SubmitJob</code> request override\n      any corresponding parameter defaults from the job definition.</p>"
+          }
+        },
+        "schedulingPriority": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The scheduling priority for jobs that are submitted with this job definition. This only\n      affects jobs in job queues with a fair-share policy. Jobs with a higher scheduling priority\n      are scheduled before jobs with a lower scheduling priority.</p>\n         <p>The minimum supported value is 0 and the maximum supported value is 9999.</p>"
+          }
+        },
+        "containerProperties": {
+          "target": "com.amazonaws.batch#ContainerProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object with properties specific to Amazon ECS-based single-node container-based jobs. If the\n      job definition's <code>type</code> parameter is <code>container</code>, then you must specify\n      either <code>containerProperties</code> or <code>nodeProperties</code>. This must not be\n      specified for Amazon EKS-based job definitions.</p>\n         <note>\n            <p>If the job runs on Fargate resources, then you must not specify\n          <code>nodeProperties</code>; use only <code>containerProperties</code>.</p>\n         </note>"
+          }
+        },
+        "nodeProperties": {
+          "target": "com.amazonaws.batch#NodeProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object with properties specific to multi-node parallel jobs. If you specify node\n      properties for a job, it becomes a multi-node parallel job. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/multi-node-parallel-jobs.html\">Multi-node Parallel\n        Jobs</a> in the <i>Batch User Guide</i>.</p>\n         <note>\n            <p>If the job runs on Fargate resources, then you must not specify\n          <code>nodeProperties</code>; use <code>containerProperties</code> instead.</p>\n         </note>\n         <note>\n            <p>If the job runs on Amazon EKS resources, then you must not specify\n          <code>nodeProperties</code>.</p>\n         </note>"
+          }
+        },
+        "retryStrategy": {
+          "target": "com.amazonaws.batch#RetryStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The retry strategy to use for failed jobs that are submitted with this job definition. Any\n      retry strategy that's specified during a <a>SubmitJob</a> operation overrides the\n      retry strategy defined here. If a job is terminated due to a timeout, it isn't retried.</p>"
+          }
+        },
+        "propagateTags": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether to propagate the tags from the job or job definition to the\n      corresponding Amazon ECS task. If no value is specified, the tags are not propagated. Tags can only\n      be propagated to the tasks during task creation. For tags with the same name, job tags are\n      given priority over job definitions tags. If the total number of combined tags from the job\n      and job definition is over 50, the job is moved to the <code>FAILED</code> state.</p>\n         <note>\n            <p>If the job runs on Amazon EKS resources, then you must not specify\n        <code>propagateTags</code>.</p>\n         </note>"
+          }
+        },
+        "timeout": {
+          "target": "com.amazonaws.batch#JobTimeout",
+          "traits": {
+            "smithy.api#documentation": "<p>The timeout configuration for jobs that are submitted with this job definition, after\n      which Batch terminates your jobs if they have not finished. If a job is terminated due to a\n      timeout, it isn't retried. The minimum value for the timeout is 60 seconds. Any timeout\n      configuration that's specified during a <a>SubmitJob</a> operation overrides the\n      timeout configuration defined here. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/job_timeouts.html\">Job Timeouts</a> in the\n        <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the job definition to help you categorize and organize your\n      resources. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using-tags.html\">Tagging Amazon Web Services Resources</a> in\n        <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "platformCapabilities": {
+          "target": "com.amazonaws.batch#PlatformCapabilityList",
+          "traits": {
+            "smithy.api#documentation": "<p>The platform capabilities required by the job definition. If no value is specified, it\n      defaults to <code>EC2</code>. To run the job on Fargate resources, specify\n        <code>FARGATE</code>.</p>\n         <note>\n            <p>If the job runs on Amazon EKS resources, then you must not specify\n          <code>platformCapabilities</code>.</p>\n         </note>"
+          }
+        },
+        "eksProperties": {
+          "target": "com.amazonaws.batch#EksProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object with properties that are specific to Amazon EKS-based jobs. This must not be\n      specified for Amazon ECS based job definitions.</p>"
+          }
+        },
+        "ecsProperties": {
+          "target": "com.amazonaws.batch#EcsProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object with properties that are specific to Amazon ECS-based jobs. This must not be\n      specified for Amazon EKS-based job definitions.</p>"
+          }
+        },
+        "consumableResourceProperties": {
+          "target": "com.amazonaws.batch#ConsumableResourceProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains a list of consumable resources required by the job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>RegisterJobDefinition</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#RegisterJobDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "jobDefinitionName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the job definition.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobDefinitionArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job definition.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "revision": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The revision of the job definition.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#RepositoryCredentials": {
+      "type": "structure",
+      "members": {
+        "credentialsParameter": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the secret containing the private repository\n   credentials.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The repository credentials for private registry authentication.</p>"
+      }
+    },
+    "com.amazonaws.batch#ResourceRequirement": {
+      "type": "structure",
+      "members": {
+        "value": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The quantity of the specified resource to reserve for the container. The values vary based\n   on the <code>type</code> specified.</p>\n         <dl>\n            <dt>type=\"GPU\"</dt>\n            <dd>\n               <p>The number of physical GPUs to reserve for the container. Make sure that the number of\n      GPUs reserved for all containers in a job doesn't exceed the number of available GPUs on the\n      compute resource that the job is launched on.</p>\n               <note>\n                  <p>GPUs aren't available for jobs that are running on Fargate resources.</p>\n               </note>\n            </dd>\n            <dt>type=\"MEMORY\"</dt>\n            <dd>\n               <p>The memory hard limit (in MiB) present to the container. This parameter is supported for\n      jobs that are running on Amazon EC2 resources. If your container attempts to exceed the memory\n      specified, the container is terminated. This parameter maps to <code>Memory</code> in the\n      <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the\n       <code>--memory</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. You\n      must specify at least 4 MiB of memory for a job. This is required but can be specified in\n      several places for multi-node parallel (MNP) jobs. It must be specified for each node at least\n      once. This parameter maps to <code>Memory</code> in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a>\n      section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the <code>--memory</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>.</p>\n               <note>\n                  <p>If you're trying to maximize your resource utilization by providing your jobs as much\n       memory as possible for a particular instance type, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/memory-management.html\">Memory management</a> in the\n        <i>Batch User Guide</i>.</p>\n               </note>\n               <p>For jobs that are running on Fargate resources, then <code>value</code> is the hard\n      limit (in MiB), and must match one of the supported values and the <code>VCPU</code> values\n      must be one of the values supported for that memory value.</p>\n               <dl>\n                  <dt>value = 512</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 0.25</p>\n                  </dd>\n                  <dt>value = 1024</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 0.25 or 0.5</p>\n                  </dd>\n                  <dt>value = 2048</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 0.25, 0.5, or 1</p>\n                  </dd>\n                  <dt>value = 3072</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 0.5, or 1</p>\n                  </dd>\n                  <dt>value = 4096</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 0.5, 1, or 2</p>\n                  </dd>\n                  <dt>value = 5120, 6144, or 7168</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 1 or 2</p>\n                  </dd>\n                  <dt>value = 8192</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 1, 2, or 4</p>\n                  </dd>\n                  <dt>value = 9216, 10240, 11264, 12288, 13312, 14336, or 15360</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 2 or 4</p>\n                  </dd>\n                  <dt>value = 16384</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 2, 4, or 8</p>\n                  </dd>\n                  <dt>value = 17408, 18432, 19456, 21504, 22528, 23552, 25600, 26624, 27648, 29696, or 30720</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 4</p>\n                  </dd>\n                  <dt>value = 20480, 24576, or 28672</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 4 or 8</p>\n                  </dd>\n                  <dt>value = 36864, 45056, 53248, or 61440</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 8</p>\n                  </dd>\n                  <dt>value = 32768, 40960, 49152, or 57344</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 8 or 16</p>\n                  </dd>\n                  <dt>value = 65536, 73728, 81920, 90112, 98304, 106496, 114688, or 122880</dt>\n                  <dd>\n                     <p>\n                        <code>VCPU</code> = 16</p>\n                  </dd>\n               </dl>\n            </dd>\n            <dt>type=\"VCPU\"</dt>\n            <dd>\n               <p>The number of vCPUs reserved for the container. This parameter maps to\n       <code>CpuShares</code> in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the\n      <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the <code>--cpu-shares</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. Each vCPU is equivalent to 1,024 CPU shares.\n      For Amazon EC2 resources, you must specify at least one vCPU. This is required but can be specified\n      in several places; it must be specified for each node at least once.</p>\n               <p>The default for the Fargate On-Demand vCPU resource count quota is 6 vCPUs. For more\n      information about Fargate quotas, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/ecs-service.html#service-quotas-fargate\">Fargate quotas</a>\n      in the <i>Amazon Web Services General Reference</i>.</p>\n               <p>For jobs that are running on Fargate resources, then <code>value</code> must match one\n      of the supported values and the <code>MEMORY</code> values must be one of the values supported\n      for that <code>VCPU</code> value. The supported values are 0.25, 0.5, 1, 2, 4, 8, and\n      16</p>\n               <dl>\n                  <dt>value = 0.25</dt>\n                  <dd>\n                     <p>\n                        <code>MEMORY</code> = 512, 1024, or 2048</p>\n                  </dd>\n                  <dt>value = 0.5</dt>\n                  <dd>\n                     <p>\n                        <code>MEMORY</code> = 1024, 2048, 3072, or 4096</p>\n                  </dd>\n                  <dt>value = 1</dt>\n                  <dd>\n                     <p>\n                        <code>MEMORY</code> = 2048, 3072, 4096, 5120, 6144, 7168, or 8192</p>\n                  </dd>\n                  <dt>value = 2</dt>\n                  <dd>\n                     <p>\n                        <code>MEMORY</code> = 4096, 5120, 6144, 7168, 8192, 9216, 10240, 11264, 12288, 13312, 14336, 15360, or 16384</p>\n                  </dd>\n                  <dt>value = 4</dt>\n                  <dd>\n                     <p>\n                        <code>MEMORY</code> = 8192, 9216, 10240, 11264, 12288, 13312, 14336, 15360, 16384, 17408, 18432, 19456,\n     20480, 21504, 22528, 23552, 24576, 25600, 26624, 27648, 28672, 29696, or 30720</p>\n                  </dd>\n                  <dt>value = 8</dt>\n                  <dd>\n                     <p>\n                        <code>MEMORY</code> = 16384, 20480, 24576, 28672, 32768, 36864, 40960, 45056, 49152, 53248, 57344, or 61440\n</p>\n                  </dd>\n                  <dt>value = 16</dt>\n                  <dd>\n                     <p>\n                        <code>MEMORY</code> = 32768, 40960, 49152, 57344, 65536, 73728, 81920, 90112, 98304, 106496, 114688, or 122880\n</p>\n                  </dd>\n               </dl>\n            </dd>\n         </dl>",
+            "smithy.api#required": {}
+          }
+        },
+        "type": {
+          "target": "com.amazonaws.batch#ResourceType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of resource to assign to a container. The supported resources include\n    <code>GPU</code>, <code>MEMORY</code>, and <code>VCPU</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type and amount of a resource to assign to a container. The supported resources include\n    <code>GPU</code>, <code>MEMORY</code>, and <code>VCPU</code>.</p>"
+      }
+    },
+    "com.amazonaws.batch#ResourceRequirements": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ResourceRequirement"
+      }
+    },
+    "com.amazonaws.batch#ResourceType": {
+      "type": "enum",
+      "members": {
+        "GPU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GPU"
+          }
+        },
+        "VCPU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VCPU"
+          }
+        },
+        "MEMORY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEMORY"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#RetryAction": {
+      "type": "enum",
+      "members": {
+        "RETRY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RETRY"
+          }
+        },
+        "EXIT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXIT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#RetryStrategy": {
+      "type": "structure",
+      "members": {
+        "attempts": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of times to move a job to the <code>RUNNABLE</code> status. You can specify\n   between 1 and 10 attempts. If the value of <code>attempts</code> is greater than one, the job is\n   retried on failure the same number of attempts as the value.</p>"
+          }
+        },
+        "evaluateOnExit": {
+          "target": "com.amazonaws.batch#EvaluateOnExitList",
+          "traits": {
+            "smithy.api#documentation": "<p>Array of up to 5 objects that specify the conditions where jobs are retried or failed. If\n   this parameter is specified, then the <code>attempts</code> parameter must also be specified. If\n   none of the listed conditions match, then the job is retried.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The retry strategy that's associated with a job. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/job_retries.html\">Automated job retries</a> in the\n    <i>Batch User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#RuntimePlatform": {
+      "type": "structure",
+      "members": {
+        "operatingSystemFamily": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The operating system for the compute environment. Valid values are:\n    <code>LINUX</code> (default), <code>WINDOWS_SERVER_2019_CORE</code>,\n    <code>WINDOWS_SERVER_2019_FULL</code>, <code>WINDOWS_SERVER_2022_CORE</code>, and\n    <code>WINDOWS_SERVER_2022_FULL</code>.</p>\n         <note>\n            <p>The following parameters can\u2019t be set for Windows containers: <code>linuxParameters</code>,\n     <code>privileged</code>, <code>user</code>, <code>ulimits</code>,\n     <code>readonlyRootFilesystem</code>, and <code>efsVolumeConfiguration</code>.</p>\n         </note>\n         <note>\n            <p>The Batch Scheduler checks the compute environments that are attached to the job queue before \n    registering a task definition with Fargate. In this scenario, the job queue is where the job is \n    submitted. If the job requires a Windows container and the first compute environment is <code>LINUX</code>, \n    the compute environment is skipped and the next compute environment is checked until a Windows-based \n    compute environment is found.</p>\n         </note>\n         <note>\n            <p>Fargate Spot is not supported on Windows-based containers on Fargate. \n    A job queue will be blocked if a Windows job is submitted to a job \n    queue with only Fargate Spot compute environments. However, you can attach both <code>FARGATE</code> and\n     <code>FARGATE_SPOT</code> compute environments to the same job queue.</p>\n         </note>"
+          }
+        },
+        "cpuArchitecture": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The vCPU architecture. The default value is <code>X86_64</code>. Valid values are\n    <code>X86_64</code> and <code>ARM64</code>.</p>\n         <note>\n            <p>This parameter must be set to <code>X86_64</code> for Windows containers.</p>\n         </note>\n         <note>\n            <p>Fargate Spot is not supported on Windows-based containers on\n    Fargate. A job queue will be blocked if a Windows job is\n    submitted to a job queue with only Fargate Spot compute environments. However, you can attach\n    both <code>FARGATE</code> and <code>FARGATE_SPOT</code> compute environments to the same job\n    queue.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> An object that represents the compute environment architecture for Batch jobs on\n   Fargate. </p>"
+      }
+    },
+    "com.amazonaws.batch#S3FilesVolumeConfiguration": {
+      "type": "structure",
+      "members": {
+        "fileSystemArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the S3Files file system to use.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "rootDirectory": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The directory within the S3Files file system to mount as the root directory.</p>"
+          }
+        },
+        "transitEncryptionPort": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The port to use when sending encrypted data between the Amazon ECS host and the S3Files file system\n   server.</p>"
+          }
+        },
+        "accessPointArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the S3Files access point to use.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This is used when you're using an S3Files file system for job storage.</p>"
+      }
+    },
+    "com.amazonaws.batch#SchedulingPolicyDetail": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the fair-share scheduling policy.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "arn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the scheduling policy. An example is\n     <code>arn:<i>aws</i>:batch:<i>us-east-1</i>:<i>123456789012</i>:scheduling-policy/<i>HighPriority</i>\n            </code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "quotaSharePolicy": {
+          "target": "com.amazonaws.batch#QuotaSharePolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The quota share scheduling policy details.</p>"
+          }
+        },
+        "fairsharePolicy": {
+          "target": "com.amazonaws.batch#FairsharePolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The fair-share scheduling policy details.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the fair-share scheduling policy to categorize and organize your resources.\n   Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services resources</a> in\n    <i>Amazon Web Services General Reference</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents a scheduling policy.</p>"
+      }
+    },
+    "com.amazonaws.batch#SchedulingPolicyDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#SchedulingPolicyDetail"
+      }
+    },
+    "com.amazonaws.batch#SchedulingPolicyListingDetail": {
+      "type": "structure",
+      "members": {
+        "arn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of the scheduling policy.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains the details of a scheduling policy that's returned in a\n    <code>ListSchedulingPolicy</code> action.</p>"
+      }
+    },
+    "com.amazonaws.batch#SchedulingPolicyListingDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#SchedulingPolicyListingDetail"
+      }
+    },
+    "com.amazonaws.batch#Secret": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the secret.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "valueFrom": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The secret to expose to the container. The supported values are either the full Amazon Resource Name (ARN) of\n   the Secrets Manager secret or the full ARN of the parameter in the Amazon Web Services Systems Manager Parameter Store.</p>\n         <note>\n            <p>If the Amazon Web Services Systems Manager Parameter Store parameter exists in the same Region as the job you're\n    launching, then you can use either the full Amazon Resource Name (ARN) or name of the parameter. If the parameter\n    exists in a different Region, then the full ARN must be specified.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the secret to expose to your container. Secrets can be exposed to\n   a container in the following ways:</p>\n         <ul>\n            <li>\n               <p>To inject sensitive data into your containers as environment variables, use the\n      <code>secrets</code> container definition parameter.</p>\n            </li>\n            <li>\n               <p>To reference sensitive information in the log configuration of a container, use the\n      <code>secretOptions</code> container definition parameter.</p>\n            </li>\n         </ul>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/specifying-sensitive-data.html\">Specifying sensitive data</a> in the\n    <i>Batch User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#SecretList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#Secret"
+      }
+    },
+    "com.amazonaws.batch#ServerException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.batch#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>These errors are usually caused by a server issue.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.batch#ServiceEnvironmentDetail": {
+      "type": "structure",
+      "members": {
+        "serviceEnvironmentName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the service environment.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceEnvironmentArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the service environment.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceEnvironmentType": {
+          "target": "com.amazonaws.batch#ServiceEnvironmentType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of service environment. For SageMaker Training jobs, this value is <code>SAGEMAKER_TRAINING</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#ServiceEnvironmentState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the service environment. Valid values are <code>ENABLED</code> and <code>DISABLED</code>.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#ServiceEnvironmentStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the service environment.</p>"
+          }
+        },
+        "capacityLimits": {
+          "target": "com.amazonaws.batch#CapacityLimits",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The capacity limits for the service environment. This defines the maximum resources that can be used by service jobs in this environment.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags associated with the service environment. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using-tags.html\">Tagging your Batch resources</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about a service environment, including its configuration, state, and capacity limits.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceEnvironmentDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ServiceEnvironmentDetail"
+      }
+    },
+    "com.amazonaws.batch#ServiceEnvironmentOrder": {
+      "type": "structure",
+      "members": {
+        "order": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The order of the service environment. Job queues with a higher priority are evaluated first when associated with the same service environment.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceEnvironment": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or ARN of the service environment.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the order of a service environment for a job queue. This determines the priority order when multiple service environments are associated with the same job queue.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceEnvironmentOrders": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ServiceEnvironmentOrder"
+      }
+    },
+    "com.amazonaws.batch#ServiceEnvironmentState": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#ServiceEnvironmentStatus": {
+      "type": "enum",
+      "members": {
+        "CREATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATING"
+          }
+        },
+        "UPDATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATING"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        },
+        "DELETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED"
+          }
+        },
+        "VALID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALID"
+          }
+        },
+        "INVALID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INVALID"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#ServiceEnvironmentType": {
+      "type": "enum",
+      "members": {
+        "SAGEMAKER_TRAINING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SAGEMAKER_TRAINING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#ServiceJobAttemptDetail": {
+      "type": "structure",
+      "members": {
+        "serviceResourceId": {
+          "target": "com.amazonaws.batch#ServiceResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The service resource identifier associated with the service job attempt.</p>"
+          }
+        },
+        "startedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job attempt was started.</p>"
+          }
+        },
+        "stoppedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job attempt stopped running.</p>"
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that provides additional details for the current status of the service job attempt.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about an attempt to run a service job.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobAttemptDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ServiceJobAttemptDetail"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobCapacityUsageDetail": {
+      "type": "structure",
+      "members": {
+        "capacityUnit": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unit of measure for the service job capacity usage. For service jobs, this is the\n                instance type.</p>"
+          }
+        },
+        "quantity": {
+          "target": "com.amazonaws.batch#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>The quantity of capacity being used by the service job, measured in the units\n            specified by <code>capacityUnit</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The capacity usage for a service job, including the unit of\n            measure and quantity of resources being consumed.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobCapacityUsageDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ServiceJobCapacityUsageDetail"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobCapacityUsageSummary": {
+      "type": "structure",
+      "members": {
+        "capacityUnit": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unit of measure for the service job capacity usage. For service jobs, this is the\n                instance type.</p>"
+          }
+        },
+        "quantity": {
+          "target": "com.amazonaws.batch#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>The quantity of capacity being used by the service job, measured in the units\n            specified by <code>capacityUnit</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The capacity usage for a service job, including the unit of\n            measure and quantity of resources being used.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobCapacityUsageSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ServiceJobCapacityUsageSummary"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobEvaluateOnExit": {
+      "type": "structure",
+      "members": {
+        "action": {
+          "target": "com.amazonaws.batch#ServiceJobRetryAction",
+          "traits": {
+            "smithy.api#documentation": "<p>The action to take if the service job exits with the specified condition. Valid values are <code>RETRY</code> and <code>EXIT</code>.</p>"
+          }
+        },
+        "onStatusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains a glob pattern to match against the StatusReason returned for a job. The pattern can contain up to 512 characters and can contain all printable characters. It can optionally end with an asterisk (*) so that only the start of the string needs to be an exact match.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies conditions for when to exit or retry a service job based on the exit status or status reason.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobEvaluateOnExitList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ServiceJobEvaluateOnExit"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobPreemptedAttempt": {
+      "type": "structure",
+      "members": {
+        "serviceResourceId": {
+          "target": "com.amazonaws.batch#ServiceResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The service resource identifier associated with the service job attempt.</p>"
+          }
+        },
+        "startedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job attempt was started.</p>"
+          }
+        },
+        "stoppedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job attempt stopped running.</p>"
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that provides additional details for the current status of the service job attempt.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about a preempted attempt of a service job.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobPreemptionConfiguration": {
+      "type": "structure",
+      "members": {
+        "preemptionRetriesBeforeTermination": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of times a service job can be retried after it is preempted.  A job will be terminated when preemption retries have been exhausted.\n      If this field is unset, preempted jobs will be requeued an unlimited number of times. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the service job behavior when preempted.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobPreemptionSummary": {
+      "type": "structure",
+      "members": {
+        "preemptedAttemptCount": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The total number of times the service job has been preempted.</p>"
+          }
+        },
+        "recentPreemptedAttempts": {
+          "target": "com.amazonaws.batch#ServiceJobRecentPreemptedAttemptList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the most recent preemption attempts for the service job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Summarizes the preemptions of the service job. This field appears on a service job\n        when it has been preempted.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobRecentPreemptedAttemptList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ServiceJobPreemptedAttempt"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobRetryAction": {
+      "type": "enum",
+      "members": {
+        "RETRY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RETRY"
+          }
+        },
+        "EXIT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXIT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#ServiceJobRetryStrategy": {
+      "type": "structure",
+      "members": {
+        "attempts": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The number of times to move a service job to <code>RUNNABLE</code> status. You can specify between 1 and 10 attempts.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "evaluateOnExit": {
+          "target": "com.amazonaws.batch#ServiceJobEvaluateOnExitList",
+          "traits": {
+            "smithy.api#documentation": "<p>Array of <code>ServiceJobEvaluateOnExit</code> objects that specify conditions under which the service job should be retried or failed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The retry strategy for service jobs. This defines how many times to retry a failed service job and under what conditions. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/service-job-retries.html\">Service job retry strategies</a> in the <i>Batch User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobStatus": {
+      "type": "enum",
+      "members": {
+        "SUBMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUBMITTED"
+          }
+        },
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "RUNNABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNABLE"
+          }
+        },
+        "SCHEDULED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCHEDULED"
+          }
+        },
+        "STARTING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STARTING"
+          }
+        },
+        "RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNING"
+          }
+        },
+        "SUCCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCEEDED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#ServiceJobSummary": {
+      "type": "structure",
+      "members": {
+        "latestAttempt": {
+          "target": "com.amazonaws.batch#LatestServiceJobAttempt",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about the latest attempt for the service job.</p>"
+          }
+        },
+        "capacityUsage": {
+          "target": "com.amazonaws.batch#ServiceJobCapacityUsageSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The capacity usage information for this service job, including the unit of measure and\n            quantity of resources being used.</p>"
+          }
+        },
+        "createdAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job was created.</p>"
+          }
+        },
+        "jobArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the service job.</p>"
+          }
+        },
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job ID for the service job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the service job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "scheduledAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job was scheduled for\n            execution.</p>"
+          }
+        },
+        "serviceJobType": {
+          "target": "com.amazonaws.batch#ServiceJobType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of service job. For SageMaker Training jobs, this value is <code>SAGEMAKER_TRAINING</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "shareIdentifier": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The share identifier for the job.</p>"
+          }
+        },
+        "quotaShareName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The quota share for the service job.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.batch#ServiceJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the service job. </p>"
+          }
+        },
+        "statusReason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short string to provide more details on the current status of the service job.</p>"
+          }
+        },
+        "startedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job was started.</p>"
+          }
+        },
+        "stoppedAt": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The Unix timestamp (in milliseconds) for when the service job stopped running.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Summary information about a service job.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ServiceJobSummary"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobTimeout": {
+      "type": "structure",
+      "members": {
+        "attemptDurationSeconds": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum duration in seconds that a service job attempt can run. After this time is reached, Batch terminates the service job attempt.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The timeout configuration for service jobs. </p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceJobType": {
+      "type": "enum",
+      "members": {
+        "SAGEMAKER_TRAINING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SAGEMAKER_TRAINING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#ServiceResourceId": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.batch#ServiceResourceIdName",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the resource identifier. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "value": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The value of the resource identifier. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Batch unique identifier.</p>"
+      }
+    },
+    "com.amazonaws.batch#ServiceResourceIdName": {
+      "type": "enum",
+      "members": {
+        "SAGEMAKER_TRAINING_JOB_ARN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TrainingJobArn"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#ShareAttributes": {
+      "type": "structure",
+      "members": {
+        "shareIdentifier": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A share identifier or share identifier prefix. If the string ends with an asterisk\n   (*), this entry specifies the weight factor to use for share identifiers that start with\n   that prefix. The list of share identifiers in a fair-share policy can't overlap. For\n   example, you can't have one that specifies a <code>shareIdentifier</code> of <code>UserA*</code>\n   and another that specifies a <code>shareIdentifier</code> of <code>UserA1</code>.</p>\n         <p>There can be no more than 500 share identifiers active in a job queue.</p>\n         <p>The string is limited to 255 alphanumeric characters, and can be followed by an asterisk\n   (*).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "weightFactor": {
+          "target": "com.amazonaws.batch#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The weight factor for the share identifier. The default value is 1.0. A lower value has\n   a higher priority for compute resources. For example, jobs that use a share identifier with a\n   weight factor of 0.125 (1/8) get 8 times the compute resources of jobs that use a share\n   identifier with a weight factor of 1.</p>\n         <p>The smallest supported value is 0.0001, and the largest supported value is 999.9999.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the weights for the share identifiers for the fair-share policy. Share\n   identifiers that aren't included have a default weight of <code>1.0</code>.</p>"
+      }
+    },
+    "com.amazonaws.batch#ShareAttributesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#ShareAttributes"
+      }
+    },
+    "com.amazonaws.batch#String": {
+      "type": "string"
+    },
+    "com.amazonaws.batch#StringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#String"
+      }
+    },
+    "com.amazonaws.batch#SubmitJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#SubmitJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#SubmitJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Submits an Batch job from a job definition. Parameters that are specified during <a>SubmitJob</a> override parameters defined in the job definition. vCPU and memory\n      requirements that are specified in the <code>resourceRequirements</code> objects in the job\n      definition are the exception. They can't be overridden this way using the <code>memory</code>\n      and <code>vcpus</code> parameters. Rather, you must specify updates to job definition\n      parameters in a <code>resourceRequirements</code> object that's included in the\n        <code>containerOverrides</code> parameter.</p>\n         <note>\n            <p>Job queues with a scheduling policy are limited to 500 active share identifiers at\n        a time. </p>\n         </note>\n         <important>\n            <p>Jobs that run on Fargate resources can't be guaranteed to run for more than 14 days.\n        This is because, after 14 days, Fargate resources might become unavailable and job might be\n        terminated.</p>\n         </important>",
+        "smithy.api#examples": [
+          {
+            "title": "To submit a job to a queue",
+            "documentation": "This example submits a simple container job called example to the HighPriority job queue.",
+            "input": {
+              "jobName": "example",
+              "jobQueue": "HighPriority",
+              "jobDefinition": "sleep60"
+            },
+            "output": {
+              "jobName": "example",
+              "jobId": "876da822-4198-45f2-a252-6cea32512ea8"
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/submitjob",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#SubmitJobRequest": {
+      "type": "structure",
+      "members": {
+        "jobName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the job. It can be up to 128 letters long. The first character must be\n      alphanumeric, can contain uppercase and lowercase letters, numbers, hyphens (-), and\n      underscores (_).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job queue where the job is submitted. You can specify either the name or the Amazon Resource Name (ARN)\n      of the queue.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "shareIdentifier": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The share identifier for the job. Don't specify this parameter if the job queue doesn't\n      have a fair-share scheduling policy. If the job queue has a fair-share scheduling policy, then this parameter must\n      be specified.</p>\n         <p>This string is limited to 255 alphanumeric characters, and can be followed by an asterisk\n      (*).</p>"
+          }
+        },
+        "schedulingPriorityOverride": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The scheduling priority for the job. This only affects jobs in job queues with a \n      fair-share policy. Jobs with a higher scheduling priority are scheduled before jobs with a lower\n      scheduling priority. This overrides any scheduling priority in the job definition and works only \n      within a single share identifier.</p>\n         <p>The minimum supported value is 0 and the maximum supported value is 9999.</p>"
+          }
+        },
+        "arrayProperties": {
+          "target": "com.amazonaws.batch#ArrayProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The array properties for the submitted job, such as the size of the array. The array size\n      can be between 2 and 10,000. If you specify array properties for a job, it becomes an array\n      job. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/array_jobs.html\">Array Jobs</a> in the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "dependsOn": {
+          "target": "com.amazonaws.batch#JobDependencyList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of dependencies for the job. A job can depend upon a maximum of 20 jobs. You can\n      specify a <code>SEQUENTIAL</code> type dependency without specifying a job ID for array jobs\n      so that each child array job completes sequentially, starting at index 0. You can also specify\n      an <code>N_TO_N</code> type dependency with a job ID for array jobs. In that case, each index\n      child of this job must wait for the corresponding index child of each dependency to complete\n      before it can begin.</p>"
+          }
+        },
+        "jobDefinition": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job definition used by this job. This value can be one of\n      <code>definition-name</code>, <code>definition-name:revision</code>, or the Amazon Resource Name (ARN) for the\n      job definition, with or without the revision\n          (<code>arn:aws:batch:<i>region</i>:<i>account</i>:job-definition/<i>definition-name</i>:<i>revision</i>\n            </code>,\n      or\n          <code>arn:aws:batch:<i>region</i>:<i>account</i>:job-definition/<i>definition-name</i>\n            </code>).</p>\n         <p>If the revision is not specified, then the latest active revision is used.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "parameters": {
+          "target": "com.amazonaws.batch#ParametersMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional parameters passed to the job that replace parameter substitution placeholders\n      that are set in the job definition. Parameters are specified as a key and value pair mapping.\n      Parameters in a <code>SubmitJob</code> request override any corresponding parameter defaults\n      from the job definition.</p>"
+          }
+        },
+        "containerOverrides": {
+          "target": "com.amazonaws.batch#ContainerOverrides",
+          "traits": {
+            "smithy.api#documentation": "<p>An object with properties that override the defaults for the job definition that specify\n      the name of a container in the specified job definition and the overrides it should receive.\n      You can override the default command for a container, which is specified in the job definition\n      or the Docker image, with a <code>command</code> override. You can also override existing\n      environment variables on a container or add new environment variables to it with an\n        <code>environment</code> override.</p>"
+          }
+        },
+        "nodeOverrides": {
+          "target": "com.amazonaws.batch#NodeOverrides",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of node overrides in JSON format that specify the node range to target and the\n      container overrides for that node range.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources; use\n          <code>containerOverrides</code> instead.</p>\n         </note>"
+          }
+        },
+        "retryStrategy": {
+          "target": "com.amazonaws.batch#RetryStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The retry strategy to use for failed jobs from this <a>SubmitJob</a> operation.\n      When a retry strategy is specified here, it overrides the retry strategy defined in the job\n      definition.</p>"
+          }
+        },
+        "propagateTags": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether to propagate the tags from the job or job definition to the\n      corresponding Amazon ECS task. If no value is specified, the tags aren't propagated. Tags can only\n      be propagated to the tasks during task creation. For tags with the same name, job tags are\n      given priority over job definitions tags. If the total number of combined tags from the job\n      and job definition is over 50, the job is moved to the <code>FAILED</code> state. When\n      specified, this overrides the tag propagation setting in the job definition.</p>"
+          }
+        },
+        "timeout": {
+          "target": "com.amazonaws.batch#JobTimeout",
+          "traits": {
+            "smithy.api#documentation": "<p>The timeout configuration for this <a>SubmitJob</a> operation. You can specify\n      a timeout duration after which Batch terminates your jobs if they haven't finished. If a job\n      is terminated due to a timeout, it isn't retried. The minimum value for the timeout is 60\n      seconds. This configuration overrides any timeout configuration specified in the job\n      definition. For array jobs, child jobs have the same timeout configuration as the parent job.\n      For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/job_timeouts.html\">Job Timeouts</a> in the\n        <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the job request to help you categorize and organize your\n      resources. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services\n        Resources</a> in <i>Amazon Web Services General Reference</i>.</p>"
+          }
+        },
+        "eksPropertiesOverride": {
+          "target": "com.amazonaws.batch#EksPropertiesOverride",
+          "traits": {
+            "smithy.api#documentation": "<p>An object, with properties that override defaults for the job definition, can only be specified for jobs that are run on Amazon EKS resources.</p>"
+          }
+        },
+        "ecsPropertiesOverride": {
+          "target": "com.amazonaws.batch#EcsPropertiesOverride",
+          "traits": {
+            "smithy.api#documentation": "<p>An object, with properties that override defaults for the job definition, can only be specified for jobs that are run on Amazon ECS resources.</p>"
+          }
+        },
+        "consumableResourcePropertiesOverride": {
+          "target": "com.amazonaws.batch#ConsumableResourceProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains overrides for the consumable resources of a job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>SubmitJob</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#SubmitJobResponse": {
+      "type": "structure",
+      "members": {
+        "jobArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the job.</p>"
+          }
+        },
+        "jobName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier for the job.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#SubmitServiceJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#SubmitServiceJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#SubmitServiceJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Submits a service job to a specified job queue to run on SageMaker AI. A service job is a unit of work that you submit to Batch for execution on SageMaker AI.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/submitservicejob",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#SubmitServiceJobRequest": {
+      "type": "structure",
+      "members": {
+        "jobName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the service job. It can be up to 128 characters long. It can contain uppercase and lowercase letters, numbers, hyphens (-), and underscores (_).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job queue into which the service job is submitted. You can specify either the name or the ARN of the queue. The job queue must have the type <code>SAGEMAKER_TRAINING</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "retryStrategy": {
+          "target": "com.amazonaws.batch#ServiceJobRetryStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The retry strategy to use for failed service jobs that are submitted with this service job request. </p>"
+          }
+        },
+        "schedulingPriority": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The scheduling priority of the service job.  Valid values are integers between 0 and 9999.</p>"
+          }
+        },
+        "serviceRequestPayload": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The request, in JSON, for the service that the SubmitServiceJob operation is queueing. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceJobType": {
+          "target": "com.amazonaws.batch#ServiceJobType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of service job. For SageMaker Training jobs, specify <code>SAGEMAKER_TRAINING</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "shareIdentifier": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The share identifier for the service job. Don't specify this parameter if the job\n            queue doesn't have a fair-share scheduling policy. If the job queue has a fair-share\n            scheduling policy, then this parameter must be specified.</p>"
+          }
+        },
+        "quotaShareName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The quota share for the service job. Don't specify this parameter if the job queue\n        doesn't have a quota share scheduling policy. If the job queue has a quota share scheduling policy,\n        then this parameter must be specified.</p>"
+          }
+        },
+        "preemptionConfiguration": {
+          "target": "com.amazonaws.batch#ServiceJobPreemptionConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the service job behavior when preempted.</p>"
+          }
+        },
+        "timeoutConfig": {
+          "target": "com.amazonaws.batch#ServiceJobTimeout",
+          "traits": {
+            "smithy.api#documentation": "<p>The timeout configuration for the service job. If none is specified, Batch defers to the default timeout of the underlying service handling the job.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you apply to the service job request. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/using-tags.html\">Tagging your Batch resources</a>.</p>"
+          }
+        },
+        "clientToken": {
+          "target": "com.amazonaws.batch#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. This token is used to ensure idempotency of requests. If this parameter is specified and two submit requests with identical payloads and <code>clientToken</code>s are received, these requests are considered the same request and the second request is rejected.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#SubmitServiceJobResponse": {
+      "type": "structure",
+      "members": {
+        "jobArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the service job.</p>"
+          }
+        },
+        "jobName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the service job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier for the service job.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.batch#TagKeysList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#TagKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.batch#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Associates the specified tags to a resource with the specified <code>resourceArn</code>.\n      If existing tags on a resource aren't specified in the request parameters, they aren't\n      changed. When a resource is deleted, the tags that are associated with that resource are\n      deleted as well. Batch resources that support tags are compute environments, jobs, job definitions, job queues,\n and scheduling policies. ARNs for child jobs of array and multi-node parallel (MNP) jobs aren't supported.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "TagResource Example",
+            "documentation": "This demonstrates calling the TagResource action.",
+            "input": {
+              "resourceArn": "arn:aws:batch:us-east-1:123456789012:job-definition/sleep30:1",
+              "tags": {
+                "Stage": "Alpha"
+              }
+            },
+            "output": {}
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/tags/{resourceArn}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "resourceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource that tags are added to. Batch resources that support tags are compute environments, jobs, job definitions, job queues,\n and scheduling policies. ARNs for child jobs of array and multi-node parallel (MNP) jobs aren't supported.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.batch#TagrisTagsMap",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The tags that you apply to the resource to help you categorize and organize your\n      resources. Each tag consists of a key and an optional value. For more information, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services\n        Resources</a> in <i>Amazon Web Services General Reference</i>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>TagResource</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#TagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.batch#TagrisTagsMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#TagKey"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#TagValue"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.batch#TagsMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.batch#String"
+      },
+      "value": {
+        "target": "com.amazonaws.batch#String"
+      }
+    },
+    "com.amazonaws.batch#TaskContainerDependency": {
+      "type": "structure",
+      "members": {
+        "containerName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the container.</p>"
+          }
+        },
+        "condition": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The dependency condition of the container. The following are the available conditions and\n   their behavior:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>START</code> - This condition emulates the behavior of links and volumes today. It\n     validates that a dependent container is started before permitting other containers to start.\n    </p>\n            </li>\n            <li>\n               <p>\n                  <code>COMPLETE</code> - This condition validates that a dependent container runs to\n     completion (exits) before permitting other containers to start. This can be useful for\n     nonessential containers that run a script and then exit. This condition can't be set on an\n     essential container. </p>\n            </li>\n            <li>\n               <p>\n                  <code>SUCCESS</code> - This condition is the same as <code>COMPLETE</code>, but it also\n     requires that the container exits with a zero status. This condition can't be set on an\n     essential container. </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of containers that this task depends on.</p>"
+      }
+    },
+    "com.amazonaws.batch#TaskContainerDependencyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#TaskContainerDependency"
+      }
+    },
+    "com.amazonaws.batch#TaskContainerDetails": {
+      "type": "structure",
+      "members": {
+        "command": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The command that's passed to the container. This parameter maps to <code>Cmd</code> in the\n   <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the <code>COMMAND</code>\n   parameter to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. For more information, see\n    <a href=\"https://docs.docker.com/engine/reference/builder/#cmd\">https://docs.docker.com/engine/reference/builder/#cmd</a>.</p>"
+          }
+        },
+        "dependsOn": {
+          "target": "com.amazonaws.batch#TaskContainerDependencyList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of containers that this container depends on.</p>"
+          }
+        },
+        "environment": {
+          "target": "com.amazonaws.batch#EnvironmentVariables",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables to pass to a container. This parameter maps to <code>Env</code> in\n   the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a> and the\n    <code>--env</code> option to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>.</p>\n         <important>\n            <p>We don't recommend using plaintext environment variables for sensitive information, such as\n    credential data.</p>\n         </important>"
+          }
+        },
+        "essential": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>If the essential parameter of a container is marked as <code>true</code>, and that container\n   fails or stops for any reason, all other containers that are part of the task are stopped. If the\n    <code>essential</code> parameter of a container is marked as false, its failure doesn't affect\n   the rest of the containers in a task. If this parameter is omitted, a container is assumed to be\n   essential.</p>\n         <p>All jobs must have at least one essential container. If you have an application that's\n   composed of multiple containers, group containers that are used for a common purpose into\n   components, and separate the different components into multiple task definitions. For more\n   information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/application_architecture.html\">Application\n    Architecture</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+          }
+        },
+        "firelensConfiguration": {
+          "target": "com.amazonaws.batch#FirelensConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The FireLens configuration for the container. This is used to specify and configure a\n            log router for container logs. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html\">Custom log</a> routing in the <i>Amazon Elastic Container Service Developer\n                    Guide</i>.</p>"
+          }
+        },
+        "image": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The image used to start a container. This string is passed directly to the Docker daemon. By\n   default, images in the Docker Hub registry are available. Other repositories are specified with\n   either <code>repository-url/image:tag</code> or <code>repository-url/image@digest</code>. Up to\n   255 letters (uppercase and lowercase), numbers, hyphens, underscores, colons, periods, forward\n   slashes, and number signs are allowed. This parameter maps to <code>Image</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <code>IMAGE</code> parameter of the <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">\n               <i>docker\n     run</i>\n            </a>.</p>"
+          }
+        },
+        "linuxParameters": {
+          "target": "com.amazonaws.batch#LinuxParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Linux-specific modifications that are applied to the container, such as Linux kernel\n   capabilities. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KernelCapabilities.html\">KernelCapabilities</a>.</p>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
+          }
+        },
+        "logConfiguration": {
+          "target": "com.amazonaws.batch#LogConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The log configuration specification for the container.</p>\n         <p>This parameter maps to <code>LogConfig</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <code>--log-driver</code> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker\n   run</a>.</p>\n         <p>By default, containers use the same logging driver that the Docker daemon uses. However the\n   container can use a different logging driver than the Docker daemon by specifying a log driver\n   with this parameter in the container definition. To use a different logging driver for a\n   container, the log system must be configured properly on the container instance (or on a\n   different log server for remote logging options). For more information about the options for\n   different supported log drivers, see <a href=\"https://docs.docker.com/engine/admin/logging/overview/\">Configure logging drivers </a>\n   in the <i>Docker documentation</i>.</p>\n         <note>\n            <p>Amazon ECS currently supports a subset of the logging drivers available to the Docker daemon\n    (shown in the <code>LogConfiguration</code> data type). Additional log drivers may be available\n    in future releases of the Amazon ECS container agent.</p>\n         </note>\n         <p>This parameter requires version 1.18 of the Docker Remote API or greater on your container\n   instance. To check the Docker Remote API version on your container instance, log in to your\n   container instance and run the following command: sudo docker version <code>--format\n    '{{.Server.APIVersion}}'</code>\n         </p>\n         <note>\n            <p>The Amazon ECS container agent running on a container instance must register the logging drivers\n    available on that instance with the <code>ECS_AVAILABLE_LOGGING_DRIVERS</code> environment\n    variable before containers placed on that instance can use these log configuration options. For\n    more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html\">Amazon ECS container agent\n     configuration</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         </note>"
+          }
+        },
+        "mountPoints": {
+          "target": "com.amazonaws.batch#MountPoints",
+          "traits": {
+            "smithy.api#documentation": "<p>The mount points for data volumes in your container.</p>\n         <p>This parameter maps to <code>Volumes</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <a href=\"\">--volume</a> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker\n   run</a>.</p>\n         <p>Windows containers can mount whole directories on the same drive as\n    <code>$env:ProgramData</code>. Windows containers can't mount directories on a different drive,\n   and mount point can't be across drives.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a container.</p>"
+          }
+        },
+        "privileged": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is <code>true</code>, the container is given elevated privileges on the\n   host container instance (similar to the <code>root</code> user). This parameter maps to\n    <code>Privileged</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <code>--privileged</code> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker\n   run</a>.</p>\n         <note>\n            <p>This parameter is not supported for Windows containers or tasks run on Fargate.</p>\n         </note>"
+          }
+        },
+        "readonlyRootFilesystem": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is true, the container is given read-only access to its root file\n   system. This parameter maps to <code>ReadonlyRootfs</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <code>--read-only</code> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker\n   run</a>.</p>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
+          }
+        },
+        "repositoryCredentials": {
+          "target": "com.amazonaws.batch#RepositoryCredentials",
+          "traits": {
+            "smithy.api#documentation": "<p>The private repository authentication credentials to use.</p>"
+          }
+        },
+        "resourceRequirements": {
+          "target": "com.amazonaws.batch#ResourceRequirements",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and amount of a resource to assign to a container. The only supported resource is a\n   GPU.</p>"
+          }
+        },
+        "secrets": {
+          "target": "com.amazonaws.batch#SecretList",
+          "traits": {
+            "smithy.api#documentation": "<p>The secrets to pass to the container. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html\">Specifying Sensitive\n    Data</a> in the Amazon Elastic Container Service Developer Guide.</p>"
+          }
+        },
+        "ulimits": {
+          "target": "com.amazonaws.batch#Ulimits",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ulimits</code> to set in the container. If a <code>ulimit</code> value is\n   specified in a task definition, it overrides the default values set by Docker. This parameter\n   maps to <code>Ulimits</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <code>--ulimit</code> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker\n   run</a>.</p>\n         <p>Amazon ECS tasks hosted on Fargate use the default resource limit values set by the operating\n   system with the exception of the nofile resource limit parameter which Fargate overrides. The\n    <code>nofile</code> resource limit sets a restriction on the number of open files that a\n   container can use. The default <code>nofile</code> soft limit is <code>1024</code> and the\n   default hard limit is <code>65535</code>.</p>\n         <p>This parameter requires version 1.18 of the Docker Remote API or greater on your container\n   instance. To check the Docker Remote API version on your container instance, log in to your\n   container instance and run the following command: sudo docker version <code>--format\n    '{{.Server.APIVersion}}'</code>\n         </p>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
+          }
+        },
+        "user": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The user to use inside the container. This parameter maps to User in the Create a container\n   section of the Docker Remote API and the --user option to docker run.</p>\n         <note>\n            <p>When running tasks using the <code>host</code> network mode, don't run containers using the\n     <code>root user (UID 0)</code>. We recommend using a non-root user for better security.</p>\n         </note>\n         <p>You can specify the <code>user</code> using the following formats. If specifying a UID or\n   GID, you must specify it as a positive integer.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>user</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>user:group</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>uid</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>uid:gid</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>user:gi</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>uid:group</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code></code>\n               </p>\n            </li>\n         </ul>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
+          }
+        },
+        "startTimeout": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Time duration (in seconds) to wait before giving up on resolving dependencies for a\n   container. The minimum value is 2 seconds and the maximum value for Fargate is 120\n   seconds.</p>"
+          }
+        },
+        "stopTimeout": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Time duration (in seconds) to wait before the container is forcefully killed if it doesn't\n   exit normally on its own. The minimum value is 2 seconds and the maximum value for Fargate is\n   120 seconds. If the parameter is not specified, the default value of 30 seconds is used. For\n   tasks that use the EC2 launch type, if the <code>stopTimeout</code> parameter isn't specified,\n   the value set for the Amazon ECS container agent configuration variable\n    <code>ECS_CONTAINER_STOP_TIMEOUT</code> is used. If neither the <code>stopTimeout</code>\n   parameter nor the <code>ECS_CONTAINER_STOP_TIMEOUT</code> agent configuration variable are set,\n   then the default value of 30 seconds is used.</p>"
+          }
+        },
+        "exitCode": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The exit code returned upon completion.</p>"
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A short (255 max characters) human-readable string to provide additional details for a\n   running or stopped container.</p>"
+          }
+        },
+        "logStreamName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the CloudWatch Logs log stream that's associated with the container. The log group for\n   Batch jobs is /aws/batch/job. Each container attempt receives a log stream name when they reach\n   the <code>RUNNING</code> status. </p>"
+          }
+        },
+        "networkInterfaces": {
+          "target": "com.amazonaws.batch#NetworkInterfaceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The network interfaces that are associated with the job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details for the container in this task attempt.</p>"
+      }
+    },
+    "com.amazonaws.batch#TaskContainerOverrides": {
+      "type": "structure",
+      "members": {
+        "command": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The command to send to the container that overrides the default command from the Docker\n   image or the job definition.</p>\n         <note>\n            <p>This parameter can't contain an empty string.</p>\n         </note>"
+          }
+        },
+        "environment": {
+          "target": "com.amazonaws.batch#EnvironmentVariables",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables to send to the container. You can add new environment variables,\n   which are added to the container at launch, or you can override the existing environment\n   variables from the Docker image or the job definition.</p>\n         <note>\n            <p>Environment variables cannot start with <code>AWS_BATCH</code>. This naming convention is\n    reserved for variables that Batch sets.</p>\n         </note>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A pointer to the container that you want to override. The container's name provides a unique\n   identifier for the container being used.</p>"
+          }
+        },
+        "resourceRequirements": {
+          "target": "com.amazonaws.batch#ResourceRequirements",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and amount of resources to assign to a container. This overrides the settings in\n   the job definition. The supported resources include <code>GPU</code>, <code>MEMORY</code>, and\n    <code>VCPU</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The overrides that should be sent to a container.</p>\n         <p>For information about using Batch overrides when you connect event sources to targets, see\n    <a href=\"https://docs.aws.amazon.com/eventbridge/latest/pipes-reference/API_BatchContainerOverrides.html\">BatchContainerOverrides</a>.</p>"
+      }
+    },
+    "com.amazonaws.batch#TaskContainerProperties": {
+      "type": "structure",
+      "members": {
+        "command": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The command that's passed to the container. This parameter maps to <code>Cmd</code> in the\n    <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker\n    Remote API</a> and the <code>COMMAND</code> parameter to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. For more information,\n   see <a href=\"https://docs.docker.com/engine/reference/builder/#cmd\">Dockerfile reference:\n    CMD</a>.</p>"
+          }
+        },
+        "dependsOn": {
+          "target": "com.amazonaws.batch#TaskContainerDependencyList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of containers that this container depends on.</p>"
+          }
+        },
+        "environment": {
+          "target": "com.amazonaws.batch#EnvironmentVariables",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables to pass to a container. This parameter maps to Env in the <a href=\"https://docs.docker.com/engine/api/v1.23/#create-a-container\">Create a container</a>\n   section of the <a href=\"https://docs.docker.com/engine/api/v1.23/\">Docker Remote API</a>\n   and the <code>--env</code> parameter to <a href=\"https://docs.docker.com/engine/reference/run/\">docker run</a>. </p>\n         <important>\n            <p>We don't recommend using plaintext environment variables for sensitive information, such as\n    credential data.</p>\n         </important>\n         <note>\n            <p>Environment variables cannot start with <code>AWS_BATCH</code>. This naming convention is\n    reserved for variables that Batch sets.</p>\n         </note>"
+          }
+        },
+        "essential": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>If the essential parameter of a container is marked as <code>true</code>, and that container\n   fails or stops for any reason, all other containers that are part of the task are stopped. If the\n    <code>essential</code> parameter of a container is marked as false, its failure doesn't affect\n   the rest of the containers in a task. If this parameter is omitted, a container is assumed to be\n   essential.</p>\n         <p>All jobs must have at least one essential container. If you have an application that's\n   composed of multiple containers, group containers that are used for a common purpose into\n   components, and separate the different components into multiple task definitions. For more\n   information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/application_architecture.html\">Application\n    Architecture</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+          }
+        },
+        "firelensConfiguration": {
+          "target": "com.amazonaws.batch#FirelensConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The FireLens configuration for the container. This is used to specify and configure a\n            log router for container logs. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html\">Custom log</a> routing in the <i>Amazon Elastic Container Service Developer\n                    Guide</i>.</p>"
+          }
+        },
+        "image": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The image used to start a container. This string is passed directly to the Docker daemon. By\n   default, images in the Docker Hub registry are available. Other repositories are specified with\n   either <code>repository-url/image:tag</code> or <code>repository-url/image@digest</code>. Up to\n   255 letters (uppercase and lowercase), numbers, hyphens, underscores, colons, periods, forward\n   slashes, and number signs are allowed. This parameter maps to <code>Image</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <code>IMAGE</code> parameter of the <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">\n               <i>docker\n     run</i>\n            </a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "linuxParameters": {
+          "target": "com.amazonaws.batch#LinuxParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Linux-specific modifications that are applied to the container, such as Linux kernel\n   capabilities. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KernelCapabilities.html\">KernelCapabilities</a>.</p>"
+          }
+        },
+        "logConfiguration": {
+          "target": "com.amazonaws.batch#LogConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The log configuration specification for the container.</p>\n         <p>This parameter maps to <code>LogConfig</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <code>--log-driver</code> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker\n   run</a>.</p>\n         <p>By default, containers use the same logging driver that the Docker daemon uses. However the\n   container can use a different logging driver than the Docker daemon by specifying a log driver\n   with this parameter in the container definition. To use a different logging driver for a\n   container, the log system must be configured properly on the container instance (or on a\n   different log server for remote logging options). For more information about the options for\n   different supported log drivers, see <a href=\"https://docs.docker.com/engine/admin/logging/overview/\">Configure logging drivers </a>\n   in the <i>Docker documentation</i>.</p>\n         <note>\n            <p>Amazon ECS currently supports a subset of the logging drivers available to the Docker daemon\n    (shown in the <code>LogConfiguration</code> data type). Additional log drivers may be available\n    in future releases of the Amazon ECS container agent.</p>\n         </note>\n         <p>This parameter requires version 1.18 of the Docker Remote API or greater on your container\n   instance. To check the Docker Remote API version on your container instance, log in to your\n   container instance and run the following command: sudo docker version <code>--format\n    '{{.Server.APIVersion}}'</code>\n         </p>\n         <note>\n            <p>The Amazon ECS container agent running on a container instance must register the logging drivers\n    available on that instance with the <code>ECS_AVAILABLE_LOGGING_DRIVERS</code> environment\n    variable before containers placed on that instance can use these log configuration options. For\n    more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html\">Amazon ECS container agent\n     configuration</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         </note>"
+          }
+        },
+        "mountPoints": {
+          "target": "com.amazonaws.batch#MountPoints",
+          "traits": {
+            "smithy.api#documentation": "<p>The mount points for data volumes in your container.</p>\n         <p>This parameter maps to <code>Volumes</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <a href=\"\">--volume</a> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker\n   run</a>.</p>\n         <p>Windows containers can mount whole directories on the same drive as\n    <code>$env:ProgramData</code>. Windows containers can't mount directories on a different drive,\n   and mount point can't be across drives.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a container. The name can be used as a unique identifier to target your\n    <code>dependsOn</code> and <code>Overrides</code> objects. </p>"
+          }
+        },
+        "privileged": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is <code>true</code>, the container is given elevated privileges on the\n   host container instance (similar to the <code>root</code> user). This parameter maps to\n    <code>Privileged</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <code>--privileged</code> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker\n   run</a>.</p>\n         <note>\n            <p>This parameter is not supported for Windows containers or tasks run on Fargate.</p>\n         </note>"
+          }
+        },
+        "readonlyRootFilesystem": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>When this parameter is true, the container is given read-only access to its root file\n   system. This parameter maps to <code>ReadonlyRootfs</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <code>--read-only</code> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker\n   run</a>.</p>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
+          }
+        },
+        "repositoryCredentials": {
+          "target": "com.amazonaws.batch#RepositoryCredentials",
+          "traits": {
+            "smithy.api#documentation": "<p>The private repository authentication credentials to use.</p>"
+          }
+        },
+        "resourceRequirements": {
+          "target": "com.amazonaws.batch#ResourceRequirements",
+          "traits": {
+            "smithy.api#documentation": "<p>The type and amount of a resource to assign to a container. The only supported resource is a\n   GPU.</p>"
+          }
+        },
+        "secrets": {
+          "target": "com.amazonaws.batch#SecretList",
+          "traits": {
+            "smithy.api#documentation": "<p>The secrets to pass to the container. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html\">Specifying Sensitive\n    Data</a> in the Amazon Elastic Container Service Developer Guide.</p>"
+          }
+        },
+        "ulimits": {
+          "target": "com.amazonaws.batch#Ulimits",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ulimits</code> to set in the container. If a <code>ulimit</code> value is\n   specified in a task definition, it overrides the default values set by Docker. This parameter\n   maps to <code>Ulimits</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a\n    container</a> section of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker\n    Remote API</a> and the <code>--ulimit</code> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker\n   run</a>.</p>\n         <p>Amazon ECS tasks hosted on Fargate use the default resource limit values set by the operating\n   system with the exception of the nofile resource limit parameter which Fargate overrides. The\n    <code>nofile</code> resource limit sets a restriction on the number of open files that a\n   container can use. The default <code>nofile</code> soft limit is <code>1024</code> and the\n   default hard limit is <code>65535</code>.</p>\n         <p>This parameter requires version 1.18 of the Docker Remote API or greater on your container\n   instance. To check the Docker Remote API version on your container instance, log in to your\n   container instance and run the following command: sudo docker version <code>--format\n    '{{.Server.APIVersion}}'</code>\n         </p>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
+          }
+        },
+        "user": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The user to use inside the container. This parameter maps to User in the Create a container\n   section of the Docker Remote API and the --user option to docker run.</p>\n         <note>\n            <p>When running tasks using the <code>host</code> network mode, don't run containers using the\n     <code>root user (UID 0)</code>. We recommend using a non-root user for better security.</p>\n         </note>\n         <p>You can specify the <code>user</code> using the following formats. If specifying a UID or\n   GID, you must specify it as a positive integer.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>user</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>user:group</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>uid</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>uid:gid</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>user:gi</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>uid:group</code>\n               </p>\n            </li>\n         </ul>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
+          }
+        },
+        "startTimeout": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Time duration (in seconds) to wait before giving up on resolving dependencies for a\n   container. The minimum value is 2 seconds and the maximum value for Fargate is 120\n   seconds.</p>"
+          }
+        },
+        "stopTimeout": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Time duration (in seconds) to wait before the container is forcefully killed if it doesn't\n   exit normally on its own. The minimum value is 2 seconds and the maximum value for Fargate is\n   120 seconds. If the parameter is not specified, the default value of 30 seconds is used. For\n   tasks that use the EC2 launch type, if the <code>stopTimeout</code> parameter isn't specified,\n   the value set for the Amazon ECS container agent configuration variable\n    <code>ECS_CONTAINER_STOP_TIMEOUT</code> is used. If neither the <code>stopTimeout</code>\n   parameter nor the <code>ECS_CONTAINER_STOP_TIMEOUT</code> agent configuration variable are set,\n   then the default value of 30 seconds is used.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Container properties are used for Amazon ECS-based job definitions. These properties to describe\n   the container that's launched as part of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#TaskPropertiesOverride": {
+      "type": "structure",
+      "members": {
+        "containers": {
+          "target": "com.amazonaws.batch#ListTaskContainerOverrides",
+          "traits": {
+            "smithy.api#documentation": "<p>The overrides for the container definition of a job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains overrides for the task definition of a job.</p>"
+      }
+    },
+    "com.amazonaws.batch#TerminateJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#TerminateJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#TerminateJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Terminates a job in a job queue. Jobs that are in the <code>STARTING</code> or\n        <code>RUNNING</code> state are terminated, which causes them to transition to\n        <code>FAILED</code>. Jobs that have not progressed to the <code>STARTING</code> state are\n      cancelled.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To terminate a job",
+            "documentation": "This example terminates a job with the specified job ID.",
+            "input": {
+              "reason": "Terminating job.",
+              "jobId": "61e743ed-35e4-48da-b2de-5c8333821c84"
+            },
+            "output": {}
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/terminatejob",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#TerminateJobRequest": {
+      "type": "structure",
+      "members": {
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Batch job ID of the job to terminate.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A message to attach to the job that explains the reason for canceling it. This message is\n      returned by future <a>DescribeJobs</a> operations on the job. It is also\n      recorded in the Batch activity logs.</p>\n         <p>This parameter has as limit of 1024 characters.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>TerminateJob</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#TerminateJobResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#TerminateServiceJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#TerminateServiceJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#TerminateServiceJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Terminates a service job in a job queue. </p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/terminateservicejob",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#TerminateServiceJobRequest": {
+      "type": "structure",
+      "members": {
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The service job ID of the service job to terminate.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A message to attach to the service job that explains the reason for canceling it. This message is returned by <code>DescribeServiceJob</code> operations on the service job.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#TerminateServiceJobResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#Tmpfs": {
+      "type": "structure",
+      "members": {
+        "containerPath": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The absolute file path in the container where the <code>tmpfs</code> volume is\n   mounted.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "size": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The size (in MiB) of the <code>tmpfs</code> volume.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "mountOptions": {
+          "target": "com.amazonaws.batch#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of <code>tmpfs</code> volume mount options.</p>\n         <p>Valid values: \"<code>defaults</code>\" | \"<code>ro</code>\" | \"<code>rw</code>\" |\n    \"<code>suid</code>\" | \"<code>nosuid</code>\" | \"<code>dev</code>\" | \"<code>nodev</code>\" |\n    \"<code>exec</code>\" | \"<code>noexec</code>\" | \"<code>sync</code>\" | \"<code>async</code>\" |\n    \"<code>dirsync</code>\" | \"<code>remount</code>\" | \"<code>mand</code>\" | \"<code>nomand</code>\" |\n    \"<code>atime</code>\" | \"<code>noatime</code>\" | \"<code>diratime</code>\" |\n    \"<code>nodiratime</code>\" | \"<code>bind</code>\" | \"<code>rbind\" | \"unbindable\" | \"runbindable\" |\n    \"private\" | \"rprivate\" | \"shared\" | \"rshared\" | \"slave\" | \"rslave\" | \"relatime</code>\" |\n    \"<code>norelatime</code>\" | \"<code>strictatime</code>\" | \"<code>nostrictatime</code>\" |\n    \"<code>mode</code>\" | \"<code>uid</code>\" | \"<code>gid</code>\" | \"<code>nr_inodes</code>\" |\n    \"<code>nr_blocks</code>\" | \"<code>mpol</code>\"</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The container path, mount options, and size of the <code>tmpfs</code> mount.</p>\n         <note>\n            <p>This object isn't applicable to jobs that are running on Fargate resources.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.batch#TmpfsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#Tmpfs"
+      }
+    },
+    "com.amazonaws.batch#Ulimit": {
+      "type": "structure",
+      "members": {
+        "hardLimit": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The hard limit for the <code>ulimit</code> type. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The <code>type</code> of the <code>ulimit</code>. Valid values are: <code>core</code> |\n    <code>cpu</code> | <code>data</code> | <code>fsize</code> | <code>locks</code> |\n    <code>memlock</code> | <code>msgqueue</code> | <code>nice</code> | <code>nofile</code> |\n    <code>nproc</code> | <code>rss</code> | <code>rtprio</code> | <code>rttime</code> |\n    <code>sigpending</code> | <code>stack</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "softLimit": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The soft limit for the <code>ulimit</code> type.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The <code>ulimit</code> settings to pass to the container. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html\">Ulimit</a>.</p>\n         <note>\n            <p>This object isn't applicable to jobs that are running on Fargate resources.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.batch#Ulimits": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#Ulimit"
+      }
+    },
+    "com.amazonaws.batch#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#UntagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes specified tags from an Batch resource.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "UntagResource Example",
+            "documentation": "This demonstrates calling the UntagResource action.",
+            "input": {
+              "resourceArn": "arn:aws:batch:us-east-1:123456789012:job-definition/sleep30:1",
+              "tagKeys": [
+                "Stage"
+              ]
+            },
+            "output": {}
+          }
+        ],
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v1/tags/{resourceArn}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "resourceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource from which to delete tags. Batch resources that support tags are compute environments, jobs, job definitions, job queues,\n and scheduling policies. ARNs for child jobs of array and multi-node parallel (MNP) jobs aren't supported.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "tagKeys": {
+          "target": "com.amazonaws.batch#TagKeysList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The keys of the tags to be removed.</p>",
+            "smithy.api#httpQuery": "tagKeys",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>UntagResource</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#UntagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateComputeEnvironment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#UpdateComputeEnvironmentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#UpdateComputeEnvironmentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an Batch compute environment.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To update a compute environment",
+            "documentation": "This example disables the P2OnDemand compute environment so it can be deleted.",
+            "input": {
+              "computeEnvironment": "P2OnDemand",
+              "state": "DISABLED"
+            },
+            "output": {
+              "computeEnvironmentName": "P2OnDemand",
+              "computeEnvironmentArn": "arn:aws:batch:us-east-1:012345678910:compute-environment/P2OnDemand"
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/updatecomputeenvironment",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#UpdateComputeEnvironmentRequest": {
+      "type": "structure",
+      "members": {
+        "computeEnvironment": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or full Amazon Resource Name (ARN) of the compute environment to update.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#CEState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the compute environment. Compute environments in the <code>ENABLED</code>\n      state can accept jobs from a queue and scale in or out automatically based on the workload\n      demand of its associated queues.</p>\n         <p>If the state is <code>ENABLED</code>, then the Batch scheduler can attempt to place jobs\n      from an associated job queue on the compute resources within the environment. If the compute\n      environment is managed, then it can scale its instances out or in automatically, based on the\n      job queue demand.</p>\n         <p>If the state is <code>DISABLED</code>, then the Batch scheduler doesn't attempt to place\n      jobs within the environment. Jobs in a <code>STARTING</code> or <code>RUNNING</code> state\n      continue to progress normally. Managed compute environments in the <code>DISABLED</code> state\n      don't scale out. </p>\n         <note>\n            <p>Compute environments in a <code>DISABLED</code> state may continue to incur billing\n        charges, for example, if they have running instances due to jobs that are still executing or a non-zero <code>minvCpus</code> setting. To prevent additional charges, disable and delete the compute environment.</p>\n         </note>\n         <p>When an instance is idle, the instance scales down to the <code>minvCpus</code> value.\n      However, the instance size doesn't change. For example, consider a <code>c5.8xlarge</code>\n      instance with a <code>minvCpus</code> value of <code>4</code> and a <code>desiredvCpus</code>\n      value of <code>36</code>. This instance doesn't scale down to a <code>c5.large</code>\n      instance.</p>"
+          }
+        },
+        "unmanagedvCpus": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of vCPUs expected to be used for an unmanaged compute environment.\n      Don't specify this parameter for a managed compute environment. This parameter is only used\n      for fair-share scheduling to reserve vCPU capacity for new share identifiers. If this\n      parameter isn't provided for a fair-share job queue, no vCPU capacity is reserved.</p>"
+          }
+        },
+        "computeResources": {
+          "target": "com.amazonaws.batch#ComputeResourceUpdate",
+          "traits": {
+            "smithy.api#documentation": "<p>Details of the compute resources managed by the compute environment. Required for a\n      managed compute environment. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html\">Compute Environments</a> in the\n        <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "serviceRole": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The full Amazon Resource Name (ARN) of the IAM role that allows Batch to make calls to other Amazon Web Services\n      services on your behalf. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/service_IAM_role.html\">Batch service IAM role</a> in the\n        <i>Batch User Guide</i>.</p>\n         <important>\n            <p>If the compute environment has a service-linked role, it can't be changed to use a\n        regular IAM role. Likewise, if the compute environment has a regular IAM role, it can't\n        be changed to use a service-linked role. To update the parameters for the compute\n        environment that require an infrastructure update to change, the <b>AWSServiceRoleForBatch</b> service-linked role must be used. For more information,\n        see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating\n          compute environments</a> in the <i>Batch User Guide</i>.</p>\n         </important>\n         <p>If your specified role has a path other than <code>/</code>, then you must either specify\n      the full role ARN (recommended) or prefix the role name with the path.</p>\n         <note>\n            <p>Depending on how you created your Batch service role, its ARN might contain the\n          <code>service-role</code> path prefix. When you only specify the name of the service role,\n        Batch assumes that your ARN doesn't use the <code>service-role</code> path prefix. Because\n        of this, we recommend that you specify the full ARN of your service role when you create\n        compute environments.</p>\n         </note>"
+          }
+        },
+        "updatePolicy": {
+          "target": "com.amazonaws.batch#UpdatePolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the updated infrastructure update policy for the compute environment. For more\n      information about infrastructure updates, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in\n      the <i>Batch User Guide</i>.</p>"
+          }
+        },
+        "context": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>UpdateComputeEnvironment</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateComputeEnvironmentResponse": {
+      "type": "structure",
+      "members": {
+        "computeEnvironmentName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the compute environment. It can be up to 128 characters long. It can contain uppercase and\n lowercase letters, numbers, hyphens (-), and underscores (_).</p>"
+          }
+        },
+        "computeEnvironmentArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the compute environment.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateConsumableResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#UpdateConsumableResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#UpdateConsumableResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a consumable resource.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To update a consumable resource",
+            "documentation": "Updates a consumable resource.",
+            "input": {
+              "consumableResource": "myConsumableResource",
+              "operation": "ADD",
+              "quantity": 12
+            },
+            "output": {
+              "consumableResourceName": "myConsumableResource",
+              "consumableResourceArn": "arn:aws:batch:us-east-1:012345678910:consumable-resource/myConsumableResource",
+              "totalQuantity": 135
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/updateconsumableresource",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#UpdateConsumableResourceRequest": {
+      "type": "structure",
+      "members": {
+        "consumableResource": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or ARN of the consumable resource to be updated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "operation": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates how the quantity of the consumable resource will be updated. Must be one of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SET</code>\n               </p>\n               <p>Sets the quantity of the resource to the value specified by the <code>quantity</code>\n                    parameter.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ADD</code>\n               </p>\n               <p>Increases the quantity of the resource by the value specified by the <code>quantity</code>\n                    parameter.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REMOVE</code>\n               </p>\n               <p>Reduces the quantity of the resource by the value specified by the <code>quantity</code>\n                    parameter.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "quantity": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The change in the total quantity of the consumable resource. The <code>operation</code>\n            parameter determines whether the value specified here will be the new total quantity, or\n            the amount by which the total quantity will be increased or reduced. Must be a non-negative \n            value.</p>"
+          }
+        },
+        "clientToken": {
+          "target": "com.amazonaws.batch#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If this parameter is specified and two update requests with identical payloads and \n          <code>clientToken</code>s are received, these requests are considered the same request. Both requests will succeed, but the update will only happen once. A <code>clientToken</code> is valid for 8 hours.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateConsumableResourceResponse": {
+      "type": "structure",
+      "members": {
+        "consumableResourceName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the consumable resource to be updated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "consumableResourceArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the consumable resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "totalQuantity": {
+          "target": "com.amazonaws.batch#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The total amount of the consumable resource that is available.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateJobQueue": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#UpdateJobQueueRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#UpdateJobQueueResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a job queue.</p>",
+        "smithy.api#examples": [
+          {
+            "title": "To update a job queue",
+            "documentation": "This example disables a job queue so that it can be deleted.",
+            "input": {
+              "state": "DISABLED",
+              "jobQueue": "GPGPU"
+            },
+            "output": {
+              "jobQueueName": "GPGPU",
+              "jobQueueArn": "arn:aws:batch:us-east-1:012345678910:job-queue/GPGPU"
+            }
+          }
+        ],
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/updatejobqueue",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#UpdateJobQueueRequest": {
+      "type": "structure",
+      "members": {
+        "jobQueue": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or the Amazon Resource Name (ARN) of the job queue.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#JQState",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the queue's ability to accept new jobs. If the job queue state is\n        <code>ENABLED</code>, it can accept jobs. If the job queue state is <code>DISABLED</code>,\n      new jobs can't be added to the queue, but jobs already in the queue can finish.</p>"
+          }
+        },
+        "schedulingPolicyArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of the fair-share scheduling policy. Once a job queue is created, the fair-share\n      scheduling policy can be replaced but not removed. The format is\n          <code>aws:<i>Partition</i>:batch:<i>Region</i>:<i>Account</i>:scheduling-policy/<i>Name</i>\n            </code>.\n      For example,\n        <code>aws:aws:batch:us-west-2:123456789012:scheduling-policy/MySchedulingPolicy</code>.</p>"
+          }
+        },
+        "priority": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The priority of the job queue. Job queues with a higher priority (or a higher integer\n      value for the <code>priority</code> parameter) are evaluated first when associated with the\n      same compute environment. Priority is determined in descending order. For example, a job queue\n      with a priority value of <code>10</code> is given scheduling preference over a job queue with\n      a priority value of <code>1</code>. All of the compute environments must be either EC2\n        (<code>EC2</code> or <code>SPOT</code>) or Fargate (<code>FARGATE</code> or\n        <code>FARGATE_SPOT</code>). EC2 and Fargate compute environments can't be mixed.</p>"
+          }
+        },
+        "computeEnvironmentOrder": {
+          "target": "com.amazonaws.batch#ComputeEnvironmentOrders",
+          "traits": {
+            "smithy.api#documentation": "<p>Details the set of compute environments mapped to a job queue and their order relative to\n      each other. This is one of the parameters used by the job scheduler to determine which compute\n      environment runs a given job. Compute environments must be in the <code>VALID</code> state\n      before you can associate them with a job queue. All of the compute environments must be either\n      EC2 (<code>EC2</code> or <code>SPOT</code>) or Fargate (<code>FARGATE</code> or\n        <code>FARGATE_SPOT</code>). EC2 and Fargate compute environments can't be mixed.</p>\n         <note>\n            <p>All compute environments that are associated with a job queue must share the same\n        architecture. Batch doesn't support mixing compute environment architecture types in a\n        single job queue.</p>\n         </note>"
+          }
+        },
+        "serviceEnvironmentOrder": {
+          "target": "com.amazonaws.batch#ServiceEnvironmentOrders",
+          "traits": {
+            "smithy.api#documentation": "<p>The order of the service environment associated with the job queue. Job queues with a higher priority are evaluated first when associated with the same service environment.</p>"
+          }
+        },
+        "jobStateTimeLimitActions": {
+          "target": "com.amazonaws.batch#JobStateTimeLimitActions",
+          "traits": {
+            "smithy.api#documentation": "<p>The set of actions that Batch perform on jobs that remain at the head of the job queue in the specified state longer than specified times. Batch will perform each action after <code>maxTimeSeconds</code> has passed. (<b>Note</b>: The minimum value for maxTimeSeconds is 600 (10 minutes) and its maximum value is 86,400 (24 hours).)</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>UpdateJobQueue</code>.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateJobQueueResponse": {
+      "type": "structure",
+      "members": {
+        "jobQueueName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the job queue.</p>"
+          }
+        },
+        "jobQueueArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the job queue.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#UpdatePolicy": {
+      "type": "structure",
+      "members": {
+        "terminateJobsOnUpdate": {
+          "target": "com.amazonaws.batch#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether jobs are automatically terminated when the compute environment\n   infrastructure is updated. The default value is <code>false</code>.</p>"
+          }
+        },
+        "jobExecutionTimeoutMinutes": {
+          "target": "com.amazonaws.batch#JobExecutionTimeoutMinutes",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the job timeout (in minutes) when the compute environment infrastructure is\n   updated. The default value is 30. The maximum value is 7200.</p>\n         <note>\n            <p>Increasing <code>jobExecutionTimeoutMinutes</code> during infrastructure updates delays \n    the replacement of instances with new instances that include updates such as security patches, \n    but provides more time for jobs to execute. Consider the security implications of this tradeoff \n    when setting timeout values.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the infrastructure update policy for the Amazon EC2 compute environment. For more information\n   about infrastructure updates, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html\">Updating compute environments</a> in the\n    <i>Batch User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.batch#UpdateQuotaShare": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#UpdateQuotaShareRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#UpdateQuotaShareResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a quota share.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/updatequotashare",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#UpdateQuotaShareRequest": {
+      "type": "structure",
+      "members": {
+        "quotaShareArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the quota share to update.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "capacityLimits": {
+          "target": "com.amazonaws.batch#QuotaShareCapacityLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that specifies the quantity and type of compute capacity allocated to the quota share.</p>"
+          }
+        },
+        "resourceSharingConfiguration": {
+          "target": "com.amazonaws.batch#QuotaShareResourceSharingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a quota share reserves, lends, or both lends and borrows idle compute capacity.</p>"
+          }
+        },
+        "preemptionConfiguration": {
+          "target": "com.amazonaws.batch#QuotaSharePreemptionConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the preemption behavior for jobs in a quota share.</p>"
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#QuotaShareState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the quota share. If the quota share is <code>ENABLED</code>, it is able to accept jobs.\n    If the quota share is <code>DISABLED</code>, new jobs won't be accepted but jobs already submitted can finish.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateQuotaShareResponse": {
+      "type": "structure",
+      "members": {
+        "quotaShareName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the quota share.</p>"
+          }
+        },
+        "quotaShareArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the quota share.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateSchedulingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#UpdateSchedulingPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#UpdateSchedulingPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a scheduling policy.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/updateschedulingpolicy",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#UpdateSchedulingPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "arn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the scheduling policy to update.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "quotaSharePolicy": {
+          "target": "com.amazonaws.batch#QuotaSharePolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The quota share scheduling policy details. Once set during creation, a quotaSharePolicy cannot be removed or changed to a fairsharePolicy.</p>"
+          }
+        },
+        "fairsharePolicy": {
+          "target": "com.amazonaws.batch#FairsharePolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The fair-share policy scheduling details. Once set during creation, a fairsharePolicy cannot be removed or changed to a quotaSharePolicy.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters for <code>UpdateSchedulingPolicy</code>. </p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateSchedulingPolicyResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateServiceEnvironment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#UpdateServiceEnvironmentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#UpdateServiceEnvironmentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a service environment. You can update the state of a service environment from <code>ENABLED</code> to <code>DISABLED</code> to prevent new service jobs from being placed in the service environment.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/updateserviceenvironment",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#UpdateServiceEnvironmentRequest": {
+      "type": "structure",
+      "members": {
+        "serviceEnvironment": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or ARN of the service environment to update.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "state": {
+          "target": "com.amazonaws.batch#ServiceEnvironmentState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the service environment. </p>"
+          }
+        },
+        "capacityLimits": {
+          "target": "com.amazonaws.batch#CapacityLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>The capacity limits for the service environment. This defines the maximum resources that can be used by service jobs in this environment.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateServiceEnvironmentResponse": {
+      "type": "structure",
+      "members": {
+        "serviceEnvironmentName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the service environment that was updated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceEnvironmentArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the service environment that was updated.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateServiceJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.batch#UpdateServiceJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.batch#UpdateServiceJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.batch#ClientException"
+        },
+        {
+          "target": "com.amazonaws.batch#ServerException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates the priority of a specified service job in an Batch job queue.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/updateservicejob",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.batch#UpdateServiceJobRequest": {
+      "type": "structure",
+      "members": {
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Batch job ID of the job to update.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "schedulingPriority": {
+          "target": "com.amazonaws.batch#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The scheduling priority for the job. This only affects jobs in job queues with a\n      quota-share or fair-share scheduling policy. Jobs with a higher scheduling priority are scheduled before jobs with a lower\n      scheduling priority within a share.</p>\n         <p>The minimum supported value is 0 and the maximum supported value is 9999.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.batch#UpdateServiceJobResponse": {
+      "type": "structure",
+      "members": {
+        "jobArn": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the job.</p>"
+          }
+        },
+        "jobName": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the job.</p>"
+          }
+        },
+        "jobId": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.batch#UserdataType": {
+      "type": "enum",
+      "members": {
+        "EKS_BOOTSTRAP_SH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EKS_BOOTSTRAP_SH"
+          }
+        },
+        "EKS_NODEADM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EKS_NODEADM"
+          }
+        }
+      }
+    },
+    "com.amazonaws.batch#Volume": {
+      "type": "structure",
+      "members": {
+        "host": {
+          "target": "com.amazonaws.batch#Host",
+          "traits": {
+            "smithy.api#documentation": "<p>The contents of the <code>host</code> parameter determine whether your data volume persists\n   on the host container instance and where it's stored. If the host parameter is empty, then the\n   Docker daemon assigns a host path for your data volume. However, the data isn't guaranteed to\n   persist after the containers that are associated with it stop running.</p>\n         <note>\n            <p>This parameter isn't applicable to jobs that are running on Fargate resources and\n    shouldn't be provided.</p>\n         </note>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.batch#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the volume. It can be up to 255 characters long. It can contain uppercase and lowercase letters,\n numbers, hyphens (-), and underscores (_). This name is referenced in the\n    <code>sourceVolume</code> parameter of container definition <code>mountPoints</code>.</p>"
+          }
+        },
+        "efsVolumeConfiguration": {
+          "target": "com.amazonaws.batch#EFSVolumeConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>This parameter is specified when you're using an Amazon Elastic File System file system for job storage. Jobs\n   that are running on Fargate resources must specify a <code>platformVersion</code> of at least\n    <code>1.4.0</code>.</p>"
+          }
+        },
+        "s3filesVolumeConfiguration": {
+          "target": "com.amazonaws.batch#S3FilesVolumeConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>This parameter is specified when you're using an S3Files file system for job storage.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A data volume that's used in a job's container properties.</p>"
+      }
+    },
+    "com.amazonaws.batch#Volumes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.batch#Volume"
+      }
+    }
+  }
+}

--- a/crates/fakecloud-batch/Cargo.toml
+++ b/crates/fakecloud-batch/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fakecloud-batch"
+description = "AWS Batch implementation for FakeCloud"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+version.workspace = true
+
+[dependencies]
+fakecloud-aws = { workspace = true }
+fakecloud-core = { workspace = true }
+fakecloud-persistence = { workspace = true }
+async-trait = { workspace = true }
+bytes = { workspace = true }
+http = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/fakecloud-batch/src/lib.rs
+++ b/crates/fakecloud-batch/src/lib.rs
@@ -1,0 +1,16 @@
+//! AWS Batch (`batch`) restJson1 service for fakecloud.
+//!
+//! Batch 0 (foundation): vendored Smithy model + crate scaffold + restJson1
+//! routing for all 45 operations + the core control plane (compute
+//! environments, job queues, job definitions, tags). Real container-backed job
+//! execution (SubmitJob -> ECS task) and the remaining resource families land
+//! in later batches; unimplemented operations return a faithful
+//! `ServerException`/not-implemented error rather than a fake success.
+
+pub mod service;
+pub mod state;
+
+pub use service::BatchService;
+pub use state::{
+    BatchAccounts, BatchSnapshot, BatchState, SharedBatchState, BATCH_SNAPSHOT_SCHEMA_VERSION,
+};

--- a/crates/fakecloud-batch/src/service.rs
+++ b/crates/fakecloud-batch/src/service.rs
@@ -1,0 +1,757 @@
+//! AWS Batch restJson1 service dispatch + core control plane.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use http::{Method, StatusCode};
+use serde_json::{json, Map, Value};
+use tokio::sync::Mutex as AsyncMutex;
+use uuid::Uuid;
+
+use fakecloud_aws::arn::Arn;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_persistence::{SnapshotHook, SnapshotStore};
+
+use crate::state::{BatchSnapshot, SharedBatchState, BATCH_SNAPSHOT_SCHEMA_VERSION};
+
+const SUPPORTED_ACTIONS: &[&str] = &[
+    "CancelJob",
+    "CreateComputeEnvironment",
+    "CreateConsumableResource",
+    "CreateJobQueue",
+    "CreateQuotaShare",
+    "CreateSchedulingPolicy",
+    "CreateServiceEnvironment",
+    "DeleteComputeEnvironment",
+    "DeleteConsumableResource",
+    "DeleteJobQueue",
+    "DeleteQuotaShare",
+    "DeleteSchedulingPolicy",
+    "DeleteServiceEnvironment",
+    "DeregisterJobDefinition",
+    "DescribeComputeEnvironments",
+    "DescribeConsumableResource",
+    "DescribeJobDefinitions",
+    "DescribeJobQueues",
+    "DescribeJobs",
+    "DescribeQuotaShare",
+    "DescribeSchedulingPolicies",
+    "DescribeServiceEnvironments",
+    "DescribeServiceJob",
+    "GetJobQueueSnapshot",
+    "ListConsumableResources",
+    "ListJobs",
+    "ListJobsByConsumableResource",
+    "ListQuotaShares",
+    "ListSchedulingPolicies",
+    "ListServiceJobs",
+    "ListTagsForResource",
+    "RegisterJobDefinition",
+    "SubmitJob",
+    "SubmitServiceJob",
+    "TagResource",
+    "TerminateJob",
+    "TerminateServiceJob",
+    "UntagResource",
+    "UpdateComputeEnvironment",
+    "UpdateConsumableResource",
+    "UpdateJobQueue",
+    "UpdateQuotaShare",
+    "UpdateSchedulingPolicy",
+    "UpdateServiceEnvironment",
+    "UpdateServiceJob",
+];
+
+/// Mutating actions trigger a snapshot write after success.
+const MUTATING_ACTIONS: &[&str] = &[
+    "CreateComputeEnvironment",
+    "UpdateComputeEnvironment",
+    "DeleteComputeEnvironment",
+    "CreateJobQueue",
+    "UpdateJobQueue",
+    "DeleteJobQueue",
+    "RegisterJobDefinition",
+    "DeregisterJobDefinition",
+    "SubmitJob",
+    "CancelJob",
+    "TerminateJob",
+    "TagResource",
+    "UntagResource",
+];
+
+pub struct BatchService {
+    state: SharedBatchState,
+    snapshot_store: Option<Arc<dyn SnapshotStore>>,
+    snapshot_lock: Arc<AsyncMutex<()>>,
+}
+
+impl BatchService {
+    pub fn new(state: SharedBatchState) -> Self {
+        Self {
+            state,
+            snapshot_store: None,
+            snapshot_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
+        self.snapshot_store = Some(store);
+        self
+    }
+
+    async fn save_snapshot(&self) {
+        let Some(store) = self.snapshot_store.clone() else {
+            return;
+        };
+        let _guard = self.snapshot_lock.lock().await;
+        let bytes = {
+            let snap = BatchSnapshot {
+                schema_version: BATCH_SNAPSHOT_SCHEMA_VERSION,
+                accounts: Some(self.state.read().clone()),
+            };
+            serde_json::to_vec(&snap).unwrap_or_default()
+        };
+        let _ = tokio::task::spawn_blocking(move || store.save(&bytes)).await;
+    }
+
+    /// CloudFormation write-through hook (used once the CFN provisioner lands).
+    pub fn snapshot_hook(&self) -> Option<SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let store = store.clone();
+            let state = state.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                let _guard = lock.lock().await;
+                let bytes = {
+                    let snap = BatchSnapshot {
+                        schema_version: BATCH_SNAPSHOT_SCHEMA_VERSION,
+                        accounts: Some(state.read().clone()),
+                    };
+                    serde_json::to_vec(&snap).unwrap_or_default()
+                };
+                let _ = tokio::task::spawn_blocking(move || store.save(&bytes)).await;
+            })
+        }))
+    }
+
+    /// Map the restJson1 request (POST /v1/<op>, plus the /v1/tags/{arn}
+    /// family) to its operation name.
+    fn resolve_action(req: &AwsRequest) -> Option<&'static str> {
+        let segs = &req.path_segments;
+        if segs.first().map(|s| s.as_str()) != Some("v1") {
+            return None;
+        }
+        // Tag family: /v1/tags/{resourceArn}
+        if segs.get(1).map(|s| s.as_str()) == Some("tags") {
+            return match req.method {
+                Method::GET => Some("ListTagsForResource"),
+                Method::POST => Some("TagResource"),
+                Method::DELETE => Some("UntagResource"),
+                _ => None,
+            };
+        }
+        let op = segs.get(1)?.as_str();
+        Some(match op {
+            "canceljob" => "CancelJob",
+            "createcomputeenvironment" => "CreateComputeEnvironment",
+            "createconsumableresource" => "CreateConsumableResource",
+            "createjobqueue" => "CreateJobQueue",
+            "createquotashare" => "CreateQuotaShare",
+            "createschedulingpolicy" => "CreateSchedulingPolicy",
+            "createserviceenvironment" => "CreateServiceEnvironment",
+            "deletecomputeenvironment" => "DeleteComputeEnvironment",
+            "deleteconsumableresource" => "DeleteConsumableResource",
+            "deletejobqueue" => "DeleteJobQueue",
+            "deletequotashare" => "DeleteQuotaShare",
+            "deleteschedulingpolicy" => "DeleteSchedulingPolicy",
+            "deleteserviceenvironment" => "DeleteServiceEnvironment",
+            "deregisterjobdefinition" => "DeregisterJobDefinition",
+            "describecomputeenvironments" => "DescribeComputeEnvironments",
+            "describeconsumableresource" => "DescribeConsumableResource",
+            "describejobdefinitions" => "DescribeJobDefinitions",
+            "describejobqueues" => "DescribeJobQueues",
+            "describejobs" => "DescribeJobs",
+            "describequotashare" => "DescribeQuotaShare",
+            "describeschedulingpolicies" => "DescribeSchedulingPolicies",
+            "describeserviceenvironments" => "DescribeServiceEnvironments",
+            "describeservicejob" => "DescribeServiceJob",
+            "getjobqueuesnapshot" => "GetJobQueueSnapshot",
+            "listconsumableresources" => "ListConsumableResources",
+            "listjobs" => "ListJobs",
+            "listjobsbyconsumableresource" => "ListJobsByConsumableResource",
+            "listquotashares" => "ListQuotaShares",
+            "listschedulingpolicies" => "ListSchedulingPolicies",
+            "listservicejobs" => "ListServiceJobs",
+            "registerjobdefinition" => "RegisterJobDefinition",
+            "submitjob" => "SubmitJob",
+            "submitservicejob" => "SubmitServiceJob",
+            "terminatejob" => "TerminateJob",
+            "terminateservicejob" => "TerminateServiceJob",
+            "updatecomputeenvironment" => "UpdateComputeEnvironment",
+            "updateconsumableresource" => "UpdateConsumableResource",
+            "updatejobqueue" => "UpdateJobQueue",
+            "updatequotashare" => "UpdateQuotaShare",
+            "updateschedulingpolicy" => "UpdateSchedulingPolicy",
+            "updateserviceenvironment" => "UpdateServiceEnvironment",
+            "updateservicejob" => "UpdateServiceJob",
+            _ => return None,
+        })
+    }
+
+    fn dispatch(&self, action: &str, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        match action {
+            "CreateComputeEnvironment" => self.create_compute_environment(req),
+            "DescribeComputeEnvironments" => self.describe_compute_environments(req),
+            "DeleteComputeEnvironment" => self.delete_compute_environment(req),
+            "CreateJobQueue" => self.create_job_queue(req),
+            "DescribeJobQueues" => self.describe_job_queues(req),
+            "DeleteJobQueue" => self.delete_job_queue(req),
+            "RegisterJobDefinition" => self.register_job_definition(req),
+            "DescribeJobDefinitions" => self.describe_job_definitions(req),
+            "DeregisterJobDefinition" => self.deregister_job_definition(req),
+            "TagResource" => self.tag_resource(req),
+            "UntagResource" => self.untag_resource(req),
+            "ListTagsForResource" => self.list_tags_for_resource(req),
+            other => Err(AwsServiceError::action_not_implemented("batch", other)),
+        }
+    }
+}
+
+fn obj(v: &Value) -> Map<String, Value> {
+    v.as_object().cloned().unwrap_or_default()
+}
+
+fn client_error(code: &str, msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, code, msg.into())
+}
+
+impl BatchService {
+    fn arn(&self, account: &str, region: &str, resource: &str) -> String {
+        Arn::new("batch", region, account, resource).to_string()
+    }
+
+    // ---- Compute environments ----
+
+    fn create_compute_environment(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let name = body
+            .get("computeEnvironmentName")
+            .and_then(Value::as_str)
+            .ok_or_else(|| client_error("ClientException", "computeEnvironmentName is required"))?
+            .to_string();
+        let arn = self.arn(
+            &req.account_id,
+            &req.region,
+            &format!("compute-environment/{name}"),
+        );
+        let mut stored = obj(&body);
+        stored.insert("computeEnvironmentArn".into(), json!(arn));
+        stored.insert("status".into(), json!("VALID"));
+        stored.insert("statusReason".into(), json!("ComputeEnvironment Healthy"));
+        stored
+            .entry("state".to_string())
+            .or_insert_with(|| json!("ENABLED"));
+        stored.insert("uuid".into(), json!(Uuid::new_v4().to_string()));
+
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        if st.compute_environments.contains_key(&name) {
+            return Err(client_error(
+                "ClientException",
+                format!("Object already exists: {name}"),
+            ));
+        }
+        st.compute_environments
+            .insert(name.clone(), Value::Object(stored));
+        Ok(AwsResponse::ok_json(json!({
+            "computeEnvironmentName": name,
+            "computeEnvironmentArn": arn,
+        })))
+    }
+
+    fn describe_compute_environments(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let wanted = string_set(&body, "computeEnvironments");
+        let accounts = self.state.read();
+        let items: Vec<Value> = accounts
+            .get(&req.account_id)
+            .map(|st| {
+                st.compute_environments
+                    .values()
+                    .filter(|ce| {
+                        match_named(
+                            ce,
+                            &wanted,
+                            "computeEnvironmentName",
+                            "computeEnvironmentArn",
+                        )
+                    })
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(AwsResponse::ok_json(
+            json!({ "computeEnvironments": items }),
+        ))
+    }
+
+    fn delete_compute_environment(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let name = arn_or_name(&body, "computeEnvironment")?;
+        let mut accounts = self.state.write();
+        accounts
+            .get_or_create(&req.account_id)
+            .compute_environments
+            .remove(&name);
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    // ---- Job queues ----
+
+    fn create_job_queue(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let name = body
+            .get("jobQueueName")
+            .and_then(Value::as_str)
+            .ok_or_else(|| client_error("ClientException", "jobQueueName is required"))?
+            .to_string();
+        let arn = self.arn(&req.account_id, &req.region, &format!("job-queue/{name}"));
+        let mut stored = obj(&body);
+        stored.insert("jobQueueArn".into(), json!(arn));
+        stored.insert("status".into(), json!("VALID"));
+        stored.insert("statusReason".into(), json!("JobQueue Healthy"));
+        stored
+            .entry("state".to_string())
+            .or_insert_with(|| json!("ENABLED"));
+
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        if st.job_queues.contains_key(&name) {
+            return Err(client_error(
+                "ClientException",
+                format!("Object already exists: {name}"),
+            ));
+        }
+        st.job_queues.insert(name.clone(), Value::Object(stored));
+        Ok(AwsResponse::ok_json(json!({
+            "jobQueueName": name,
+            "jobQueueArn": arn,
+        })))
+    }
+
+    fn describe_job_queues(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let wanted = string_set(&body, "jobQueues");
+        let accounts = self.state.read();
+        let items: Vec<Value> = accounts
+            .get(&req.account_id)
+            .map(|st| {
+                st.job_queues
+                    .values()
+                    .filter(|q| match_named(q, &wanted, "jobQueueName", "jobQueueArn"))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(AwsResponse::ok_json(json!({ "jobQueues": items })))
+    }
+
+    fn delete_job_queue(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let name = arn_or_name(&body, "jobQueue")?;
+        let mut accounts = self.state.write();
+        accounts
+            .get_or_create(&req.account_id)
+            .job_queues
+            .remove(&name);
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    // ---- Job definitions (revisioned) ----
+
+    fn register_job_definition(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let name = body
+            .get("jobDefinitionName")
+            .and_then(Value::as_str)
+            .ok_or_else(|| client_error("ClientException", "jobDefinitionName is required"))?
+            .to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let revision = st.job_def_revisions.entry(name.clone()).or_insert(0);
+        *revision += 1;
+        let revision = *revision;
+        let arn = self.arn(
+            &req.account_id,
+            &req.region,
+            &format!("job-definition/{name}:{revision}"),
+        );
+        let mut stored = obj(&body);
+        stored.insert("jobDefinitionArn".into(), json!(arn));
+        stored.insert("revision".into(), json!(revision));
+        stored.insert("status".into(), json!("ACTIVE"));
+        st.job_definitions
+            .insert(format!("{name}:{revision}"), Value::Object(stored));
+        Ok(AwsResponse::ok_json(json!({
+            "jobDefinitionName": name,
+            "jobDefinitionArn": arn,
+            "revision": revision,
+        })))
+    }
+
+    fn describe_job_definitions(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let wanted = string_set(&body, "jobDefinitions");
+        let name_filter = body
+            .get("jobDefinitionName")
+            .and_then(Value::as_str)
+            .map(|s| s.to_string());
+        let status_filter = body
+            .get("status")
+            .and_then(Value::as_str)
+            .map(|s| s.to_string());
+        let accounts = self.state.read();
+        let items: Vec<Value> = accounts
+            .get(&req.account_id)
+            .map(|st| {
+                st.job_definitions
+                    .values()
+                    .filter(|jd| {
+                        // Match by arn (in `jobDefinitions`), by name, or all.
+                        let arn_ok = wanted.is_empty()
+                            || jd
+                                .get("jobDefinitionArn")
+                                .and_then(Value::as_str)
+                                .map(|a| wanted.contains(a))
+                                .unwrap_or(false)
+                            || jd
+                                .get("jobDefinitionName")
+                                .and_then(Value::as_str)
+                                .map(|n| wanted.contains(n))
+                                .unwrap_or(false);
+                        let name_ok = name_filter.as_deref().is_none_or(|n| {
+                            jd.get("jobDefinitionName").and_then(Value::as_str) == Some(n)
+                        });
+                        let status_ok = status_filter
+                            .as_deref()
+                            .is_none_or(|s| jd.get("status").and_then(Value::as_str) == Some(s));
+                        arn_ok && name_ok && status_ok
+                    })
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(AwsResponse::ok_json(json!({ "jobDefinitions": items })))
+    }
+
+    fn deregister_job_definition(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let id = body
+            .get("jobDefinition")
+            .and_then(Value::as_str)
+            .ok_or_else(|| client_error("ClientException", "jobDefinition is required"))?;
+        // Accept "name:revision" or an ARN ending in name:revision.
+        let key = id.rsplit('/').next().unwrap_or(id).to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        if let Some(jd) = st.job_definitions.get_mut(&key) {
+            if let Some(o) = jd.as_object_mut() {
+                o.insert("status".into(), json!("INACTIVE"));
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    // ---- Tags ----
+
+    fn tag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = req
+            .path_segments
+            .get(2)
+            .map(|s| percent_decode(s))
+            .ok_or_else(|| client_error("ClientException", "resourceArn is required"))?;
+        let body = req.json_body();
+        let tags = body
+            .get("tags")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        let mut accounts = self.state.write();
+        let entry = accounts
+            .get_or_create(&req.account_id)
+            .tags
+            .entry(arn)
+            .or_default();
+        for (k, v) in tags {
+            if let Some(s) = v.as_str() {
+                entry.insert(k, s.to_string());
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn untag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = req
+            .path_segments
+            .get(2)
+            .map(|s| percent_decode(s))
+            .ok_or_else(|| client_error("ClientException", "resourceArn is required"))?;
+        let keys: Vec<String> = req
+            .query_params
+            .iter()
+            .filter(|(k, _)| k.as_str() == "tagKeys" || k.starts_with("tagKeys"))
+            .map(|(_, v)| v.clone())
+            .collect();
+        let mut accounts = self.state.write();
+        if let Some(entry) = accounts.get_or_create(&req.account_id).tags.get_mut(&arn) {
+            for k in keys {
+                entry.remove(&k);
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn list_tags_for_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = req
+            .path_segments
+            .get(2)
+            .map(|s| percent_decode(s))
+            .ok_or_else(|| client_error("ClientException", "resourceArn is required"))?;
+        let accounts = self.state.read();
+        let tags = accounts
+            .get(&req.account_id)
+            .and_then(|st| st.tags.get(&arn))
+            .map(|m| {
+                m.iter()
+                    .map(|(k, v)| (k.clone(), json!(v)))
+                    .collect::<Map<String, Value>>()
+            })
+            .unwrap_or_default();
+        Ok(AwsResponse::ok_json(json!({ "tags": tags })))
+    }
+}
+
+/// Read a JSON string array into a set of owned strings.
+fn string_set(body: &Value, key: &str) -> std::collections::HashSet<String> {
+    body.get(key)
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// True if `wanted` is empty (match-all) or the resource's name/arn is wanted.
+fn match_named(
+    res: &Value,
+    wanted: &std::collections::HashSet<String>,
+    name_key: &str,
+    arn_key: &str,
+) -> bool {
+    if wanted.is_empty() {
+        return true;
+    }
+    let name = res.get(name_key).and_then(Value::as_str);
+    let arn = res.get(arn_key).and_then(Value::as_str);
+    name.map(|n| wanted.contains(n)).unwrap_or(false)
+        || arn.map(|a| wanted.contains(a)).unwrap_or(false)
+}
+
+/// Resolve a delete/describe identifier that may be a name or an ARN to the
+/// store key (the resource name = last ARN path segment).
+fn arn_or_name(body: &Value, key: &str) -> Result<String, AwsServiceError> {
+    let raw = body
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| client_error("ClientException", format!("{key} is required")))?;
+    Ok(raw.rsplit('/').next().unwrap_or(raw).to_string())
+}
+
+fn percent_decode(s: &str) -> String {
+    // ARNs in the path are percent-encoded by SDKs; decode the common escapes.
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(b) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
+                out.push(b as char);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+#[async_trait]
+impl AwsService for BatchService {
+    fn service_name(&self) -> &str {
+        "batch"
+    }
+
+    fn supported_actions(&self) -> &[&str] {
+        SUPPORTED_ACTIONS
+    }
+
+    async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let Some(action) = Self::resolve_action(&req) else {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Unknown operation: {} {}", req.method, req.raw_path),
+            ));
+        };
+        let result = self.dispatch(action, &req);
+        if MUTATING_ACTIONS.contains(&action)
+            && matches!(result.as_ref(), Ok(resp) if resp.status.is_success())
+        {
+            self.save_snapshot().await;
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::BatchAccounts;
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+
+    fn svc() -> BatchService {
+        BatchService::new(Arc::new(RwLock::new(BatchAccounts::new())))
+    }
+
+    fn req(path: &str, body: Value) -> AwsRequest {
+        let p = path.split('?').next().unwrap_or(path);
+        let path_segments: Vec<String> = p
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+        AwsRequest {
+            service: "batch".into(),
+            action: String::new(),
+            region: "us-east-1".into(),
+            account_id: "123456789012".into(),
+            request_id: "t".into(),
+            headers: http::HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: bytes::Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments,
+            raw_path: path.to_string(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn body_of(r: AwsResponse) -> Value {
+        serde_json::from_slice(r.body.expect_bytes()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn compute_environment_lifecycle() {
+        let s = svc();
+        let r = s
+            .handle(req(
+                "/v1/createcomputeenvironment",
+                json!({"computeEnvironmentName": "ce1", "type": "MANAGED"}),
+            ))
+            .await
+            .unwrap();
+        let v = body_of(r);
+        assert_eq!(v["computeEnvironmentName"], "ce1");
+        assert!(v["computeEnvironmentArn"]
+            .as_str()
+            .unwrap()
+            .contains("compute-environment/ce1"));
+
+        let d = body_of(
+            s.handle(req("/v1/describecomputeenvironments", json!({})))
+                .await
+                .unwrap(),
+        );
+        let ces = d["computeEnvironments"].as_array().unwrap();
+        assert_eq!(ces.len(), 1);
+        assert_eq!(ces[0]["status"], "VALID");
+        assert_eq!(ces[0]["state"], "ENABLED");
+
+        s.handle(req(
+            "/v1/deletecomputeenvironment",
+            json!({"computeEnvironment": "ce1"}),
+        ))
+        .await
+        .unwrap();
+        let d2 = body_of(
+            s.handle(req("/v1/describecomputeenvironments", json!({})))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(d2["computeEnvironments"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn job_definition_revisions_increment() {
+        let s = svc();
+        for expected in 1..=3 {
+            let v = body_of(
+                s.handle(req(
+                    "/v1/registerjobdefinition",
+                    json!({"jobDefinitionName": "jd", "type": "container"}),
+                ))
+                .await
+                .unwrap(),
+            );
+            assert_eq!(v["revision"], expected);
+        }
+        let d = body_of(
+            s.handle(req(
+                "/v1/describejobdefinitions",
+                json!({"jobDefinitionName": "jd"}),
+            ))
+            .await
+            .unwrap(),
+        );
+        assert_eq!(d["jobDefinitions"].as_array().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn unimplemented_op_errors_not_fakes() {
+        let s = svc();
+        let err = match s
+            .handle(req("/v1/submitjob", json!({"jobName": "j"})))
+            .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("SubmitJob must not fake-succeed in the foundation batch"),
+        };
+        assert_eq!(err.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[test]
+    fn routes_tag_family_by_method() {
+        let mut r = req("/v1/tags/arn%3Aaws", json!({}));
+        r.method = Method::GET;
+        assert_eq!(
+            BatchService::resolve_action(&r),
+            Some("ListTagsForResource")
+        );
+        r.method = Method::DELETE;
+        assert_eq!(BatchService::resolve_action(&r), Some("UntagResource"));
+    }
+}

--- a/crates/fakecloud-batch/src/state.rs
+++ b/crates/fakecloud-batch/src/state.rs
@@ -1,0 +1,68 @@
+//! In-memory state for AWS Batch. Control-plane resources are JSON-backed
+//! (the raw create input plus generated metadata, echoed verbatim on read),
+//! mirroring the Glue/Athena pattern. Real container-backed job execution
+//! lands in a later batch.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub type SharedBatchState = Arc<RwLock<BatchAccounts>>;
+
+/// A JSON-backed named-resource store: name -> (raw input + generated fields).
+pub type JsonStore = BTreeMap<String, Value>;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct BatchAccounts {
+    pub accounts: BTreeMap<String, BatchState>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct BatchState {
+    /// Compute environments keyed by name.
+    #[serde(default)]
+    pub compute_environments: JsonStore,
+    /// Job queues keyed by name.
+    #[serde(default)]
+    pub job_queues: JsonStore,
+    /// Job definitions keyed by `name:revision`; the active revision per name
+    /// is resolved at read time.
+    #[serde(default)]
+    pub job_definitions: JsonStore,
+    /// Jobs keyed by jobId.
+    #[serde(default)]
+    pub jobs: JsonStore,
+    /// Tags keyed by resource ARN -> { key: value }.
+    #[serde(default)]
+    pub tags: BTreeMap<String, BTreeMap<String, String>>,
+    /// Per-job-definition-name highest revision allocated.
+    #[serde(default)]
+    pub job_def_revisions: BTreeMap<String, i64>,
+}
+
+impl BatchAccounts {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get_or_create(&mut self, account_id: &str) -> &mut BatchState {
+        self.accounts.entry(account_id.to_string()).or_default()
+    }
+
+    pub fn get(&self, account_id: &str) -> Option<&BatchState> {
+        self.accounts.get(account_id)
+    }
+}
+
+/// On-disk snapshot envelope; versioned so format changes fail loudly.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct BatchSnapshot {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub accounts: Option<BatchAccounts>,
+}
+
+pub const BATCH_SNAPSHOT_SCHEMA_VERSION: u32 = 1;

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -44,6 +44,7 @@ fakecloud-glue = { workspace = true }
 fakecloud-cloudwatch = { workspace = true }
 fakecloud-application-autoscaling = { workspace = true }
 fakecloud-autoscaling = { workspace = true }
+fakecloud-batch = { workspace = true }
 fakecloud-wafv2 = { workspace = true }
 fakecloud-athena = { workspace = true }
 fakecloud-ec2 = { workspace = true }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -402,6 +402,8 @@ async fn main() {
     let autoscaling_state: fakecloud_autoscaling::SharedAutoScalingState = Arc::new(
         parking_lot::RwLock::new(fakecloud_autoscaling::AutoScalingAccounts::new()),
     );
+    let batch_state: fakecloud_batch::SharedBatchState =
+        Arc::new(parking_lot::RwLock::new(fakecloud_batch::BatchAccounts::new()));
     let wafv2_state: fakecloud_wafv2::SharedWafv2State = Arc::new(parking_lot::RwLock::new(
         fakecloud_wafv2::Wafv2Accounts::new(),
     ));
@@ -3071,6 +3073,58 @@ async fn main() {
         cfn_snapshot_hooks.insert("autoscaling", h);
     }
     registry.register(Arc::new(autoscaling_service));
+
+    // AWS Batch — control plane (compute environments, job queues, job
+    // definitions). Real container-backed job execution lands in a later batch.
+    let batch_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("batch").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_batch::BatchSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_batch::BATCH_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "batch persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_batch::BATCH_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                *batch_state.write() = accounts;
+                                tracing::info!("loaded batch persistence snapshot");
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse batch persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no batch persistence snapshot found; starting empty");
+                }
+                Err(err) => {
+                    fatal_exit(format_args!("failed to read batch persistence snapshot: {err}"))
+                }
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let mut batch_service = fakecloud_batch::BatchService::new(batch_state.clone());
+    if let Some(store) = batch_snapshot_store.clone() {
+        batch_service = batch_service.with_snapshot_store(store);
+    }
+    registry.register(Arc::new(batch_service));
+
     let wafv2_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
             let data_path = persistence_config

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -402,8 +402,9 @@ async fn main() {
     let autoscaling_state: fakecloud_autoscaling::SharedAutoScalingState = Arc::new(
         parking_lot::RwLock::new(fakecloud_autoscaling::AutoScalingAccounts::new()),
     );
-    let batch_state: fakecloud_batch::SharedBatchState =
-        Arc::new(parking_lot::RwLock::new(fakecloud_batch::BatchAccounts::new()));
+    let batch_state: fakecloud_batch::SharedBatchState = Arc::new(parking_lot::RwLock::new(
+        fakecloud_batch::BatchAccounts::new(),
+    ));
     let wafv2_state: fakecloud_wafv2::SharedWafv2State = Arc::new(parking_lot::RwLock::new(
         fakecloud_wafv2::Wafv2Accounts::new(),
     ));
@@ -3111,9 +3112,9 @@ async fn main() {
                 Ok(None) => {
                     tracing::info!("no batch persistence snapshot found; starting empty");
                 }
-                Err(err) => {
-                    fatal_exit(format_args!("failed to read batch persistence snapshot: {err}"))
-                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read batch persistence snapshot: {err}"
+                )),
             }
             Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
         } else {

--- a/scripts/generate-operations-index.sh
+++ b/scripts/generate-operations-index.sh
@@ -68,6 +68,7 @@ SERVICES=(
     "route53|Route 53|route53"
     "wafv2|WAF v2|wafv2"
     "application-autoscaling|Application Auto Scaling|application-autoscaling"
+    "batch|Batch|batch"
     "athena|Athena|athena"
     "acm|ACM|acm"
     "cloudwatch|CloudWatch (Metrics & Alarms)|cloudwatch"

--- a/website/content/docs/operations/_index.md
+++ b/website/content/docs/operations/_index.md
@@ -2635,6 +2635,54 @@ This is a surface listing, not an implementation manifest. For fakecloud's per-s
 - `TagResource`
 - `UntagResource`
 
+## [Batch](@/docs/services/batch.md)
+
+- `CancelJob`
+- `CreateComputeEnvironment`
+- `CreateConsumableResource`
+- `CreateJobQueue`
+- `CreateQuotaShare`
+- `CreateSchedulingPolicy`
+- `CreateServiceEnvironment`
+- `DeleteComputeEnvironment`
+- `DeleteConsumableResource`
+- `DeleteJobQueue`
+- `DeleteQuotaShare`
+- `DeleteSchedulingPolicy`
+- `DeleteServiceEnvironment`
+- `DeregisterJobDefinition`
+- `DescribeComputeEnvironments`
+- `DescribeConsumableResource`
+- `DescribeJobDefinitions`
+- `DescribeJobQueues`
+- `DescribeJobs`
+- `DescribeQuotaShare`
+- `DescribeSchedulingPolicies`
+- `DescribeServiceEnvironments`
+- `DescribeServiceJob`
+- `GetJobQueueSnapshot`
+- `ListConsumableResources`
+- `ListJobs`
+- `ListJobsByConsumableResource`
+- `ListQuotaShares`
+- `ListSchedulingPolicies`
+- `ListServiceJobs`
+- `ListTagsForResource`
+- `RegisterJobDefinition`
+- `SubmitJob`
+- `SubmitServiceJob`
+- `TagResource`
+- `TerminateJob`
+- `TerminateServiceJob`
+- `UntagResource`
+- `UpdateComputeEnvironment`
+- `UpdateConsumableResource`
+- `UpdateJobQueue`
+- `UpdateQuotaShare`
+- `UpdateSchedulingPolicy`
+- `UpdateServiceEnvironment`
+- `UpdateServiceJob`
+
 ## [Athena](@/docs/services/athena.md)
 
 - `BatchGetNamedQuery`


### PR DESCRIPTION
## Summary
Cycle-5 fc-next-step winner: **AWS Batch** (real container-backed job execution — the structural moat every rival fakes: ministack auto-succeeds, Moto leaky, LocalStack paywalls it; 56 LocalStack reactions). This is **batch 0 — foundation**.

- Vendored AWS Batch Smithy model (`aws-models/batch.json`, restJson1, 45 ops).
- New crate `fakecloud-batch`: JSON-backed state + restJson1 path routing for all 45 ops (`POST /v1/<op>` + `/v1/tags/{arn}`).
- **Core control plane implemented for real:** compute environments, job queues, revisioned job definitions, tags — with persistence + snapshot hook.
- Unimplemented ops (SubmitJob/job execution, scheduling policies, consumable resources, service environments/jobs, quota shares) return a faithful **501 InvalidAction**, never a fake success.
- Wired into the server (registration + persistent snapshot restore), workspace members + version pin, release.yml publish list.

The decision report (blind collection → scoring → adversarial disconfirm that overturned the blind IAM/Cognito picks as already-shipped) is at `next-step-reports/2026-06-27-cycle5.md`.

## Test plan
- `cargo nextest run -p fakecloud-batch` 4 pass (CE lifecycle, JD revision increment, unimplemented-op-501-not-fake, tag-family routing).
- `cargo clippy -p fakecloud-batch --bin fakecloud --all-targets -- -D warnings` clean.
- `cargo build --bin fakecloud` registers the service.

## Surface
New service scaffold with no user-usable capability yet (SubmitJob unimplemented), so docs/website/SDK are intentionally deferred to the control-plane-complete batch where the service is actually usable — stated here rather than silently omitted. Conformance baseline unchanged (new services are onboarded explicitly; `autoscaling` isn't in it either).

## Next batches
control-plane completion → SubmitJob real ECS-backed container execution → array jobs/dependencies → CloudFormation provisioner + tfacc, docs/SDK synced once usable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded the AWS Batch service with restJson1 routing and a real control plane for compute environments, job queues, and revisioned job definitions. Registered the service with persistence and added it to the ops index and docs; SubmitJob and execution are not implemented yet and return 501.

- **New Features**
  - Vendored AWS Batch Smithy model `aws-models/batch.json` (45 ops).
  - New crate `fakecloud-batch`: JSON-backed state and routing for all ops (`POST /v1/<op>`, `/v1/tags/{arn}`).
  - Implemented control plane: Create/Describe/Delete ComputeEnvironment, Create/Describe/Delete JobQueue, Register/Describe/Deregister JobDefinition (revisioned), Tag/Untag/ListTags.
  - Wired into `fakecloud-server`: service registration, persistent snapshot restore; added to workspace and `release.yml` publish list.
  - Registered Batch in `scripts/generate-operations-index.sh` and updated the website operations listing.

<sup>Written for commit 314cab33f60cae766f68557fe0514e9b74442f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

