### PR TITLE
fix(dynamodb): return conflicting Item on failed conditional write

### DIFF
--- a/crates/fakecloud-aws/src/error.rs
+++ b/crates/fakecloud-aws/src/error.rs
@@ -59,15 +59,32 @@ pub fn json_error_response(
     code: &str,
     message: &str,
 ) -> (StatusCode, String, Bytes) {
-    let body = serde_json::json!({
-        "__type": code,
-        "message": message,
-    });
+    json_error_response_with_fields(status, code, message, &[])
+}
+
+/// Build an AWS JSON error response carrying additional top-level members (e.g.
+/// DynamoDB's `ConditionalCheckFailedException.Item`). Each field value is
+/// parsed as JSON when possible (so an object/array is embedded as-is) and
+/// otherwise emitted as a JSON string.
+pub fn json_error_response_with_fields(
+    status: StatusCode,
+    code: &str,
+    message: &str,
+    extra_fields: &[(String, String)],
+) -> (StatusCode, String, Bytes) {
+    let mut body = serde_json::Map::new();
+    body.insert("__type".to_string(), serde_json::json!(code));
+    body.insert("message".to_string(), serde_json::json!(message));
+    for (key, value) in extra_fields {
+        let parsed = serde_json::from_str(value)
+            .unwrap_or_else(|_| serde_json::Value::String(value.clone()));
+        body.insert(key.clone(), parsed);
+    }
 
     (
         status,
         "application/x-amz-json-1.1".to_string(),
-        Bytes::from(body.to_string()),
+        Bytes::from(serde_json::Value::Object(body).to_string()),
     )
 }
 

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -1045,7 +1045,12 @@ fn build_error_response_with_fields(
             extra_fields,
         ),
         AwsProtocol::Json | AwsProtocol::RestJson => {
-            fakecloud_aws::error::json_error_response(status, code, message)
+            fakecloud_aws::error::json_error_response_with_fields(
+                status,
+                code,
+                message,
+                extra_fields,
+            )
         }
     };
 

