### PR TITLE
feat(batch): retryStrategy + timeout (batch 5)

### DIFF
--- a/crates/fakecloud-batch/src/service.rs
+++ b/crates/fakecloud-batch/src/service.rs
@@ -1143,8 +1143,10 @@ async fn launch(
                 region.to_string(),
                 request_id.to_string(),
                 job_id.to_string(),
+                job_name.to_string(),
                 cluster,
                 task_arn,
+                container,
             );
         }
         Err(err) => {
@@ -1311,7 +1313,9 @@ async fn launch_ecs_task(
 
 /// Poll the ECS task in the background and map its real lifecycle + container
 /// exit code onto the Batch job status. NO auto-success: the job only reaches
-/// SUCCEEDED when the real container exits 0.
+/// SUCCEEDED when the real container exits 0. Honors the job's `retryStrategy`
+/// (re-launch a failed attempt up to `attempts` times) and `timeout`
+/// (`attemptDurationSeconds` caps each attempt).
 #[allow(clippy::too_many_arguments)]
 fn spawn_status_sync(
     ctx: &LaunchCtx,
@@ -1320,93 +1324,216 @@ fn spawn_status_sync(
     region: String,
     request_id: String,
     job_id: String,
+    job_name: String,
     cluster: String,
     task_arn: String,
+    container: Value,
 ) {
     let batch_state = ctx.batch_state.clone();
     let snapshot_store = ctx.snapshot_store.clone();
     let snapshot_lock = ctx.snapshot_lock.clone();
+    let ecs_runtime = ctx.ecs_runtime.clone();
     tokio::spawn(async move {
-        let ecs = fakecloud_ecs::EcsService::new(ecs_state);
+        let ecs = fakecloud_ecs::EcsService::new(ecs_state.clone());
         let src = bare_request(&account_id, &region, &request_id);
-        for _ in 0..900u32 {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            let resp = match ecs
-                .handle(ecs_request(
-                    "DescribeTasks",
-                    json!({ "cluster": cluster, "tasks": [task_arn] }),
-                    &src,
-                ))
-                .await
-            {
-                Ok(r) => r,
-                Err(_) => continue,
-            };
-            let body = parse_body(&resp);
-            let Some(task) = body.pointer("/tasks/0") else {
-                continue;
-            };
-            let last = task.get("lastStatus").and_then(Value::as_str).unwrap_or("");
-            let (new_status, exit_code, reason) = match last {
-                "RUNNING" => ("RUNNING", None, None),
-                "STOPPED" => {
-                    let code = task
-                        .pointer("/containers/0/exitCode")
-                        .and_then(Value::as_i64);
-                    let reason = task
-                        .get("stoppedReason")
-                        .and_then(Value::as_str)
-                        .map(String::from);
-                    if code == Some(0) {
-                        ("SUCCEEDED", code, reason)
-                    } else {
-                        (
-                            "FAILED",
-                            code,
-                            reason.or(Some("Essential container exited".into())),
-                        )
-                    }
-                }
-                _ => continue,
-            };
-            let terminal = matches!(new_status, "SUCCEEDED" | "FAILED");
-            {
-                let mut accounts = batch_state.write();
-                if let Some(j) = accounts
-                    .get_or_create(&account_id)
-                    .jobs
-                    .get_mut(&job_id)
-                    .and_then(|j| j.as_object_mut())
+        // retryStrategy.attempts (1-10) and timeout.attemptDurationSeconds.
+        let (max_attempts, timeout_secs) = {
+            let accounts = batch_state.read();
+            let j = accounts.get(&account_id).and_then(|s| s.jobs.get(&job_id));
+            let ma = j
+                .and_then(|j| j.pointer("/retryStrategy/attempts"))
+                .and_then(Value::as_i64)
+                .unwrap_or(1)
+                .clamp(1, 10);
+            let to = j
+                .and_then(|j| j.pointer("/timeout/attemptDurationSeconds"))
+                .and_then(Value::as_i64)
+                .filter(|t| *t > 0);
+            (ma, to)
+        };
+        let max_polls = timeout_secs.unwrap_or(900).min(900) as u32;
+        let mut task = task_arn;
+        let mut attempt: i64 = 1;
+        loop {
+            // Poll this attempt's task until it stops or the timeout elapses.
+            let mut outcome: Option<(Option<i64>, Option<String>)> = None; // (exitCode, reason)
+            let mut succeeded = false;
+            for _ in 0..max_polls {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                let resp = match ecs
+                    .handle(ecs_request(
+                        "DescribeTasks",
+                        json!({ "cluster": cluster, "tasks": [task] }),
+                        &src,
+                    ))
+                    .await
                 {
-                    j.insert("status".into(), json!(new_status));
-                    if let Some(c) = exit_code {
-                        let container = j
-                            .entry("container".to_string())
-                            .or_insert_with(|| json!({}));
-                        if let Some(o) = container.as_object_mut() {
-                            o.insert("exitCode".into(), json!(c));
+                    Ok(r) => r,
+                    Err(_) => continue,
+                };
+                let body = parse_body(&resp);
+                let Some(t) = body.pointer("/tasks/0") else {
+                    continue;
+                };
+                match t.get("lastStatus").and_then(Value::as_str).unwrap_or("") {
+                    "RUNNING" => {
+                        let mut accounts = batch_state.write();
+                        if let Some(j) = accounts
+                            .get_or_create(&account_id)
+                            .jobs
+                            .get_mut(&job_id)
+                            .and_then(|j| j.as_object_mut())
+                        {
+                            if j.get("status").and_then(Value::as_str) != Some("RUNNING") {
+                                j.insert("status".into(), json!("RUNNING"));
+                            }
                         }
                     }
-                    if let Some(r) = reason {
-                        j.insert("statusReason".into(), json!(r.clone()));
-                        if let Some(o) = j.get_mut("container").and_then(|v| v.as_object_mut()) {
-                            o.insert("reason".into(), json!(r));
+                    "STOPPED" => {
+                        let code = t.pointer("/containers/0/exitCode").and_then(Value::as_i64);
+                        let reason = t
+                            .get("stoppedReason")
+                            .and_then(Value::as_str)
+                            .map(String::from);
+                        if code == Some(0) {
+                            succeeded = true;
+                        } else {
+                            outcome =
+                                Some((code, reason.or(Some("Essential container exited".into()))));
                         }
+                        break;
                     }
-                    if terminal {
-                        j.insert(
-                            "stoppedAt".into(),
-                            json!(chrono::Utc::now().timestamp_millis()),
-                        );
-                    }
+                    _ => continue,
                 }
             }
-            save_snapshot_now(&batch_state, &snapshot_store, &snapshot_lock).await;
-            if terminal {
+
+            if succeeded {
+                set_job_terminal(
+                    &batch_state,
+                    &account_id,
+                    &job_id,
+                    "SUCCEEDED",
+                    Some(0),
+                    None,
+                );
+                save_snapshot_now(&batch_state, &snapshot_store, &snapshot_lock).await;
+                break;
+            }
+
+            // Failure (or timeout when `outcome` is None).
+            let (exit_code, reason) =
+                outcome.unwrap_or((None, Some("Job attempt duration exceeded timeout".into())));
+            if attempt < max_attempts {
+                // Record the failed attempt and re-launch a fresh task.
+                {
+                    let mut accounts = batch_state.write();
+                    if let Some(j) = accounts
+                        .get_or_create(&account_id)
+                        .jobs
+                        .get_mut(&job_id)
+                        .and_then(|j| j.as_object_mut())
+                    {
+                        let attempts = j.entry("attempts".to_string()).or_insert_with(|| json!([]));
+                        if let Some(a) = attempts.as_array_mut() {
+                            a.push(json!({
+                                "exitCode": exit_code,
+                                "statusReason": reason,
+                            }));
+                        }
+                        j.insert("status".into(), json!("RUNNABLE"));
+                    }
+                }
+                save_snapshot_now(&batch_state, &snapshot_store, &snapshot_lock).await;
+                match launch_ecs_task(
+                    &ecs_state,
+                    &ecs_runtime,
+                    &src,
+                    &job_id,
+                    &job_name,
+                    &container,
+                )
+                .await
+                {
+                    Ok((_, new_task)) => {
+                        task = new_task;
+                        attempt += 1;
+                        let mut accounts = batch_state.write();
+                        if let Some(j) = accounts
+                            .get_or_create(&account_id)
+                            .jobs
+                            .get_mut(&job_id)
+                            .and_then(|j| j.as_object_mut())
+                        {
+                            j.insert("status".into(), json!("STARTING"));
+                            j.insert("ecsTaskArn".into(), json!(task));
+                        }
+                        continue;
+                    }
+                    Err(_) => {
+                        set_job_terminal(
+                            &batch_state,
+                            &account_id,
+                            &job_id,
+                            "FAILED",
+                            exit_code,
+                            reason,
+                        );
+                        save_snapshot_now(&batch_state, &snapshot_store, &snapshot_lock).await;
+                        break;
+                    }
+                }
+            } else {
+                set_job_terminal(
+                    &batch_state,
+                    &account_id,
+                    &job_id,
+                    "FAILED",
+                    exit_code,
+                    reason,
+                );
+                save_snapshot_now(&batch_state, &snapshot_store, &snapshot_lock).await;
                 break;
             }
         }
     });
+}
+
+/// Write a job's terminal status + `container.exitCode`/reason + `stoppedAt`.
+fn set_job_terminal(
+    batch_state: &SharedBatchState,
+    account_id: &str,
+    job_id: &str,
+    status: &str,
+    exit_code: Option<i64>,
+    reason: Option<String>,
+) {
+    let mut accounts = batch_state.write();
+    if let Some(j) = accounts
+        .get_or_create(account_id)
+        .jobs
+        .get_mut(job_id)
+        .and_then(|j| j.as_object_mut())
+    {
+        j.insert("status".into(), json!(status));
+        if let Some(c) = exit_code {
+            let container = j
+                .entry("container".to_string())
+                .or_insert_with(|| json!({}));
+            if let Some(o) = container.as_object_mut() {
+                o.insert("exitCode".into(), json!(c));
+            }
+        }
+        if let Some(r) = reason {
+            j.insert("statusReason".into(), json!(r.clone()));
+            if let Some(o) = j.get_mut("container").and_then(|v| v.as_object_mut()) {
+                o.insert("reason".into(), json!(r));
+            }
+        }
+        j.insert(
+            "stoppedAt".into(),
+            json!(chrono::Utc::now().timestamp_millis()),
+        );
+    }
 }
 
 /// Build an ECS `AwsRequest` (awsJson1.1) carrying the originating

--- a/crates/fakecloud-e2e/tests/batch_real_execution.rs
+++ b/crates/fakecloud-e2e/tests/batch_real_execution.rs
@@ -34,7 +34,9 @@ fn require_docker_or_skip(test: &str) -> bool {
 
 const IMAGE: &str = "public.ecr.aws/docker/library/alpine:3.20";
 
-async fn run_job(batch: &aws_sdk_batch::Client, name: &str, command: Vec<&str>) -> String {
+/// Create the CE / JQ / JD (`<name>-*`) with an alpine container running
+/// `command`; no job is submitted.
+async fn setup(batch: &aws_sdk_batch::Client, name: &str, command: Vec<&str>) {
     batch
         .create_compute_environment()
         .compute_environment_name(format!("{name}-ce"))
@@ -80,6 +82,10 @@ async fn run_job(batch: &aws_sdk_batch::Client, name: &str, command: Vec<&str>) 
         .send()
         .await
         .expect("register JD");
+}
+
+async fn run_job(batch: &aws_sdk_batch::Client, name: &str, command: Vec<&str>) -> String {
+    setup(batch, name, command).await;
     let job = batch
         .submit_job()
         .job_name(format!("{name}-job"))
@@ -205,4 +211,69 @@ async fn array_job_runs_every_child_and_parent_succeeds() {
         .and_then(|a| a.status_summary())
         .expect("array statusSummary");
     assert_eq!(summary.get("SUCCEEDED"), Some(&3));
+}
+
+#[tokio::test]
+async fn retry_strategy_reattempts_a_failing_job() {
+    if !require_docker_or_skip("retry_strategy_reattempts_a_failing_job") {
+        return;
+    }
+    let s = TestServer::start().await;
+    let batch = aws_sdk_batch::Client::new(&s.aws_config().await);
+    setup(&batch, "retry", vec!["sh", "-c", "exit 4"]).await;
+    let job_id = batch
+        .submit_job()
+        .job_name("retry-job")
+        .job_queue("retry-q")
+        .job_definition("retry-jd")
+        .retry_strategy(
+            aws_sdk_batch::types::RetryStrategy::builder()
+                .attempts(2)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("submit")
+        .job_id()
+        .unwrap()
+        .to_string();
+
+    assert_eq!(wait_terminal(&batch, &job_id).await, "FAILED");
+    // Two attempts were made: one recorded retry + the final.
+    let d = batch.describe_jobs().jobs(&job_id).send().await.unwrap();
+    assert_eq!(d.jobs()[0].attempts().len(), 1);
+    assert_eq!(d.jobs()[0].container().and_then(|c| c.exit_code()), Some(4));
+}
+
+#[tokio::test]
+async fn timeout_fails_an_overrunning_job() {
+    if !require_docker_or_skip("timeout_fails_an_overrunning_job") {
+        return;
+    }
+    let s = TestServer::start().await;
+    let batch = aws_sdk_batch::Client::new(&s.aws_config().await);
+    setup(&batch, "tmo", vec!["sh", "-c", "sleep 60; exit 0"]).await;
+    let job_id = batch
+        .submit_job()
+        .job_name("tmo-job")
+        .job_queue("tmo-q")
+        .job_definition("tmo-jd")
+        .timeout(
+            aws_sdk_batch::types::JobTimeout::builder()
+                .attempt_duration_seconds(2)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("submit")
+        .job_id()
+        .unwrap()
+        .to_string();
+
+    assert_eq!(wait_terminal(&batch, &job_id).await, "FAILED");
+    let d = batch.describe_jobs().jobs(&job_id).send().await.unwrap();
+    assert!(d.jobs()[0]
+        .status_reason()
+        .unwrap_or_default()
+        .contains("timeout"));
 }

--- a/website/content/docs/services/batch.md
+++ b/website/content/docs/services/batch.md
@@ -23,15 +23,16 @@ containers, and Batch is built to run real jobs on that same engine.
 - **Jobs — real container execution** — `SubmitJob` launches the job definition's `containerProperties` (image / command / vcpus / memory / environment, with this submit's `containerOverrides` applied) as a **real container** on fakecloud's ECS task engine, and drives the job status off the container's actual lifecycle: `SUBMITTED → STARTING → RUNNING → SUCCEEDED` when the container exits 0, or `FAILED` (carrying the real `container.exitCode`) on a non-zero exit. This is the wedge: every other free emulator fakes Batch compute (MiniStack jumps straight to `SUCCEEDED` with no container). With no container runtime available the job stays `SUBMITTED` honestly — never an auto-success. `DescribeJobs` / `ListJobs` (filter by queue / status) report live status + exit code; `CancelJob` / `TerminateJob` stop a job.
 - **Array jobs** — `SubmitJob` with `arrayProperties.size = N` spawns `N` real child containers (`<jobId>:<index>`), each with `AWS_BATCH_JOB_ARRAY_INDEX` set so it can select its slice of work. The parent's status and `arrayProperties.statusSummary` aggregate the children live — `SUCCEEDED` only when every child exits 0.
 - **Job dependencies** — `SubmitJob` with `dependsOn` parks the job at `PENDING` and launches it only once every dependency has `SUCCEEDED`; if any dependency `FAILED`, the dependent job fails with "Dependent job failed". The wait never blocks the `SubmitJob` call.
+- **Retry + timeout** — `retryStrategy.attempts` re-launches a failed container up to that many times (each prior attempt recorded under `attempts[]`); `timeout.attemptDurationSeconds` caps each attempt and fails the job with "Job attempt duration exceeded timeout" if the container overruns.
 - **Tags** — `TagResource`, `UntagResource`, `ListTagsForResource`.
 
 Terraform / CloudFormation can provision a full Batch stack
 (`aws_batch_compute_environment`, `aws_batch_job_queue`,
 `aws_batch_job_definition`, `aws_batch_scheduling_policy`) and an SDK client can
-submit jobs (single, array, or dependency-chained) that run real containers and
-report their real exit codes.
+submit jobs (single, array, dependency-chained, retried, or timed-out) that run
+real containers and report their real exit codes.
 
 ## Coming next
 
-Retry strategies + timeouts, and a CloudFormation provisioner for
-`AWS::Batch::*`.
+A CloudFormation provisioner for `AWS::Batch::*` resources + Terraform
+acceptance-test coverage.


### PR DESCRIPTION
## Summary
AWS Batch batch 5 — **retry strategies + job timeouts**.

- `spawn_status_sync` loops over attempts: on a non-zero container exit, if `retryStrategy.attempts` remain it records the failed attempt under `attempts[]` and **re-launches a fresh ECS task** (status `RUNNABLE → STARTING`), else fails the job. Attempts clamped to AWS's 1-10.
- `timeout.attemptDurationSeconds` caps each attempt's poll loop; an overrunning container fails the job with "Job attempt duration exceeded timeout".
- Extracted `set_job_terminal` for the SUCCEEDED/FAILED write.

## Test plan
- Docker-gated e2e: `retry_strategy_reattempts_a_failing_job` (exit 4, attempts=2 → FAILED with one recorded retry + exitCode 4) and `timeout_fails_an_overrunning_job` (sleep 60, attemptDurationSeconds=2 → FAILED "timeout"). Both pass locally.
- Existing success/fail/array/dependsOn e2e unaffected; `cargo clippy -p fakecloud-batch -p fakecloud-e2e --all-targets -- -D warnings` clean. Docs updated.

## Next (final Batch batch)
CloudFormation provisioner for `AWS::Batch::ComputeEnvironment/JobQueue/JobDefinition` (write-through + snapshot hook) + Terraform acceptance-test coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS Batch retry strategies and per-attempt timeouts to real job execution. Failed attempts re-launch up to `retryStrategy.attempts` (1–10) with attempts recorded; overruns fail with a clear timeout reason. Docs updated and e2e coverage added.

- New Features
  - Honor `retryStrategy.attempts`: on non‑zero exit, record in `attempts[]` and re-launch a fresh ECS task (RUNNABLE → STARTING) until attempts are exhausted.
  - Honor `timeout.attemptDurationSeconds`: cap each attempt; on overrun, fail with "Job attempt duration exceeded timeout".
  - Set RUNNING on first task start; terminal status writes keep real `container.exitCode` and `statusReason`.

- Refactors
  - Extracted `set_job_terminal` helper for SUCCEEDED/FAILED writes.

<sup>Written for commit b670f64685dcc671756d99299d42013e5d4ae47e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

