### PR TITLE
fix(batch): reconcile in-flight jobs on restart instead of zombies

### DIFF
--- a/crates/fakecloud-batch/src/service.rs
+++ b/crates/fakecloud-batch/src/service.rs
@@ -159,6 +159,42 @@ impl BatchService {
         }))
     }
 
+    /// Reconcile jobs restored from a snapshot. After a restart the background
+    /// drivers that advance a job (status-sync / dependency-waiter) are gone and
+    /// the backing ECS task was already STOPPED by the ECS reconcile, so an
+    /// in-flight job can never reach a terminal state on its own — it would hang
+    /// at RUNNING/PENDING forever. Fail every non-terminal job with a clear
+    /// reason instead of leaving a zombie.
+    pub async fn reconcile_persisted_jobs(&self) {
+        const NON_TERMINAL: &[&str] = &["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"];
+        let now = chrono::Utc::now().timestamp_millis();
+        let mut changed = false;
+        {
+            let mut accounts = self.state.write();
+            for acct in accounts.accounts.values_mut() {
+                for job in acct.jobs.values_mut() {
+                    let Some(o) = job.as_object_mut() else {
+                        continue;
+                    };
+                    let st = o.get("status").and_then(Value::as_str).unwrap_or("");
+                    if NON_TERMINAL.contains(&st) {
+                        o.insert("status".into(), json!("FAILED"));
+                        o.insert(
+                            "statusReason".into(),
+                            json!("Job interrupted by a fakecloud restart"),
+                        );
+                        o.entry("stoppedAt".to_string())
+                            .or_insert_with(|| json!(now));
+                        changed = true;
+                    }
+                }
+            }
+        }
+        if changed {
+            self.save_snapshot().await;
+        }
+    }
+
     /// Map the restJson1 request (POST /v1/<op>, plus the /v1/tags/{arn}
     /// family) to its operation name.
     fn resolve_action(req: &AwsRequest) -> Option<&'static str> {
@@ -2342,6 +2378,54 @@ mod tests {
                 .unwrap(),
         );
         assert_eq!(d["jobs"][0]["status"], "SUBMITTED");
