### PR TITLE
fix(cloudformation): drain container spawns + detach custom resources + teardown on the changeset/update/delete paths

### DIFF
--- a/crates/fakecloud-autoscaling/src/cfn_provision.rs
+++ b/crates/fakecloud-autoscaling/src/cfn_provision.rs
@@ -33,3 +33,24 @@ pub async fn cfn_reconcile_capacity(
     let svc = AutoScalingService::new(asg_state).with_ec2(ec2_state, ec2_runtime);
     svc.reconcile_group(&account_id, &group_name, &region).await;
 }
+
+/// Terminate the REAL EC2 instances launched for a CFN-provisioned Auto Scaling
+/// Group when its stack is deleted (or the group is removed by a stack update).
+/// Mirrors `cfn_reconcile_capacity` for teardown: the group record has already
+/// been removed by the synchronous provisioner delete, so this reaps the
+/// orphaned instance containers via the EC2 runtime so a stack delete does not
+/// leak real EC2 containers. Intended to be `tokio::spawn`ed by the
+/// CloudFormation delete drain. No-op (nothing real to reap) with no EC2
+/// backend wired.
+pub async fn cfn_terminate_instances(
+    asg_state: SharedAutoScalingState,
+    ec2_state: fakecloud_ec2::SharedEc2State,
+    ec2_runtime: Option<Arc<fakecloud_ec2::Ec2Runtime>>,
+    instance_ids: Vec<String>,
+    account_id: String,
+    region: String,
+) {
+    let svc = AutoScalingService::new(asg_state).with_ec2(ec2_state, ec2_runtime);
+    svc.cfn_terminate_instances(&account_id, &region, &instance_ids)
+        .await;
+}

--- a/crates/fakecloud-autoscaling/src/service.rs
+++ b/crates/fakecloud-autoscaling/src/service.rs
@@ -110,6 +110,37 @@ impl AutoScalingService {
         }
     }
 
+    /// Terminate the REAL EC2 instances that backed a CFN-provisioned Auto
+    /// Scaling Group when its stack is deleted. Public entry for the
+    /// CloudFormation delete drain: the group record itself has already been
+    /// removed by the synchronous provisioner delete, so this reaps the
+    /// orphaned instance containers that the direct `DeleteAutoScalingGroup`
+    /// path leaves running. No-op when there is no EC2 backend wired.
+    pub async fn cfn_terminate_instances(&self, account_id: &str, region: &str, ids: &[String]) {
+        if ids.is_empty() {
+            return;
+        }
+        let req = AwsRequest {
+            service: "autoscaling".to_string(),
+            action: "DeleteAutoScalingGroup".to_string(),
+            region: region.to_string(),
+            account_id: account_id.to_string(),
+            request_id: Uuid::new_v4().to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        };
+        self.terminate_ec2_instances(ids, &req).await;
+    }
+
     async fn terminate_ec2_instances(&self, ids: &[String], req: &AwsRequest) {
         let Some(ec2_state) = self.ec2_state.clone() else {
             return;

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -914,7 +914,13 @@ impl CloudFormationService {
                     })?
                 };
 
-                let provisioner = self.provisioner(&found_stack_id, &aid, &req.region);
+                // `provisioner_deferred`: apply_resource_updates runs inside the
+                // state write lock below; a synchronous custom-resource Lambda
+                // invoke there would stall every other CFN op behind the lock and
+                // could block the client (cdk/sam/`aws cloudformation deploy`)
+                // past its read timeout. Queue those invokes and drain them off
+                // the request path after the lock is dropped (bug-audit 0.2).
+                let provisioner = self.provisioner_deferred(&found_stack_id, &aid, &req.region);
 
                 // Cross-stack exports for `Fn::ImportValue` in resource
                 // properties (1.5); collected before the write lock.
@@ -1056,6 +1062,27 @@ impl CloudFormationService {
                         "ValidationError",
                         msg,
                     ));
