### PR TITLE
fix(rds-data): UTF-8 SQL, k8s host, database param, txn reaper, typed MySQL results

### DIFF
--- a/crates/fakecloud-e2e/tests/rds_data_api.rs
+++ b/crates/fakecloud-e2e/tests/rds_data_api.rs
@@ -317,3 +317,194 @@ async fn rds_data_api_decodes_rich_column_types() {
         "jsonb -> stringValue (compact JSON)"
     );
 }
+
+/// Non-ASCII SQL (multi-byte UTF-8 literals and string parameters) must reach
+/// the engine intact rather than being byte-cast into Latin-1 mojibake, and the
+/// `database` request override must route the statement to the named database.
+#[tokio::test]
+async fn rds_data_api_utf8_literals_and_database_override() {
+    let server = TestServer::start().await;
+    let rds = server.rds_client().await;
+
+    rds.create_db_instance()
+        .db_instance_identifier("rdsdata-utf8")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .expect("create postgres instance");
+
+    let instance = helpers::wait_for_db_available(&rds, "rdsdata-utf8", 240).await;
+    let arn = instance
+        .db_instance_arn()
+        .expect("db instance arn")
+        .to_string();
+
+    let data = aws_sdk_rdsdata::Client::new(&server.aws_config().await);
+    let secret = "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-AbCdEf";
+
+    // A multi-byte literal embedded directly in the SQL text.
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("CREATE TABLE u (id int, name text)")
+        .send()
+        .await
+        .expect("create table");
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("INSERT INTO u (id, name) VALUES (1, 'café 日本 €')")
+        .send()
+        .await
+        .expect("insert literal");
+    // A multi-byte string parameter.
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("INSERT INTO u (id, name) VALUES (2, :name)")
+        .parameters(param("name", Field::StringValue("naïve Ωmega".into())))
+        .send()
+        .await
+        .expect("insert param");
+
+    let resp = data
+        .execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("SELECT name FROM u ORDER BY id")
+        .send()
+        .await
+        .expect("select utf8");
+    let records = resp.records();
+    assert_eq!(
+        records[0][0].as_string_value().map(String::as_str).ok(),
+        Some("café 日本 €"),
+        "multi-byte literal round-trips intact (not mojibake)"
+    );
+    assert_eq!(
+        records[1][0].as_string_value().map(String::as_str).ok(),
+        Some("naïve Ωmega"),
+        "multi-byte string parameter round-trips intact"
+    );
+
+    // `database` override: create a second database and route statements to it.
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("CREATE DATABASE otherdb")
+        .send()
+        .await
+        .expect("create database");
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .database("otherdb")
+        .sql("CREATE TABLE only_here (id int)")
+        .send()
+        .await
+        .expect("create table in otherdb");
+
+    // The table exists in otherdb...
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .database("otherdb")
+        .sql("SELECT count(*) FROM only_here")
+        .send()
+        .await
+        .expect("table visible in otherdb");
+    // ...and NOT in the default database (proving the override actually routed).
+    let in_default = data
+        .execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("SELECT count(*) FROM only_here")
+        .send()
+        .await;
+    assert!(
+        in_default.is_err(),
+        "table created via database=otherdb must not exist in the default db"
+    );
+}
+
+/// MySQL path: a real INSERT returns the auto-increment key in `generatedFields`
+/// (as AWS Aurora MySQL does), and typed values round-trip through the Data API.
+#[tokio::test]
+async fn rds_data_api_mysql_generated_fields() {
+    let server = TestServer::start().await;
+    let rds = server.rds_client().await;
+
+    rds.create_db_instance()
+        .db_instance_identifier("rdsdata-mysql")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("mysql")
+        .engine_version("8.0")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .expect("create mysql instance");
+
+    let instance = helpers::wait_for_db_available(&rds, "rdsdata-mysql", 300).await;
+    let arn = instance
+        .db_instance_arn()
+        .expect("db instance arn")
+        .to_string();
+
+    let data = aws_sdk_rdsdata::Client::new(&server.aws_config().await);
+    let secret = "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-AbCdEf";
+
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("CREATE TABLE m (id int AUTO_INCREMENT PRIMARY KEY, name text)")
+        .send()
+        .await
+        .expect("create table");
+
+    let insert = data
+        .execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("INSERT INTO m (name) VALUES (:name)")
+        .parameters(param("name", Field::StringValue("widget".into())))
+        .send()
+        .await
+        .expect("insert");
+    assert_eq!(insert.number_of_records_updated(), 1);
+
+    let resp = data
+        .execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("SELECT id, name FROM m")
+        .send()
+        .await
+        .expect("select");
+    let records = resp.records();
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records[0][0].as_long_value().ok(),
+        Some(&1),
+        "auto-increment produced id 1"
+    );
+    assert_eq!(
+        records[0][1].as_string_value().map(String::as_str).ok(),
+        Some("widget")
+    );
+
+    let generated = insert.generated_fields();
+    assert_eq!(
+        generated.first().and_then(|f| f.as_long_value().ok()),
+        Some(&1),
+        "MySQL INSERT returns the auto-increment id in generatedFields"
+    );
+}

