### PR TITLE
fix(dynamodb): atomic counter, decimal SET/ADD, sparse-index scan, Transact idempotency, TTL stream records

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -390,6 +390,27 @@ impl DynamoDbService {
             1,
             36,
         )?;
+
+        // Idempotency: a retried transaction carrying the same ClientRequestToken
+        // (within the window) must be applied at most once and replay the
+        // original result. Reusing a token with a different body is rejected.
+        // The hash covers the whole request body, so the token field itself is
+        // part of the identity — only an identical retry replays.
+        let client_token = body["ClientRequestToken"].as_str().map(str::to_string);
+        let request_hash = {
+            use std::hash::{Hash, Hasher};
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            req.body.hash(&mut h);
+            h.finish()
+        };
+        if let Some(token) = client_token.as_deref() {
+            if let Some(cached) =
+                self.transact_idempotency_lookup(&req.account_id, token, request_hash)?
+            {
+                return Ok(cached);
+            }
+        }
+
         validate_optional_enum_value(
             "returnConsumedCapacity",
             &body["ReturnConsumedCapacity"],
@@ -900,6 +921,12 @@ impl DynamoDbService {
                 old_image.as_ref(),
                 new_image.as_ref(),
             );
+        }
+
+        // Cache the committed outcome so an identical retry with the same
+        // ClientRequestToken replays this result instead of re-applying.
+        if let Some(token) = client_token.as_deref() {
+            self.transact_idempotency_store(&req.account_id, token, request_hash, &result);
         }
 
         Self::ok_json(result)

--- a/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
@@ -466,6 +466,24 @@ pub(crate) fn evaluate_set_rhs(
     expr_attr_names: &HashMap<String, String>,
     expr_attr_values: &HashMap<String, Value>,
 ) -> Result<Option<Value>, AwsServiceError> {
+    // Arithmetic is checked first so a top-level `+`/`-` is split before the
+    // `if_not_exists(`/`list_append(` prefixes are tested. The canonical
+    // atomic-counter idiom `if_not_exists(#c, :zero) + :inc` (and its mirror
+    // `:inc + if_not_exists(#c, :zero)`) has `if_not_exists` as an *operand*
+    // of `+`, not the whole RHS. `parse_arithmetic` only splits at a top-level
+    // operator (depth 0), so a bare `if_not_exists(a, :b)` or `list_append(a, b)`
+    // call — whose only `+`/`-` would be inside the parens — falls through.
+    if let Some((arith_left, arith_right, is_add)) = parse_arithmetic(right) {
+        return evaluate_arithmetic_rhs(
+            arith_left,
+            arith_right,
+            is_add,
+            item,
+            expr_attr_names,
+            expr_attr_values,
+        );
+    }
+
     if let Some(rest) = right
         .strip_prefix("if_not_exists(")
         .or_else(|| right.strip_prefix("if_not_exists ("))
@@ -490,23 +508,43 @@ pub(crate) fn evaluate_set_rhs(
         ));
     }
 
-    if let Some((arith_left, arith_right, is_add)) = parse_arithmetic(right) {
-        return evaluate_arithmetic_rhs(
-            arith_left,
-            arith_right,
-            is_add,
-            item,
-            expr_attr_names,
-            expr_attr_values,
-        );
-    }
-
     Ok(resolve_ref_or_path(
         right,
         item,
         expr_attr_names,
         expr_attr_values,
     ))
+}
+
+/// Evaluate a single arithmetic operand. Each side of a `+`/`-` may itself be
+/// an `if_not_exists(path, :default)` call (the initialize-or-increment idiom),
+/// a value reference, or a document path. Returns the resolved AttributeValue
+/// or `None` when the operand resolves to nothing (e.g. a missing attribute
+/// with no `if_not_exists` guard).
+pub(crate) fn evaluate_arithmetic_operand(
+    operand: &str,
+    item: &HashMap<String, AttributeValue>,
+    expr_attr_names: &HashMap<String, String>,
+    expr_attr_values: &HashMap<String, Value>,
+) -> Option<Value> {
+    let operand = operand.trim();
+    if let Some(rest) = operand
+        .strip_prefix("if_not_exists(")
+        .or_else(|| operand.strip_prefix("if_not_exists ("))
+    {
+        // As an arithmetic operand, `if_not_exists(path, :default)` evaluates to
+        // the *value of path* when it exists, otherwise the default — unlike the
+        // top-level SET-RHS variant, where an existing path collapses to a no-op
+        // (`None`). Returning `None` here would drop the operand and fail the
+        // whole expression with a type error.
+        let inner = rest.strip_suffix(')')?;
+        let mut split = inner.splitn(2, ',');
+        let (check, default) = (split.next()?, split.next()?);
+        return resolve_ref_or_path(check.trim(), item, expr_attr_names, expr_attr_values).or_else(
+            || resolve_ref_or_path(default.trim(), item, expr_attr_names, expr_attr_values),
+        );
+    }
+    resolve_ref_or_path(operand, item, expr_attr_names, expr_attr_values)
 }
 
 /// `if_not_exists(path, :val)` — evaluates to nothing when `path` already
@@ -567,36 +605,32 @@ pub(crate) fn evaluate_arithmetic_rhs(
     expr_attr_names: &HashMap<String, String>,
     expr_attr_values: &HashMap<String, Value>,
 ) -> Result<Option<Value>, AwsServiceError> {
-    let left_val = resolve_ref_or_path(arith_left.trim(), item, expr_attr_names, expr_attr_values);
+    let left_val = evaluate_arithmetic_operand(arith_left, item, expr_attr_names, expr_attr_values);
     let right_val =
-        resolve_ref_or_path(arith_right.trim(), item, expr_attr_names, expr_attr_values);
+        evaluate_arithmetic_operand(arith_right, item, expr_attr_names, expr_attr_values);
 
-    let left_num = extract_number(&left_val).ok_or_else(|| {
+    let bad_operand = || {
         AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "ValidationException",
             "An operand in the update expression has an incorrect data type",
         )
-    })?;
-    let right_num = extract_number(&right_val).ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            "An operand in the update expression has an incorrect data type",
-        )
-    })?;
-
-    let result = if is_add {
-        left_num + right_num
-    } else {
-        left_num - right_num
     };
 
-    let num_str = if result == result.trunc() {
-        format!("{}", result as i64)
-    } else {
-        format!("{result}")
-    };
+    let left_num = left_val
+        .as_ref()
+        .and_then(|v| v.get("N"))
+        .and_then(|n| n.as_str())
+        .ok_or_else(bad_operand)?;
+    let right_num = right_val
+        .as_ref()
+        .and_then(|v| v.get("N"))
+        .and_then(|n| n.as_str())
+        .ok_or_else(bad_operand)?;
+
+    // Arbitrary-precision decimal arithmetic — f64 silently rounds past 2^53
+    // and an `as i64` cast saturates past ~9.2e18, corrupting large counters.
+    let num_str = decimal_add_sub(left_num, right_num, is_add).ok_or_else(bad_operand)?;
 
     Ok(Some(json!({ "N": num_str })))
 }
@@ -784,3 +818,75 @@ pub(crate) use schemas::*;
 pub(crate) use table_descriptions::*;
 pub(crate) use table_lookup::*;
 pub(crate) use updates::*;
