### PR TITLE
fix(kinesis,s3): GetRecords ChildShards after split, no duplicate CommonPrefix across pages

### DIFF
--- a/crates/fakecloud-e2e/tests/kinesis.rs
+++ b/crates/fakecloud-e2e/tests/kinesis.rs
@@ -782,3 +782,76 @@ async fn kinesis_subscribe_to_shard_streams_records() {
         "SubscribeToShard must stream the put record to the consumer"
     );
 }
+
+// bug-audit 2026-06-27, T1.11: GetRecords on a split (closed + drained) shard
+// must return ChildShards so KCL / Lambda ESM can fan out to the children.
+#[tokio::test]
+async fn kinesis_get_records_returns_child_shards_after_split() {
+    let server = TestServer::start().await;
+    let client = server.kinesis_client().await;
+
+    client
+        .create_stream()
+        .stream_name("split-me")
+        .shard_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    let shards = client
+        .list_shards()
+        .stream_name("split-me")
+        .send()
+        .await
+        .unwrap();
+    let shard = &shards.shards()[0];
+    let shard_id = shard.shard_id().to_string();
+    let ending: u128 = shard
+        .hash_key_range()
+        .unwrap()
+        .ending_hash_key()
+        .parse()
+        .unwrap();
+    let mid = (ending / 2 + 1).to_string();
+
+    client
+        .split_shard()
+        .stream_name("split-me")
+        .shard_to_split(&shard_id)
+        .new_starting_hash_key(mid)
+        .send()
+        .await
+        .unwrap();
+
+    let it = client
+        .get_shard_iterator()
+        .stream_name("split-me")
+        .shard_id(&shard_id)
+        .shard_iterator_type(ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap()
+        .shard_iterator()
+        .unwrap()
+        .to_string();
+
+    let recs = client
+        .get_records()
+        .shard_iterator(it)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        recs.next_shard_iterator().is_none(),
+        "closed+drained parent returns null NextShardIterator"
+    );
+    let children = recs.child_shards();
+    assert_eq!(children.len(), 2, "two child shards from the split");
+    for c in children {
+        assert!(
+            c.parent_shards().contains(&shard_id),
+            "child lists the split parent"
+        );
+        assert!(c.hash_key_range().is_some());
+    }
+}

--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -329,6 +329,54 @@ async fn s3_list_objects_v2() {
     assert_eq!(prefixes[0].prefix().unwrap(), "dir/");
 }
 
