### PR TITLE
fix(kms,sns): bind EncryptionContext in GenerateDataKey*WithoutPlaintext; route unsigned SNS confirmation URLs

### DIFF
--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -523,6 +523,10 @@ fn infer_service_from_action(action: &str) -> Option<String> {
         | "CreateReceiptFilter"
         | "DeleteReceiptFilter"
         | "ListReceiptFilters" => Some("ses".to_string()),
+        // SNS subscription handshake: the SubscribeURL / UnsubscribeUrl that SNS
+        // hands to HTTP/S and email subscribers are unsigned bare GETs (no auth
+        // header), so the service must be inferred from the action alone.
+        "ConfirmSubscription" | "Unsubscribe" => Some("sns".to_string()),
         _ => None,
     }
 }
@@ -768,6 +772,41 @@ mod tests {
             infer_service_from_action("ListIdentities").as_deref(),
             Some("ses")
         );
+    }
+
+    #[test]
+    fn infer_service_from_action_maps_sns_confirmation_flow() {
+        // SNS hands subscribers unsigned SubscribeURL / UnsubscribeUrl GETs,
+        // so the service must be inferred from the action alone.
+        assert_eq!(
+            infer_service_from_action("ConfirmSubscription").as_deref(),
+            Some("sns")
+        );
+        assert_eq!(
+            infer_service_from_action("Unsubscribe").as_deref(),
+            Some("sns")
+        );
+    }
+
+    #[test]
+    fn detect_service_routes_unsigned_confirm_subscription_to_sns() {
+        // Mirror the bare GET an HTTP/S subscriber issues at the SubscribeURL:
+        // no Authorization header, bare-localhost Host, Action in the query.
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "localhost:4566".parse().unwrap());
+        let mut query_params = HashMap::new();
+        query_params.insert("Action".to_string(), "ConfirmSubscription".to_string());
+        query_params.insert(
+            "TopicArn".to_string(),
+            "arn:aws:sns:us-east-1:000000000000:t".to_string(),
+        );
+        query_params.insert("Token".to_string(), "abc123".to_string());
+
+        let detected = detect_service(&headers, &query_params, &Bytes::new())
+            .expect("ConfirmSubscription must route to a service");
+        assert_eq!(detected.service, "sns");
+        assert_eq!(detected.action, "ConfirmSubscription");
+        assert_eq!(detected.protocol, AwsProtocol::Query);
     }
 
     #[test]

--- a/crates/fakecloud-e2e/tests/sns_http_confirm.rs
+++ b/crates/fakecloud-e2e/tests/sns_http_confirm.rs
@@ -316,6 +316,99 @@ async fn sns_http_subscribe_posts_confirmation_envelope_and_publish_routes_after
     assert_eq!(n_body["Message"], "after-confirm");
 }
 
