### PR TITLE
fix(s3): max-keys=0 returns empty non-truncated page

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -4838,3 +4838,45 @@ async fn s3_get_zero_byte_multipart_part_does_not_panic() {
         .expect("get 0-byte part must succeed");
     assert_eq!(got.content_length(), Some(0));
 }
+
+#[tokio::test]
+async fn list_objects_max_keys_zero_is_empty_not_truncated() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+    client.create_bucket().bucket("mk0").send().await.unwrap();
+    for key in ["a.txt", "b.txt"] {
+        client
+            .put_object()
+            .bucket("mk0")
+            .key(key)
+            .body(ByteStream::from_static(b"x"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // V2: max-keys=0 -> empty, not truncated, no continuation token (the old
+    // empty token was self-rejecting on the next request).
+    let v2 = client
+        .list_objects_v2()
+        .bucket("mk0")
+        .max_keys(0)
+        .send()
+        .await
+        .expect("list v2 max-keys=0");
+    assert_eq!(v2.key_count(), Some(0));
+    assert_eq!(v2.is_truncated(), Some(false));
+    assert!(v2.next_continuation_token().is_none());
+
+    // V1: same — empty, not truncated, no NextMarker.
+    let v1 = client
+        .list_objects()
+        .bucket("mk0")
+        .max_keys(0)
+        .send()
+        .await
+        .expect("list v1 max-keys=0");
+    assert!(v1.contents().is_empty());
+    assert_eq!(v1.is_truncated(), Some(false));
+    assert!(v1.next_marker().is_none());
+}

--- a/crates/fakecloud-s3/src/service/objects/list.rs
+++ b/crates/fakecloud-s3/src/service/objects/list.rs
@@ -105,6 +105,12 @@ impl S3Service {
             count += 1;
         }
 
+        // max-keys=0 returns an empty page with IsTruncated=false (no marker),
+        // not a truncated empty NextMarker.
+        if max_keys == 0 {
+            is_truncated = false;
+        }
+
         let mut common_prefixes_xml = String::new();
         for cp in &common_prefixes {
             let display_cp = if encoding_type.as_deref() == Some("url") {
@@ -321,6 +327,13 @@ impl S3Service {
             ));
             last_key = key.clone();
             count += 1;
+        }
+
+        // max-keys=0 is a valid "give me just the count/metadata" request: AWS
+        // returns an empty page with IsTruncated=false, not a truncated empty
+        // continuation token (which the next request would reject).
+        if max_keys == 0 {
+            is_truncated = false;
         }
 
         let encoding_type = req.query_params.get("encoding-type").cloned();


### PR DESCRIPTION
2026-06-27 bug-hunt Tier 1 finding 1.19 (S3).

`ListObjectsV2`/`ListObjects` with `max-keys=0` hit `count >= max_keys` (0 >= 0) on the first object, setting `IsTruncated=true` and emitting a continuation token over an empty `last_key` (`base64("") = ""`), which the next request rejects with `InvalidArgument`. AWS returns `KeyCount=0`, `IsTruncated=false`, no token. Force `is_truncated=false` when `max-keys=0` in both handlers.

Test: put 2 objects, list with `max-keys=0` via V2 and V1 -> empty, not truncated, no token / NextMarker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes S3 ListObjects/ListObjectsV2 when max-keys=0 to return an empty, non-truncated page with no continuation token/NextMarker, matching AWS. Prevents InvalidArgument errors caused by an empty continuation token.

- **Bug Fixes**
  - Force is_truncated=false when max_keys==0 in both list handlers.
  - Added e2e test covering V1 and V2: empty results, IsTruncated=false, no token/NextMarker.

<sup>Written for commit 19586885334ee24b106f004e4021b7a45d929ad8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

