### PR TITLE
fix(iam): PathPrefix + pagination in ListAttached*Policies

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -3692,3 +3692,98 @@ async fn iam_account_seeds_default_service_linked_roles() {
     assert!(names.contains(&"AWSServiceRoleForSupport"));
     assert!(names.contains(&"AWSServiceRoleForTrustedAdvisor"));
 }
+
+#[tokio::test]
+async fn list_attached_role_policies_filters_path_and_paginates() {
+    let server = helpers::TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#;
+    client
+        .create_role()
+        .role_name("r1")
+        .assume_role_policy_document("{}")
+        .send()
+        .await
+        .unwrap();
+
+    // Two managed policies on different paths.
+    let team = client
+        .create_policy()
+        .policy_name("TeamPol")
+        .path("/team/")
+        .policy_document(doc)
+        .send()
+        .await
+        .unwrap();
+    let team_arn = team.policy().unwrap().arn().unwrap().to_string();
+    let other = client
+        .create_policy()
+        .policy_name("OtherPol")
+        .policy_document(doc)
+        .send()
+        .await
+        .unwrap();
+    let other_arn = other.policy().unwrap().arn().unwrap().to_string();
+    for arn in [&team_arn, &other_arn] {
+        client
+            .attach_role_policy()
+            .role_name("r1")
+            .policy_arn(arn)
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // PathPrefix selects only the matching policy.
+    let filtered = client
+        .list_attached_role_policies()
+        .role_name("r1")
+        .path_prefix("/team/")
+        .send()
+        .await
+        .unwrap();
+    let arns: Vec<&str> = filtered
+        .attached_policies()
+        .iter()
+        .filter_map(|p| p.policy_arn())
+        .collect();
+    assert_eq!(arns, vec![team_arn.as_str()], "PathPrefix must filter");
+
+    // MaxItems=1 truncates and yields a marker; the second page returns the rest.
+    let page1 = client
+        .list_attached_role_policies()
+        .role_name("r1")
+        .max_items(1)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page1.attached_policies().len(), 1);
+    assert!(
+        page1.is_truncated(),
+        "MaxItems=1 over 2 policies must truncate"
+    );
+    let marker = page1
+        .marker()
+        .expect("a truncated page must carry a marker");
+    let page2 = client
+        .list_attached_role_policies()
+        .role_name("r1")
+        .marker(marker)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page2.attached_policies().len(), 1);
+    assert!(!page2.is_truncated());
+    // Across both pages, every attachment appears exactly once.
+    let mut seen: Vec<String> = page1
+        .attached_policies()
+        .iter()
+        .chain(page2.attached_policies())
+        .filter_map(|p| p.policy_arn().map(str::to_string))
+        .collect();
+    seen.sort();
+    let mut expected = vec![team_arn, other_arn];
+    expected.sort();
+    assert_eq!(seen, expected);
+}

--- a/crates/fakecloud-iam/src/iam_service/groups.rs
+++ b/crates/fakecloud-iam/src/iam_service/groups.rs
@@ -624,23 +624,17 @@ impl IamService {
             )
         })?;
 