+
+#[cfg(test)]
+mod set_rhs_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn names() -> HashMap<String, String> {
+        HashMap::from([("#c".to_string(), "count".to_string())])
+    }
+    fn values() -> HashMap<String, Value> {
+        HashMap::from([
+            (":zero".to_string(), json!({"N": "0"})),
+            (":inc".to_string(), json!({"N": "1"})),
+        ])
+    }
+
+    // bug-audit 2026-06-28: the canonical initialize-or-increment counter idiom
+    // `SET #c = if_not_exists(#c, :zero) + :inc` was a silent no-op (the whole
+    // RHS was handed to the if_not_exists evaluator, which bailed). Both operand
+    // orderings must compute `(if_not_exists(c, 0)) + 1`.
+    #[test]
+    fn atomic_counter_from_absent_both_orderings() {
+        let item: HashMap<String, AttributeValue> = HashMap::new();
+        let r1 = evaluate_set_rhs(
+            "if_not_exists(#c, :zero) + :inc",
+            &item,
+            &names(),
+            &values(),
+        )
+        .unwrap();
+        assert_eq!(r1, Some(json!({"N": "1"})));
+        let r2 = evaluate_set_rhs(
+            ":inc + if_not_exists(#c, :zero)",
+            &item,
+            &names(),
+            &values(),
+        )
+        .unwrap();
+        assert_eq!(r2, Some(json!({"N": "1"})));
+    }
+
+    #[test]
+    fn atomic_counter_from_existing_both_orderings() {
+        let item: HashMap<String, AttributeValue> =
+            HashMap::from([("count".to_string(), json!({"N": "41"}))]);
+        let r1 = evaluate_set_rhs(
+            "if_not_exists(#c, :zero) + :inc",
+            &item,
+            &names(),
+            &values(),
+        )
+        .unwrap();
+        assert_eq!(r1, Some(json!({"N": "42"})));
+        let r2 = evaluate_set_rhs(
+            ":inc + if_not_exists(#c, :zero)",
+            &item,
+            &names(),
+            &values(),
+        )
+        .unwrap();
+        assert_eq!(r2, Some(json!({"N": "42"})));
+    }
+
+    // A bare if_not_exists / list_append (no top-level operator) still routes to
+    // its own evaluator rather than being misparsed as arithmetic.
+    #[test]
+    fn bare_if_not_exists_still_works() {
+        let item: HashMap<String, AttributeValue> = HashMap::new();
+        let r = evaluate_set_rhs("if_not_exists(#c, :zero)", &item, &names(), &values()).unwrap();
+        assert_eq!(r, Some(json!({"N": "0"})));
+    }
+}

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -93,6 +93,135 @@ fn compare_magnitude(a: &(String, String), b: &(String, String)) -> std::cmp::Or
         .then_with(|| a.1.cmp(&b.1))
 }
 
+/// Add (`is_add`) or subtract two DynamoDB Number strings with arbitrary
+/// precision, returning the normalized result string.
+///
+/// DynamoDB numbers are 38-significant-digit decimals; parsing operands to
+/// `f64` rounds past 2^53 and saturates an `as i64` cast past ~9.2e18, so a
+/// `SET #c = #c + :inc` or `ADD #c :inc` on a large counter silently corrupts
+/// the value. This works directly on the decimal digit strings instead.
+/// Returns `None` only if either operand is not a valid number.
+/// bug-audit 2026-06-28.
+pub(crate) fn decimal_add_sub(a: &str, b: &str, is_add: bool) -> Option<String> {
+    let (a_neg, (a_int, a_frac)) = normalize_decimal(a)?;
+    let (mut b_neg, (b_int, b_frac)) = normalize_decimal(b)?;
+    if !is_add {
+        b_neg = !b_neg;
+    }
+
+    let (res_neg, (res_int, res_frac)) = if a_neg == b_neg {
+        // Same sign: add magnitudes, keep the sign.
+        (a_neg, add_magnitude(&a_int, &a_frac, &b_int, &b_frac))
+    } else {
+        // Opposite signs: subtract the smaller magnitude from the larger and
+        // take the larger's sign.
+        match compare_magnitude(
+            &(a_int.clone(), a_frac.clone()),
+            &(b_int.clone(), b_frac.clone()),
+        ) {
+            std::cmp::Ordering::Equal => (false, (String::new(), String::new())),
+            std::cmp::Ordering::Greater => (a_neg, sub_magnitude(&a_int, &a_frac, &b_int, &b_frac)),
+            std::cmp::Ordering::Less => (b_neg, sub_magnitude(&b_int, &b_frac, &a_int, &a_frac)),
+        }
+    };
+
+    Some(format_decimal(res_neg, &res_int, &res_frac))
+}
+
+/// Right-pad a fractional digit string with zeros to `len`.
+fn pad_frac(frac: &str, len: usize) -> String {
+    let mut s = frac.to_string();
+    s.extend(std::iter::repeat_n('0', len.saturating_sub(s.len())));
+    s
+}
+
+/// Split a digit string into `(int, frac)` where `frac` is the last
+/// `frac_len` digits (front-padded with zeros if the string is too short).
+fn split_at_frac(digits: &str, frac_len: usize) -> (String, String) {
+    if digits.len() <= frac_len {
+        let padded = format!("{}{}", "0".repeat(frac_len - digits.len()), digits);
+        (String::new(), padded)
+    } else {
+        let (i, f) = digits.split_at(digits.len() - frac_len);
+        (i.to_string(), f.to_string())
+    }
+}
+
+/// Add two non-negative magnitudes given as `(int_digits, frac_digits)`.
+fn add_magnitude(ai: &str, af: &str, bi: &str, bf: &str) -> (String, String) {
+    let flen = af.len().max(bf.len());
+    let a_digits = format!("{ai}{}", pad_frac(af, flen));
+    let b_digits = format!("{bi}{}", pad_frac(bf, flen));
+    split_at_frac(&add_digit_strings(&a_digits, &b_digits), flen)
+}
+
+/// Subtract magnitude `(bi, bf)` from `(ai, af)`, assuming the first is
+/// greater than or equal to the second.
+fn sub_magnitude(ai: &str, af: &str, bi: &str, bf: &str) -> (String, String) {
+    let flen = af.len().max(bf.len());
+    let a_digits = format!("{ai}{}", pad_frac(af, flen));
+    let b_digits = format!("{bi}{}", pad_frac(bf, flen));
+    split_at_frac(&sub_digit_strings(&a_digits, &b_digits), flen)
+}
+
+/// Schoolbook addition of two non-negative integer digit strings.
+fn add_digit_strings(a: &str, b: &str) -> String {
+    let a: Vec<u8> = a.bytes().rev().map(|c| c - b'0').collect();
+    let b: Vec<u8> = b.bytes().rev().map(|c| c - b'0').collect();
+    let n = a.len().max(b.len());
+    let mut out = Vec::with_capacity(n + 1);
+    let mut carry = 0u8;
+    for i in 0..n {
+        let x = a.get(i).copied().unwrap_or(0) + b.get(i).copied().unwrap_or(0) + carry;
+        out.push(b'0' + x % 10);
+        carry = x / 10;
+    }
+    if carry > 0 {
+        out.push(b'0' + carry);
+    }
+    out.reverse();
+    String::from_utf8(out).unwrap_or_else(|_| "0".to_string())
+}
+
+/// Schoolbook subtraction `a - b` of two non-negative integer digit strings,
+/// assuming `a >= b`.
+fn sub_digit_strings(a: &str, b: &str) -> String {
+    let a: Vec<i16> = a.bytes().rev().map(|c| (c - b'0') as i16).collect();
+    let b: Vec<i16> = b.bytes().rev().map(|c| (c - b'0') as i16).collect();
+    let mut out = Vec::with_capacity(a.len());
+    let mut borrow = 0i16;
+    for (i, &ad) in a.iter().enumerate() {
+        let mut x = ad - borrow - b.get(i).copied().unwrap_or(0);
+        if x < 0 {
+            x += 10;
+            borrow = 1;
+        } else {
+            borrow = 0;
+        }
+        out.push(b'0' + x as u8);
+    }
+    while out.len() > 1 && *out.last().unwrap() == b'0' {
+        out.pop();
+    }
+    out.reverse();
+    String::from_utf8(out).unwrap_or_else(|_| "0".to_string())
+}
+
+/// Render a signed `(int, frac)` magnitude as a DynamoDB Number string with
+/// insignificant zeros stripped and no trailing `.0` for integral results.
+fn format_decimal(neg: bool, int: &str, frac: &str) -> String {
+    let int_t = int.trim_start_matches('0');
+    let frac_t = frac.trim_end_matches('0');
+    let is_zero = int_t.is_empty() && frac_t.is_empty();
+    let sign = if neg && !is_zero { "-" } else { "" };
+    let int_disp = if int_t.is_empty() { "0" } else { int_t };
+    if frac_t.is_empty() {
+        format!("{sign}{int_disp}")
+    } else {
+        format!("{sign}{int_disp}.{frac_t}")
+    }
+}
+
 /// Two AttributeValues are comparable by the relational operators (`<`, `<=`,
 /// `>`, `>=`, BETWEEN) only when they share a scalar type (S, N, or B).
 /// DynamoDB does not match a comparison across mismatched types; without this
