### PR TITLE
fix(glue,cloudwatch,logs): order list results most-recent-first like AWS

### DIFF
--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -832,6 +832,15 @@ impl CloudWatchService {
             .map_err(|_| invalid_param("EndTime must be ISO 8601"))?
             .with_timezone(&Utc);
 
+        // Default ScanBy is TimestampDescending (newest first); callers read
+        // Values[0] as the latest datapoint. The bucket map is ascending, so
+        // reverse unless the caller asked for TimestampAscending.
+        let descending = req
+            .query_params
+            .get("ScanBy")
+            .map(|s| s != "TimestampAscending")
+            .unwrap_or(true);
+
         // GetMetricData declares only InvalidNextToken, so it never rejects an
         // empty / malformed query list with a 4xx — it returns empty results.
         let queries = collect_indexed(req, "MetricDataQueries");
@@ -892,6 +901,10 @@ impl CloudWatchService {
                                 timestamps
                                     .push(ts.to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
                                 values.push(v);
+                            }
+                            if descending {
+                                timestamps.reverse();
+                                values.reverse();
                             }
                         }
                     }

--- a/crates/fakecloud-e2e/tests/cloudwatch.rs
+++ b/crates/fakecloud-e2e/tests/cloudwatch.rs
@@ -145,6 +145,68 @@ async fn get_metric_data_returns_per_query_results() {
 }
 
 #[tokio::test]
+async fn get_metric_data_honors_scan_by() {
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+    let now = chrono::Utc::now();
+
+    // Two datapoints, two periods apart -> two buckets: older=1.0, newer=2.0.
+    for (offset, v) in [(-120i64, 1.0_f64), (0, 2.0)] {
+        cw.put_metric_data()
+            .namespace("Scan")
+            .metric_data(
+                MetricDatum::builder()
+                    .metric_name("M")
+                    .value(v)
+                    .timestamp(AwsDateTime::from_secs(now.timestamp() + offset))
+                    .build(),
+            )
+            .send()
+            .await
+            .expect("put");
+    }
+
+    let query = |scan: Option<aws_sdk_cloudwatch::types::ScanBy>| {
+        let mut b = cw
+            .get_metric_data()
+            .start_time(AwsDateTime::from_secs(now.timestamp() - 600))
+            .end_time(AwsDateTime::from_secs(now.timestamp() + 600))
+            .metric_data_queries(
+                MetricDataQuery::builder()
+                    .id("q1")
+                    .metric_stat(
+                        MetricStat::builder()
+                            .metric(
+                                CwMetric::builder()
+                                    .namespace("Scan")
+                                    .metric_name("M")
+                                    .build(),
+                            )
+                            .period(60)
+                            .stat("Sum")
+                            .build(),
+                    )
+                    .build(),
+            );
+        if let Some(s) = scan {
+            b = b.scan_by(s);
+        }
+        b
+    };
+
+    // Default is TimestampDescending -> newest (2.0) first.
+    let desc = query(None).send().await.unwrap();
+    assert_eq!(desc.metric_data_results()[0].values(), &[2.0, 1.0]);
+
+    // TimestampAscending -> oldest (1.0) first.
+    let asc = query(Some(aws_sdk_cloudwatch::types::ScanBy::TimestampAscending))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(asc.metric_data_results()[0].values(), &[1.0, 2.0]);
+}
+
+#[tokio::test]
 async fn alarm_lifecycle_and_set_state() {
     let server = TestServer::start().await;
     let cw = server.cloudwatch_client().await;

--- a/crates/fakecloud-e2e/tests/glue.rs
+++ b/crates/fakecloud-e2e/tests/glue.rs
@@ -1078,3 +1078,58 @@ async fn update_crawler_schedule_persists_expression() {
     let sched = got.crawler().and_then(|c| c.schedule()).expect("schedule");
     assert_eq!(sched.schedule_expression(), Some("cron(0 12 * * ? *)"));
 }
+
+#[tokio::test]
+async fn get_job_runs_orders_most_recent_first() {
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+    glue.create_job()
+        .name("ordered-job")
+        .role("arn:aws:iam::123456789012:role/glue")
+        .command(
+            aws_sdk_glue::types::JobCommand::builder()
+                .name("glueetl")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create job");
+
+    // Three runs, spaced so their StartedOn timestamps are distinct.
+    let mut ids = Vec::new();
+    for _ in 0..3 {
+        let r = glue
+            .start_job_run()
+            .job_name("ordered-job")
+            .send()
+            .await
+            .expect("start run");
+        ids.push(r.job_run_id().unwrap().to_string());
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+
+    let runs = glue
+        .get_job_runs()
+        .job_name("ordered-job")
+        .send()
+        .await
+        .expect("get job runs");
+    let starts: Vec<i64> = runs
+        .job_runs()
+        .iter()
+        .filter_map(|r| r.started_on())
+        .map(|t| t.as_secs_f64() as i64)
+        .collect();
+    assert_eq!(runs.job_runs().len(), 3);
+    // The newest run (last started) must be JobRuns[0].
+    assert_eq!(
+        runs.job_runs()[0].id(),
+        Some(ids.last().unwrap().as_str()),
+        "GetJobRuns must return the most recent run first"
+    );
+    // Non-increasing StartedOn across the list.
+    assert!(
+        starts.windows(2).all(|w| w[0] >= w[1]),
+        "job runs must be ordered by StartedOn descending, got {starts:?}"
+    );
+}

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -2933,3 +2933,73 @@ async fn logs_delivery_destination_reports_type_and_tags() {
         Some("obs")
     );
 }
+
+#[tokio::test]
+async fn describe_log_streams_orders_by_last_event_time() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+    client
+        .create_log_group()
+        .log_group_name("/order/test")
+        .send()
+        .await
+        .unwrap();
+    for name in ["alpha", "bravo"] {
+        client
+            .create_log_stream()
+            .log_group_name("/order/test")
+            .log_stream_name(name)
+            .send()
+            .await
+            .unwrap();
+    }
+    // "alpha" gets the OLDER event; "bravo" the NEWER one. By name alpha sorts
+    // first; by LastEventTime bravo is newest.
+    client
+        .put_log_events()
+        .log_group_name("/order/test")
+        .log_stream_name("alpha")
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(1_000_000)
+                .message("old")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_log_events()
+        .log_group_name("/order/test")
+        .log_stream_name("bravo")
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(9_000_000)
+                .message("new")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_log_streams()
+        .log_group_name("/order/test")
+        .order_by(aws_sdk_cloudwatchlogs::types::OrderBy::LastEventTime)
+        .descending(true)
+        .send()
+        .await
+        .unwrap();
+    let names: Vec<&str> = resp
+        .log_streams()
+        .iter()
+        .filter_map(|s| s.log_stream_name())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["bravo", "alpha"],
+        "LastEventTime descending must put the newest-event stream first"
+    );
+}