-        let members: String = group
-            .attached_policies
-            .iter()
-            .map(|arn| {
-                let policy_name = super::attached_policy_name(state, arn);
-                format!(
-                    "      <member>\n        <PolicyName>{policy_name}</PolicyName>\n        <PolicyArn>{arn}</PolicyArn>\n      </member>"
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let (members, is_truncated, next_marker) =
+            super::paginate_attached_policies(state, &group.attached_policies, req);
+        let marker_section = next_marker
+            .map(|m| format!("\n    <Marker>{m}</Marker>"))
+            .unwrap_or_default();
 
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListAttachedGroupPoliciesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListAttachedGroupPoliciesResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
     <AttachedPolicies>
 {members}
     </AttachedPolicies>

--- a/crates/fakecloud-iam/src/iam_service/helpers.rs
+++ b/crates/fakecloud-iam/src/iam_service/helpers.rs
@@ -793,6 +793,74 @@ pub(crate) fn attached_policy_name(state: &crate::state::IamState, arn: &str) ->
         .unwrap_or_else(|| arn.rsplit('/').next().unwrap_or(arn).to_string())
 }
 
+/// The IAM path embedded in a policy ARN: everything between `:policy` and the
+/// final `/` before the name, e.g. `…:policy/foo/bar/Name` -> `/foo/bar/`,
+/// `…:policy/Name` -> `/`. Used to filter ListAttached*Policies by `PathPrefix`.
+pub(crate) fn policy_path_from_arn(arn: &str) -> String {
+    arn.split(":policy")
+        .nth(1)
+        .and_then(|rest| rest.rfind('/').map(|i| rest[..=i].to_string()))
+        .unwrap_or_else(|| "/".to_string())
+}
+
+/// Filter a list of attached-policy ARNs by `PathPrefix` and paginate with the
+/// IAM `Marker`/`MaxItems` triad (cursor = policy ARN). Returns the rendered
+/// `<member>` block, the truncation flag, and the next marker. Shared by
+/// ListAttached{Role,User,Group}Policies, which all hardcoded IsTruncated=false
+/// and ignored PathPrefix.
+pub(crate) fn paginate_attached_policies(
+    state: &crate::state::IamState,
+    arns: &[String],
+    req: &AwsRequest,
+) -> (String, bool, Option<String>) {
+    let path_prefix = req.query_params.get("PathPrefix").cloned();
+    let max_items: usize = req
+        .query_params
+        .get("MaxItems")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(100);
+    let marker = req.query_params.get("Marker").cloned();
+
+    let mut items: Vec<(String, String)> = arns
+        .iter()
+        .filter(|arn| {
+            path_prefix
+                .as_ref()
+                .is_none_or(|p| policy_path_from_arn(arn).starts_with(p))
+        })
+        .map(|arn| (attached_policy_name(state, arn), arn.clone()))
+        .collect();
+    items.sort_by(|a, b| a.1.cmp(&b.1));
+
+    let start = marker
+        .as_ref()
+        .and_then(|m| items.iter().position(|(_, a)| a == m).map(|p| p + 1))
+        .unwrap_or(0);
+    let rest: Vec<(String, String)> = items.into_iter().skip(start).collect();
+    let is_truncated = rest.len() > max_items;
+    let page = if is_truncated {
+        &rest[..max_items]
+    } else {
+        &rest[..]
+    };
+    let next_marker = if is_truncated {
+        page.last().map(|(_, a)| a.clone())
+    } else {
+        None
+    };
+
+    let members = page
+        .iter()
+        .map(|(name, arn)| {
+            format!(
+                "      <member>\n        <PolicyName>{name}</PolicyName>\n        <PolicyArn>{arn}</PolicyArn>\n      </member>"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    (members, is_truncated, next_marker)
+}
+
 /// Extract a required query parameter, returning the supplied IAM-specific
 /// wire error code when missing. The shared `required_param` helper hard-codes
 /// `MissingParameter`, which isn't in any IAM operation's Smithy error list.

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -672,22 +672,17 @@ impl IamService {
             .cloned()
             .unwrap_or_default();
 
-        let members: String = policy_arns
-            .iter()
-            .map(|arn| {
-                let policy_name = super::attached_policy_name(state, arn);
-                format!(
-                    "      <member>\n        <PolicyName>{policy_name}</PolicyName>\n        <PolicyArn>{arn}</PolicyArn>\n      </member>"
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let (members, is_truncated, next_marker) =
+            super::paginate_attached_policies(state, &policy_arns, req);
+        let marker_section = next_marker
+            .map(|m| format!("\n    <Marker>{m}</Marker>"))
+            .unwrap_or_default();
 
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListAttachedRolePoliciesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListAttachedRolePoliciesResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
     <AttachedPolicies>
 {members}
     </AttachedPolicies>

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -1610,22 +1610,17 @@ impl IamService {
             .cloned()
             .unwrap_or_default();
 
-        let members: String = policy_arns
-            .iter()
-            .map(|arn| {
-                let policy_name = super::attached_policy_name(state, arn);
-                format!(
-                    "      <member>\n        <PolicyName>{policy_name}</PolicyName>\n        <PolicyArn>{arn}</PolicyArn>\n      </member>"
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let (members, is_truncated, next_marker) =
+            super::paginate_attached_policies(state, &policy_arns, req);
+        let marker_section = next_marker
+            .map(|m| format!("\n    <Marker>{m}</Marker>"))
+            .unwrap_or_default();
 
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListAttachedUserPoliciesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListAttachedUserPoliciesResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
     <AttachedPolicies>
 {members}
     </AttachedPolicies>


### PR DESCRIPTION
2026-06-27 bug-hunt Tier 1 finding 1.15.

`ListAttachedRolePolicies` / `ListAttachedUserPolicies` / `ListAttachedGroupPolicies` hardcoded `IsTruncated=false` and ignored `PathPrefix`, `Marker`, and `MaxItems`. boto3 paginators and terraform treated page 1 as the complete set, and `PathPrefix` queries returned unfiltered data.

Add a shared `paginate_attached_policies` helper: filter by the path embedded in each policy ARN, marker-cursor by ARN, MaxItems-bounded; render `IsTruncated` + `Marker` from it across all three handlers.

Test: attach two policies on different paths to a role; PathPrefix selects only the matching one; MaxItems=1 truncates with a marker and the second page returns the rest (each attachment exactly once). IAM unit suite (496) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IAM ListAttachedRolePolicies/UserPolicies/GroupPolicies to honor PathPrefix and real pagination (Marker/MaxItems). Restores correct filtering and makes boto3 and Terraform paginators behave correctly.

- **Bug Fixes**
  - Added shared `paginate_attached_policies` to filter by policy ARN path, paginate by ARN cursor, respect `MaxItems`, and emit `IsTruncated` + `Marker`.
  - Wired the helper into all three list operations so they no longer hardcode `IsTruncated=false` or ignore `PathPrefix`, `Marker`, `MaxItems`.
  - Added an e2e test covering PathPrefix filtering and two-page pagination.

<sup>Written for commit 09e73b3555545f7952bcf72bb5c9052c209b9ae6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

