### PR TITLE
fix(dynamodb): PartiQL UPDATE param order, nested REMOVE, non-ASCII WHERE panic

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
@@ -336,8 +336,7 @@ pub(crate) fn apply_update_expression(
             }
             UpdateAction::Remove => {
                 for attr_ref in assignments {
-                    let attr = resolve_attr_name(attr_ref.trim(), expr_attr_names);
-                    item.remove(&attr);
+                    remove_path(item, attr_ref.trim(), expr_attr_names);
                 }
             }
             UpdateAction::Add => {

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -246,19 +246,27 @@ pub(crate) fn execute_partiql_in_state(
             (after_set, "")
         };
         let table = get_table_mut(&mut state.tables, &table_name)?;
+        // Positional `?` parameters bind in textual order: the SET clause comes
+        // before WHERE, so SET consumes parameters[0..set_count] and WHERE the
+        // rest. Evaluate WHERE against the parameters that follow the SET ones.
+        let set_param_count = count_params_in_str(set_clause);
         let matched_indices = if !where_clause.is_empty() {
-            find_partiql_where_indices(table, where_clause, parameters)?
+            let where_params: &[Value] = if set_param_count <= parameters.len() {
+                &parameters[set_param_count..]
+            } else {
+                &[]
+            };
+            find_partiql_where_indices(table, where_clause, where_params)?
         } else {
             (0..table.items.len()).collect()
         };
-        let param_offset = count_params_in_str(where_clause);
         let assignments: Vec<&str> = set_clause.split(',').collect();
         let mut last_key: Option<HashMap<String, AttributeValue>> = None;
         let mut last_old: Option<HashMap<String, AttributeValue>> = None;
         let mut last_new: Option<HashMap<String, AttributeValue>> = None;
         for idx in &matched_indices {
             last_old = Some(table.items[*idx].clone());
-            let mut local_offset = param_offset;
+            let mut local_offset = 0;
             for assignment in &assignments {
                 let assignment = assignment.trim();
                 if let Some((attr, val_str)) = assignment.split_once('=') {
@@ -979,7 +987,10 @@ fn split_two_args(
 /// - `BETWEEN x AND y` — the inner AND must not split the clause
 /// - `IN (a, b, c)` — internal commas/ANDs are inside parens, never matched
 pub(crate) fn split_partiql_and_clauses(where_clause: &str) -> Vec<&str> {
-    let upper = where_clause.to_uppercase();
+    // ASCII-only uppercasing so `upper` stays byte-for-byte aligned with
+    // `where_clause`; Unicode `to_uppercase()` can change byte length and make
+    // the `upper.as_bytes()[i..i+5]` slices below run past the end (panic).
+    let upper = where_clause.to_ascii_uppercase();
     if !upper.contains(" AND ") {
         return vec![where_clause.trim()];
     }
@@ -1167,5 +1178,25 @@ mod number_compare_tests {
         // Both negative: larger magnitude is the smaller value.
         assert_eq!(compare_number_strings("-100", "-1"), Ordering::Less);
         assert_eq!(compare_number_strings("-1", "-100"), Ordering::Greater);
+    }
+}
+
+#[cfg(test)]
+mod split_and_clause_tests {
+    use super::*;
+
+    // bug-audit 2026-06-27, T2.1: a length-shrinking non-ASCII char in the WHERE
+    // clause must not panic. Unicode `to_uppercase()` could make the uppercased
+    // buffer shorter than the original, so byte-index slices ran past its end.
+    #[test]
+    fn non_ascii_where_clause_does_not_panic() {
+        // 'ﬀ' (U+FB00) is 3 bytes and uppercases to "FF" (2 bytes) under Unicode
+        // folding — the exact shrink that triggered the original panic.
+        let _ = split_partiql_and_clauses("ﬀ AND a = 1");
+        let _ = split_partiql_and_clauses("name = 'café' AND id = 1");
+        let _ = split_partiql_and_clauses("日本 BETWEEN 1 AND 10 AND x = 2");
+        // Sanity: ASCII splitting still works.
+        let parts = split_partiql_and_clauses("a = 1 AND b = 2");
+        assert_eq!(parts.len(), 2);
     }
 }

--- a/crates/fakecloud-dynamodb/src/service/helpers/updates.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/updates.rs
@@ -42,6 +42,111 @@ pub(crate) fn assign_nested_path(
     Ok(())
 }
 
+/// One step of a document path: a map key or a list index.
+enum PathSeg {
+    Key(String),
+    Index(usize),
+}
+
+/// Strip a trailing `[N]` list index off a single path segment, returning the
+/// name and the index. `name` may itself be a `#placeholder`.
+fn strip_trailing_index(part: &str) -> Option<(&str, usize)> {
+    let part = part.trim();
+    if !part.ends_with(']') {
+        return None;
+    }
+    let open = part.rfind('[')?;
+    let idx: usize = part[open + 1..part.len() - 1].parse().ok()?;
+    let name = part[..open].trim();
+    if name.is_empty() {
+        return None;
+    }
+    Some((name, idx))
+}
+
+/// Parse a document path (`a`, `#a`, `a.b.c`, `a.b[2].c`, `tags[0]`) into
+/// resolved segments. Returns `None` for an empty/invalid path.
+fn parse_path_segments(
+    path: &str,
+    expr_attr_names: &HashMap<String, String>,
+) -> Option<Vec<PathSeg>> {
+    let mut segs = Vec::new();
+    for part in path.split('.') {
+        let part = part.trim();
+        let (name, idx) = match strip_trailing_index(part) {
+            Some((n, i)) => (n, Some(i)),
+            None => (part, None),
+        };
+        if name.is_empty() {
+            return None;
+        }
+        segs.push(PathSeg::Key(resolve_attr_name(name, expr_attr_names)));
+        if let Some(i) = idx {
+            segs.push(PathSeg::Index(i));
+        }
+    }
+    if segs.is_empty() {
+        None
+    } else {
+        Some(segs)
+    }
+}
+
+/// Remove the attribute at `path`, supporting top-level names, `#name`
+/// placeholders, dotted nested map paths (`a.b.c`), and list indices
+/// (`tags[0]`, `a.b[2]`). A path through a missing parent is a silent no-op,
+/// matching DynamoDB's behavior that `REMOVE` of an absent path succeeds.
+pub(crate) fn remove_path(
+    item: &mut HashMap<String, AttributeValue>,
+    path: &str,
+    expr_attr_names: &HashMap<String, String>,
+) {
+    let Some(segs) = parse_path_segments(path, expr_attr_names) else {
+        return;
+    };
+    // Top-level attribute: remove the key directly.
+    if segs.len() == 1 {
+        if let PathSeg::Key(k) = &segs[0] {
+            item.remove(k);
+        }
+        return;
+    }
+    let PathSeg::Key(top) = &segs[0] else {
+        return;
+    };
+    let Some(mut cur) = item.get_mut(top) else {
+        return;
+    };
+    // Descend to the parent of the leaf.
+    for seg in &segs[1..segs.len() - 1] {
+        cur = match seg {
+            PathSeg::Key(k) => match cur.get_mut("M").and_then(|m| m.get_mut(k)) {
+                Some(v) => v,
+                None => return,
+            },
+            PathSeg::Index(i) => match cur.get_mut("L").and_then(|l| l.get_mut(*i)) {
+                Some(v) => v,
+                None => return,
+            },
+        };
+    }
+    // Remove the leaf from its parent container.
+    match segs.last().expect("len >= 2") {
+        PathSeg::Key(k) => {
+            if let Some(map) = cur.get_mut("M").and_then(|m| m.as_object_mut()) {
+                map.remove(k);
+            }
+        }
+        PathSeg::Index(i) => {
+            if let Some(list) = cur.get_mut("L").and_then(|l| l.as_array_mut()) {
+                if *i < list.len() {
+                    list.remove(*i);
+                }
+            }
+        }
+    }
+}
+
 pub(crate) fn extract_number(val: &Option<Value>) -> Option<f64> {
     val.as_ref()
         .and_then(|v| v.get("N"))
@@ -196,4 +301,53 @@ pub(crate) fn apply_delete_assignment(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod remove_path_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn names() -> HashMap<String, String> {
+        HashMap::new()
+    }
+
+    // bug-audit 2026-06-27, T1.3: REMOVE of a nested map path / list index used
+    // to delete a literal top-level key (a no-op). It must reach into the path.
+    #[test]
+    fn removes_nested_map_path() {
+        let mut item: HashMap<String, AttributeValue> = HashMap::new();
+        item.insert(
+            "profile".to_string(),
+            json!({"M": {"first": {"S": "a"}, "middle": {"S": "b"}}}),
+        );
+        remove_path(&mut item, "profile.middle", &names());
+        assert_eq!(
+            item["profile"],
+            json!({"M": {"first": {"S": "a"}}}),
+            "nested map key removed, sibling kept"
+        );
+    }
+
+    #[test]
+    fn removes_list_index() {
+        let mut item: HashMap<String, AttributeValue> = HashMap::new();
+        item.insert(
+            "tags".to_string(),
+            json!({"L": [{"S": "x"}, {"S": "y"}, {"S": "z"}]}),
+        );
+        remove_path(&mut item, "tags[1]", &names());
+        assert_eq!(item["tags"], json!({"L": [{"S": "x"}, {"S": "z"}]}));
+    }
+
+    #[test]
+    fn removes_top_level_and_tolerates_missing() {
+        let mut item: HashMap<String, AttributeValue> = HashMap::new();
+        item.insert("a".to_string(), json!({"S": "1"}));
+        remove_path(&mut item, "a", &names());
+        assert!(!item.contains_key("a"));
+        // Missing path is a silent no-op (no panic).
+        remove_path(&mut item, "ghost.child", &names());
+        remove_path(&mut item, "ghost[3]", &names());
+    }
 }

--- a/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
+++ b/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
@@ -382,3 +382,83 @@ async fn ddb_partiql_delete_emits_stream_record() {
         "REMOVE",
     );
 }
+
+// bug-audit 2026-06-27, T1.2: positional `?` parameters bind in textual order.
+// In `UPDATE t SET x=? WHERE y=?`, SET must consume parameters[0] and WHERE
+// parameters[1]; they were previously swapped.
+#[tokio::test]
+async fn ddb_partiql_update_positional_param_order() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    create_streamed_table(&ddb, "ParamOrder").await;
+    put_row(&ddb, "ParamOrder", "r1", 1, "orig").await;
+
+    ddb.execute_statement()
+        .statement("UPDATE \"ParamOrder\" SET s=? WHERE pk=?")
+        .parameters(AttributeValue::S("updated".into()))
+        .parameters(AttributeValue::S("r1".into()))
+        .send()
+        .await
+        .expect("parameterized update");
+
+    let got = ddb
+        .get_item()
+        .table_name("ParamOrder")
+        .key("pk", AttributeValue::S("r1".into()))
+        .send()
+        .await
+        .unwrap();
+    let item = got.item().expect("row exists");
+    assert_eq!(
+        item.get("s")
+            .and_then(|v| v.as_s().ok())
+            .map(String::as_str),
+        Some("updated"),
+        "SET bound parameters[0] and WHERE matched on parameters[1]"
+    );
+}
+
+// bug-audit 2026-06-27, T1.3: REMOVE of a nested map path must delete the
+// nested attribute, not a literal top-level key (which was a silent no-op).
+#[tokio::test]
+async fn ddb_update_remove_nested_path() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    create_streamed_table(&ddb, "NestedRemove").await;
+
+    ddb.put_item()
+        .table_name("NestedRemove")
+        .item("pk", AttributeValue::S("r1".into()))
+        .item(
+            "profile",
+            AttributeValue::M(
+                [
+                    ("first".to_string(), AttributeValue::S("a".into())),
+                    ("middle".to_string(), AttributeValue::S("b".into())),
+                ]
+                .into(),
+            ),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    ddb.update_item()
+        .table_name("NestedRemove")
+        .key("pk", AttributeValue::S("r1".into()))
+        .update_expression("REMOVE profile.middle")
+        .send()
+        .await
+        .expect("remove nested");
+
+    let got = ddb
+        .get_item()
+        .table_name("NestedRemove")
+        .key("pk", AttributeValue::S("r1".into()))
+        .send()
+        .await
+        .unwrap();
+    let profile = got.item().unwrap().get("profile").unwrap().as_m().unwrap();
+    assert!(!profile.contains_key("middle"), "nested key removed");
+    assert!(profile.contains_key("first"), "sibling key kept");
+}


### PR DESCRIPTION
Bug-hunt batch 2 (cycle 6). Three DynamoDB fixes.

- **PartiQL UPDATE positional params swapped (HIGH, data corruption).** `UPDATE t SET x=? WHERE y=?` bound the SET value from the WHERE parameter and vice versa — WHERE was evaluated from parameter index 0 and SET started after it. Since SET is textually first, SET now consumes `parameters[0..set_count]` and WHERE the rest.
- **UpdateExpression nested REMOVE no-op (HIGH).** `REMOVE profile.middle` / `REMOVE tags[0]` removed a literal top-level key named `"profile.middle"` instead of descending. A new `remove_path` resolves dotted map paths and list indices (mirroring the SET writer); missing paths stay a silent no-op like AWS.
- **Non-ASCII WHERE panic (HIGH, DoS).** `split_partiql_and_clauses` uppercased with Unicode `to_uppercase()` (can change byte length) then sliced by byte indices bounds-checked against the original string — a length-shrinking char (`'ﬀ'` -> `"FF"`) ran the slice past the end and dropped the connection. Now `to_ascii_uppercase()`, keeping buffers byte-aligned.

## Tests
Unit: `remove_path` (nested map / list index / missing-path no-op), non-ASCII split no-panic. E2E: parameterized UPDATE order round-trip, nested REMOVE round-trip. Full dynamodb lib suite (322) + partiql e2e (7) green.

Builds clean; `clippy --all-targets -D warnings` clean; fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three DynamoDB issues: corrects PartiQL `UPDATE` parameter binding order, makes `REMOVE` handle nested paths and list indices, and prevents a panic on non-ASCII `WHERE` clauses. Prevents wrong-row matches/writes and avoids connection drops on Unicode input.

- **Bug Fixes**
  - PartiQL `UPDATE`: bind `?` in textual order. `SET` consumes the first N params; `WHERE` uses the rest.
  - UpdateExpression `REMOVE`: resolves dotted paths and list indices (e.g., `profile.middle`, `tags[0]`). Missing paths are no-ops.
  - WHERE parser: use ASCII uppercasing to keep byte alignment and avoid slicing panics on chars like `ﬀ`.

<sup>Written for commit 60d431dc5be50a755e277f00be6332e33a81e816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

