### PR TITLE
feat(rds-data): transactions and BatchExecuteStatement (batch 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4157,6 +4157,7 @@ dependencies = [
  "fakecloud-rds",
  "http 1.4.0",
  "mysql_async",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/fakecloud-e2e/tests/rds_data_api.rs
+++ b/crates/fakecloud-e2e/tests/rds_data_api.rs
@@ -93,3 +93,144 @@ async fn rds_data_api_executes_real_sql_with_typed_params() {
         "includeResultMetadata returns column metadata"
     );
 }
+
+/// Transactions hold a real connection open across requests: a rolled-back
+/// transaction leaves no rows, and a BatchExecuteStatement committed inside a
+/// transaction persists every parameter set. This proves Begin/Commit/Rollback
+/// run against the genuine engine, not an in-memory fake.
+#[tokio::test]
+async fn rds_data_api_transactions_and_batch() {
+    let server = TestServer::start().await;
+    let rds = server.rds_client().await;
+
+    rds.create_db_instance()
+        .db_instance_identifier("rdsdata-txn")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .expect("create postgres instance");
+
+    let instance = helpers::wait_for_db_available(&rds, "rdsdata-txn", 240).await;
+    let arn = instance
+        .db_instance_arn()
+        .expect("db instance arn")
+        .to_string();
+
+    let data = aws_sdk_rdsdata::Client::new(&server.aws_config().await);
+    let secret = "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-AbCdEf";
+
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("CREATE TABLE accounts (id int, name text)")
+        .send()
+        .await
+        .expect("create table");
+
+    // A transaction that is rolled back leaves no trace.
+    let tx = data
+        .begin_transaction()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .send()
+        .await
+        .expect("begin transaction");
+    let txid = tx.transaction_id().expect("transaction id").to_string();
+    assert!(!txid.is_empty(), "transaction id is non-empty");
+
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .transaction_id(&txid)
+        .sql("INSERT INTO accounts (id, name) VALUES (:id, :name)")
+        .parameters(param("id", Field::LongValue(1)))
+        .parameters(param("name", Field::StringValue("rollme".into())))
+        .send()
+        .await
+        .expect("insert in transaction");
+
+    data.rollback_transaction()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .transaction_id(&txid)
+        .send()
+        .await
+        .expect("rollback");
+
+    let after_rollback = data
+        .execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("SELECT id FROM accounts")
+        .send()
+        .await
+        .expect("select after rollback");
+    assert_eq!(
+        after_rollback.records().len(),
+        0,
+        "rolled-back insert left no rows"
+    );
+
+    // A BatchExecuteStatement committed inside a transaction persists every set.
+    let tx2 = data
+        .begin_transaction()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .send()
+        .await
+        .expect("begin transaction 2");
+    let txid2 = tx2.transaction_id().expect("transaction id 2").to_string();
+
+    let batch = data
+        .batch_execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .transaction_id(&txid2)
+        .sql("INSERT INTO accounts (id, name) VALUES (:id, :name)")
+        .parameter_sets(vec![
+            param("id", Field::LongValue(10)),
+            param("name", Field::StringValue("alice".into())),
+        ])
+        .parameter_sets(vec![
+            param("id", Field::LongValue(20)),
+            param("name", Field::StringValue("bob".into())),
+        ])
+        .send()
+        .await
+        .expect("batch execute in transaction");
+    assert_eq!(
+        batch.update_results().len(),
+        2,
+        "one update result per parameter set"
+    );
+
+    data.commit_transaction()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .transaction_id(&txid2)
+        .send()
+        .await
+        .expect("commit");
+
+    let committed = data
+        .execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("SELECT id, name FROM accounts ORDER BY id")
+        .send()
+        .await
+        .expect("select after commit");
+    let records = committed.records();
+    assert_eq!(records.len(), 2, "both batch rows committed");
+    assert_eq!(records[0][0].as_long_value().ok(), Some(&10));
+    assert_eq!(
+        records[1][1].as_string_value().map(String::as_str).ok(),
+        Some("bob")
+    );
+}

--- a/crates/fakecloud-rds-data/Cargo.toml
+++ b/crates/fakecloud-rds-data/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = { workspace = true }
 mysql_async = "0.34"
+rand = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/fakecloud-rds-data/src/service.rs
+++ b/crates/fakecloud-rds-data/src/service.rs
@@ -1,8 +1,11 @@
 //! RDS Data API (`rds-data`) restJson1 dispatch + real SQL execution.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use http::{Method, StatusCode};
 use serde_json::{json, Map, Value};
+use tokio::sync::Mutex;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_rds::SharedRdsState;
@@ -27,13 +30,26 @@ struct DbConn {
     db_name: String,
 }
 
+/// A live connection held open across requests for the lifetime of a
+/// transaction, keyed by `transactionId`. Postgres drives its connection on a
+/// spawned task that lives as long as the `Client`; MySQL owns its socket.
+enum HeldConn {
+    Pg(tokio_postgres::Client),
+    MySql(mysql_async::Conn),
+}
+
 pub struct RdsDataService {
     rds_state: SharedRdsState,
+    /// Open transactions: `transactionId` -> the connection running its `BEGIN`.
+    transactions: Mutex<HashMap<String, HeldConn>>,
 }
 
 impl RdsDataService {
     pub fn new(rds_state: SharedRdsState) -> Self {
-        Self { rds_state }
+        Self {
+            rds_state,
+            transactions: Mutex::new(HashMap::new()),
+        }
     }
 
     /// Map the restJson1 request (`POST /<Op>`) to its operation name.
@@ -77,21 +93,32 @@ impl RdsDataService {
         })
     }
 
