### PR TITLE
feat(rds-data): typed-result fidelity for rich column types (batch 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,16 +4152,19 @@ version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "chrono",
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-rds",
  "http 1.4.0",
  "mysql_async",
  "rand 0.8.5",
+ "rust_decimal",
  "serde",
  "serde_json",
  "tokio",
  "tokio-postgres",
+ "uuid",
 ]
 
 [[package]]
@@ -6660,8 +6663,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
+ "chrono",
  "fallible-iterator",
  "postgres-protocol",
+ "serde_core",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -7188,6 +7195,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
+ "postgres-types",
  "rand 0.8.5",
  "rkyv",
  "serde",

--- a/crates/fakecloud-e2e/tests/rds_data_api.rs
+++ b/crates/fakecloud-e2e/tests/rds_data_api.rs
@@ -234,3 +234,86 @@ async fn rds_data_api_transactions_and_batch() {
         Some("bob")
     );
 }
+
+/// Non-scalar Postgres column types (NUMERIC, TIMESTAMP, UUID, JSONB) come back
+/// as AWS `stringValue` rather than silently collapsing to `isNull` (which is
+/// what happens when these binary-format columns hit a `String` decode).
+#[tokio::test]
+async fn rds_data_api_decodes_rich_column_types() {
+    let server = TestServer::start().await;
+    let rds = server.rds_client().await;
+
+    rds.create_db_instance()
+        .db_instance_identifier("rdsdata-types")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .expect("create postgres instance");
+
+    let instance = helpers::wait_for_db_available(&rds, "rdsdata-types", 240).await;
+    let arn = instance
+        .db_instance_arn()
+        .expect("db instance arn")
+        .to_string();
+
+    let data = aws_sdk_rdsdata::Client::new(&server.aws_config().await);
+    let secret = "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-AbCdEf";
+
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("CREATE TABLE rich (n numeric(10,2), ts timestamp, u uuid, j jsonb)")
+        .send()
+        .await
+        .expect("create table");
+
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql(
+            "INSERT INTO rich VALUES (123.45, '2024-01-02 03:04:05', \
+             '550e8400-e29b-41d4-a716-446655440000', '{\"k\": \"v\"}')",
+        )
+        .send()
+        .await
+        .expect("insert rich types");
+
+    let resp = data
+        .execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("SELECT n, ts, u, j FROM rich")
+        .send()
+        .await
+        .expect("select rich");
+
+    let records = resp.records();
+    assert_eq!(records.len(), 1);
+    let row = &records[0];
+    assert_eq!(
+        row[0].as_string_value().map(String::as_str).ok(),
+        Some("123.45"),
+        "numeric -> stringValue"
+    );
+    assert_eq!(
+        row[1].as_string_value().map(String::as_str).ok(),
+        Some("2024-01-02 03:04:05"),
+        "timestamp -> stringValue"
+    );
+    assert_eq!(
+        row[2].as_string_value().map(String::as_str).ok(),
+        Some("550e8400-e29b-41d4-a716-446655440000"),
+        "uuid -> stringValue"
+    );
+    assert_eq!(
+        row[3].as_string_value().map(String::as_str).ok(),
+        Some("{\"k\":\"v\"}"),
+        "jsonb -> stringValue (compact JSON)"
+    );
+}

--- a/crates/fakecloud-rds-data/Cargo.toml
+++ b/crates/fakecloud-rds-data/Cargo.toml
@@ -17,9 +17,16 @@ http = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-tokio-postgres = { workspace = true }
+tokio-postgres = { workspace = true, features = [
+    "with-chrono-0_4",
+    "with-uuid-1",
+    "with-serde_json-1",
+] }
 mysql_async = "0.34"
 rand = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/fakecloud-rds-data/src/service.rs
+++ b/crates/fakecloud-rds-data/src/service.rs
@@ -609,6 +609,17 @@ async fn pg_run(
     Ok(Value::Object(out))
 }
 
