### PR TITLE
fix(cloudformation): make CFN-provisioned Batch resources match API-created

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/batch.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/batch.rs
@@ -13,6 +13,15 @@ fn prop_str<'a>(p: &'a Value, k: &str) -> Option<&'a str> {
     p.get(k).and_then(|v| v.as_str())
 }
 
+/// Copy a CloudFormation PascalCase property into the stored record under its
+/// camelCase API key (so a CFN-created resource reads back identically to an
+/// API-created one).
+fn copy_prop(stored: &mut Map<String, Value>, props: &Value, cfn_key: &str, api_key: &str) {
+    if let Some(v) = props.get(cfn_key) {
+        stored.insert(api_key.to_string(), v.clone());
+    }
+}
+
 impl ResourceProvisioner {
     fn batch_arn(&self, kind: &str, name: &str) -> String {
         format!(
@@ -21,6 +30,26 @@ impl ResourceProvisioner {
             self.account_id,
             Uuid::new_v4().simple()
         )
+    }
+
+    /// Seed the batch tag store from a resource's CFN `Tags` map (a JSON object),
+    /// so a CFN-created resource's tags survive on `ListTagsForResource` /
+    /// `Describe*` exactly like an API-created one's.
+    fn seed_batch_tags(&self, arn: &str, props: &Value) {
+        let Some(tags) = props.get("Tags").and_then(|v| v.as_object()) else {
+            return;
+        };
+        let mut state = self.batch_state.write();
+        let entry = state
+            .get_or_create(&self.account_id)
+            .tags
+            .entry(arn.to_string())
+            .or_default();
+        for (k, v) in tags {
+            if let Some(s) = v.as_str() {
+                entry.insert(k.clone(), s.to_string());
+            }
+        }
     }
 
     pub(super) fn create_batch_compute_environment(
@@ -32,6 +61,7 @@ impl ResourceProvisioner {
             .map(String::from)
             .unwrap_or_else(|| resource.logical_id.clone());
         let arn = self.batch_arn("compute-environment", &name);
+        let uuid = Uuid::new_v4().to_string();
         let mut stored = Map::new();
         stored.insert("computeEnvironmentName".into(), json!(name));
         stored.insert("computeEnvironmentArn".into(), json!(arn));
@@ -45,18 +75,35 @@ impl ResourceProvisioner {
         );
         stored.insert("status".into(), json!("VALID"));
         stored.insert("statusReason".into(), json!("ComputeEnvironment Healthy"));
-        if let Some(cr) = props.get("ComputeResources") {
-            stored.insert("computeResources".into(), cr.clone());
-        }
-        if let Some(role) = props.get("ServiceRole") {
-            stored.insert("serviceRole".into(), role.clone());
+        // Every managed/unmanaged CE is backed by an ECS cluster whose ARN the
+        // live CreateComputeEnvironment synthesizes; mirror it so CFN-created
+        // and API-created environments read back identically.
+        stored.insert(
+            "ecsClusterArn".into(),
+            json!(format!(
+                "arn:aws:ecs:{}:{}:cluster/AWSBatch-{name}-{uuid}",
+                self.region, self.account_id
+            )),
+        );
+        stored.insert("uuid".into(), json!(uuid));
+        for (cfn, api) in [
+            ("ComputeResources", "computeResources"),
+            ("ServiceRole", "serviceRole"),
+            ("UnmanagedvCpus", "unmanagedvCpus"),
+            ("EksConfiguration", "eksConfiguration"),
+            ("Context", "context"),
+            ("ReplaceComputeEnvironment", "replaceComputeEnvironment"),
+            ("Tags", "tags"),
+        ] {
+            copy_prop(&mut stored, props, cfn, api);
         }
         self.batch_state
             .write()
             .get_or_create(&self.account_id)
             .compute_environments
             .insert(name.clone(), Value::Object(stored));
-        Ok(ProvisionResult::new(arn))
+        self.seed_batch_tags(&arn, props);
+        Ok(ProvisionResult::new(arn.clone()).with("ComputeEnvironmentArn", arn))
     }
 
     pub(super) fn create_batch_job_queue(
@@ -76,19 +123,26 @@ impl ResourceProvisioner {
             json!(prop_str(props, "State").unwrap_or("ENABLED")),
         );
         stored.insert("status".into(), json!("VALID"));
+        stored.insert("statusReason".into(), json!("JobQueue Healthy"));
         stored.insert(
             "priority".into(),
             props.get("Priority").cloned().unwrap_or(json!(1)),
         );
-        if let Some(order) = props.get("ComputeEnvironmentOrder") {
-            stored.insert("computeEnvironmentOrder".into(), order.clone());
+        for (cfn, api) in [
+            ("ComputeEnvironmentOrder", "computeEnvironmentOrder"),
+            ("SchedulingPolicyArn", "schedulingPolicyArn"),
+            ("JobStateTimeLimitActions", "jobStateTimeLimitActions"),
+            ("Tags", "tags"),
+        ] {
+            copy_prop(&mut stored, props, cfn, api);
         }
         self.batch_state
             .write()
             .get_or_create(&self.account_id)
             .job_queues
             .insert(name.clone(), Value::Object(stored));
-        Ok(ProvisionResult::new(arn))
+        self.seed_batch_tags(&arn, props);
+        Ok(ProvisionResult::new(arn.clone()).with("JobQueueArn", arn))
     }
 
     pub(super) fn create_batch_job_definition(
@@ -99,30 +153,89 @@ impl ResourceProvisioner {
         let name = prop_str(props, "JobDefinitionName")
             .map(String::from)
             .unwrap_or_else(|| resource.logical_id.clone());
-        let mut state = self.batch_state.write();
-        let acct = state.get_or_create(&self.account_id);
-        let revision = acct.job_def_revisions.entry(name.clone()).or_insert(0);
-        *revision += 1;
-        let revision = *revision;
+        let arn;
+        {
+            let mut state = self.batch_state.write();
+            let acct = state.get_or_create(&self.account_id);
+            let revision = acct.job_def_revisions.entry(name.clone()).or_insert(0);
+            *revision += 1;
+            let revision = *revision;
+            arn = format!(
+                "arn:aws:batch:{}:{}:job-definition/{name}:{revision}",
+                self.region, self.account_id
+            );
+            let mut stored = Map::new();
+            stored.insert("jobDefinitionName".into(), json!(name));
+            stored.insert("jobDefinitionArn".into(), json!(arn));
+            stored.insert(
+                "type".into(),
+                json!(prop_str(props, "Type").unwrap_or("container")),
+            );
+            stored.insert("revision".into(), json!(revision));
+            stored.insert("status".into(), json!("ACTIVE"));
+            for (cfn, api) in [
+                ("ContainerProperties", "containerProperties"),
+                ("Parameters", "parameters"),
+                ("Timeout", "timeout"),
+                ("RetryStrategy", "retryStrategy"),
+                ("PlatformCapabilities", "platformCapabilities"),
+                ("PropagateTags", "propagateTags"),
+                ("SchedulingPriority", "schedulingPriority"),
+                ("NodeProperties", "nodeProperties"),
+                ("EksProperties", "eksProperties"),
+                ("Tags", "tags"),
+            ] {
+                copy_prop(&mut stored, props, cfn, api);
+            }
+            // AWS defaults the optional containerProperties list members to empty
+            // arrays and echoes them on describe; the live RegisterJobDefinition
+            // does the same, so a CFN-created definition must too.
+            if let Some(cp) = stored
+                .get_mut("containerProperties")
+                .and_then(Value::as_object_mut)
+            {
+                for key in [
+                    "environment",
+                    "mountPoints",
+                    "resourceRequirements",
+                    "secrets",
+                    "ulimits",
+                    "volumes",
+                ] {
+                    cp.entry(key.to_string()).or_insert_with(|| json!([]));
+                }
+            }
+            acct.job_definitions
+                .insert(format!("{name}:{revision}"), Value::Object(stored));
+        }
+        self.seed_batch_tags(&arn, props);
+        Ok(ProvisionResult::new(arn))
+    }
+
+    pub(super) fn create_batch_scheduling_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = prop_str(props, "Name")
+            .map(String::from)
+            .unwrap_or_else(|| resource.logical_id.clone());
         let arn = format!(
-            "arn:aws:batch:{}:{}:job-definition/{name}:{revision}",
+            "arn:aws:batch:{}:{}:scheduling-policy/{name}",
             self.region, self.account_id
         );
         let mut stored = Map::new();
-        stored.insert("jobDefinitionName".into(), json!(name));
-        stored.insert("jobDefinitionArn".into(), json!(arn));
-        stored.insert(
-            "type".into(),
-            json!(prop_str(props, "Type").unwrap_or("container")),
-        );
-        stored.insert("revision".into(), json!(revision));
-        stored.insert("status".into(), json!("ACTIVE"));
-        if let Some(cp) = props.get("ContainerProperties") {
-            stored.insert("containerProperties".into(), cp.clone());
-        }
-        acct.job_definitions
-            .insert(format!("{name}:{revision}"), Value::Object(stored));
-        Ok(ProvisionResult::new(arn))
+        stored.insert("name".into(), json!(name));
+        stored.insert("arn".into(), json!(arn));
+        copy_prop(&mut stored, props, "FairsharePolicy", "fairsharePolicy");
+        copy_prop(&mut stored, props, "Tags", "tags");
+        self.batch_state
+            .write()
+            .get_or_create(&self.account_id)
+            .scheduling_policies
+            .insert(name.clone(), Value::Object(stored));
+        self.seed_batch_tags(&arn, props);
+        Ok(ProvisionResult::new(arn.clone()).with("Arn", arn))
     }
 
     /// Delete a Batch resource by physical id (the ARN returned at create);
@@ -145,6 +258,10 @@ impl ResourceProvisioner {
             "AWS::Batch::JobDefinition" => {
                 acct.job_definitions
                     .retain(|_, v| !arn_matches(v, "jobDefinitionArn"));
+            }
+            "AWS::Batch::SchedulingPolicy" => {
+                acct.scheduling_policies
+                    .retain(|_, v| !arn_matches(v, "arn"));
             }
             _ => {}
         }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1056,6 +1056,7 @@ impl ResourceProvisioner {
             "AWS::Batch::ComputeEnvironment" => self.create_batch_compute_environment(resource),
             "AWS::Batch::JobQueue" => self.create_batch_job_queue(resource),
             "AWS::Batch::JobDefinition" => self.create_batch_job_definition(resource),
+            "AWS::Batch::SchedulingPolicy" => self.create_batch_scheduling_policy(resource),
             "AWS::EC2::VPC" => self.create_ec2_vpc(resource),
             "AWS::EC2::Subnet" => self.create_ec2_subnet(resource),
             "AWS::EC2::SecurityGroup" => self.create_ec2_security_group(resource),
@@ -1637,7 +1638,8 @@ impl ResourceProvisioner {
             }
             "AWS::Batch::ComputeEnvironment"
             | "AWS::Batch::JobQueue"
-            | "AWS::Batch::JobDefinition" => {
+            | "AWS::Batch::JobDefinition"
+            | "AWS::Batch::SchedulingPolicy" => {
                 self.delete_batch(&resource.resource_type, &resource.physical_id);
                 Ok(())
             }

--- a/crates/fakecloud-e2e/tests/cloudformation_batch.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_batch.rs
@@ -64,13 +64,19 @@ async fn cfn_provisions_batch_resources() {
         "CREATE_COMPLETE"
     );
 
-    // The compute environment exists in the batch service.
+    // The compute environment exists in the batch service, and (like an
+    // API-created one) reports its backing ECS cluster ARN.
     let ces = batch.describe_compute_environments().send().await.unwrap();
+    let ce = ces
+        .compute_environments()
+        .iter()
+        .find(|c| c.compute_environment_name() == Some("cfn-ce"))
+        .expect("CFN compute environment should exist");
     assert!(
-        ces.compute_environments()
-            .iter()
-            .any(|c| c.compute_environment_name() == Some("cfn-ce")),
-        "CFN compute environment should exist"
+        ce.ecs_cluster_arn()
+            .is_some_and(|a| a.contains(":cluster/")),
+        "CFN compute environment should report ecsClusterArn, got {:?}",
+        ce.ecs_cluster_arn()
     );
 
     // The job queue exists.
@@ -109,5 +115,96 @@ async fn cfn_provisions_batch_resources() {
             .iter()
             .all(|c| c.compute_environment_name() != Some("cfn-ce")),
         "stack delete should remove the compute environment"
+    );
+}
+
+const GETATT_TEMPLATE: &str = r#"{
+  "Resources": {
+    "SP": {
+      "Type": "AWS::Batch::SchedulingPolicy",
+      "Properties": { "Name": "cfn-sp" }
+    },
+    "CE": {
+      "Type": "AWS::Batch::ComputeEnvironment",
+      "Properties": { "ComputeEnvironmentName": "getatt-ce", "Type": "MANAGED" }
+    },
+    "JQ": {
+      "Type": "AWS::Batch::JobQueue",
+      "Properties": {
+        "JobQueueName": "getatt-q",
+        "Priority": 1,
+        "SchedulingPolicyArn": { "Ref": "SP" },
+        "ComputeEnvironmentOrder": [
+          { "Order": 1, "ComputeEnvironment": { "Ref": "CE" } }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "CeArn": { "Value": { "Fn::GetAtt": ["CE", "ComputeEnvironmentArn"] } },
+    "QArn": { "Value": { "Fn::GetAtt": ["JQ", "JobQueueArn"] } },
+    "SpArn": { "Value": { "Ref": "SP" } }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_batch_getatt_and_scheduling_policy_resolve() {
+    let s = TestServer::start().await;
+    let cfn = s.cloudformation_client().await;
+    let batch = aws_sdk_batch::Client::new(&s.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("getatt-stack")
+        .template_body(GETATT_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("getatt-stack")
+        .send()
+        .await
+        .unwrap();
+    let outputs = described.stacks()[0].outputs();
+    let out = |key: &str| {
+        outputs
+            .iter()
+            .find(|o| o.output_key() == Some(key))
+            .and_then(|o| o.output_value())
+            .unwrap_or("")
+            .to_string()
+    };
+
+    // Fn::GetAtt resolves to the real ARNs, not the "Logical.Attr" placeholder.
+    let ce_arn = out("CeArn");
+    assert!(
+        ce_arn.starts_with("arn:aws:batch:") && ce_arn.contains(":compute-environment/"),
+        "CE GetAtt should resolve to the ARN, got {ce_arn:?}"
+    );
+    let q_arn = out("QArn");
+    assert!(
+        q_arn.starts_with("arn:aws:batch:") && q_arn.contains(":job-queue/"),
+        "JobQueue GetAtt should resolve to the ARN, got {q_arn:?}"
+    );
+
+    // The scheduling policy was provisioned (its own resource type), and the
+    // JobQueue's SchedulingPolicyArn Ref resolved to its real ARN.
+    let sp_arn = out("SpArn");
+    assert!(
+        sp_arn.contains(":scheduling-policy/"),
+        "SchedulingPolicy Ref should resolve to the ARN, got {sp_arn:?}"
+    );
+    let sps = batch
+        .describe_scheduling_policies()
+        .arns(sp_arn.clone())
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        sps.scheduling_policies()
+            .iter()
+            .any(|p| p.arn() == Some(sp_arn.as_str())),
+        "CFN-provisioned scheduling policy should exist in the batch service"
     );
 }


### PR DESCRIPTION
The `AWS::Batch::*` provisioner re-derived each resource and drifted from the live service handlers (2026-06-27 bug-hunt, Tier 1: findings 1.7-1.10).

## Fixes
- **1.7 Fn::GetAtt** — capture `ComputeEnvironmentArn` / `JobQueueArn` / scheduling-policy `Arn` so a GetAtt resolves to the real ARN instead of baking the literal `"Logical.Attr"` placeholder (broke CDK/Outputs).
- **1.8 JobDefinition parity** — default the six `containerProperties` list members to empty arrays (mirroring `RegisterJobDefinition`) and pass through `Parameters`/`Timeout`/`RetryStrategy`/`PlatformCapabilities`/`PropagateTags`/`SchedulingPriority`/`NodeProperties`/`EksProperties`/`Tags`, previously dropped.
- **1.9 CE/JQ parity** — CE synthesizes `ecsClusterArn` + `uuid` and carries `UnmanagedvCpus`/`EksConfiguration`/`Context`/`Tags`; JobQueue adds `statusReason` and carries `SchedulingPolicyArn`/`JobStateTimeLimitActions`/`Tags`. Tags seed the authoritative batch tag store so reads reflect a CFN-created resource's tags.
- **1.10 SchedulingPolicy provisioner** — new `AWS::Batch::SchedulingPolicy` create + delete, so a JobQueue's `SchedulingPolicyArn: {Ref}` resolves to a real policy ARN.

## Tests
Extended `cloudformation_batch` e2e: CE/JobQueue `Fn::GetAtt` resolve to real ARNs (not placeholders); the scheduling policy provisions and is describable; CE reports `ecsClusterArn`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings CloudFormation `AWS::Batch::*` provisioning back in line with the real Batch API so CFN-created resources read the same as API-created ones. `Fn::GetAtt` now returns real ARNs, and missing fields/tags are preserved; adds SchedulingPolicy provisioning.

- **Bug Fixes**
  - `Fn::GetAtt` for CE/JQ returns real `ComputeEnvironmentArn`/`JobQueueArn` (no more "Logical.Attr").
  - ComputeEnvironment: synthesize `ecsClusterArn` and `uuid`; keep `UnmanagedvCpus`, `EksConfiguration`, `Context`, `Tags`.
  - JobQueue: keep `SchedulingPolicyArn`, `JobStateTimeLimitActions`, `Tags`; add `statusReason`.
  - JobDefinition: pass through `Parameters`, `Timeout`, `RetryStrategy`, `PlatformCapabilities`, `PropagateTags`, `SchedulingPriority`, `NodeProperties`, `EksProperties`, `Tags`; default optional `containerProperties` arrays to [].
  - Tags: seed the Batch tag store so `ListTagsForResource`/`Describe*` reflect CFN `Tags`.

- **New Features**
  - Provisioner for `AWS::Batch::SchedulingPolicy` (create/delete); `Ref` resolves to the real policy ARN.
  - E2E tests cover `GetAtt` ARNs, CE `ecsClusterArn`, and describing the scheduling policy.

<sup>Written for commit a0a6a73e15594b53b4101133cf04404e8aba795f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

