### PR TITLE
feat(cloudformation): back CFN-provisioned AutoScaling groups with real instances (batch 2)

### DIFF
--- a/crates/fakecloud-autoscaling/src/cfn_provision.rs
+++ b/crates/fakecloud-autoscaling/src/cfn_provision.rs
@@ -1,0 +1,35 @@
+//! CloudFormation-driven container backing for Auto Scaling Groups.
+//!
+//! When `AWS::AutoScaling::AutoScalingGroup` is provisioned through a
+//! CloudFormation stack, the CFN provisioner inserts the group record
+//! synchronously (control plane only, `instances` empty so `Ref`/`GetAtt`
+//! resolve during provisioning), then asks autoscaling to reconcile it to its
+//! desired capacity by launching REAL container-backed EC2 instances — the
+//! same instances the direct `CreateAutoScalingGroup` path spawns via
+//! `RunInstances`. This mirrors that background reconcile for an
+//! already-inserted group, so a CFN-provisioned ASG is genuinely backed by real
+//! instances, not phantom metadata.
+
+use std::sync::Arc;
+
+use crate::AutoScalingService;
+use crate::SharedAutoScalingState;
+
+/// Reconcile a CFN-provisioned Auto Scaling Group to its desired capacity by
+/// launching REAL EC2 instances. No-op if the group is gone (e.g. the stack was
+/// deleted before reconciliation ran). Intended to be `tokio::spawn`ed by the
+/// CloudFormation `CreateStack` drain so stack creation never blocks on a
+/// container boot/pull (the #1539/#1730 timeout lesson). With no EC2 backend
+/// wired (CI / metadata-only) the group still reaches desired capacity via
+/// synthesized instance ids, matching the direct API path.
+pub async fn cfn_reconcile_capacity(
+    asg_state: SharedAutoScalingState,
+    ec2_state: fakecloud_ec2::SharedEc2State,
+    ec2_runtime: Option<Arc<fakecloud_ec2::Ec2Runtime>>,
+    group_name: String,
+    account_id: String,
+    region: String,
+) {
+    let svc = AutoScalingService::new(asg_state).with_ec2(ec2_state, ec2_runtime);
+    svc.reconcile_group(&account_id, &group_name, &region).await;
+}

--- a/crates/fakecloud-autoscaling/src/lib.rs
+++ b/crates/fakecloud-autoscaling/src/lib.rs
@@ -7,6 +7,7 @@
 //! launches real container-backed EC2 instances (batch 2), closing the gap
 //! every rival has where an ASG scales to a *mock* instance.
 
+pub mod cfn_provision;
 pub mod service;
 pub mod state;
 