+                }
+
+                // The change set executed successfully. Back any newly-added
+                // container resources (RDS / ElastiCache / ECS / ASG) with REAL
+                // containers and reap any removed ones, both off the request
+                // path -- cdk/sam/`aws cloudformation deploy` provision via
+                // ExecuteChangeSet, so without this their container-backed
+                // resources sit at `creating` forever and stack deletes leak
+                // containers (the #2031-#2034 create-side hardening reaching the
+                // changeset path, bug-audit 0.1/0.3/0.4). Then run any deferred
+                // custom-resource Lambda invokes (0.2).
+                {
+                    let handles =
+                        crate::service::ContainerBackingHandles::from_provisioner(&provisioner);
+                    handles.spawn_container_intents(std::mem::take(
+                        &mut *provisioner.pending_container_spawns.lock(),
+                    ));
+                    handles.spawn_teardown_intents(std::mem::take(
+                        &mut *provisioner.pending_container_teardowns.lock(),
+                    ));
+                    crate::service::spawn_custom_invokes(&provisioner);
                 }
 
                 // Resolve the template's `Outputs` for the newly provisioned

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/autoscaling.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/autoscaling.rs
@@ -202,16 +202,36 @@ impl ResourceProvisioner {
 
     /// Delete an AutoScaling LaunchConfiguration / Group by physical id (name).
     pub(super) fn delete_autoscaling(&self, resource_type: &str, name: &str) {
-        let mut st = self.autoscaling_state.write();
-        let acct = st.get_or_create(&self.account_id);
-        match resource_type {
-            "AWS::AutoScaling::LaunchConfiguration" => {
-                acct.launch_configurations.remove(name);
+        let removed_instance_ids = {
+            let mut st = self.autoscaling_state.write();
+            let acct = st.get_or_create(&self.account_id);
+            match resource_type {
+                "AWS::AutoScaling::LaunchConfiguration" => {
+                    acct.launch_configurations.remove(name);
+                    Vec::new()
+                }
+                "AWS::AutoScaling::AutoScalingGroup" => acct
+                    .groups
+                    .remove(name)
+                    .map(|g| {
+                        g.instances
+                            .iter()
+                            .map(|i| i.instance_id.clone())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default(),
+                _ => Vec::new(),
             }
-            "AWS::AutoScaling::AutoScalingGroup" => {
-                acct.groups.remove(name);
-            }
-            _ => {}
+        };
+        // Queue terminating the REAL EC2 instances the group launched so the
+        // stack delete drain reaps them instead of leaking real EC2 containers.
+        // Captured before the group record was removed above.
+        if !removed_instance_ids.is_empty() {
+            self.pending_container_teardowns.lock().push(
+                super::ContainerTeardownIntent::AsgInstances {
+                    instance_ids: removed_instance_ids,
+                },
+            );
         }
     }
 }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
@@ -113,9 +113,13 @@ impl ResourceProvisioner {
             ec2_runtime: self.ec2_runtime.clone(),
             ecs_runtime: self.ecs_runtime.clone(),
             elasticache_runtime: self.elasticache_runtime.clone(),
-            // Share the parent's queue so nested-stack container resources are
-            // drained and backed by the same CreateStack.
+            // Share the parent's queues so nested-stack container resources are
+            // drained and backed/reaped by the same parent op, and any deferred
+            // custom-resource invokes are drained alongside the parent's.
             pending_container_spawns: self.pending_container_spawns.clone(),
+            pending_container_teardowns: self.pending_container_teardowns.clone(),
+            pending_custom_invokes: self.pending_custom_invokes.clone(),
+            defer_custom_invokes: self.defer_custom_invokes,
             s3_store: self.s3_store.clone(),
             account_id: self.account_id.clone(),
             region: self.region.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ecs.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ecs.rs
@@ -425,14 +425,30 @@ impl ResourceProvisioner {
             return Ok(());
         };
         let key = format!("{cluster}/{service}");
-        let mut accounts = self.ecs_state.write();
-        let state = accounts.get_or_create(&self.account_id);
-        if state.services.remove(&key).is_some() {
-            if let Some(c) = state.clusters.get_mut(&cluster) {
-                if c.active_services_count > 0 {
-                    c.active_services_count -= 1;
+        let removed = {
+            let mut accounts = self.ecs_state.write();
+            let state = accounts.get_or_create(&self.account_id);
+            if state.services.remove(&key).is_some() {
+                if let Some(c) = state.clusters.get_mut(&cluster) {
+                    if c.active_services_count > 0 {
+                        c.active_services_count -= 1;
+                    }
                 }
+                true
+            } else {
+                false
             }
+        };
+        // Queue stopping the REAL tasks (containers) the service was running so
+        // the stack delete drain reaps them instead of leaking them. The task
+        // records live separately from the service record removed above.
+        if removed && self.ecs_runtime.is_some() {
+            self.pending_container_teardowns.lock().push(
+                super::ContainerTeardownIntent::EcsService {
+                    cluster_name: cluster,
+                    service_name: service,
+                },
+            );
         }
         Ok(())
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -916,6 +916,32 @@ pub struct ResourceProvisioner {
     /// boot — the #1539/#1730 timeout lesson). Shared via `Arc` so the drain
     /// can read it after the provisioner is moved into `spawn_blocking`.
     pub pending_container_spawns: Arc<parking_lot::Mutex<Vec<ContainerSpawnIntent>>>,
+    /// Teardown intents queued by container-backed delete provisioners during a
+    /// synchronous delete pass (stack delete, or a stack update that removes a
+    /// resource). The in-memory record is removed synchronously (so
+    /// `DescribeStacks` reflects the deletion at once); the REAL backing
+    /// container is reaped in the background by the CloudFormation delete drain,
+    /// mirroring `pending_container_spawns` for teardown. Without this drain a
+    /// stack delete would leak the running RDS / ElastiCache / ECS / EC2
+    /// containers (the create-side #2031-#2034 hardening never reached delete).
+    pub pending_container_teardowns: Arc<parking_lot::Mutex<Vec<ContainerTeardownIntent>>>,
+    /// Custom-resource (`Custom::*`) Lambda invoke intents queued during a
+    /// changeset/update provision when `defer_custom_invokes` is set. Invoking
+    /// the Lambda synchronously (`invoke_lambda_sync`) can cold-pull a container
+    /// image for minutes -- far past the client's 60s read timeout -- and, on
+    /// the changeset/update path, it ran while holding the CloudFormation state
+    /// write lock, stalling every other CFN op behind it. Queueing here lets the
+    /// caller drain + `tokio::spawn` the invokes off the request path after the
+    /// lock is dropped, mirroring how `CreateStack` provisions custom resources
+    /// off the request path.
+    pub pending_custom_invokes: Arc<parking_lot::Mutex<Vec<CustomInvokeIntent>>>,
+    /// When `true`, `create_custom_resource` / `delete_custom_resource` queue
+    /// their Lambda invoke onto `pending_custom_invokes` instead of running it
+    /// synchronously. Set on the changeset/update/delete provisioners; left
+    /// `false` for `CreateStack` (which already provisions off the request path
+    /// in a detached task, so its synchronous invoke never blocks the client or
+    /// the state lock).
+    pub defer_custom_invokes: bool,
     /// Fine-grained S3 disk store. Bucket create/delete (and bucket-policy
     /// updates) write through this so a CFN-provisioned bucket lands on disk,
     /// matching the real `CreateBucket`/`DeleteBucket` handlers. A
@@ -955,6 +981,43 @@ pub enum ContainerSpawnIntent {
         cluster_name: String,
         service_name: String,
     },
+}
+
+/// A container-backed resource the synchronous delete pass removed from memory
+/// that still has a REAL backing container to reap. Drained by the
+/// CloudFormation delete path (stack delete / update-removed) and backgrounded
+/// so the stack op never blocks on a container stop. Mirrors
+/// [`ContainerSpawnIntent`] for teardown.
+#[derive(Debug, Clone)]
+pub enum ContainerTeardownIntent {
+    /// `AWS::RDS::DBInstance` -- stop + remove the Postgres/MySQL container and
+    /// its persisted data volume.
+    RdsInstance { identifier: String },
+    /// `AWS::ElastiCache::CacheCluster` -- stop + remove the Redis/Memcached
+    /// container and its data volume.
+    ElastiCacheCluster { cache_cluster_id: String },
+    /// `AWS::ElastiCache::ReplicationGroup` -- stop + remove the Redis container
+    /// and its data volume.
+    ElastiCacheReplicationGroup { replication_group_id: String },
+    /// `AWS::ECS::Service` -- stop the REAL tasks (containers) the service was
+    /// running. The cluster + service name locate the orphaned task records.
+    EcsService {
+        cluster_name: String,
+        service_name: String,
+    },
+    /// `AWS::AutoScaling::AutoScalingGroup` -- terminate the REAL EC2 instances
+    /// the group launched (captured before the group record was removed).
+    AsgInstances { instance_ids: Vec<String> },
+}
+
+/// A queued custom-resource (`Custom::*`) Lambda invocation. Built by
+/// `create_custom_resource` / `delete_custom_resource` when
+/// `defer_custom_invokes` is set, drained and `tokio::spawn`ed off the request
+/// path so a cold image pull never blocks the client or the CFN state lock.
+#[derive(Debug, Clone)]
+pub struct CustomInvokeIntent {
+    pub service_token: String,
+    pub payload: String,
 }
 
 mod acm;
@@ -3711,7 +3774,18 @@ impl ResourceProvisioner {
         });
 
         let payload = serde_json::to_string(&event).map_err(|e| e.to_string())?;
-        self.invoke_lambda_sync(service_token, &payload)?;
+        if self.defer_custom_invokes {
+            // Changeset/update path: queue the invoke so the caller runs it off
+            // the request path after the state write lock is dropped. The Lambda
+            // response is not consumed for `GetAtt` (the physical id is generated
+            // below regardless), so deferring loses nothing.
+            self.pending_custom_invokes.lock().push(CustomInvokeIntent {
+                service_token: service_token.to_string(),
+                payload,
+            });
+        } else {
+            self.invoke_lambda_sync(service_token, &payload)?;
+        }
 
         // Physical resource ID: use a generated ID (the Lambda could return one,
         // but for simplicity we generate one here).
@@ -3742,8 +3816,15 @@ impl ResourceProvisioner {
 
         let payload = serde_json::to_string(&event).map_err(|e| e.to_string())?;
 
-        // Best-effort: don't fail stack deletion if Lambda invocation fails
-        if let Err(e) = self.invoke_lambda_sync(&service_token, &payload) {
+        if self.defer_custom_invokes {
+            // Stack-delete / update-removed path: queue the Delete invoke so the
+            // caller runs it off the request path after the lock is dropped.
+            self.pending_custom_invokes.lock().push(CustomInvokeIntent {
+                service_token,
+                payload,
+            });
+        } else if let Err(e) = self.invoke_lambda_sync(&service_token, &payload) {
+            // Best-effort: don't fail stack deletion if Lambda invocation fails
             tracing::warn!(
                 "Custom resource delete Lambda invocation failed for {}: {e}",
                 resource.logical_id
@@ -4475,9 +4556,18 @@ impl ResourceProvisioner {
     }
 
     fn delete_ec_cache_cluster(&self, physical_id: &str) -> Result<(), String> {
-        let mut accounts = self.elasticache_state.write();
-        let state = accounts.get_or_create(&self.account_id);
-        state.cache_clusters.remove(physical_id);
+        {
+            let mut accounts = self.elasticache_state.write();
+            let state = accounts.get_or_create(&self.account_id);
+            state.cache_clusters.remove(physical_id);
+        }
+        if self.elasticache_runtime.is_some() {
+            self.pending_container_teardowns.lock().push(
+                ContainerTeardownIntent::ElastiCacheCluster {
+                    cache_cluster_id: physical_id.to_string(),
+                },
+            );
+        }
         Ok(())
     }
 
@@ -4738,9 +4828,18 @@ impl ResourceProvisioner {
     }
 
     fn delete_ec_replication_group(&self, physical_id: &str) -> Result<(), String> {
-        let mut accounts = self.elasticache_state.write();
-        let state = accounts.get_or_create(&self.account_id);
-        state.replication_groups.remove(physical_id);
+        {
+            let mut accounts = self.elasticache_state.write();
+            let state = accounts.get_or_create(&self.account_id);
+            state.replication_groups.remove(physical_id);
+        }
+        if self.elasticache_runtime.is_some() {
+            self.pending_container_teardowns.lock().push(
+                ContainerTeardownIntent::ElastiCacheReplicationGroup {
+                    replication_group_id: physical_id.to_string(),
+                },
+            );
+        }
         Ok(())
     }
 
@@ -6206,6 +6305,9 @@ mod tests {
             ecs_runtime: None,
             elasticache_runtime: None,
             pending_container_spawns: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            pending_container_teardowns: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            pending_custom_invokes: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            defer_custom_invokes: false,
             s3_store: Arc::new(fakecloud_persistence::s3::MemoryS3Store::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
@@ -632,9 +632,22 @@ impl ResourceProvisioner {
     }
 
     pub(super) fn delete_rds_db_instance(&self, physical_id: &str) -> Result<(), String> {
-        let mut accounts = self.rds_state.write();
-        let state = accounts.get_or_create(&self.account_id);
-        state.instances.remove(physical_id);
+        {
+            let mut accounts = self.rds_state.write();
+            let state = accounts.get_or_create(&self.account_id);
+            state.instances.remove(physical_id);
+        }
+        // Queue the REAL container teardown when a runtime is wired, so the stack
+        // delete drain stops + removes the Postgres/MySQL container and its data
+        // volume instead of leaking it (the create-side #2031 hardening for the
+        // delete path).
+        if self.rds_runtime.is_some() {
+            self.pending_container_teardowns.lock().push(
+                super::ContainerTeardownIntent::RdsInstance {
+                    identifier: physical_id.to_string(),
+                },
+            );
+        }
         Ok(())
     }
 

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -376,6 +376,264 @@ struct CreateStackContext {
     resource_defs: Vec<template::ResourceDefinition>,
 }
 
+/// Owned clones of the service-state + container-runtime handles a provisioner
+/// holds, so the spawn / teardown drains can `tokio::spawn` REAL container work
+/// after the provisioner itself has been moved (CreateStack moves it into
+/// `spawn_blocking`) or after the CFN state lock has been dropped (the
+/// changeset/update/delete paths). Centralizes the per-resource-type match that
+/// backs a freshly-provisioned container resource or reaps a deleted one, so the
+/// CreateStack / ExecuteChangeSet / UpdateStack / DeleteStack paths stay in
+/// lockstep (the #2031-#2034 create-side hardening reaching every path).
+pub(crate) struct ContainerBackingHandles {
+    account_id: String,
+    region: String,
+    rds_state: fakecloud_rds::SharedRdsState,
+    rds_runtime: Option<Arc<fakecloud_rds::runtime::RdsRuntime>>,
+    ec2_state: fakecloud_ec2::SharedEc2State,
+    ec2_runtime: Option<Arc<fakecloud_ec2::runtime::Ec2Runtime>>,
+    autoscaling_state: fakecloud_autoscaling::SharedAutoScalingState,
+    elasticache_state: fakecloud_elasticache::SharedElastiCacheState,
+    elasticache_runtime: Option<Arc<fakecloud_elasticache::runtime::ElastiCacheRuntime>>,
+    ecs_state: fakecloud_ecs::SharedEcsState,
+    ecs_runtime: Option<Arc<fakecloud_ecs::runtime::EcsRuntime>>,
+}
+
+impl ContainerBackingHandles {
+    pub(crate) fn from_provisioner(p: &ResourceProvisioner) -> Self {
+        Self {
+            account_id: p.account_id.clone(),
+            region: p.region.clone(),
+            rds_state: p.rds_state.clone(),
+            rds_runtime: p.rds_runtime.clone(),
+            ec2_state: p.ec2_state.clone(),
+            ec2_runtime: p.ec2_runtime.clone(),
+            autoscaling_state: p.autoscaling_state.clone(),
+            elasticache_state: p.elasticache_state.clone(),
+            elasticache_runtime: p.elasticache_runtime.clone(),
+            ecs_state: p.ecs_state.clone(),
+            ecs_runtime: p.ecs_runtime.clone(),
+        }
+    }
+
+    /// Back each freshly-inserted container resource with a REAL container in a
+    /// detached task, so the stack op never blocks on a container boot/pull (the
+    /// #1539/#1730 timeout lesson). Drains the provisioner's queued spawn intents.
+    pub(crate) fn spawn_container_intents(
+        &self,
+        intents: Vec<crate::resource_provisioner::ContainerSpawnIntent>,
+    ) {
+        use crate::resource_provisioner::ContainerSpawnIntent;
+        for intent in intents {
+            match intent {
+                ContainerSpawnIntent::RdsInstance { identifier } => {
+                    if let Some(runtime) = self.rds_runtime.clone() {
+                        let rds_state = self.rds_state.clone();
+                        let account = self.account_id.clone();
+                        let region = self.region.clone();
+                        tokio::spawn(async move {
+                            fakecloud_rds::cfn_provision::cfn_ensure_instance_container(
+                                rds_state, runtime, identifier, account, region,
+                            )
+                            .await;
+                        });
+                    }
+                }
+                ContainerSpawnIntent::AsgInstances { group_name } => {
+                    let asg_state = self.autoscaling_state.clone();
+                    let ec2_state = self.ec2_state.clone();
+                    let ec2_runtime = self.ec2_runtime.clone();
+                    let account = self.account_id.clone();
+                    let region = self.region.clone();
+                    tokio::spawn(async move {
+                        fakecloud_autoscaling::cfn_provision::cfn_reconcile_capacity(
+                            asg_state,
+                            ec2_state,
+                            ec2_runtime,
+                            group_name,
+                            account,
+                            region,
+                        )
+                        .await;
+                    });
+                }
+                ContainerSpawnIntent::ElastiCacheCluster { cache_cluster_id } => {
+                    if let Some(runtime) = self.elasticache_runtime.clone() {
+                        let ec_state = self.elasticache_state.clone();
+                        let account = self.account_id.clone();
+                        tokio::spawn(async move {
+                            fakecloud_elasticache::cfn_provision::cfn_ensure_cluster_container(
+                                ec_state,
+                                runtime,
+                                cache_cluster_id,
+                                account,
+                            )
+                            .await;
+                        });
+                    }
+                }
+                ContainerSpawnIntent::ElastiCacheReplicationGroup {
+                    replication_group_id,
+                } => {
+                    if let Some(runtime) = self.elasticache_runtime.clone() {
+                        let ec_state = self.elasticache_state.clone();
+                        let account = self.account_id.clone();
+                        tokio::spawn(async move {
+                            fakecloud_elasticache::cfn_provision::cfn_ensure_replication_group_container(
+                                ec_state,
+                                runtime,
+                                replication_group_id,
+                                account,
+                            )
+                            .await;
+                        });
+                    }
+                }
+                ContainerSpawnIntent::EcsServiceTasks {
+                    cluster_name,
+                    service_name,
+                } => {
+                    if let Some(runtime) = self.ecs_runtime.clone() {
+                        let ecs_state = self.ecs_state.clone();
+                        let account = self.account_id.clone();
+                        tokio::spawn(async move {
+                            fakecloud_ecs::cfn_provision::cfn_launch_service_tasks(
+                                ecs_state,
+                                runtime,
+                                cluster_name,
+                                service_name,
+                                account,
+                            )
+                            .await;
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    /// Reap the REAL backing container for each deleted container resource in a
+    /// detached task, so a stack delete (or update-removed) never leaks a
+    /// running RDS / ElastiCache / ECS / EC2 container. Drains the provisioner's
+    /// queued teardown intents.
+    pub(crate) fn spawn_teardown_intents(
+        &self,
+        intents: Vec<crate::resource_provisioner::ContainerTeardownIntent>,
+    ) {
+        use crate::resource_provisioner::ContainerTeardownIntent;
+        for intent in intents {
+            match intent {
+                ContainerTeardownIntent::RdsInstance { identifier } => {
+                    if let Some(runtime) = self.rds_runtime.clone() {
+                        let account = self.account_id.clone();
+                        tokio::spawn(async move {
+                            fakecloud_rds::cfn_provision::cfn_teardown_instance_container(
+                                runtime, identifier, account,
+                            )
+                            .await;
+                        });
+                    }
+                }
+                ContainerTeardownIntent::ElastiCacheCluster { cache_cluster_id } => {
+                    if let Some(runtime) = self.elasticache_runtime.clone() {
+                        tokio::spawn(async move {
+                            fakecloud_elasticache::cfn_provision::cfn_teardown_cluster_container(
+                                runtime,
+                                cache_cluster_id,
+                            )
+                            .await;
+                        });
+                    }
+                }
+                ContainerTeardownIntent::ElastiCacheReplicationGroup {
+                    replication_group_id,
+                } => {
+                    if let Some(runtime) = self.elasticache_runtime.clone() {
+                        tokio::spawn(async move {
+                            fakecloud_elasticache::cfn_provision::cfn_teardown_replication_group_container(
+                                runtime,
+                                replication_group_id,
+                            )
+                            .await;
+                        });
+                    }
+                }
+                ContainerTeardownIntent::EcsService {
+                    cluster_name,
+                    service_name,
+                } => {
+                    if let Some(runtime) = self.ecs_runtime.clone() {
+                        let ecs_state = self.ecs_state.clone();
+                        let account = self.account_id.clone();
+                        tokio::spawn(async move {
+                            fakecloud_ecs::cfn_provision::cfn_stop_service_tasks(
+                                ecs_state,
+                                runtime,
+                                cluster_name,
+                                service_name,
+                                account,
+                            )
+                            .await;
+                        });
+                    }
+                }
+                ContainerTeardownIntent::AsgInstances { instance_ids } => {
+                    let asg_state = self.autoscaling_state.clone();
+                    let ec2_state = self.ec2_state.clone();
+                    let ec2_runtime = self.ec2_runtime.clone();
+                    let account = self.account_id.clone();
+                    let region = self.region.clone();
+                    tokio::spawn(async move {
+                        fakecloud_autoscaling::cfn_provision::cfn_terminate_instances(
+                            asg_state,
+                            ec2_state,
+                            ec2_runtime,
+                            instance_ids,
+                            account,
+                            region,
+                        )
+                        .await;
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Drain a provisioner's queued custom-resource Lambda invokes (`Custom::*`),
+/// running each off the request path in a detached task so a cold image pull
+/// never blocks the client or stalls the CFN state lock. Used by the
+/// changeset/update/delete paths (where `defer_custom_invokes` is set).
+pub(crate) fn spawn_custom_invokes(provisioner: &ResourceProvisioner) {
+    let intents = std::mem::take(&mut *provisioner.pending_custom_invokes.lock());
+    if intents.is_empty() {
+        return;
+    }
+    let delivery = provisioner.delivery.clone();
+    for intent in intents {
+        let delivery = delivery.clone();
+        tokio::spawn(async move {
+            match delivery
+                .invoke_lambda(&intent.service_token, &intent.payload)
+                .await
+            {
+                Some(Ok(_)) => {
+                    tracing::info!(
+                        "Custom resource Lambda {} invoked successfully",
+                        intent.service_token
+                    );
+                }
+                Some(Err(e)) => {
+                    tracing::warn!(
+                        "Custom resource Lambda {} invocation failed: {e}",
+                        intent.service_token
+                    );
+                }
+                None => {}
+            }
+        });
+    }
+}
+
 impl CloudFormationService {
     pub fn new(state: SharedCloudFormationState, deps: CloudFormationDeps) -> Self {
         Self {
@@ -480,10 +738,36 @@ impl CloudFormationService {
             ecs_runtime: self.deps.ecs_runtime.clone(),
             elasticache_runtime: self.deps.elasticache_runtime.clone(),
             pending_container_spawns: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            pending_container_teardowns: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            pending_custom_invokes: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            // CreateStack provisions in a detached task, so its synchronous
+            // custom-resource invoke never blocks the client or the state lock.
+            // The changeset/update/delete paths run inside the request, so they
+            // flip this on (see `provisioner_deferred`) to queue the invoke and
+            // drain it off the request path instead.
+            defer_custom_invokes: false,
             s3_store: self.s3_store.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
             stack_id: stack_id.to_string(),
+        }
+    }
+
+    /// Build a provisioner for the changeset/update/delete paths, which run
+    /// inside the request rather than in a detached `CreateStack` task. These
+    /// queue custom-resource Lambda invokes (`defer_custom_invokes`) so a cold
+    /// image pull never blocks the client past its read timeout or stalls every
+    /// other CFN op behind the state write lock; the caller drains and
+    /// `tokio::spawn`s the queued invokes after dropping the lock.
+    pub(crate) fn provisioner_deferred(
+        &self,
+        stack_id: &str,
+        account_id: &str,
+        region: &str,
+    ) -> ResourceProvisioner {
+        ResourceProvisioner {
+            defer_custom_invokes: true,
+            ..self.provisioner(stack_id, account_id, region)
         }
     }
 
@@ -1043,16 +1327,7 @@ impl CloudFormationService {
         // into spawn_blocking, so the post-provision drain (below) can back
         // freshly-inserted container resources with REAL containers.
         let container_spawns = provisioner.pending_container_spawns.clone();
-        let rds_runtime_for_spawn = provisioner.rds_runtime.clone();
-        let rds_state_for_spawn = provisioner.rds_state.clone();
-        let region_for_spawn = provisioner.region.clone();
-        let ec2_state_for_spawn = provisioner.ec2_state.clone();
-        let ec2_runtime_for_spawn = provisioner.ec2_runtime.clone();
-        let autoscaling_state_for_spawn = provisioner.autoscaling_state.clone();
-        let elasticache_state_for_spawn = provisioner.elasticache_state.clone();
-        let elasticache_runtime_for_spawn = provisioner.elasticache_runtime.clone();
-        let ecs_state_for_spawn = provisioner.ecs_state.clone();
-        let ecs_runtime_for_spawn = provisioner.ecs_runtime.clone();
+        let backing_handles = ContainerBackingHandles::from_provisioner(&provisioner);
 
         // The provisioning loop is fully synchronous (it may block on cold
         // image pulls / custom-resource Lambda invokes). Hand it to a
@@ -1106,101 +1381,7 @@ impl CloudFormationService {
         // CreateStack never blocks on a container boot/pull — the record is
         // already inserted as "creating" and flips to "available" when the
         // container is up (the #1539/#1730 timeout lesson).
-        {
-            let intents = std::mem::take(&mut *container_spawns.lock());
-            for intent in intents {
-                match intent {
-                    crate::resource_provisioner::ContainerSpawnIntent::RdsInstance {
-                        identifier,
-                    } => {
-                        if let Some(runtime) = rds_runtime_for_spawn.clone() {
-                            let rds_state = rds_state_for_spawn.clone();
-                            let account = account_id.clone();
-                            let region = region_for_spawn.clone();
-                            tokio::spawn(async move {
-                                fakecloud_rds::cfn_provision::cfn_ensure_instance_container(
-                                    rds_state, runtime, identifier, account, region,
-                                )
-                                .await;
-                            });
-                        }
-                    }
-                    crate::resource_provisioner::ContainerSpawnIntent::AsgInstances {
-                        group_name,
-                    } => {
-                        let asg_state = autoscaling_state_for_spawn.clone();
-                        let ec2_state = ec2_state_for_spawn.clone();
-                        let ec2_runtime = ec2_runtime_for_spawn.clone();
-                        let account = account_id.clone();
-                        let region = region_for_spawn.clone();
-                        tokio::spawn(async move {
-                            fakecloud_autoscaling::cfn_provision::cfn_reconcile_capacity(
-                                asg_state,
-                                ec2_state,
-                                ec2_runtime,
-                                group_name,
-                                account,
-                                region,
-                            )
-                            .await;
-                        });
-                    }
-                    crate::resource_provisioner::ContainerSpawnIntent::ElastiCacheCluster {
-                        cache_cluster_id,
-                    } => {
-                        if let Some(runtime) = elasticache_runtime_for_spawn.clone() {
-                            let ec_state = elasticache_state_for_spawn.clone();
-                            let account = account_id.clone();
-                            tokio::spawn(async move {
-                                fakecloud_elasticache::cfn_provision::cfn_ensure_cluster_container(
-                                    ec_state,
-                                    runtime,
-                                    cache_cluster_id,
-                                    account,
-                                )
-                                .await;
-                            });
-                        }
-                    }
-                    crate::resource_provisioner::ContainerSpawnIntent::ElastiCacheReplicationGroup {
-                        replication_group_id,
-                    } => {
-                        if let Some(runtime) = elasticache_runtime_for_spawn.clone() {
-                            let ec_state = elasticache_state_for_spawn.clone();
-                            let account = account_id.clone();
-                            tokio::spawn(async move {
-                                fakecloud_elasticache::cfn_provision::cfn_ensure_replication_group_container(
-                                    ec_state,
-                                    runtime,
-                                    replication_group_id,
-                                    account,
-                                )
-                                .await;
-                            });
-                        }
-                    }
-                    crate::resource_provisioner::ContainerSpawnIntent::EcsServiceTasks {
-                        cluster_name,
-                        service_name,
-                    } => {
-                        if let Some(runtime) = ecs_runtime_for_spawn.clone() {
-                            let ecs_state = ecs_state_for_spawn.clone();
-                            let account = account_id.clone();
-                            tokio::spawn(async move {
-                                fakecloud_ecs::cfn_provision::cfn_launch_service_tasks(
-                                    ecs_state,
-                                    runtime,
-                                    cluster_name,
-                                    service_name,
-                                    account,
-                                )
-                                .await;
-                            });
-                        }
-                    }
-                }
-            }
-        }
+        backing_handles.spawn_container_intents(std::mem::take(&mut *container_spawns.lock()));
 
         let outputs =
             Self::resolve_template_outputs(&template_body, &parameters, &resources, &state);
@@ -1374,12 +1555,26 @@ impl CloudFormationService {
                 // Build the provisioner while we still have the stack_id
                 // Drop the write lock temporarily so the provisioner can read state
                 drop(accounts);
-                let provisioner = self.provisioner(&stack_id, &req.account_id, &req.region);
+                // `provisioner_deferred`: queue any custom-resource Delete Lambda
+                // invokes so a cold image pull never blocks the client past its
+                // read timeout (drained off the request path below).
+                let provisioner =
+                    self.provisioner_deferred(&stack_id, &req.account_id, &req.region);
 
                 // Delete resources in reverse order
                 for resource in resources.iter().rev() {
                     let _ = provisioner.delete_resource(resource);
                 }
+
+                // Reap the REAL backing containers for the deleted container
+                // resources (RDS / ElastiCache / ECS / ASG-EC2) off the request
+                // path, so a stack delete does not leak running containers (the
+                // create-side #2031-#2034 hardening reaching the delete path).
+                // Each delete_resource above only removed the in-memory record.
+                ContainerBackingHandles::from_provisioner(&provisioner).spawn_teardown_intents(
+                    std::mem::take(&mut *provisioner.pending_container_teardowns.lock()),
+                );
+                spawn_custom_invokes(&provisioner);
 
                 // Re-acquire the write lock to update stack status
                 let mut accounts = self.state.write();
@@ -1645,7 +1840,12 @@ impl CloudFormationService {
             &input.parameters,
         )?;
 
-        let provisioner = self.provisioner(&found_stack_id, &req.account_id, &req.region);
+        // `provisioner_deferred`: apply_resource_updates runs inside the state
+        // write lock below; a synchronous custom-resource Lambda invoke there
+        // would stall every other CFN op behind the lock and could block the
+        // client past its read timeout. Queue those invokes and drain them off
+        // the request path after the lock is dropped.
+        let provisioner = self.provisioner_deferred(&found_stack_id, &req.account_id, &req.region);
 
         // Cross-stack exports for `Fn::ImportValue` in resource properties (1.5).
         // Computed before the write lock (collect_account_imports takes a read
@@ -1804,6 +2004,22 @@ impl CloudFormationService {
                 resources_snapshot,
             )
         };
+
+        // The update succeeded (failures returned above). Back any newly-added
+        // container resources with REAL containers and reap any removed ones,
+        // both off the request path (the #2031-#2034 create-side hardening
+        // reaching the update path), then run any deferred custom-resource
+        // invokes.
+        {
+            let handles = ContainerBackingHandles::from_provisioner(&provisioner);
+            handles.spawn_container_intents(std::mem::take(
+                &mut *provisioner.pending_container_spawns.lock(),
+            ));
+            handles.spawn_teardown_intents(std::mem::take(
+                &mut *provisioner.pending_container_teardowns.lock(),
+            ));
+            spawn_custom_invokes(&provisioner);
+        }
 
         let outputs = Self::resolve_template_outputs(
             &input.template_body,

--- a/crates/fakecloud-e2e/tests/cloudformation_changeset_backing.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_changeset_backing.rs
@@ -1,0 +1,231 @@
+//! CloudFormation `ExecuteChangeSet` / `DeleteStack` back container resources
+//! with REAL containers and reap them on delete, exactly like the `CreateStack`
+//! path (#2031-#2034). `cdk deploy`, `sam deploy`, and `aws cloudformation
+//! deploy` all provision through CreateChangeSet + ExecuteChangeSet (not raw
+//! CreateStack), so without the changeset-side drain a CFN-provisioned RDS /
+//! ElastiCache / ECS / ASG resource sat at `creating` forever and a stack
+//! delete leaked the backing container.
+//!
+//! Robust to CI with no container runtime the same way the existing
+//! `cloudformation_*_backing` tests are: with no runtime the record is inserted
+//! as `available` immediately; with a runtime the detached drain flips it from
+//! `creating` to `available`. Either way the resource reaches `available`, so we
+//! poll for that. On delete the in-memory record is removed in both modes
+//! (and, with a runtime, the backing container is stopped), so we assert the
+//! resource is no longer described.
+
+mod helpers;
+
+use helpers::TestServer;
+
+/// An RDS instance added to an existing stack via the change-set path (the CDK /
+/// SAM / `aws cloudformation deploy` update flow) must reach `available`, and a
+/// stack delete must remove it -- the create-side container drain + delete-side
+/// teardown reaching the changeset path (bug-audit 0.1 / 0.3).
+#[tokio::test]
+async fn execute_change_set_provisions_and_deletes_rds_instance() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let rds = aws_sdk_rds::Client::new(&server.aws_config().await);
+
+    // Stack starts with a single SQS queue (no container backing).
+    let base_template = r#"{
+        "Resources": {
+            "Seed": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {"QueueName": "cs-rds-seed"}
+            }
+        }
+    }"#;
+    cfn.create_stack()
+        .stack_name("cs-rds-stack")
+        .template_body(base_template)
+        .send()
+        .await
+        .expect("create_stack");
+
+    // Change set adds an RDS DB instance (keeping the queue).
+    let with_rds = r#"{
+        "Resources": {
+            "Seed": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {"QueueName": "cs-rds-seed"}
+            },
+            "Db": {
+                "Type": "AWS::RDS::DBInstance",
+                "Properties": {
+                    "DBInstanceIdentifier": "cs-rds-instance",
+                    "DBInstanceClass": "db.t4g.micro",
+                    "Engine": "postgres",
+                    "EngineVersion": "16.0",
+                    "MasterUsername": "admin",
+                    "MasterUserPassword": "hunter2-secret",
+                    "AllocatedStorage": "20"
+                }
+            }
+        }
+    }"#;
+    let cs = cfn
+        .create_change_set()
+        .stack_name("cs-rds-stack")
+        .change_set_name("add-rds")
+        .template_body(with_rds)
+        .send()
+        .await
+        .expect("create_change_set");
+    let cs_id = cs.id().expect("change set id").to_string();
+
+    cfn.execute_change_set()
+        .change_set_name(&cs_id)
+        .send()
+        .await
+        .expect("execute_change_set");
+
+    // The instance must reach `available` -- this is the bug: before the
+    // changeset-side drain it stayed `creating` forever whenever a runtime was
+    // wired (and was never backed by a real container).
+    let available = helpers::wait_until(std::time::Duration::from_secs(15), || {
+        let rds = rds.clone();
+        async move {
+            let out = rds
+                .describe_db_instances()
+                .db_instance_identifier("cs-rds-instance")
+                .send()
+                .await
+                .ok()?;
+            let inst = out.db_instances().first()?;
+            (inst.db_instance_status() == Some("available")).then_some(true)
+        }
+    })
+    .await;
+    assert_eq!(
+        available,
+        Some(true),
+        "changeset-provisioned RDS instance must reach available"
+    );
+
+    // Stack delete must remove the instance (and, with a runtime, stop its
+    // container instead of leaking it).
+    cfn.delete_stack()
+        .stack_name("cs-rds-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let gone = helpers::wait_until(std::time::Duration::from_secs(15), || {
+        let rds = rds.clone();
+        async move {
+            match rds
+                .describe_db_instances()
+                .db_instance_identifier("cs-rds-instance")
+                .send()
+                .await
+            {
+                // DBInstanceNotFound -> deleted.
+                Err(_) => Some(true),
+                // Still present -> not yet deleted.
+                Ok(out) if out.db_instances().is_empty() => Some(true),
+                Ok(_) => None,
+            }
+        }
+    })
+    .await;
+    assert_eq!(
+        gone,
+        Some(true),
+        "stack delete must remove the changeset-provisioned RDS instance"
+    );
+}
+
+/// Same propagation gap for a first-time stack created entirely through a
+/// `CREATE` change set (the `aws cloudformation deploy` / SAM / CDK first
+/// deploy). The ElastiCache cluster must reach `available` on execute and be
+/// gone after the stack delete.
+#[tokio::test]
+async fn create_change_set_provisions_and_deletes_elasticache_cluster() {
+    use aws_sdk_cloudformation::types::ChangeSetType;
+
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let ec = aws_sdk_elasticache::Client::new(&server.aws_config().await);
+
+    let template = r#"{
+        "Resources": {
+            "Cache": {
+                "Type": "AWS::ElastiCache::CacheCluster",
+                "Properties": {
+                    "ClusterName": "cs-ec-cluster",
+                    "CacheNodeType": "cache.t4g.micro",
+                    "Engine": "redis",
+                    "EngineVersion": "7.1",
+                    "NumCacheNodes": 1,
+                    "Port": 6379
+                }
+            }
+        }
+    }"#;
+
+    cfn.create_change_set()
+        .stack_name("cs-ec-stack")
+        .change_set_name("create-ec")
+        .change_set_type(ChangeSetType::Create)
+        .template_body(template)
+        .send()
+        .await
+        .expect("create_change_set");
+
+    cfn.execute_change_set()
+        .stack_name("cs-ec-stack")
+        .change_set_name("create-ec")
+        .send()
+        .await
+        .expect("execute_change_set");
+
+    let available = helpers::wait_until(std::time::Duration::from_secs(15), || {
+        let ec = ec.clone();
+        async move {
+            let out = ec
+                .describe_cache_clusters()
+                .cache_cluster_id("cs-ec-cluster")
+                .send()
+                .await
+                .ok()?;
+            let cluster = out.cache_clusters().first()?;
+            (cluster.cache_cluster_status() == Some("available")).then_some(true)
+        }
+    })
+    .await;
+    assert_eq!(
+        available,
+        Some(true),
+        "changeset-provisioned cache cluster must reach available"
+    );
+
+    cfn.delete_stack()
+        .stack_name("cs-ec-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let gone = helpers::wait_until(std::time::Duration::from_secs(15), || {
+        let ec = ec.clone();
+        async move {
+            match ec
+                .describe_cache_clusters()
+                .cache_cluster_id("cs-ec-cluster")
+                .send()
+                .await
+            {
+                Err(_) => Some(true),
+                Ok(out) if out.cache_clusters().is_empty() => Some(true),
+                Ok(_) => None,
+            }
+        }
+    })
+    .await;
+    assert_eq!(
+        gone,
+        Some(true),
+        "stack delete must remove the changeset-provisioned cache cluster"
+    );
+}

--- a/crates/fakecloud-ecs/src/cfn_provision.rs
+++ b/crates/fakecloud-ecs/src/cfn_provision.rs
@@ -64,3 +64,45 @@ pub async fn cfn_launch_service_tasks(
             .run_task(state.clone(), id, account_id.clone());
     }
 }
+
+/// Stop the REAL tasks (containers) backing a CFN-provisioned ECS service when
+/// its stack is deleted (or the service is removed by a stack update). Mirrors
+/// the direct `DeleteService` teardown (`stop_task` per running task) so a stack
+/// delete does not leak the running task containers. The service record itself
+/// has already been removed by the synchronous provisioner delete; this reaps
+/// the orphaned task containers and drops their records. Intended to be
+/// `tokio::spawn`ed by the CloudFormation delete drain.
+pub async fn cfn_stop_service_tasks(
+    state: SharedEcsState,
+    runtime: Arc<EcsRuntime>,
+    cluster_name: String,
+    service_name: String,
+    account_id: String,
+) {
+    let task_ids = {
+        let mut accounts = state.write();
+        let Some(st) = accounts.get_mut(&account_id) else {
+            return;
+        };
+        let service_tag = format!("ecs-svc/{service_name}");
+        let ids: Vec<String> = st
+            .tasks
+            .iter()
+            .filter(|(_, t)| {
+                t.started_by.as_deref() == Some(service_tag.as_str())
+                    && t.cluster_name == cluster_name
+                    && t.last_status != "STOPPED"
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+        ids
+    };
+
+    for id in &task_ids {
+        runtime.stop_task(id, "CloudFormation stack deletion").await;
+        let mut accounts = state.write();
+        if let Some(st) = accounts.get_mut(&account_id) {
+            st.tasks.remove(id);
+        }
+    }
+}

--- a/crates/fakecloud-elasticache/src/cfn_provision.rs
+++ b/crates/fakecloud-elasticache/src/cfn_provision.rs
@@ -195,3 +195,28 @@ pub async fn cfn_ensure_replication_group_container(
         runtime.stop_container(&replication_group_id).await;
     }
 }
+
+/// Stop and reap the REAL container backing a CFN-provisioned cache cluster
+/// when its stack is deleted (or the resource is removed by a stack update).
+/// Mirrors the direct `DeleteCacheCluster` teardown (`stop_container` +
+/// `remove_data_volume`) so a stack delete does not leak the running engine
+/// container. Intended to be `tokio::spawn`ed by the CloudFormation delete
+/// drain after the in-memory record has already been removed.
+pub async fn cfn_teardown_cluster_container(
+    runtime: Arc<ElastiCacheRuntime>,
+    cache_cluster_id: String,
+) {
+    runtime.stop_container(&cache_cluster_id).await;
+    runtime.remove_data_volume(&cache_cluster_id).await;
+}
+
+/// Stop and reap the REAL container backing a CFN-provisioned replication group
+/// when its stack is deleted. Mirrors the direct `DeleteReplicationGroup`
+/// teardown so a stack delete does not leak the running Redis container.
+pub async fn cfn_teardown_replication_group_container(
+    runtime: Arc<ElastiCacheRuntime>,
+    replication_group_id: String,
+) {
+    runtime.stop_container(&replication_group_id).await;
+    runtime.remove_data_volume(&replication_group_id).await;
+}

--- a/crates/fakecloud-rds/src/cfn_provision.rs
+++ b/crates/fakecloud-rds/src/cfn_provision.rs
@@ -111,3 +111,19 @@ pub async fn cfn_ensure_instance_container(
         }
     }
 }
+
+/// Stop and reap the REAL container backing a CFN-provisioned DB instance when
+/// its stack is deleted (or the resource is removed by a stack update). Mirrors
+/// the direct `DeleteDBInstance` teardown (`stop_container` +
+/// `remove_data_volume`) so a stack delete does not leak the running Postgres /
+/// MySQL container or its persisted data volume. Intended to be `tokio::spawn`ed
+/// by the CloudFormation delete drain after the in-memory record has already
+/// been removed.
+pub async fn cfn_teardown_instance_container(
+    runtime: Arc<RdsRuntime>,
+    identifier: String,
+    account_id: String,
+) {
+    runtime.stop_container(&identifier).await;
+    runtime.remove_data_volume(&account_id, &identifier).await;
+}


### PR DESCRIPTION
## Summary

The #2031-#2034 series made CloudFormation provision REAL containers for RDS / AutoScaling / ElastiCache / ECS, but only the async `CreateStack` path was hardened. The mechanism (a `create_*` provisioner pushes a `ContainerSpawnIntent`; the caller drains it and `tokio::spawn`s the real backing) plus the custom-resource detach lived ONLY in `finish_create_stack`. The changeset/update/delete paths -- which are exactly what `cdk deploy`, `sam deploy`, and `aws cloudformation deploy` use -- were left behind. This PR brings `ExecuteChangeSet` / `UpdateStack` / `DeleteStack` up to the same fidelity, closing the propagation gap.

## Bugs fixed

- **0.1 - container spawns never drained on changeset/update.** `ExecuteChangeSet` and `UpdateStack` (via `apply_resource_updates` -> `create_resource`) pushed spawn intents but never drained them, so a CDK/SAM/deploy-created RDS/ECS/ElastiCache/ASG sat at `creating` with no real container. Both paths now drain `pending_container_spawns` after the state lock is dropped, `tokio::spawn`ing the same `fakecloud_<svc>::cfn_provision::*` backing fns `CreateStack` uses.

- **0.2 - custom-resource Lambda invoke ran under the state write lock on `ExecuteChangeSet`.** `invoke_lambda_sync` (a `block_on` on `delivery.invoke_lambda`) could cold-pull a container image for minutes, blocking past the 60s client timeout AND stalling every other CFN op behind the lock. The changeset/update/delete provisioners now use a new `provisioner_deferred` builder that sets `defer_custom_invokes`: `create_custom_resource` / `delete_custom_resource` queue the invoke onto `pending_custom_invokes` instead of running it inline, and the caller drains + detaches it off the request path after dropping the lock. The generated physical id is unchanged (the Lambda response was never consumed for `GetAtt`), so nothing is lost. `CreateStack` is untouched (it already provisions off the request path in a detached task).

- **0.3 - stack DELETE leaked the real spawned containers.** The CFN `delete_resource` impls for RDS / ElastiCache / ECS only removed the in-memory record. They now push `ContainerTeardownIntent`s, and `DeleteStack` + update-removed drain them, `tokio::spawn`ing new `cfn_teardown_*` / `cfn_stop_service_tasks` fns that mirror the direct service deletes (`stop_container` + `remove_data_volume`, `stop_task`).

- **0.4 - ASG/EC2 instances launched by `cfn_reconcile_capacity` were not terminated on stack delete.** The CFN ASG delete now captures the group's instance ids before removing the record and queues an `AsgInstances` teardown that terminates the real EC2 instances via a new `cfn_terminate_instances` (scoped to the CFN path; see note below).

## Shared plumbing

The per-resource-type spawn/teardown match is factored into a `ContainerBackingHandles` helper reused by all four paths (CreateStack now uses it too, replacing its inline match), plus a `spawn_custom_invokes` drain. New `ContainerTeardownIntent` enum + `CustomInvokeIntent` struct + `pending_container_teardowns` / `pending_custom_invokes` / `defer_custom_invokes` fields on the provisioner (nested-stack child provisioner shares the parent's queues).

## Tests

New `crates/fakecloud-e2e/tests/cloudformation_changeset_backing.rs`:
- `execute_change_set_provisions_and_deletes_rds_instance` - adds an RDS instance to an existing stack via the change-set path, asserts it reaches `available`, then `DeleteStack` and asserts it is gone.
- `create_change_set_provisions_and_deletes_elasticache_cluster` - first-time stack via a `CREATE` change set, cache cluster reaches `available`, gone after delete.

Both follow the existing no-container-runtime CI fallback convention (poll for `available`; record is inserted `available` immediately with no runtime, flips from `creating` with one) and never silently skip.

## Validation

- `cargo build` (workspace + `--bin fakecloud`): clean
- `cargo fmt --all -- --check`: clean
- `cargo clippy -p fakecloud-cloudformation -p fakecloud-rds -p fakecloud-autoscaling -p fakecloud-elasticache -p fakecloud-ecs --all-targets -- -D warnings`: clean
- `cargo test -p fakecloud-cloudformation`: 248 passed
- `cargo test` on rds/autoscaling/elasticache/ecs: all passed
- new e2e tests + existing `cloudformation_execute_change_set` / `_rds_db` / `_elasticache_backing` / `_ecs_backing` / `_autoscaling` / `cloudformation`: all passed

## Risk to double-check before merge

- The direct `DeleteAutoScalingGroup` handler (`fakecloud-autoscaling/src/service.rs`) still does not terminate instances; 0.4 is scoped to the CFN delete path to avoid making the sync direct handler async. A clean shared fix for the direct path can follow.
- `UpdateStack` / `ExecuteChangeSet` provisioning still runs synchronously under the state lock for non-custom-resource resources (fast in-memory ops). Only the custom-resource Lambda invoke is deferred/detached; this matches the actual blocking source.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings `ExecuteChangeSet`, `UpdateStack`, and `DeleteStack` up to CreateStack parity for container-backed resources and custom resources, preventing stuck “creating”, lock stalls, and leaked containers.

- **Bug Fixes**
  - Drained container spawn intents on change set/update and launched REAL backing work off the request path (RDS, ElastiCache, ECS, ASG).
  - Deferred custom-resource Lambda invokes under a new `provisioner_deferred`, queued to `pending_custom_invokes` and spawned after dropping the state lock.
  - Queued teardown intents on delete/update-removed and reaped REAL containers in background (RDS instances, ElastiCache clusters/replication groups, ECS service tasks).
  - Captured and terminated ASG-launched EC2 instances on stack delete via new teardown path.

- **Refactors**
  - Added `ContainerBackingHandles` with `spawn_container_intents` and `spawn_teardown_intents` to unify Create/ExecuteChangeSet/Update/Delete behavior; CreateStack now uses it.
  - Introduced `ContainerTeardownIntent`, `CustomInvokeIntent`, and queues `pending_container_teardowns`/`pending_custom_invokes` with a `defer_custom_invokes` flag; nested provisioners share parent queues.
  - Added e2e tests for change set provisioning and deletion of RDS and ElastiCache resources.

<sup>Written for commit d7592de45020139dcbac54b9ca7877d71c8527d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

