### PR TITLE
chore(release): bump workspace to v0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4044,7 +4044,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4170,7 +4170,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -114,187 +114,187 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.27.0")
+    testImplementation("dev.fakecloud:fakecloud:0.28.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.27.0</version>
+    <version>0.28.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.27.0"
+version = "0.28.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.27.0"
+version = "0.28.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v0.28.0.

## New service
- **RDS Data API** (`rds-data`, new `fakecloud-rds-data` crate): runs real SQL on the backing Postgres/MySQL containers — typed parameters and results (including `bytea`/`BLOB` round-trips), transactions (Begin/Commit/Rollback over a held connection), `BatchExecuteStatement`, type fidelity (numeric/timestamp/uuid/json/decimal), conformance coverage (253 variants), and full docs/SDK-metadata sync. Now **42 services / 3,723 operations / 124,508 conformance variants**.

## Bug-hunt fixes (cycle 6, #2012-#2019)
rds-data hardening (UTF-8 SQL, k8s host, database param, txn reaper, typed MySQL results); DynamoDB PartiQL UPDATE param-order + nested REMOVE + non-ASCII WHERE panic; Lambda GetFunctionConcurrency/ListFunctions(ALL)/ListAliases MaxItems; IAM GetUser/UpdateRole; CloudWatch PutMetricData Values/Counts; Logs FilterLogEvents endTime; Kinesis GetRecords ChildShards; S3 delimiter pagination; CFN ASG LaunchTemplate; Step Functions ListMapRuns ARN; API Gateway GenerateClientCertificate real PEM.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump workspace and SDKs to v0.28.0. This release adds the RDS Data API and ships fixes across DynamoDB, Lambda, IAM, CloudWatch/Logs, Kinesis, S3, CloudFormation, Step Functions, and API Gateway.

- **New Features**
  - RDS Data API (`rds-data`, new `fakecloud-rds-data` crate): run real SQL on Postgres/MySQL with typed params/results, transactions, and batch execution.

- **Bug Fixes**
  - Hardening across DynamoDB, Lambda, IAM, CloudWatch/Logs, Kinesis, S3, CloudFormation, Step Functions, and API Gateway.

<sup>Written for commit ea62b2b37c0ae62f7eccb9f0503fe870353f1bcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