--- a/crates/fakecloud-rds-data/src/service.rs
+++ b/crates/fakecloud-rds-data/src/service.rs
@@ -1,11 +1,14 @@
 //! RDS Data API (`rds-data`) restJson1 dispatch + real SQL execution.
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 
 use async_trait::async_trait;
 use http::{Method, StatusCode};
 use serde_json::{json, Map, Value};
 use tokio::sync::Mutex;
+use tokio::time::{Duration, Instant};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_rds::SharedRdsState;
@@ -19,6 +22,13 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "ExecuteSql",
 ];
 
+/// Idle transactions are rolled back and their connection released after this
+/// long with no statement, mirroring the AWS RDS Data API's ~3-minute idle
+/// transaction timeout. Without this, a client that begins a transaction and
+/// never commits (crash, dropped handle) would leak a backing DB connection
+/// forever, eventually exhausting the container's `max_connections`.
+const TXN_IDLE_TIMEOUT: Duration = Duration::from_secs(180);
+
 /// Connection parameters captured from a resolved `DbInstance` (owned so the
 /// state read-lock is dropped before we touch the network).
 struct DbConn {
@@ -28,27 +38,58 @@ struct DbConn {
     user: String,
     password: String,
     db_name: String,
+    /// Optional schema (`search_path` on Postgres); ignored on MySQL where the
+    /// schema is the database.
+    schema: Option<String>,
 }
 
 /// A live connection held open across requests for the lifetime of a
-/// transaction, keyed by `transactionId`. Postgres drives its connection on a
-/// spawned task that lives as long as the `Client`; MySQL owns its socket.
+/// transaction. Postgres drives its connection on a spawned task that lives as
+/// long as the `Client`; MySQL owns its socket.
 enum HeldConn {
     Pg(tokio_postgres::Client),
     MySql(mysql_async::Conn),
 }
 
+/// One open transaction. The connection has its own lock so the global
+/// transactions-map lock is never held across an awaited SQL statement (a slow
+/// statement in one transaction must not block begin/commit/rollback of
+/// another). `last_used` drives the idle reaper.
+struct TxnEntry {
+    /// `None` once the transaction has been committed/rolled-back or reaped.
+    conn: Mutex<Option<HeldConn>>,
+    last_used: StdMutex<Instant>,
+}
+
+impl TxnEntry {
+    fn touch(&self) {
+        if let Ok(mut t) = self.last_used.lock() {
+            *t = Instant::now();
+        }
+    }
+}
+
+type TxnMap = Arc<Mutex<HashMap<String, Arc<TxnEntry>>>>;
+
 pub struct RdsDataService {
     rds_state: SharedRdsState,
-    /// Open transactions: `transactionId` -> the connection running its `BEGIN`.
-    transactions: Mutex<HashMap<String, HeldConn>>,
+    /// Open transactions: `transactionId` -> the held connection running its
+    /// `BEGIN`.
+    transactions: TxnMap,
 }
 
 impl RdsDataService {
     pub fn new(rds_state: SharedRdsState) -> Self {
+        let transactions: TxnMap = Arc::new(Mutex::new(HashMap::new()));
+        // Reap idle transactions so abandoned ones don't leak DB connections.
+        // Only spawn when a tokio runtime is present (it always is in the
+        // server; absent in some unit-test constructions).
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(reap_idle_transactions(transactions.clone()));
+        }
         Self {
             rds_state,
-            transactions: Mutex::new(HashMap::new()),
+            transactions,
         }
     }
 
@@ -85,16 +126,23 @@ impl RdsDataService {
         })?;
         Some(DbConn {
             engine: inst.engine.clone(),
-            host: resolve_db_host(),
+            // Use the address the RDS runtime actually recorded for this
+            // instance (Docker sibling host or k8s Pod IP). Re-deriving a
+            // Docker-only sibling host here would break the k8s backend and
+            // shell out to `docker info` on every request.
+            host: inst.endpoint_address.clone(),
             port: inst.host_port,
             user: inst.master_username.clone(),
             password: inst.master_user_password.clone(),
             db_name: inst.db_name.clone().unwrap_or_default(),
+            schema: None,
         })
     }
 