+    }
+
+    #[tokio::test]
+    async fn reconcile_fails_in_flight_jobs_after_restart() {
+        // Simulate a restart: a snapshot restored a job in a non-terminal state
+        // whose background driver no longer exists. Reconcile must fail it
+        // (with a clear reason) rather than leave it frozen forever.
+        let s = svc();
+        mk_queue(&s, "q").await;
+        s.handle(req(
+            "/v1/registerjobdefinition",
+            json!({"jobDefinitionName": "jd", "type": "container",
+                   "containerProperties": {"image": "alpine"}}),
+        ))
+        .await
+        .unwrap();
+        let sub = body_of(
+            s.handle(req(
+                "/v1/submitjob",
+                json!({"jobName": "j", "jobQueue": "q", "jobDefinition": "jd"}),
+            ))
+            .await
+            .unwrap(),
+        );
+        let id = sub["jobId"].as_str().unwrap().to_string();
+
+        s.reconcile_persisted_jobs().await;
+
+        let d = body_of(
+            s.handle(req("/v1/describejobs", json!({"jobs": [id]})))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(d["jobs"][0]["status"], "FAILED");
+        assert_eq!(
+            d["jobs"][0]["statusReason"],
+            "Job interrupted by a fakecloud restart"
+        );
+        assert!(d["jobs"][0]["stoppedAt"].is_i64());
+
+        // A second reconcile is a no-op: already-terminal jobs are untouched.
+        s.reconcile_persisted_jobs().await;
+        let d2 = body_of(
+            s.handle(req("/v1/describejobs", json!({"jobs": [id]})))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(d2["jobs"][0]["status"], "FAILED");
     }
 
     #[test]

--- a/crates/fakecloud-e2e/tests/batch_real_execution.rs
+++ b/crates/fakecloud-e2e/tests/batch_real_execution.rs
@@ -277,3 +277,55 @@ async fn timeout_fails_an_overrunning_job() {
         .unwrap_or_default()
         .contains("timeout"));
 }
+
+#[tokio::test]
+async fn restart_fails_in_flight_job_instead_of_zombie() {
+    if !require_docker_or_skip("restart_fails_in_flight_job_instead_of_zombie") {
+        return;
+    }
+    // A long-running job is in flight when the server restarts. Its background
+    // driver and backing ECS task don't survive the restart, so without
+    // reconciliation it would hang at RUNNING forever. It must come back FAILED.
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let batch = aws_sdk_batch::Client::new(&server.aws_config().await);
+    setup(&batch, "restart", vec!["sh", "-c", "sleep 120"]).await;
+    let job = batch
+        .submit_job()
+        .job_name("restart-job")
+        .job_queue("restart-q")
+        .job_definition("restart-jd")
+        .send()
+        .await
+        .expect("submit job");
+    let id = job.job_id().unwrap().to_string();
+
+    // Let it get genuinely in-flight before pulling the rug.
+    let mut in_flight = false;
+    for _ in 0..120 {
+        let st = batch.describe_jobs().jobs(&id).send().await.unwrap().jobs()[0]
+            .status()
+            .map(|s| s.as_str().to_string())
+            .unwrap_or_default();
+        if st == "RUNNING" || st == "STARTING" {
+            in_flight = true;
+            break;
+        }
+        assert!(st != "SUCCEEDED" && st != "FAILED", "job ended early: {st}");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    assert!(in_flight, "job never became in-flight");
+
+    server.restart().await;
+    let batch = aws_sdk_batch::Client::new(&server.aws_config().await);
+    let d = batch.describe_jobs().jobs(&id).send().await.unwrap();
+    assert_eq!(
+        d.jobs()[0].status().map(|s| s.as_str()),
+        Some("FAILED"),
+        "in-flight job must be failed by restart reconcile, not left a zombie"
+    );
+    assert_eq!(
+        d.jobs()[0].status_reason(),
+        Some("Job interrupted by a fakecloud restart")
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3126,6 +3126,9 @@ async fn main() {
     if let Some(store) = batch_snapshot_store.clone() {
         batch_service = batch_service.with_snapshot_store(store);
     }
+    // Fail any jobs left mid-flight by a restart (their drivers + ECS tasks are
+    // gone) so they don't hang forever.
+    batch_service.reconcile_persisted_jobs().await;
     if let Some(h) = batch_service.snapshot_hook() {
         cfn_snapshot_hooks.insert("batch", h);
     }


### PR DESCRIPTION
2026-06-27 bug-hunt Tier 4 finding 4.1.

## Bug
After a restart, a Batch job restored in a non-terminal state (SUBMITTED/PENDING/RUNNABLE/STARTING/RUNNING) had no background driver (`spawn_status_sync` / `spawn_dependency_waiter`) re-spawned, and its backing ECS task was already STOPPed by the ECS reconcile — so it could **never** reach a terminal state and hung forever. `DescribeJobs` reported RUNNING indefinitely, `dependsOn` jobs never released, array parents never aggregated. Same failure shape as #1338/#914/#1752.

## Fix
`BatchService::reconcile_persisted_jobs()`, invoked from `main.rs` right after the batch snapshot is restored (mirroring ECS `reconcile_persisted_tasks`). Every non-terminal job is failed with `statusReason = "Job interrupted by a fakecloud restart"` + a `stoppedAt`, then the snapshot is re-saved. Idempotent (already-terminal jobs untouched).

## Tests
- Unit: submit -> reconcile -> FAILED + reason; second reconcile is a no-op.
- Docker-gated e2e: submit a real long-running (`sleep 120`) container on a **persistent** server, wait until it's genuinely in-flight, `restart()`, assert it comes back FAILED with the reason — not a zombie.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconcile in-flight Batch jobs on restart by failing them with a clear reason, instead of leaving zombies that hang forever and block dependencies. Adds `BatchService::reconcile_persisted_jobs()` and runs it on server startup so non-terminal jobs move to FAILED with `stoppedAt`.

- **Bug Fixes**
  - On startup, fail any `SUBMITTED`/`PENDING`/`RUNNABLE`/`STARTING`/`RUNNING` job with `statusReason = "Job interrupted by a fakecloud restart"` and set `stoppedAt` (idempotent).
  - Mirrors ECS task reconciliation to prevent stuck RUNNING states and unblock `dependsOn` and array aggregations.
  - Tests: unit coverage and Docker e2e verifying a long-running job becomes FAILED after a persistent server restart.

<sup>Written for commit 7d8ec851e1f941894fec7b93ecca8870be5a48da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

