### PR TITLE
fix(iam): paginate inline-policy listings

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -3787,3 +3787,46 @@ async fn list_attached_role_policies_filters_path_and_paginates() {
     expected.sort();
     assert_eq!(seen, expected);
 }
+
+#[tokio::test]
+async fn list_role_policies_paginates_inline_policies() {
+    let server = helpers::TestServer::start().await;
+    let client = server.iam_client().await;
+    let doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#;
+    client
+        .create_role()
+        .role_name("r")
+        .assume_role_policy_document("{}")
+        .send()
+        .await
+        .unwrap();
+    for name in ["pa", "pb", "pc"] {
+        client
+            .put_role_policy()
+            .role_name("r")
+            .policy_name(name)
+            .policy_document(doc)
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // MaxItems=1 truncates with a marker; pages cover all three exactly once.
+    let mut seen: Vec<String> = Vec::new();
+    let mut marker: Option<String> = None;
+    for _ in 0..5 {
+        let mut b = client.list_role_policies().role_name("r").max_items(1);
+        if let Some(m) = &marker {
+            b = b.marker(m);
+        }
+        let resp = b.send().await.unwrap();
+        seen.extend(resp.policy_names().iter().cloned());
+        if resp.is_truncated() {
+            marker = Some(resp.marker().unwrap().to_string());
+        } else {
+            break;
+        }
+    }
+    seen.sort();
+    assert_eq!(seen, vec!["pa", "pb", "pc"]);
+}

--- a/crates/fakecloud-iam/src/iam_service/groups.rs
+++ b/crates/fakecloud-iam/src/iam_service/groups.rs
@@ -516,17 +516,15 @@ impl IamService {
         })?;
 
         let policy_names: Vec<String> = group.inline_policies.keys().cloned().collect();
-        let members: String = policy_names
-            .iter()
-            .map(|name| format!("      <member>{name}</member>"))
-            .collect::<Vec<_>>()
-            .join("\n");
-
+        let (members, is_truncated, next_marker) = super::paginate_policy_names(policy_names, req);
+        let marker_section = next_marker
+            .map(|m| format!("\n    <Marker>{m}</Marker>"))
+            .unwrap_or_default();
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListGroupPoliciesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListGroupPoliciesResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
     <PolicyNames>
 {members}
     </PolicyNames>

--- a/crates/fakecloud-iam/src/iam_service/helpers.rs
+++ b/crates/fakecloud-iam/src/iam_service/helpers.rs
@@ -793,6 +793,45 @@ pub(crate) fn attached_policy_name(state: &crate::state::IamState, arn: &str) ->
         .unwrap_or_else(|| arn.rsplit('/').next().unwrap_or(arn).to_string())
 }
 
+/// Filter a list of inline-policy names by the IAM `Marker`/`MaxItems` triad
+/// (cursor = policy name, sorted) and render the `<member>` block. Shared by
+/// ListRolePolicies/ListUserPolicies/ListGroupPolicies, which all hardcoded
+/// IsTruncated=false and ignored pagination.
+pub(crate) fn paginate_policy_names(
+    mut names: Vec<String>,
+    req: &AwsRequest,
+) -> (String, bool, Option<String>) {
+    let max_items: usize = req
+        .query_params
+        .get("MaxItems")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(100);
+    let marker = req.query_params.get("Marker").cloned();
+    names.sort();
+    let start = marker
+        .as_ref()
+        .and_then(|m| names.iter().position(|n| n == m).map(|p| p + 1))
+        .unwrap_or(0);
+    let rest: Vec<String> = names.into_iter().skip(start).collect();
+    let is_truncated = rest.len() > max_items;
+    let page = if is_truncated {
+        &rest[..max_items]
+    } else {
+        &rest[..]
+    };
+    let next_marker = if is_truncated {
+        page.last().cloned()
+    } else {
+        None
+    };
+    let members = page
+        .iter()
+        .map(|n| format!("      <member>{n}</member>"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    (members, is_truncated, next_marker)
+}
+
 /// The IAM path embedded in a policy ARN: everything between `:policy` and the
 /// final `/` before the name, e.g. `…:policy/foo/bar/Name` -> `/foo/bar/`,
 /// `…:policy/Name` -> `/`. Used to filter ListAttached*Policies by `PathPrefix`.

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -844,7 +844,25 @@ impl IamService {
             .map(|m| m.keys().cloned().collect())
             .unwrap_or_default();
 
-        let xml = xml_responses::list_role_policies_response(&policy_names, &req.request_id);
+        let (members, is_truncated, next_marker) = super::paginate_policy_names(policy_names, req);
+        let marker_section = next_marker
+            .map(|m| format!("\n    <Marker>{m}</Marker>"))
+            .unwrap_or_default();
+        let xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListRolePoliciesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <ListRolePoliciesResult>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
+    <PolicyNames>
+{members}
+    </PolicyNames>
+  </ListRolePoliciesResult>
+  <ResponseMetadata>
+    <RequestId>{}</RequestId>
+  </ResponseMetadata>
+</ListRolePoliciesResponse>"#,
+            req.request_id
+        );
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 }

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -1757,17 +1757,15 @@ impl IamService {
             .map(|m| m.keys().cloned().collect())
             .unwrap_or_default();
 
-        let members: String = policy_names
-            .iter()
-            .map(|name| format!("      <member>{name}</member>"))
-            .collect::<Vec<_>>()
-            .join("\n");
-
+        let (members, is_truncated, next_marker) = super::paginate_policy_names(policy_names, req);
+        let marker_section = next_marker
+            .map(|m| format!("\n    <Marker>{m}</Marker>"))
+            .unwrap_or_default();
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListUserPoliciesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListUserPoliciesResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
     <PolicyNames>
 {members}
     </PolicyNames>


### PR DESCRIPTION
2026-06-27 bug-hunt Tier 1 finding 1.19 (IAM, final item).

`ListRolePolicies` / `ListUserPolicies` / `ListGroupPolicies` hardcoded `IsTruncated=false` and ignored `Marker`/`MaxItems`, so a boto3 paginator treated page 1 as complete. Add a shared `paginate_policy_names` helper (sorted, cursor = policy name, MaxItems-bounded) and render `IsTruncated` + `Marker` across all three handlers.

Test: three inline policies on a role; `MaxItems=1` pages through all three with a marker, each exactly once. IAM unit + e2e green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pagination for IAM inline policy listings so SDK paginators work correctly. `ListRolePolicies`, `ListUserPolicies`, and `ListGroupPolicies` now honor `MaxItems`/`Marker` and return proper `IsTruncated` and `Marker`.

- Bug Fixes
  - Added shared `paginate_policy_names` helper (sorted by name; name-based cursor; `MaxItems`-bounded).
  - Updated all three handlers to remove hardcoded `IsTruncated=false` and emit `IsTruncated` + `Marker` in the XML.
  - Added e2e test covering `MaxItems=1` pagination across three inline policies.

<sup>Written for commit 85520c472a6eba64c84021d68913e2f1cd76e33b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

