### PR TITLE
fix(cloudwatch,logs): accept PutMetricData Values/Counts, FilterLogEvents endTime inclusive

### DIFF
--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -367,6 +367,58 @@ pub(crate) fn collect_indexed(req: &AwsRequest, prefix: &str) -> Vec<HashMap<Str
     by_index.into_values().collect()
 }
 
+/// Collect an indexed `<prefix>.member.N` numeric array out of a flattened
+/// MetricData member (e.g. `Values.member.1`, `Counts.member.1`).
+fn collect_member_numbers(
+    member: &HashMap<String, String>,
+    prefix: &str,
+) -> Result<Vec<f64>, AwsServiceError> {
+    let needle = format!("{prefix}.member.");
+    let mut by_index: BTreeMap<u32, f64> = BTreeMap::new();
+    for (k, v) in member.iter() {
+        let Some(idx_str) = k.strip_prefix(&needle) else {
+            continue;
+        };
+        let Ok(idx) = idx_str.parse::<u32>() else {
+            continue;
+        };
+        let n = v
+            .parse::<f64>()
+            .map_err(|_| invalid_param(format!("{prefix} entries must be numbers")))?;
+        by_index.insert(idx, n);
+    }
+    Ok(by_index.into_values().collect())
+}
+
+/// Build a [`StatisticSet`] from a MetricDatum's `Values`/`Counts` distribution.
+/// Returns `Ok(None)` when no `Values` array is present.
+fn values_counts_statistic(
+    member: &HashMap<String, String>,
+) -> Result<Option<StatisticSet>, AwsServiceError> {
+    let values = collect_member_numbers(member, "Values")?;
+    if values.is_empty() {
+        return Ok(None);
+    }
+    let counts = collect_member_numbers(member, "Counts")?;
+    let mut sample_count = 0.0;
+    let mut sum = 0.0;
+    let mut minimum = f64::INFINITY;
+    let mut maximum = f64::NEG_INFINITY;
+    for (i, v) in values.iter().enumerate() {
+        let c = counts.get(i).copied().unwrap_or(1.0);
+        sample_count += c;
+        sum += v * c;
+        minimum = minimum.min(*v);
+        maximum = maximum.max(*v);
+    }
+    Ok(Some(StatisticSet {
+        sample_count,
+        sum,
+        minimum,
+        maximum,
+    }))
+}
+
 fn parse_dimensions(member: &HashMap<String, String>, prefix: &str) -> BTreeMap<String, String> {
     let mut dims: BTreeMap<u32, (Option<String>, Option<String>)> = BTreeMap::new();
     let needle = format!("{prefix}.member.");
@@ -654,9 +706,17 @@ impl CloudWatchService {
                 None
             };
 
+            // A `Values`/`Counts` value-distribution is collapsed into a
+            // StatisticSet (which the statistics path already aggregates), so
+            // the common histogram publish path stops 400-ing.
+            let statistic_values = match statistic_values {
+                Some(s) => Some(s),
+                None => values_counts_statistic(&member)?,
+            };
+
             if value.is_none() && statistic_values.is_none() {
                 return Err(invalid_param(
-                    "MetricData entry must supply either Value or StatisticValues",
+                    "MetricData entry must supply either Value, StatisticValues, or Values",
                 ));
             }
 

--- a/crates/fakecloud-e2e/tests/cloudwatch.rs
+++ b/crates/fakecloud-e2e/tests/cloudwatch.rs
@@ -41,6 +41,52 @@ async fn put_and_list_metrics() {
     assert_eq!(metrics[0].namespace(), Some("MyApp"));
 }
 
+// bug-audit 2026-06-27, T1.5: PutMetricData must accept the Values/Counts
+// value-distribution publish path (previously 400'd), and the distribution must
+// aggregate into the statistics.
+#[tokio::test]
+async fn put_metric_data_accepts_values_and_counts() {
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+    let now = chrono::Utc::now();
+
+    cw.put_metric_data()
+        .namespace("Dist")
+        .metric_data(
+            MetricDatum::builder()
+                .metric_name("Latency")
+                .values(10.0)
+                .values(20.0)
+                .counts(2.0)
+                .counts(3.0)
+                .timestamp(AwsDateTime::from_secs(now.timestamp()))
+                .build(),
+        )
+        .send()
+        .await
+        .expect("put values/counts distribution");
+
+    let stats = cw
+        .get_metric_statistics()
+        .namespace("Dist")
+        .metric_name("Latency")
+        .start_time(AwsDateTime::from_secs(now.timestamp() - 600))
+        .end_time(AwsDateTime::from_secs(now.timestamp() + 600))
+        .period(60)
+        .statistics(Statistic::Sum)
+        .statistics(Statistic::SampleCount)
+        .statistics(Statistic::Maximum)
+        .send()
+        .await
+        .expect("stats");
+
+    let dp = &stats.datapoints()[0];
+    // sum = 10*2 + 20*3 = 80, sample_count = 5, max = 20.
+    assert!((dp.sum().unwrap() - 80.0).abs() < 1e-6);
+    assert_eq!(dp.sample_count().unwrap(), 5.0);
+    assert!((dp.maximum().unwrap() - 20.0).abs() < 1e-6);
+}
+
 #[tokio::test]
 async fn get_metric_statistics_aggregates_by_period() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -3003,3 +3003,56 @@ async fn describe_log_streams_orders_by_last_event_time() {
         "LastEventTime descending must put the newest-event stream first"
     );
 }