+/// Append a fractional-seconds suffix only when non-zero, with trailing zeros
+/// trimmed, matching Postgres's own `timestamp::text` rendering.
+fn pg_timestamp_text(base: impl std::fmt::Display, micros: u32) -> String {
+    if micros == 0 {
+        return base.to_string();
+    }
+    let frac = format!("{micros:06}");
+    let frac = frac.trim_end_matches('0');
+    format!("{base}.{frac}")
+}
+
 fn pg_field(row: &tokio_postgres::Row, i: usize, ty: &tokio_postgres::types::Type) -> Value {
     use tokio_postgres::types::Type;
     macro_rules! opt {
@@ -620,6 +631,20 @@ fn pg_field(row: &tokio_postgres::Row, i: usize, ty: &tokio_postgres::types::Typ
             }
         }};
     }
+    // Types that AWS surfaces as `stringValue` (numeric/decimal, temporal,
+    // UUID, JSON): decode them with their real Rust representation and render
+    // the canonical text, rather than letting them fall through to the
+    // `String` arm — which fails for these binary-format columns and would
+    // wrongly report `isNull`.
+    macro_rules! strv {
+        ($t:ty, $conv:expr) => {{
+            let v: Option<$t> = row.try_get(i).unwrap_or(None);
+            match v {
+                Some(x) => json!({ "stringValue": $conv(x) }),
+                None => json!({ "isNull": true }),
+            }
+        }};
+    }
     match *ty {
         Type::BOOL => opt!(bool, "booleanValue", |x| x),
         Type::INT2 => opt!(i16, "longValue", |x| x as i64),
@@ -627,6 +652,27 @@ fn pg_field(row: &tokio_postgres::Row, i: usize, ty: &tokio_postgres::types::Typ
         Type::INT8 => opt!(i64, "longValue", |x: i64| x),
         Type::FLOAT4 => opt!(f32, "doubleValue", |x| x as f64),
         Type::FLOAT8 => opt!(f64, "doubleValue", |x: f64| x),
+        Type::NUMERIC => strv!(rust_decimal::Decimal, |d: rust_decimal::Decimal| d
+            .to_string()),
+        Type::UUID => strv!(uuid::Uuid, |u: uuid::Uuid| u.to_string()),
+        Type::JSON | Type::JSONB => {
+            strv!(serde_json::Value, |j: serde_json::Value| j.to_string())
+        }
+        Type::TIMESTAMP => strv!(chrono::NaiveDateTime, |t: chrono::NaiveDateTime| {
+            pg_timestamp_text(
+                t.format("%Y-%m-%d %H:%M:%S"),
+                t.and_utc().timestamp_subsec_micros(),
+            )
+        }),
+        Type::TIMESTAMPTZ => strv!(chrono::DateTime<chrono::Utc>, |t: chrono::DateTime<
+            chrono::Utc,
+        >| format!(
+            "{}{}",
+            pg_timestamp_text(t.format("%Y-%m-%d %H:%M:%S"), t.timestamp_subsec_micros()),
+            t.format("%:z")
+        )),
+        Type::DATE => strv!(chrono::NaiveDate, |d: chrono::NaiveDate| d.to_string()),
+        Type::TIME => strv!(chrono::NaiveTime, |t: chrono::NaiveTime| t.to_string()),
         Type::BYTEA => {
             let v: Option<Vec<u8>> = row.try_get(i).unwrap_or(None);
             match v {
@@ -737,7 +783,48 @@ fn my_field(row: &mysql_async::Row, i: usize) -> Value {
             Ok(s) => json!({ "stringValue": s }),
             Err(_) => json!({ "blobValue": b64_encode(b) }),
         },
-        Some(other) => json!({ "stringValue": format!("{other:?}") }),
+        // Temporal columns arrive as typed Date/Time values under the binary
+        // protocol; render the canonical SQL text instead of the debug form.
+        Some(V::Date(y, mo, d, h, mi, s, us)) => {
+            json!({ "stringValue": format_mysql_datetime(*y, *mo, *d, *h, *mi, *s, *us) })
+        }
+        Some(V::Time(neg, days, h, mi, s, us)) => {
+            json!({ "stringValue": format_mysql_time(*neg, *days, *h, *mi, *s, *us) })
+        }
+    }
+}
+
+/// Render a MySQL `DATE`/`DATETIME`/`TIMESTAMP` value as canonical SQL text,
+/// dropping the time portion for a pure date.
+#[allow(clippy::too_many_arguments)]
+fn format_mysql_datetime(
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    min: u8,
+    sec: u8,
+    micros: u32,
+) -> String {
+    let date = format!("{year:04}-{month:02}-{day:02}");
+    if hour == 0 && min == 0 && sec == 0 && micros == 0 {
+        return date;
+    }
+    if micros == 0 {
+        format!("{date} {hour:02}:{min:02}:{sec:02}")
+    } else {
+        format!("{date} {hour:02}:{min:02}:{sec:02}.{micros:06}")
+    }
+}
+
+/// Render a MySQL `TIME` value (a signed duration) as canonical SQL text.
+fn format_mysql_time(neg: bool, days: u32, hours: u8, mins: u8, secs: u8, micros: u32) -> String {
+    let sign = if neg { "-" } else { "" };
+    let total_hours = days * 24 + hours as u32;
+    if micros == 0 {
+        format!("{sign}{total_hours:02}:{mins:02}:{secs:02}")
+    } else {
+        format!("{sign}{total_hours:02}:{mins:02}:{secs:02}.{micros:06}")
     }
 }
 


### PR DESCRIPTION
Batch 3 of the RDS Data API (`rds-data`). Closes the typed-result gap for non-scalar column types.

## Problem
`ExecuteStatement` decoded BOOL/INT/FLOAT/BYTEA/text correctly, but every other Postgres column (NUMERIC, TIMESTAMP, TIMESTAMPTZ, DATE, TIME, UUID, JSON/JSONB) fell through to the `String` decode arm. Those columns use a binary wire format that does not decode as `String`, so `try_get` failed and the field was silently reported as `isNull` — a real value disappearing from the result set.

## Fix
- Postgres: decode NUMERIC (`rust_decimal::Decimal`), TIMESTAMP/TIMESTAMPTZ/DATE/TIME (`chrono`), UUID (`uuid`), JSON/JSONB (`serde_json::Value`) and render each as AWS `stringValue`. Timestamps use Postgres's own canonical text (fractional seconds only when present, trailing zeros trimmed).
- MySQL: format `Date`/`Time` protocol values as canonical SQL text instead of the Rust debug form.
- `tokio-postgres` gains `with-chrono-0_4` / `with-uuid-1` / `with-serde_json-1`; adds `rust_decimal` (`db-tokio-postgres`).

## Tests
New Docker-gated e2e (`rds_data_api_decodes_rich_column_types`): inserts NUMERIC/TIMESTAMP/UUID/JSONB and asserts each comes back as the expected `stringValue` against a real Postgres container. Passes locally; the existing typed-param and transaction tests still pass.

Builds clean; `clippy --all-targets -D warnings` clean; fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes typed-result gaps in `rds-data` `ExecuteStatement` by correctly decoding Postgres NUMERIC/TIMESTAMP/TIMESTAMPTZ/DATE/TIME/UUID/JSON(B) to AWS `stringValue`, and by rendering MySQL DATE/DATETIME/TIME as canonical SQL text. Prevents real values from collapsing to `isNull` and improves result fidelity.

- **Bug Fixes**
  - Postgres: decode via `rust_decimal`, `chrono`, `uuid`, and `serde_json`; timestamps use Postgres-style text with trimmed fractional seconds and timezone for `TIMESTAMPTZ`.
  - MySQL: output canonical SQL text for `DATE`/`DATETIME`/`TIME` (includes sign and microseconds) instead of Rust debug forms.
  - Removes the fallback `String` decode path that caused binary columns to return `isNull`.

- **Dependencies**
  - Enable `tokio-postgres` features: `with-chrono-0_4`, `with-uuid-1`, `with-serde_json-1`.
  - Add `rust_decimal` (feature `db-tokio-postgres`), plus `chrono` and `uuid`.

<sup>Written for commit 174f676bc8adfb0681a5ebff4a1763da212f4a64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