+/// Regression for the dead confirmation handshake at the default endpoint:
+/// a real HTTP/S subscriber confirms by issuing an UNSIGNED bare GET at the
+/// SubscribeURL SNS hands it (no Authorization header). Previously these
+/// unsigned `?Action=ConfirmSubscription` / `?Action=Unsubscribe` GETs fell
+/// through to the apigateway catch-all and 404'd, so subscriptions stayed
+/// PendingConfirmation forever. This drives the real subscriber round-trip:
+/// confirm via the SubscribeURL, then unsubscribe via the UnsubscribeUrl,
+/// both as plain unauthenticated GETs.
+#[tokio::test]
+async fn sns_unsigned_subscribe_and_unsubscribe_urls_route_to_sns() {
+    let server = TestServer::start().await;
+    let sns = server.sns_client().await;
+    let subscriber = MockSubscriber::start().await;
+
+    let topic = sns
+        .create_topic()
+        .name("unsigned-url-e2e")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("http")
+        .endpoint(&subscriber.url)
+        .send()
+        .await
+        .unwrap();
+
+    // Capture the confirmation envelope and pull out the SubscribeURL exactly
+    // as a real subscriber would.
+    let requests = subscriber.wait_for(1, Duration::from_secs(30)).await;
+    let body: serde_json::Value =
+        serde_json::from_str(requests[0].body()).expect("confirmation body is JSON");
+    let subscribe_url = body["SubscribeURL"].as_str().unwrap().to_string();
+    assert!(subscribe_url.contains("Action=ConfirmSubscription"));
+
+    // UNSIGNED GET to the SubscribeURL — no auth header at all. Must reach the
+    // SNS handler (not 404 via apigateway) and confirm the subscription.
+    let resp = reqwest::get(&subscribe_url).await.unwrap();
+    assert!(
+        resp.status().is_success(),
+        "unsigned ConfirmSubscription GET must succeed, got {}",
+        resp.status()
+    );
+    let confirm_body = resp.text().await.unwrap();
+    assert!(
+        confirm_body.contains("ConfirmSubscriptionResult"),
+        "expected SNS ConfirmSubscription XML, got: {confirm_body}"
+    );
+
+    // It must no longer be PendingConfirmation: publish should now fan out.
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("after-unsigned-confirm")
+        .send()
+        .await
+        .unwrap();
+    let requests = subscriber.wait_for(2, Duration::from_secs(30)).await;
+    let notification = &requests[1];
+    let n_body: serde_json::Value =
+        serde_json::from_str(notification.body()).expect("notification body is JSON");
+    assert_eq!(n_body["Type"], "Notification");
+    assert_eq!(n_body["Message"], "after-unsigned-confirm");
+
+    // The Notification carries the UnsubscribeUrl — also an unsigned GET.
+    let unsubscribe_url = n_body["UnsubscribeURL"].as_str().unwrap().to_string();
+    assert!(unsubscribe_url.contains("Action=Unsubscribe"));
+
+    let resp = reqwest::get(&unsubscribe_url).await.unwrap();
+    assert!(
+        resp.status().is_success(),
+        "unsigned Unsubscribe GET must succeed, got {}",
+        resp.status()
+    );
+
+    // After unsubscribe, publishing must not deliver anything new.
+    let before = subscriber.received.lock().await.len();
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("after-unsubscribe")
+        .send()
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert_eq!(
+        subscriber.received.lock().await.len(),
+        before,
+        "publish after unsubscribe must not fan out"
+    );
+}
+
 #[tokio::test]
 async fn sns_http_confirm_rejects_bad_token() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -429,8 +429,20 @@ impl KmsService {
 
         let num_bytes = data_key_size_from_body(&body)?;
         let data_key_bytes: Vec<u8> = rand_bytes(num_bytes);
-        let _ = base64::engine::general_purpose::STANDARD.encode(&data_key_bytes);
-        let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, &data_key_bytes);
+
+        // Bind the caller's EncryptionContext into the AAD, identical to the
+        // GenerateDataKey (with-plaintext) sibling. Previously this used
+        // crate::blob::encode (AAD = key-id only), so a data key generated here
+        // with an EncryptionContext could never be decrypted with that context
+        // (AEAD mismatch -> InvalidCiphertextException) and Decrypt with no
+        // context wrongly succeeded.
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let blob = crate::blob::encode_with_context(
+            &state.master_key_bytes,
+            &key.key_id,
+            &data_key_bytes,
+            &ec_aad,
+        );
         let ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(&blob);
 
         Ok(AwsResponse::json(
@@ -1022,7 +1034,17 @@ impl KmsService {
         let (private_key_bytes, public_key_bytes) = generate_data_keypair_bytes(&key_pair_spec)?;
         let public_key_b64 = base64::engine::general_purpose::STANDARD.encode(&public_key_bytes);
 
-        let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, &private_key_bytes);
+        // Bind the caller's EncryptionContext into the AAD, identical to the
+        // GenerateDataKeyPair (with-plaintext) sibling. Previously this used
+        // crate::blob::encode (AAD = key-id only), so the private key could
+        // never be decrypted with its EncryptionContext.
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let blob = crate::blob::encode_with_context(
+            &state.master_key_bytes,
+            &key.key_id,
+            &private_key_bytes,
+            &ec_aad,
+        );
         let private_ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(&blob);
 
         Ok(AwsResponse::json(

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -3161,3 +3161,110 @@ fn create_external_origin_key_is_pending_import_and_disabled() {
     assert_eq!(body["KeyMetadata"]["Enabled"], json!(true));
     assert_eq!(body["KeyMetadata"]["KeyState"], json!("Enabled"));
 }
+
+#[test]
+fn generate_data_key_without_plaintext_binds_encryption_context() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+
+    let gen = svc
+        .generate_data_key_without_plaintext(&make_request(
+            "GenerateDataKeyWithoutPlaintext",
+            json!({
+                "KeyId": key_id,
+                "KeySpec": "AES_256",
+                "EncryptionContext": {"app": "prod"}
+            }),
+        ))
+        .unwrap();
+    let gen_body: Value = serde_json::from_slice(gen.body.expect_bytes()).unwrap();
+    let ciphertext = gen_body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    // Matching context decrypts.
+    svc.decrypt(&make_request(
+        "Decrypt",
+        json!({
+            "CiphertextBlob": &ciphertext,
+            "EncryptionContext": {"app": "prod"}
+        }),
+    ))
+    .expect("matching EC must decrypt the WithoutPlaintext data key");
+
+    // Wrong context fails.
+    let err = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({
+                "CiphertextBlob": &ciphertext,
+                "EncryptionContext": {"app": "staging"}
+            }),
+        ))
+        .err()
+        .expect("wrong EC must error");
+    assert!(format!("{err:?}").contains("InvalidCiphertextException"));
+
+    // Absent context fails (context must provide real protection).
+    let err = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({"CiphertextBlob": &ciphertext}),
+        ))
+        .err()
+        .expect("missing EC must error");
+    assert!(format!("{err:?}").contains("InvalidCiphertextException"));
+}
+
+#[test]
+fn generate_data_key_pair_without_plaintext_binds_encryption_context() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+
+    let gen = svc
+        .generate_data_key_pair_without_plaintext(&make_request(
+            "GenerateDataKeyPairWithoutPlaintext",
+            json!({
+                "KeyId": key_id,
+                "KeyPairSpec": "RSA_2048",
+                "EncryptionContext": {"app": "prod"}
+            }),
+        ))
+        .unwrap();
+    let gen_body: Value = serde_json::from_slice(gen.body.expect_bytes()).unwrap();
+    let ciphertext = gen_body["PrivateKeyCiphertextBlob"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Matching context decrypts.
+    svc.decrypt(&make_request(
+        "Decrypt",
+        json!({
+            "CiphertextBlob": &ciphertext,
+            "EncryptionContext": {"app": "prod"}
+        }),
+    ))
+    .expect("matching EC must decrypt the WithoutPlaintext private key");
+
+    // Wrong context fails.
+    let err = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({
+                "CiphertextBlob": &ciphertext,
+                "EncryptionContext": {"app": "staging"}
+            }),
+        ))
+        .err()
+        .expect("wrong EC must error");
+    assert!(format!("{err:?}").contains("InvalidCiphertextException"));
+
+    // Absent context fails.
+    let err = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({"CiphertextBlob": &ciphertext}),
+        ))
+        .err()
+        .expect("missing EC must error");
+    assert!(format!("{err:?}").contains("InvalidCiphertextException"));
+}


