### PR TITLE
fix(dynamodb): cross-type relational comparisons in FilterExpression don't match

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
@@ -273,7 +273,9 @@ pub(crate) fn key_cond_between(
     let actual = item.get(&attr_name);
     match (actual, lo, hi) {
         (Some(a), Some(l), Some(h)) => {
-            compare_attribute_values(Some(a), Some(l)) != std::cmp::Ordering::Less
+            comparable_types(Some(a), Some(l))
+                && comparable_types(Some(a), Some(h))
+                && compare_attribute_values(Some(a), Some(l)) != std::cmp::Ordering::Less
                 && compare_attribute_values(Some(a), Some(h)) != std::cmp::Ordering::Greater
         }
         _ => false,
@@ -313,15 +315,25 @@ pub(crate) fn key_cond_simple_comparison(
         return match *op {
             "=" => values_equal(actual, expected),
             "<>" => !values_equal(actual, expected),
-            "<" => compare_attribute_values(actual, expected) == std::cmp::Ordering::Less,
-            ">" => compare_attribute_values(actual, expected) == std::cmp::Ordering::Greater,
+            "<" => {
+                comparable_types(actual, expected)
+                    && compare_attribute_values(actual, expected) == std::cmp::Ordering::Less
+            }
+            ">" => {
+                comparable_types(actual, expected)
+                    && compare_attribute_values(actual, expected) == std::cmp::Ordering::Greater
+            }
             "<=" => {
-                let cmp = compare_attribute_values(actual, expected);
-                cmp == std::cmp::Ordering::Less || cmp == std::cmp::Ordering::Equal
+                comparable_types(actual, expected) && {
+                    let cmp = compare_attribute_values(actual, expected);
+                    cmp == std::cmp::Ordering::Less || cmp == std::cmp::Ordering::Equal
+                }
             }
             ">=" => {
-                let cmp = compare_attribute_values(actual, expected);
-                cmp == std::cmp::Ordering::Greater || cmp == std::cmp::Ordering::Equal
+                comparable_types(actual, expected) && {
+                    let cmp = compare_attribute_values(actual, expected);
+                    cmp == std::cmp::Ordering::Greater || cmp == std::cmp::Ordering::Equal
+                }
             }
             _ => false,
         };

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -93,6 +93,21 @@ fn compare_magnitude(a: &(String, String), b: &(String, String)) -> std::cmp::Or
         .then_with(|| a.1.cmp(&b.1))
 }
 
+/// Two AttributeValues are comparable by the relational operators (`<`, `<=`,
+/// `>`, `>=`, BETWEEN) only when they share a scalar type (S, N, or B).
+/// DynamoDB does not match a comparison across mismatched types; without this
+/// guard, `compare_attribute_values` falls back to `Equal` for a type mismatch,
+/// which wrongly satisfies `<=`/`>=`/BETWEEN.
+pub(crate) fn comparable_types(a: Option<&Value>, b: Option<&Value>) -> bool {
+    match (
+        a.and_then(attribute_type_and_value),
+        b.and_then(attribute_type_and_value),
+    ) {
+        (Some((ta, _)), Some((tb, _))) => ta == tb && matches!(ta, "S" | "N" | "B"),
+        _ => false,
+    }
+}
+
 pub(crate) fn compare_attribute_values(a: Option<&Value>, b: Option<&Value>) -> std::cmp::Ordering {
     match (a, b) {
         (None, None) => std::cmp::Ordering::Equal,

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -5585,3 +5585,67 @@ async fn conditional_check_failure_returns_old_item() {
         "the returned item should be the current (v=1) item"
     );
 }
+
+// bug-audit 2026-06-27, T1.12: a relational FilterExpression comparison across
+// mismatched types must not match (DynamoDB only compares same-typed values).
+#[tokio::test]
+async fn dynamodb_filter_cross_type_comparison_does_not_match() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("CrossType")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_item()
+        .table_name("CrossType")
+        .item("id", AttributeValue::S("r1".to_string()))
+        .item("n", AttributeValue::N("5".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    // Number attribute `n` compared `<=` a STRING value: no match.
+    let mismatched = client
+        .scan()
+        .table_name("CrossType")
+        .filter_expression("n <= :s")
+        .expression_attribute_values(":s", AttributeValue::S("10".to_string()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        mismatched.count(),
+        0,
+        "cross-type n <= :string must not match"
+    );
+
+    // Same number type: matches.
+    let matched = client
+        .scan()
+        .table_name("CrossType")
+        .filter_expression("n <= :v")
+        .expression_attribute_values(":v", AttributeValue::N("10".to_string()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(matched.count(), 1, "same-type n <= :number matches");
+}


### PR DESCRIPTION
Cycle-6 bug-hunt backlog (T1.12).

A FilterExpression / KeyConditionExpression relational comparison (`<`, `<=`, `>`, `>=`, BETWEEN) across mismatched attribute types wrongly matched: `compare_attribute_values` falls back to `Ordering::Equal` on a type mismatch, which satisfies `<=`/`>=`/BETWEEN. So `n <= :s` (Number attribute vs String value) returned the item, and an optimistic-lock `version >= :v` guard could wrongly pass. The relational operators now require both operands to share a scalar type (S/N/B) — DynamoDB only compares same-typed values. (`=`/`<>` already used exact typed equality; the PartiQL `compare_attr` path already returned no-match for cross-type.)

E2E asserts `n <= :string` doesn't match while `n <= :number` does. dynamodb lib (322) green. Builds clean; clippy `-D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB FilterExpression/KeyConditionExpression so relational comparisons don’t match across mismatched types. Relational operators now require both sides to share a scalar type (S/N/B), preventing false positives like `n <= :s` and protecting optimistic-lock guards.

- **Bug Fixes**
  - Added `comparable_types` and gated `<`, `<=`, `>`, `>=`, and `BETWEEN` on same-type operands (S/N/B).
  - Wired the guard into `key_cond_simple_comparison` and `key_cond_between`; equality/inequality remain exact typed.
  - Added e2e test verifying `n <= :string` yields no match while `n <= :number` matches (addresses Linear T1.12).

<sup>Written for commit 5bde3ced6d32a6793485b8d4bd00b12bb47be349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

