### PR TITLE
fix(release): publish fakecloud-batch after its dependency fakecloud-ecs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,6 @@ jobs:
           publish fakecloud-acm
           publish fakecloud-application-autoscaling
           publish fakecloud-autoscaling
-          publish fakecloud-batch
           publish fakecloud-wafv2
           publish fakecloud-cloudwatch
           publish fakecloud-glue
@@ -229,6 +228,7 @@ jobs:
           publish fakecloud-athena         # depends on glue, s3
           publish fakecloud-route53        # depends on cloudfront, elbv2, logs, s3
           publish fakecloud-ecs            # depends on logs, secretsmanager, ssm
+          publish fakecloud-batch          # depends on ecs (drives ECS for real job execution)
 
           # Layer 6: depends on layer 5
           publish fakecloud-stepfunctions  # depends on dynamodb


### PR DESCRIPTION
## Bug
`fakecloud-batch` depends on `fakecloud-ecs` (`crates/fakecloud-batch/Cargo.toml`: it drives the ECS runtime for real container-backed job execution), but `.github/workflows/release.yml` listed `publish fakecloud-batch` in Layer 3a while `fakecloud-ecs` is in Layer 5.

On the next release tag, `cargo publish -p fakecloud-batch` runs a verify build that resolves deps from the crates.io sparse index. At that point `fakecloud-ecs@<tag>` is not yet published, so the build fails ("no matching package named fakecloud-ecs") and the publish job's error branch `exit 1`s, aborting the entire remaining publish list (sns/secretsmanager/cognito/elbv2/s3/ecr/ecs/dynamodb/route53/cloudformation + the `fakecloud` bin). Half-published release.

## Fix
Move `publish fakecloud-batch` to after `publish fakecloud-ecs` (Layer 5). batch's other internal deps (aws/persistence/core) already precede ecs, so this satisfies the full graph. Nothing depends on batch except the server bin (published last).

Found by the 2026-06-27 bug-hunt (Tier 0). Must land before the v0.27.0 release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release workflow to publish `fakecloud-batch` after its dependency `fakecloud-ecs` in `.github/workflows/release.yml`. This avoids `cargo publish` failures on tags and prevents half-published releases.

<sup>Written for commit 175a7ee3b6739570596e562fd02544d565361cc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

