### PR TITLE
fix(autoscaling): report LaunchTemplate + LoadBalancerNames in describe

### DIFF
--- a/crates/fakecloud-autoscaling/src/service.rs
+++ b/crates/fakecloud-autoscaling/src/service.rs
@@ -1017,6 +1017,34 @@ fn group_xml(g: &AutoScalingGroup) -> String {
         .iter()
         .map(|a| format!("<member>{}</member>", xesc(a)))
         .collect();
+    let lbs: String = g
+        .load_balancer_names
+        .iter()
+        .map(|a| format!("<member>{}</member>", xesc(a)))
+        .collect();
+    // A launch-template-backed ASG (the modern default) must report its
+    // LaunchTemplate, or terraform reads it back empty and shows perpetual drift.
+    let lt = g
+        .launch_template
+        .as_ref()
+        .map(|lt| {
+            format!(
+                "<LaunchTemplate>{}{}{}</LaunchTemplate>",
+                lt.launch_template_id
+                    .as_deref()
+                    .map(|v| el("LaunchTemplateId", v))
+                    .unwrap_or_default(),
+                lt.launch_template_name
+                    .as_deref()
+                    .map(|v| el("LaunchTemplateName", v))
+                    .unwrap_or_default(),
+                lt.version
+                    .as_deref()
+                    .map(|v| el("Version", v))
+                    .unwrap_or_default(),
+            )
+        })
+        .unwrap_or_default();
     let tags: String = g
         .tags
         .iter()
@@ -1032,8 +1060,9 @@ fn group_xml(g: &AutoScalingGroup) -> String {
         })
         .collect();
     format!(
-        "<member>{}{}{}{}{}{}{}{}{}{}{}<AvailabilityZones>{azs}</AvailabilityZones>\
+        "<member>{}{}{}{lt}{}{}{}{}{}{}{}{}<AvailabilityZones>{azs}</AvailabilityZones>\
          <Instances>{instances}</Instances><TargetGroupARNs>{tgs}</TargetGroupARNs>\
+         <LoadBalancerNames>{lbs}</LoadBalancerNames>\
          <Tags>{tags}</Tags>{}{}{}</member>",
         el("AutoScalingGroupName", &g.name),
         el("AutoScalingGroupARN", &g.arn),

--- a/crates/fakecloud-e2e/tests/autoscaling_describe.rs
+++ b/crates/fakecloud-e2e/tests/autoscaling_describe.rs
@@ -1,0 +1,54 @@
+//! DescribeAutoScalingGroups must report a launch-template-backed group's
+//! LaunchTemplate and its LoadBalancerNames, or terraform reads them back empty
+//! and shows perpetual drift. DesiredCapacity=0 keeps this container-free.
+
+mod helpers;
+
+use helpers::TestServer;
+
+#[tokio::test]
+async fn describe_asg_round_trips_launch_template_and_load_balancers() {
+    let s = TestServer::start().await;
+    let asg = aws_sdk_autoscaling::Client::new(&s.aws_config().await);
+
+    asg.create_auto_scaling_group()
+        .auto_scaling_group_name("lt-asg")
+        .launch_template(
+            aws_sdk_autoscaling::types::LaunchTemplateSpecification::builder()
+                .launch_template_id("lt-0abc1230000000000")
+                .version("$Latest")
+                .build(),
+        )
+        .min_size(0)
+        .max_size(2)
+        .desired_capacity(0)
+        .availability_zones("us-east-1a")
+        .load_balancer_names("classic-elb-1")
+        .send()
+        .await
+        .expect("create ASG");
+
+    let d = asg
+        .describe_auto_scaling_groups()
+        .auto_scaling_group_names("lt-asg")
+        .send()
+        .await
+        .unwrap();
+    let g = d
+        .auto_scaling_groups()
+        .iter()
+        .find(|g| g.auto_scaling_group_name() == Some("lt-asg"))
+        .expect("ASG should exist");
+
+    let lt = g
+        .launch_template()
+        .expect("DescribeAutoScalingGroups must report the LaunchTemplate");
+    assert_eq!(lt.launch_template_id(), Some("lt-0abc1230000000000"));
+    assert_eq!(lt.version(), Some("$Latest"));
+
+    assert_eq!(
+        g.load_balancer_names(),
+        &["classic-elb-1".to_string()],
+        "Classic-ELB attachment must round-trip"
+    );
+}


### PR DESCRIPTION
2026-06-27 bug-hunt Tier 1 finding 1.13.

A launch-template-backed ASG (the modern default — launch configs are deprecated) came back from `DescribeAutoScalingGroups` with **no** `LaunchTemplate`: the spec was parsed and stored on create but never rendered in `group_xml`. terraform read `launch_template` back empty -> perpetual drift. `LoadBalancerNames` (Classic-ELB attachments) had the same parse-store-but-never-render gap.

Render both. Test: create an ASG with a launch template + Classic-ELB name (DesiredCapacity 0, container-free), assert both round-trip on describe. autoscaling unit suite (7) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix DescribeAutoScalingGroups to include the group's LaunchTemplate and LoadBalancerNames. This stops Terraform drift for launch-template-backed Auto Scaling groups.

- **Bug Fixes**
  - Render LaunchTemplate (id, name, version) in group_xml when present.
  - Render LoadBalancerNames for Classic ELB attachments.
  - Add e2e test to verify both fields round-trip on describe.

<sup>Written for commit c517f58dd372b283ea203a7757057b20d27dc851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