--- a/crates/fakecloud-glue/src/jobs.rs
+++ b/crates/fakecloud-glue/src/jobs.rs
@@ -291,11 +291,16 @@ impl GlueService {
         let runs: Vec<Value> = accounts
             .get(&req.account_id)
             .map(|s| {
-                s.job_runs
+                // AWS returns job runs most-recent-first; clients read
+                // JobRuns[0] as the latest run. The state map is UUID-keyed
+                // (random order), so sort by StartedOn descending.
+                let mut matching: Vec<_> = s
+                    .job_runs
                     .values()
                     .filter(|r| r.job_name == job_name)
-                    .map(job_run_to_json)
-                    .collect()
+                    .collect();
+                matching.sort_by_key(|r| std::cmp::Reverse(r.started_on));
+                matching.into_iter().map(job_run_to_json).collect()
             })
             .unwrap_or_default();
         Ok(AwsResponse::ok_json(json!({ "JobRuns": runs })))

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -224,19 +224,37 @@ impl LogsService {
             )
         })?;
 
+        let descending = body["descending"].as_bool().unwrap_or(false);
         let mut streams: Vec<&LogStream> = group
             .log_streams
             .values()
             .filter(|s| prefix.is_empty() || s.name.starts_with(prefix))
             .collect();
-        streams.sort_by(|a, b| a.name.cmp(&b.name));
+        // orderBy=LastEventTime is the canonical "find the newest stream" query;
+        // streams with no events sort first (None < Some), as AWS does. Default
+        // ascending; `descending` flips it.
+        if order_by == "LastEventTime" {
+            streams.sort_by(|a, b| {
+                a.last_event_timestamp
+                    .cmp(&b.last_event_timestamp)
+                    .then_with(|| a.name.cmp(&b.name))
+            });
+        } else {
+            streams.sort_by(|a, b| a.name.cmp(&b.name));
+        }
+        if descending {
+            streams.reverse();
+        }
 
-        // Handle pagination with token format: logGroupName@lastStreamName
+        // Handle pagination with token format: logGroupName@lastStreamName.
+        // Resume after the named stream in whatever sorted order is in effect
+        // (positional, so LastEventTime ordering paginates correctly too).
         let start_idx = if let Some(token) = next_token {
             if let Some((_group, last_stream)) = token.split_once('@') {
                 streams
                     .iter()
-                    .position(|s| s.name.as_str() > last_stream)
+                    .position(|s| s.name.as_str() == last_stream)
+                    .map(|p| p + 1)
                     .unwrap_or(streams.len())
             } else {
                 streams.len() // invalid token -> empty results


### PR DESCRIPTION
2026-06-27 bug-hunt Tier 1 finding 1.16.

The "read element [0] = latest" idiom was broken across three services:
- **Glue GetJobRuns** iterated a UUID-keyed map (random order); now sorts by `StartedOn` descending so `JobRuns[0]` is the latest run.
- **CloudWatch GetMetricData** ignored `ScanBy` and always returned oldest-first; now honors it with the AWS default `TimestampDescending` (newest first).
- **Logs DescribeLogStreams** ignored `orderBy=LastEventTime` and `descending`; now sorts by `lastEventTimestamp` when requested and flips on `descending`. Pagination now resumes positionally so LastEventTime ordering paginates correctly too.

Tests: an e2e for each (Glue newest run first; CW default-descending vs TimestampAscending; Logs LastEventTime descending puts the newest-event stream first). Glue/CW/Logs unit suites green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Glue, CloudWatch, and Logs return results newest-first to match AWS. This lets clients safely treat the first item as the latest and fixes ordering-dependent pagination.

- **Bug Fixes**
  - Glue GetJobRuns: sort by StartedOn descending so `JobRuns[0]` is the latest run.
  - CloudWatch GetMetricData: honor `ScanBy` with default `TimestampDescending` (newest first).
  - Logs DescribeLogStreams: honor `orderBy=LastEventTime` and `descending`; sort by last event time and paginate positionally so ordering is consistent.

<sup>Written for commit 92bf2550aeaa2aae76bbd2f8a900a35d07d65130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