-    async fn execute_statement(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let body = req.json_body();
+    /// Common front-matter for the credentialed ops: validate `secretArn` and
+    /// resolve the `resourceArn` to a connection.
+    fn require_conn(&self, req: &AwsRequest, body: &Value) -> Result<DbConn, AwsServiceError> {
         let resource_arn = body
             .get("resourceArn")
             .and_then(Value::as_str)
             .ok_or_else(|| bad_request("resourceArn is required"))?;
-        let sql = body
-            .get("sql")
-            .and_then(Value::as_str)
-            .ok_or_else(|| bad_request("sql is required"))?;
         // secretArn is required by AWS but fakecloud trusts the resourceArn for
         // credential resolution (the secret would carry the same master creds).
         if body.get("secretArn").and_then(Value::as_str).is_none() {
             return Err(bad_request("secretArn is required"));
         }
+        self.resolve_conn(&req.account_id, resource_arn)
+            .ok_or_else(|| {
+                bad_request(format!(
+                    "HttpEndpoint is not enabled for resource {resource_arn} (no such DB)"
+                ))
+            })
+    }
+
+    async fn execute_statement(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let sql = body
+            .get("sql")
+            .and_then(Value::as_str)
+            .ok_or_else(|| bad_request("sql is required"))?;
         let include_metadata = body
             .get("includeResultMetadata")
             .and_then(Value::as_bool)
@@ -103,26 +130,165 @@ impl RdsDataService {
             .unwrap_or(false);
         let params = parse_parameters(body.get("parameters"));
 
-        let conn = self
-            .resolve_conn(&req.account_id, resource_arn)
-            .ok_or_else(|| {
-                bad_request(format!(
-                    "HttpEndpoint is not enabled for resource {resource_arn} (no such DB)"
-                ))
-            })?;
+        // Inside a transaction: run on the held connection so the statement
+        // shares the open transaction's visibility and is committed/rolled back
+        // atomically with the others.
+        if let Some(txid) = body.get("transactionId").and_then(Value::as_str) {
+            // Validate the resource still resolves (AWS still checks it), but the
+            // actual execution rides the held connection.
+            self.require_conn(req, &body)?;
+            let mut txns = self.transactions.lock().await;
+            let held = txns.get_mut(txid).ok_or_else(|| not_found_txn(txid))?;
+            let value = match held {
+                HeldConn::Pg(client) => {
+                    pg_run(client, sql, &params, include_metadata, format_json).await?
+                }
+                HeldConn::MySql(conn) => {
+                    my_run(conn, sql, &params, include_metadata, format_json).await?
+                }
+            };
+            return Ok(AwsResponse::ok_json(value));
+        }
 
+        let conn = self.require_conn(req, &body)?;
         let engine = conn.engine.to_lowercase();
-        let result = if engine.contains("postgres") {
-            pg_execute(&conn, sql, &params, include_metadata, format_json).await
-        } else if engine.contains("mysql") || engine.contains("maria") {
-            mysql_execute(&conn, sql, &params, include_metadata, format_json).await
+        let value = if engine.contains("postgres") {
+            let client = pg_connect(&conn).await?;
+            pg_run(&client, sql, &params, include_metadata, format_json).await?
+        } else if is_mysql(&engine) {
+            let mut c = my_connect(&conn).await?;
+            let v = my_run(&mut c, sql, &params, include_metadata, format_json).await;
+            let _ = c.disconnect().await;
+            v?
         } else {
-            return Err(bad_request(format!(
-                "RDS Data API is not supported for engine {}",
-                conn.engine
-            )));
+            return Err(unsupported_engine(&conn.engine));
         };
-        result.map(AwsResponse::ok_json)
+        Ok(AwsResponse::ok_json(value))
+    }
+
+    async fn begin_transaction(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let conn = self.require_conn(req, &body)?;
+        let engine = conn.engine.to_lowercase();
+
+        let held = if engine.contains("postgres") {
+            let client = pg_connect(&conn).await?;
+            client
+                .batch_execute("BEGIN")
+                .await
+                .map_err(|e| bad_request(format!("could not begin transaction: {e}")))?;
+            HeldConn::Pg(client)
+        } else if is_mysql(&engine) {
+            use mysql_async::prelude::Queryable;
+            let mut c = my_connect(&conn).await?;
+            c.query_drop("START TRANSACTION")
+                .await
+                .map_err(|e| bad_request(format!("could not begin transaction: {e}")))?;
+            HeldConn::MySql(c)
+        } else {
+            return Err(unsupported_engine(&conn.engine));
+        };
+
+        let txid = gen_transaction_id();
+        self.transactions.lock().await.insert(txid.clone(), held);
+        Ok(AwsResponse::ok_json(json!({ "transactionId": txid })))
+    }
+
+    /// Shared body for Commit/Rollback: pull the held connection out of the map
+    /// and run the terminal SQL on it.
+    async fn finish_transaction(
+        &self,
+        req: &AwsRequest,
+        sql_keyword: &str,
+        status: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let txid = body
+            .get("transactionId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| bad_request("transactionId is required"))?;
+        let held = self
+            .transactions
+            .lock()
+            .await
+            .remove(txid)
+            .ok_or_else(|| not_found_txn(txid))?;
+        match held {
+            HeldConn::Pg(client) => {
+                client
+                    .batch_execute(sql_keyword)
+                    .await
+                    .map_err(|e| bad_request(format!("{e}")))?;
+            }
+            HeldConn::MySql(mut conn) => {
+                use mysql_async::prelude::Queryable;
+                conn.query_drop(sql_keyword)
+                    .await
+                    .map_err(|e| bad_request(format!("{e}")))?;
+                let _ = conn.disconnect().await;
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({ "transactionStatus": status })))
+    }
+
+    async fn batch_execute_statement(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let sql = body
+            .get("sql")
+            .and_then(Value::as_str)
+            .ok_or_else(|| bad_request("sql is required"))?;
+        let sets = parse_parameter_sets(body.get("parameterSets"));
+
+        // Run every parameter set on one connection so the whole batch shares a
+        // transaction when `transactionId` is given.
+        if let Some(txid) = body.get("transactionId").and_then(Value::as_str) {
+            self.require_conn(req, &body)?;
+            let mut txns = self.transactions.lock().await;
+            let held = txns.get_mut(txid).ok_or_else(|| not_found_txn(txid))?;
+            let mut results = Vec::with_capacity(sets.len().max(1));
+            match held {
+                HeldConn::Pg(client) => {
+                    for set in run_each(&sets) {
+                        pg_run(client, sql, set, false, false).await?;
+                        results.push(json!({ "generatedFields": [] }));
+                    }
+                }
+                HeldConn::MySql(conn) => {
+                    for set in run_each(&sets) {
+                        my_run(conn, sql, set, false, false).await?;
+                        results.push(json!({ "generatedFields": [] }));
+                    }
+                }
+            }
+            return Ok(AwsResponse::ok_json(json!({ "updateResults": results })));
+        }
+
+        let conn = self.require_conn(req, &body)?;
+        let engine = conn.engine.to_lowercase();
+        let mut results = Vec::with_capacity(sets.len().max(1));
+        if engine.contains("postgres") {
+            let client = pg_connect(&conn).await?;
+            for set in run_each(&sets) {
+                pg_run(&client, sql, set, false, false).await?;
+                results.push(json!({ "generatedFields": [] }));
+            }
+        } else if is_mysql(&engine) {
+            let mut c = my_connect(&conn).await?;
+            for set in run_each(&sets) {
+                if let Err(e) = my_run(&mut c, sql, set, false, false).await {
+                    let _ = c.disconnect().await;
+                    return Err(e);
+                }
+                results.push(json!({ "generatedFields": [] }));
+            }
+            let _ = c.disconnect().await;
+        } else {
+            return Err(unsupported_engine(&conn.engine));
+        }
+        Ok(AwsResponse::ok_json(json!({ "updateResults": results })))
     }
 }
 
@@ -146,12 +312,23 @@ impl AwsService for RdsDataService {
         };
         match action {
             "ExecuteStatement" => self.execute_statement(&req).await,
-            // Transactions + batch land in a later batch; return an honest
-            // not-implemented rather than a fake success.
+            "BatchExecuteStatement" => self.batch_execute_statement(&req).await,
+            "BeginTransaction" => self.begin_transaction(&req).await,
+            "CommitTransaction" => {
+                self.finish_transaction(&req, "COMMIT", "Transaction Committed")
+                    .await
+            }
+            "RollbackTransaction" => {
+                self.finish_transaction(&req, "ROLLBACK", "Rollback Complete")
+                    .await
+            }
+            // ExecuteSql is the deprecated, secret-less precursor to
+            // ExecuteStatement and was removed from the public API. Return an
+            // honest error rather than a fake success.
             other => Err(AwsServiceError::aws_error(
-                StatusCode::NOT_IMPLEMENTED,
+                StatusCode::BAD_REQUEST,
                 "BadRequestException",
-                format!("rds-data operation {other} is not yet implemented"),
+                format!("rds-data operation {other} is not supported"),
             )),
         }
     }
@@ -159,6 +336,30 @@ impl AwsService for RdsDataService {
 
 fn bad_request(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "BadRequestException", msg.into())
+}
+
+fn not_found_txn(txid: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "BadRequestException",
+        format!("Transaction {txid} is not found"),
+    )
+}
+
+fn unsupported_engine(engine: &str) -> AwsServiceError {
+    bad_request(format!("RDS Data API is not supported for engine {engine}"))
+}
+
+fn is_mysql(engine_lower: &str) -> bool {
+    engine_lower.contains("mysql") || engine_lower.contains("maria")
+}
+
+/// AWS transaction ids are long opaque base64-ish tokens; mirror the shape.
+fn gen_transaction_id() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 48];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    b64_encode(&bytes)
 }
 
 /// The host fakecloud's RDS containers are reachable at (sibling-container aware).