@@ -1205,6 +1334,42 @@ mod number_compare_tests {
         // Both negative: larger magnitude is the smaller value.
         assert_eq!(compare_number_strings("-100", "-1"), Ordering::Less);
         assert_eq!(compare_number_strings("-1", "-100"), Ordering::Greater);
+    }
+
+    // bug-audit 2026-06-28: SET/ADD arithmetic must be arbitrary precision.
+    // f64 rounds past 2^53 and `as i64` saturates past ~9.2e18, corrupting
+    // large counters; decimal_add_sub works on the digit strings instead.
+    #[test]
+    fn decimal_add_sub_big_integers_exact() {
+        // Far beyond 2^53 (9007199254740992) and i64::MAX (9223372036854775807).
+        assert_eq!(
+            decimal_add_sub("9007199254740992", "1", true).unwrap(),
+            "9007199254740993"
+        );
+        assert_eq!(
+            decimal_add_sub("99999999999999999999999999999999999999", "1", true).unwrap(),
+            "100000000000000000000000000000000000000"
+        );
+        assert_eq!(
+            decimal_add_sub("9223372036854775807", "9223372036854775807", true).unwrap(),
+            "18446744073709551614"
+        );
+    }
+
+    #[test]
+    fn decimal_add_sub_signs_and_fractions() {
+        assert_eq!(decimal_add_sub("5", "3", false).unwrap(), "2");
+        assert_eq!(decimal_add_sub("3", "5", false).unwrap(), "-2");
+        assert_eq!(decimal_add_sub("-5", "3", true).unwrap(), "-2");
+        assert_eq!(decimal_add_sub("5", "-3", true).unwrap(), "2");
+        assert_eq!(decimal_add_sub("0.1", "0.2", true).unwrap(), "0.3");
+        assert_eq!(decimal_add_sub("1.5", "2.5", true).unwrap(), "4");
+        assert_eq!(decimal_add_sub("10", "10", false).unwrap(), "0");
+        assert_eq!(decimal_add_sub("100.25", "0.75", true).unwrap(), "101");
+        // Carry/borrow across the decimal point.
+        assert_eq!(decimal_add_sub("1", "0.001", false).unwrap(), "0.999");
+        // Non-numeric operand is rejected.
+        assert!(decimal_add_sub("abc", "1", true).is_none());
     }
 }
 

