### PR TITLE
fix(cloudformation): honor LaunchTemplate/MixedInstancesPolicy on CFN AutoScalingGroup

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/autoscaling.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/autoscaling.rs
@@ -5,11 +5,32 @@
 //! real container instances are a runtime concern, not CFN-time). cycle 4.
 
 use chrono::Utc;
-use fakecloud_autoscaling::state::{AsgInstance, AutoScalingGroup, LaunchConfiguration};
+use fakecloud_autoscaling::state::{
+    AsgInstance, AutoScalingGroup, LaunchConfiguration, LaunchTemplateSpec,
+};
 use serde_json::Value;
 use uuid::Uuid;
 
 use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+
+/// Parse a CFN `LaunchTemplate` / `LaunchTemplateSpecification` block
+/// (`{LaunchTemplateId|LaunchTemplateName, Version}`) into a [`LaunchTemplateSpec`].
+fn parse_cfn_launch_template(v: Option<&Value>) -> Option<LaunchTemplateSpec> {
+    let obj = v?;
+    let id = obj.get("LaunchTemplateId").and_then(|x| x.as_str());
+    let name = obj.get("LaunchTemplateName").and_then(|x| x.as_str());
+    if id.is_none() && name.is_none() {
+        return None;
+    }
+    Some(LaunchTemplateSpec {
+        launch_template_id: id.map(String::from),
+        launch_template_name: name.map(String::from),
+        version: obj
+            .get("Version")
+            .and_then(|x| x.as_str())
+            .map(String::from),
+    })
+}
 
 fn prop_str<'a>(p: &'a Value, k: &str) -> Option<&'a str> {
     p.get(k).and_then(|v| v.as_str())
@@ -105,6 +126,17 @@ impl ResourceProvisioner {
             azs.push(format!("{}a", self.region));
         }
         let lcn = prop_str(props, "LaunchConfigurationName").map(String::from);
+        // Modern templates use LaunchTemplate (or MixedInstancesPolicy) instead
+        // of the legacy LaunchConfigurationName; honor both so the launch spec
+        // isn't silently dropped.
+        let launch_template =
+            parse_cfn_launch_template(props.get("LaunchTemplate")).or_else(|| {
+                props
+                    .get("MixedInstancesPolicy")
+                    .and_then(|m| m.get("LaunchTemplate"))
+                    .and_then(|lt| lt.get("LaunchTemplateSpecification"))
+                    .and_then(|spec| parse_cfn_launch_template(Some(spec)))
+            });
         let vpc_zone_identifier = props
             .get("VPCZoneIdentifier")
             .and_then(|v| v.as_array())
@@ -137,7 +169,7 @@ impl ResourceProvisioner {
             arn: arn.clone(),
             name: name.clone(),
             launch_configuration_name: lcn,
-            launch_template: None,
+            launch_template,
             min_size,
             max_size,
             desired_capacity: desired,

--- a/crates/fakecloud-e2e/tests/cloudformation_autoscaling.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_autoscaling.rs
@@ -78,3 +78,44 @@ async fn cfn_provisions_autoscaling_group() {
         "stack delete should remove the ASG"
     );
 }
+
+// bug-audit 2026-06-27, T1.8: a CFN ASG declared with a LaunchTemplate (not the
+// legacy LaunchConfigurationName) must carry the launch template, not drop it.
+const TEMPLATE_LT: &str = r#"{
+  "Resources": {
+    "ASG": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "Properties": {
+        "MinSize": "1", "MaxSize": "2", "DesiredCapacity": "1",
+        "LaunchTemplate": { "LaunchTemplateId": "lt-0abc123", "Version": "3" },
+        "AvailabilityZones": ["us-east-1a"]
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_asg_honors_launch_template() {
+    let s = TestServer::start().await;
+    let cfn = s.cloudformation_client().await;
+    let asg = aws_sdk_autoscaling::Client::new(&s.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("asg-lt-stack")
+        .template_body(TEMPLATE_LT)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let groups = asg.describe_auto_scaling_groups().send().await.unwrap();
+    let g = groups
+        .auto_scaling_groups()
+        .iter()
+        .find(|g| g.auto_scaling_group_name() == Some("ASG"))
+        .expect("CFN ASG exists");
+    let lt = g
+        .launch_template()
+        .expect("launch template carried from CFN");
+    assert_eq!(lt.launch_template_id(), Some("lt-0abc123"));
+    assert_eq!(lt.version(), Some("3"));
+}


### PR DESCRIPTION
Bug-hunt batch 6 (cycle 6).

The CFN `AWS::AutoScaling::AutoScalingGroup` provisioner read only the legacy `LaunchConfigurationName` and hardcoded `launch_template: None`, so a group declared with a `LaunchTemplate` (the modern CDK/CFN shape) or a `MixedInstancesPolicy` was created with no launch spec at all and DescribeAutoScalingGroups reported none. It now parses the LaunchTemplate / LaunchTemplateSpecification block (`LaunchTemplateId`/`LaunchTemplateName` + `Version`) and carries it onto the group.

E2E test asserts a CFN ASG with a LaunchTemplate reports it. Builds clean; clippy `-D warnings` clean.

(The sibling finding — CFN ASG/RDS minting placeholder instances/DBs with no real container — is the larger architectural "provisioner should spawn through the real runtime" change, tracked separately.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CloudFormation `AWS::AutoScaling::AutoScalingGroup` to honor `LaunchTemplate` and `MixedInstancesPolicy`. CFN-created groups now retain and report their launch template instead of dropping it.

- **Bug Fixes**
  - Parse CFN `LaunchTemplate`/`LaunchTemplateSpecification` (`LaunchTemplateId`/`LaunchTemplateName` + `Version`) and persist it to the group; keeps support for `LaunchConfigurationName`.
  - Add e2e test in `fakecloud-e2e` verifying `DescribeAutoScalingGroups` returns the launch template for a CFN ASG.

<sup>Written for commit 9234c9c6af536fa5d59f8c8099e98b99f535158a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