@@ -178,8 +379,10 @@ enum SqlValue {
     Blob(Vec<u8>),
 }
 
+type Params = Vec<(String, SqlValue)>;
+
 /// Parse `parameters[]` into `(name, value)` pairs in request order.
-fn parse_parameters(params: Option<&Value>) -> Vec<(String, SqlValue)> {
+fn parse_parameters(params: Option<&Value>) -> Params {
     let Some(arr) = params.and_then(Value::as_array) else {
         return Vec::new();
     };
@@ -206,6 +409,24 @@ fn parse_parameters(params: Option<&Value>) -> Vec<(String, SqlValue)> {
             Some((name, sv))
         })
         .collect()
+}
+
+/// Parse `parameterSets` (a list of parameter lists) for BatchExecuteStatement.
+fn parse_parameter_sets(sets: Option<&Value>) -> Vec<Params> {
+    let Some(arr) = sets.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    arr.iter().map(|s| parse_parameters(Some(s))).collect()
+}
+
+/// A batch with no parameter sets still runs the statement once (AWS treats an
+/// empty `parameterSets` as a single parameterless execution).
+fn run_each(sets: &[Params]) -> Vec<&[(String, SqlValue)]> {
+    if sets.is_empty() {
+        vec![&[]]
+    } else {
+        sets.iter().map(Vec::as_slice).collect()
+    }
 }
 
 /// Substitute AWS `:name` named placeholders with the SQL literal rendering of
