### PR TITLE
fix(lambda,iam): GetFunctionConcurrency empty, GetUser stable, UpdateRole keeps Description

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -3830,3 +3830,56 @@ async fn list_role_policies_paginates_inline_policies() {
     seen.sort();
     assert_eq!(seen, vec!["pa", "pb", "pc"]);
 }
+
+// bug-audit 2026-06-27, T1.7: UpdateRole must not clear Description when only
+// another field (e.g. MaxSessionDuration) is updated.
+#[tokio::test]
+async fn iam_update_role_preserves_description() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_role()
+        .role_name("svc")
+        .assume_role_policy_document("{\"Version\":\"2012-10-17\",\"Statement\":[]}")
+        .description("important role")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .update_role()
+        .role_name("svc")
+        .max_session_duration(7200)
+        .send()
+        .await
+        .unwrap();
+
+    let got = client.get_role().role_name("svc").send().await.unwrap();
+    let role = got.role().unwrap();
+    assert_eq!(role.max_session_duration(), Some(7200));
+    assert_eq!(
+        role.description(),
+        Some("important role"),
+        "description retained when only max-session-duration is updated"
+    );
+}
+
+// bug-audit 2026-06-27, T1.6: GetUser with no UserName returns a stable
+// identity, not a fresh random user each call.
+#[tokio::test]
+async fn iam_get_user_no_name_is_deterministic() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let a = client.get_user().send().await.unwrap();
+    let b = client.get_user().send().await.unwrap();
+    let ua = a.user().unwrap();
+    let ub = b.user().unwrap();
+    assert_eq!(
+        ua.user_id(),
+        ub.user_id(),
+        "GetUser without a name returns a stable user id"
+    );
+    assert_eq!(ua.user_name(), ub.user_name());
+}

--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -1324,3 +1324,55 @@ async fn lambda_runtime_management_config_404s_after_function_delete() {
         .expect_err("must 404 after function delete");
     assert!(err.into_service_error().is_resource_not_found_exception());
 }
+
+// bug-audit 2026-06-27, T1.4: GetFunctionConcurrency on a function with no
+// reserved concurrency returns an empty body, not ReservedConcurrentExecutions:0
+// (0 means "throttle to zero" in Lambda, not "unset").
+#[tokio::test]
+async fn lambda_get_function_concurrency_unset_is_empty() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("conc-func")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let unset = client
+        .get_function_concurrency()
+        .function_name("conc-func")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        unset.reserved_concurrent_executions(),
+        None,
+        "unset reserved concurrency is absent, not 0"
+    );
+
+    // After putting a real value, it round-trips.
+    client
+        .put_function_concurrency()
+        .function_name("conc-func")
+        .reserved_concurrent_executions(5)
+        .send()
+        .await
+        .unwrap();
+    let set = client
+        .get_function_concurrency()
+        .function_name("conc-func")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(set.reserved_concurrent_executions(), Some(5));
+}

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -296,11 +296,12 @@ impl IamService {
             )
         })?;
 
-        // UpdateRole: if Description is provided, set it; if absent, clear it
+        // UpdateRole: Description and MaxSessionDuration are independent
+        // optionals. Only update Description when it's actually supplied;
+        // omitting it leaves the existing description unchanged (AWS does not
+        // clear it just because another field was updated).
         if let Some(desc) = req.query_params.get("Description") {
             role.description = Some(desc.clone());
-        } else {
-            role.description = None;
         }
         if let Some(dur) = req
             .query_params

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -211,16 +211,37 @@ impl IamService {
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        // If no UserName specified, return current/default user
+        // If no UserName specified, GetUser returns the user that owns the
+        // calling credentials.
         let user_name = match req.query_params.get("UserName") {
             Some(name) => name.clone(),
             None => {
+                // Resolve the caller from their access key id and return that
+                // real, persisted user when it exists.
+                let access_key_id = req.access_key_id.as_deref().unwrap_or("");
+                let caller = state
+                    .access_keys
+                    .iter()
+                    .find_map(|(user, keys)| {
+                        keys.iter()
+                            .any(|k| k.access_key_id == access_key_id)
+                            .then(|| user.clone())
+                    })
+                    .and_then(|u| state.users.get(&u));
+                if let Some(user) = caller {
+                    let xml = xml_responses::get_user_response(user, &req.request_id);
+                    return Ok(AwsResponse::xml(StatusCode::OK, xml));
+                }
+                // Otherwise return a stable synthetic identity. A *deterministic*
+                // id/date (not a fresh random one per call) so repeated GetUser
+                // calls and follow-ups by the returned name are consistent.
                 let default_user = IamUser {
-                    user_id: format!("AIDA{}", generate_id()),
+                    user_id: format!("AIDA{}DEFLT", state.account_id),
                     arn: Arn::global("iam", &state.account_id, "user/default_user").to_string(),
                     user_name: "default_user".to_string(),
                     path: "/".to_string(),
-                    created_at: Utc::now(),
+                    created_at: chrono::DateTime::from_timestamp(1_577_836_800, 0)
+                        .unwrap_or_default(),
                     tags: Vec::new(),
                     permissions_boundary: None,
                 };

--- a/crates/fakecloud-lambda/src/extras/concurrency.rs
+++ b/crates/fakecloud-lambda/src/extras/concurrency.rs
@@ -37,12 +37,13 @@ impl LambdaService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let region = self.region_for(account_id);
         self.with_state_read(account_id, &region, |state| {
-            let n = state
-                .function_concurrency
-                .get(function_name)
-                .copied()
-                .unwrap_or(0);
-            ok(json!({"ReservedConcurrentExecutions": n}))
+            // No reserved concurrency configured -> AWS returns an empty body,
+            // not `ReservedConcurrentExecutions: 0` (which means "throttle to
+            // zero", the opposite of unset).
+            match state.function_concurrency.get(function_name).copied() {
+                Some(n) => ok(json!({ "ReservedConcurrentExecutions": n })),
+                None => ok(json!({})),
+            }
         })
     }
 


### PR DESCRIPTION
Bug-hunt batch 3 (cycle 6). Three contained correctness fixes.

- **Lambda GetFunctionConcurrency (HIGH).** Returned `ReservedConcurrentExecutions: 0` for a function with no reserved concurrency — but `0` means "throttle to zero" in Lambda, the opposite of unset, so Terraform reads false drift. AWS returns an empty body when none is configured.
- **IAM GetUser with no UserName (MEDIUM).** Fabricated a fresh random user (new AIDA id + `now()` date) every call. Now resolves the caller from their access-key id and returns that real user, otherwise a stable synthetic identity (deterministic id/date) so repeated calls + follow-ups are consistent.
- **IAM UpdateRole (MEDIUM).** Cleared `Description` whenever it was omitted, so `update-role --max-session-duration ...` silently wiped it. Description and MaxSessionDuration are independent optionals; Description is now only changed when supplied.

## Tests
E2E for each: empty-vs-set concurrency round-trip, GetUser determinism, UpdateRole preserves description. iam lib suite (496) green.

Builds clean; `clippy --all-targets -D warnings` clean; fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Lambda reserved concurrency, IAM GetUser resolution, and IAM UpdateRole description handling to match AWS and prevent drift or accidental wipes.

- **Bug Fixes**
  - Lambda GetFunctionConcurrency: return empty body when no reserved concurrency (not 0).
  - IAM GetUser: without UserName, resolve caller from access key; otherwise return a stable synthetic user (deterministic id/date).
  - IAM UpdateRole: keep existing Description unless a new Description is provided.

<sup>Written for commit 9b8d56ce60b141fbd98b0ddd3f5d4d1add07f765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

