### PR TITLE
fix(logs): FilterLogEvents nextToken dedup on same-timestamp events

### DIFF
--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -1018,7 +1018,7 @@ impl LogsService {
         };
 
         for (_, stream) in streams {
-            for event in &stream.events {
+            for (idx, event) in stream.events.iter().enumerate() {
                 if let Some(cutoff) = retention_cutoff {
                     if event.timestamp < cutoff {
                         continue;
@@ -1041,7 +1041,11 @@ impl LogsService {
                     continue;
                 }
 
-                let event_id = format!("{}-{}", stream.name, event.timestamp);
+                // Include the per-stream event index so two events with the
+                // same millisecond timestamp get distinct eventIds; otherwise a
+                // nextToken whose cursor is a shared eventId resumes at the
+                // first of the group and re-delivers the rest.
+                let event_id = format!("{}-{}-{}", stream.name, event.timestamp, idx);
 
                 filtered_events.push(json!({
                     "logStreamName": stream.name,
@@ -1318,6 +1322,56 @@ mod tests {
         for e in events {
             assert!(e["logStreamName"].as_str().unwrap().starts_with("web"));
         }
+    }
+
+    #[test]
+    fn filter_log_events_paginates_same_timestamp_without_duplicates() {
+        let svc = make_service();
+        create_group(&svc, "dup");
+        create_stream(&svc, "dup", "s1");
+        // Three events sharing one millisecond timestamp (recent, so they
+        // aren't dropped as too-old by PutLogEvents).
+        let ts = chrono::Utc::now().timestamp_millis();
+        let req = make_request(
+            "PutLogEvents",
+            json!({
+                "logGroupName": "dup",
+                "logStreamName": "s1",
+                "logEvents": [
+                    {"timestamp": ts, "message": "a"},
+                    {"timestamp": ts, "message": "b"},
+                    {"timestamp": ts, "message": "c"},
+                ],
+            }),
+        );
+        svc.put_log_events(&req).unwrap();
+
+        // Page through one at a time; every event must appear exactly once.
+        let mut seen: Vec<String> = Vec::new();
+        let mut token: Option<String> = None;
+        for _ in 0..5 {
+            let mut body = json!({"logGroupName": "dup", "limit": 1});
+            if let Some(t) = &token {
+                body["nextToken"] = json!(t);
+            }
+            let resp = svc
+                .filter_log_events(&make_request("FilterLogEvents", body))
+                .unwrap();
+            let out: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            for e in out["events"].as_array().unwrap() {
+                seen.push(e["message"].as_str().unwrap().to_string());
+            }
+            match out["nextToken"].as_str() {
+                Some(t) => token = Some(t.to_string()),
+                None => break,
+            }
+        }
+        seen.sort();
+        assert_eq!(
+            seen,
+            vec!["a", "b", "c"],
+            "same-timestamp events must each be delivered exactly once across pages"
+        );
     }
 
     // ---- FilterLogEvents pattern matching tests ----


### PR DESCRIPTION
2026-06-27 bug-hunt Tier 1 finding 1.19 (Logs).

The `FilterLogEvents` eventId cursor was `{stream}-{timestamp}`, so two events in the same millisecond shared an id; a `nextToken` whose cursor was that shared id resumed at the *first* of the group (via `position()`) and re-delivered the rest. Include the per-stream event index in the eventId so same-timestamp events get distinct ids and pagination resumes exactly once per event.

Test: three events at one timestamp, paged one-at-a-time, each delivered exactly once.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate event delivery in `FilterLogEvents` pagination by giving same-timestamp events unique `eventId`s, so `nextToken` resumes exactly once per event.

- **Bug Fixes**
  - Event IDs now include the per-stream index (`{stream}-{timestamp}-{idx}`); previously `{stream}-{timestamp}` caused re-delivery when multiple events shared a millisecond timestamp.
  - Added a test that writes three same-timestamp events and pages with `limit: 1`; each event is returned exactly once.

<sup>Written for commit bda48e3ffc1e2d094cd1b1f8044c9aca6a152142. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

