### PR TITLE
fix(cloudwatch,logs): GetMetricStatistics honors Unit filter, DescribeLogGroups reports metricFilterCount

### DIFF
--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -814,6 +814,10 @@ impl CloudWatchService {
         }
 
         let dim_filter = parse_dimensions_query(req, "Dimensions");
+        // When a Unit is given, only datapoints published with that exact unit
+        // are aggregated (AWS treats an unspecified unit as "None"); otherwise
+        // mixing units gives a meaningless statistic.
+        let unit_filter = req.query_params.get("Unit").cloned();
 
         let state = self.state.read();
         let mut datapoints: Vec<(DateTime<Utc>, BTreeMap<String, f64>)> = Vec::new();
@@ -824,6 +828,11 @@ impl CloudWatchService {
                     for d in data.iter() {
                         if d.metric_name != metric_name {
                             continue;
+                        }
+                        if let Some(uf) = &unit_filter {
+                            if d.unit.as_deref().unwrap_or("None") != uf {
+                                continue;
+                            }
                         }
                         if !dim_filter
                             .iter()

--- a/crates/fakecloud-e2e/tests/cloudwatch.rs
+++ b/crates/fakecloud-e2e/tests/cloudwatch.rs
@@ -390,3 +390,51 @@ async fn dashboard_put_get_delete_roundtrip() {
         .iter()
         .all(|e| e.dashboard_name() != Some("dash1")));
 }
+
+// bug-audit 2026-06-27, T1.14: GetMetricStatistics must honor the Unit filter
+// instead of mixing datapoints across units.
+#[tokio::test]
+async fn get_metric_statistics_filters_by_unit() {
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+    let now = chrono::Utc::now();
+
+    cw.put_metric_data()
+        .namespace("U")
+        .metric_data(
+            MetricDatum::builder()
+                .metric_name("M")
+                .value(10.0)
+                .unit(StandardUnit::Count)
+                .timestamp(AwsDateTime::from_secs(now.timestamp()))
+                .build(),
+        )
+        .metric_data(
+            MetricDatum::builder()
+                .metric_name("M")
+                .value(999.0)
+                .unit(StandardUnit::Milliseconds)
+                .timestamp(AwsDateTime::from_secs(now.timestamp()))
+                .build(),
+        )
+        .send()
+        .await
+        .expect("put");
+
+    let stats = cw
+        .get_metric_statistics()
+        .namespace("U")
+        .metric_name("M")
+        .start_time(AwsDateTime::from_secs(now.timestamp() - 600))
+        .end_time(AwsDateTime::from_secs(now.timestamp() + 600))
+        .period(60)
+        .statistics(Statistic::Sum)
+        .unit(StandardUnit::Count)
+        .send()
+        .await
+        .expect("stats");
+    assert!(
+        (stats.datapoints()[0].sum().unwrap() - 10.0).abs() < 1e-6,
+        "only the Count datapoint aggregated, not the Milliseconds one"
+    );
+}

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -3056,3 +3056,41 @@ async fn logs_filter_log_events_end_time_inclusive() {
         "event at endTime is returned (endTime inclusive)"
     );
 }
+
+// bug-audit 2026-06-27, T1.14: DescribeLogGroups must report the real
+// metricFilterCount, not a hardcoded 0.
+#[tokio::test]
+async fn logs_describe_log_groups_reports_metric_filter_count() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+    client
+        .create_log_group()
+        .log_group_name("/mf/test")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_metric_filter()
+        .log_group_name("/mf/test")
+        .filter_name("errors")
+        .filter_pattern("ERROR")
+        .metric_transformations(
+            aws_sdk_cloudwatchlogs::types::MetricTransformation::builder()
+                .metric_name("ErrorCount")
+                .metric_namespace("MyApp")
+                .metric_value("1")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_log_groups()
+        .log_group_name_prefix("/mf/test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.log_groups()[0].metric_filter_count(), Some(1));
+}

--- a/crates/fakecloud-logs/src/service/groups.rs
+++ b/crates/fakecloud-logs/src/service/groups.rs
@@ -186,13 +186,18 @@ impl LogsService {
             .iter()
             .map(|g| {
                 let log_group_arn = g.arn.trim_end_matches(":*").to_string();
+                let metric_filter_count = state
+                    .metric_filters
+                    .iter()
+                    .filter(|mf| mf.log_group_name == g.name)
+                    .count();
                 let mut obj = json!({
                     "logGroupName": g.name,
                     "arn": g.arn,
                     "logGroupArn": log_group_arn,
                     "creationTime": g.creation_time,
                     "storedBytes": g.stored_bytes,
-                    "metricFilterCount": 0,
+                    "metricFilterCount": metric_filter_count,
                     // Real AWS DescribeLogGroups always returns logGroupClass.
                     // Terraform's `aws_cloudwatch_log_group` provider asserts
                     // `log_group_class == "STANDARD"` on every refresh, so


### PR DESCRIPTION
Cycle-6 bug-hunt backlog (T1.14 remainder).

- **GetMetricStatistics ignored the Unit filter**, aggregating datapoints across different units into a meaningless statistic. Now only aggregates datapoints matching the requested Unit (unspecified treated as "None", per AWS).
- **DescribeLogGroups returned a hardcoded metricFilterCount of 0**; now counts the metric filters attached to each log group.

E2E tests for both. cloudwatch + logs lib suites green. Builds clean; clippy `-D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two correctness issues: `GetMetricStatistics` now honors the `Unit` filter, and `DescribeLogGroups` returns the real `metricFilterCount`. This prevents mixed-unit stats and reports accurate filter counts.

- **Bug Fixes**
  - `fakecloud-cloudwatch`: Aggregate only datapoints with the requested `Unit` (unspecified treated as "None").
  - `fakecloud-logs`: `DescribeLogGroups` now counts metric filters per group and returns that number.
  - Added e2e tests for both cases.

<sup>Written for commit 2555a1f81436c4238abc7654591b9decc9ca0641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

