### PR TITLE
fix(stepfunctions,apigateway): ListMapRuns stateMachineArn, real GenerateClientCertificate PEM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
  "http 1.4.0",
  "parking_lot",
  "percent-encoding",
+ "rcgen",
  "regex",
  "reqwest",
  "serde",

--- a/crates/fakecloud-apigateway/Cargo.toml
+++ b/crates/fakecloud-apigateway/Cargo.toml
@@ -15,6 +15,7 @@ fakecloud-elbv2 = { workspace = true }
 fakecloud-wafv2 = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+rcgen = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-apigateway/src/service_vpc_links_etc.rs
+++ b/crates/fakecloud-apigateway/src/service_vpc_links_etc.rs
@@ -504,10 +504,7 @@ impl ApiGatewayService {
             );
             o.insert(
                 "pemEncodedCertificate".to_string(),
-                Value::String(
-                    "-----BEGIN CERTIFICATE-----\nfakecloud-stub\n-----END CERTIFICATE-----"
-                        .to_string(),
-                ),
+                Value::String(generate_client_certificate_pem()),
             );
         }
         let mut accounts = self.state.write();
@@ -585,4 +582,15 @@ impl ApiGatewayService {
         });
         ok(v.clone())
     }
+}
+
+/// Generate a real self-signed X.509 certificate (PEM) for the API Gateway
+/// client certificate, so callers configuring backend mTLS trust get a
+/// parseable cert instead of a placeholder string.
+fn generate_client_certificate_pem() -> String {
+    rcgen::generate_simple_self_signed(vec!["apigateway-client.amazonaws.com".to_string()])
+        .map(|c| c.cert.pem())
+        .unwrap_or_else(|_| {
+            "-----BEGIN CERTIFICATE-----\nfakecloud-stub\n-----END CERTIFICATE-----".to_string()
+        })
 }

--- a/crates/fakecloud-e2e/tests/apigateway.rs
+++ b/crates/fakecloud-e2e/tests/apigateway.rs
@@ -1007,3 +1007,28 @@ async fn update_request_validator_keeps_boolean_flags() {
         .expect("get_request_validator");
     assert!(got.validate_request_body());
 }
+
+// bug-audit 2026-06-27, T6.3: GenerateClientCertificate must return a real,
+// parseable PEM certificate, not a placeholder string.
+#[tokio::test]
+async fn apigw_generate_client_certificate_returns_real_pem() {
+    let server = TestServer::start().await;
+    let client = server.apigateway_client().await;
+
+    let cert = client
+        .generate_client_certificate()
+        .send()
+        .await
+        .expect("generate client certificate");
+    let pem = cert.pem_encoded_certificate().expect("pem present");
+    assert!(pem.contains("-----BEGIN CERTIFICATE-----"));
+    assert!(!pem.contains("fakecloud-stub"), "not a placeholder");
+
+    // The body between the PEM markers must be valid base64 DER (a real cert).
+    let body: String = pem.lines().filter(|l| !l.starts_with("-----")).collect();
+    use base64::Engine;
+    let der = base64::engine::general_purpose::STANDARD
+        .decode(body.trim())
+        .expect("PEM body is valid base64 DER");
+    assert!(der.len() > 100, "decoded certificate is non-trivial");
+}

--- a/crates/fakecloud-stepfunctions/src/service/map_runs.rs
+++ b/crates/fakecloud-stepfunctions/src/service/map_runs.rs
@@ -60,7 +60,7 @@ impl StepFunctionsService {
                 json!({
                     "mapRunArn": r.map_run_arn,
                     "executionArn": r.execution_arn,
-                    "stateMachineArn": "",
+                    "stateMachineArn": state_machine_arn_from_execution(&r.execution_arn),
                     "startDate": r.start_date.timestamp(),
                     "stopDate": r.stop_date.map(|d| d.timestamp()),
                 })
@@ -97,5 +97,34 @@ impl StepFunctionsService {
             mr.tolerated_failure_count = c;
         }
         Ok(AwsResponse::ok_json(json!({})))
+    }
+}
+
+/// Derive the state-machine ARN from an execution ARN.
+/// `arn:aws:states:R:A:execution:Name:ExecName` -> `arn:aws:states:R:A:stateMachine:Name`.
+fn state_machine_arn_from_execution(execution_arn: &str) -> String {
+    if let Some((prefix, rest)) = execution_arn.split_once(":execution:") {
+        let sm_name = rest.split(':').next().unwrap_or("");
+        format!("{prefix}:stateMachine:{sm_name}")
+    } else {
+        String::new()
+    }
+}
+
+#[cfg(test)]
+mod sm_arn_tests {
+    use super::state_machine_arn_from_execution;
+
+    // bug-audit 2026-06-27, T6.4: ListMapRuns must report the owning state
+    // machine ARN, derived from the execution ARN.
+    #[test]
+    fn derives_state_machine_arn() {
+        assert_eq!(
+            state_machine_arn_from_execution(
+                "arn:aws:states:us-east-1:123456789012:execution:MyMachine:exec-7"
+            ),
+            "arn:aws:states:us-east-1:123456789012:stateMachine:MyMachine"
+        );
+        assert_eq!(state_machine_arn_from_execution("not-an-arn"), "");
     }
 }


### PR DESCRIPTION
Bug-hunt batch 8 (cycle 6). Two stub fixes.

- **Step Functions ListMapRuns stateMachineArn (LOW-MEDIUM).** Returned an empty `stateMachineArn` for every map run. Now derived from the execution ARN (`...:execution:Name:Exec` -> `...:stateMachine:Name`), so tooling can correlate a map run to its state machine.
- **API Gateway GenerateClientCertificate (MEDIUM).** Returned a hardcoded non-parseable PEM (`fakecloud-stub`), useless for backend mTLS trust. Now returns a real self-signed X.509 certificate via rcgen.

Unit test for the ARN derivation; e2e asserting the client certificate is a real base64-DER-decodable PEM. Builds clean; clippy `-D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two stubs: Step Functions ListMapRuns now returns the correct stateMachineArn. API Gateway GenerateClientCertificate now returns a real self‑signed X.509 PEM for backend mTLS.

- **Bug Fixes**
  - Step Functions: derive `stateMachineArn` from `executionArn` (`...:execution:Name:Exec` -> `...:stateMachine:Name`).
  - API Gateway: generate a real certificate via `rcgen` instead of a placeholder PEM.

- **Dependencies**
  - Add `rcgen` to `fakecloud-apigateway`.

<sup>Written for commit 51c1df03892a619cdb42a5345077ac5cc7aaf9fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

