### PR TITLE
fix(sns): UnsubscribeURL carries SubscriptionArn, not TopicArn

### DIFF
--- a/crates/fakecloud-sns/src/helpers.rs
+++ b/crates/fakecloud-sns/src/helpers.rs
@@ -363,6 +363,7 @@ pub(crate) fn generate_confirmation_token() -> String {
 pub(crate) fn build_sns_envelope(
     message_id: &str,
     topic_arn: &str,
+    subscription_arn: &str,
     subject: &Option<String>,
     message: &str,
     message_attributes: &serde_json::Map<String, Value>,
@@ -406,7 +407,7 @@ pub(crate) fn build_sns_envelope(
         "UnsubscribeURL".to_string(),
         Value::String(format!(
             "{}/?Action=Unsubscribe&SubscriptionArn={}",
-            endpoint, topic_arn
+            endpoint, subscription_arn
         )),
     );
     if !message_attributes.is_empty() {
@@ -463,7 +464,7 @@ pub(crate) fn collect_topic_subscribers(
                 .get("RawMessageDelivery")
                 .map(|v| v == "true")
                 .unwrap_or(false);
-            (s.endpoint.clone(), raw)
+            (s.endpoint.clone(), raw, s.subscription_arn.clone())
         })
         .collect();
 

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -1786,8 +1786,8 @@ pub(crate) struct SnsLambdaEventInput<'a> {
 /// `collect_topic_subscribers` so the fan-out loop doesn't have to
 /// re-filter the subscriptions map five times inline.
 pub(crate) struct TopicSubscribers {
-    /// (queue_arn, raw_message_delivery)
-    pub(crate) sqs: Vec<(String, bool)>,
+    /// (queue_arn, raw_message_delivery, subscription_arn)
+    pub(crate) sqs: Vec<(String, bool, String)>,
     pub(crate) http: Vec<HttpSubscriber>,
     /// (function_arn, subscription_arn)
     pub(crate) lambda: Vec<(String, String)>,

--- a/crates/fakecloud-sns/src/service_publish.rs
+++ b/crates/fakecloud-sns/src/service_publish.rs
@@ -722,11 +722,11 @@ pub(crate) fn fan_out_to_subscribers(
 
 pub(crate) fn deliver_to_sqs_subscribers(
     delivery: &Arc<DeliveryBus>,
-    subs: &[(String, bool)],
+    subs: &[(String, bool, String)],
     ctx: &TopicFanoutContext<'_>,
 ) {
     let sqs_message = ctx.body_for_protocol("sqs");
-    for (queue_arn, raw) in subs {
+    for (queue_arn, raw, subscription_arn) in subs {
         if *raw {
             let mut sqs_msg_attrs = HashMap::new();
             for (k, v) in ctx.message_attributes {
@@ -751,6 +751,7 @@ pub(crate) fn deliver_to_sqs_subscribers(
             let envelope_str = build_sns_envelope(
                 ctx.msg_id,
                 ctx.topic_arn,
+                subscription_arn,
                 &ctx.subject.map(|s| s.to_string()),
                 &sqs_message,
                 ctx.envelope_attrs,
@@ -780,6 +781,7 @@ pub(crate) fn deliver_to_http_subscribers(
         let body = build_sns_envelope(
             ctx.msg_id,
             ctx.topic_arn,
+            &sub.subscription_arn,
             &ctx.subject.map(|s| s.to_string()),
             &protocol_body,
             ctx.envelope_attrs,

--- a/crates/fakecloud-sns/src/service_tests.rs
+++ b/crates/fakecloud-sns/src/service_tests.rs
@@ -66,11 +66,13 @@ fn build_sns_lambda_event_uses_real_subscription_arn() {
 fn build_sns_envelope_uses_configured_endpoint() {
     let endpoint = "http://myhost:5555";
     let topic_arn = "arn:aws:sns:us-east-1:123456789012:my-topic";
+    let subscription_arn = "arn:aws:sns:us-east-1:123456789012:my-topic:1a2b3c4d-uuid";
     let attrs = serde_json::Map::new();
 
     let envelope = build_sns_envelope(
         "msg-002",
         topic_arn,
+        subscription_arn,
         &None,
         "test message",
         &attrs,
@@ -83,9 +85,11 @@ fn build_sns_envelope_uses_configured_endpoint() {
         unsub_url.starts_with("http://myhost:5555/"),
         "UnsubscribeURL should use the configured endpoint, got: {unsub_url}"
     );
+    // AWS's UnsubscribeURL carries the SubscriptionArn, not the TopicArn —
+    // calling Unsubscribe with a TopicArn is rejected.
     assert!(
-        unsub_url.contains(topic_arn),
-        "UnsubscribeURL should contain topic ARN"
+        unsub_url.contains(subscription_arn),
+        "UnsubscribeURL should contain the subscription ARN, got: {unsub_url}"
     );
 }
 


### PR DESCRIPTION
2026-06-27 bug-hunt Tier 1 finding 1.17.

SQS- and HTTP-delivered SNS notifications interpolated the **TopicArn** into the `UnsubscribeURL`'s `SubscriptionArn` slot (`helpers.rs` `build_sns_envelope`), so a framework that auto-unsubscribes by GET-ing `UnsubscribeURL` called `Unsubscribe` with a TopicArn and was rejected. The Lambda delivery path already used the subscription ARN (proving it's a bug).

Thread the subscription ARN through the SQS subscriber list (`Vec<(queue, raw, sub_arn)>`) and `build_sns_envelope`, and use it in the URL.

Test: `build_sns_envelope`'s UnsubscribeURL contains the subscription ARN. SNS unit suite (218) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SNS UnsubscribeURL to carry the SubscriptionArn (not the TopicArn) in SQS and HTTP notifications, so auto-unsubscribe works as expected. The Lambda path was already correct.

- Bug Fixes
  - Threaded `subscription_arn` through SQS subscribers and `build_sns_envelope`, and used it in `UnsubscribeURL` for SQS/HTTP deliveries.
  - Updated `TopicSubscribers.sqs` to `(queue_arn, raw_message_delivery, subscription_arn)` and added tests asserting the URL contains the subscription ARN.

<sup>Written for commit 2caee4bce6f9c6d138bfe6ed28e55243dc954dd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

