### PR TITLE
fix(dynamodb): ExecuteStatement honors Limit and paginates via NextToken

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -920,6 +920,8 @@ impl DynamoDbService {
         // itself a ValidationException.
         let statement = require_str_with_code(&body, "Statement", "ValidationException")?;
         let parameters = body["Parameters"].as_array().cloned().unwrap_or_default();
+        let limit = body["Limit"].as_i64().filter(|&n| n > 0);
+        let next_token = body["NextToken"].as_str().map(str::to_string);
 
         // Hold the write lock only long enough to mutate state and
         // capture the change capture record. Stream records are
@@ -932,7 +934,13 @@ impl DynamoDbService {
             let state = accounts.get_or_create(&req.account_id);
             let region = state.region.clone();
             let outcome = execute_partiql_in_state(state, statement, &parameters)?;
-            let response = outcome.response.clone();
+            // ExecuteStatement honors Limit + NextToken on a SELECT result set
+            // (AWS paginates PartiQL SELECTs); the token is an opaque offset.
+            let response = apply_execute_statement_pagination(
+                outcome.response.clone(),
+                limit,
+                next_token.as_deref(),
+            );
 
             let kinesis_info = if let (Some(table_name), Some(event_name)) =
                 (outcome.table_name.as_ref(), outcome.event_name.as_ref())
@@ -1300,6 +1308,38 @@ impl DynamoDbService {
 
         Self::ok_json(json!({ "Responses": applied_responses }))
     }
+}
+
+/// Apply `Limit` + `NextToken` to a PartiQL SELECT response. The token is an
+/// opaque base64-encoded offset into the (deterministically ordered) result
+/// set. No-op for write statements (which carry no `Items`).
+fn apply_execute_statement_pagination(
+    mut response: Value,
+    limit: Option<i64>,
+    next_token: Option<&str>,
+) -> Value {
+    use base64::Engine;
+    let b64 = base64::engine::general_purpose::STANDARD;
+    let Some(items) = response.get("Items").and_then(Value::as_array) else {
+        return response;
+    };
+    let total = items.len();
+    let start = next_token
+        .and_then(|t| b64.decode(t).ok())
+        .and_then(|b| String::from_utf8(b).ok())
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(0)
+        .min(total);
+    let end = match limit {
+        Some(l) => start.saturating_add(l as usize).min(total),
+        None => total,
+    };
+    let page: Vec<Value> = items[start..end].to_vec();
+    response["Items"] = Value::Array(page);
+    if end < total {
+        response["NextToken"] = json!(b64.encode(end.to_string()));
+    }
+    response
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
+++ b/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
@@ -491,3 +491,36 @@ async fn ddb_partiql_large_integer_comparison_is_exact() {
         "9007199254740993 > 9007199254740992 holds with exact decimal comparison"
     );
 }
+
+// bug-audit 2026-06-27, T1.12: ExecuteStatement (PartiQL SELECT) must honor
+// Limit and return/accept NextToken for pagination.
+#[tokio::test]
+async fn ddb_partiql_execute_statement_paginates() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    create_streamed_table(&ddb, "Paged").await;
+    for (i, pk) in ["p1", "p2", "p3"].iter().enumerate() {
+        put_row(&ddb, "Paged", pk, i as i64, "x").await;
+    }
+
+    let page1 = ddb
+        .execute_statement()
+        .statement("SELECT pk FROM \"Paged\"")
+        .limit(2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page1.items().len(), 2, "Limit caps the page");
+    let token = page1.next_token().expect("more results -> NextToken");
+
+    let page2 = ddb
+        .execute_statement()
+        .statement("SELECT pk FROM \"Paged\"")
+        .limit(2)
+        .next_token(token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page2.items().len(), 1, "remaining item on page 2");
+    assert!(page2.next_token().is_none(), "last page has no NextToken");
+}


### PR DESCRIPTION
Cycle-6 bug-hunt backlog (T1.12).

PartiQL ExecuteStatement (SELECT) returned the entire result set, ignoring `Limit` and never emitting `NextToken` — clients couldn't paginate a large PartiQL query. It now caps the page at `Limit`, returns an opaque base64-offset `NextToken` when rows remain, and resumes from a supplied token. Write statements unaffected.

E2E paginates a 3-item SELECT with Limit=2 across two pages. dynamodb lib (322) green. Builds clean; clippy `-D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PartiQL ExecuteStatement pagination: SELECT now honors `Limit` and returns/accepts `NextToken` so clients can page large results. Addresses T1.12.

- **Bug Fixes**
  - Enforced pagination for SELECT: apply `Limit`, emit `NextToken` when more results remain, and resume from a provided token; write statements are unchanged.
  - Added an e2e test that paginates a 3-item SELECT with `Limit=2` across two pages and verifies token behavior.

<sup>Written for commit 589f233160b86aa080f00447269f0f42161836af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