### PR DESCRIPTION
Fixes two confirmed HIGH bugs.

## Bug 1 - KMS WithoutPlaintext variants drop EncryptionContext AAD binding

`GenerateDataKeyWithoutPlaintext` and `GenerateDataKeyPairWithoutPlaintext` wrapped the data key with `blob::encode` (AAD = key-id only), while the with-plaintext siblings correctly use `encode_with_context`. `Decrypt` builds AAD = key_id + canonical(EncryptionContext), so a data key generated WithoutPlaintext + EncryptionContext could NEVER be decrypted with the matching context (AEAD mismatch -> InvalidCiphertextException), and Decrypt with NO context wrongly succeeded (context gave zero protection).

Both `*WithoutPlaintext` paths now use `encode_with_context` with the request's EncryptionContext, identical to the with-plaintext siblings and the earlier `GenerateDataKey` fix.

## Bug 2 - Unsigned SNS ConfirmSubscription/Unsubscribe URLs 404

An HTTP/S (or email) subscriber confirms by issuing an UNSIGNED `GET /?Action=ConfirmSubscription&TopicArn=...&Token=...` (and `Unsubscribe` similarly) at the SubscribeURL/UnsubscribeUrl SNS hands out (default endpoint `http://localhost:4566`). With no auth header and a bare-localhost host, `infer_service_from_action` had no SNS entries, so `detect_service` returned None and the request fell to the apigateway catch-all -> 404 NotFoundException. The confirmation handshake was dead at the default endpoint and subscriptions stayed PendingConfirmation forever.

`ConfirmSubscription` and `Unsubscribe` (the only actions SNS emits in unsigned URLs) now map to `sns` in `infer_service_from_action`.

## Tests

- KMS unit: `generate_data_key_without_plaintext_binds_encryption_context` and `generate_data_key_pair_without_plaintext_binds_encryption_context` prove the returned ciphertext decrypts only with the matching EncryptionContext and fails with InvalidCiphertextException for wrong/absent context.
- Core unit: `detect_service_routes_unsigned_confirm_subscription_to_sns` and `infer_service_from_action_maps_sns_confirmation_flow` assert the unsigned GET routes to sns.
- E2E (`sns_http_confirm.rs`): `sns_unsigned_subscribe_and_unsubscribe_urls_route_to_sns` drives the real subscriber round-trip - confirm via the SubscribeURL then unsubscribe via the UnsubscribeUrl, both as plain unauthenticated GETs, asserting fan-out starts after confirm and stops after unsubscribe.

## Validation

- cargo build, fmt check, clippy (kms/core/sns, all-targets, -D warnings): clean
- cargo test kms/sns/core: 218+ pass, 4 new pass
- cargo test -p fakecloud-e2e --no-run: compiles
- sns_http_confirm e2e: 3/3 pass (run locally)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes KMS data key generation to bind the EncryptionContext in WithoutPlaintext flows, and routes unsigned SNS ConfirmSubscription/Unsubscribe URLs to SNS so confirmations work instead of 404.

- **Bug Fixes**
  - KMS: `GenerateDataKeyWithoutPlaintext` and `GenerateDataKeyPairWithoutPlaintext` now use `encode_with_context` with the request’s EncryptionContext. Decrypt requires the matching context and fails for wrong or missing context.
  - SNS: `ConfirmSubscription` and `Unsubscribe` are mapped in `infer_service_from_action` to `sns`, so unsigned SubscribeURL/UnsubscribeUrl GETs reach the SNS handler instead of falling through to a 404.

<sup>Written for commit a136c059684f15fffcc8584391083d3e37f548a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