--- a/crates/fakecloud-autoscaling/src/service.rs
+++ b/crates/fakecloud-autoscaling/src/service.rs
@@ -899,6 +899,34 @@ impl AutoScalingService {
     /// change. The EC2 calls happen OFF the state lock (no `.await` under the
     /// parking_lot guard); the lock is only taken to read inputs and apply
     /// results.
+    /// Reconcile a group to its desired capacity outside the request path (e.g.
+    /// CloudFormation provisioning). Synthesizes a minimal `AwsRequest` — the
+    /// EC2 calls only read `region`/`account_id`/`request_id` off it — and runs
+    /// the same `apply_capacity` reconciliation the direct API path uses, so a
+    /// CFN-provisioned ASG ends up with REAL container-backed instances (or
+    /// synthesized ids when no EC2 backend is wired, e.g. CI).
+    pub async fn reconcile_group(&self, account: &str, name: &str, region: &str) {
+        let req = AwsRequest {
+            service: "autoscaling".to_string(),
+            action: "ReconcileGroup".to_string(),
+            region: region.to_string(),
+            account_id: account.to_string(),
+            request_id: "cfn".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        };
+        self.apply_capacity(account, name, &req).await;
+    }
+
     async fn apply_capacity(&self, account: &str, name: &str, req: &AwsRequest) {
         let (target, current_ids, azs, image_id, instance_type, subnet) = {
             let accounts = self.state.read();

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/autoscaling.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/autoscaling.rs
@@ -148,21 +148,13 @@ impl ResourceProvisioner {
             })
             .or_else(|| prop_str(props, "VPCZoneIdentifier").map(String::from));
 
-        // Placeholder instances to satisfy the desired capacity (the service's
-        // control-plane behavior; runtime launches real ones via the API path).
-        let instances: Vec<AsgInstance> = (0..desired.max(0))
-            .map(|k| {
-                let hex = Uuid::new_v4().simple().to_string();
-                AsgInstance {
-                    instance_id: format!("i-{}", &hex[..17]),
-                    availability_zone: azs[k as usize % azs.len()].clone(),
-                    lifecycle_state: "InService".to_string(),
-                    health_status: "Healthy".to_string(),
-                    launch_configuration_name: lcn.clone(),
-                    protected_from_scale_in: false,
-                }
-            })
-            .collect();
+        // Insert the group as control-plane only (no instances). After
+        // provisioning, `CreateStack` drains an `AsgInstances` spawn intent that
+        // reconciles the group to its desired capacity by launching REAL
+        // container-backed EC2 instances via the EC2 runtime — the same
+        // instances the direct `CreateAutoScalingGroup` path spawns — instead of
+        // the phantom placeholder metadata this used to insert at CFN time.
+        let instances: Vec<AsgInstance> = Vec::new();
 
         let arn = self.asg_arn("autoScalingGroup", &name);
         let group = AutoScalingGroup {
@@ -200,6 +192,11 @@ impl ResourceProvisioner {
             .get_or_create(&self.account_id)
             .groups
             .insert(name.clone(), group);
+        self.pending_container_spawns
+            .lock()
+            .push(super::ContainerSpawnIntent::AsgInstances {
+                group_name: name.clone(),
+            });
         Ok(ProvisionResult::new(name).with("Arn", arn))
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -935,6 +935,10 @@ pub enum ContainerSpawnIntent {
     /// `AWS::RDS::DBInstance` — back the inserted DbInstance with a real
     /// Postgres/MySQL container via the RDS runtime.
     RdsInstance { identifier: String },
+    /// `AWS::AutoScaling::AutoScalingGroup` — reconcile the inserted group to
+    /// its desired capacity by launching real container-backed EC2 instances
+    /// via the EC2 runtime, matching the direct `CreateAutoScalingGroup` path.
+    AsgInstances { group_name: String },
 }
 
 mod acm;

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -1046,6 +1046,9 @@ impl CloudFormationService {
         let rds_runtime_for_spawn = provisioner.rds_runtime.clone();
         let rds_state_for_spawn = provisioner.rds_state.clone();
         let region_for_spawn = provisioner.region.clone();
+        let ec2_state_for_spawn = provisioner.ec2_state.clone();
+        let ec2_runtime_for_spawn = provisioner.ec2_runtime.clone();
+        let autoscaling_state_for_spawn = provisioner.autoscaling_state.clone();
 
         // The provisioning loop is fully synchronous (it may block on cold
         // image pulls / custom-resource Lambda invokes). Hand it to a
@@ -1117,6 +1120,26 @@ impl CloudFormationService {
                                 .await;
                             });
                         }
+                    }
+                    crate::resource_provisioner::ContainerSpawnIntent::AsgInstances {
+                        group_name,
+                    } => {
+                        let asg_state = autoscaling_state_for_spawn.clone();
+                        let ec2_state = ec2_state_for_spawn.clone();
+                        let ec2_runtime = ec2_runtime_for_spawn.clone();
+                        let account = account_id.clone();
+                        let region = region_for_spawn.clone();
+                        tokio::spawn(async move {
+                            fakecloud_autoscaling::cfn_provision::cfn_reconcile_capacity(
+                                asg_state,
+                                ec2_state,
+                                ec2_runtime,
+                                group_name,
+                                account,
+                                region,
+                            )
+                            .await;
+                        });
                     }
                 }
             }

--- a/crates/fakecloud-e2e/tests/cloudformation_autoscaling.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_autoscaling.rs
@@ -53,7 +53,22 @@ async fn cfn_provisions_autoscaling_group() {
         "CFN launch configuration should exist"
     );
 
