### PR TITLE
fix(stepfunctions): glue:StartJobRun.sync returns the real GetJobRun

### DIFF
--- a/crates/fakecloud-e2e/tests/sfn_sync.rs
+++ b/crates/fakecloud-e2e/tests/sfn_sync.rs
@@ -473,3 +473,69 @@ async fn sfn_start_sync_malformed_choice_variable_does_not_drop_connection() {
         resp.status()
     );
 }
+
+// bug-audit 2026-06-27, T6.1: glue:startJobRun.sync returns the real GetJobRun
+// (full JobRun shape, actual state) instead of a hardcoded synthetic SUCCEEDED.
+#[tokio::test]
+async fn sfn_sync_glue_start_job_run_returns_real_job_run() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let glue = server.glue_client().await;
+
+    glue.create_job()
+        .name("etl-job")
+        .role("arn:aws:iam::123456789012:role/glue")
+        .command(
+            aws_sdk_glue::types::JobCommand::builder()
+                .name("glueetl")
+                .script_location("s3://example/script.py")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let definition = json!({
+        "StartAt": "RunJob",
+        "States": {
+            "RunJob": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::glue:startJobRun.sync",
+                "Parameters": { "JobName": "etl-job" },
+                "End": true
+            }
+        }
+    });
+    let created = sfn
+        .create_state_machine()
+        .name("glue-sync-sm")
+        .definition(definition.to_string())
+        .role_arn("arn:aws:iam::123456789012:role/sfn-role")
+        .send()
+        .await
+        .unwrap();
+    let started = sfn
+        .start_execution()
+        .state_machine_arn(created.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let desc = wait_for_execution_full(&sfn, started.execution_arn()).await;
+    assert_eq!(
+        desc.status().as_str(),
+        "SUCCEEDED",
+        "cause={:?}",
+        desc.cause()
+    );
+    let output: Value = serde_json::from_str(desc.output().expect("output")).unwrap();
+    let jr = &output["JobRun"];
+    assert_eq!(jr["JobRunState"].as_str(), Some("SUCCEEDED"));
+    // Real GetJobRun shape carries the run Id (the synthetic stub had it too,
+    // but also JobName/StartedOn which the real shape includes).
+    assert!(jr["Id"].is_string(), "real JobRun has an Id: {output}");
+    assert!(
+        jr["JobName"].is_string(),
+        "real JobRun has JobName: {output}"
+    );
+}

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1557,28 +1557,57 @@ async fn sync_wait(
             sync_wait_states_start_execution(registry, initial, account_id, timeout_seconds).await
         }
         ("glue", "StartJobRun") => {
-            // Glue has no real job runner in fakecloud; treat the run as
-            // immediately SUCCEEDED so `.sync` callers see a terminal
-            // result rather than spinning forever. Real AWS would poll
-            // `GetJobRun` until JobRunState in {SUCCEEDED,FAILED,STOPPED,
-            // TIMEOUT}, so we synthesize the SUCCEEDED shape.
+            // Poll the real Glue `GetJobRun` (the job run was created by the
+            // StartJobRun integration that ran just before this waiter), so the
+            // `.sync` result is the actual run — full JobRun shape, and a
+            // FAILED/STOPPED/TIMEOUT state surfaces as a task failure rather
+            // than a hardcoded SUCCEEDED.
             let job_run_id = initial
                 .get("JobRunId")
                 .and_then(Value::as_str)
-                .unwrap_or("synthetic")
+                .unwrap_or_default()
                 .to_string();
             let job_name = input
                 .get("JobName")
                 .and_then(Value::as_str)
-                .unwrap_or("")
+                .unwrap_or_default()
                 .to_string();
-            Ok(json!({
-                "JobRun": {
-                    "Id": job_run_id,
-                    "JobName": job_name,
-                    "JobRunState": "SUCCEEDED",
+            let deadline = sync_deadline(timeout_seconds);
+            loop {
+                let described = call_sdk_action(
+                    registry,
+                    "glue",
+                    "GetJobRun",
+                    &json!({ "JobName": job_name, "RunId": job_run_id }),
+                    account_id,
+                )
+                .await?;
+                let state = described
+                    .get("JobRun")
+                    .and_then(|r| r.get("JobRunState"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                match state {
+                    "SUCCEEDED" => return Ok(described),
+                    "FAILED" | "STOPPED" | "TIMEOUT" | "ERROR" => {
+                        return Err((
+                            "States.TaskFailed".to_string(),
+                            format!("Glue job run {job_run_id} ended in state {state}"),
+                        ));
+                    }
+                    _ => {}
                 }
-            }))
+                if std::time::Instant::now() >= deadline {
+                    return Err((
+                        "States.Timeout".to_string(),
+                        format!(
+                            "glue:startJobRun.sync timed out after {}s for run {job_run_id}",
+                            sync_timeout_secs(timeout_seconds)
+                        ),
+                    ));
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(SYNC_POLL_INTERVAL_MS)).await;
+            }
         }
         _ => Err((
             "States.TaskFailed".to_string(),


### PR DESCRIPTION
Cycle-6 bug-hunt backlog (T6.1).

The Step Functions `.sync` waiter for `glue:StartJobRun` synthesized a constant `{JobRunState: SUCCEEDED}` shape regardless of the actual run. It now polls the real Glue `GetJobRun` (the run was created by the StartJobRun integration that ran just before), returning the full JobRun shape and surfacing FAILED/STOPPED/TIMEOUT as `States.TaskFailed` instead of a fake success.

E2E runs a `glue:startJobRun.sync` Task against a created Glue job, asserting the full real JobRun. stepfunctions lib (188) + sfn_sync e2e green. Builds clean; clippy `-D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `glue:StartJobRun.sync` to poll real Glue `GetJobRun` and return the actual `JobRun` payload instead of a synthetic SUCCEEDED. Failed terminal states now fail the task, and wait timeouts are respected.

- **Bug Fixes**
  - Polls `GetJobRun` until terminal; returns the full `JobRun` on `SUCCEEDED`.
  - Surfaces `FAILED`, `STOPPED`, `TIMEOUT`, `ERROR` as `States.TaskFailed`; emits `States.Timeout` on wait expiry.
  - Adds an e2e test that runs `glue:startJobRun.sync` and asserts the real `JobRun` (including `Id` and `JobName`) is returned.

<sup>Written for commit 384cbfbaa620b33dc2de0c83f098e4d614914d91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