@@ -296,15 +517,8 @@ fn is_ident_char(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_'
 }
 
-async fn pg_execute(
-    conn: &DbConn,
-    sql: &str,
-    params: &[(String, SqlValue)],
-    include_metadata: bool,
-    format_json: bool,
-) -> Result<Value, AwsServiceError> {
+async fn pg_connect(conn: &DbConn) -> Result<tokio_postgres::Client, AwsServiceError> {
     use tokio_postgres::NoTls;
-
     let cs = format!(
         "host={} port={} user={} password={} dbname={}",
         conn.host, conn.port, conn.user, conn.password, conn.db_name
@@ -315,7 +529,16 @@ async fn pg_execute(
     tokio::spawn(async move {
         let _ = connection.await;
     });
+    Ok(client)
+}
 
+async fn pg_run(
+    client: &tokio_postgres::Client,
+    sql: &str,
+    params: &[(String, SqlValue)],
+    include_metadata: bool,
+    format_json: bool,
+) -> Result<Value, AwsServiceError> {
     let stmt = inline_params(sql, params, pg_literal);
     let no_params: &[&(dyn tokio_postgres::types::ToSql + Sync)] = &[];
 
@@ -421,25 +644,28 @@ fn pg_field(row: &tokio_postgres::Row, i: usize, ty: &tokio_postgres::types::Typ
     }
 }
 
-async fn mysql_execute(
-    conn: &DbConn,
-    sql: &str,
-    params: &[(String, SqlValue)],
-    include_metadata: bool,
-    format_json: bool,
-) -> Result<Value, AwsServiceError> {
-    use mysql_async::prelude::*;
-    use mysql_async::{Column, OptsBuilder, Row};
-
+async fn my_connect(conn: &DbConn) -> Result<mysql_async::Conn, AwsServiceError> {
+    use mysql_async::OptsBuilder;
     let opts = OptsBuilder::default()
         .ip_or_hostname(conn.host.as_str())
         .tcp_port(conn.port)
         .user(Some(&conn.user))
         .pass(Some(&conn.password))
         .db_name(Some(&conn.db_name));
-    let mut c = mysql_async::Conn::new(opts)
+    mysql_async::Conn::new(opts)
         .await
-        .map_err(|e| bad_request(format!("could not connect to database: {e}")))?;
+        .map_err(|e| bad_request(format!("could not connect to database: {e}")))
+}
+
+async fn my_run(
+    c: &mut mysql_async::Conn,
+    sql: &str,
+    params: &[(String, SqlValue)],
+    include_metadata: bool,
+    format_json: bool,
+) -> Result<Value, AwsServiceError> {
+    use mysql_async::prelude::Queryable;
+    use mysql_async::{Column, Row};
 
     let stmt = inline_params(sql, params, mysql_literal);
     let rows: Vec<Row> = c
@@ -447,7 +673,6 @@ async fn mysql_execute(
         .await
         .map_err(|e| bad_request(format!("{e}")))?;
     let affected = c.affected_rows();
-    let _ = c.disconnect().await;
 
     let mut out = Map::new();
     if rows.is_empty() {

--- a/website/content/docs/services/rds-data.md
+++ b/website/content/docs/services/rds-data.md
@@ -18,17 +18,20 @@ real query.
 - **Typed parameters** — `:name` named parameters with `stringValue`,
   `longValue`, `doubleValue`, `booleanValue`, `blobValue`, and `isNull`,
   coerced to the column's real type.
-- **Typed results** — `records` as typed `Field`s (integers → `longValue`,
-  text → `stringValue`, `bytea`/`BLOB` → `blobValue`, etc.), with optional
+- **Typed results** — `records` as typed `Field`s (integers -> `longValue`,
+  text -> `stringValue`, `bytea`/`BLOB` -> `blobValue`, etc.), with optional
   `columnMetadata` (`includeResultMetadata`) and `formattedRecords`
   (`formatRecordsAs=JSON`). Writes report `numberOfRecordsUpdated`.
 - **Binary round-trips** — a `bytea` / `BLOB` column round-trips through
   `blobValue`, where rival emulators return an empty value.
-
-## Coming next
-
-`BatchExecuteStatement` and transactions (`BeginTransaction` /
-`CommitTransaction` / `RollbackTransaction`) over a held connection.
+- **Transactions** — `BeginTransaction` returns a `transactionId` backed by a
+  real database connection held open across requests. `ExecuteStatement` and
+  `BatchExecuteStatement` calls that pass the `transactionId` run on that same
+  connection, and `CommitTransaction` / `RollbackTransaction` commit or roll
+  back the genuine engine transaction.
+- **BatchExecuteStatement** — runs one statement across many `parameterSets`,
+  returning one `updateResults` entry per set, on a single connection (the
+  transaction's connection when a `transactionId` is given).
 
 ## Example
 
@@ -47,4 +50,17 @@ data.execute_statement(resourceArn=arn, secretArn=secret,
 resp = data.execute_statement(resourceArn=arn, secretArn=secret,
     sql="SELECT id, name FROM t", includeResultMetadata=True)
 # resp["records"] -> [[{"longValue": 1}, {"stringValue": "alice"}]]
+```
+
+Transactions and batch writes share one held connection:
+
+```python
+tx = data.begin_transaction(resourceArn=arn, secretArn=secret)["transactionId"]
+data.batch_execute_statement(resourceArn=arn, secretArn=secret, transactionId=tx,
+    sql="INSERT INTO t (id, name) VALUES (:id, :name)",
+    parameterSets=[
+        [{"name": "id", "value": {"longValue": 2}}, {"name": "name", "value": {"stringValue": "bob"}}],
+        [{"name": "id", "value": {"longValue": 3}}, {"name": "name", "value": {"stringValue": "carol"}}],
+    ])
+data.commit_transaction(resourceArn=arn, secretArn=secret, transactionId=tx)
 ```


### PR DESCRIPTION
Batch 2 of the RDS Data API (`rds-data`) service. Adds the transaction and batch operations on top of batch 1's `ExecuteStatement`.

## What's new
- **BeginTransaction** opens a real DB connection, runs `BEGIN` / `START TRANSACTION`, and holds it open keyed by a generated `transactionId`.
- **ExecuteStatement / BatchExecuteStatement** with a `transactionId` run on that same held connection, sharing the open transaction's visibility.
- **CommitTransaction / RollbackTransaction** issue `COMMIT` / `ROLLBACK` on the held connection and release it.
- **BatchExecuteStatement** runs one statement across every `parameterSet` on a single connection, returning one `updateResults` entry per set.

The pg/mysql execution paths are split into `connect` + `run` helpers so the same typed-result code serves both the autocommit (fresh connection) and transaction (held connection) cases.

## Tests
New Docker-gated e2e (`rds_data_api_transactions_and_batch`): a rolled-back insert leaves zero rows, then a batch insert committed inside a transaction persists both rows, against a real Postgres container. Passes locally.

## Docs
`website/content/docs/services/rds-data.md` updated: transactions + batch moved from "Coming next" to supported, with a batch-in-transaction example.

Builds clean; `clippy --all-targets -D warnings` clean; fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds transactions and `BatchExecuteStatement` to the RDS Data API, backed by real held DB connections for correct visibility and commit/rollback behavior.
`ExecuteStatement` and `BatchExecuteStatement` now accept a `transactionId` and run on the same connection.

- **New Features**
  - `BeginTransaction` opens a real connection and starts a transaction; `CommitTransaction` and `RollbackTransaction` finalize it and release the connection.
  - `ExecuteStatement`/`BatchExecuteStatement` with `transactionId` run on the held connection and share transaction visibility.
  - `BatchExecuteStatement` runs the SQL once per `parameterSet` and returns one `updateResults` item per set (empty sets run once).
  - Split Postgres/MySQL paths into connect + run helpers; reuse existing typed results logic. Added e2e test and updated docs.

- **Dependencies**
  - Add `rand` for generating opaque `transactionId`s.

<sup>Written for commit f96c1ae504ea265211289233b55154f8799aecfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