--- a/crates/fakecloud-dynamodb/src/service/helpers/updates.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/updates.rs
@@ -190,16 +190,13 @@ pub(crate) fn apply_add_assignment(
     if let Some(add_val) = add_val {
         if let Some(existing) = item.get(&attr) {
             if let (Some(existing_num), Some(add_num)) = (
-                extract_number(&Some(existing.clone())),
-                extract_number(&Some(add_val.clone())),
+                existing.get("N").and_then(|n| n.as_str()),
+                add_val.get("N").and_then(|n| n.as_str()),
             ) {
-                let result = existing_num + add_num;
-                let num_str = if result == result.trunc() {
-                    format!("{}", result as i64)
-                } else {
-                    format!("{result}")
-                };
-                item.insert(attr, json!({"N": num_str}));
+                // Arbitrary-precision decimal add — f64 rounds past 2^53.
+                if let Some(num_str) = decimal_add_sub(existing_num, add_num, true) {
+                    item.insert(attr, json!({"N": num_str}));
+                }
             } else if let Some(existing_set) = existing.get("SS").and_then(|v| v.as_array()) {
                 if let Some(add_set) = add_val.get("SS").and_then(|v| v.as_array()) {
                     let mut merged: Vec<Value> = existing_set.clone();

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -637,18 +637,11 @@ fn add_to_attribute(
                 cur.get("N").and_then(|v| v.as_str()),
                 val.get("N").and_then(|v| v.as_str()),
             ) {
-                let sum = a
-                    .parse::<f64>()
-                    .map_err(|_| invalid("ADD operand is not a number".into()))?
-                    + b.parse::<f64>()
-                        .map_err(|_| invalid("ADD operand is not a number".into()))?;
-                // Format without a trailing `.0` for integral results, matching
-                // how DynamoDB returns numeric attributes.
-                let s = if sum.fract() == 0.0 {
-                    format!("{}", sum as i64)
-                } else {
-                    format!("{sum}")
-                };
+                // Arbitrary-precision decimal add: f64 silently rounds past
+                // 2^53 and an `as i64` cast saturates past ~9.2e18, corrupting
+                // large counters. Integral results carry no trailing `.0`.
+                let s = crate::service::helpers::decimal_add_sub(a, b, true)
+                    .ok_or_else(|| invalid("ADD operand is not a number".into()))?;
                 item.insert(attr.to_string(), json!({ "N": s }));
             } else {
                 // Set union for SS/NS/BS.

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -32,11 +32,54 @@ use crate::state::{
 /// release the write lock and deliver one change record is extremely wasteful.
 /// Extracting only the fields the delivery path actually reads (destinations,
 /// arn, name) keeps the clone small.
-pub(super) struct KinesisDeliveryTarget {
+#[derive(Clone)]
+pub(crate) struct KinesisDeliveryTarget {
     pub destinations: Vec<KinesisDestination>,
     pub arn: String,
     pub name: String,
 }
+
+/// Build a Kinesis delivery target for a table when it has at least one active
+/// streaming destination. Free-function twin of
+/// [`DynamoDbService::kinesis_target`] so the TTL processor (no `&self`) can
+/// reuse it.
+pub(crate) fn kinesis_target_for(table: &DynamoTable) -> Option<KinesisDeliveryTarget> {
+    if table
+        .kinesis_destinations
+        .iter()
+        .any(|d| d.destination_status == "ACTIVE")
+    {
+        Some(KinesisDeliveryTarget {
+            destinations: table.kinesis_destinations.clone(),
+            arn: table.arn.clone(),
+            name: table.name.clone(),
+        })
+    } else {
+        None
+    }
+}
+
+/// A cached `TransactWriteItems` outcome, keyed by (account, client request
+/// token). AWS treats a retried transaction carrying the same
+/// `ClientRequestToken` (within a ~10 minute window) as the *same* request: it
+/// is applied at most once and the original response is replayed. Without this,
+/// a client-side retry re-applies the whole transaction (a non-idempotent
+/// `ADD` advances twice).
+struct TransactIdempotencyEntry {
+    /// When the original transaction committed; entries older than the window
+    /// are purged and treated as fresh.
+    stored_at: std::time::Instant,
+    /// Hash of the original request body, used to detect a token reused with
+    /// different parameters (AWS returns `IdempotentParameterMismatchException`).
+    request_hash: u64,
+    /// The exact JSON result returned for the original transaction.
+    response: Value,
+}
+
+/// The window for which a `ClientRequestToken` short-circuits a replay. AWS
+/// documents idempotency as lasting "a few minutes"; 10 minutes matches the
+/// commonly observed behavior.
+const TRANSACT_IDEMPOTENCY_WINDOW: std::time::Duration = std::time::Duration::from_secs(600);
 
 /// Operation flavor for the per-item KMS audit-trail emitter. Reads
 /// emit a paired `Decrypt` after `GenerateDataKey`; writes only emit
@@ -59,6 +102,11 @@ pub struct DynamoDbService {
     /// between state.read().clone() and store.save() and leave older
     /// bytes as the final on-disk state.
     snapshot_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Recent `TransactWriteItems` outcomes keyed by (account, ClientRequestToken)
+    /// for idempotent retry handling. In-memory only (lost on restart, which
+    /// matches AWS's short idempotency window).
+    transact_idempotency:
+        Arc<parking_lot::Mutex<HashMap<(String, String), TransactIdempotencyEntry>>>,
 }
 
 impl DynamoDbService {
@@ -72,7 +120,56 @@ impl DynamoDbService {
             kms_hook: None,
             region: "us-east-1".to_string(),
             snapshot_lock: Arc::new(tokio::sync::Mutex::new(())),
+            transact_idempotency: Arc::new(parking_lot::Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Look up a cached `TransactWriteItems` result for an idempotent retry.
+    ///
+    /// Returns `Ok(Some(response))` to replay the original result for a matching
+    /// (token, request) within the window, `Err(..)` with
+    /// `IdempotentParameterMismatchException` when the same token is reused with
+    /// a different body, and `Ok(None)` when this is a fresh request (no token,
+    /// expired entry, or first use).
+    pub(crate) fn transact_idempotency_lookup(
+        &self,
+        account_id: &str,
+        token: &str,
+        request_hash: u64,
+    ) -> Result<Option<AwsResponse>, AwsServiceError> {
+        let mut cache = self.transact_idempotency.lock();
+        // Drop entries past the window so the map cannot grow unbounded.
+        cache.retain(|_, e| e.stored_at.elapsed() < TRANSACT_IDEMPOTENCY_WINDOW);
+        match cache.get(&(account_id.to_string(), token.to_string())) {
+            Some(entry) if entry.request_hash == request_hash => {
+                Ok(Some(AwsResponse::ok_json(entry.response.clone())))
+            }
+            Some(_) => Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "IdempotentParameterMismatchException",
+                "Request parameters do not match the parameters of a previous \
+                 request with the same client request token",
+            )),
+            None => Ok(None),
+        }
+    }
+
+    /// Record a successful `TransactWriteItems` outcome for replay.
+    pub(crate) fn transact_idempotency_store(
+        &self,
+        account_id: &str,
+        token: &str,
+        request_hash: u64,
+        response: &Value,
+    ) {
+        self.transact_idempotency.lock().insert(
+            (account_id.to_string(), token.to_string()),
+            TransactIdempotencyEntry {
+                stored_at: std::time::Instant::now(),
+                request_hash,
+                response: response.clone(),
+            },
+        );
     }
 
     pub fn with_s3(mut self, s3_state: SharedS3State) -> Self {
@@ -187,19 +284,7 @@ impl DynamoDbService {
     }
 
     fn kinesis_target(table: &DynamoTable) -> Option<KinesisDeliveryTarget> {
-        if table
-            .kinesis_destinations
-            .iter()
-            .any(|d| d.destination_status == "ACTIVE")
-        {
-            Some(KinesisDeliveryTarget {
-                destinations: table.kinesis_destinations.clone(),
-                arn: table.arn.clone(),
-                name: table.name.clone(),
-            })
-        } else {
-            None
-        }
+        kinesis_target_for(table)
     }
 
     /// Deliver a change record to all active Kinesis streaming destinations for a table.
@@ -215,51 +300,9 @@ impl DynamoDbService {
             Some(d) => d,
             None => return,
         };
-
-        let active_destinations: Vec<_> = target
-            .destinations
-            .iter()
-            .filter(|d| d.destination_status == "ACTIVE")
-            .collect();
-
-        if active_destinations.is_empty() {
-            return;
-        }
-
-        let mut record = json!({
-            "eventID": uuid::Uuid::new_v4().to_string(),
-            "eventName": event_name,
-            "eventVersion": "1.1",
-            "eventSource": "aws:dynamodb",
-            "awsRegion": target.arn.split(':').nth(3).unwrap_or("us-east-1"),
-            "dynamodb": {
-                "Keys": keys,
-                // Use the shared atomic monotonic counter (not wall-clock
-                // nanoseconds): a single BatchWriteItem fires up to 25
-                // deliveries with no delay, which collide on coarse clocks
-                // and invert on NTP steps. bug-audit 2026-06-15, 4.5.
-                "SequenceNumber": crate::streams::next_stream_sequence(),
-                "SizeBytes": serde_json::to_string(keys).map(|s| s.len()).unwrap_or(0),
-                "StreamViewType": "NEW_AND_OLD_IMAGES",
-            },
-            "eventSourceARN": &target.arn,
-            "tableName": &target.name,
-        });
-
-        if let Some(old) = old_image {
-            record["dynamodb"]["OldImage"] = json!(old);
-        }
-        if let Some(new) = new_image {
-            record["dynamodb"]["NewImage"] = json!(new);
-        }
-
-        let record_str = serde_json::to_string(&record).unwrap_or_default();
-        let encoded = base64::engine::general_purpose::STANDARD.encode(&record_str);
-        let partition_key = serde_json::to_string(keys).unwrap_or_default();
-
-        for dest in active_destinations {
-            delivery.send_to_kinesis(&dest.stream_arn, &encoded, &partition_key);
-        }
+        deliver_kinesis_change(
+            delivery, target, event_name, keys, old_image, new_image, None,
+        );
     }
 
     fn parse_body(req: &AwsRequest) -> Result<Value, AwsServiceError> {
@@ -274,6 +317,73 @@ impl DynamoDbService {
 
     fn ok_json(body: Value) -> Result<AwsResponse, AwsServiceError> {
         Ok(AwsResponse::ok_json(body))
+    }
+}
+
+/// Build and dispatch a Kinesis change record to every active streaming
+/// destination of a table. Shared by [`DynamoDbService::deliver_to_kinesis_destinations`]
+/// and the TTL processor (which is a free function with no `&self`), so both
+/// emit the identical record shape. `user_identity` is set only for
+/// system-generated changes such as TTL expirations.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn deliver_kinesis_change(
+    delivery: &DeliveryBus,
+    target: &KinesisDeliveryTarget,
+    event_name: &str,
+    keys: &HashMap<String, AttributeValue>,
+    old_image: Option<&HashMap<String, AttributeValue>>,
+    new_image: Option<&HashMap<String, AttributeValue>>,
+    user_identity: Option<&crate::state::StreamUserIdentity>,
+) {
+    let active_destinations: Vec<_> = target
+        .destinations
+        .iter()
+        .filter(|d| d.destination_status == "ACTIVE")
+        .collect();
+
+    if active_destinations.is_empty() {
+        return;
+    }
+
+    let mut record = json!({
+        "eventID": uuid::Uuid::new_v4().to_string(),
+        "eventName": event_name,
+        "eventVersion": "1.1",
+        "eventSource": "aws:dynamodb",
+        "awsRegion": target.arn.split(':').nth(3).unwrap_or("us-east-1"),
+        "dynamodb": {
+            "Keys": keys,
+            // Use the shared atomic monotonic counter (not wall-clock
+            // nanoseconds): a single BatchWriteItem fires up to 25
+            // deliveries with no delay, which collide on coarse clocks
+            // and invert on NTP steps. bug-audit 2026-06-15, 4.5.
+            "SequenceNumber": crate::streams::next_stream_sequence(),
+            "SizeBytes": serde_json::to_string(keys).map(|s| s.len()).unwrap_or(0),
+            "StreamViewType": "NEW_AND_OLD_IMAGES",
+        },
+        "eventSourceARN": &target.arn,
+        "tableName": &target.name,
+    });
+
+    if let Some(old) = old_image {
+        record["dynamodb"]["OldImage"] = json!(old);
+    }
+    if let Some(new) = new_image {
+        record["dynamodb"]["NewImage"] = json!(new);
+    }
+    if let Some(ui) = user_identity {
+        record["userIdentity"] = json!({
+            "principalId": ui.principal_id,
+            "type": ui.identity_type,
+        });
+    }
+
+    let record_str = serde_json::to_string(&record).unwrap_or_default();
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&record_str);
+    let partition_key = serde_json::to_string(keys).unwrap_or_default();
+
+    for dest in active_destinations {
+        delivery.send_to_kinesis(&dest.stream_arn, &encoded, &partition_key);
     }
 }
 

--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -448,6 +448,16 @@ impl DynamoDbService {
         let mut matched: Vec<&HashMap<String, AttributeValue>> = table
             .items
             .iter()
+            .filter(|item| {
+                // Sparse index: an index only contains items that carry every
+                // one of its key attributes. AWS never returns (or counts) an
+                // item missing the index hash/range key on an index scan, so
+                // skip those before the segment filter and the count.
+                if index_name.is_some() && !index_key_attrs.iter().all(|k| item.contains_key(k)) {
+                    return false;
+                }
+                true
+            })
             .filter(|item| match (segment, total_segments) {
                 (Some(seg), Some(total)) => {
                     use std::collections::hash_map::DefaultHasher;

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -172,6 +172,30 @@ pub struct StreamRecord {
     pub dynamodb: DynamoDbStreamRecord,
     pub event_source_arn: String,
     pub timestamp: DateTime<Utc>,
+    /// Set only for system-generated changes. TTL deletions carry
+    /// `{principalId: "dynamodb.amazonaws.com", type: "Service"}` so consumers
+    /// can distinguish an expiry REMOVE from a user-driven DeleteItem. Absent
+    /// (and omitted from the wire) for ordinary writes.
+    #[serde(default)]
+    pub user_identity: Option<StreamUserIdentity>,
+}
+
+/// `userIdentity` block on a stream record. Present only for system-generated
+/// events such as TTL expirations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamUserIdentity {
+    pub principal_id: String,
+    pub identity_type: String,
+}
+
+impl StreamUserIdentity {
+    /// The marker AWS attaches to a TTL-expiry REMOVE record.
+    pub fn ttl() -> Self {
+        Self {
+            principal_id: "dynamodb.amazonaws.com".to_string(),
+            identity_type: "Service".to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -113,6 +113,7 @@ pub fn generate_stream_record(
         },
         event_source_arn: table.stream_arn.clone().unwrap_or_default(),
         timestamp: Utc::now(),
+        user_identity: None,
     })
 }
 

--- a/crates/fakecloud-dynamodb/src/streams_dataplane.rs
+++ b/crates/fakecloud-dynamodb/src/streams_dataplane.rs
@@ -274,7 +274,7 @@ fn stream_record_to_json(r: &crate::state::StreamRecord, table: &DynamoTable) ->
     if let Some(oi) = r.dynamodb.old_image.as_ref() {
         dynamodb["OldImage"] = json!(oi);
     }
-    json!({
+    let mut out = json!({
         "eventID": r.event_id,
         "eventName": r.event_name,
         "eventVersion": r.event_version,
@@ -282,7 +282,17 @@ fn stream_record_to_json(r: &crate::state::StreamRecord, table: &DynamoTable) ->
         "awsRegion": r.aws_region,
         "eventSourceARN": table.stream_arn.clone().unwrap_or_default(),
         "dynamodb": dynamodb,
-    })
+    });
+    if let Some(ui) = r.user_identity.as_ref() {
+        // The DynamoDB Streams GetRecords wire shape capitalizes the Identity
+        // members (`PrincipalId`, `Type`) even though the surrounding record
+        // keys are camelCase; this matches what the AWS SDKs deserialize.
+        out["userIdentity"] = json!({
+            "PrincipalId": ui.principal_id,
+            "Type": ui.identity_type,
+        });
+    }
+    out
 }
 
 fn stream_label(stream_arn: &str) -> String {
@@ -435,6 +445,7 @@ mod tests {
                 size_bytes: 16,
                 stream_view_type: "NEW_AND_OLD_IMAGES".into(),
             },
+            user_identity: None,
         };
         table.stream_records.write().push(rec);
         s.tables.insert("widgets".to_string(), table);
@@ -516,6 +527,7 @@ mod tests {
                 size_bytes: 16,
                 stream_view_type: "NEW_AND_OLD_IMAGES".into(),
             },
+            user_identity: None,
         };
         table.stream_records.write().push(rec);
     }

--- a/crates/fakecloud-dynamodb/src/ttl.rs
+++ b/crates/fakecloud-dynamodb/src/ttl.rs
@@ -1,63 +1,173 @@
-use crate::state::SharedDynamoDbState;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use fakecloud_core::delivery::DeliveryBus;
+
+use crate::state::{AttributeValue, SharedDynamoDbState, StreamUserIdentity};
+
+/// A Kinesis change record collected during a TTL sweep and dispatched after
+/// the state write lock is released: (target, keys, old_image).
+type PendingTtlKinesis = (
+    crate::service::KinesisDeliveryTarget,
+    HashMap<String, AttributeValue>,
+    HashMap<String, AttributeValue>,
+);
 
 /// Process TTL expirations across all tables.
 ///
 /// Iterates every table with TTL enabled, checks each item for the configured
 /// TTL attribute, and deletes items whose TTL value (epoch seconds as a Number)
-/// is less than the current time.
+/// is less than the current time. Each expiry emits a `REMOVE` stream record
+/// (and Kinesis delivery, when `delivery` is supplied) carrying the
+/// `dynamodb.amazonaws.com` userIdentity marker AWS attaches to TTL deletions.
 ///
 /// Returns the total number of expired (deleted) items.
 pub fn process_ttl_expirations(state: &SharedDynamoDbState) -> usize {
+    process_ttl_expirations_with(state, None)
+}
+
+/// Like [`process_ttl_expirations`] but with a Kinesis [`DeliveryBus`] so
+/// TTL-expiry REMOVE records reach a table's active Kinesis streaming
+/// destinations.
+pub fn process_ttl_expirations_with(
+    state: &SharedDynamoDbState,
+    delivery: Option<&Arc<DeliveryBus>>,
+) -> usize {
     let now = chrono::Utc::now().timestamp();
-    process_ttl_expirations_at(state, now)
+    process_ttl_expirations_at_with(state, now, delivery)
 }
 
 /// Same as [`process_ttl_expirations`] but accepts an explicit "now" timestamp,
 /// making it easy to test without time manipulation.
 pub fn process_ttl_expirations_at(state: &SharedDynamoDbState, now_epoch: i64) -> usize {
+    process_ttl_expirations_at_with(state, now_epoch, None)
+}
+
+/// Core TTL sweep with an explicit clock and an optional Kinesis delivery bus.
+pub fn process_ttl_expirations_at_with(
+    state: &SharedDynamoDbState,
+    now_epoch: i64,
+    delivery: Option<&Arc<DeliveryBus>>,
+) -> usize {
     let mut total_expired = 0;
-    let mut mas = state.write();
+    // Kinesis deliveries collected under the lock and fired after it is
+    // released, mirroring the put/delete paths (the delivery bus may take its
+    // own locks, so we never hold the DynamoDB write lock across delivery).
+    let mut pending_kinesis: Vec<PendingTtlKinesis> = Vec::new();
+    {
+        let mut mas = state.write();
 
-    // Process TTL across all accounts
-    for (_, acct_state) in mas.iter_mut() {
-        for table in acct_state.tables.values_mut() {
-            if !table.ttl_enabled {
-                continue;
-            }
+        // Process TTL across all accounts
+        for (_, acct_state) in mas.iter_mut() {
+            let region = acct_state.region.clone();
+            for table in acct_state.tables.values_mut() {
+                if !table.ttl_enabled {
+                    continue;
+                }
 
-            let ttl_attr = match &table.ttl_attribute {
-                Some(attr) => attr.clone(),
-                None => continue,
-            };
-
-            let before = table.items.len();
-            table.items.retain(|item| {
-                let av = match item.get(&ttl_attr) {
-                    Some(v) => v,
-                    None => return true, // no TTL attribute → keep
+                let ttl_attr = match &table.ttl_attribute {
+                    Some(attr) => attr.clone(),
+                    None => continue,
                 };
 
-                // TTL attribute must be a Number ({"N": "..."})
-                let epoch = match av.as_object().and_then(|obj| obj.get("N")) {
-                    Some(n) => match n.as_str().and_then(|s| s.parse::<i64>().ok()) {
-                        Some(v) => v,
-                        None => return true, // non-numeric → keep
-                    },
-                    None => return true, // not a Number type → keep
-                };
+                // Partition into kept vs. expired so we can emit a REMOVE
+                // record per expired item rather than silently dropping it.
+                let mut kept: Vec<HashMap<String, AttributeValue>> =
+                    Vec::with_capacity(table.items.len());
+                let mut expired: Vec<HashMap<String, AttributeValue>> = Vec::new();
+                for item in std::mem::take(&mut table.items) {
+                    if is_expired(&item, &ttl_attr, now_epoch) {
+                        expired.push(item);
+                    } else {
+                        kept.push(item);
+                    }
+                }
+                table.items = kept;
 
-                // Keep if TTL is in the future (or exactly now)
-                epoch >= now_epoch
-            });
-            let removed = before - table.items.len();
-            if removed > 0 {
+                if expired.is_empty() {
+                    continue;
+                }
+                total_expired += expired.len();
                 table.recalculate_stats();
+
+                let kinesis_target = crate::service::kinesis_target_for(table);
+                for item in expired {
+                    let keys = extract_key_by_schema(table, &item);
+
+                    if let Some(record) = crate::streams::generate_stream_record(
+                        table,
+                        "REMOVE",
+                        keys.clone(),
+                        Some(item.clone()),
+                        None,
+                        &region,
+                    ) {
+                        let mut record = record;
+                        record.user_identity = Some(StreamUserIdentity::ttl());
+                        crate::streams::add_stream_record(table, record);
+                    }
+
+                    if delivery.is_some() {
+                        if let Some(target) = kinesis_target.clone() {
+                            pending_kinesis.push((target, keys, item));
+                        }
+                    }
+                }
             }
-            total_expired += removed;
+        } // end per-account loop
+    } // write lock released here
+
+    if let Some(delivery) = delivery {
+        let ttl_identity = StreamUserIdentity::ttl();
+        for (target, keys, old_image) in pending_kinesis {
+            crate::service::deliver_kinesis_change(
+                delivery,
+                &target,
+                "REMOVE",
+                &keys,
+                Some(&old_image),
+                None,
+                Some(&ttl_identity),
+            );
         }
-    } // end per-account loop
+    }
 
     total_expired
+}
+
+/// Whether `item` is past its TTL. Items lacking the attribute, with a
+/// non-Number type, or with a non-numeric value are never expired (kept).
+fn is_expired(item: &HashMap<String, AttributeValue>, ttl_attr: &str, now_epoch: i64) -> bool {
+    let Some(av) = item.get(ttl_attr) else {
+        return false;
+    };
+    let epoch = av
+        .as_object()
+        .and_then(|obj| obj.get("N"))
+        .and_then(|n| n.as_str())
+        .and_then(|s| s.parse::<i64>().ok());
+    match epoch {
+        Some(e) => e < now_epoch,
+        None => false,
+    }
+}
+
+/// Extract the table's primary key (hash + optional range) from an item.
+fn extract_key_by_schema(
+    table: &crate::state::DynamoTable,
+    item: &HashMap<String, AttributeValue>,
+) -> HashMap<String, AttributeValue> {
+    let mut key = HashMap::new();
+    let hash = table.hash_key_name();
+    if let Some(v) = item.get(hash) {
+        key.insert(hash.to_string(), v.clone());
+    }
+    if let Some(range) = table.range_key_name() {
+        if let Some(v) = item.get(range) {
+            key.insert(range.to_string(), v.clone());
+        }
+    }
+    key
 }
 
 #[cfg(test)]
@@ -270,6 +380,49 @@ mod tests {
         let count = process_ttl_expirations_at(&state, now);
         assert_eq!(count, 2);
         assert_eq!(state.read().default_ref().tables["t1"].items.len(), 3);
+    }
+
+    // bug-audit 2026-06-28: a TTL expiry must publish a REMOVE stream record
+    // (carrying the dynamodb.amazonaws.com userIdentity marker) just like any
+    // other delete path, not silently drop the item.
+    #[test]
+    fn ttl_expiry_emits_remove_stream_record() {
+        let state = make_state();
+        let now = 1_000_000;
+
+        let mut table = make_table("t1", true, Some("ttl"));
+        table.stream_enabled = true;
+        table.stream_view_type = Some("NEW_AND_OLD_IMAGES".to_string());
+        table.stream_arn = Some(format!("{}/stream/2026-06-28", table.arn));
+        table
+            .items
+            .push(make_item("a", Some(json!({"N": "999999"}))));
+        state
+            .write()
+            .default_mut()
+            .tables
+            .insert("t1".to_string(), table);
+
+        let count = process_ttl_expirations_at(&state, now);
+        assert_eq!(count, 1);
+
+        let s = state.read();
+        let records = s.default_ref().tables["t1"].stream_records.read();
+        assert_eq!(records.len(), 1, "one REMOVE stream record emitted");
+        let rec = &records[0];
+        assert_eq!(rec.event_name, "REMOVE");
+        let ui = rec
+            .user_identity
+            .as_ref()
+            .expect("TTL record carries userIdentity");
+        assert_eq!(ui.principal_id, "dynamodb.amazonaws.com");
+        assert_eq!(ui.identity_type, "Service");
+        // The expiring item is captured as the OldImage and the key is present.
+        assert_eq!(
+            rec.dynamodb.old_image.as_ref().unwrap()["pk"],
+            json!({"S": "a"})
+        );
+        assert_eq!(rec.dynamodb.keys["pk"], json!({"S": "a"}));
     }
 
     #[test]

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -5779,3 +5779,488 @@ async fn dynamodb_batch_execute_statement_error_code_is_enum() {
         "missing-table statement reports ResourceNotFound, not a bogus ValidationException"
     );
 }
+
+// bug-audit 2026-06-28: the canonical atomic-counter idiom
+// `SET #c = if_not_exists(#c, :zero) + :inc` was a silent no-op (the whole RHS
+// went to the if_not_exists evaluator, which dropped the assignment), and the
+// mirror form raised a spurious type error. Both orderings must initialize and
+// then increment, from an absent and an existing attribute.
+#[tokio::test]
+async fn dynamodb_atomic_counter_initialize_or_increment() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("Counters")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Increment from absent (initializes to 0 then +1) using the standard form.
+    let resp = client
+        .update_item()
+        .table_name("Counters")
+        .key("id", AttributeValue::S("a".to_string()))
+        .update_expression("SET #c = if_not_exists(#c, :zero) + :inc")
+        .expression_attribute_names("#c", "count")
+        .expression_attribute_values(":zero", AttributeValue::N("0".to_string()))
+        .expression_attribute_values(":inc", AttributeValue::N("1".to_string()))
+        .return_values(aws_sdk_dynamodb::types::ReturnValue::UpdatedNew)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.attributes()
+            .unwrap()
+            .get("count")
+            .unwrap()
+            .as_n()
+            .unwrap(),
+        "1",
+        "initialize-or-increment from absent yields 1"
+    );
+
+    // Increment again on the existing value.
+    let resp = client
+        .update_item()
+        .table_name("Counters")
+        .key("id", AttributeValue::S("a".to_string()))
+        .update_expression("SET #c = if_not_exists(#c, :zero) + :inc")
+        .expression_attribute_names("#c", "count")
+        .expression_attribute_values(":zero", AttributeValue::N("0".to_string()))
+        .expression_attribute_values(":inc", AttributeValue::N("1".to_string()))
+        .return_values(aws_sdk_dynamodb::types::ReturnValue::UpdatedNew)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.attributes()
+            .unwrap()
+            .get("count")
+            .unwrap()
+            .as_n()
+            .unwrap(),
+        "2"
+    );
+
+    // Mirror operand ordering must work identically (used to throw).
+    let resp = client
+        .update_item()
+        .table_name("Counters")
+        .key("id", AttributeValue::S("b".to_string()))
+        .update_expression("SET #c = :inc + if_not_exists(#c, :zero)")
+        .expression_attribute_names("#c", "count")
+        .expression_attribute_values(":zero", AttributeValue::N("0".to_string()))
+        .expression_attribute_values(":inc", AttributeValue::N("5".to_string()))
+        .return_values(aws_sdk_dynamodb::types::ReturnValue::UpdatedNew)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.attributes()
+            .unwrap()
+            .get("count")
+            .unwrap()
+            .as_n()
+            .unwrap(),
+        "5",
+        "mirror operand ordering initializes-or-increments"
+    );
+}
+
+// bug-audit 2026-06-28: SET/ADD arithmetic ran through f64, which rounds past
+// 2^53 and saturates an `as i64` cast past ~9.2e18. Large counters must add
+// exactly via arbitrary-precision decimals.
+#[tokio::test]
+async fn dynamodb_add_big_integer_exact() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("BigCounters")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Seed just below 2^53 and ADD 1 -> must land exactly on 2^53 + ... .
+    client
+        .put_item()
+        .table_name("BigCounters")
+        .item("id", AttributeValue::S("big".to_string()))
+        .item("count", AttributeValue::N("9007199254740992".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .update_item()
+        .table_name("BigCounters")
+        .key("id", AttributeValue::S("big".to_string()))
+        .update_expression("ADD #c :inc")
+        .expression_attribute_names("#c", "count")
+        .expression_attribute_values(":inc", AttributeValue::N("1".to_string()))
+        .return_values(aws_sdk_dynamodb::types::ReturnValue::UpdatedNew)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.attributes()
+            .unwrap()
+            .get("count")
+            .unwrap()
+            .as_n()
+            .unwrap(),
+        "9007199254740993",
+        "ADD is exact past 2^53"
+    );
+
+    // SET arithmetic on a value past i64::MAX must also be exact.
+    let resp = client
+        .update_item()
+        .table_name("BigCounters")
+        .key("id", AttributeValue::S("big".to_string()))
+        .update_expression("SET #c = #c + :huge")
+        .expression_attribute_names("#c", "count")
+        .expression_attribute_values(
+            ":huge",
+            AttributeValue::N("9223372036854775807".to_string()),
+        )
+        .return_values(aws_sdk_dynamodb::types::ReturnValue::UpdatedNew)
+        .send()
+        .await
+        .unwrap();
+    // 9007199254740993 + 9223372036854775807 = 9232379236109516800.
+    assert_eq!(
+        resp.attributes()
+            .unwrap()
+            .get("count")
+            .unwrap()
+            .as_n()
+            .unwrap(),
+        "9232379236109516800",
+        "SET + is exact across i64::MAX"
+    );
+}
+
+// bug-audit 2026-06-28: a scan on a sparse GSI returned items that lack the
+// index key attribute. AWS only projects items carrying every index key
+// attribute into the index, so such items are never returned or counted.
+#[tokio::test]
+async fn dynamodb_scan_sparse_index_excludes_unprojected_items() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("SparseIdx")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("gsiKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_indexes(
+            GlobalSecondaryIndex::builder()
+                .index_name("BySparse")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("gsiKey")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::All)
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // One item carries the index key, one does not.
+    client
+        .put_item()
+        .table_name("SparseIdx")
+        .item("id", AttributeValue::S("has".to_string()))
+        .item("gsiKey", AttributeValue::S("k1".to_string()))
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_item()
+        .table_name("SparseIdx")
+        .item("id", AttributeValue::S("missing".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .scan()
+        .table_name("SparseIdx")
+        .index_name("BySparse")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.count(),
+        1,
+        "sparse index excludes the item lacking gsiKey"
+    );
+    assert_eq!(resp.scanned_count(), 1, "ScannedCount also excludes it");
+    let items = resp.items();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].get("id").unwrap().as_s().unwrap(), "has");
+}
+
+// bug-audit 2026-06-28: a retried TransactWriteItems carrying the same
+// ClientRequestToken must apply at most once. A non-idempotent ADD previously
+// advanced twice when the SDK (or a caller) replayed the request.
+#[tokio::test]
+async fn dynamodb_transact_write_items_idempotent_token() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("IdemTxn")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let token = "fixed-idempotency-token-001";
+    let build_request = || {
+        client
+            .transact_write_items()
+            .client_request_token(token)
+            .transact_items(
+                TransactWriteItem::builder()
+                    .update(
+                        aws_sdk_dynamodb::types::Update::builder()
+                            .table_name("IdemTxn")
+                            .key("id", AttributeValue::S("c".to_string()))
+                            .update_expression("ADD #n :one")
+                            .expression_attribute_names("#n", "n")
+                            .expression_attribute_values(":one", AttributeValue::N("1".to_string()))
+                            .build()
+                            .unwrap(),
+                    )
+                    .build(),
+            )
+    };
+
+    build_request().send().await.unwrap();
+    // Replay with the identical token: must be treated as the same request.
+    build_request().send().await.unwrap();
+
+    let resp = client
+        .get_item()
+        .table_name("IdemTxn")
+        .key("id", AttributeValue::S("c".to_string()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.item().unwrap().get("n").unwrap().as_n().unwrap(),
+        "1",
+        "same-token replay applies the ADD only once"
+    );
+}
+
+// bug-audit 2026-06-28: TTL expiry deleted items silently. AWS publishes a
+// REMOVE stream record per expired item carrying the
+// `dynamodb.amazonaws.com` userIdentity marker.
+#[tokio::test]
+async fn dynamodb_ttl_expiry_emits_remove_stream_record() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let streams = server.dynamodb_streams_client().await;
+
+    let table_name = "TtlStreams";
+    ddb.create_table()
+        .table_name(table_name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .stream_specification(
+            StreamSpecification::builder()
+                .stream_enabled(true)
+                .stream_view_type(StreamViewType::NewAndOldImages)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    ddb.update_time_to_live()
+        .table_name(table_name)
+        .time_to_live_specification(
+            TimeToLiveSpecification::builder()
+                .attribute_name("ttl")
+                .enabled(true)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Item already expired (ttl in the past).
+    ddb.put_item()
+        .table_name(table_name)
+        .item("pk", AttributeValue::S("gone".to_string()))
+        .item("ttl", AttributeValue::N("1".to_string()))
+        .send()
+        .await
+        .unwrap();
+
+    // Force the TTL processor to run now.
+    let url = format!(
+        "{}/_fakecloud/dynamodb/ttl-processor/tick",
+        server.endpoint()
+    );
+    let tick: serde_json::Value = reqwest::Client::new()
+        .post(&url)
+        .send()
+        .await
+        .expect("ttl tick")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(tick["expiredItems"].as_u64(), Some(1));
+
+    let table = ddb
+        .describe_table()
+        .table_name(table_name)
+        .send()
+        .await
+        .unwrap();
+    let stream_arn = table
+        .table()
+        .unwrap()
+        .latest_stream_arn()
+        .unwrap()
+        .to_string();
+
+    let desc = streams
+        .describe_stream()
+        .stream_arn(&stream_arn)
+        .send()
+        .await
+        .unwrap();
+    let shard_id = desc
+        .stream_description()
+        .unwrap()
+        .shards()
+        .first()
+        .unwrap()
+        .shard_id()
+        .unwrap()
+        .to_string();
+    let it = streams
+        .get_shard_iterator()
+        .stream_arn(&stream_arn)
+        .shard_id(&shard_id)
+        .shard_iterator_type(aws_sdk_dynamodbstreams::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let records = streams
+        .get_records()
+        .shard_iterator(it.shard_iterator().unwrap())
+        .send()
+        .await
+        .unwrap();
+    let r = records.records();
+
+    // PutItem -> INSERT, TTL expiry -> REMOVE.
+    let remove = r
+        .iter()
+        .find(|rec| rec.event_name().unwrap().as_str() == "REMOVE")
+        .expect("a REMOVE record for the expired item");
+    let ui = remove
+        .user_identity()
+        .expect("TTL REMOVE carries userIdentity");
+    assert_eq!(ui.principal_id(), Some("dynamodb.amazonaws.com"));
+    assert_eq!(ui.r#type(), Some("Service"));
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -758,6 +758,9 @@ async fn main() {
     let ecr_introspection_state = ecr_state.clone();
     let ecs_introspection_state = ecs_state.clone();
     let dynamodb_ttl_state = dynamodb_state.clone();
+    // TTL-expiry REMOVE records flow to a table's Kinesis streaming
+    // destinations through the same delivery bus the service uses.
+    let dynamodb_ttl_delivery = delivery_for_dynamodb.clone();
     let secretsmanager_rotation_state = secretsmanager_state.clone();
     // Clone state refs for simulation endpoints
     let sqs_sim_expiration_state = sqs_state.clone();
@@ -5504,8 +5507,12 @@ async fn main() {
             "/_fakecloud/dynamodb/ttl-processor/tick",
             axum::routing::post({
                 let ds = dynamodb_ttl_state;
+                let delivery = dynamodb_ttl_delivery;
                 move || async move {
-                    let count = fakecloud_dynamodb::ttl::process_ttl_expirations(&ds);
+                    let count = fakecloud_dynamodb::ttl::process_ttl_expirations_with(
+                        &ds,
+                        Some(&delivery),
+                    );
                     axum::Json(types::TtlTickResponse {
                         expired_items: count as u64,
                     })


### PR DESCRIPTION
Fixes a cluster of confirmed DynamoDB correctness bugs, all in `crates/fakecloud-dynamodb`.

## Fixes

1. **Atomic-counter idiom was a silent no-op (HIGH).** `SET #c = if_not_exists(#c, :zero) + :inc` evaluated to nothing (the whole RHS was handed to the `if_not_exists` evaluator, which bailed and dropped the assignment), and the mirror form `:inc + if_not_exists(...)` raised a spurious type error. Arithmetic is now parsed first, and each `+`/`-` operand can itself be an `if_not_exists(path, :default)` that resolves to the existing value or the default. Both operand orderings now initialize-or-increment correctly: `(if_not_exists(c, 0)) + inc`.

2. **SET arithmetic / ADD lost precision past 2^53 (MED).** SET `+`/`-` and ADD parsed operands with `f64` (rounds past 2^53) and formatted via an `as i64` cast (saturates past ~9.2e18). Added arbitrary-precision decimal add/subtract (`decimal_add_sub`) built on the existing comparison-fix decimal decomposition, reused by the SET-expression, UPDATE-expression ADD, and AttributeUpdates ADD paths.

3. **Scan on a sparse GSI/LSI returned items lacking the index key (MED).** An index scan pulled straight from the base table without requiring the index key attributes. It now skips items missing any index hash/range key attribute, and Count/ScannedCount reflect the exclusion.

4. **TransactWriteItems ignored ClientRequestToken idempotency (MED).** A retried transaction with the same token now replays the original result (applied at most once) within a 10-minute window; reusing a token with a different body returns `IdempotentParameterMismatchException`. Cached in-memory on the service, keyed by (account, token).

5. **TTL expiration emitted no Stream/Kinesis REMOVE record (MED).** TTL deletes silently dropped items. Each expiry now emits a `REMOVE` stream record and Kinesis delivery carrying the TTL `userIdentity` marker (`principalId = dynamodb.amazonaws.com`, `type = Service`), matching the other delete paths. The TTL admin tick is wired with the DynamoDB delivery bus.

## Tests

- Unit (`fakecloud-dynamodb`): decimal add/sub big-integer + signs/fractions; atomic counter from absent/existing in both operand orderings; bare `if_not_exists` still routes correctly; TTL expiry emits a REMOVE record with the userIdentity marker.
- E2E (`fakecloud-e2e/tests/dynamodb.rs`): atomic counter initialize-or-increment (both orderings); ADD/SET exact past 2^53 and across i64::MAX; sparse-GSI scan excludes the unprojected item (Count and ScannedCount); same-token TransactWriteItems replay applies the ADD once; TTL tick produces a REMOVE stream record with `userIdentity`.

## Validation

- `cargo build` (workspace + bin) OK
- `cargo fmt --all -- --check` OK
- `cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings` clean
- `cargo test -p fakecloud-dynamodb` 328 pass
- `cargo test -p fakecloud-e2e --test dynamodb --test dynamodb_streams --test dynamodb_persistence` all pass (81 + 3 + 2)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiple DynamoDB correctness bugs in `crates/fakecloud-dynamodb` affecting counters, number math, sparse index scans, transaction idempotency, and TTL stream/Kinesis events. Aligns behavior with AWS and prevents no-ops, precision loss, and missing REMOVE records.

- **Bug Fixes**
  - SET/ADD now use arbitrary-precision decimal math; exact past 2^53 and beyond `i64::MAX`.
  - Atomic counter idiom works in both operand orders: `if_not_exists(#c, :zero) + :inc` and `:inc + if_not_exists(#c, :zero)`.
  - Sparse GSI/LSI scans skip items missing index key attributes; Count and ScannedCount updated.
  - `TransactWriteItems` honors `ClientRequestToken` idempotency: identical retries replay within ~10 minutes; mismatches return `IdempotentParameterMismatchException`.
  - TTL expirations emit `REMOVE` records to Streams and Kinesis with `userIdentity` set to `dynamodb.amazonaws.com` Service.

<sup>Written for commit e2ee46a48b1e76d1ec21931e237324e0a2c5737f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

