### PR TITLE
chore(release): bump workspace to v0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3595,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4079,7 +4079,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4337,7 +4337,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -114,183 +114,183 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.26.0"
+version = "0.27.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.26.0")
+    testImplementation("dev.fakecloud:fakecloud:0.27.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.26.0</version>
+    <version>0.27.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.26.0"
+version = "0.27.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.26.0"
+version = "0.27.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v0.27.0.

Highlights since v0.26.0:
- **New AWS Batch service** (`fakecloud-batch`): control plane + real ECS-backed container job execution, array jobs, dependsOn, retry/timeout, CloudFormation `AWS::Batch::*` provisioner, terraform-provider-aws acceptance coverage.
- **Bug-hunt sweep (#1991-#2006)**: release topo-order fix; Batch input-safety (percent-decode panic, array-size bound), ListJobs/tags/queue-validation, CFN drift, restart reconcile; EC2 DescribeInstances architecture; DynamoDB conditional-write Item; ASG LaunchTemplate/LoadBalancerNames + desired bounds; IAM PathPrefix + inline-policy pagination; SNS UnsubscribeURL; Glue/CloudWatch/Logs ordering; Cognito ES256 WebAuthn verification; S3 max-keys=0; Glue GetTables Expression; Logs FilterLogEvents dedup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.27.0. Updates all crates and SDKs to `0.27.0`, adds `fakecloud-batch` (AWS Batch) with ECS-backed job execution, and ships a broad sweep of stability fixes.

- **New Features**
  - `fakecloud-batch`: control plane, ECS-backed jobs, array jobs, `dependsOn`, retries/timeouts; CloudFormation `AWS::Batch::*` provisioning and Terraform acceptance coverage.

- **Bug Fixes**
  - Stability and parity fixes across Batch, EC2, DynamoDB, Auto Scaling, IAM, SNS, Glue, CloudWatch/Logs, Cognito, and S3.
  - Improvements include safer request inputs, better pagination/listing, stricter validation, reduced drift, more reliable reconcile flows, and consistent event ordering.

<sup>Written for commit f23f683f89dd3cb6eea457d31ce0a97a7afa7172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