-    /// Common front-matter for the credentialed ops: validate `secretArn` and
-    /// resolve the `resourceArn` to a connection.
+    /// Common front-matter for the credentialed ops: validate `secretArn`,
+    /// resolve the `resourceArn` to a connection, and apply the request's
+    /// `database`/`schema` overrides (AWS lets a single resource serve many
+    /// databases — Aurora clusters often have no default DB name at all).
     fn require_conn(&self, req: &AwsRequest, body: &Value) -> Result<DbConn, AwsServiceError> {
         let resource_arn = body
             .get("resourceArn")
@@ -105,12 +153,24 @@ impl RdsDataService {
         if body.get("secretArn").and_then(Value::as_str).is_none() {
             return Err(bad_request("secretArn is required"));
         }
-        self.resolve_conn(&req.account_id, resource_arn)
+        let mut conn = self
+            .resolve_conn(&req.account_id, resource_arn)
             .ok_or_else(|| {
                 bad_request(format!(
                     "HttpEndpoint is not enabled for resource {resource_arn} (no such DB)"
                 ))
-            })
+            })?;
+        if let Some(db) = body.get("database").and_then(Value::as_str) {
+            if !db.is_empty() {
+                conn.db_name = db.to_string();
+            }
+        }
+        conn.schema = body
+            .get("schema")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        Ok(conn)
     }
 
     async fn execute_statement(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -137,8 +197,12 @@ impl RdsDataService {
             // Validate the resource still resolves (AWS still checks it), but the
             // actual execution rides the held connection.
             self.require_conn(req, &body)?;
-            let mut txns = self.transactions.lock().await;
-            let held = txns.get_mut(txid).ok_or_else(|| not_found_txn(txid))?;
+            let entry = self.txn_entry(txid).await?;
+            entry.touch();
+            // Lock only this transaction's connection, not the whole map, so a
+            // slow statement here can't block other transactions.
+            let mut guard = entry.conn.lock().await;
+            let held = guard.as_mut().ok_or_else(|| not_found_txn(txid))?;
             let value = match held {
                 HeldConn::Pg(client) => {
                     pg_run(client, sql, &params, include_metadata, format_json).await?
@@ -190,8 +254,23 @@ impl RdsDataService {
         };
 
         let txid = gen_transaction_id();
-        self.transactions.lock().await.insert(txid.clone(), held);
+        let entry = Arc::new(TxnEntry {
+            conn: Mutex::new(Some(held)),
+            last_used: StdMutex::new(Instant::now()),
+        });
+        self.transactions.lock().await.insert(txid.clone(), entry);
         Ok(AwsResponse::ok_json(json!({ "transactionId": txid })))
+    }
+
+    /// Look up an open transaction's entry, cloning the `Arc` so the map lock is
+    /// released before the caller locks the connection itself.
+    async fn txn_entry(&self, txid: &str) -> Result<Arc<TxnEntry>, AwsServiceError> {
+        self.transactions
+            .lock()
+            .await
+            .get(txid)
+            .cloned()
+            .ok_or_else(|| not_found_txn(txid))
     }
 
     /// Shared body for Commit/Rollback: pull the held connection out of the map
@@ -207,27 +286,21 @@ impl RdsDataService {
             .get("transactionId")
             .and_then(Value::as_str)
             .ok_or_else(|| bad_request("transactionId is required"))?;
-        let held = self
+        let entry = self
             .transactions
             .lock()
             .await
             .remove(txid)
             .ok_or_else(|| not_found_txn(txid))?;
-        match held {
-            HeldConn::Pg(client) => {
-                client
-                    .batch_execute(sql_keyword)
-                    .await
-                    .map_err(|e| bad_request(format!("{e}")))?;
-            }
-            HeldConn::MySql(mut conn) => {
-                use mysql_async::prelude::Queryable;
-                conn.query_drop(sql_keyword)
-                    .await
-                    .map_err(|e| bad_request(format!("{e}")))?;
-                let _ = conn.disconnect().await;
-            }
-        }
+        // Take ownership of the connection (waiting for any in-flight statement
+        // on it to finish) and run the terminal SQL.
+        let held = entry
+            .conn
+            .lock()
+            .await
+            .take()
+            .ok_or_else(|| not_found_txn(txid))?;
+        finish_held(held, sql_keyword).await?;
         Ok(AwsResponse::ok_json(json!({ "transactionStatus": status })))
     }
 
@@ -246,8 +319,10 @@ impl RdsDataService {
         // transaction when `transactionId` is given.
         if let Some(txid) = body.get("transactionId").and_then(Value::as_str) {
             self.require_conn(req, &body)?;
-            let mut txns = self.transactions.lock().await;
-            let held = txns.get_mut(txid).ok_or_else(|| not_found_txn(txid))?;
+            let entry = self.txn_entry(txid).await?;
+            entry.touch();
+            let mut guard = entry.conn.lock().await;
+            let held = guard.as_mut().ok_or_else(|| not_found_txn(txid))?;
             let mut results = Vec::with_capacity(sets.len().max(1));
             match held {
                 HeldConn::Pg(client) => {
@@ -362,11 +437,54 @@ fn gen_transaction_id() -> String {
     b64_encode(&bytes)
 }
 
-/// The host fakecloud's RDS containers are reachable at (sibling-container aware).
-fn resolve_db_host() -> String {
-    let cli =
-        fakecloud_core::container_net::detect_container_cli().unwrap_or_else(|| "docker".into());
-    fakecloud_core::container_net::HostNetworking::detect(&cli).sibling_host
+/// Run the terminal SQL (`COMMIT`/`ROLLBACK`) on a connection taken out of a
+/// transaction entry and release it.
+async fn finish_held(held: HeldConn, sql_keyword: &str) -> Result<(), AwsServiceError> {
+    match held {
+        HeldConn::Pg(client) => {
+            client
+                .batch_execute(sql_keyword)
+                .await
+                .map_err(|e| bad_request(format!("{e}")))?;
+        }
+        HeldConn::MySql(mut conn) => {
+            use mysql_async::prelude::Queryable;
+            conn.query_drop(sql_keyword)
+                .await
+                .map_err(|e| bad_request(format!("{e}")))?;
+            let _ = conn.disconnect().await;
+        }
+    }
+    Ok(())
+}
+
+/// Background sweep: roll back and release any transaction idle longer than
+/// [`TXN_IDLE_TIMEOUT`], so an abandoned `BeginTransaction` never leaks its
+/// backing DB connection forever.
+async fn reap_idle_transactions(transactions: TxnMap) {
+    let mut tick = tokio::time::interval(Duration::from_secs(30));
+    loop {
+        tick.tick().await;
+        let now = Instant::now();
+        let stale: Vec<(String, Arc<TxnEntry>)> = {
+            let map = transactions.lock().await;
+            map.iter()
+                .filter(|(_, e)| {
+                    e.last_used
+                        .lock()
+                        .map(|t| now.duration_since(*t) > TXN_IDLE_TIMEOUT)
+                        .unwrap_or(false)
+                })
+                .map(|(id, e)| (id.clone(), e.clone()))
+                .collect()
+        };
+        for (id, entry) in stale {
+            transactions.lock().await.remove(&id);
+            if let Some(held) = entry.conn.lock().await.take() {
+                let _ = finish_held(held, "ROLLBACK").await;
+            }
+        }
+    }
 }
 
 /// A single positional SQL parameter resolved from an AWS `SqlParameter`.
@@ -456,14 +574,28 @@ fn inline_params(
                 continue;
             }
         }
-        out.push(bytes[i] as char);
-        i += 1;
+        // Copy one whole UTF-8 character. `:` and identifier bytes are ASCII, so
+        // the placeholder scan above only ever fires on a char boundary; here we
+        // must advance by the full character width, not a single byte, or
+        // multi-byte literals (e.g. 'café') would be corrupted into mojibake.
+        let ch = sql[i..]
+            .chars()
+            .next()
+            .expect("byte index is on a char boundary");
+        out.push(ch);
+        i += ch.len_utf8();
     }
     out
 }
 
 fn sql_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "''"))
+}
+
+/// Quote an SQL identifier (schema/table name) so a caller-supplied `schema`
+/// can't break out of the `SET search_path` statement.
+fn quote_ident(s: &str) -> String {
+    format!("\"{}\"", s.replace('"', "\"\""))
 }
 
 /// SQL literal for postgres.
@@ -529,6 +661,12 @@ async fn pg_connect(conn: &DbConn) -> Result<tokio_postgres::Client, AwsServiceE
     tokio::spawn(async move {
         let _ = connection.await;
     });
+    if let Some(schema) = &conn.schema {
+        client
+            .batch_execute(&format!("SET search_path TO {}", quote_ident(schema)))
+            .await
+            .map_err(|e| bad_request(format!("could not set schema: {e}")))?;
+    }
     Ok(client)
 }
 
@@ -561,7 +699,11 @@ async fn pg_run(
         .map_err(|e| bad_request(format!("{e}")))?;
     if rows.is_empty() {
         out.insert("numberOfRecordsUpdated".into(), json!(0));
-        out.insert("records".into(), json!([]));
+        if format_json {
+            out.insert("formattedRecords".into(), json!("[]"));
+        } else {
+            out.insert("records".into(), json!([]));
+        }
         return Ok(Value::Object(out));
     }
 
@@ -714,16 +856,49 @@ async fn my_run(
     use mysql_async::{Column, Row};
 
     let stmt = inline_params(sql, params, mysql_literal);
+    let mut out = Map::new();
+
+    // Route writes through `query_drop` so the connection retains the INSERT's
+    // OK packet (and thus `last_insert_id`); `query` collecting rows can leave a
+    // result-set terminator as the last packet.
+    if !returns_rows(&stmt) {
+        c.query_drop(stmt.as_str())
+            .await
+            .map_err(|e| bad_request(format!("{e}")))?;
+        out.insert("numberOfRecordsUpdated".into(), json!(c.affected_rows()));
+        // AWS Aurora MySQL surfaces the auto-increment key in `generatedFields`
+        // (Postgres needs `RETURNING` instead, so its arm omits this). Read it
+        // back explicitly on the same connection — robust across the text
+        // protocol regardless of which OK packet the driver retained.
+        let generated: Option<u64> = c
+            .query_first("SELECT LAST_INSERT_ID()")
+            .await
+            .ok()
+            .flatten()
+            .filter(|id: &u64| *id != 0);
+        if let Some(id) = generated {
+            out.insert(
+                "generatedFields".into(),
+                json!([{ "longValue": id as i64 }]),
+            );
+        }
+        out.insert("records".into(), json!([]));
+        return Ok(Value::Object(out));
+    }
+
     let rows: Vec<Row> = c
         .query(stmt.as_str())
         .await
         .map_err(|e| bad_request(format!("{e}")))?;
     let affected = c.affected_rows();
 
-    let mut out = Map::new();
     if rows.is_empty() {
         out.insert("numberOfRecordsUpdated".into(), json!(affected));
-        out.insert("records".into(), json!([]));
+        if format_json {
+            out.insert("formattedRecords".into(), json!("[]"));
+        } else {
+            out.insert("records".into(), json!([]));
+        }
         return Ok(Value::Object(out));
     }
 
@@ -749,7 +924,7 @@ async fn my_run(
         let mut rec: Vec<Value> = Vec::with_capacity(cols.len());
         let mut jr = Map::new();
         for (i, col) in cols.iter().enumerate() {
-            let field = my_field(row, i);
+            let field = my_field(row, i, col.column_type());
             if format_json {
                 jr.insert(col.name_str().to_string(), field_to_plain(&field));
             }
@@ -771,18 +946,19 @@ async fn my_run(
     Ok(Value::Object(out))
 }
 
-fn my_field(row: &mysql_async::Row, i: usize) -> Value {
+fn my_field(row: &mysql_async::Row, i: usize, ty: mysql_async::consts::ColumnType) -> Value {
     use mysql_async::Value as V;
     match row.as_ref(i) {
         Some(V::NULL) | None => json!({ "isNull": true }),
+        // Binary-protocol typed values (kept for completeness).
         Some(V::Int(n)) => json!({ "longValue": n }),
         Some(V::UInt(n)) => json!({ "longValue": *n as i64 }),
         Some(V::Float(f)) => json!({ "doubleValue": *f as f64 }),
         Some(V::Double(d)) => json!({ "doubleValue": d }),
-        Some(V::Bytes(b)) => match std::str::from_utf8(b) {
-            Ok(s) => json!({ "stringValue": s }),
-            Err(_) => json!({ "blobValue": b64_encode(b) }),
-        },
+        // Under the text protocol every column arrives as raw bytes, so coerce
+        // numeric columns to the right typed Field by the column's declared
+        // type rather than always returning `stringValue`.
+        Some(V::Bytes(b)) => my_bytes_field(b, ty),
         // Temporal columns arrive as typed Date/Time values under the binary
         // protocol; render the canonical SQL text instead of the debug form.
         Some(V::Date(y, mo, d, h, mi, s, us)) => {
@@ -791,6 +967,33 @@ fn my_field(row: &mysql_async::Row, i: usize) -> Value {
         Some(V::Time(neg, days, h, mi, s, us)) => {
             json!({ "stringValue": format_mysql_time(*neg, *days, *h, *mi, *s, *us) })
         }
+    }
+}
+
+/// Coerce a text-protocol byte column to a typed AWS Field by its MySQL type.
+/// Integers -> `longValue`, real/double -> `doubleValue`; decimals, dates,
+/// times, and strings stay `stringValue`; non-UTF-8 bytes (true binary/blob)
+/// become `blobValue`.
+fn my_bytes_field(b: &[u8], ty: mysql_async::consts::ColumnType) -> Value {
+    use mysql_async::consts::ColumnType::*;
+    let as_str = std::str::from_utf8(b).ok();
+    match ty {
+        MYSQL_TYPE_TINY | MYSQL_TYPE_SHORT | MYSQL_TYPE_LONG | MYSQL_TYPE_LONGLONG
+        | MYSQL_TYPE_INT24 | MYSQL_TYPE_YEAR => {
+            if let Some(n) = as_str.and_then(|s| s.parse::<i64>().ok()) {
+                return json!({ "longValue": n });
+            }
+        }
+        MYSQL_TYPE_FLOAT | MYSQL_TYPE_DOUBLE => {
+            if let Some(d) = as_str.and_then(|s| s.parse::<f64>().ok()) {
+                return json!({ "doubleValue": d });
+            }
+        }
+        _ => {}
+    }
+    match as_str {
+        Some(s) => json!({ "stringValue": s }),
+        None => json!({ "blobValue": b64_encode(b) }),
     }
 }
 


### PR DESCRIPTION
Bug-hunt batch 1 (cycle 6). Hardening sweep for the freshly-shipped RDS Data API crate — the Tier-0 cluster from the 2026-06-27 bug audit.

## Fixes
- **UTF-8 corruption (HIGH).** `inline_params` pushed each SQL byte as a `char`, turning every multi-byte literal/parameter (`'café'`, CJK, `'€'`) into Latin-1 mojibake before it reached the engine — silent data corruption on write, silent zero-match on read. Now copies whole UTF-8 characters.
- **k8s breakage + per-request blocking (HIGH).** `resolve_conn` re-derived a Docker-only sibling host via a synchronous `docker info` shell-out on every statement — blocking the async runtime and returning an unreachable address on the k8s RDS backend. Now uses the instance's recorded `endpoint_address` (Docker sibling host / k8s Pod IP); shell-out removed.
- **`database`/`schema` ignored (MEDIUM-HIGH).** The request's `database` field is now honored (Aurora clusters often have no default DB), and `schema` sets the Postgres `search_path`.
- **Abandoned-transaction connection leak (MEDIUM).** A background reaper rolls back and releases transactions idle > 180s (matching AWS's ~3-min idle timeout), so a crashed client can't exhaust the backing container's `max_connections`.
- **Transaction lock contention (LOW-MEDIUM).** The global transactions-map lock was held across awaited SQL, serializing all transactions behind one slow statement. Each transaction now owns its connection lock; the map lock is released first.
- **MySQL typed results were all `stringValue`.** The text protocol returns every column as bytes, so integers/floats came back as strings (the MySQL path had zero e2e coverage). `my_field` now coerces by the column's declared type (int -> `longValue`, real/double -> `doubleValue`), `ExecuteStatement` returns the auto-increment key in `generatedFields` like Aurora MySQL, and empty SELECTs with `formatRecordsAs=JSON` return `formattedRecords "[]"`.

## Tests
New Docker-gated e2e: UTF-8 literal + parameter round-trips, the `database` override (table created in `otherdb` is invisible in the default DB), and the previously-untested MySQL path (typed results + `generatedFields`). All 5 rds-data e2e tests pass; rds-data conformance holds at 253/253.

Builds clean; `clippy --all-targets -D warnings` clean; fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the RDS Data API by fixing UTF-8 handling, host resolution, and transaction management. Adds typed MySQL results and honors `database`/`schema`, reducing contention and preventing leaks.

- Bug Fixes
  - Preserve UTF-8 in SQL literals and parameters (no mojibake).
  - Use recorded instance `endpoint_address`; remove per-request `docker info` shell-out; k8s works.
  - Honor request `database`; `schema` sets Postgres `search_path`.
  - Add 180s idle transaction reaper to release abandoned connections.
  - Avoid global lock contention by locking per transaction.
  - MySQL: coerce ints/floats to typed fields, include auto-increment id in `generatedFields`, and return `formattedRecords: "[]"` for empty JSON selects.

<sup>Written for commit 73f18eeefc95490714fc81084109665c23313a85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

