### PR TITLE
feat(cloudformation): back CFN-provisioned RDS with a real container (batch 1)

### DIFF
--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -2562,6 +2562,10 @@ mod tests {
             glue: Arc::new(parking_lot::RwLock::new(fakecloud_glue::GlueAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
             lambda_runtime: None,
+            rds_runtime: None,
+            ec2_runtime: None,
+            ecs_runtime: None,
+            elasticache_runtime: None,
         }
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
@@ -109,6 +109,13 @@ impl ResourceProvisioner {
             cloudformation_state: self.cloudformation_state.clone(),
             delivery: self.delivery.clone(),
             lambda_runtime: self.lambda_runtime.clone(),
+            rds_runtime: self.rds_runtime.clone(),
+            ec2_runtime: self.ec2_runtime.clone(),
+            ecs_runtime: self.ecs_runtime.clone(),
+            elasticache_runtime: self.elasticache_runtime.clone(),
+            // Share the parent's queue so nested-stack container resources are
+            // drained and backed by the same CreateStack.
+            pending_container_spawns: self.pending_container_spawns.clone(),
             s3_store: self.s3_store.clone(),
             account_id: self.account_id.clone(),
             region: self.region.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -902,6 +902,20 @@ pub struct ResourceProvisioner {
     /// images (see `CloudFormationDeps::lambda_runtime`). `None` outside a
     /// configured runtime (e.g. unit tests).
     pub lambda_runtime: Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
+    /// Container runtimes for stateful services whose CFN-provisioned resources
+    /// must be backed by REAL containers. See `CloudFormationDeps`. `None`
+    /// (no Docker/Podman, e.g. CI/unit tests) keeps metadata-only provisioning.
+    pub rds_runtime: Option<Arc<fakecloud_rds::runtime::RdsRuntime>>,
+    pub ec2_runtime: Option<Arc<fakecloud_ec2::runtime::Ec2Runtime>>,
+    pub ecs_runtime: Option<Arc<fakecloud_ecs::runtime::EcsRuntime>>,
+    pub elasticache_runtime: Option<Arc<fakecloud_elasticache::runtime::ElastiCacheRuntime>>,
+    /// Intents queued by container-backed provisioners during the synchronous
+    /// provisioning pass. After provisioning, `CreateStack` drains these and
+    /// backs each freshly-inserted record with a real container in the
+    /// background (so `CreateStack` returns without blocking on a container
+    /// boot — the #1539/#1730 timeout lesson). Shared via `Arc` so the drain
+    /// can read it after the provisioner is moved into `spawn_blocking`.
+    pub pending_container_spawns: Arc<parking_lot::Mutex<Vec<ContainerSpawnIntent>>>,
     /// Fine-grained S3 disk store. Bucket create/delete (and bucket-policy
     /// updates) write through this so a CFN-provisioned bucket lands on disk,
     /// matching the real `CreateBucket`/`DeleteBucket` handlers. A
@@ -910,6 +924,17 @@ pub struct ResourceProvisioner {
     pub account_id: String,
     pub region: String,
     pub stack_id: String,
+}
+
+/// A container-backed resource the synchronous provisioning pass inserted as a
+/// "creating" record that now needs a real backing container. Drained by
+/// `CreateStack` after provisioning and backgrounded so the stack create call
+/// never blocks on a container boot/pull.
+#[derive(Debug, Clone)]
+pub enum ContainerSpawnIntent {
+    /// `AWS::RDS::DBInstance` — back the inserted DbInstance with a real
+    /// Postgres/MySQL container via the RDS runtime.
+    RdsInstance { identifier: String },
 }
 
 mod acm;
@@ -6116,6 +6141,11 @@ mod tests {
             )),
             delivery: Arc::new(DeliveryBus::new()),
             lambda_runtime: None,
+            rds_runtime: None,
+            ec2_runtime: None,
+            ecs_runtime: None,
+            elasticache_runtime: None,
+            pending_container_spawns: Arc::new(parking_lot::Mutex::new(Vec::new())),
             s3_store: Arc::new(fakecloud_persistence::s3::MemoryS3Store::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
@@ -448,6 +448,18 @@ impl ResourceProvisioner {
             .unwrap_or_default();
         let tags = parse_rds_tags(props.get("Tags"));
 
+        // When an RDS container runtime is configured, the record is inserted as
+        // "creating" and `CreateStack` drains a spawn intent that backs it with
+        // a real Postgres/MySQL container (flipping it to "available" once up),
+        // matching the direct `CreateDBInstance` path. Without a runtime (CI /
+        // metadata-only) it stays "available" with no container, as before.
+        let back_with_container = self.rds_runtime.is_some();
+        let initial_status = if back_with_container {
+            "creating"
+        } else {
+            "available"
+        };
+
         let mut accounts = self.rds_state.write();
         let state = accounts.get_or_create(&self.account_id);
         let arn = state.db_instance_arn(&identifier);
@@ -462,7 +474,7 @@ impl ResourceProvisioner {
             db_instance_class: class,
             engine,
             engine_version,
-            db_instance_status: "available".to_string(),
+            db_instance_status: initial_status.to_string(),
             master_username,
             db_name,
             endpoint_address,
@@ -602,6 +614,15 @@ impl ResourceProvisioner {
         let endpoint = inst.endpoint_address.clone();
         let endpoint_port = inst.port;
         state.instances.insert(identifier.clone(), inst);
+        drop(accounts);
+
+        if back_with_container {
+            self.pending_container_spawns
+                .lock()
+                .push(super::ContainerSpawnIntent::RdsInstance {
+                    identifier: identifier.clone(),
+                });
+        }
 
         Ok(ProvisionResult::new(identifier.clone())
             .with("DBInstanceArn", arn)

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -323,6 +323,17 @@ pub struct CloudFormationDeps {
     /// runtime is configured — provisioning still works, the first Invoke just
     /// falls back to a cold pull.
     pub lambda_runtime: Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
+    /// Container runtimes for the stateful services whose CFN-provisioned
+    /// resources must be backed by REAL containers (not phantom metadata).
+    /// When present, the provisioner inserts the resource record synchronously
+    /// (so `Ref`/`GetAtt` resolve during provisioning) and then backs it with a
+    /// real container in the background — the same container the direct API
+    /// path spawns. `None` (no Docker/Podman, e.g. CI) keeps the metadata-only
+    /// behavior, matching how the direct API degrades without a runtime.
+    pub rds_runtime: Option<Arc<fakecloud_rds::runtime::RdsRuntime>>,
+    pub ec2_runtime: Option<Arc<fakecloud_ec2::runtime::Ec2Runtime>>,
+    pub ecs_runtime: Option<Arc<fakecloud_ecs::runtime::EcsRuntime>>,
+    pub elasticache_runtime: Option<Arc<fakecloud_elasticache::runtime::ElastiCacheRuntime>>,
 }
 
 pub struct CloudFormationService {
@@ -464,6 +475,11 @@ impl CloudFormationService {
             cloudformation_state: self.state.clone(),
             delivery: self.deps.delivery.clone(),
             lambda_runtime: self.deps.lambda_runtime.clone(),
+            rds_runtime: self.deps.rds_runtime.clone(),
+            ec2_runtime: self.deps.ec2_runtime.clone(),
+            ecs_runtime: self.deps.ecs_runtime.clone(),
+            elasticache_runtime: self.deps.elasticache_runtime.clone(),
+            pending_container_spawns: Arc::new(parking_lot::Mutex::new(Vec::new())),
             s3_store: self.s3_store.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1023,6 +1039,14 @@ impl CloudFormationService {
             resource_defs,
         } = ctx;
 
+        // Capture the container-spawn handles before the provisioner is moved
+        // into spawn_blocking, so the post-provision drain (below) can back
+        // freshly-inserted container resources with REAL containers.
+        let container_spawns = provisioner.pending_container_spawns.clone();
+        let rds_runtime_for_spawn = provisioner.rds_runtime.clone();
+        let rds_state_for_spawn = provisioner.rds_state.clone();
+        let region_for_spawn = provisioner.region.clone();
+
         // The provisioning loop is fully synchronous (it may block on cold
         // image pulls / custom-resource Lambda invokes). Hand it to a
         // blocking thread so it never stalls a tokio worker.
@@ -1069,6 +1093,34 @@ impl CloudFormationService {
                 return;
             }
         };
+
+        // Provisioning succeeded: back any container-backed resources (RDS
+        // instances, ...) with REAL containers. Each spawn is detached so
+        // CreateStack never blocks on a container boot/pull — the record is
+        // already inserted as "creating" and flips to "available" when the
+        // container is up (the #1539/#1730 timeout lesson).
+        {
+            let intents = std::mem::take(&mut *container_spawns.lock());
+            for intent in intents {
+                match intent {
+                    crate::resource_provisioner::ContainerSpawnIntent::RdsInstance {
+                        identifier,
+                    } => {
+                        if let Some(runtime) = rds_runtime_for_spawn.clone() {
+                            let rds_state = rds_state_for_spawn.clone();
+                            let account = account_id.clone();
+                            let region = region_for_spawn.clone();
+                            tokio::spawn(async move {
+                                fakecloud_rds::cfn_provision::cfn_ensure_instance_container(
+                                    rds_state, runtime, identifier, account, region,
+                                )
+                                .await;
+                            });
+                        }
+                    }
+                }
+            }
+        }
 
         let outputs =
             Self::resolve_template_outputs(&template_body, &parameters, &resources, &state);
@@ -2514,6 +2566,10 @@ mod tests {
             glue: Arc::new(parking_lot::RwLock::new(fakecloud_glue::GlueAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
             lambda_runtime: None,
+            rds_runtime: None,
+            ec2_runtime: None,
+            ecs_runtime: None,
+            elasticache_runtime: None,
         };
         CloudFormationService::new(cf_state, deps)
     }

--- a/crates/fakecloud-e2e/tests/rds_data_api.rs
+++ b/crates/fakecloud-e2e/tests/rds_data_api.rs
@@ -508,3 +508,98 @@ async fn rds_data_api_mysql_generated_fields() {
         "MySQL INSERT returns the auto-increment id in generatedFields"
     );
 }
+
+// A DBInstance provisioned through a CloudFormation stack must be backed by a
+// REAL Postgres container (not phantom metadata): once the stack reports the
+// instance available, RDS Data API runs genuine SQL against it. This is the
+// CFN-provisioner-spawns-real-infrastructure guarantee — rivals' CFN paths
+// only stamp metadata, so a CFN-created DB is unusable there.
+#[tokio::test]
+async fn cfn_provisioned_rds_instance_is_a_real_connectable_postgres() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let rds = server.rds_client().await;
+
+    let template = r#"{
+      "AWSTemplateFormatVersion": "2010-09-09",
+      "Resources": {
+        "Db": {
+          "Type": "AWS::RDS::DBInstance",
+          "Properties": {
+            "DBInstanceIdentifier": "cfn-realpg",
+            "DBInstanceClass": "db.t3.micro",
+            "Engine": "postgres",
+            "EngineVersion": "16.3",
+            "MasterUsername": "admin",
+            "MasterUserPassword": "secret123",
+            "DBName": "appdb",
+            "AllocatedStorage": "20"
+          }
+        }
+      },
+      "Outputs": {
+        "Arn": {"Value": {"Fn::GetAtt": ["Db", "DBInstanceArn"]}}
+      }
+    }"#;
+
+    cfn.create_stack()
+        .stack_name("cfn-realpg-stack")
+        .template_body(template)
+        .send()
+        .await
+        .expect("create_stack");
+
+    // The container boots in the background (CreateStack does not block on it);
+    // wait for the stack-provisioned instance to flip creating -> available.
+    let instance = helpers::wait_for_db_available(&rds, "cfn-realpg", 240).await;
+    let arn = instance
+        .db_instance_arn()
+        .expect("db instance arn")
+        .to_string();
+
+    let data = aws_sdk_rdsdata::Client::new(&server.aws_config().await);
+    let secret = "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-AbCdEf";
+
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("CREATE TABLE cfn_t (id int, name text)")
+        .send()
+        .await
+        .expect("CREATE TABLE on the CFN-provisioned Postgres");
+
+    data.execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("INSERT INTO cfn_t (id, name) VALUES (:id, :name)")
+        .parameters(param("id", Field::LongValue(42)))
+        .parameters(param("name", Field::StringValue("provisioned".into())))
+        .send()
+        .await
+        .expect("INSERT on the CFN-provisioned Postgres");
+
+    let resp = data
+        .execute_statement()
+        .resource_arn(&arn)
+        .secret_arn(secret)
+        .sql("SELECT id, name FROM cfn_t WHERE id = :id")
+        .parameters(param("id", Field::LongValue(42)))
+        .send()
+        .await
+        .expect("SELECT on the CFN-provisioned Postgres");
+
+    let records = resp.records();
+    assert_eq!(records.len(), 1, "one row from the real CFN-provisioned db");
+    let row = &records[0];
+    assert_eq!(row[0].as_long_value().ok(), Some(&42));
+    assert_eq!(
+        row[1].as_string_value().ok().map(String::as_str),
+        Some("provisioned")
+    );
+
+    cfn.delete_stack()
+        .stack_name("cfn-realpg-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+}

--- a/crates/fakecloud-rds/src/cfn_provision.rs
+++ b/crates/fakecloud-rds/src/cfn_provision.rs
@@ -1,0 +1,113 @@
+//! CloudFormation-driven container backing for RDS instances.
+//!
+//! When `AWS::RDS::DBInstance` is provisioned through a CloudFormation stack,
+//! the CFN provisioner inserts the `DbInstance` record synchronously (so
+//! `Ref`/`GetAtt` resolve during provisioning) with status `creating`, then
+//! asks RDS to back it with a REAL Postgres/MySQL container — the same
+//! container the direct `CreateDBInstance` path spawns. This mirrors that
+//! background task for an already-inserted record, so a CFN-provisioned RDS
+//! instance is genuinely connectable, not phantom metadata.
+
+use std::sync::Arc;
+
+use crate::runtime::RdsRuntime;
+use crate::SharedRdsState;
+
+/// Default logical DB name per engine when the template omits `DBName`,
+/// matching what the direct `CreateDBInstance` path uses.
+fn default_db_name(engine: &str) -> &'static str {
+    match engine {
+        "mysql" | "mariadb" => "mysql",
+        "oracle-ee" | "oracle-se2" | "oracle-ee-cdb" | "oracle-se2-cdb" => "ORCL",
+        "sqlserver-ee" | "sqlserver-se" | "sqlserver-ex" | "sqlserver-web" => "master",
+        "db2-se" | "db2-ae" => "BLUDB",
+        _ => "postgres",
+    }
+}
+
+/// Back an already-inserted (status `creating`) DBInstance with a real
+/// container and flip it to `available`. No-op if the record is gone (e.g. the
+/// stack was deleted before the container booted). Intended to be `tokio::spawn`ed
+/// by the CloudFormation `CreateStack` drain so stack creation never blocks on a
+/// container boot/pull (the #1539/#1730 timeout lesson).
+pub async fn cfn_ensure_instance_container(
+    state: SharedRdsState,
+    runtime: Arc<RdsRuntime>,
+    identifier: String,
+    account_id: String,
+    region: String,
+) {
+    // Snapshot the create parameters from the inserted record.
+    let params = {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create(&account_id);
+        match st.instances.get(&identifier) {
+            Some(inst) => {
+                let db_name = inst
+                    .db_name
+                    .clone()
+                    .unwrap_or_else(|| default_db_name(&inst.engine).to_string());
+                (
+                    inst.engine.clone(),
+                    inst.engine_version.clone(),
+                    inst.master_username.clone(),
+                    inst.master_user_password.clone(),
+                    db_name,
+                    inst.tags.clone(),
+                )
+            }
+            None => return,
+        }
+    };
+    let (engine, engine_version, username, password, db_name, tags) = params;
+
+    match runtime
+        .ensure_postgres(
+            &identifier,
+            &engine,
+            &engine_version,
+            &username,
+            &password,
+            &db_name,
+            &account_id,
+            &region,
+            &tags,
+        )
+        .await
+    {
+        Ok(running) => {
+            // Apply the update in a block so the (non-Send) write guard is
+            // dropped before any `.await` below.
+            let present = {
+                let mut accounts = state.write();
+                let st = accounts.get_or_create(&account_id);
+                if let Some(inst) = st.instances.get_mut(&identifier) {
+                    inst.db_instance_status = "available".to_string();
+                    inst.endpoint_address = running.endpoint_address;
+                    inst.port = i32::from(running.endpoint_port);
+                    inst.host_port = running.host_port;
+                    inst.container_id = running.container_id;
+                    true
+                } else {
+                    false
+                }
+            };
+            if !present {
+                // Deleted mid-boot: reap the orphaned container.
+                runtime.stop_container(&identifier).await;
+            }
+        }
+        Err(error) => {
+            tracing::error!(
+                %error,
+                db_instance_identifier = %identifier,
+                "CFN-provisioned RDS instance failed to start its container",
+            );
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(&account_id);
+            if let Some(inst) = st.instances.get_mut(&identifier) {
+                inst.db_instance_status = "failed".to_string();
+            }
+        }
+    }
+}

--- a/crates/fakecloud-rds/src/lib.rs
+++ b/crates/fakecloud-rds/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cfn_provision;
 pub mod extras;
 pub mod runtime;
 pub(crate) mod service;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -941,6 +941,10 @@ async fn main() {
             glue: glue_state.clone(),
             delivery: delivery_for_cf,
             lambda_runtime: container_runtime.clone(),
+            rds_runtime: rds_runtime.clone(),
+            ec2_runtime: ec2_runtime.clone(),
+            ecs_runtime: ecs_runtime.clone(),
+            elasticache_runtime: elasticache_runtime.clone(),
         },
     );
     if let Some(store) = cloudformation_snapshot_store {

--- a/website/content/docs/services/cloudformation.md
+++ b/website/content/docs/services/cloudformation.md
@@ -60,6 +60,8 @@ Full control plane: `CreateStackSet`, `UpdateStackSet`, `DeleteStackSet`, `Descr
 
 Resources of these types create real backing state in the corresponding fakecloud service. Any other resource type — including real AWS types fakecloud doesn't model (e.g. `AWS::CloudFormation::WaitConditionHandle`) — is accepted and recorded as provisioned without allocating underlying state, rather than failing the stack; `Ref` on it resolves to its logical ID. Dependent operations that need real backing state may still fail.
 
+For **container-backed** services, a CloudFormation-provisioned resource is backed by the same **real container** the direct API spawns, not phantom metadata. A CFN-created `AWS::RDS::DBInstance` is a genuinely connectable Postgres/MySQL: the record is inserted synchronously (so `Ref`/`GetAtt` resolve during provisioning) and the container boots in the background, so `CreateStack` never blocks on the image pull; the instance flips from `creating` to `available` once the container is up. When no container runtime is configured (e.g. CI without Docker/Podman), provisioning degrades to metadata-only, exactly as the direct API does.
+
 - **API Gateway v1** — `RestApi`, `Resource`, `Method`, `Model`, `RequestValidator`, `Authorizer`, `Deployment`, `Stage`, `ApiKey`, `UsagePlan`, `UsagePlanKey`, `DomainName`, `BasePathMapping`, `GatewayResponse`
 - **API Gateway v2** — `Api`, `Stage`, `Route`, `RouteResponse`, `Integration`, `IntegrationResponse`, `Authorizer`, `Deployment`, `Model`, `DomainName`, `ApiMapping`, `VpcLink`
 - **Application Auto Scaling** — `ScalableTarget`, `ScalingPolicy`


### PR DESCRIPTION
## Summary

CloudFormation's resource provisioner re-implemented resource creation by inserting metadata directly, **bypassing each service's real container-spawning path**. A CFN-created `AWS::RDS::DBInstance` was phantom — it reported `available` but had no backing container, so it was **not connectable**, while the same instance via the direct API is a real Postgres/MySQL. Every rival emulator's CFN provisioner is metadata-only here; fakecloud is the only one that runs real containers, so wiring CFN to them is a structural differentiator (next-step decision 2026-06-28).

This is **batch 1** of the CFN-real-infrastructure series: it establishes the shared async-provision plumbing and wires RDS as the first service.

### Plumbing
- `CloudFormationDeps` + `ResourceProvisioner` carry the container runtimes (rds/ec2/ecs/elasticache), mirroring the existing `lambda_runtime` field.
- Container-backed provisioners queue a `ContainerSpawnIntent` during the synchronous provisioning pass, shared via `Arc` so the drain can read it after the provisioner is moved into `spawn_blocking`; nested stacks share the parent's queue.
- After provisioning succeeds, `CreateStack` drains the intents and spawns each real container in a **detached task** — `CreateStack` never blocks on a container boot/pull (the #1539/#1730 timeout lesson). The record is inserted as `creating` synchronously (so `Ref`/`GetAtt` resolve) and flips to `available` when the container is up.

### RDS
- New `fakecloud_rds::cfn_provision::cfn_ensure_instance_container` backs an inserted `DbInstance` via the same `RdsRuntime::ensure_postgres` the direct `CreateDBInstance` path uses. Without a runtime (CI) it stays metadata-only, matching how the direct API degrades.

## Test plan
- New e2e `cfn_provisioned_rds_instance_is_a_real_connectable_postgres`: provisions an RDS instance through a stack, waits for `available`, then runs real `CREATE TABLE` / `INSERT` / `SELECT` via the RDS Data API against it. **Passes locally (18s, real Docker Postgres).**
- Existing `cfn_provisions_rds_db_instance_and_cluster` still green (no status assertion; degrades cleanly).
- `clippy --all-targets -D warnings` clean on both crates.

## Surface
- **Docs:** `cloudformation.md` documents the container-backed provisioning guarantee.
- **SDKs:** no new API surface (behavioral change to provisioning) -> no SDK change.

Batches 2-5 follow: Auto Scaling, EC2 instances, ECS + ElastiCache, then restart-reconcile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backs CloudFormation-provisioned `AWS::RDS::DBInstance` with a real Postgres/MySQL container using the same runtime as the direct API. Adds async container-spawn plumbing so `CreateStack` returns promptly; resources start as `creating` and flip to `available` when the container is up.

- **New Features**
  - `CloudFormationDeps`/`ResourceProvisioner` now carry container runtimes for `rds`, `ec2`, `ecs`, and `elasticache`; RDS is wired in this batch.
  - Synchronous provisioning enqueues `ContainerSpawnIntent`; after success, CFN drains and spawns containers in detached tasks; nested stacks share the queue.
  - RDS: insert instance as `creating`, queue spawn, then `fakecloud_rds::cfn_provision::cfn_ensure_instance_container` starts the container and updates endpoint/status.
  - Graceful fallback: without a runtime (e.g., CI), instances remain metadata-only and `available`, matching the direct API.
  - Added e2e to run real SQL via RDS Data API against a CFN-created instance; docs note the container-backed guarantee.

<sup>Written for commit 992185c0950954748ed469d5656cd97763b8ed03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

