### PR TITLE
fix(ec2): report real AMI architecture in DescribeInstances

### DIFF
--- a/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
+++ b/crates/fakecloud-e2e/tests/ec2_instance_control_plane.rs
@@ -641,3 +641,68 @@ async fn default_network_acl_cannot_be_deleted() {
         "got {err:?}"
     );
 }
+
+#[tokio::test]
+async fn describe_instances_reports_ami_architecture() {
+    let s = TestServer::start().await;
+    let c = s.ec2_client().await;
+    // arm64 AMI from the seeded catalogue (Graviton).
+    let arm = "ami-0a1b2c3d4e5f60007";
+    let resp = c
+        .run_instances()
+        .image_id(arm)
+        .min_count(1)
+        .max_count(1)
+        .send()
+        .await
+        .unwrap();
+    let id = resp.instances()[0].instance_id().unwrap().to_string();
+
+    let d = c
+        .describe_instances()
+        .instance_ids(&id)
+        .send()
+        .await
+        .unwrap();
+    let inst = &d.reservations()[0].instances()[0];
+    assert_eq!(
+        inst.architecture().map(|a| a.as_str()),
+        Some("arm64"),
+        "instance should report its AMI's architecture, not hardcoded x86_64"
+    );
+
+    // The architecture filter uses the real value: arm64 matches, x86_64 doesn't.
+    let arm_hits = c
+        .describe_instances()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("architecture")
+                .values("arm64")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(arm_hits
+        .reservations()
+        .iter()
+        .flat_map(|r| r.instances())
+        .any(|i| i.instance_id() == Some(id.as_str())));
+
+    let x86_hits = c
+        .describe_instances()
+        .filters(
+            aws_sdk_ec2::types::Filter::builder()
+                .name("architecture")
+                .values("x86_64")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(!x86_hits
+        .reservations()
+        .iter()
+        .flat_map(|r| r.instances())
+        .any(|i| i.instance_id() == Some(id.as_str())));
+}

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -56,11 +56,23 @@ fn sg_name_map(state: &Ec2State) -> HashMap<String, String> {
         .collect()
 }
 
+/// Resolve an instance's CPU architecture from its AMI in the seeded/owned
+/// catalogue (arm64 for Graviton images), defaulting to x86_64 when the AMI
+/// isn't known.
+fn arch_for(state: &Ec2State, image_id: &str) -> String {
+    state
+        .images
+        .get(image_id)
+        .map(|img| img.architecture.clone())
+        .unwrap_or_else(|| "x86_64".to_string())
+}
+
 fn instance_xml(
     i: &Instance,
     tags: &[Tag],
     owner: &str,
     sg_names: &HashMap<String, String>,
+    architecture: &str,
 ) -> String {
     let groups: Vec<String> = i
         .security_group_ids
@@ -125,7 +137,7 @@ fn instance_xml(
         ec2_elem("instanceType", &i.instance_type),
         ec2_elem("launchTime", &i.launch_time),
         ec2_elem("amiLaunchIndex", &i.ami_launch_index.to_string()),
-        ec2_elem("architecture", "x86_64"),
+        ec2_elem("architecture", architecture),
         ec2_elem("rootDeviceType", "ebs"),
         ec2_elem("rootDeviceName", "/dev/xvda"),
         ec2_elem("virtualizationType", "hvm"),
@@ -392,7 +404,8 @@ pub(crate) async fn run_instances(
                 "instance",
             );
             let tags = state.tags_for(id).to_vec();
-            rendered.push(instance_xml(&inst, &tags, &owner, &sg_names));
+            let architecture = arch_for(state, &inst.image_id);
+            rendered.push(instance_xml(&inst, &tags, &owner, &sg_names, &architecture));
             state.instances.insert(id.clone(), inst);
         }
     }
@@ -795,7 +808,14 @@ pub(crate) fn describe_instances(
         .instances
         .values()
         .filter(|i| wanted.is_empty() || wanted.contains(&i.instance_id))
-        .filter(|i| inst_match(i, state.tags_for(&i.instance_id), &filters))
+        .filter(|i| {
+            inst_match(
+                i,
+                state.tags_for(&i.instance_id),
+                &filters,
+                &arch_for(state, &i.image_id),
+            )
+        })
         .collect();
     matching.sort_by(|a, b| {
         a.reservation_id
@@ -820,6 +840,7 @@ pub(crate) fn describe_instances(
                 state.tags_for(&i.instance_id),
                 &owner,
                 &sg_names,
+                &arch_for(state, &i.image_id),
             ));
     }
     let reservations: Vec<String> = order
@@ -850,7 +871,7 @@ fn parse_max_results(params: &HashMap<String, String>) -> Option<usize> {
         .and_then(|v| v.parse::<usize>().ok())
 }
 
-fn inst_match(i: &Instance, tags: &[Tag], filters: &[Filter]) -> bool {
+fn inst_match(i: &Instance, tags: &[Tag], filters: &[Filter], architecture: &str) -> bool {
     use crate::service_helpers::filter_value_matches;
     filters.iter().all(|f| {
         let candidates: Vec<String> = match f.name.as_str() {
@@ -865,7 +886,7 @@ fn inst_match(i: &Instance, tags: &[Tag], filters: &[Filter]) -> bool {
             "private-ip-address" => vec![i.private_ip.clone()],
             "ip-address" => i.public_ip.clone().into_iter().collect(),
             "key-name" => i.key_name.clone().into_iter().collect(),
-            "architecture" => vec!["x86_64".to_string()],
+            "architecture" => vec![architecture.to_string()],
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
@@ -909,7 +930,14 @@ pub(crate) fn describe_instance_status(
         .values()
         .filter(|i| wanted.is_empty() || wanted.contains(&i.instance_id))
         .filter(|i| include_all || i.state_name == "running")
-        .filter(|i| inst_match(i, state.tags_for(&i.instance_id), &filters))
+        .filter(|i| {
+            inst_match(
+                i,
+                state.tags_for(&i.instance_id),
+                &filters,
+                &arch_for(state, &i.image_id),
+            )
+        })
         .collect();
     matching.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
     let (page, token) = crate::service_helpers::paginate(&matching, next_token, max_results);


### PR DESCRIPTION
2026-06-27 bug-hunt Tier 1 finding 1.14.

DescribeInstances hardcoded `architecture=x86_64` (`instance.rs` output + the `architecture` filter), even though the seeded AMI catalogue carries real per-AMI architecture. Graviton/arm64 instances were misreported and `Filter Name=architecture,Value=arm64` returned zero.

Resolve the architecture from the instance's AMI in the catalogue (default x86_64 for unknown AMIs) in both the output and the filter.

Test: launch an arm64 catalogue AMI -> instance reports arm64; architecture filter matches arm64, not x86_64. EC2 unit suite (59) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report each EC2 instance’s actual AMI architecture in DescribeInstances and make the architecture filter return correct results (including arm64). Graviton instances now show arm64; x86_64 is only used when the AMI is unknown.

- **Bug Fixes**
  - Resolve architecture from the seeded AMI catalog; default to x86_64 if the AMI isn’t in the catalog.
  - Use the resolved value in DescribeInstances output and for the `architecture` filter in both DescribeInstances and DescribeInstanceStatus.
  - Add an e2e test for an arm64 AMI to verify output and filter behavior.

<sup>Written for commit 3d9fc8b43b7b3325dc969e19f926c068f02fc3c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

