### PR TITLE
fix(lambda): ListFunctions(ALL) lists versions, ListAliases/ListVersionsByFunction MaxItems 1..10000

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -1376,3 +1376,82 @@ async fn lambda_get_function_concurrency_unset_is_empty() {
         .unwrap();
     assert_eq!(set.reserved_concurrent_executions(), Some(5));
 }
+
+// bug-audit 2026-06-27, T1.13: ListFunctions(FunctionVersion=ALL) returns the
+// published numbered versions too (not only $LATEST), and the alias/version
+// list MaxItems range is 1..10000 (no spurious 400 above 50).
+#[tokio::test]
+async fn lambda_list_functions_all_versions_and_maxitems() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("verfn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    client
+        .publish_version()
+        .function_name("verfn")
+        .send()
+        .await
+        .unwrap();
+    // Change $LATEST so the next publish creates a distinct version (AWS dedupes
+    // an unchanged publish).
+    client
+        .update_function_configuration()
+        .function_name("verfn")
+        .description("v2")
+        .send()
+        .await
+        .unwrap();
+    client
+        .publish_version()
+        .function_name("verfn")
+        .send()
+        .await
+        .unwrap();
+
+    let all = client
+        .list_functions()
+        .function_version(aws_sdk_lambda::types::FunctionVersion::All)
+        .send()
+        .await
+        .unwrap();
+    let versions: Vec<&str> = all
+        .functions()
+        .iter()
+        .filter(|f| f.function_name() == Some("verfn"))
+        .map(|f| f.version().unwrap())
+        .collect();
+    assert!(
+        versions.contains(&"$LATEST") && versions.contains(&"1") && versions.contains(&"2"),
+        "ListFunctions(ALL) lists $LATEST + published versions, got {versions:?}"
+    );
+
+    // MaxItems above 50 must be accepted for ListVersionsByFunction.
+    client
+        .list_versions_by_function()
+        .function_name("verfn")
+        .max_items(100)
+        .send()
+        .await
+        .expect("MaxItems=100 accepted for ListVersionsByFunction");
+    // ...and for ListAliases.
+    client
+        .list_aliases()
+        .function_name("verfn")
+        .max_items(100)
+        .send()
+        .await
+        .expect("MaxItems=100 accepted for ListAliases");
+}

--- a/crates/fakecloud-lambda/src/extras/mod.rs
+++ b/crates/fakecloud-lambda/src/extras/mod.rs
@@ -714,11 +714,13 @@ impl LambdaService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let region = self.region_for(account_id);
+        // ListVersionsByFunction MaxItems range is 1..10000 in the Smithy model
+        // (default 50), not capped at 50.
         let max_items: usize = req
             .query_params
             .get("MaxItems")
             .and_then(|v| v.parse::<usize>().ok())