+// bug-audit 2026-06-27, T1.10: a delimiter listing paginated with a small
+// max-keys must emit each CommonPrefix exactly once across pages (the cursor
+// used to point at the first member key, re-emitting the prefix next page).
+#[tokio::test]
+async fn s3_list_objects_v2_delimiter_pagination_no_dup_prefix() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+    client.create_bucket().bucket("dlim").send().await.unwrap();
+    for key in &["a/1", "a/2", "b/1", "c/1"] {
+        client
+            .put_object()
+            .bucket("dlim")
+            .key(*key)
+            .body(ByteStream::from_static(b"x"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let mut prefixes: Vec<String> = Vec::new();
+    let mut token: Option<String> = None;
+    loop {
+        let mut req = client
+            .list_objects_v2()
+            .bucket("dlim")
+            .delimiter("/")
+            .max_keys(1);
+        if let Some(t) = &token {
+            req = req.continuation_token(t);
+        }
+        let resp = req.send().await.unwrap();
+        for p in resp.common_prefixes() {
+            prefixes.push(p.prefix().unwrap().to_string());
+        }
+        if resp.is_truncated() == Some(true) {
+            token = resp.next_continuation_token().map(String::from);
+        } else {
+            break;
+        }
+    }
+
+    assert_eq!(
+        prefixes,
+        vec!["a/", "b/", "c/"],
+        "each CommonPrefix appears exactly once across pages"
+    );
+}
+
 #[tokio::test]
 async fn s3_copy_object() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -599,6 +599,39 @@ impl KinesisService {
         let total_records = shard.records.len();
         let shard_closed = !shard.is_open;
 
+        // When a split/merged shard is fully drained, AWS returns `ChildShards`
+        // alongside the null NextShardIterator so KCL / Lambda ESM can fan out
+        // to the child shard(s) instead of stalling at the parent.
+        let child_shards: Vec<Value> = if shard_closed && end_index >= total_records {
+            stream
+                .shards
+                .iter()
+                .filter(|c| {
+                    c.parent_shard_id.as_deref() == Some(lease.shard_id.as_str())
+                        || c.adjacent_parent_shard_id.as_deref() == Some(lease.shard_id.as_str())
+                })
+                .map(|c| {
+                    let mut parents = Vec::new();
+                    if let Some(p) = &c.parent_shard_id {
+                        parents.push(p.clone());
+                    }
+                    if let Some(p) = &c.adjacent_parent_shard_id {
+                        parents.push(p.clone());
+                    }
+                    json!({
+                        "ShardId": c.shard_id,
+                        "ParentShards": parents,
+                        "HashKeyRange": {
+                            "StartingHashKey": c.starting_hash_key,
+                            "EndingHashKey": c.ending_hash_key,
+                        },
+                    })
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         // MillisBehindLatest is the real time gap between the last record
         // returned in this batch and the newest (tip) record in the shard —
         // not a 0/1 flag. Consumers (Lambda ESM IteratorAge alarms, KCL
@@ -623,11 +656,15 @@ impl KinesisService {
             json!(state.insert_iterator(&lease.stream_name, &lease.shard_id, end_index))
         };
 
-        Ok(AwsResponse::ok_json(json!({
+        let mut response = json!({
             "MillisBehindLatest": millis_behind_latest,
             "NextShardIterator": next_iterator,
             "Records": records,
-        })))
+        });
+        if !child_shards.is_empty() {
+            response["ChildShards"] = Value::Array(child_shards);
+        }
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn put_record(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {

--- a/crates/fakecloud-s3/src/service/objects/list.rs
+++ b/crates/fakecloud-s3/src/service/objects/list.rs
@@ -49,8 +49,15 @@ impl S3Service {
             if !key.starts_with(&prefix) {
                 continue;
             }
-            if !marker.is_empty() && key.as_str() <= marker.as_str() {
-                continue;
+            if !marker.is_empty() {
+                // A marker that is a CommonPrefix (ends with the delimiter) must
+                // skip every key under it, or the next page re-emits the prefix.
+                let under_resumed_prefix = delimiter.as_deref().is_some_and(|d| {
+                    !d.is_empty() && marker.ends_with(d) && key.starts_with(marker.as_str())
+                });
+                if key.as_str() <= marker.as_str() || under_resumed_prefix {
+                    continue;
+                }
             }
 
             // Handle delimiter-based grouping
@@ -64,8 +71,10 @@ impl S3Service {
                                 is_truncated = true;
                                 break;
                             }
+                            // Cursor is the CommonPrefix so the next page resumes
+                            // past the whole group, not at its first member.
+                            last_key = cp.clone();
                             common_prefixes.push(cp);
-                            last_key = key.clone();
                             count += 1;
                         }
                         continue;
@@ -251,8 +260,16 @@ impl S3Service {
             if !key.starts_with(&prefix) {
                 continue;
             }
-            if !effective_start.is_empty() && key.as_str() <= effective_start {
-                continue;
+            if !effective_start.is_empty() {
+                // When the cursor is a CommonPrefix (it ends with the
+                // delimiter), skip every key rolled into that prefix — otherwise
+                // resuming re-emits the same CommonPrefix on the next page.
+                let under_resumed_prefix = !delimiter.is_empty()
+                    && effective_start.ends_with(delimiter.as_str())
+                    && key.starts_with(effective_start);
+                if key.as_str() <= effective_start || under_resumed_prefix {
+                    continue;
+                }
             }
 
             // Handle delimiter-based grouping
@@ -269,8 +286,10 @@ impl S3Service {
                             is_truncated = true;
                             break;
                         }
+                        // Cursor is the CommonPrefix itself so the next page
+                        // resumes past the whole group, not at its first member.
+                        last_key = cp.clone();
                         common_prefixes.push(cp);
-                        last_key = key.clone();
                         count += 1;
                     }
                     continue;


### PR DESCRIPTION
Bug-hunt batch 5 (cycle 6). Two cross-service correctness fixes.

- **Kinesis GetRecords ChildShards (MEDIUM).** A split/merged shard that is closed and fully drained returned a null NextShardIterator but no `ChildShards`, so KCL / Lambda ESM consumers stalled at the parent instead of fanning out. It now returns `ChildShards` (ShardId, ParentShards, HashKeyRange) for the children naming this shard as a parent.
- **S3 delimiter CommonPrefix duplicated across pages (MEDIUM).** When max-keys cut a page mid-prefix, the continuation cursor pointed at the first member key of the prefix, so the next page re-entered the group and re-emitted the prefix. The cursor is now the CommonPrefix itself, and resume skips every key under an already-emitted prefix. Fixed for both ListObjectsV2 (`NextContinuationToken`) and ListObjects V1 (`NextMarker`).

## Tests
E2E: ChildShards after SplitShard; paginated delimiter listing emits each prefix exactly once. s3 lib (368) + kinesis lib (120) + s3 listing e2e green.

Builds clean; `clippy --all-targets -D warnings` clean; fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two cross-service bugs: Kinesis `GetRecords` now returns `ChildShards` after a split so consumers can fan out, and S3 delimiter listings no longer duplicate `CommonPrefixes` across pages.

- **Bug Fixes**
  - Kinesis: When a split/merged parent shard is closed and fully drained, `GetRecords` now includes `ChildShards` (`ShardId`, `ParentShards`, `HashKeyRange`) instead of stalling with a null iterator (`fakecloud-kinesis`).
  - S3: For `delimiter` listings in `ListObjectsV2` and V1, the continuation cursor is the `CommonPrefix` and resume skips keys under it, so each prefix appears once (`fakecloud-s3`).

<sup>Written for commit 36d818b19d8eefa7a0ce33fd31f1dbdae0130618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