+
+// bug-audit 2026-06-27, T1.14: FilterLogEvents endTime is inclusive — an event
+// whose timestamp equals endTime must be returned (it was dropped by `>= end`).
+#[tokio::test]
+async fn logs_filter_log_events_end_time_inclusive() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/filter/end")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_log_stream()
+        .log_group_name("/filter/end")
+        .log_stream_name("s1")
+        .send()
+        .await
+        .unwrap();
+
+    let base = chrono::Utc::now().timestamp_millis();
+    client
+        .put_log_events()
+        .log_group_name("/filter/end")
+        .log_stream_name("s1")
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(base)
+                .message("at-boundary")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // endTime exactly at the event's timestamp must still include it.
+    let resp = client
+        .filter_log_events()
+        .log_group_name("/filter/end")
+        .start_time(base)
+        .end_time(base)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.events().len(),
+        1,
+        "event at endTime is returned (endTime inclusive)"
+    );
+}

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -1048,7 +1048,10 @@ impl LogsService {
                     }
                 }
                 if let Some(end) = end_time {
-                    if event.timestamp >= end {
+                    // FilterLogEvents endTime is inclusive: only events with a
+                    // timestamp *later* than endTime are dropped (unlike
+                    // GetLogEvents, whose endTime is exclusive).
+                    if event.timestamp > end {
                         continue;
                     }
                 }


### PR DESCRIPTION
Bug-hunt batch 4 (cycle 6). CloudWatch + Logs correctness.

- **CloudWatch PutMetricData rejected Values/Counts (HIGH).** The value-distribution publish path (`MetricDatum.Values` + `.Counts`) 400'd, even though it's a common documented way to publish metrics. It's now collapsed into a StatisticSet (sample_count = Σcounts, sum = Σ value*count, min/max over values) — which the statistics path already aggregates — so GetMetricStatistics reports it correctly.
- **Logs FilterLogEvents endTime was exclusive (MEDIUM).** `timestamp >= end` dropped the boundary event; AWS FilterLogEvents endTime is inclusive (only events *later* than endTime are excluded), so it's now `>`. GetLogEvents (genuinely exclusive endTime) is unchanged.

## Tests
E2E: Values/Counts distribution aggregates into Sum/SampleCount/Maximum; FilterLogEvents endTime boundary event is returned.

Builds clean; `clippy --all-targets -D warnings` clean; fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two correctness issues to match AWS behavior. `PutMetricData` now accepts `Values`/`Counts` distributions, and `FilterLogEvents` treats `endTime` as inclusive to return the boundary event.

- **Bug Fixes**
  - CloudWatch: Convert `Values`/`Counts` to a `StatisticSet` (sum = Σ v*c, sample_count = Σ c, min/max over values) to avoid 400s; `GetMetricStatistics` aggregates correctly.
  - Logs: Make `FilterLogEvents` `endTime` inclusive (only drop events with timestamp > end); `GetLogEvents` stays exclusive.
  - Tests: Added e2e coverage for distribution aggregation and the inclusive `endTime` boundary.

<sup>Written for commit 5fd1844f52dd490ce3207d428dc0ca5eaa09de10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

