### PR TITLE
fix(dynamodb): PartiQL exact large-integer numbers, BatchExecuteStatement error code enum

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -1048,9 +1048,22 @@ impl DynamoDbService {
                         }
                     }
                     Err(e) => {
+                        // BatchStatementError.Code is the BatchStatementErrorCodeEnum
+                        // (ValidationError, ConditionalCheckFailed, ...), not the
+                        // top-level "ValidationException" name.
+                        let code = match e.code() {
+                            "ConditionalCheckFailedException" => "ConditionalCheckFailed",
+                            "ResourceNotFoundException" => "ResourceNotFound",
+                            "DuplicateItemException" => "DuplicateItem",
+                            "TransactionConflictException" => "TransactionConflict",
+                            "ProvisionedThroughputExceededException" => {
+                                "ProvisionedThroughputExceeded"
+                            }
+                            _ => "ValidationError",
+                        };
                         responses.push(json!({
                             "Error": {
-                                "Code": "ValidationException",
+                                "Code": code,
                                 "Message": e.to_string()
                             }
                         }));

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -839,9 +839,13 @@ pub(crate) fn compare_attr(lhs: Option<&Value>, rhs: &Value) -> Option<i32> {
         l.get("N").and_then(|v| v.as_str()),
         r.get("N").and_then(|v| v.as_str()),
     ) {
-        let an: f64 = a.parse().ok()?;
-        let bn: f64 = b.parse().ok()?;
-        return Some(an.partial_cmp(&bn).map(|o| o as i32).unwrap_or(0));
+        // Compare the decimal strings directly: parsing to f64 silently rounds
+        // past 2^53, so two distinct large integers would compare Equal.
+        return Some(match compare_number_strings(a, b) {
+            std::cmp::Ordering::Less => -1,
+            std::cmp::Ordering::Equal => 0,
+            std::cmp::Ordering::Greater => 1,
+        });
     }
     if let (Some(a), Some(b)) = (
         l.get("S").and_then(|v| v.as_str()),
@@ -1067,7 +1071,15 @@ pub(crate) fn parse_partiql_literal(
         let inner = &s[1..s.len() - 1];
         Some(json!({"S": inner}))
     } else if let Ok(n) = s.parse::<f64>() {
-        let num_str = if n == n.trunc() {
+        // Preserve the exact decimal text for integer literals — going through
+        // f64 silently rounds past 2^53, so a 17+ digit id would be stored
+        // wrong. Fractional/scientific literals still normalize via f64.
+        let is_integer = s
+            .bytes()
+            .all(|b| b.is_ascii_digit() || b == b'-' || b == b'+');
+        let num_str = if is_integer {
+            s.strip_prefix('+').unwrap_or(s).to_string()
+        } else if n == n.trunc() {
             format!("{}", n as i64)
         } else {
             format!("{n}")

--- a/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
+++ b/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
@@ -462,3 +462,32 @@ async fn ddb_update_remove_nested_path() {
     assert!(!profile.contains_key("middle"), "nested key removed");
     assert!(profile.contains_key("first"), "sibling key kept");
 }
+
+// bug-audit 2026-06-27, T1.12: PartiQL numeric comparisons must use the exact
+// decimal value, not f64 (which rounds past 2^53 so two distinct large ints
+// compare equal).
+#[tokio::test]
+async fn ddb_partiql_large_integer_comparison_is_exact() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    create_streamed_table(&ddb, "BigInt").await;
+
+    // 2^53 + 1 — indistinguishable from 2^53 under f64.
+    ddb.execute_statement()
+        .statement("INSERT INTO \"BigInt\" value {'pk':'a','n':9007199254740993}")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = ddb
+        .execute_statement()
+        .statement("SELECT pk FROM \"BigInt\" WHERE n > 9007199254740992")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.items().len(),
+        1,
+        "9007199254740993 > 9007199254740992 holds with exact decimal comparison"
+    );
+}

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -5649,3 +5649,32 @@ async fn dynamodb_filter_cross_type_comparison_does_not_match() {
         .unwrap();
     assert_eq!(matched.count(), 1, "same-type n <= :number matches");
 }
+
+// bug-audit 2026-06-27, T1.12: a failing BatchExecuteStatement entry must report
+// a BatchStatementErrorCodeEnum value (e.g. ResourceNotFound), not the invalid
+// hardcoded "ValidationException".
+#[tokio::test]
+async fn dynamodb_batch_execute_statement_error_code_is_enum() {
+    use aws_sdk_dynamodb::types::{BatchStatementErrorCodeEnum, BatchStatementRequest};
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    let resp = client
+        .batch_execute_statement()
+        .statements(
+            BatchStatementRequest::builder()
+                .statement("SELECT * FROM \"NoSuchTable\" WHERE pk = 'x'")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let err = resp.responses()[0].error().expect("statement errored");
+    assert_eq!(
+        err.code(),
+        Some(&BatchStatementErrorCodeEnum::ResourceNotFound),
+        "missing-table statement reports ResourceNotFound, not a bogus ValidationException"
+    );
+}


### PR DESCRIPTION
Cycle-6 bug-hunt backlog (T1.12).

- **PartiQL large-integer precision.** Numeric literals and comparisons went through f64, rounding integers past 2^53: an inserted 17+ digit id stored the wrong value, and `WHERE n > <big>` treated two distinct large integers as equal. The literal parser now preserves the exact decimal text for integer literals, and `compare_attr` compares decimal strings directly.
- **BatchExecuteStatement error code.** A failing statement reported `Code: "ValidationException"` — not a member of `BatchStatementErrorCodeEnum`. It now maps to the enum (ValidationError / ConditionalCheckFailed / ResourceNotFound / DuplicateItem / TransactionConflict / ProvisionedThroughputExceeded).

E2E: exact `9007199254740993 > 9007199254740992` comparison; missing-table batch statement reports `ResourceNotFound`. dynamodb lib (322) + partiql e2e (8) green. Builds clean; clippy `-D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PartiQL large-integer handling to keep exact integers and returns proper `BatchStatementErrorCodeEnum` values in `BatchExecuteStatement`. Addresses Linear T1.12.

- **Bug Fixes**
  - PartiQL: Preserve exact integer text in the literal parser and compare numeric strings in `compare_attr` to avoid `f64` rounding (e.g., 9007199254740993 > 9007199254740992).
  - BatchExecuteStatement: Map service exceptions to enum codes (`ValidationError`, `ConditionalCheckFailed`, `ResourceNotFound`, `DuplicateItem`, `TransactionConflict`, `ProvisionedThroughputExceeded`) instead of `"ValidationException"` (e2e covers missing table -> `ResourceNotFound`).

<sup>Written for commit c0bf7ee9132090073a53b364614f22d0fa36915f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