-            .map(|n| n.clamp(1, 50))
+            .map(|n| n.clamp(1, 10000))
             .unwrap_or(50);
         let marker = req.query_params.get("Marker").cloned();
         self.with_state_read(account_id, &region, |state| {

--- a/crates/fakecloud-lambda/src/service/functions.rs
+++ b/crates/fakecloud-lambda/src/service/functions.rs
@@ -396,22 +396,57 @@ impl LambdaService {
         let accounts = self.state.read();
         let empty = LambdaState::new(account_id, "");
         let state = accounts.get(account_id).unwrap_or(&empty);
-        let functions: Vec<Value> = state
+        let all_versions = function_version == Some("ALL");
+        let mut functions: Vec<Value> = state
             .functions
             .values()
             .map(|f| self.function_config_json(f))
             .collect();
+        if all_versions {
+            // FunctionVersion=ALL also lists every published numbered version,
+            // not just $LATEST.
+            for snaps in state.function_version_snapshots.values() {
+                for snap in snaps.values() {
+                    functions.push(self.function_config_json(snap));
+                }
+            }
+            // Order by function name, then $LATEST ahead of ascending versions.
+            functions.sort_by(|a, b| {
+                let an = a["FunctionName"].as_str().unwrap_or_default();
+                let bn = b["FunctionName"].as_str().unwrap_or_default();
+                an.cmp(bn)
+                    .then_with(|| version_sort_key(a).cmp(&version_sort_key(b)))
+            });
+        }
 
         // Honor Marker/MaxItems. AWS orders ListFunctions by FunctionName and
         // carries NextMarker as a string even on the final page (empty there).
-        let (page, next_marker) = super::paginate_marker(functions, marker, max_items, |f| {
-            f["FunctionName"].as_str().unwrap_or_default().to_string()
-        });
+        // With ALL versions, key on the ARN (unique per version) so duplicate
+        // function names don't collide in the pagination marker.
+        let key: fn(&Value) -> String = if all_versions { farn_key } else { fname_key };
+        let (page, next_marker) = super::paginate_marker(functions, marker, max_items, key);
         let response = json!({
             "Functions": page,
             "NextMarker": next_marker,
         });
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+    }
+}
+
+fn fname_key(f: &Value) -> String {
+    f["FunctionName"].as_str().unwrap_or_default().to_string()
+}
+
+fn farn_key(f: &Value) -> String {
+    f["FunctionArn"].as_str().unwrap_or_default().to_string()
+}
+
+/// Sort key for ListFunctions(ALL): `$LATEST` first (0), then numbered versions
+/// in ascending numeric order.
+fn version_sort_key(f: &Value) -> (u8, u64) {
+    match f["Version"].as_str() {
+        Some("$LATEST") | None => (0, 0),
+        Some(v) => (1, v.parse::<u64>().unwrap_or(u64::MAX)),
     }
 }

--- a/crates/fakecloud-lambda/src/service/mod.rs
+++ b/crates/fakecloud-lambda/src/service/mod.rs
@@ -1237,13 +1237,15 @@ impl AwsService for LambdaService {
                     format!("MaxItems must be a number (got '{raw}')"),
                 )
             })?;
+            // ListAliases' MaxItems range is 1..10000 in the Smithy model (only
+            // the layer / url-config / provisioned-concurrency / event-invoke
+            // lists cap at 50), so it must not be grouped with the 50-cap ops.
             let max = match action {
                 "ListLayers"
                 | "ListLayerVersions"
                 | "ListFunctionUrlConfigs"
                 | "ListProvisionedConcurrencyConfigs"
-                | "ListFunctionEventInvokeConfigs"
-                | "ListAliases" => 50,
+                | "ListFunctionEventInvokeConfigs" => 50,
                 _ => 10000,
             };
             if !(1..=max).contains(&n) {


### PR DESCRIPTION
Bug-hunt batch 7 (cycle 6). Lambda control-plane list correctness.

- **ListFunctions(FunctionVersion=ALL)** returned only each function's `$LATEST`, omitting published numbered versions. It now also emits the per-version snapshots (ordered by name, `$LATEST` then ascending versions), keyed by ARN for pagination so duplicate names don't collide in the marker.
- **ListAliases MaxItems** was grouped with the 50-cap ops, so 51..10000 returned a spurious 400. Its Smithy range is 1..10000; removed from the 50-cap group.
- **ListVersionsByFunction MaxItems** clamped to 50; its range is 1..10000 (default 50). Clamp widened.

E2E covers ALL-versions listing + MaxItems=100 on both lists. lambda lib (207) green. Builds clean; clippy `-D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Lambda list behavior: `ListFunctions(FunctionVersion=ALL)` now returns `$LATEST` plus all published versions, and `MaxItems` for `ListAliases` and `ListVersionsByFunction` accepts 1..10000. Pagination for ALL versions now uses function ARN to avoid marker collisions.

- **Bug Fixes**
  - `ListFunctions(ALL)` emits per-version snapshots and sorts by name, with `$LATEST` first then ascending version numbers.
  - Uses `FunctionArn` for pagination keys when listing ALL versions to prevent duplicate-name marker collisions.
  - Sets `MaxItems` range to 1..10000 for `ListAliases` and `ListVersionsByFunction` (default 50); adds e2e coverage for ALL-versions listing and `MaxItems=100`.

<sup>Written for commit fb688a46d75cc8f92394768e0838dc4d1eb00f5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

