### PR TITLE
fix(dynamodb): index Query/Scan FilterExpression only sees projected attrs

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -240,6 +240,27 @@ impl DynamoDbService {
 
         if let Some(filter) = filter_expression.as_deref() {
             matched.retain(|item| {
+                // On an index query with a non-ALL projection, the filter can
+                // only see attributes projected into the index — DynamoDB does
+                // not fetch non-projected attributes from the base table, so a
+                // filter referencing one sees it as absent.
+                if let Some((proj, key_attrs)) = query_index_projection.as_ref() {
+                    if proj.projection_type != "ALL" {
+                        let projected = apply_index_projection(
+                            (*item).clone(),
+                            proj,
+                            key_attrs,
+                            &table_pk_hash,
+                            table_pk_range.as_deref(),
+                        );
+                        return evaluate_filter_expression(
+                            filter,
+                            &projected,
+                            &expr_attr_names,
+                            &expr_attr_values,
+                        );
+                    }
+                }
                 evaluate_filter_expression(filter, item, &expr_attr_names, &expr_attr_values)
             });
         }
@@ -472,6 +493,27 @@ impl DynamoDbService {
 
         if let Some(filter) = filter_expression.as_deref() {
             matched.retain(|item| {
+                // On an index scan with a non-ALL projection, the filter can
+                // only see attributes projected into the index — DynamoDB does
+                // not fetch non-projected attributes from the base table, so a
+                // filter referencing one sees it as absent.
+                if let Some(ref proj) = index_projection {
+                    if proj.projection_type != "ALL" {
+                        let projected = apply_index_projection(
+                            (*item).clone(),
+                            proj,
+                            &index_key_attrs,
+                            &hash_key_name,
+                            range_key_name.as_deref(),
+                        );
+                        return evaluate_filter_expression(
+                            filter,
+                            &projected,
+                            &expr_attr_names,
+                            &expr_attr_values,
+                        );
+                    }
+                }
                 evaluate_filter_expression(filter, item, &expr_attr_names, &expr_attr_values)
             });
         }

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -448,6 +448,107 @@ async fn dynamodb_scan_with_index_name_applies_projection() {
     assert!(!item.contains_key("title"));
 }
 
+// On a GSI with a non-ALL projection, a FilterExpression can only reference
+// attributes projected into the index. DynamoDB does not fetch non-projected
+// attributes from the base table to evaluate the filter, so a filter on such
+// an attribute sees it as absent and never matches.
+#[tokio::test]
+async fn dynamodb_query_gsi_filter_on_non_projected_attribute_sees_absent() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("GsiFilterTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("category")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_indexes(
+            GlobalSecondaryIndex::builder()
+                .index_name("ByCategory")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("category")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::KeysOnly)
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_item()
+        .table_name("GsiFilterTable")
+        .item("id", AttributeValue::S("a".into()))
+        .item("category", AttributeValue::S("books".into()))
+        .item("title", AttributeValue::S("Rust".into()))
+        .send()
+        .await
+        .unwrap();
+
+    // Filter on 'title' — NOT projected into the KEYS_ONLY index. The base item
+    // has title="Rust", but the index can't see it, so the filter must drop it.
+    let resp = client
+        .query()
+        .table_name("GsiFilterTable")
+        .index_name("ByCategory")
+        .key_condition_expression("category = :c")
+        .expression_attribute_values(":c", AttributeValue::S("books".into()))
+        .filter_expression("title = :t")
+        .expression_attribute_values(":t", AttributeValue::S("Rust".into()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.count(),
+        0,
+        "filter on non-projected attribute must see it as absent"
+    );
+    // ScannedCount still reflects the key-matched item examined pre-filter.
+    assert_eq!(resp.scanned_count(), 1);
+
+    // Control: filter on the projected index key works normally.
+    let resp = client
+        .query()
+        .table_name("GsiFilterTable")
+        .index_name("ByCategory")
+        .key_condition_expression("category = :c")
+        .expression_attribute_values(":c", AttributeValue::S("books".into()))
+        .filter_expression("category = :c")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.count(), 1);
+}
+
 #[tokio::test]
 async fn dynamodb_scan_with_unknown_index_name_errors() {
     let server = TestServer::start().await;


### PR DESCRIPTION
## Problem

On a GSI/LSI with a non-ALL projection (`KEYS_ONLY` / `INCLUDE`), a `FilterExpression` may reference attributes that are not projected into the index. fakecloud evaluated the filter against the full base-table item, so a filter on a non-projected attribute matched when real DynamoDB would not.

Real DynamoDB does **not** fetch non-projected attributes from the base table to evaluate an index filter — the filter sees them as absent and the item is dropped. (Incident-bank class: correctness — no error, just wrong output.)

## Fix

Project each examined item to its index-projected attribute set (table PK + index keys + `INCLUDE` non-key attrs) **before** evaluating the `FilterExpression`, for both the Query and Scan index paths. `ScannedCount` still reflects pre-filter examined items, matching AWS.

## Test

New e2e `dynamodb_query_gsi_filter_on_non_projected_attribute_sees_absent`: GSI `KEYS_ONLY` + filter on a non-projected attr returns `Count=0`, `ScannedCount=1`; control filter on the projected index key still matches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes index Query/Scan filter evaluation to only see attributes projected into the index on non-ALL projections, matching real DynamoDB. Prevents false matches when filtering on non-projected attributes.

- **Bug Fixes**
  - In `fakecloud-dynamodb`, project each examined item to index-projected fields (table PK, index keys, `INCLUDE` attrs) before applying `FilterExpression` on index Query and Scan.
  - Preserve `ScannedCount` as the pre-filter examined count.
  - Add e2e test in `fakecloud-e2e` for GSI `KEYS_ONLY`: filter on a non-projected attr yields Count=0 (ScannedCount=1); filter on the projected key passes.

<sup>Written for commit 60cd4530c55658f1ae7cd0d0b213b8bbfc671cd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