-    let groups = asg.describe_auto_scaling_groups().send().await.unwrap();
+    // Reconciliation to desired capacity happens in a detached task after
+    // CreateStack returns (so the call never blocks on launching instances), so
+    // poll until the group reports its 2 instances.
+    let groups = helpers::wait_until(std::time::Duration::from_secs(10), || {
+        let asg = asg.clone();
+        async move {
+            let out = asg.describe_auto_scaling_groups().send().await.ok()?;
+            let found = out
+                .auto_scaling_groups()
+                .iter()
+                .any(|g| g.desired_capacity() == Some(2) && g.instances().len() == 2);
+            found.then_some(out)
+        }
+    })
+    .await
+    .expect("CFN ASG reconciled to desired capacity of 2");
     let g = groups
         .auto_scaling_groups()
         .iter()
@@ -118,4 +133,69 @@ async fn cfn_asg_honors_launch_template() {
         .expect("launch template carried from CFN");
     assert_eq!(lt.launch_template_id(), Some("lt-0abc123"));
     assert_eq!(lt.version(), Some("3"));
+}
+
+// batch 2: a CFN-provisioned ASG must reconcile to REAL container-backed EC2
+// instances (via the same RunInstances path the direct CreateAutoScalingGroup
+// API uses), not the phantom placeholder metadata the provisioner used to
+// insert at CFN time. The launched instances must therefore appear in EC2
+// DescribeInstances. This holds with or without a container runtime: with no
+// runtime the EC2 records are metadata-only but still real EC2 instances.
+#[tokio::test]
+async fn cfn_asg_launches_real_ec2_instances() {
+    let s = TestServer::start().await;
+    let cfn = s.cloudformation_client().await;
+    let asg = aws_sdk_autoscaling::Client::new(&s.aws_config().await);
+    let ec2 = s.ec2_client().await;
+
+    cfn.create_stack()
+        .stack_name("asg-real-stack")
+        .template_body(TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    // Reconciliation runs in a detached task after CreateStack returns; poll
+    // until the group reports its 2 instances and capture their ids.
+    let asg_ids = helpers::wait_until(std::time::Duration::from_secs(10), || {
+        let asg = asg.clone();
+        async move {
+            let out = asg.describe_auto_scaling_groups().send().await.ok()?;
+            let g = out
+                .auto_scaling_groups()
+                .iter()
+                .find(|g| g.desired_capacity() == Some(2))?;
+            if g.instances().len() != 2 {
+                return None;
+            }
+            let ids: Vec<String> = g
+                .instances()
+                .iter()
+                .filter_map(|i| i.instance_id().map(String::from))
+                .collect();
+            (ids.len() == 2).then_some(ids)
+        }
+    })
+    .await
+    .expect("CFN ASG reconciled to 2 real instances");
+
+    // Those exact instances are REAL EC2 instances (not phantom ASG metadata).
+    let running = ec2
+        .describe_instances()
+        .instance_ids(asg_ids[0].clone())
+        .instance_ids(asg_ids[1].clone())
+        .send()
+        .await
+        .unwrap();
+    let ec2_ids: Vec<String> = running
+        .reservations()
+        .iter()
+        .flat_map(|r| r.instances())
+        .filter_map(|i| i.instance_id().map(String::from))
+        .collect();
+    assert_eq!(
+        ec2_ids.len(),
+        2,
+        "both CFN-provisioned ASG instances must exist in EC2: {ec2_ids:?}"
+    );
 }

--- a/crates/fakecloud-e2e/tests/cloudformation_autoscaling_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_autoscaling_persistence.rs
@@ -37,6 +37,25 @@ async fn cfn_provisioned_asg_survives_restart() {
         .await
         .expect("create_stack");
 
+    // The group reconciles to its desired capacity in a detached task after
+    // CreateStack returns; wait for that to land before restarting so the
+    // reconciled instances are part of the persisted snapshot.
+    {
+        let asg = aws_sdk_autoscaling::Client::new(&server.aws_config().await);
+        helpers::wait_until(std::time::Duration::from_secs(10), || {
+            let asg = asg.clone();
+            async move {
+                let out = asg.describe_auto_scaling_groups().send().await.ok()?;
+                out.auto_scaling_groups()
+                    .iter()
+                    .any(|g| g.desired_capacity() == Some(2) && g.instances().len() == 2)
+                    .then_some(())
+            }
+        })
+        .await
+        .expect("CFN ASG reconciled to desired capacity before restart");
+    }
+
     server.restart().await;
     let asg = aws_sdk_autoscaling::Client::new(&server.aws_config().await);
 

--- a/website/content/docs/services/cloudformation.md
+++ b/website/content/docs/services/cloudformation.md
@@ -60,12 +60,13 @@ Full control plane: `CreateStackSet`, `UpdateStackSet`, `DeleteStackSet`, `Descr
 
 Resources of these types create real backing state in the corresponding fakecloud service. Any other resource type — including real AWS types fakecloud doesn't model (e.g. `AWS::CloudFormation::WaitConditionHandle`) — is accepted and recorded as provisioned without allocating underlying state, rather than failing the stack; `Ref` on it resolves to its logical ID. Dependent operations that need real backing state may still fail.
 
-For **container-backed** services, a CloudFormation-provisioned resource is backed by the same **real container** the direct API spawns, not phantom metadata. A CFN-created `AWS::RDS::DBInstance` is a genuinely connectable Postgres/MySQL: the record is inserted synchronously (so `Ref`/`GetAtt` resolve during provisioning) and the container boots in the background, so `CreateStack` never blocks on the image pull; the instance flips from `creating` to `available` once the container is up. When no container runtime is configured (e.g. CI without Docker/Podman), provisioning degrades to metadata-only, exactly as the direct API does.
+For **container-backed** services, a CloudFormation-provisioned resource is backed by the same **real container** the direct API spawns, not phantom metadata. A CFN-created `AWS::RDS::DBInstance` is a genuinely connectable Postgres/MySQL: the record is inserted synchronously (so `Ref`/`GetAtt` resolve during provisioning) and the container boots in the background, so `CreateStack` never blocks on the image pull; the instance flips from `creating` to `available` once the container is up. A CFN-created `AWS::AutoScaling::AutoScalingGroup` likewise reconciles to **real container-backed EC2 instances**: the group record is inserted synchronously (control plane only), then a background task launches its desired capacity through the same `RunInstances` path the direct `CreateAutoScalingGroup` API uses, so the launched instances show up in EC2 `DescribeInstances` instead of being phantom ASG metadata. When no container runtime is configured (e.g. CI without Docker/Podman), provisioning degrades to metadata-only, exactly as the direct API does.
 
 - **API Gateway v1** — `RestApi`, `Resource`, `Method`, `Model`, `RequestValidator`, `Authorizer`, `Deployment`, `Stage`, `ApiKey`, `UsagePlan`, `UsagePlanKey`, `DomainName`, `BasePathMapping`, `GatewayResponse`
 - **API Gateway v2** — `Api`, `Stage`, `Route`, `RouteResponse`, `Integration`, `IntegrationResponse`, `Authorizer`, `Deployment`, `Model`, `DomainName`, `ApiMapping`, `VpcLink`
 - **Application Auto Scaling** — `ScalableTarget`, `ScalingPolicy`
 - **Athena** — `WorkGroup`, `DataCatalog`, `NamedQuery`, `PreparedStatement`
+- **Auto Scaling** — `LaunchConfiguration`, `AutoScalingGroup` (the group reconciles its `DesiredCapacity` to real container-backed EC2 instances)
 - **ACM** — `Certificate`, `Account`
 - **CloudFormation** — `Stack` (nested), `CustomResource` / `Custom::*`
 - **CloudFront** — `Distribution`, `Function`, `CachePolicy`, `OriginRequestPolicy`, `ResponseHeadersPolicy`, `KeyGroup`, `PublicKey`, `OriginAccessControl`, `CloudFrontOriginAccessIdentity`
@@ -146,7 +147,7 @@ aws --endpoint-url http://localhost:4566 cloudformation list-exports
 
 ## Gotchas
 
-- **Not every resource type provisions something.** Types in the provisioner list above create real backing state. Anything else (the remaining `AWS::EC2::*` types such as `Instance` / `NatGateway` / `Route`, `AWS::AutoScaling::*`, etc.) is recorded but has no underlying resource, so a follow-up call against that service will 404.
+- **Not every resource type provisions something.** Types in the provisioner list above create real backing state. Anything else (the remaining `AWS::EC2::*` types such as `Instance` / `NatGateway` / `Route`, etc.) is recorded but has no underlying resource, so a follow-up call against that service will 404.
 - **Drift always reports IN_SYNC.** fakecloud is the source of truth for backing state, so real drift never occurs. The drift API still round-trips IDs and statuses for tooling that polls them.
 - **SAM expansion runs at create time.** A re-uploaded template still requires `Capabilities=[CAPABILITY_AUTO_EXPAND]` on operations that touch transforms.
 


### PR DESCRIPTION
## Summary

CloudFormation's resource provisioner inserted **phantom** `AsgInstance` metadata to satisfy an `AWS::AutoScaling::AutoScalingGroup`'s `DesiredCapacity`, while the direct `CreateAutoScalingGroup` API launches **REAL container-backed EC2 instances** via `RunInstances` (the #8367/#1972 path). So a CFN-provisioned ASG reported instances that did not exist in EC2, whereas the same group via the API does. Every rival emulator's CFN provisioner is metadata-only here; fakecloud already runs real instances on the API path, so wiring CFN to it is a structural differentiator.

This is **batch 2** of the CFN-real-infrastructure series (batch 1 = RDS, #2031). It reuses the same spawn-intent plumbing batch 1 established.

### Spawn-intent pattern (reused from batch 1)
- New `ContainerSpawnIntent::AsgInstances { group_name }` variant.
- The ASG provisioner inserts the group **control plane only** (empty `instances`, so `Ref`/`GetAtt` and `DescribeAutoScalingGroups` still resolve during provisioning), then queues the intent on the shared `pending_container_spawns`.
- After provisioning succeeds, `CreateStack` drains the intent and reconciles the group in a **detached task**, so `CreateStack` never blocks on launching instances (the #1539/#1730 timeout lesson).

### Auto Scaling
- New `fakecloud_autoscaling::cfn_provision::cfn_reconcile_capacity` builds an `AutoScalingService::new(asg_state).with_ec2(ec2_state, ec2_runtime)` and calls a new `AutoScalingService::reconcile_group`, which synthesizes a minimal `AwsRequest` (only `region`/`account_id`/`request_id` are read by the EC2 calls) and runs the exact same `apply_capacity` reconciliation the direct API uses. With no EC2 runtime (CI) it degrades to metadata-only instances, matching how the direct API degrades.

### EC2::Instance
Out of scope and **not included**: `AWS::EC2::Instance` is not currently a provisioned resource type (the EC2 provisioner only handles VPC / Subnet / SecurityGroup / InternetGateway / RouteTable). Adding a brand-new resource type is beyond this batch; ASG is the deliverable.

## Test plan
- New e2e `cfn_asg_launches_real_ec2_instances`: provisions an ASG through a stack, polls until it reconciles to 2 instances, then asserts those exact ids appear in EC2 `DescribeInstances` (proving they are real EC2 instances, not phantom ASG metadata). Holds with or without a container runtime.
- Updated the existing `cfn_provisions_autoscaling_group` and `cfn_provisioned_asg_survives_restart` to poll for the now-async reconciliation (the persistence test waits before restart so the reconciled instances are snapshotted).
- All 4 ASG CFN e2e tests pass locally in metadata-only mode (no Docker).
- `cargo fmt --all -- --check`, `clippy --all-targets -D warnings`, and unit tests green on both touched crates.

## Surface
- **Docs:** `cloudformation.md` now documents the ASG container-backed guarantee, adds Auto Scaling to the provisioner list, and removes the stale claim that `AWS::AutoScaling::*` has no underlying resource.
- **SDKs:** no new API surface (behavioral change to provisioning) -> no SDK change.

Batches 3-5 follow: EC2 instances, ECS + ElastiCache, then restart-reconcile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CloudFormation now backs `AWS::AutoScaling::AutoScalingGroup` with real container-backed EC2 instances, matching the direct `CreateAutoScalingGroup` path. Groups are inserted control-plane only and reconciled in the background to `DesiredCapacity` via `RunInstances`, so no phantom metadata and `CreateStack` doesn’t block.

- **New Features**
  - `fakecloud-cloudformation`: queues `AsgInstances { group_name }` spawn intent; inserts groups with empty `instances`.
  - `fakecloud-autoscaling`: adds `cfn_provision::cfn_reconcile_capacity` and `AutoScalingService::reconcile_group` to run the same capacity logic as the API path.
  - Background reconcile degrades to metadata-only when no EC2 runtime is configured, matching direct API behavior.
  - E2E: new test verifies ASG-launched instance IDs appear in EC2 `DescribeInstances`; existing tests poll for async reconcile. Docs now list Auto Scaling and document the real-instance guarantee.

<sup>Written for commit e99d5daf50093de431b59d87fb0bc0ae3faef939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