--- a/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
@@ -8,6 +8,20 @@ pub(crate) fn evaluate_condition(
     expr_attr_names: &HashMap<String, String>,
     expr_attr_values: &HashMap<String, Value>,
 ) -> Result<(), AwsServiceError> {
+    evaluate_condition_with_return(condition, existing, expr_attr_names, expr_attr_values, None)
+}
+
+/// Like [`evaluate_condition`], but when the check fails and
+/// `return_values_on_failure == Some("ALL_OLD")`, attach the conflicting item
+/// to the `ConditionalCheckFailedException` (AWS returns it under `Item` so
+/// optimistic-locking clients can read current state without an extra GetItem).
+pub(crate) fn evaluate_condition_with_return(
+    condition: &str,
+    existing: Option<&HashMap<String, AttributeValue>>,
+    expr_attr_names: &HashMap<String, String>,
+    expr_attr_values: &HashMap<String, Value>,
+    return_values_on_failure: Option<&str>,
+) -> Result<(), AwsServiceError> {
     // ConditionExpression and FilterExpression share the same DynamoDB grammar,
     // so we delegate to evaluate_filter_expression. An empty map models "item
     // doesn't exist" correctly: attribute_exists → false, attribute_not_exists
@@ -15,14 +29,22 @@ pub(crate) fn evaluate_condition(
     let empty = HashMap::new();
     let item = existing.unwrap_or(&empty);
     if evaluate_filter_expression(condition, item, expr_attr_names, expr_attr_values) {
-        Ok(())
-    } else {
-        Err(AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ConditionalCheckFailedException",
-            "The conditional request failed",
-        ))
+        return Ok(());
     }
+    let mut fields = Vec::new();
+    if return_values_on_failure == Some("ALL_OLD") {
+        if let Some(existing_item) = existing {
+            if let Ok(s) = serde_json::to_string(&json!(existing_item)) {
+                fields.push(("Item".to_string(), s));
+            }
+        }
+    }
+    Err(AwsServiceError::aws_error_with_fields(
+        StatusCode::BAD_REQUEST,
+        "ConditionalCheckFailedException",
+        "The conditional request failed",
+        fields,
+    ))
 }
 
 pub(crate) fn extract_function_arg<'a>(expr: &'a str, func_name: &str) -> Option<&'a str> {

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -8,10 +8,10 @@ use fakecloud_core::validation::*;
 
 use super::{
     apply_update_expression, build_consumed_capacity, build_item_collection_metrics,
-    evaluate_condition, extract_key, get_table, get_table_mut, parse_expression_attribute_names,
-    parse_expression_attribute_values, project_item, require_object, require_str,
-    resolve_write_condition, return_consumed_mode, return_icm_mode, validate_key_attributes_in_key,
-    validate_key_in_item, AttributeValue, DynamoDbService,
+    evaluate_condition_with_return, extract_key, get_table, get_table_mut,
+    parse_expression_attribute_names, parse_expression_attribute_values, project_item,
+    require_object, require_str, resolve_write_condition, return_consumed_mode, return_icm_mode,
+    validate_key_attributes_in_key, validate_key_in_item, AttributeValue, DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -25,6 +25,9 @@ impl DynamoDbService {
         let condition =
             resolve_write_condition(&body, &mut expr_attr_names, &mut expr_attr_values)?;
         let return_values = body["ReturnValues"].as_str().unwrap_or("NONE").to_string();
+        let return_values_on_failure = body["ReturnValuesOnConditionCheckFailure"]
+            .as_str()
+            .map(String::from);
         let return_consumed = return_consumed_mode(&body).to_string();
         let return_icm = return_icm_mode(&body).to_string();
 
@@ -43,7 +46,13 @@ impl DynamoDbService {
 
             if let Some(cond) = condition.as_deref() {
                 let existing = existing_idx.map(|i| &table.items[i]);
-                evaluate_condition(cond, existing, &expr_attr_names, &expr_attr_values)?;
+                evaluate_condition_with_return(
+                    cond,
+                    existing,
+                    &expr_attr_names,
+                    &expr_attr_values,
+                    return_values_on_failure.as_deref(),
+                )?;
             }
 
             let old_item_for_return = if return_values == "ALL_OLD" {
@@ -257,7 +266,13 @@ impl DynamoDbService {
 
             if let Some(cond) = condition.as_deref() {
                 let existing = existing_idx.map(|i| &table.items[i]);
-                evaluate_condition(cond, existing, &expr_attr_names, &expr_attr_values)?;
+                evaluate_condition_with_return(
+                    cond,
+                    existing,
+                    &expr_attr_names,
+                    &expr_attr_values,
+                    body["ReturnValuesOnConditionCheckFailure"].as_str(),
+                )?;
             }
 
             let return_values = body["ReturnValues"].as_str().unwrap_or("NONE");
@@ -350,7 +365,13 @@ impl DynamoDbService {
 
         if let Some(cond) = condition.as_deref() {
             let existing = existing_idx.map(|i| &table.items[i]);
-            evaluate_condition(cond, existing, &expr_attr_names, &expr_attr_values)?;
+            evaluate_condition_with_return(
+                cond,
+                existing,
+                &expr_attr_names,
+                &expr_attr_values,
+                body["ReturnValuesOnConditionCheckFailure"].as_str(),
+            )?;
         }
 
         let return_values = body["ReturnValues"].as_str().unwrap_or("NONE");

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -4,9 +4,9 @@ use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, BillingMode, ContributorInsightsAction, Delete,
     DeleteRequest, Get, GlobalSecondaryIndex, KeySchemaElement, KeyType, OnDemandThroughput,
     PointInTimeRecoverySpecification, Projection, ProjectionType, ProvisionedThroughput, Put,
-    PutRequest, Replica, ScalarAttributeType, SseSpecification, SseType, StreamSpecification,
-    StreamViewType, TableClass, Tag, TimeToLiveSpecification, TransactGetItem, TransactWriteItem,
-    WriteRequest,
+    PutRequest, Replica, ReturnValuesOnConditionCheckFailure, ScalarAttributeType,
+    SseSpecification, SseType, StreamSpecification, StreamViewType, TableClass, Tag,
+    TimeToLiveSpecification, TransactGetItem, TransactWriteItem, WriteRequest,
 };
 use helpers::TestServer;
 use std::collections::HashMap;
@@ -5514,5 +5514,74 @@ async fn dynamodb_table_class_create_and_update() {
             .unwrap()
             .table_class(),
         Some(&TableClass::Standard)
+    );
+}
+
+#[tokio::test]
+async fn conditional_check_failure_returns_old_item() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+    client
+        .create_table()
+        .table_name("Cond")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Seed an item with v=1.
+    let mut item = HashMap::new();
+    item.insert("pk".to_string(), AttributeValue::S("p1".into()));
+    item.insert("v".to_string(), AttributeValue::N("1".into()));
+    client
+        .put_item()
+        .table_name("Cond")
+        .set_item(Some(item))
+        .send()
+        .await
+        .unwrap();
+
+    // A conditional PutItem that fails, asking for the conflicting item back.
+    let mut item2 = HashMap::new();
+    item2.insert("pk".to_string(), AttributeValue::S("p1".into()));
+    item2.insert("v".to_string(), AttributeValue::N("2".into()));
+    let err = client
+        .put_item()
+        .table_name("Cond")
+        .set_item(Some(item2))
+        .condition_expression("attribute_not_exists(pk)")
+        .return_values_on_condition_check_failure(ReturnValuesOnConditionCheckFailure::AllOld)
+        .send()
+        .await
+        .expect_err("condition must fail");
+
+    let svc = err.into_service_error();
+    let cc = match svc {
+        aws_sdk_dynamodb::operation::put_item::PutItemError::ConditionalCheckFailedException(
+            cc,
+        ) => cc,
+        other => panic!("expected ConditionalCheckFailedException, got {other:?}"),
+    };
+    let returned = cc
+        .item()
+        .expect("ALL_OLD should return the conflicting item on the exception");
+    assert_eq!(
+        returned.get("v"),
+        Some(&AttributeValue::N("1".to_string())),
+        "the returned item should be the current (v=1) item"
     );
 }


### PR DESCRIPTION
2026-06-27 bug-hunt Tier 1 finding 1.12.

With `ReturnValuesOnConditionCheckFailure=ALL_OLD`, AWS returns the `ConditionalCheckFailedException` carrying the current item under `Item` (`aws-models/dynamodb.json`), so optimistic-locking helpers (aws-sdk-js v3, aws-sdk-go v2) read current state without an extra GetItem. `PutItem`/`UpdateItem`/`DeleteItem` ignored the flag and returned a bare exception.

## Fix
- The shared JSON error builder (`fakecloud-aws`) dropped `extra_fields` entirely — no JSON-protocol service could attach members to an error body. Add `json_error_response_with_fields` (each value parsed as JSON when possible) and route the Json/RestJson error path through it.
- `evaluate_condition_with_return` attaches the existing item as `Item` when the check fails and ALL_OLD was requested; the three write ops pass their flag through.

Test: a failing conditional PutItem with ALL_OLD surfaces the current (v=1) item on the exception. DDB/aws/core unit suites green (35/223/318).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB conditional writes to return the conflicting item when a condition fails with `ReturnValuesOnConditionCheckFailure=ALL_OLD`, matching AWS behavior. This lets optimistic-locking clients read the current state without an extra GetItem.

- **Bug Fixes**
  - `PutItem`/`UpdateItem`/`DeleteItem` now include `Item` in `ConditionalCheckFailedException` when `ALL_OLD` is requested.
  - Added `json_error_response_with_fields` and routed JSON/RestJson errors through it to carry extra members.
  - Introduced `evaluate_condition_with_return` and plumbed the flag through write paths; added an e2e test for a failing conditional `PutItem`.

<sup>Written for commit 87e652ae587a1d0bd956df21df2c791ee29e66ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

