### PR TITLE
feat(cloudformation): provision AWS::Batch::* resources + tfacc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,6 +3373,7 @@ dependencies = [
  "fakecloud-athena",
  "fakecloud-autoscaling",
  "fakecloud-aws",
+ "fakecloud-batch",
  "fakecloud-cloudfront",
  "fakecloud-cloudwatch",
  "fakecloud-cognito",

--- a/crates/fakecloud-batch/src/service.rs
+++ b/crates/fakecloud-batch/src/service.rs
@@ -287,7 +287,17 @@ impl BatchService {
         stored
             .entry("state".to_string())
             .or_insert_with(|| json!("ENABLED"));
-        stored.insert("uuid".into(), json!(Uuid::new_v4().to_string()));
+        let uuid = Uuid::new_v4().to_string();
+        // Managed compute environments are backed by a real ECS cluster; AWS
+        // returns its ARN and the provider (and ECS console) read it back.
+        stored.insert(
+            "ecsClusterArn".into(),
+            json!(format!(
+                "arn:aws:ecs:{}:{}:cluster/AWSBatch-{name}-{uuid}",
+                req.region, req.account_id
+            )),
+        );
+        stored.insert("uuid".into(), json!(uuid));
 
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
@@ -429,6 +439,24 @@ impl BatchService {
         stored.insert("jobDefinitionArn".into(), json!(arn));
         stored.insert("revision".into(), json!(revision));
         stored.insert("status".into(), json!("ACTIVE"));
+        // AWS defaults the optional list members of containerProperties to empty
+        // arrays and echoes them back on describe; clients (the terraform
+        // provider) read these back and expect them present.
+        if let Some(cp) = stored
+            .get_mut("containerProperties")
+            .and_then(Value::as_object_mut)
+        {
+            for key in [
+                "environment",
+                "mountPoints",
+                "resourceRequirements",
+                "secrets",
+                "ulimits",
+                "volumes",
+            ] {
+                cp.entry(key.to_string()).or_insert_with(|| json!([]));
+            }
+        }
         st.job_definitions
             .insert(format!("{name}:{revision}"), Value::Object(stored));
         Ok(AwsResponse::ok_json(json!({

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -43,6 +43,7 @@ fakecloud-apigatewayv2 = { workspace = true }
 fakecloud-ses = { workspace = true }
 fakecloud-application-autoscaling = { workspace = true }
 fakecloud-autoscaling = { workspace = true }
+fakecloud-batch = { workspace = true }
 fakecloud-athena = { workspace = true }
 fakecloud-firehose = { workspace = true }
 fakecloud-glue = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -2537,6 +2537,9 @@ mod tests {
             autoscaling: Arc::new(parking_lot::RwLock::new(
                 fakecloud_autoscaling::AutoScalingAccounts::new(),
             )),
+            batch: Arc::new(parking_lot::RwLock::new(
+                fakecloud_batch::BatchAccounts::new(),
+            )),
             ecs: shared::<fakecloud_ecs::EcsState>(),
             acm: Arc::new(RwLock::new(fakecloud_acm::AcmAccounts::new())),
             elasticache: shared::<fakecloud_elasticache::ElastiCacheState>(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/batch.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/batch.rs
@@ -1,0 +1,152 @@
+//! `AWS::Batch::*` CloudFormation provisioning. Creates compute environments,
+//! job queues, and job definitions as real records in the `batch` service
+//! state (the control plane; real job execution is a runtime concern, not
+//! CFN-time). Writes through the batch service's snapshot hook so the
+//! resources survive a restart (the #1766 lesson).
+
+use serde_json::{json, Map, Value};
+use uuid::Uuid;
+
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+
+fn prop_str<'a>(p: &'a Value, k: &str) -> Option<&'a str> {
+    p.get(k).and_then(|v| v.as_str())
+}
+
+impl ResourceProvisioner {
+    fn batch_arn(&self, kind: &str, name: &str) -> String {
+        format!(
+            "arn:aws:batch:{}:{}:{kind}/{name}-{}",
+            self.region,
+            self.account_id,
+            Uuid::new_v4().simple()
+        )
+    }
+
+    pub(super) fn create_batch_compute_environment(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = prop_str(props, "ComputeEnvironmentName")
+            .map(String::from)
+            .unwrap_or_else(|| resource.logical_id.clone());
+        let arn = self.batch_arn("compute-environment", &name);
+        let mut stored = Map::new();
+        stored.insert("computeEnvironmentName".into(), json!(name));
+        stored.insert("computeEnvironmentArn".into(), json!(arn));
+        stored.insert(
+            "type".into(),
+            json!(prop_str(props, "Type").unwrap_or("MANAGED")),
+        );
+        stored.insert(
+            "state".into(),
+            json!(prop_str(props, "State").unwrap_or("ENABLED")),
+        );
+        stored.insert("status".into(), json!("VALID"));
+        stored.insert("statusReason".into(), json!("ComputeEnvironment Healthy"));
+        if let Some(cr) = props.get("ComputeResources") {
+            stored.insert("computeResources".into(), cr.clone());
+        }
+        if let Some(role) = props.get("ServiceRole") {
+            stored.insert("serviceRole".into(), role.clone());
+        }
+        self.batch_state
+            .write()
+            .get_or_create(&self.account_id)
+            .compute_environments
+            .insert(name.clone(), Value::Object(stored));
+        Ok(ProvisionResult::new(arn))
+    }
+
+    pub(super) fn create_batch_job_queue(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = prop_str(props, "JobQueueName")
+            .map(String::from)
+            .unwrap_or_else(|| resource.logical_id.clone());
+        let arn = self.batch_arn("job-queue", &name);
+        let mut stored = Map::new();
+        stored.insert("jobQueueName".into(), json!(name));
+        stored.insert("jobQueueArn".into(), json!(arn));
+        stored.insert(
+            "state".into(),
+            json!(prop_str(props, "State").unwrap_or("ENABLED")),
+        );
+        stored.insert("status".into(), json!("VALID"));
+        stored.insert(
+            "priority".into(),
+            props.get("Priority").cloned().unwrap_or(json!(1)),
+        );
+        if let Some(order) = props.get("ComputeEnvironmentOrder") {
+            stored.insert("computeEnvironmentOrder".into(), order.clone());
+        }
+        self.batch_state
+            .write()
+            .get_or_create(&self.account_id)
+            .job_queues
+            .insert(name.clone(), Value::Object(stored));
+        Ok(ProvisionResult::new(arn))
+    }
+
+    pub(super) fn create_batch_job_definition(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = prop_str(props, "JobDefinitionName")
+            .map(String::from)
+            .unwrap_or_else(|| resource.logical_id.clone());
+        let mut state = self.batch_state.write();
+        let acct = state.get_or_create(&self.account_id);
+        let revision = acct.job_def_revisions.entry(name.clone()).or_insert(0);
+        *revision += 1;
+        let revision = *revision;
+        let arn = format!(
+            "arn:aws:batch:{}:{}:job-definition/{name}:{revision}",
+            self.region, self.account_id
+        );
+        let mut stored = Map::new();
+        stored.insert("jobDefinitionName".into(), json!(name));
+        stored.insert("jobDefinitionArn".into(), json!(arn));
+        stored.insert(
+            "type".into(),
+            json!(prop_str(props, "Type").unwrap_or("container")),
+        );
+        stored.insert("revision".into(), json!(revision));
+        stored.insert("status".into(), json!("ACTIVE"));
+        if let Some(cp) = props.get("ContainerProperties") {
+            stored.insert("containerProperties".into(), cp.clone());
+        }
+        acct.job_definitions
+            .insert(format!("{name}:{revision}"), Value::Object(stored));
+        Ok(ProvisionResult::new(arn))
+    }
+
+    /// Delete a Batch resource by physical id (the ARN returned at create);
+    /// matches the stored record by its `*Arn` field so hyphenated resource
+    /// names round-trip cleanly.
+    pub(super) fn delete_batch(&self, resource_type: &str, physical_id: &str) {
+        let mut state = self.batch_state.write();
+        let acct = state.get_or_create(&self.account_id);
+        let arn_matches =
+            |v: &Value, key: &str| v.get(key).and_then(|a| a.as_str()) == Some(physical_id);
+        match resource_type {
+            "AWS::Batch::ComputeEnvironment" => {
+                acct.compute_environments
+                    .retain(|_, v| !arn_matches(v, "computeEnvironmentArn"));
+            }
+            "AWS::Batch::JobQueue" => {
+                acct.job_queues
+                    .retain(|_, v| !arn_matches(v, "jobQueueArn"));
+            }
+            "AWS::Batch::JobDefinition" => {
+                acct.job_definitions
+                    .retain(|_, v| !arn_matches(v, "jobDefinitionArn"));
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
@@ -91,6 +91,7 @@ impl ResourceProvisioner {
             rds_state: self.rds_state.clone(),
             ec2_state: self.ec2_state.clone(),
             autoscaling_state: self.autoscaling_state.clone(),
+            batch_state: self.batch_state.clone(),
             ecs_state: self.ecs_state.clone(),
             acm_state: self.acm_state.clone(),
             elasticache_state: self.elasticache_state.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -881,6 +881,7 @@ pub struct ResourceProvisioner {
     pub rds_state: SharedRdsState,
     pub ec2_state: fakecloud_ec2::SharedEc2State,
     pub autoscaling_state: fakecloud_autoscaling::SharedAutoScalingState,
+    pub batch_state: fakecloud_batch::SharedBatchState,
     pub ecs_state: SharedEcsState,
     pub acm_state: SharedAcmState,
     pub elasticache_state: SharedElastiCacheState,
@@ -916,6 +917,7 @@ mod apigw;
 mod apigwv2;
 mod athena;
 mod autoscaling;
+mod batch;
 mod cloudformation;
 mod cloudwatch;
 mod cognito;
@@ -1051,6 +1053,9 @@ impl ResourceProvisioner {
                 self.create_autoscaling_launch_configuration(resource)
             }
             "AWS::AutoScaling::AutoScalingGroup" => self.create_autoscaling_group(resource),
+            "AWS::Batch::ComputeEnvironment" => self.create_batch_compute_environment(resource),
+            "AWS::Batch::JobQueue" => self.create_batch_job_queue(resource),
+            "AWS::Batch::JobDefinition" => self.create_batch_job_definition(resource),
             "AWS::EC2::VPC" => self.create_ec2_vpc(resource),
             "AWS::EC2::Subnet" => self.create_ec2_subnet(resource),
             "AWS::EC2::SecurityGroup" => self.create_ec2_security_group(resource),
@@ -1628,6 +1633,12 @@ impl ResourceProvisioner {
             }
             "AWS::AutoScaling::LaunchConfiguration" | "AWS::AutoScaling::AutoScalingGroup" => {
                 self.delete_autoscaling(&resource.resource_type, &resource.physical_id);
+                Ok(())
+            }
+            "AWS::Batch::ComputeEnvironment"
+            | "AWS::Batch::JobQueue"
+            | "AWS::Batch::JobDefinition" => {
+                self.delete_batch(&resource.resource_type, &resource.physical_id);
                 Ok(())
             }
             "AWS::ECS::Cluster" => self.delete_ecs_cluster(&resource.physical_id),
@@ -6045,6 +6056,7 @@ mod tests {
             autoscaling_state: Arc::new(RwLock::new(
                 fakecloud_autoscaling::AutoScalingAccounts::new(),
             )),
+            batch_state: Arc::new(RwLock::new(fakecloud_batch::BatchAccounts::new())),
             ecs_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -123,6 +123,7 @@ fn service_key_for_type(resource_type: &str) -> Option<&'static str> {
         // hook in the server.
         "EC2" => "ec2",
         "AutoScaling" => "autoscaling",
+        "Batch" => "batch",
         "ApplicationAutoScaling" => "application-autoscaling",
         _ => return None,
     })
@@ -298,6 +299,7 @@ pub struct CloudFormationDeps {
     pub rds: fakecloud_rds::SharedRdsState,
     pub ec2: fakecloud_ec2::SharedEc2State,
     pub autoscaling: fakecloud_autoscaling::SharedAutoScalingState,
+    pub batch: fakecloud_batch::SharedBatchState,
     pub ecs: fakecloud_ecs::SharedEcsState,
     pub acm: fakecloud_acm::SharedAcmState,
     pub elasticache: fakecloud_elasticache::SharedElastiCacheState,
@@ -444,6 +446,7 @@ impl CloudFormationService {
             rds_state: self.deps.rds.clone(),
             ec2_state: self.deps.ec2.clone(),
             autoscaling_state: self.deps.autoscaling.clone(),
+            batch_state: self.deps.batch.clone(),
             ecs_state: self.deps.ecs.clone(),
             acm_state: self.deps.acm.clone(),
             elasticache_state: self.deps.elasticache.clone(),
@@ -2452,6 +2455,7 @@ mod tests {
             autoscaling: Arc::new(RwLock::new(
                 fakecloud_autoscaling::AutoScalingAccounts::new(),
             )),
+            batch: Arc::new(RwLock::new(fakecloud_batch::BatchAccounts::new())),
             ecs: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",

--- a/crates/fakecloud-e2e/tests/cloudformation_batch.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_batch.rs
@@ -1,0 +1,113 @@
+//! CloudFormation provisions AWS::Batch::ComputeEnvironment / JobQueue /
+//! JobDefinition as real records in the `batch` service control plane.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "Resources": {
+    "CE": {
+      "Type": "AWS::Batch::ComputeEnvironment",
+      "Properties": {
+        "ComputeEnvironmentName": "cfn-ce",
+        "Type": "MANAGED",
+        "State": "ENABLED"
+      }
+    },
+    "JQ": {
+      "Type": "AWS::Batch::JobQueue",
+      "Properties": {
+        "JobQueueName": "cfn-q",
+        "Priority": 1,
+        "ComputeEnvironmentOrder": [
+          { "Order": 1, "ComputeEnvironment": { "Ref": "CE" } }
+        ]
+      }
+    },
+    "JD": {
+      "Type": "AWS::Batch::JobDefinition",
+      "Properties": {
+        "JobDefinitionName": "cfn-jd",
+        "Type": "container",
+        "ContainerProperties": {
+          "Image": "public.ecr.aws/docker/library/alpine:3.20",
+          "Vcpus": 1,
+          "Memory": 512
+        }
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_batch_resources() {
+    let s = TestServer::start().await;
+    let cfn = s.cloudformation_client().await;
+    let batch = aws_sdk_batch::Client::new(&s.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("batch-stack")
+        .template_body(TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("batch-stack")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described.stacks()[0].stack_status().unwrap().as_str(),
+        "CREATE_COMPLETE"
+    );
+
+    // The compute environment exists in the batch service.
+    let ces = batch.describe_compute_environments().send().await.unwrap();
+    assert!(
+        ces.compute_environments()
+            .iter()
+            .any(|c| c.compute_environment_name() == Some("cfn-ce")),
+        "CFN compute environment should exist"
+    );
+
+    // The job queue exists.
+    let qs = batch.describe_job_queues().send().await.unwrap();
+    assert!(
+        qs.job_queues()
+            .iter()
+            .any(|q| q.job_queue_name() == Some("cfn-q")),
+        "CFN job queue should exist"
+    );
+
+    // The job definition exists (revision 1).
+    let jds = batch
+        .describe_job_definitions()
+        .job_definition_name("cfn-jd")
+        .send()
+        .await
+        .unwrap();
+    let jd = jds
+        .job_definitions()
+        .iter()
+        .find(|d| d.job_definition_name() == Some("cfn-jd"))
+        .expect("CFN job definition should exist");
+    assert_eq!(jd.revision(), Some(1));
+
+    // Deleting the stack removes the compute environment.
+    cfn.delete_stack()
+        .stack_name("batch-stack")
+        .send()
+        .await
+        .unwrap();
+    let after = batch.describe_compute_environments().send().await.unwrap();
+    assert!(
+        after
+            .compute_environments()
+            .iter()
+            .all(|c| c.compute_environment_name() != Some("cfn-ce")),
+        "stack delete should remove the compute environment"
+    );
+}

--- a/crates/fakecloud-e2e/tests/cloudformation_batch_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_batch_persistence.rs
@@ -1,0 +1,78 @@
+//! A CloudFormation-provisioned AWS::Batch::* stack survives a restart in
+//! persistent mode. Regression for the #1766-class gap: the CFN provisioner
+//! writes straight into `batch_state`, so without a `cfn_snapshot_hooks` entry
+//! for "batch" the resources would vanish on restart.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "Resources": {
+    "CE": {
+      "Type": "AWS::Batch::ComputeEnvironment",
+      "Properties": { "ComputeEnvironmentName": "persist-ce", "Type": "MANAGED" }
+    },
+    "JQ": {
+      "Type": "AWS::Batch::JobQueue",
+      "Properties": {
+        "JobQueueName": "persist-q",
+        "Priority": 1,
+        "ComputeEnvironmentOrder": [
+          { "Order": 1, "ComputeEnvironment": { "Ref": "CE" } }
+        ]
+      }
+    },
+    "JD": {
+      "Type": "AWS::Batch::JobDefinition",
+      "Properties": { "JobDefinitionName": "persist-jd", "Type": "container" }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisioned_batch_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let cfn = server.cloudformation_client().await;
+
+    cfn.create_stack()
+        .stack_name("batch-persist")
+        .template_body(TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    server.restart().await;
+    let batch = aws_sdk_batch::Client::new(&server.aws_config().await);
+
+    // The compute environment provisioned by CFN survives the restart.
+    let ces = batch.describe_compute_environments().send().await.unwrap();
+    assert!(
+        ces.compute_environments()
+            .iter()
+            .any(|c| c.compute_environment_name() == Some("persist-ce")),
+        "CFN compute environment should survive restart"
+    );
+
+    // The job queue survives too.
+    let qs = batch.describe_job_queues().send().await.unwrap();
+    assert!(
+        qs.job_queues()
+            .iter()
+            .any(|q| q.job_queue_name() == Some("persist-q")),
+        "CFN job queue should survive restart"
+    );
+
+    // And the job definition.
+    let jds = batch
+        .describe_job_definitions()
+        .job_definition_name("persist-jd")
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        !jds.job_definitions().is_empty(),
+        "CFN job definition should survive restart"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -924,6 +924,7 @@ async fn main() {
             rds: rds_state.clone(),
             ec2: ec2_state.clone(),
             autoscaling: autoscaling_state.clone(),
+            batch: batch_state.clone(),
             ecs: ecs_state.clone(),
             acm: acm_state.clone(),
             elasticache: elasticache_state.clone(),
@@ -3124,6 +3125,9 @@ async fn main() {
         .with_ecs(ecs_state.clone(), ecs_runtime.clone());
     if let Some(store) = batch_snapshot_store.clone() {
         batch_service = batch_service.with_snapshot_store(store);
+    }
+    if let Some(h) = batch_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("batch", h);
     }
     registry.register(Arc::new(batch_service));
 

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -785,6 +785,17 @@ pub const SERVICES: &[Service] = &[
         run_regex: "^TestAccAutoScaling(Group|LaunchConfiguration)_basic$",
         deny: &[],
     },
+    Service {
+        name: "batch",
+        // AWS Batch: the `_basic` smoke for a compute environment
+        // (`aws_batch_compute_environment`), a job queue (`aws_batch_job_queue`),
+        // and a job definition (`aws_batch_job_definition`). The control plane
+        // round-trips the compute-environment status/state, the queue's
+        // compute-environment order + priority, and the revisioned job
+        // definition the provider reads back on refresh.
+        run_regex: "^TestAccBatch(ComputeEnvironment|JobQueue|JobDefinition)_basic$",
+        deny: &[],
+    },
 ];
 
 /// CI matrix shards. One GitHub Actions job per entry.
@@ -1192,6 +1203,12 @@ pub const SHARDS: &[Shard] = &[
         name: "autoscaling",
         service: "autoscaling",
         run_regex: "^TestAccAutoScaling(Group|LaunchConfiguration)_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "batch",
+        service: "batch",
+        run_regex: "^TestAccBatch(ComputeEnvironment|JobQueue|JobDefinition)_basic$",
         extra_deny: &[],
     },
 ];

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -306,6 +306,7 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_CLOUDFRONT", "cloudfront"),
     ("AWS_ENDPOINT_URL_EC2", "ec2"),
     ("AWS_ENDPOINT_URL_ECS", "ecs"),
+    ("AWS_ENDPOINT_URL_BATCH", "batch"),
     ("AWS_ENDPOINT_URL_COGNITO_IDENTITY", "cognito-identity"),
     ("AWS_ENDPOINT_URL_SCHEDULER", "scheduler"),
     ("AWS_ENDPOINT_URL_WAFV2", "wafv2"),

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -243,6 +243,11 @@ async fn autoscaling_acceptance() {
 }
 
 #[tokio::test]
+async fn batch_acceptance() {
+    run_shard("batch").await;
+}
+
+#[tokio::test]
 async fn scheduler_acceptance() {
     run_shard("scheduler").await;
 }

--- a/website/content/docs/services/batch.md
+++ b/website/content/docs/services/batch.md
@@ -25,14 +25,13 @@ containers, and Batch is built to run real jobs on that same engine.
 - **Job dependencies** — `SubmitJob` with `dependsOn` parks the job at `PENDING` and launches it only once every dependency has `SUCCEEDED`; if any dependency `FAILED`, the dependent job fails with "Dependent job failed". The wait never blocks the `SubmitJob` call.
 - **Retry + timeout** — `retryStrategy.attempts` re-launches a failed container up to that many times (each prior attempt recorded under `attempts[]`); `timeout.attemptDurationSeconds` caps each attempt and fails the job with "Job attempt duration exceeded timeout" if the container overruns.
 - **Tags** — `TagResource`, `UntagResource`, `ListTagsForResource`.
+- **CloudFormation** — `AWS::Batch::ComputeEnvironment`, `AWS::Batch::JobQueue`, and `AWS::Batch::JobDefinition` are provisioned into the Batch control plane when a stack is created (and removed on stack delete). The provisioned resources persist across a restart in persistent mode.
 
 Terraform / CloudFormation can provision a full Batch stack
 (`aws_batch_compute_environment`, `aws_batch_job_queue`,
 `aws_batch_job_definition`, `aws_batch_scheduling_policy`) and an SDK client can
 submit jobs (single, array, dependency-chained, retried, or timed-out) that run
-real containers and report their real exit codes.
-
-## Coming next
-
-A CloudFormation provisioner for `AWS::Batch::*` resources + Terraform
-acceptance-test coverage.
+real containers and report their real exit codes. The
+`terraform-provider-aws` Batch acceptance suite
+(`TestAccBatchComputeEnvironment_basic`, `TestAccBatchJobQueue_basic`,
+`TestAccBatchJobDefinition_basic`) runs against fakecloud.


### PR DESCRIPTION
Final batch of the AWS Batch service: CloudFormation provisioning + terraform-provider-aws acceptance coverage.

## What

- **CFN provisioner** for `AWS::Batch::ComputeEnvironment`, `AWS::Batch::JobQueue`, `AWS::Batch::JobDefinition`. Resources are written into the Batch control plane on stack create and removed on stack delete.
- **Restart-safe**: registers a `cfn_snapshot_hooks` entry for `batch`, so CFN-provisioned resources survive a restart in persistent mode (the #1766 write-through lesson). Delete matches the stored record by its `*Arn` field so hyphenated names round-trip cleanly.
- **tfacc**: new `batch` service + shard running `TestAccBatch(ComputeEnvironment|JobQueue|JobDefinition)_basic`, with `AWS_ENDPOINT_URL_BATCH` routing.
- **Tests**: CFN e2e (stack creates CE/JQ/JD, delete removes them) + a restart-persistence e2e. Both green locally.
- Docs page updated.

## Verification

- `cargo build --bin fakecloud` clean
- `cargo clippy -p fakecloud-cloudformation -p fakecloud-tfacc` clean
- e2e `cfn_provisions_batch_resources` + `cfn_provisioned_batch_survives_restart` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for `AWS::Batch::ComputeEnvironment`, `AWS::Batch::JobQueue`, and `AWS::Batch::JobDefinition`. Stacks create real Batch control-plane records that persist across restarts and are cleaned up on delete; TF acc tests now pass cleanly.

- **New Features**
  - CFN provisioner writes to Batch state and registers a `cfn_snapshot_hooks` entry for `batch` (restart-safe).
  - Delete matches resources by `*Arn` so hyphenated names round-trip cleanly.
  - `tfacc`: new `batch` service/shard running `TestAccBatch(ComputeEnvironment|JobQueue|JobDefinition)_basic` with `AWS_ENDPOINT_URL_BATCH`.
  - E2E coverage for CFN create/delete and restart persistence; docs updated.

- **Bug Fixes**
  - Compute environments now return `ecsClusterArn` on describe.
  - Job definitions default optional `containerProperties` lists (environment, mountPoints, resourceRequirements, secrets, ulimits, volumes) to empty arrays.

<sup>Written for commit ebc8dbf1cd1074158fa1ee5c301ba6768d76d9da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

