### PR TITLE
fix(stepfunctions): idempotent StartExecution, history detail keys, Choice/Pass field handling

### DIFF
--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -1016,11 +1016,23 @@ async fn sfn_start_execution_with_name() {
 
     wait_for_execution(&client, start.execution_arn()).await;
 
-    // Duplicate execution name should fail
+    // Duplicate name with the SAME input is idempotent: AWS returns the
+    // existing execution ARN with HTTP 200 (not ExecutionAlreadyExists).
+    let dup = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("my-execution")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dup.execution_arn(), start.execution_arn());
+
+    // Duplicate name with a DIFFERENT input must fail with ExecutionAlreadyExists.
     let err = client
         .start_execution()
         .state_machine_arn(create.state_machine_arn())
         .name("my-execution")
+        .input("{\"changed\": true}")
         .send()
         .await;
     assert!(err.is_err());

--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -922,6 +922,28 @@ async fn sfn_get_execution_history() {
 
     // First event should be ExecutionStarted
     assert_eq!(events[0].r#type().as_str(), "ExecutionStarted");
+
+    // AWS collapses every *StateEntered into the single stateEnteredEventDetails
+    // key (and *StateExited into stateExitedEventDetails). With the wrong key,
+    // the SDK deserializes these as None and the state name is lost. Assert the
+    // SDK can read a non-null name off both.
+    let entered = events
+        .iter()
+        .find(|e| e.r#type().as_str() == "PassStateEntered")
+        .expect("PassStateEntered event present");
+    let entered_details = entered
+        .state_entered_event_details()
+        .expect("stateEnteredEventDetails deserialized (collapsed key)");
+    assert!(!entered_details.name().is_empty());
+
+    let exited = events
+        .iter()
+        .find(|e| e.r#type().as_str() == "PassStateExited")
+        .expect("PassStateExited event present");
+    let exited_details = exited
+        .state_exited_event_details()
+        .expect("stateExitedEventDetails deserialized (collapsed key)");
+    assert!(!exited_details.name().is_empty());
 }
 
 #[tokio::test]
@@ -4123,4 +4145,181 @@ async fn sfn_introspection_execution_tree_not_found() {
     );
     let resp = reqwest::get(&url).await.unwrap();
     assert_eq!(resp.status().as_u16(), 404);
+}
+
+#[tokio::test]
+async fn sfn_start_execution_idempotent_same_input() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("idem-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let first = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("dedup")
+        .input(r#"{"a":1}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Same name AND same input -> 200 with the existing executionArn.
+    let second = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("dedup")
+        .input(r#"{"a":1}"#)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(first.execution_arn(), second.execution_arn());
+}
+
+#[tokio::test]
+async fn sfn_start_execution_conflict_different_input() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let create = client
+        .create_state_machine()
+        .name("idem-conflict-sm")
+        .definition(simple_definition())
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("dedup")
+        .input(r#"{"a":1}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Same name, DIFFERENT input -> ExecutionAlreadyExists.
+    let err = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .name("dedup")
+        .input(r#"{"a":2}"#)
+        .send()
+        .await
+        .unwrap_err();
+
+    let svc_err = err.into_service_error();
+    assert!(
+        svc_err.is_execution_already_exists(),
+        "expected ExecutionAlreadyExists, got: {svc_err:?}"
+    );
+}
+
+#[tokio::test]
+async fn sfn_choice_applies_output_path() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let def = json!({
+        "StartAt": "Choose",
+        "States": {
+            "Choose": {
+                "Type": "Choice",
+                "Choices": [{"Variable": "$.x", "NumericEquals": 1, "Next": "Done"}],
+                "Default": "Done",
+                "OutputPath": "$.payload"
+            },
+            "Done": {"Type": "Pass", "End": true}
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("choice-outputpath-sm")
+        .definition(def)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"x":1,"payload":{"kept":true}}"#)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        wait_for_execution(&client, start.execution_arn()).await,
+        "SUCCEEDED"
+    );
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap()).unwrap();
+    // OutputPath narrowed the Choice output to $.payload; "x" must be gone.
+    assert_eq!(output, json!({"kept": true}));
+}
+
+#[tokio::test]
+async fn sfn_pass_evaluates_parameters() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let def = json!({
+        "StartAt": "Build",
+        "States": {
+            "Build": {
+                "Type": "Pass",
+                "Parameters": {"renamed.$": "$.value", "constant": "fixed"},
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("pass-parameters-sm")
+        .definition(def)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{"value":42,"ignored":"z"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        wait_for_execution(&client, start.execution_arn()).await,
+        "SUCCEEDED"
+    );
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap()).unwrap();
+    assert_eq!(output, json!({"renamed": 42, "constant": "fixed"}));
 }

--- a/crates/fakecloud-stepfunctions/src/interpreter_helpers.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_helpers.rs
@@ -318,6 +318,16 @@ pub(crate) fn run_choice_state(
 
     match evaluate_choice(state_def, &processed_input) {
         Some(next) => {
+            // A Choice state has no Parameters/ResultPath, so its effective
+            // result is the InputPath-filtered input; OutputPath then filters
+            // what flows to the next state. Previously the raw input was
+            // forwarded, silently ignoring OutputPath.
+            let output_path = state_def["OutputPath"].as_str();
+            let output = if output_path == Some("null") {
+                json!({})
+            } else {
+                apply_output_path(&processed_input, output_path)
+            };
             add_event(
                 shared_state,
                 execution_arn,
@@ -325,10 +335,10 @@ pub(crate) fn run_choice_state(
                 entered_event_id,
                 json!({
                     "name": name,
-                    "output": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
+                    "output": serde_json::to_string(&output).expect("serde_json::Value serialization is infallible"),
                 }),
             );
-            Advance::Next(next, input)
+            Advance::Next(next, output)
         }
         None => Advance::Fail(
             "States.NoChoiceMatched".to_string(),
@@ -349,10 +359,19 @@ pub(crate) fn execute_pass_state(state_def: &Value, input: &Value) -> Value {
         apply_input_path(input, input_path)
     };
 
+    // A Pass state may carry a Parameters template that builds a new payload
+    // from the effective input (and intrinsics). It transforms the effective
+    // input before Result/ResultPath; previously it was ignored entirely.
+    let transformed = if let Some(params) = state_def.get("Parameters") {
+        apply_parameters(params, &effective_input, None)
+    } else {
+        effective_input
+    };
+
     let result = if let Some(r) = state_def.get("Result") {
         r.clone()
     } else {
-        effective_input.clone()
+        transformed
     };
 
     let after_result = if result_path == Some("null") {
@@ -1453,6 +1472,39 @@ mod tests {
         // contains '(' and starts with States. -> true, then evaluate
         // returns Err -> Null.
         assert_eq!(out["y"], Value::Null);
+    }
+
+    #[test]
+    fn pass_state_evaluates_parameters_template() {
+        // A Pass state with Parameters builds a fresh result from the template,
+        // resolving $-references against the (InputPath-filtered) input.
+        let state_def = json!({
+            "Type": "Pass",
+            "Parameters": {
+                "renamed.$": "$.value",
+                "constant": "fixed",
+            },
+            "End": true,
+        });
+        let input = json!({"value": 99, "ignored": "x"});
+        let out = execute_pass_state(&state_def, &input);
+        assert_eq!(out["renamed"], json!(99));
+        assert_eq!(out["constant"], json!("fixed"));
+        // The non-templated field is dropped (Parameters builds a new payload).
+        assert!(out.get("ignored").is_none());
+    }
+
+    #[test]
+    fn pass_state_parameters_then_output_path() {
+        // Parameters builds the result, OutputPath then narrows it.
+        let state_def = json!({
+            "Type": "Pass",
+            "Parameters": {"a.$": "$.n", "b": 1},
+            "OutputPath": "$.a",
+            "End": true,
+        });
+        let out = execute_pass_state(&state_def, &json!({"n": 7}));
+        assert_eq!(out, json!(7));
     }
 }
 

--- a/crates/fakecloud-stepfunctions/src/service/executions.rs
+++ b/crates/fakecloud-stepfunctions/src/service/executions.rs
@@ -43,11 +43,23 @@ impl StepFunctionsService {
             .ok_or_else(|| state_machine_not_found(sm_arn))?;
 
         let sm_name = sm.name.clone();
+        let sm_type = sm.machine_type;
         let definition = sm.definition.clone();
         let exec_arn = state.execution_arn(&sm_name, &execution_name);
 
-        // Check for duplicate execution name
-        if state.executions.contains_key(&exec_arn) {
+        // Handle name collisions. For STANDARD workflows, StartExecution is
+        // idempotent: re-issuing the same name AND the same input returns the
+        // existing executionArn with HTTP 200, while a different input is a
+        // 400 ExecutionAlreadyExists. (EXPRESS has no idempotency.)
+        if let Some(existing) = state.executions.get(&exec_arn) {
+            let same_input = sm_type == crate::state::StateMachineType::Standard
+                && execution_input_matches(existing.input.as_deref(), input.as_deref());
+            if same_input {
+                return Ok(AwsResponse::ok_json(json!({
+                    "executionArn": existing.execution_arn,
+                    "startDate": existing.start_date.timestamp() as f64,
+                })));
+            }
             return Err(AwsServiceError::aws_error(
                 StatusCode::CONFLICT,
                 "ExecutionAlreadyExists",

--- a/crates/fakecloud-stepfunctions/src/service/mod.rs
+++ b/crates/fakecloud-stepfunctions/src/service/mod.rs
@@ -726,12 +726,42 @@ fn execution_to_json(exec: &Execution) -> Value {
     resp
 }
 
-/// Convert event type like "PassStateEntered" to the details key format "passStateEntered".
+/// Convert an event type to the JSON key prefix used in the `HistoryEvent`
+/// shape (the full key is `<prefix>EventDetails`).
+///
+/// AWS collapses every `*StateEntered` event type (Pass/Task/Choice/Wait/Map/
+/// Parallel/Succeed/...) into a single `stateEnteredEventDetails` member, and
+/// every `*StateExited` into `stateExitedEventDetails`. All other event types
+/// map by lowercasing the first character (`TaskScheduled` ->
+/// `taskScheduledEventDetails`). Without the collapse, SDK deserializers see an
+/// unknown key like `passStateEnteredEventDetails` and return null name/input.
 fn camel_to_details_key(event_type: &str) -> String {
+    if event_type.ends_with("StateEntered") {
+        return "stateEntered".to_string();
+    }
+    if event_type.ends_with("StateExited") {
+        return "stateExited".to_string();
+    }
     let mut chars = event_type.chars();
     match chars.next() {
         None => String::new(),
         Some(c) => c.to_lowercase().to_string() + chars.as_str(),
+    }
+}
+
+/// Compare two StartExecution inputs for STANDARD idempotency. A missing input
+/// defaults to `{}` (AWS's default execution input). Comparison is structural
+/// (parsed JSON), so insignificant whitespace differences still dedup; inputs
+/// that fail to parse fall back to an exact string match.
+fn execution_input_matches(stored: Option<&str>, incoming: Option<&str>) -> bool {
+    let stored = stored.unwrap_or("{}");
+    let incoming = incoming.unwrap_or("{}");
+    match (
+        serde_json::from_str::<Value>(stored),
+        serde_json::from_str::<Value>(incoming),
+    ) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => stored == incoming,
     }
 }
 
@@ -1293,17 +1323,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_execution_duplicate_name() {
+    async fn start_execution_same_name_same_input_is_idempotent() {
         let svc = StepFunctionsService::new(make_state());
         let arn = create_sm(&svc, "dup-exec");
 
         let body = json!({
             "stateMachineArn": arn,
             "name": "same-name",
+            "input": "{\"a\":1}",
+        });
+        let req = make_request("StartExecution", &body.to_string());
+        let first = body_json(&svc.start_execution(&req).unwrap());
+
+        // Same name AND same input -> 200 with the existing executionArn.
+        let req = make_request("StartExecution", &body.to_string());
+        let second = body_json(&svc.start_execution(&req).unwrap());
+        assert_eq!(first["executionArn"], second["executionArn"]);
+        assert_eq!(first["startDate"], second["startDate"]);
+    }
+
+    #[tokio::test]
+    async fn start_execution_same_name_different_input_conflicts() {
+        let svc = StepFunctionsService::new(make_state());
+        let arn = create_sm(&svc, "dup-exec-diff");
+
+        let req = make_request(
+            "StartExecution",
+            &json!({
+                "stateMachineArn": arn,
+                "name": "same-name",
+                "input": "{\"a\":1}",
+            })
+            .to_string(),
+        );
+        svc.start_execution(&req).unwrap();
+
+        // Same name, DIFFERENT input -> 400 ExecutionAlreadyExists.
+        let req = make_request(
+            "StartExecution",
+            &json!({
+                "stateMachineArn": arn,
+                "name": "same-name",
+                "input": "{\"a\":2}",
+            })
+            .to_string(),
+        );
+        let err = expect_err(svc.start_execution(&req));
+        assert!(err.to_string().contains("ExecutionAlreadyExists"));
+    }
+
+    #[tokio::test]
+    async fn start_execution_express_name_collision_never_idempotent() {
+        let svc = StepFunctionsService::new(make_state());
+        let arn = create_express_sm(&svc, "dup-exec-express");
+
+        let body = json!({
+            "stateMachineArn": arn,
+            "name": "same-name",
+            "input": "{\"a\":1}",
         });
         let req = make_request("StartExecution", &body.to_string());
         svc.start_execution(&req).unwrap();
 
+        // EXPRESS has no idempotency: even an identical re-issue conflicts.
         let req = make_request("StartExecution", &body.to_string());
         let err = expect_err(svc.start_execution(&req));
         assert!(err.to_string().contains("ExecutionAlreadyExists"));
@@ -1604,7 +1686,14 @@ mod tests {
 
     #[test]
     fn test_camel_to_details_key() {
-        assert_eq!(camel_to_details_key("PassStateEntered"), "passStateEntered");
+        // All *StateEntered / *StateExited types collapse to one key each.
+        assert_eq!(camel_to_details_key("PassStateEntered"), "stateEntered");
+        assert_eq!(camel_to_details_key("TaskStateEntered"), "stateEntered");
+        assert_eq!(camel_to_details_key("ChoiceStateExited"), "stateExited");
+        assert_eq!(camel_to_details_key("MapStateExited"), "stateExited");
+        // Other event types keep first-char-lowercased prefix.
+        assert_eq!(camel_to_details_key("TaskScheduled"), "taskScheduled");
+        assert_eq!(camel_to_details_key("ExecutionStarted"), "executionStarted");
         assert_eq!(camel_to_details_key(""), "");
     }
 


### PR DESCRIPTION
Fixes a cluster of confirmed Step Functions correctness bugs surfaced by the 2026-06-28 bug hunt.

## Bugs fixed

1. **StartExecution was never idempotent (HIGH).** A name collision always returned 400 ExecutionAlreadyExists without comparing input. AWS (STANDARD) returns the existing executionArn with HTTP 200 when the name AND input match; only a different input returns 400. Now compares the stored input on collision and returns the existing execution when identical.

2. **GetExecutionHistory used the wrong details key for every State Entered/Exited event (HIGH).** The key was derived by lowercasing the first char, yielding `taskStateEnteredEventDetails` / `passStateExitedEventDetails` etc. AWS collapses all `*StateEntered` types into `stateEnteredEventDetails` and all `*StateExited` into `stateExitedEventDetails`. SDK deserializers were returning null name/input/output across the whole history. Now mapped to the collapsed keys.

3. **Choice ignored OutputPath; Pass ignored Parameters (MEDIUM).** A Choice state forwarded raw input instead of applying its OutputPath; a Pass state passed input through instead of evaluating its Parameters template. Both now apply the same OutputPath/Parameters evaluation the other states use.

## Tests
E2E coverage in crates/fakecloud-e2e/tests/stepfunctions.rs for idempotent StartExecution (same-input 200 / different-input 400), collapsed history detail keys, and Choice OutputPath + Pass Parameters.

Local: build, fmt --check, clippy --all-targets -D warnings, 192 unit tests, e2e compile all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Step Functions idempotency, history event detail keys, and Choice/Pass field handling to match AWS behavior. Adds explicit E2E tests for idempotent `StartExecution`.

- **Bug Fixes**
  - `StartExecution` idempotent for `STANDARD`: same name + input returns existing `executionArn` (200) via structural JSON compare; different input returns 400 `ExecutionAlreadyExists`. `EXPRESS` unchanged.
  - `GetExecutionHistory` uses collapsed detail keys: all `*StateEntered` -> `stateEnteredEventDetails`, all `*StateExited` -> `stateExitedEventDetails`, restoring SDK `name`/`input`/`output`.
  - State evaluation: Choice applies `OutputPath`; Pass evaluates `Parameters` to build the payload before `Result`/`ResultPath` and `OutputPath`.

<sup>Written for commit 3be0f4ebbfc015333c144b6e9fce2094fb3b27ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

