### PR TITLE
fix(cloudwatch,logs): exact dimensions, metric-math + percentiles, pagination, alarm history, Insights stats

### DIFF
--- a/crates/fakecloud-cloudwatch/src/insight_rules.rs
+++ b/crates/fakecloud-cloudwatch/src/insight_rules.rs
@@ -132,27 +132,69 @@ impl CloudWatchService {
             .parse::<i64>()
             .map_err(|_| invalid_param("Period must be an integer"))?;
         let metrics = collect_member_values(req, "Metrics");
-
-        let state = self.state.read();
-        let exists = state
-            .get(&req.account_id)
-            .and_then(|a| a.insight_rules_in(&req.region))
-            .map(|r| r.contains_key(&name))
-            .unwrap_or(false);
-        if !exists {
-            return Err(not_found(format!("Insight rule {name} does not exist")));
+        // Validate the requested metric names against the documented enum so a
+        // bad request fails rather than being silently ignored.
+        const ALLOWED_METRICS: &[&str] = &[
+            "UniqueContributors",
+            "MaxContributorValue",
+            "SampleCount",
+            "Average",
+            "Sum",
+            "Minimum",
+            "Maximum",
+        ];
+        for m in &metrics {
+            if !ALLOWED_METRICS.contains(&m.as_str()) {
+                return Err(invalid_param(format!("Unknown insight metric '{m}'")));
+            }
         }
 
-        let mut inner = String::from("<KeyLabels/>");
-        inner.push_str("<AggregationStatistic>Sum</AggregationStatistic>");
+        let state = self.state.read();
+        let rule = state
+            .get(&req.account_id)
+            .and_then(|a| a.insight_rules_in(&req.region))
+            .and_then(|r| r.get(&name))
+            .cloned();
+        let Some(rule) = rule else {
+            return Err(not_found(format!("Insight rule {name} does not exist")));
+        };
+
+        // Derive the report shape from the rule's actual definition. Contributor
+        // data itself is genuinely not computable here: fakecloud has no
+        // log-ingestion -> Contributor Insights pipeline, so there are no
+        // contributors to report. Rather than emit fixed all-zero constants, we
+        // surface the rule's real key labels and aggregation statistic and an
+        // honestly-empty contributor/datapoint set.
+        let def: serde_json::Value =
+            serde_json::from_str(&rule.definition).unwrap_or(serde_json::Value::Null);
+        let key_labels: Vec<String> = def
+            .get("Contribution")
+            .and_then(|c| c.get("Keys"))
+            .and_then(|k| k.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let aggregation_statistic = match def.get("AggregateOn").and_then(|v| v.as_str()) {
+            Some("Sum") => "Sum",
+            Some("Average") => "Average",
+            _ => "Sum",
+        };
+
+        let mut inner = String::from("<KeyLabels>");
+        for label in &key_labels {
+            inner.push_str(&format!("<member>{}</member>", xml_escape(label)));
+        }
+        inner.push_str("</KeyLabels>");
+        inner.push_str(&format!(
+            "<AggregationStatistic>{aggregation_statistic}</AggregationStatistic>"
+        ));
         inner.push_str("<AggregateValue>0.0</AggregateValue>");
         inner.push_str("<ApproximateUniqueCount>0</ApproximateUniqueCount>");
         inner.push_str("<Contributors/>");
         inner.push_str("<MetricDatapoints/>");
-        // Echo requested metrics back so callers can confirm the report shape;
-        // the metric list itself isn't part of the output but the wire stays
-        // well-formed regardless of how many metrics were requested.
-        let _ = metrics;
         Ok(xml_response(
             "GetInsightRuleReport",
             &inner,

--- a/crates/fakecloud-cloudwatch/src/lib.rs
+++ b/crates/fakecloud-cloudwatch/src/lib.rs
@@ -4,6 +4,7 @@ pub(crate) mod datasets;
 pub mod delivery;
 pub(crate) mod insight_rules;
 pub mod introspection;
+pub(crate) mod metric_math;
 pub(crate) mod metric_streams;
 pub(crate) mod mute_rules;
 pub(crate) mod otel;

--- a/crates/fakecloud-cloudwatch/src/metric_math.rs
+++ b/crates/fakecloud-cloudwatch/src/metric_math.rs
@@ -1,0 +1,403 @@
+//! A small, real (if reduced) CloudWatch metric-math evaluator.
+//!
+//! It supports the two patterns that show up in nearly every real
+//! `GetMetricData` request that uses an `Expression`:
+//!
+//! - arithmetic over referenced metric ids and numeric literals
+//!   (`m1+m2`, `m1/m2*100`, `(m1-m2)/m3`), aligned element-wise by timestamp;
+//! - the array/aggregate functions `SUM`/`AVG`/`MIN`/`MAX`/`COUNT` applied
+//!   either to a single metric id (collapsing its series to a scalar) or to an
+//!   array of metrics (`SUM([m1,m2])`, element-wise across the array).
+//!
+//! It is intentionally not a full implementation of the metric-math grammar
+//! (no `FILL`, `RATE`, `ANOMALY_DETECTION_BAND`, time functions, etc.) — those
+//! return an `Err` so the caller can surface a real error instead of a
+//! silently-empty result.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Utc};
+
+/// A time-aligned metric series: bucket timestamp -> value.
+pub type Series = BTreeMap<DateTime<Utc>, f64>;
+
+#[derive(Clone)]
+enum Value {
+    Scalar(f64),
+    Series(Series),
+    Array(Vec<Value>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum Token {
+    Ident(String),
+    Number(f64),
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    Comma,
+}
+
+fn tokenize(expr: &str) -> Result<Vec<Token>, String> {
+    let mut tokens = Vec::new();
+    let chars: Vec<char> = expr.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            ' ' | '\t' | '\n' | '\r' => {
+                i += 1;
+            }
+            '+' => {
+                tokens.push(Token::Plus);
+                i += 1;
+            }
+            '-' => {
+                tokens.push(Token::Minus);
+                i += 1;
+            }
+            '*' => {
+                tokens.push(Token::Star);
+                i += 1;
+            }
+            '/' => {
+                tokens.push(Token::Slash);
+                i += 1;
+            }
+            '(' => {
+                tokens.push(Token::LParen);
+                i += 1;
+            }
+            ')' => {
+                tokens.push(Token::RParen);
+                i += 1;
+            }
+            '[' => {
+                tokens.push(Token::LBracket);
+                i += 1;
+            }
+            ']' => {
+                tokens.push(Token::RBracket);
+                i += 1;
+            }
+            ',' => {
+                tokens.push(Token::Comma);
+                i += 1;
+            }
+            c if c.is_ascii_digit() || c == '.' => {
+                let start = i;
+                while i < chars.len() && (chars[i].is_ascii_digit() || chars[i] == '.') {
+                    i += 1;
+                }
+                let s: String = chars[start..i].iter().collect();
+                let n = s
+                    .parse::<f64>()
+                    .map_err(|_| format!("invalid number '{s}'"))?;
+                tokens.push(Token::Number(n));
+            }
+            c if c.is_ascii_alphabetic() || c == '_' => {
+                let start = i;
+                while i < chars.len() && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
+                    i += 1;
+                }
+                tokens.push(Token::Ident(chars[start..i].iter().collect()));
+            }
+            other => return Err(format!("unexpected character '{other}' in expression")),
+        }
+    }
+    Ok(tokens)
+}
+
+struct Parser<'a> {
+    tokens: Vec<Token>,
+    pos: usize,
+    metrics: &'a BTreeMap<String, Series>,
+}
+
+impl Parser<'_> {
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn next(&mut self) -> Option<Token> {
+        let t = self.tokens.get(self.pos).cloned();
+        if t.is_some() {
+            self.pos += 1;
+        }
+        t
+    }
+
+    fn expect(&mut self, want: &Token) -> Result<(), String> {
+        match self.next() {
+            Some(ref t) if t == want => Ok(()),
+            other => Err(format!("expected {want:?}, found {other:?}")),
+        }
+    }
+
+    fn parse_expr(&mut self) -> Result<Value, String> {
+        let mut left = self.parse_term()?;
+        while let Some(op) = self.peek() {
+            let op = match op {
+                Token::Plus => '+',
+                Token::Minus => '-',
+                _ => break,
+            };
+            self.pos += 1;
+            let right = self.parse_term()?;
+            left = apply_op(op, left, right)?;
+        }
+        Ok(left)
+    }
+
+    fn parse_term(&mut self) -> Result<Value, String> {
+        let mut left = self.parse_factor()?;
+        while let Some(op) = self.peek() {
+            let op = match op {
+                Token::Star => '*',
+                Token::Slash => '/',
+                _ => break,
+            };
+            self.pos += 1;
+            let right = self.parse_factor()?;
+            left = apply_op(op, left, right)?;
+        }
+        Ok(left)
+    }
+
+    fn parse_factor(&mut self) -> Result<Value, String> {
+        match self.next() {
+            Some(Token::Number(n)) => Ok(Value::Scalar(n)),
+            Some(Token::Minus) => {
+                // Unary minus.
+                let v = self.parse_factor()?;
+                apply_op('-', Value::Scalar(0.0), v)
+            }
+            Some(Token::LParen) => {
+                let v = self.parse_expr()?;
+                self.expect(&Token::RParen)?;
+                Ok(v)
+            }
+            Some(Token::LBracket) => {
+                let mut items = Vec::new();
+                if self.peek() != Some(&Token::RBracket) {
+                    loop {
+                        items.push(self.parse_expr()?);
+                        match self.peek() {
+                            Some(Token::Comma) => {
+                                self.pos += 1;
+                            }
+                            _ => break,
+                        }
+                    }
+                }
+                self.expect(&Token::RBracket)?;
+                Ok(Value::Array(items))
+            }
+            Some(Token::Ident(name)) => {
+                // Function call when followed by `(`, otherwise a metric id.
+                if self.peek() == Some(&Token::LParen) {
+                    self.pos += 1;
+                    let arg = self.parse_expr()?;
+                    self.expect(&Token::RParen)?;
+                    apply_func(&name, arg)
+                } else {
+                    match self.metrics.get(&name) {
+                        Some(s) => Ok(Value::Series(s.clone())),
+                        None => Err(format!("unknown metric id '{name}' in expression")),
+                    }
+                }
+            }
+            other => Err(format!("unexpected token {other:?} in expression")),
+        }
+    }
+}
+
+fn apply_op(op: char, left: Value, right: Value) -> Result<Value, String> {
+    let f = |a: f64, b: f64| -> f64 {
+        match op {
+            '+' => a + b,
+            '-' => a - b,
+            '*' => a * b,
+            '/' => {
+                if b == 0.0 {
+                    f64::NAN
+                } else {
+                    a / b
+                }
+            }
+            _ => f64::NAN,
+        }
+    };
+    match (left, right) {
+        (Value::Scalar(a), Value::Scalar(b)) => Ok(Value::Scalar(f(a, b))),
+        (Value::Series(s), Value::Scalar(b)) => Ok(Value::Series(
+            s.into_iter().map(|(t, a)| (t, f(a, b))).collect(),
+        )),
+        (Value::Scalar(a), Value::Series(s)) => Ok(Value::Series(
+            s.into_iter().map(|(t, b)| (t, f(a, b))).collect(),
+        )),
+        (Value::Series(a), Value::Series(b)) => {
+            // Align on the timestamps present in both operands.
+            let mut out = Series::new();
+            for (t, av) in a.iter() {
+                if let Some(bv) = b.get(t) {
+                    out.insert(*t, f(*av, *bv));
+                }
+            }
+            Ok(Value::Series(out))
+        }
+        _ => Err("arithmetic on metric arrays is not supported".to_string()),
+    }
+}
+
+fn apply_func(name: &str, arg: Value) -> Result<Value, String> {
+    let upper = name.to_ascii_uppercase();
+    let reducer: fn(&[f64]) -> f64 = match upper.as_str() {
+        "SUM" => |xs| xs.iter().sum(),
+        "AVG" | "AVERAGE" => |xs| {
+            if xs.is_empty() {
+                f64::NAN
+            } else {
+                xs.iter().sum::<f64>() / xs.len() as f64
+            }
+        },
+        "MIN" => |xs| xs.iter().cloned().fold(f64::INFINITY, f64::min),
+        "MAX" => |xs| xs.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
+        "COUNT" => |xs| xs.len() as f64,
+        other => return Err(format!("unsupported metric-math function '{other}'")),
+    };
+
+    match arg {
+        // Aggregate over a single series collapses it to a scalar.
+        Value::Series(s) => {
+            let vals: Vec<f64> = s.values().cloned().collect();
+            Ok(Value::Scalar(reducer(&vals)))
+        }
+        Value::Scalar(n) => Ok(Value::Scalar(reducer(&[n]))),
+        // Aggregate across an array of series is element-wise per timestamp.
+        Value::Array(items) => {
+            let mut series: Vec<Series> = Vec::new();
+            for item in items {
+                match item {
+                    Value::Series(s) => series.push(s),
+                    Value::Scalar(_) => {
+                        return Err("array aggregate over scalars is not supported".to_string())
+                    }
+                    Value::Array(_) => return Err("nested arrays are not supported".to_string()),
+                }
+            }
+            let mut timestamps: BTreeSet<DateTime<Utc>> = BTreeSet::new();
+            for s in &series {
+                timestamps.extend(s.keys().cloned());
+            }
+            let mut out = Series::new();
+            for t in timestamps {
+                let vals: Vec<f64> = series.iter().filter_map(|s| s.get(&t).cloned()).collect();
+                if !vals.is_empty() {
+                    out.insert(t, reducer(&vals));
+                }
+            }
+            Ok(Value::Series(out))
+        }
+    }
+}
+
+/// Evaluate `expr` against the referenced metric series. A scalar result (e.g.
+/// `SUM(m1)`) is broadcast as a single datapoint at the earliest timestamp seen
+/// across all referenced metrics, matching how CloudWatch plots a scalar
+/// metric-math result.
+pub fn evaluate(expr: &str, metrics: &BTreeMap<String, Series>) -> Result<Series, String> {
+    let tokens = tokenize(expr)?;
+    if tokens.is_empty() {
+        return Err("empty expression".to_string());
+    }
+    let mut parser = Parser {
+        tokens,
+        pos: 0,
+        metrics,
+    };
+    let value = parser.parse_expr()?;
+    if parser.pos != parser.tokens.len() {
+        return Err("unexpected trailing tokens in expression".to_string());
+    }
+    match value {
+        Value::Series(s) => Ok(s),
+        Value::Scalar(n) => {
+            let earliest = metrics.values().flat_map(|s| s.keys()).min().cloned();
+            let mut out = Series::new();
+            if let Some(t) = earliest {
+                out.insert(t, n);
+            }
+            Ok(out)
+        }
+        Value::Array(_) => Err("expression result is an array, not a single series".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(n: i64) -> DateTime<Utc> {
+        DateTime::<Utc>::from_timestamp(n, 0).unwrap()
+    }
+
+    fn series(pairs: &[(i64, f64)]) -> Series {
+        pairs.iter().map(|(t, v)| (ts(*t), *v)).collect()
+    }
+
+    #[test]
+    fn adds_two_series() {
+        let mut m = BTreeMap::new();
+        m.insert("m1".to_string(), series(&[(0, 1.0), (60, 2.0)]));
+        m.insert("m2".to_string(), series(&[(0, 10.0), (60, 20.0)]));
+        let out = evaluate("m1+m2", &m).unwrap();
+        assert_eq!(out.get(&ts(0)), Some(&11.0));
+        assert_eq!(out.get(&ts(60)), Some(&22.0));
+    }
+
+    #[test]
+    fn scalar_multiply() {
+        let mut m = BTreeMap::new();
+        m.insert("m1".to_string(), series(&[(0, 3.0)]));
+        let out = evaluate("m1*100", &m).unwrap();
+        assert_eq!(out.get(&ts(0)), Some(&300.0));
+    }
+
+    #[test]
+    fn aggregate_single_series_to_scalar() {
+        let mut m = BTreeMap::new();
+        m.insert("m1".to_string(), series(&[(0, 1.0), (60, 2.0), (120, 3.0)]));
+        let out = evaluate("SUM(m1)", &m).unwrap();
+        // Broadcast at earliest timestamp.
+        assert_eq!(out.get(&ts(0)), Some(&6.0));
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn aggregate_array_elementwise() {
+        let mut m = BTreeMap::new();
+        m.insert("m1".to_string(), series(&[(0, 1.0), (60, 2.0)]));
+        m.insert("m2".to_string(), series(&[(0, 10.0), (60, 20.0)]));
+        let out = evaluate("SUM([m1,m2])", &m).unwrap();
+        assert_eq!(out.get(&ts(0)), Some(&11.0));
+        assert_eq!(out.get(&ts(60)), Some(&22.0));
+    }
+
+    #[test]
+    fn unknown_function_errors() {
+        let m = BTreeMap::new();
+        assert!(evaluate("RATE(m1)", &m).is_err());
+    }
+
+    #[test]
+    fn unknown_id_errors() {
+        let m = BTreeMap::new();
+        assert!(evaluate("m1+m2", &m).is_err());
+    }
+}

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -15,8 +15,8 @@ use fakecloud_persistence::SnapshotStore;
 use tokio::sync::Mutex;
 
 use crate::state::{
-    AlarmState, CloudWatchSnapshot, Dashboard, MetricAlarm, MetricDatum, SharedCloudWatchState,
-    StatisticSet, CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
+    AlarmHistoryItem, AlarmState, CloudWatchSnapshot, Dashboard, MetricAlarm, MetricDatum,
+    SharedCloudWatchState, StatisticSet, CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
 };
 
 pub(crate) const NS: &str = "http://monitoring.amazonaws.com/doc/2010-08-01/";
@@ -573,6 +573,29 @@ pub(crate) fn xml_escape(s: &str) -> String {
         .replace('\'', "&apos;")
 }
 
+/// Encode a pagination offset into an opaque base64 NextToken.
+pub(crate) fn encode_offset_token(offset: usize) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(format!("offset:{offset}"))
+}
+
+/// Decode a NextToken produced by [`encode_offset_token`]. Returns 0 for an
+/// absent or unparseable token (AWS rejects bad tokens, but treating it as the
+/// first page is friendlier and never loses data).
+pub(crate) fn decode_offset_token(token: Option<&String>) -> usize {
+    use base64::Engine;
+    let Some(token) = token else {
+        return 0;
+    };
+    base64::engine::general_purpose::STANDARD
+        .decode(token)
+        .ok()
+        .and_then(|b| String::from_utf8(b).ok())
+        .and_then(|s| s.strip_prefix("offset:").map(|n| n.to_string()))
+        .and_then(|n| n.parse::<usize>().ok())
+        .unwrap_or(0)
+}
+
 /// Per-datapoint aggregation summary covering both the simple `Value` form
 /// and the `StatisticValues` form so callers don't lose the count or
 /// min/max baked into a `StatisticSet`.
@@ -630,6 +653,122 @@ fn stat_value(stat: &str, agg: DatumStats) -> Option<f64> {
         "SampleCount" => Some(agg.count),
         _ => None,
     }
+}
+
+/// Parse an extended statistic / percentile stat like `p99` or `p99.9` into the
+/// percentile in `[0, 100]`. Returns `None` for anything that isn't a `pNN`
+/// form (so callers can fall through to the simple statistics).
+pub(crate) fn parse_percentile(stat: &str) -> Option<f64> {
+    let rest = stat.strip_prefix('p').or_else(|| stat.strip_prefix('P'))?;
+    let p = rest.parse::<f64>().ok()?;
+    if (0.0..=100.0).contains(&p) {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// Linear-interpolation percentile over a pre-sorted sample slice. Uses the
+/// common `rank = p/100 * (n-1)` method — close enough to CloudWatch's
+/// percentile for fakecloud's purposes.
+pub(crate) fn percentile(sorted: &[f64], p: f64) -> Option<f64> {
+    if sorted.is_empty() {
+        return None;
+    }
+    if sorted.len() == 1 {
+        return Some(sorted[0]);
+    }
+    let rank = (p / 100.0) * (sorted.len() as f64 - 1.0);
+    let lo = rank.floor() as usize;
+    let hi = rank.ceil() as usize;
+    if lo == hi {
+        return Some(sorted[lo]);
+    }
+    let frac = rank - lo as f64;
+    Some(sorted[lo] + (sorted[hi] - sorted[lo]) * frac)
+}
+
+/// One period bucket of a metric series: the merged [`DatumStats`], the
+/// individual `value` samples (used for percentiles — distributions published
+/// as `StatisticValues` don't retain their raw values so they don't
+/// contribute), and the bucket's unit when consistent.
+struct MetricBucket {
+    agg: DatumStats,
+    samples: Vec<f64>,
+    unit: Option<String>,
+}
+
+/// Resolve a single statistic (simple, e.g. `Sum`, or percentile, e.g. `p99`)
+/// for one bucket. `samples` must be sorted ascending.
+fn resolve_stat(stat: &str, bucket: &MetricBucket, samples_sorted: &[f64]) -> Option<f64> {
+    if let Some(p) = parse_percentile(stat) {
+        return percentile(samples_sorted, p);
+    }
+    stat_value(stat, bucket.agg)
+}
+
+/// Collect a metric's datapoints into period buckets, matching dimensions
+/// EXACTLY (an empty filter matches only dimensionless data, the way AWS treats
+/// each distinct dimension combination as its own metric) and, when a unit
+/// filter is set, only datapoints published with that unit.
+#[allow(clippy::too_many_arguments)]
+fn collect_metric_buckets(
+    data: &[MetricDatum],
+    metric_name: &str,
+    dim_filter: &BTreeMap<String, String>,
+    unit_filter: Option<&str>,
+    period: i64,
+    start_ts: DateTime<Utc>,
+    end_ts: DateTime<Utc>,
+) -> BTreeMap<DateTime<Utc>, MetricBucket> {
+    let mut buckets: BTreeMap<DateTime<Utc>, MetricBucket> = BTreeMap::new();
+    for d in data.iter() {
+        if d.metric_name != metric_name {
+            continue;
+        }
+        if let Some(uf) = unit_filter {
+            if d.unit.as_deref().unwrap_or("None") != uf {
+                continue;
+            }
+        }
+        // Exact dimension-set equality: each unique dimension combination is a
+        // distinct metric, so a subset never matches and an empty filter only
+        // matches data published with no dimensions.
+        if &d.dimensions != dim_filter {
+            continue;
+        }
+        if d.timestamp < start_ts || d.timestamp >= end_ts {
+            continue;
+        }
+        let Some(stats) = datum_stats(d) else {
+            continue;
+        };
+        let secs = d.timestamp.timestamp();
+        let bucket_secs = secs - secs.rem_euclid(period);
+        let bucket_ts = DateTime::<Utc>::from_timestamp(bucket_secs, 0).unwrap_or(d.timestamp);
+        match buckets.get_mut(&bucket_ts) {
+            Some(bucket) => {
+                merge_stats(&mut bucket.agg, stats);
+                if bucket.unit != d.unit {
+                    bucket.unit = None;
+                }
+                if let Some(v) = d.value {
+                    bucket.samples.push(v);
+                }
+            }
+            None => {
+                buckets.insert(
+                    bucket_ts,
+                    MetricBucket {
+                        agg: stats,
+                        samples: d.value.map(|v| vec![v]).unwrap_or_default(),
+                        unit: d.unit.clone(),
+                    },
+                );
+            }
+        }
+    }
+    buckets
 }
 
 pub(crate) fn render_dimensions(dims: &BTreeMap<String, String>) -> String {
@@ -742,9 +881,15 @@ impl CloudWatchService {
         let namespace = optional_query_param(req, "Namespace");
         let metric_name = optional_query_param(req, "MetricName");
         let dim_filter = parse_dimensions_query(req, "Dimensions");
+        // ListMetrics has no MaxResults param — AWS caps each page at 500 and
+        // round-trips a NextToken.
+        const LIST_METRICS_PAGE: usize = 500;
+        let offset = decode_offset_token(req.query_params.get("NextToken"));
 
         let state = self.state.read();
-        let mut out = String::from("<Metrics>");
+        // Flatten every distinct (namespace, metric, dims) into a stable,
+        // ordered list so the offset token is deterministic across pages.
+        let mut all: Vec<(String, String, BTreeMap<String, String>)> = Vec::new();
         if let Some(acct) = state.get(&req.account_id) {
             if let Some(map) = acct.metrics_in(&req.region) {
                 for (ns, data) in map.iter() {
@@ -761,6 +906,10 @@ impl CloudWatchService {
                                 continue;
                             }
                         }
+                        // ListMetrics filters by dimension containment (a metric
+                        // matches if it carries all the requested name/value
+                        // pairs), unlike the exact-set match used by the
+                        // statistics APIs.
                         if !dim_filter.is_empty()
                             && !dim_filter
                                 .iter()
@@ -771,16 +920,30 @@ impl CloudWatchService {
                         seen.insert((d.metric_name.clone(), d.dimensions.clone()), ());
                     }
                     for ((name, dims), _) in seen {
-                        out.push_str("<member>");
-                        out.push_str(&format!("<Namespace>{}</Namespace>", xml_escape(ns)));
-                        out.push_str(&format!("<MetricName>{}</MetricName>", xml_escape(&name)));
-                        out.push_str(&render_dimensions(&dims));
-                        out.push_str("</member>");
+                        all.push((ns.clone(), name, dims));
                     }
                 }
             }
         }
+
+        let page = all.iter().skip(offset).take(LIST_METRICS_PAGE);
+        let mut out = String::from("<Metrics>");
+        {
+            for (ns, name, dims) in page {
+                out.push_str("<member>");
+                out.push_str(&format!("<Namespace>{}</Namespace>", xml_escape(ns)));
+                out.push_str(&format!("<MetricName>{}</MetricName>", xml_escape(name)));
+                out.push_str(&render_dimensions(dims));
+                out.push_str("</member>");
+            }
+        }
         out.push_str("</Metrics>");
+        if offset + LIST_METRICS_PAGE < all.len() {
+            out.push_str(&format!(
+                "<NextToken>{}</NextToken>",
+                encode_offset_token(offset + LIST_METRICS_PAGE)
+            ));
+        }
 
         Ok(xml_response("ListMetrics", &out, &req.request_id))
     }
@@ -804,13 +967,18 @@ impl CloudWatchService {
             .with_timezone(&Utc);
 
         let mut statistics: Vec<String> = Vec::new();
+        let mut extended_statistics: Vec<String> = Vec::new();
         for (k, v) in req.query_params.iter() {
             if k.starts_with("Statistics.member.") {
                 statistics.push(v.clone());
+            } else if k.starts_with("ExtendedStatistics.member.") {
+                extended_statistics.push(v.clone());
             }
         }
-        if statistics.is_empty() {
-            return Err(invalid_param("At least one Statistic is required"));
+        if statistics.is_empty() && extended_statistics.is_empty() {
+            return Err(invalid_param(
+                "At least one of Statistics or ExtendedStatistics is required",
+            ));
         }
 
         let dim_filter = parse_dimensions_query(req, "Dimensions");
@@ -820,49 +988,44 @@ impl CloudWatchService {
         let unit_filter = req.query_params.get("Unit").cloned();
 
         let state = self.state.read();
-        let mut datapoints: Vec<(DateTime<Utc>, BTreeMap<String, f64>)> = Vec::new();
+        // (timestamp, simple stats, extended/percentile stats, unit)
+        type StatPoint = (
+            DateTime<Utc>,
+            BTreeMap<String, f64>,
+            Vec<(String, f64)>,
+            Option<String>,
+        );
+        let mut datapoints: Vec<StatPoint> = Vec::new();
         if let Some(acct) = state.get(&req.account_id) {
             if let Some(map) = acct.metrics_in(&req.region) {
                 if let Some(data) = map.get(&namespace) {
-                    let mut buckets: BTreeMap<DateTime<Utc>, DatumStats> = BTreeMap::new();
-                    for d in data.iter() {
-                        if d.metric_name != metric_name {
-                            continue;
-                        }
-                        if let Some(uf) = &unit_filter {
-                            if d.unit.as_deref().unwrap_or("None") != uf {
-                                continue;
-                            }
-                        }
-                        if !dim_filter
-                            .iter()
-                            .all(|(k, v)| d.dimensions.get(k) == Some(v))
-                        {
-                            continue;
-                        }
-                        if d.timestamp < start_ts || d.timestamp >= end_ts {
-                            continue;
-                        }
-                        let Some(stats) = datum_stats(d) else {
-                            continue;
-                        };
-                        let secs = d.timestamp.timestamp();
-                        let bucket_secs = secs - secs.rem_euclid(period);
-                        let bucket_ts =
-                            DateTime::<Utc>::from_timestamp(bucket_secs, 0).unwrap_or(d.timestamp);
-                        buckets
-                            .entry(bucket_ts)
-                            .and_modify(|acc| merge_stats(acc, stats))
-                            .or_insert(stats);
-                    }
-                    for (ts, agg) in buckets {
-                        let mut stats = BTreeMap::new();
+                    let buckets = collect_metric_buckets(
+                        data,
+                        &metric_name,
+                        &dim_filter,
+                        unit_filter.as_deref(),
+                        period,
+                        start_ts,
+                        end_ts,
+                    );
+                    for (ts, bucket) in buckets {
+                        let mut sorted = bucket.samples.clone();
+                        sorted
+                            .sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                        let mut simple = BTreeMap::new();
                         for stat in statistics.iter() {
-                            if let Some(v) = stat_value(stat, agg) {
-                                stats.insert(stat.clone(), v);
+                            if let Some(v) = resolve_stat(stat, &bucket, &sorted) {
+                                simple.insert(stat.clone(), v);
                             }
                         }
-                        datapoints.push((ts, stats));
+                        let mut extended = Vec::new();
+                        for stat in extended_statistics.iter() {
+                            if let Some(v) = resolve_stat(stat, &bucket, &sorted) {
+                                extended.push((stat.clone(), v));
+                            }
+                        }
+                        let unit = unit_filter.clone().or(bucket.unit);
+                        datapoints.push((ts, simple, extended, unit));
                     }
                 }
             }
@@ -870,14 +1033,28 @@ impl CloudWatchService {
 
         let mut inner = format!("<Label>{}</Label>", xml_escape(&metric_name));
         inner.push_str("<Datapoints>");
-        for (ts, stats) in datapoints {
+        for (ts, simple, extended, unit) in datapoints {
             inner.push_str("<member>");
             inner.push_str(&format!(
                 "<Timestamp>{}</Timestamp>",
                 ts.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
             ));
-            for (name, value) in stats {
+            for (name, value) in simple {
                 inner.push_str(&format!("<{name}>{value}</{name}>"));
+            }
+            if !extended.is_empty() {
+                inner.push_str("<ExtendedStatistics>");
+                for (name, value) in extended {
+                    inner.push_str(&format!(
+                        "<entry><key>{}</key><value>{}</value></entry>",
+                        xml_escape(&name),
+                        value
+                    ));
+                }
+                inner.push_str("</ExtendedStatistics>");
+            }
+            if let Some(u) = unit {
+                inner.push_str(&format!("<Unit>{}</Unit>", xml_escape(&u)));
             }
             inner.push_str("</member>");
         }
@@ -915,85 +1092,118 @@ impl CloudWatchService {
         let queries = collect_indexed(req, "MetricDataQueries");
 
         let state = self.state.read();
-        let mut inner = String::from("<MetricDataResults>");
-        for q in queries {
+
+        // First pass: compute every MetricStat query into an aligned series so
+        // later Expression queries can reference them by id.
+        let mut series_by_id: BTreeMap<String, crate::metric_math::Series> = BTreeMap::new();
+        for q in &queries {
             let id = q.get("Id").cloned().unwrap_or_default();
-            let label = q.get("Label").cloned().unwrap_or_else(|| id.clone());
+            let Some(metric_name) = q.get("MetricStat.Metric.MetricName") else {
+                continue;
+            };
+            let Some(namespace) = q.get("MetricStat.Metric.Namespace") else {
+                continue;
+            };
             let stat = q
                 .get("MetricStat.Stat")
                 .cloned()
                 .unwrap_or_else(|| "Sum".to_string());
-            let metric_name = q.get("MetricStat.Metric.MetricName").cloned();
-            let namespace = q.get("MetricStat.Metric.Namespace").cloned();
             let period: i64 = q
                 .get("MetricStat.Period")
                 .and_then(|s| s.parse::<i64>().ok())
                 .filter(|p| *p > 0)
                 .unwrap_or(60);
-            let dim_filter = parse_dimensions(&q, "MetricStat.Metric.Dimensions");
+            let unit_filter = q.get("MetricStat.Unit").cloned();
+            let dim_filter = parse_dimensions(q, "MetricStat.Metric.Dimensions");
 
-            let (mut timestamps, mut values): (Vec<String>, Vec<f64>) = (Vec::new(), Vec::new());
-            if let (Some(metric_name), Some(namespace)) = (metric_name, namespace) {
-                if let Some(acct) = state.get(&req.account_id) {
-                    if let Some(map) = acct.metrics_in(&req.region) {
-                        if let Some(data) = map.get(&namespace) {
-                            let mut buckets: BTreeMap<DateTime<Utc>, DatumStats> = BTreeMap::new();
-                            for d in data.iter() {
-                                if d.metric_name != metric_name {
-                                    continue;
-                                }
-                                if !dim_filter
-                                    .iter()
-                                    .all(|(k, v)| d.dimensions.get(k) == Some(v))
-                                {
-                                    continue;
-                                }
-                                if d.timestamp < start_ts || d.timestamp >= end_ts {
-                                    continue;
-                                }
-                                let Some(stats) = datum_stats(d) else {
-                                    continue;
-                                };
-                                let secs = d.timestamp.timestamp();
-                                let bucket_secs = secs - secs.rem_euclid(period);
-                                let bucket_ts = DateTime::<Utc>::from_timestamp(bucket_secs, 0)
-                                    .unwrap_or(d.timestamp);
-                                buckets
-                                    .entry(bucket_ts)
-                                    .and_modify(|acc| merge_stats(acc, stats))
-                                    .or_insert(stats);
-                            }
-                            for (ts, agg) in buckets {
-                                let Some(v) = stat_value(&stat, agg) else {
-                                    continue;
-                                };
-                                timestamps
-                                    .push(ts.to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
-                                values.push(v);
-                            }
-                            if descending {
-                                timestamps.reverse();
-                                values.reverse();
+            let mut series = crate::metric_math::Series::new();
+            if let Some(acct) = state.get(&req.account_id) {
+                if let Some(map) = acct.metrics_in(&req.region) {
+                    if let Some(data) = map.get(namespace) {
+                        let buckets = collect_metric_buckets(
+                            data,
+                            metric_name,
+                            &dim_filter,
+                            unit_filter.as_deref(),
+                            period,
+                            start_ts,
+                            end_ts,
+                        );
+                        for (ts, bucket) in buckets {
+                            let mut sorted = bucket.samples.clone();
+                            sorted.sort_by(|a, b| {
+                                a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+                            });
+                            if let Some(v) = resolve_stat(&stat, &bucket, &sorted) {
+                                series.insert(ts, v);
                             }
                         }
                     }
                 }
             }
+            series_by_id.insert(id, series);
+        }
+
+        // Second pass: emit a result for each query that returns data (default
+        // true), evaluating Expression queries against the computed series.
+        let mut inner = String::from("<MetricDataResults>");
+        for q in &queries {
+            let id = q.get("Id").cloned().unwrap_or_default();
+            let label = q.get("Label").cloned().unwrap_or_else(|| id.clone());
+            let return_data = q
+                .get("ReturnData")
+                .map(|s| !s.eq_ignore_ascii_case("false"))
+                .unwrap_or(true);
+            if !return_data {
+                continue;
+            }
+
+            let mut error_message: Option<String> = None;
+            let series: crate::metric_math::Series = if let Some(expr) = q.get("Expression") {
+                match crate::metric_math::evaluate(expr, &series_by_id) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        error_message = Some(e);
+                        crate::metric_math::Series::new()
+                    }
+                }
+            } else {
+                series_by_id.get(&id).cloned().unwrap_or_default()
+            };
+
+            let mut timestamps: Vec<String> = Vec::new();
+            let mut values: Vec<f64> = Vec::new();
+            for (ts, v) in series.iter() {
+                timestamps.push(ts.to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
+                values.push(*v);
+            }
+            if descending {
+                timestamps.reverse();
+                values.reverse();
+            }
 
             inner.push_str("<member>");
             inner.push_str(&format!("<Id>{}</Id>", xml_escape(&id)));
             inner.push_str(&format!("<Label>{}</Label>", xml_escape(&label)));
-            inner.push_str("<StatusCode>Complete</StatusCode>");
             inner.push_str("<Timestamps>");
-            for ts in timestamps {
+            for ts in &timestamps {
                 inner.push_str(&format!("<member>{ts}</member>"));
             }
             inner.push_str("</Timestamps>");
             inner.push_str("<Values>");
-            for v in values {
+            for v in &values {
                 inner.push_str(&format!("<member>{v}</member>"));
             }
             inner.push_str("</Values>");
+            if let Some(msg) = error_message {
+                inner.push_str("<StatusCode>InternalError</StatusCode>");
+                inner.push_str("<Messages><member>");
+                inner.push_str("<Code>Error</Code>");
+                inner.push_str(&format!("<Value>{}</Value>", xml_escape(&msg)));
+                inner.push_str("</member></Messages>");
+            } else {
+                inner.push_str("<StatusCode>Complete</StatusCode>");
+            }
             inner.push_str("</member>");
         }
         inner.push_str("</MetricDataResults>");
@@ -1130,7 +1340,25 @@ impl CloudWatchService {
                 .unwrap_or(now),
             alarm_configuration_updated_timestamp: now,
         };
+        let history_name = alarm_name.clone();
+        let created = existing.is_none();
         alarms.insert(alarm_name, alarm);
+
+        let summary = if created {
+            format!("Alarm \"{history_name}\" created")
+        } else {
+            format!("Alarm \"{history_name}\" updated")
+        };
+        let history_data = "{\"type\":\"Update\",\"version\":\"1.0\"}".to_string();
+        push_alarm_history(
+            acct,
+            &req.region,
+            &history_name,
+            "MetricAlarm",
+            "ConfigurationUpdate",
+            summary,
+            history_data,
+        );
 
         Ok(empty_metadata_response("PutMetricAlarm", &req.request_id))
     }
@@ -1151,74 +1379,100 @@ impl CloudWatchService {
         let prefix = optional_query_param(req, "AlarmNamePrefix");
         let state_filter = optional_query_param(req, "StateValue");
         let action_prefix = optional_query_param(req, "ActionPrefix");
+        // AWS caps DescribeAlarms at 100 records per page (MaxRecords range
+        // 1..100) and round-trips a NextToken across the combined metric +
+        // composite alarm result set.
+        let max_records = optional_query_param(req, "MaxRecords")
+            .and_then(|s| s.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(100);
+        let offset = decode_offset_token(req.query_params.get("NextToken"));
+
+        // `false` = metric alarm, `true` = composite alarm; rendered lazily
+        // after the slice so we only stringify the page.
+        let matches = |name: &str, sv: &str, actions: [&[String]; 3]| -> bool {
+            if !filter_names.is_empty() && !filter_names.contains(&name.to_string()) {
+                return false;
+            }
+            if let Some(p) = prefix.as_ref() {
+                if !name.starts_with(p) {
+                    return false;
+                }
+            }
+            if let Some(want) = state_filter.as_ref() {
+                if sv != want {
+                    return false;
+                }
+            }
+            if let Some(ap) = action_prefix.as_ref() {
+                let any = actions
+                    .iter()
+                    .flat_map(|a| a.iter())
+                    .any(|a| a.starts_with(ap));
+                if !any {
+                    return false;
+                }
+            }
+            true
+        };
 
         let state = self.state.read();
-        let mut inner = String::from("<MetricAlarms>");
+        let mut combined: Vec<(bool, String)> = Vec::new();
         if let Some(acct) = state.get(&req.account_id) {
             if let Some(alarms) = acct.alarms_in(&req.region) {
                 for alarm in alarms.values() {
-                    if !filter_names.is_empty() && !filter_names.contains(&alarm.alarm_name) {
-                        continue;
+                    if matches(
+                        &alarm.alarm_name,
+                        alarm.state_value.as_str(),
+                        [
+                            &alarm.alarm_actions,
+                            &alarm.ok_actions,
+                            &alarm.insufficient_data_actions,
+                        ],
+                    ) {
+                        combined.push((false, render_alarm(alarm)));
                     }
-                    if let Some(p) = prefix.as_ref() {
-                        if !alarm.alarm_name.starts_with(p) {
-                            continue;
-                        }
-                    }
-                    if let Some(sv) = state_filter.as_ref() {
-                        if alarm.state_value.as_str() != sv {
-                            continue;
-                        }
-                    }
-                    if let Some(ap) = action_prefix.as_ref() {
-                        let any = alarm
-                            .alarm_actions
-                            .iter()
-                            .chain(alarm.ok_actions.iter())
-                            .chain(alarm.insufficient_data_actions.iter())
-                            .any(|a| a.starts_with(ap));
-                        if !any {
-                            continue;
-                        }
-                    }
-                    inner.push_str(&render_alarm(alarm));
                 }
+            }
+            if let Some(composites) = acct.composite_alarms_in(&req.region) {
+                for alarm in composites.values() {
+                    if matches(
+                        &alarm.alarm_name,
+                        alarm.state_value.as_str(),
+                        [
+                            &alarm.alarm_actions,
+                            &alarm.ok_actions,
+                            &alarm.insufficient_data_actions,
+                        ],
+                    ) {
+                        combined
+                            .push((true, crate::composite_alarms::render_composite_alarm(alarm)));
+                    }
+                }
+            }
+        }
+
+        let page: Vec<&(bool, String)> = combined.iter().skip(offset).take(max_records).collect();
+        let mut inner = String::from("<MetricAlarms>");
+        for (is_composite, body) in &page {
+            if !*is_composite {
+                inner.push_str(body);
             }
         }
         inner.push_str("</MetricAlarms>");
         inner.push_str("<CompositeAlarms>");
-        if let Some(acct) = state.get(&req.account_id) {
-            if let Some(composites) = acct.composite_alarms_in(&req.region) {
-                for alarm in composites.values() {
-                    if !filter_names.is_empty() && !filter_names.contains(&alarm.alarm_name) {
-                        continue;
-                    }
-                    if let Some(p) = prefix.as_ref() {
-                        if !alarm.alarm_name.starts_with(p) {
-                            continue;
-                        }
-                    }
-                    if let Some(sv) = state_filter.as_ref() {
-                        if alarm.state_value.as_str() != sv {
-                            continue;
-                        }
-                    }
-                    if let Some(ap) = action_prefix.as_ref() {
-                        let any = alarm
-                            .alarm_actions
-                            .iter()
-                            .chain(alarm.ok_actions.iter())
-                            .chain(alarm.insufficient_data_actions.iter())
-                            .any(|a| a.starts_with(ap));
-                        if !any {
-                            continue;
-                        }
-                    }
-                    inner.push_str(&crate::composite_alarms::render_composite_alarm(alarm));
-                }
+        for (is_composite, body) in &page {
+            if *is_composite {
+                inner.push_str(body);
             }
         }
         inner.push_str("</CompositeAlarms>");
+        if offset + max_records < combined.len() {
+            inner.push_str(&format!(
+                "<NextToken>{}</NextToken>",
+                encode_offset_token(offset + max_records)
+            ));
+        }
 
         Ok(xml_response("DescribeAlarms", &inner, &req.request_id))
     }
@@ -1280,6 +1534,9 @@ impl CloudWatchService {
         for name in &names {
             acct.alarms_in_mut(&req.region).remove(name);
             acct.composite_alarms_in_mut(&req.region).remove(name);
+            // Alarm history is tied to the alarm; AWS drops it when the alarm
+            // is deleted, so clear it here rather than orphan stale items.
+            acct.alarm_history_in_mut(&req.region).remove(name);
         }
 
         Ok(empty_metadata_response("DeleteAlarms", &req.request_id))
@@ -1350,9 +1607,26 @@ impl CloudWatchService {
                 format!("Alarm {alarm_name} not found"),
             )
         })?;
+        let old_state = alarm.state_value.as_str().to_string();
         alarm.state_value = new_state;
-        alarm.state_reason = state_reason;
+        alarm.state_reason = state_reason.clone();
         alarm.state_updated_timestamp = Utc::now();
+
+        let new_state_str = new_state.as_str().to_string();
+        let summary = format!("Alarm updated from {old_state} to {new_state_str}");
+        let history_data = format!(
+            "{{\"oldState\":{{\"stateValue\":\"{old_state}\"}},\"newState\":{{\"stateValue\":\"{new_state_str}\",\"stateReason\":\"{}\"}}}}",
+            state_reason.replace('"', "\\\"")
+        );
+        push_alarm_history(
+            acct,
+            &req.region,
+            &alarm_name,
+            "MetricAlarm",
+            "StateUpdate",
+            summary,
+            history_data,
+        );
 
         Ok(empty_metadata_response("SetAlarmState", &req.request_id))
     }
@@ -1377,9 +1651,102 @@ impl CloudWatchService {
             "ScanBy",
             &["TimestampDescending", "TimestampAscending"],
         )?;
-        // Minimal implementation: return empty history. AWS pagination tokens are
-        // not tracked locally, so callers see an empty list rather than a stub.
-        let inner = String::from("<AlarmHistoryItems></AlarmHistoryItems>");
+        let alarm_filter = optional_query_param(req, "AlarmName");
+        let type_filter = optional_query_param(req, "HistoryItemType");
+        let start_date = optional_query_param(req, "StartDate")
+            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+            .map(|d| d.with_timezone(&Utc));
+        let end_date = optional_query_param(req, "EndDate")
+            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+            .map(|d| d.with_timezone(&Utc));
+        // DescribeAlarmHistory defaults to TimestampDescending (newest first).
+        let descending = req
+            .query_params
+            .get("ScanBy")
+            .map(|s| s != "TimestampAscending")
+            .unwrap_or(true);
+        let max_records = optional_query_param(req, "MaxRecords")
+            .and_then(|s| s.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(100);
+        let offset = decode_offset_token(req.query_params.get("NextToken"));
+
+        let state = self.state.read();
+        let mut items: Vec<&AlarmHistoryItem> = Vec::new();
+        if let Some(acct) = state.get(&req.account_id) {
+            if let Some(history) = acct.alarm_history_in(&req.region) {
+                for (name, list) in history.iter() {
+                    if let Some(f) = alarm_filter.as_ref() {
+                        if name != f {
+                            continue;
+                        }
+                    }
+                    for item in list.iter() {
+                        if let Some(t) = type_filter.as_ref() {
+                            if &item.history_item_type != t {
+                                continue;
+                            }
+                        }
+                        if let Some(sd) = start_date {
+                            if item.timestamp < sd {
+                                continue;
+                            }
+                        }
+                        if let Some(ed) = end_date {
+                            if item.timestamp > ed {
+                                continue;
+                            }
+                        }
+                        items.push(item);
+                    }
+                }
+            }
+        }
+        items.sort_by_key(|i| i.timestamp);
+        if descending {
+            items.reverse();
+        }
+        let total = items.len();
+        let page: Vec<&AlarmHistoryItem> =
+            items.into_iter().skip(offset).take(max_records).collect();
+
+        let mut inner = String::from("<AlarmHistoryItems>");
+        for item in page {
+            inner.push_str("<member>");
+            inner.push_str(&format!(
+                "<AlarmName>{}</AlarmName>",
+                xml_escape(&item.alarm_name)
+            ));
+            inner.push_str(&format!(
+                "<AlarmType>{}</AlarmType>",
+                xml_escape(&item.alarm_type)
+            ));
+            inner.push_str(&format!(
+                "<Timestamp>{}</Timestamp>",
+                item.timestamp
+                    .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+            ));
+            inner.push_str(&format!(
+                "<HistoryItemType>{}</HistoryItemType>",
+                xml_escape(&item.history_item_type)
+            ));
+            inner.push_str(&format!(
+                "<HistorySummary>{}</HistorySummary>",
+                xml_escape(&item.history_summary)
+            ));
+            inner.push_str(&format!(
+                "<HistoryData>{}</HistoryData>",
+                xml_escape(&item.history_data)
+            ));
+            inner.push_str("</member>");
+        }
+        inner.push_str("</AlarmHistoryItems>");
+        if offset + max_records < total {
+            inner.push_str(&format!(
+                "<NextToken>{}</NextToken>",
+                encode_offset_token(offset + max_records)
+            ));
+        }
         Ok(xml_response(
             "DescribeAlarmHistory",
             &inner,
@@ -1513,6 +1880,31 @@ impl CloudWatchService {
         let inner = format!("<DashboardEntries>{entries}</DashboardEntries>");
         Ok(xml_response("ListDashboards", &inner, &req.request_id))
     }
+}
+
+/// Append an alarm-history record (newest appended last). Shared by
+/// PutMetricAlarm, SetAlarmState and DeleteAlarms so DescribeAlarmHistory
+/// reflects real lifecycle transitions.
+fn push_alarm_history(
+    acct: &mut crate::state::CloudWatchState,
+    region: &str,
+    alarm_name: &str,
+    alarm_type: &str,
+    history_item_type: &str,
+    history_summary: String,
+    history_data: String,
+) {
+    acct.alarm_history_in_mut(region)
+        .entry(alarm_name.to_string())
+        .or_default()
+        .push(AlarmHistoryItem {
+            alarm_name: alarm_name.to_string(),
+            alarm_type: alarm_type.to_string(),
+            timestamp: Utc::now(),
+            history_item_type: history_item_type.to_string(),
+            history_summary,
+            history_data,
+        });
 }
 
 fn render_alarm(alarm: &MetricAlarm) -> String {

--- a/crates/fakecloud-cloudwatch/src/state.rs
+++ b/crates/fakecloud-cloudwatch/src/state.rs
@@ -57,6 +57,11 @@ pub struct CloudWatchState {
     /// region -> alarm_name -> CompositeAlarm
     #[serde(default)]
     pub composite_alarms: BTreeMap<String, BTreeMap<String, CompositeAlarm>>,
+    /// region -> alarm_name -> history items (newest appended last). Populated
+    /// by PutMetricAlarm (ConfigurationUpdate), SetAlarmState (StateUpdate) and
+    /// DeleteAlarms so DescribeAlarmHistory reflects real transitions.
+    #[serde(default)]
+    pub alarm_history: BTreeMap<String, BTreeMap<String, Vec<AlarmHistoryItem>>>,
     /// Dashboards keyed by name (CloudWatch dashboards are global per
     /// account, not regional).
     #[serde(default)]
@@ -139,6 +144,20 @@ impl CloudWatchState {
         region: &str,
     ) -> &mut BTreeMap<String, CompositeAlarm> {
         self.composite_alarms.entry(region.to_string()).or_default()
+    }
+
+    pub fn alarm_history_in(
+        &self,
+        region: &str,
+    ) -> Option<&BTreeMap<String, Vec<AlarmHistoryItem>>> {
+        self.alarm_history.get(region)
+    }
+
+    pub fn alarm_history_in_mut(
+        &mut self,
+        region: &str,
+    ) -> &mut BTreeMap<String, Vec<AlarmHistoryItem>> {
+        self.alarm_history.entry(region.to_string()).or_default()
     }
 
     pub fn anomaly_detectors_in(&self, region: &str) -> Option<&BTreeMap<String, AnomalyDetector>> {
@@ -275,6 +294,21 @@ impl AlarmState {
             _ => None,
         }
     }
+}
+
+/// A single alarm-history record returned by `DescribeAlarmHistory`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlarmHistoryItem {
+    pub alarm_name: String,
+    /// `MetricAlarm` or `CompositeAlarm`.
+    pub alarm_type: String,
+    pub timestamp: DateTime<Utc>,
+    /// One of the `HistoryItemType` enum values (ConfigurationUpdate /
+    /// StateUpdate / Action).
+    pub history_item_type: String,
+    pub history_summary: String,
+    /// JSON blob (`HistoryData`) describing the transition.
+    pub history_data: String,
 }
 
 /// A composite alarm (defined by an `AlarmRule` expression over other alarms).

--- a/crates/fakecloud-e2e/tests/cloudwatch.rs
+++ b/crates/fakecloud-e2e/tests/cloudwatch.rs
@@ -438,3 +438,314 @@ async fn get_metric_statistics_filters_by_unit() {
         "only the Count datapoint aggregated, not the Milliseconds one"
     );
 }
+
+// bug-cluster: GetMetricStatistics must match dimensions as an EXACT set. A
+// dimensionless query must only see dimensionless data (not aggregate every
+// dimension combination), and an exact-set query returns only that combination.
+#[tokio::test]
+async fn get_metric_statistics_exact_dimension_matching() {
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+    let now = chrono::Utc::now();
+
+    // Two datapoints with DIFFERENT dimension sets, plus one dimensionless.
+    cw.put_metric_data()
+        .namespace("Dim")
+        .metric_data(
+            MetricDatum::builder()
+                .metric_name("M")
+                .value(5.0)
+                .dimensions(Dimension::builder().name("Service").value("api").build())
+                .timestamp(AwsDateTime::from_secs(now.timestamp()))
+                .build(),
+        )
+        .metric_data(
+            MetricDatum::builder()
+                .metric_name("M")
+                .value(7.0)
+                .dimensions(Dimension::builder().name("Service").value("worker").build())
+                .timestamp(AwsDateTime::from_secs(now.timestamp()))
+                .build(),
+        )
+        .send()
+        .await
+        .expect("put");
+
+    let start = AwsDateTime::from_secs(now.timestamp() - 600);
+    let end = AwsDateTime::from_secs(now.timestamp() + 600);
+
+    // Dimensionless query: must be EMPTY (no datapoint published without dims).
+    let dimensionless = cw
+        .get_metric_statistics()
+        .namespace("Dim")
+        .metric_name("M")
+        .start_time(start)
+        .end_time(end)
+        .period(60)
+        .statistics(Statistic::Sum)
+        .send()
+        .await
+        .expect("stats");
+    assert!(
+        dimensionless.datapoints().is_empty(),
+        "dimensionless query must not aggregate dimensioned data"
+    );
+
+    // Exact-set query: only the api datapoint (5.0), not the worker one.
+    let api = cw
+        .get_metric_statistics()
+        .namespace("Dim")
+        .metric_name("M")
+        .dimensions(Dimension::builder().name("Service").value("api").build())
+        .start_time(start)
+        .end_time(end)
+        .period(60)
+        .statistics(Statistic::Sum)
+        .send()
+        .await
+        .expect("stats");
+    assert_eq!(api.datapoints().len(), 1);
+    assert!((api.datapoints()[0].sum().unwrap() - 5.0).abs() < 1e-6);
+}
+
+// bug-cluster: GetMetricData must evaluate metric-math Expression queries.
+#[tokio::test]
+async fn get_metric_data_evaluates_expression() {
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+    let now = chrono::Utc::now();
+
+    for (name, v) in [("A", 5.0_f64), ("B", 7.0)] {
+        cw.put_metric_data()
+            .namespace("ExprNs")
+            .metric_data(
+                MetricDatum::builder()
+                    .metric_name(name)
+                    .value(v)
+                    .timestamp(AwsDateTime::from_secs(now.timestamp()))
+                    .build(),
+            )
+            .send()
+            .await
+            .expect("put");
+    }
+
+    let mk_metric_stat = |name: &str| {
+        MetricStat::builder()
+            .metric(
+                CwMetric::builder()
+                    .namespace("ExprNs")
+                    .metric_name(name)
+                    .build(),
+            )
+            .period(60)
+            .stat("Sum")
+            .build()
+    };
+
+    let resp = cw
+        .get_metric_data()
+        .start_time(AwsDateTime::from_secs(now.timestamp() - 600))
+        .end_time(AwsDateTime::from_secs(now.timestamp() + 600))
+        .metric_data_queries(
+            MetricDataQuery::builder()
+                .id("m1")
+                .metric_stat(mk_metric_stat("A"))
+                .return_data(false)
+                .build(),
+        )
+        .metric_data_queries(
+            MetricDataQuery::builder()
+                .id("m2")
+                .metric_stat(mk_metric_stat("B"))
+                .return_data(false)
+                .build(),
+        )
+        .metric_data_queries(
+            MetricDataQuery::builder()
+                .id("e1")
+                .expression("m1+m2")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("metric data");
+
+    let results = resp.metric_data_results();
+    // Only the expression result is returned (the metric inputs set
+    // ReturnData=false).
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id(), Some("e1"));
+    assert_eq!(results[0].values(), &[12.0]);
+}
+
+// bug-cluster: ExtendedStatistics (percentiles) must be computed.
+#[tokio::test]
+async fn get_metric_statistics_computes_percentiles() {
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+    let now = chrono::Utc::now();
+
+    for v in [10.0, 20.0, 30.0] {
+        cw.put_metric_data()
+            .namespace("Pct")
+            .metric_data(
+                MetricDatum::builder()
+                    .metric_name("M")
+                    .value(v)
+                    .timestamp(AwsDateTime::from_secs(now.timestamp()))
+                    .build(),
+            )
+            .send()
+            .await
+            .expect("put");
+    }
+
+    let stats = cw
+        .get_metric_statistics()
+        .namespace("Pct")
+        .metric_name("M")
+        .start_time(AwsDateTime::from_secs(now.timestamp() - 600))
+        .end_time(AwsDateTime::from_secs(now.timestamp() + 600))
+        .period(60)
+        .extended_statistics("p50")
+        .send()
+        .await
+        .expect("stats");
+
+    let dp = &stats.datapoints()[0];
+    let ext = dp
+        .extended_statistics()
+        .expect("extended statistics present");
+    // Median of {10,20,30} via linear interpolation = 20.
+    assert!((ext.get("p50").copied().unwrap() - 20.0).abs() < 1e-6);
+}
+
+// bug-cluster: DescribeAlarms must paginate via MaxRecords + NextToken.
+#[tokio::test]
+async fn describe_alarms_paginates() {
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+
+    for name in ["alarm-a", "alarm-b"] {
+        cw.put_metric_alarm()
+            .alarm_name(name)
+            .namespace("App")
+            .metric_name("Errors")
+            .statistic(Statistic::Sum)
+            .period(60)
+            .evaluation_periods(1)
+            .threshold(1.0)
+            .comparison_operator(ComparisonOperator::GreaterThanThreshold)
+            .send()
+            .await
+            .expect("put alarm");
+    }
+
+    let page1 = cw
+        .describe_alarms()
+        .max_records(1)
+        .send()
+        .await
+        .expect("page1");
+    assert_eq!(page1.metric_alarms().len(), 1);
+    let token = page1.next_token().expect("next token on first page");
+
+    let page2 = cw
+        .describe_alarms()
+        .max_records(1)
+        .next_token(token)
+        .send()
+        .await
+        .expect("page2");
+    assert_eq!(page2.metric_alarms().len(), 1);
+    assert_ne!(
+        page1.metric_alarms()[0].alarm_name(),
+        page2.metric_alarms()[0].alarm_name()
+    );
+}
+
+// bug-cluster: ListMetrics must cap each page (500) and round-trip a NextToken.
+#[tokio::test]
+async fn list_metrics_paginates() {
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+
+    // 501 distinct metrics -> first page 500 + NextToken, second page 1.
+    // Published in batches to keep each request body small.
+    let mut next = 0;
+    while next < 501 {
+        let mut put = cw.put_metric_data().namespace("Many");
+        for i in next..(next + 100).min(501) {
+            put = put.metric_data(
+                MetricDatum::builder()
+                    .metric_name(format!("M{i}"))
+                    .value(1.0)
+                    .build(),
+            );
+        }
+        put.send().await.expect("put many");
+        next += 100;
+    }
+
+    let page1 = cw
+        .list_metrics()
+        .namespace("Many")
+        .send()
+        .await
+        .expect("page1");
+    assert_eq!(page1.metrics().len(), 500);
+    let token = page1.next_token().expect("next token");
+
+    let page2 = cw
+        .list_metrics()
+        .namespace("Many")
+        .next_token(token)
+        .send()
+        .await
+        .expect("page2");
+    assert_eq!(page2.metrics().len(), 1);
+}
+
+// bug-cluster: DescribeAlarmHistory must reflect real state transitions.
+#[tokio::test]
+async fn describe_alarm_history_records_transitions() {
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+
+    cw.put_metric_alarm()
+        .alarm_name("HistAlarm")
+        .namespace("App")
+        .metric_name("Errors")
+        .statistic(Statistic::Sum)
+        .period(60)
+        .evaluation_periods(1)
+        .threshold(1.0)
+        .comparison_operator(ComparisonOperator::GreaterThanThreshold)
+        .send()
+        .await
+        .expect("put alarm");
+
+    cw.set_alarm_state()
+        .alarm_name("HistAlarm")
+        .state_value(StateValue::Alarm)
+        .state_reason("breached")
+        .send()
+        .await
+        .expect("set state");
+
+    let history = cw
+        .describe_alarm_history()
+        .alarm_name("HistAlarm")
+        .send()
+        .await
+        .expect("history");
+    let items = history.alarm_history_items();
+    assert!(!items.is_empty(), "history must not be empty");
+    assert!(
+        items
+            .iter()
+            .any(|i| i.history_item_type().map(|t| t.as_str()) == Some("StateUpdate")),
+        "a StateUpdate history item must be recorded"
+    );
+}

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -3150,3 +3150,115 @@ async fn logs_filter_log_events_json_or_pattern() {
     assert_eq!(resp.events().len(), 1, "only the ERROR/500 event matches");
     assert!(resp.events()[0].message().unwrap().contains("ERROR"));
 }
+
+// bug-cluster: Logs Insights `stats count(*) by field` returns aggregated rows,
+// and the `@ptr` from a raw query resolves via GetLogRecord.
+#[tokio::test]
+async fn logs_insights_stats_and_ptr() {
+    let server = TestServer::start().await;
+    let client = server.logs_client().await;
+
+    client
+        .create_log_group()
+        .log_group_name("/stats/e2e")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_log_stream()
+        .log_group_name("/stats/e2e")
+        .log_stream_name("s1")
+        .send()
+        .await
+        .unwrap();
+
+    let now = chrono::Utc::now().timestamp_millis();
+    let messages = [
+        r#"{"level":"ERROR","msg":"a"}"#,
+        r#"{"level":"INFO","msg":"b"}"#,
+        r#"{"level":"ERROR","msg":"c"}"#,
+        r#"{"level":"ERROR","msg":"d"}"#,
+    ];
+    let mut put = client
+        .put_log_events()
+        .log_group_name("/stats/e2e")
+        .log_stream_name("s1");
+    for (i, m) in messages.iter().enumerate() {
+        put = put.log_events(
+            InputLogEvent::builder()
+                .timestamp(now + i as i64 * 1000)
+                .message(*m)
+                .build()
+                .unwrap(),
+        );
+    }
+    put.send().await.unwrap();
+
+    let start_secs = (now / 1000) - 1;
+    let end_secs = (now / 1000) + 60;
+
+    // stats count(*) by level -> aggregated rows.
+    let q = client
+        .start_query()
+        .log_group_name("/stats/e2e")
+        .start_time(start_secs)
+        .end_time(end_secs)
+        .query_string("stats count(*) by level")
+        .send()
+        .await
+        .unwrap();
+    let qid = q.query_id().unwrap().to_string();
+    let resp = client
+        .get_query_results()
+        .query_id(&qid)
+        .send()
+        .await
+        .unwrap();
+    let rows = resp.results();
+    assert_eq!(rows.len(), 2, "one aggregated row per level");
+    let error_row = rows
+        .iter()
+        .find(|row| {
+            row.iter()
+                .any(|f| f.field() == Some("level") && f.value() == Some("ERROR"))
+        })
+        .expect("ERROR group present");
+    let count = error_row
+        .iter()
+        .find(|f| f.field() == Some("count(*)"))
+        .and_then(|f| f.value())
+        .unwrap();
+    assert_eq!(count, "3");
+
+    // A raw query yields an @ptr that GetLogRecord can resolve.
+    let q2 = client
+        .start_query()
+        .log_group_name("/stats/e2e")
+        .start_time(start_secs)
+        .end_time(end_secs)
+        .query_string("fields @message | limit 1")
+        .send()
+        .await
+        .unwrap();
+    let qid2 = q2.query_id().unwrap().to_string();
+    let resp2 = client
+        .get_query_results()
+        .query_id(&qid2)
+        .send()
+        .await
+        .unwrap();
+    let ptr = resp2.results()[0]
+        .iter()
+        .find(|f| f.field() == Some("@ptr"))
+        .and_then(|f| f.value())
+        .expect("@ptr present");
+
+    let record = client
+        .get_log_record()
+        .log_record_pointer(ptr)
+        .send()
+        .await
+        .expect("get_log_record resolves the @ptr");
+    let rec = record.log_record().expect("log record body");
+    assert!(rec.contains_key("@message"), "resolved record has @message");
+}

--- a/crates/fakecloud-logs/src/query.rs
+++ b/crates/fakecloud-logs/src/query.rs
@@ -1,22 +1,33 @@
-/// CloudWatch Logs Insights query language parser and executor.
-///
-/// Supports a subset of CWLI syntax:
-/// - `fields @timestamp, @message` — select specific fields
-/// - `filter @message like /pattern/` — filter by regex/substring
-/// - `filter field = "value"` — filter by field equality
-/// - `sort @timestamp desc` — sort results
-/// - `limit N` — limit number of results
+//! CloudWatch Logs Insights query language parser and executor.
+//!
+//! Supports the common subset of CWLI syntax as an ordered pipeline:
+//! - `fields @timestamp, @message` / `display ...` — select output fields
+//! - `filter field = "value"` / `!= ` / `like /pattern/` — filter rows
+//! - `parse @message "* [*] *" as a, b, c` — extract fields via a glob
+//! - `stats count(*) [as alias] by field, ...` — aggregate (count/sum/avg/min/
+//!   max/count_distinct), optionally grouped
+//! - `dedup field, ...` — drop duplicate rows by the given fields
+//! - `sort @timestamp desc` — order rows
+//! - `limit N` — cap row count
 use crate::state::LogEvent;
 use serde_json::{json, Value};
 
-/// Parsed representation of a CWLI query.
+/// A parsed CWLI query: an ordered pipeline of commands.
 #[derive(Debug, Default)]
 pub struct ParsedQuery {
-    pub fields: Vec<String>,
-    pub filters: Vec<FilterClause>,
-    pub sort_field: Option<String>,
-    pub sort_desc: bool,
-    pub limit: Option<usize>,
+    pub commands: Vec<Command>,
+}
+
+#[derive(Debug)]
+pub enum Command {
+    Fields(Vec<String>),
+    Display(Vec<String>),
+    Filter(FilterClause),
+    Sort { field: String, desc: bool },
+    Limit(usize),
+    Parse(ParseSpec),
+    Dedup(Vec<String>),
+    Stats { aggs: Vec<AggExpr>, by: Vec<String> },
 }
 
 #[derive(Debug)]
@@ -29,50 +40,93 @@ pub enum FilterClause {
     Like { field: String, pattern: String },
 }
 
-/// Parse a CWLI query string into a structured representation.
+/// A `parse` directive: glob `pattern` applied to `source`, binding each `*`
+/// wildcard (in order) to the corresponding name in `names`.
+#[derive(Debug)]
+pub struct ParseSpec {
+    pub source: String,
+    pub pattern: String,
+    pub names: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct AggExpr {
+    pub func: AggFunc,
+    pub field: Option<String>,
+    pub alias: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AggFunc {
+    Count,
+    Sum,
+    Avg,
+    Min,
+    Max,
+    CountDistinct,
+}
+
+/// Strip a leading keyword (followed by whitespace) from a command, returning
+/// the remainder.
+fn strip_keyword<'a>(cmd: &'a str, kw: &str) -> Option<&'a str> {
+    let rest = cmd.strip_prefix(kw)?;
+    // The keyword must be followed by whitespace (so `fieldspec` isn't matched
+    // as `fields`).
+    if rest.starts_with(|c: char| c.is_whitespace()) {
+        Some(rest.trim_start())
+    } else {
+        None
+    }
+}
+
+fn parse_field_list(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(|f| f.trim().to_string())
+        .filter(|f| !f.is_empty())
+        .collect()
+}
+
+/// Parse a CWLI query string into a structured pipeline.
 pub fn parse_query(query: &str) -> ParsedQuery {
     let mut parsed = ParsedQuery::default();
 
-    // Split on pipe delimiter, trimming whitespace
-    let commands: Vec<&str> = query.split('|').map(|s| s.trim()).collect();
-
-    for cmd in commands {
+    for raw in query.split('|') {
+        let cmd = raw.trim();
         if cmd.is_empty() {
             continue;
         }
 
-        if let Some(rest) = cmd
-            .strip_prefix("fields ")
-            .or_else(|| cmd.strip_prefix("fields\t"))
-        {
-            parsed.fields = rest
-                .split(',')
-                .map(|f| f.trim().to_string())
-                .filter(|f| !f.is_empty())
-                .collect();
-        } else if let Some(rest) = cmd
-            .strip_prefix("filter ")
-            .or_else(|| cmd.strip_prefix("filter\t"))
-        {
+        if let Some(rest) = strip_keyword(cmd, "fields") {
+            parsed
+                .commands
+                .push(Command::Fields(parse_field_list(rest)));
+        } else if let Some(rest) = strip_keyword(cmd, "display") {
+            parsed
+                .commands
+                .push(Command::Display(parse_field_list(rest)));
+        } else if let Some(rest) = strip_keyword(cmd, "filter") {
             if let Some(clause) = parse_filter_clause(rest.trim()) {
-                parsed.filters.push(clause);
+                parsed.commands.push(Command::Filter(clause));
             }
-        } else if let Some(rest) = cmd
-            .strip_prefix("sort ")
-            .or_else(|| cmd.strip_prefix("sort\t"))
-        {
+        } else if let Some(rest) = strip_keyword(cmd, "stats") {
+            parsed.commands.push(parse_stats(rest));
+        } else if let Some(rest) = strip_keyword(cmd, "parse") {
+            if let Some(spec) = parse_parse(rest) {
+                parsed.commands.push(Command::Parse(spec));
+            }
+        } else if let Some(rest) = strip_keyword(cmd, "dedup") {
+            parsed.commands.push(Command::Dedup(parse_field_list(rest)));
+        } else if let Some(rest) = strip_keyword(cmd, "sort") {
             let parts: Vec<&str> = rest.split_whitespace().collect();
             if !parts.is_empty() {
-                parsed.sort_field = Some(parts[0].to_string());
-                parsed.sort_desc =
-                    parts.get(1).map(|s| s.eq_ignore_ascii_case("desc")) == Some(true);
+                parsed.commands.push(Command::Sort {
+                    field: parts[0].to_string(),
+                    desc: parts.get(1).map(|s| s.eq_ignore_ascii_case("desc")) == Some(true),
+                });
             }
-        } else if let Some(rest) = cmd
-            .strip_prefix("limit ")
-            .or_else(|| cmd.strip_prefix("limit\t"))
-        {
+        } else if let Some(rest) = strip_keyword(cmd, "limit") {
             if let Ok(n) = rest.trim().parse::<usize>() {
-                parsed.limit = Some(n);
+                parsed.commands.push(Command::Limit(n));
             }
         }
     }
@@ -86,23 +140,19 @@ fn parse_filter_clause(s: &str) -> Option<FilterClause> {
         let field = s[..like_pos].trim().to_string();
         let pattern_str = s[like_pos + 6..].trim();
         let pattern = if pattern_str.starts_with('/') && pattern_str.ends_with('/') {
-            // Regex pattern - extract content between slashes
             pattern_str[1..pattern_str.len() - 1].to_string()
         } else {
-            // Quoted string
             unquote(pattern_str)
         };
         return Some(FilterClause::Like { field, pattern });
     }
 
-    // Try: field != "value"
     if let Some(ne_pos) = s.find(" != ") {
         let field = s[..ne_pos].trim().to_string();
         let value = unquote(s[ne_pos + 4..].trim());
         return Some(FilterClause::NotEquals { field, value });
     }
 
-    // Try: field = "value"
     if let Some(eq_pos) = s.find(" = ") {
         let field = s[..eq_pos].trim().to_string();
         let value = unquote(s[eq_pos + 3..].trim());
@@ -110,6 +160,106 @@ fn parse_filter_clause(s: &str) -> Option<FilterClause> {
     }
 
     None
+}
+
+/// Parse a `stats` command body (the text after `stats`).
+fn parse_stats(rest: &str) -> Command {
+    // Split off the optional `by <fields>` clause (case-insensitive).
+    let lower = rest.to_ascii_lowercase();
+    let (agg_part, by_part) = match lower.find(" by ") {
+        Some(pos) => (&rest[..pos], Some(rest[pos + 4..].trim())),
+        None => (rest, None),
+    };
+    let aggs = split_top_level_commas(agg_part)
+        .iter()
+        .filter_map(|s| parse_agg_expr(s.trim()))
+        .collect();
+    let by = by_part.map(parse_field_list).unwrap_or_default();
+    Command::Stats { aggs, by }
+}
+
+/// Split on commas that are not nested inside parentheses, so
+/// `count(*), avg(latency)` splits but `pct(latency, 99)` doesn't.
+fn split_top_level_commas(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut depth = 0i32;
+    let mut current = String::new();
+    for c in s.chars() {
+        match c {
+            '(' => {
+                depth += 1;
+                current.push(c);
+            }
+            ')' => {
+                depth -= 1;
+                current.push(c);
+            }
+            ',' if depth == 0 => {
+                out.push(std::mem::take(&mut current));
+            }
+            _ => current.push(c),
+        }
+    }
+    if !current.trim().is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+fn parse_agg_expr(s: &str) -> Option<AggExpr> {
+    // Split off an optional `as alias`.
+    let (expr, alias) = match s.to_ascii_lowercase().find(" as ") {
+        Some(pos) => (s[..pos].trim(), Some(s[pos + 4..].trim().to_string())),
+        None => (s.trim(), None),
+    };
+    let open = expr.find('(')?;
+    let close = expr.rfind(')')?;
+    if close < open {
+        return None;
+    }
+    let func_name = expr[..open].trim().to_ascii_lowercase();
+    let arg = expr[open + 1..close].trim();
+    let func = match func_name.as_str() {
+        "count" => AggFunc::Count,
+        "sum" => AggFunc::Sum,
+        "avg" | "average" => AggFunc::Avg,
+        "min" => AggFunc::Min,
+        "max" => AggFunc::Max,
+        "count_distinct" | "countdistinct" => AggFunc::CountDistinct,
+        _ => return None,
+    };
+    let field = if arg.is_empty() || arg == "*" {
+        None
+    } else {
+        Some(arg.to_string())
+    };
+    let alias = alias.unwrap_or_else(|| expr.to_string());
+    Some(AggExpr { func, field, alias })
+}
+
+/// Parse a `parse <source> "<glob>" as a, b, ...` command body.
+fn parse_parse(rest: &str) -> Option<ParseSpec> {
+    let rest = rest.trim();
+    // The source token is everything up to the first quote.
+    let quote_pos = rest.find(['"', '\''])?;
+    let source = rest[..quote_pos].trim().to_string();
+    if source.is_empty() {
+        return None;
+    }
+    let quote = rest.as_bytes()[quote_pos] as char;
+    let after = &rest[quote_pos + 1..];
+    let end = after.find(quote)?;
+    let pattern = after[..end].to_string();
+    let tail = after[end + 1..].trim();
+    let names = match tail.to_ascii_lowercase().strip_prefix("as ") {
+        Some(_) => parse_field_list(&tail[3..]),
+        None => Vec::new(),
+    };
+    Some(ParseSpec {
+        source,
+        pattern,
+        names,
+    })
 }
 
 fn unquote(s: &str) -> String {
@@ -120,45 +270,81 @@ fn unquote(s: &str) -> String {
     }
 }
 
-/// Get the value of a virtual field for a log event.
-fn get_field_value(event: &LogEvent, field: &str, stream_name: &str) -> Option<String> {
-    match field {
-        "@timestamp" => {
-            // Format as ISO 8601
-            let secs = event.timestamp / 1000;
-            let nsecs = ((event.timestamp % 1000) * 1_000_000) as u32;
-            if let Some(dt) = chrono::DateTime::from_timestamp(secs, nsecs) {
-                Some(dt.format("%Y-%m-%d %H:%M:%S%.3f").to_string())
-            } else {
-                Some(event.timestamp.to_string())
-            }
-        }
-        "@message" => Some(event.message.clone()),
-        "@logStream" => Some(stream_name.to_string()),
-        "@ingestionTime" => Some(event.ingestion_time.to_string()),
-        "@ptr" => Some(format!("{}/{}", stream_name, event.timestamp)),
-        _ => {
-            // Try to extract from JSON message
-            if let Ok(parsed) = serde_json::from_str::<Value>(&event.message) {
-                // Strip leading @ if present for JSON field lookup
-                let key = field.strip_prefix('@').unwrap_or(field);
-                parsed.get(key).map(|v| match v {
-                    Value::String(s) => s.clone(),
-                    other => other.to_string(),
-                })
-            } else {
-                None
-            }
+/// A materialized query row: ordered (field, value) pairs. Insertion order is
+/// preserved so output column ordering is stable.
+#[derive(Clone, Default)]
+struct Record {
+    fields: Vec<(String, String)>,
+}
+
+impl Record {
+    fn get(&self, name: &str) -> Option<&str> {
+        self.fields
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.as_str())
+    }
+
+    fn set(&mut self, name: &str, value: String) {
+        if let Some(entry) = self.fields.iter_mut().find(|(k, _)| k == name) {
+            entry.1 = value;
+        } else {
+            self.fields.push((name.to_string(), value));
         }
     }
 }
 
-/// Check if a substring pattern matches a string (simple glob-like matching).
+/// Format a timestamp (epoch millis) the way CWLI renders `@timestamp`.
+fn format_timestamp(ms: i64) -> String {
+    let secs = ms / 1000;
+    let nsecs = ((ms % 1000) * 1_000_000) as u32;
+    match chrono::DateTime::from_timestamp(secs, nsecs) {
+        Some(dt) => dt.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+        None => ms.to_string(),
+    }
+}
+
+/// Mint a GetLogRecord-compatible `@ptr`: base64(`<group>|<stream>|<index>`).
+fn encode_ptr(group: &str, stream: &str, index: usize) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(format!("{group}|{stream}|{index}").as_bytes())
+}
+
+/// Build the base record for a log event, including the synthetic `@`-fields
+/// and any top-level keys discovered from a JSON message body.
+fn build_record(event: &LogEvent, group: &str, stream: &str, index: usize) -> Record {
+    let mut r = Record::default();
+    r.set("@timestamp", format_timestamp(event.timestamp));
+    r.set("@message", event.message.clone());
+    r.set("@logStream", stream.to_string());
+    r.set("@ingestionTime", event.ingestion_time.to_string());
+    r.set("@ptr", encode_ptr(group, stream, index));
+    if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(&event.message) {
+        for (k, v) in map {
+            let value = match v {
+                Value::String(s) => s,
+                other => other.to_string(),
+            };
+            // Discovered JSON fields don't clobber the synthetic ones.
+            if r.get(&k).is_none() {
+                r.set(&k, value);
+            }
+        }
+    }
+    r
+}
+
+/// Resolve a field for filtering/grouping, allowing the `@`-stripped JSON
+/// fallback (e.g. `level` resolves a JSON key `level`).
+fn record_field(r: &Record, name: &str) -> Option<String> {
+    if let Some(v) = r.get(name) {
+        return Some(v.to_string());
+    }
+    let stripped = name.strip_prefix('@').unwrap_or(name);
+    r.get(stripped).map(|v| v.to_string())
+}
+
 fn matches_pattern(haystack: &str, pattern: &str) -> bool {
-    // Simple substring/regex-like matching without the regex crate.
-    // For `/pattern/` syntax we do substring match.
-    // For more complex patterns, we handle common regex anchors:
-    //   ^..$ for exact match, ^ for starts-with, $ for ends-with
     if let Some(inner) = pattern.strip_prefix('^').and_then(|p| p.strip_suffix('$')) {
         haystack == inner
     } else if let Some(prefix) = pattern.strip_prefix('^') {
@@ -166,111 +352,232 @@ fn matches_pattern(haystack: &str, pattern: &str) -> bool {
     } else if let Some(suffix) = pattern.strip_suffix('$') {
         haystack.ends_with(suffix)
     } else {
-        // Default: substring match
         haystack.contains(pattern)
     }
 }
 
-/// Apply a filter clause to an event, returning true if the event matches.
-fn event_matches_filter(event: &LogEvent, stream_name: &str, clause: &FilterClause) -> bool {
+fn record_matches_filter(r: &Record, clause: &FilterClause) -> bool {
     match clause {
-        FilterClause::Equals { field, value } => get_field_value(event, field, stream_name)
-            .map(|v| v == *value)
-            .unwrap_or(false),
-        FilterClause::NotEquals { field, value } => get_field_value(event, field, stream_name)
-            .map(|v| v != *value)
-            .unwrap_or(true),
-        FilterClause::Like { field, pattern } => get_field_value(event, field, stream_name)
+        FilterClause::Equals { field, value } => {
+            record_field(r, field).map(|v| v == *value).unwrap_or(false)
+        }
+        FilterClause::NotEquals { field, value } => {
+            record_field(r, field).map(|v| v != *value).unwrap_or(true)
+        }
+        FilterClause::Like { field, pattern } => record_field(r, field)
             .map(|v| matches_pattern(&v, pattern))
             .unwrap_or(false),
     }
 }
 
-/// A log event together with its stream name context, used during query execution.
-struct EventWithContext<'a> {
-    event: &'a LogEvent,
-    stream_name: &'a str,
+/// Apply a glob `parse` to a record, binding each `*` to the matching name.
+fn apply_parse(r: &mut Record, spec: &ParseSpec) {
+    let Some(source) = record_field(r, &spec.source) else {
+        return;
+    };
+    let segments: Vec<&str> = spec.pattern.split('*').collect();
+    let mut captures: Vec<String> = Vec::new();
+    let mut pos = 0usize;
+    // The first segment is a required prefix.
+    if let Some(first) = segments.first() {
+        if !source[pos..].starts_with(first) {
+            return;
+        }
+        pos += first.len();
+    }
+    for seg in segments.iter().skip(1) {
+        if seg.is_empty() {
+            // Trailing wildcard: capture the rest.
+            captures.push(source[pos..].to_string());
+            pos = source.len();
+            continue;
+        }
+        let Some(found) = source[pos..].find(seg) else {
+            return;
+        };
+        captures.push(source[pos..pos + found].to_string());
+        pos += found + seg.len();
+    }
+    for (name, value) in spec.names.iter().zip(captures) {
+        r.set(name, value);
+    }
 }
 
-/// Execute a parsed query against a set of log events.
-/// Returns results in the CloudWatch Logs Insights format: array of arrays of {field, value} objects.
+fn parse_number(s: &str) -> Option<f64> {
+    s.trim().parse::<f64>().ok()
+}
+
+/// Format an aggregate result, dropping a trailing `.0` so counts read as
+/// integers the way CloudWatch renders them.
+fn format_number(n: f64) -> String {
+    if n.fract() == 0.0 && n.abs() < 1e15 {
+        format!("{}", n as i64)
+    } else {
+        format!("{n}")
+    }
+}
+
+fn compute_agg(agg: &AggExpr, group: &[&Record]) -> String {
+    match agg.func {
+        AggFunc::Count => match &agg.field {
+            None => format_number(group.len() as f64),
+            Some(f) => {
+                let n = group
+                    .iter()
+                    .filter(|r| record_field(r, f).is_some())
+                    .count();
+                format_number(n as f64)
+            }
+        },
+        AggFunc::CountDistinct => {
+            let field = match &agg.field {
+                Some(f) => f,
+                None => return "0".to_string(),
+            };
+            let mut seen = std::collections::BTreeSet::new();
+            for r in group {
+                if let Some(v) = record_field(r, field) {
+                    seen.insert(v);
+                }
+            }
+            format_number(seen.len() as f64)
+        }
+        AggFunc::Sum | AggFunc::Avg | AggFunc::Min | AggFunc::Max => {
+            let field = match &agg.field {
+                Some(f) => f,
+                None => return "0".to_string(),
+            };
+            let nums: Vec<f64> = group
+                .iter()
+                .filter_map(|r| record_field(r, field).and_then(|v| parse_number(&v)))
+                .collect();
+            if nums.is_empty() {
+                return "0".to_string();
+            }
+            let v = match agg.func {
+                AggFunc::Sum => nums.iter().sum(),
+                AggFunc::Avg => nums.iter().sum::<f64>() / nums.len() as f64,
+                AggFunc::Min => nums.iter().cloned().fold(f64::INFINITY, f64::min),
+                AggFunc::Max => nums.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
+                _ => unreachable!(),
+            };
+            format_number(v)
+        }
+    }
+}
+
+/// One stream's events for query execution.
+pub struct QueryStream {
+    pub group_name: String,
+    pub stream_name: String,
+    /// Each event paired with its index in the stream's full event list so
+    /// `@ptr` round-trips through GetLogRecord.
+    pub events: Vec<(usize, LogEvent)>,
+}
+
+/// Execute a parsed query against a set of streams, returning results in the
+/// CloudWatch Logs Insights format: an array of rows, each an array of
+/// `{field, value}` objects.
 pub fn execute_query(
     query: &ParsedQuery,
-    events: &[(String, Vec<LogEvent>)], // (stream_name, events) pairs
+    streams: &[QueryStream],
     start_time_secs: i64,
     end_time_secs: i64,
 ) -> Vec<Value> {
-    // Collect all events with context
-    let mut all_events: Vec<EventWithContext> = Vec::new();
-    for (stream_name, stream_events) in events {
-        for event in stream_events {
+    // Materialize records inside the time window.
+    let mut records: Vec<Record> = Vec::new();
+    for stream in streams {
+        for (index, event) in &stream.events {
             let event_time_secs = event.timestamp / 1000;
             if event_time_secs >= start_time_secs && event_time_secs < end_time_secs {
-                all_events.push(EventWithContext { event, stream_name });
+                records.push(build_record(
+                    event,
+                    &stream.group_name,
+                    &stream.stream_name,
+                    *index,
+                ));
             }
         }
     }
 
-    // Apply filters
-    let filtered: Vec<&EventWithContext> = all_events
-        .iter()
-        .filter(|ec| {
-            query
-                .filters
-                .iter()
-                .all(|f| event_matches_filter(ec.event, ec.stream_name, f))
-        })
-        .collect();
+    // Default ordering is by timestamp ascending; an explicit `sort` overrides.
+    records.sort_by(|a, b| {
+        a.get("@timestamp")
+            .unwrap_or_default()
+            .cmp(b.get("@timestamp").unwrap_or_default())
+    });
 
-    // Sort
-    let mut sorted: Vec<&EventWithContext> = filtered;
-    if let Some(ref sort_field) = query.sort_field {
-        let field = sort_field.clone();
-        let desc = query.sort_desc;
-        sorted.sort_by(|a, b| {
-            let va = get_field_value(a.event, &field, a.stream_name).unwrap_or_default();
-            let vb = get_field_value(b.event, &field, b.stream_name).unwrap_or_default();
-            if desc {
-                vb.cmp(&va)
-            } else {
-                va.cmp(&vb)
+    let mut explicit_fields: Option<Vec<String>> = None;
+    let mut aggregated = false;
+
+    for cmd in &query.commands {
+        match cmd {
+            Command::Filter(clause) => {
+                records.retain(|r| record_matches_filter(r, clause));
             }
-        });
-    } else {
-        // Default: sort by timestamp ascending
-        sorted.sort_by_key(|ec| ec.event.timestamp);
+            Command::Parse(spec) => {
+                for r in records.iter_mut() {
+                    apply_parse(r, spec);
+                }
+            }
+            Command::Fields(f) | Command::Display(f) => {
+                explicit_fields = Some(f.clone());
+            }
+            Command::Dedup(fields) => {
+                let mut seen = std::collections::HashSet::new();
+                records.retain(|r| {
+                    let key: Vec<Option<String>> =
+                        fields.iter().map(|f| record_field(r, f)).collect();
+                    seen.insert(format!("{key:?}"))
+                });
+            }
+            Command::Sort { field, desc } => {
+                records.sort_by(|a, b| {
+                    let va = record_field(a, field).unwrap_or_default();
+                    let vb = record_field(b, field).unwrap_or_default();
+                    if *desc {
+                        vb.cmp(&va)
+                    } else {
+                        va.cmp(&vb)
+                    }
+                });
+            }
+            Command::Limit(n) => {
+                records.truncate(*n);
+            }
+            Command::Stats { aggs, by } => {
+                records = run_stats(&records, aggs, by);
+                aggregated = true;
+                // After aggregation, the output columns are the by-fields plus
+                // the agg aliases.
+                let mut cols: Vec<String> = by.clone();
+                cols.extend(aggs.iter().map(|a| a.alias.clone()));
+                explicit_fields = Some(cols);
+            }
+        }
     }
 
-    // Apply limit
-    if let Some(limit) = query.limit {
-        sorted.truncate(limit);
-    }
-
-    // Determine which fields to output
-    let output_fields = if query.fields.is_empty() {
-        vec![
+    // Decide output columns.
+    let mut output_fields: Vec<String> = match explicit_fields {
+        Some(f) => f,
+        None => vec![
             "@timestamp".to_string(),
             "@message".to_string(),
             "@ptr".to_string(),
-        ]
-    } else {
-        let mut fields = query.fields.clone();
-        // Always include @ptr
-        if !fields.iter().any(|f| f == "@ptr") {
-            fields.push("@ptr".to_string());
-        }
-        fields
+        ],
     };
+    // Raw (non-aggregated) results always carry @ptr so callers can drill in.
+    if !aggregated && !output_fields.iter().any(|f| f == "@ptr") {
+        output_fields.push("@ptr".to_string());
+    }
 
-    // Build result rows
-    sorted
+    records
         .iter()
-        .map(|ec| {
+        .map(|r| {
             let row: Vec<Value> = output_fields
                 .iter()
                 .filter_map(|field| {
-                    get_field_value(ec.event, field, ec.stream_name)
-                        .map(|value| json!({"field": field, "value": value}))
+                    record_field(r, field).map(|value| json!({"field": field, "value": value}))
                 })
                 .collect();
             Value::Array(row)
@@ -278,233 +585,213 @@ pub fn execute_query(
         .collect()
 }
 
+/// Group records and compute the requested aggregates, returning one synthetic
+/// record per group.
+fn run_stats(records: &[Record], aggs: &[AggExpr], by: &[String]) -> Vec<Record> {
+    use std::collections::BTreeMap;
+    let mut groups: BTreeMap<Vec<String>, Vec<&Record>> = BTreeMap::new();
+    for r in records {
+        let key: Vec<String> = by
+            .iter()
+            .map(|f| record_field(r, f).unwrap_or_default())
+            .collect();
+        groups.entry(key).or_default().push(r);
+    }
+
+    let mut out = Vec::new();
+    for (key, group) in groups {
+        let mut rec = Record::default();
+        for (field, value) in by.iter().zip(key.iter()) {
+            rec.set(field, value.clone());
+        }
+        for agg in aggs {
+            rec.set(&agg.alias, compute_agg(agg, &group));
+        }
+        out.push(rec);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn stream(name: &str, events: Vec<LogEvent>) -> QueryStream {
+        QueryStream {
+            group_name: "/g".to_string(),
+            stream_name: name.to_string(),
+            events: events.into_iter().enumerate().collect(),
+        }
+    }
+
+    fn ev(ts: i64, msg: &str) -> LogEvent {
+        LogEvent {
+            timestamp: ts,
+            message: msg.to_string(),
+            ingestion_time: ts,
+        }
+    }
+
     #[test]
     fn parse_fields_and_limit() {
         let q = parse_query("fields @timestamp, @message | limit 5");
-        assert_eq!(q.fields, vec!["@timestamp", "@message"]);
-        assert_eq!(q.limit, Some(5));
-    }
-
-    #[test]
-    fn parse_filter_equals() {
-        let q = parse_query("filter level = \"ERROR\"");
-        assert_eq!(q.filters.len(), 1);
-        match &q.filters[0] {
-            FilterClause::Equals { field, value } => {
-                assert_eq!(field, "level");
-                assert_eq!(value, "ERROR");
-            }
-            _ => panic!("expected Equals"),
+        assert_eq!(q.commands.len(), 2);
+        match &q.commands[0] {
+            Command::Fields(f) => assert_eq!(f, &vec!["@timestamp", "@message"]),
+            _ => panic!("expected Fields"),
+        }
+        match &q.commands[1] {
+            Command::Limit(n) => assert_eq!(*n, 5),
+            _ => panic!("expected Limit"),
         }
     }
 
     #[test]
-    fn parse_filter_like_regex() {
-        let q = parse_query("filter @message like /ERROR/");
-        assert_eq!(q.filters.len(), 1);
-        match &q.filters[0] {
-            FilterClause::Like { field, pattern } => {
-                assert_eq!(field, "@message");
-                assert_eq!(pattern, "ERROR");
-            }
-            _ => panic!("expected Like"),
-        }
+    fn execute_filters_events() {
+        let streams = vec![stream(
+            "s1",
+            vec![
+                ev(1000000, "ERROR: broke"),
+                ev(2000000, "INFO: ok"),
+                ev(3000000, "ERROR: again"),
+            ],
+        )];
+        let q = parse_query("filter @message like /ERROR/ | limit 10");
+        let r = execute_query(&q, &streams, 0, 10000);
+        assert_eq!(r.len(), 2);
     }
 
     #[test]
-    fn parse_sort_desc() {
+    fn execute_json_field_filter() {
+        let streams = vec![stream(
+            "s1",
+            vec![
+                ev(1000000, r#"{"level":"ERROR","msg":"fail"}"#),
+                ev(2000000, r#"{"level":"INFO","msg":"ok"}"#),
+            ],
+        )];
+        let q = parse_query(r#"filter level = "ERROR""#);
+        let r = execute_query(&q, &streams, 0, 10000);
+        assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn execute_not_equals_filter() {
+        let streams = vec![stream(
+            "s1",
+            vec![
+                ev(1000000, r#"{"level":"ERROR"}"#),
+                ev(2000000, r#"{"level":"INFO"}"#),
+            ],
+        )];
+        let q = parse_query(r#"filter level != "ERROR""#);
+        let r = execute_query(&q, &streams, 0, 10000);
+        assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn stats_count_by_field() {
+        let streams = vec![stream(
+            "s1",
+            vec![
+                ev(1000000, r#"{"level":"ERROR"}"#),
+                ev(2000000, r#"{"level":"INFO"}"#),
+                ev(3000000, r#"{"level":"ERROR"}"#),
+                ev(4000000, r#"{"level":"ERROR"}"#),
+            ],
+        )];
+        let q = parse_query("stats count(*) by level");
+        let rows = execute_query(&q, &streams, 0, 10000);
+        assert_eq!(rows.len(), 2);
+        let error_row = rows
+            .iter()
+            .find(|row| {
+                row.as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|f| f["field"] == "level" && f["value"] == "ERROR")
+            })
+            .unwrap();
+        let count = error_row
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|f| f["field"] == "count(*)")
+            .unwrap();
+        assert_eq!(count["value"], "3");
+    }
+
+    #[test]
+    fn stats_sum_avg() {
+        let streams = vec![stream(
+            "s1",
+            vec![
+                ev(1000000, r#"{"svc":"a","latency":10}"#),
+                ev(2000000, r#"{"svc":"a","latency":30}"#),
+            ],
+        )];
+        let q = parse_query("stats sum(latency) as total, avg(latency) as mean by svc");
+        let rows = execute_query(&q, &streams, 0, 10000);
+        assert_eq!(rows.len(), 1);
+        let row = rows[0].as_array().unwrap();
+        let total = row.iter().find(|f| f["field"] == "total").unwrap();
+        let mean = row.iter().find(|f| f["field"] == "mean").unwrap();
+        assert_eq!(total["value"], "40");
+        assert_eq!(mean["value"], "20");
+    }
+
+    #[test]
+    fn ptr_is_base64_group_stream_index() {
+        use base64::Engine;
+        let streams = vec![stream("s1", vec![ev(1000000, "hello")])];
+        let q = parse_query("fields @message");
+        let rows = execute_query(&q, &streams, 0, 10000);
+        let row = rows[0].as_array().unwrap();
+        let ptr = row.iter().find(|f| f["field"] == "@ptr").unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(ptr["value"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(String::from_utf8(decoded).unwrap(), "/g|s1|0");
+    }
+
+    #[test]
+    fn parse_glob_extracts_fields() {
+        let streams = vec![stream("s1", vec![ev(1000000, "GET /api 200")])];
+        let q =
+            parse_query("parse @message \"* * *\" as method, path, code | filter code = \"200\"");
+        let rows = execute_query(&q, &streams, 0, 10000);
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn dedup_drops_duplicates() {
+        let streams = vec![stream(
+            "s1",
+            vec![
+                ev(1000000, r#"{"level":"ERROR"}"#),
+                ev(2000000, r#"{"level":"ERROR"}"#),
+                ev(3000000, r#"{"level":"INFO"}"#),
+            ],
+        )];
+        let q = parse_query("dedup level");
+        let rows = execute_query(&q, &streams, 0, 10000);
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn sort_desc_by_timestamp() {
+        let streams = vec![stream(
+            "s1",
+            vec![
+                ev(1000000, "first"),
+                ev(3000000, "third"),
+                ev(2000000, "second"),
+            ],
+        )];
         let q = parse_query("sort @timestamp desc");
-        assert_eq!(q.sort_field.as_deref(), Some("@timestamp"));
-        assert!(q.sort_desc);
-    }
-
-    #[test]
-    fn parse_sort_asc() {
-        let q = parse_query("sort @timestamp asc");
-        assert_eq!(q.sort_field.as_deref(), Some("@timestamp"));
-        assert!(!q.sort_desc);
-    }
-
-    #[test]
-    fn parse_complex_query() {
-        let q = parse_query(
-            "fields @timestamp, @message | filter @message like /ERROR/ | sort @timestamp desc | limit 10",
-        );
-        assert_eq!(q.fields, vec!["@timestamp", "@message"]);
-        assert_eq!(q.filters.len(), 1);
-        assert_eq!(q.sort_field.as_deref(), Some("@timestamp"));
-        assert!(q.sort_desc);
-        assert_eq!(q.limit, Some(10));
-    }
-
-    #[test]
-    fn execute_query_filters_events() {
-        let events = vec![(
-            "stream-1".to_string(),
-            vec![
-                LogEvent {
-                    timestamp: 1000000,
-                    message: "ERROR: something broke".to_string(),
-                    ingestion_time: 1000000,
-                },
-                LogEvent {
-                    timestamp: 2000000,
-                    message: "INFO: all good".to_string(),
-                    ingestion_time: 2000000,
-                },
-                LogEvent {
-                    timestamp: 3000000,
-                    message: "ERROR: another failure".to_string(),
-                    ingestion_time: 3000000,
-                },
-            ],
-        )];
-
-        let query = parse_query("filter @message like /ERROR/ | limit 10");
-        let results = execute_query(&query, &events, 0, 10000);
-        assert_eq!(results.len(), 2);
-    }
-
-    #[test]
-    fn execute_query_limit() {
-        let events = vec![(
-            "stream-1".to_string(),
-            vec![
-                LogEvent {
-                    timestamp: 1000000,
-                    message: "msg1".to_string(),
-                    ingestion_time: 1000000,
-                },
-                LogEvent {
-                    timestamp: 2000000,
-                    message: "msg2".to_string(),
-                    ingestion_time: 2000000,
-                },
-                LogEvent {
-                    timestamp: 3000000,
-                    message: "msg3".to_string(),
-                    ingestion_time: 3000000,
-                },
-            ],
-        )];
-
-        let query = parse_query("limit 2");
-        let results = execute_query(&query, &events, 0, 10000);
-        assert_eq!(results.len(), 2);
-    }
-
-    #[test]
-    fn execute_query_fields_selection() {
-        let events = vec![(
-            "stream-1".to_string(),
-            vec![LogEvent {
-                timestamp: 1000000,
-                message: "hello".to_string(),
-                ingestion_time: 1000000,
-            }],
-        )];
-
-        let query = parse_query("fields @message");
-        let results = execute_query(&query, &events, 0, 10000);
-        assert_eq!(results.len(), 1);
-
-        let row = results[0].as_array().unwrap();
-        let field_names: Vec<&str> = row.iter().map(|f| f["field"].as_str().unwrap()).collect();
-        assert!(field_names.contains(&"@message"));
-        assert!(field_names.contains(&"@ptr")); // always included
-        assert!(!field_names.contains(&"@timestamp")); // not requested
-    }
-
-    #[test]
-    fn execute_query_sort_desc() {
-        let events = vec![(
-            "stream-1".to_string(),
-            vec![
-                LogEvent {
-                    timestamp: 1000000,
-                    message: "first".to_string(),
-                    ingestion_time: 1000000,
-                },
-                LogEvent {
-                    timestamp: 3000000,
-                    message: "third".to_string(),
-                    ingestion_time: 3000000,
-                },
-                LogEvent {
-                    timestamp: 2000000,
-                    message: "second".to_string(),
-                    ingestion_time: 2000000,
-                },
-            ],
-        )];
-
-        let query = parse_query("sort @timestamp desc");
-        let results = execute_query(&query, &events, 0, 10000);
-        assert_eq!(results.len(), 3);
-        // First result should have the latest timestamp
-        let first_msg = results[0]
-            .as_array()
-            .unwrap()
-            .iter()
-            .find(|f| f["field"].as_str() == Some("@message"))
-            .unwrap();
-        assert_eq!(first_msg["value"].as_str().unwrap(), "third");
-    }
-
-    #[test]
-    fn execute_query_json_field_filter() {
-        let events = vec![(
-            "stream-1".to_string(),
-            vec![
-                LogEvent {
-                    timestamp: 1000000,
-                    message: r#"{"level":"ERROR","msg":"fail"}"#.to_string(),
-                    ingestion_time: 1000000,
-                },
-                LogEvent {
-                    timestamp: 2000000,
-                    message: r#"{"level":"INFO","msg":"ok"}"#.to_string(),
-                    ingestion_time: 2000000,
-                },
-            ],
-        )];
-
-        let query = parse_query(r#"filter level = "ERROR""#);
-        let results = execute_query(&query, &events, 0, 10000);
-        assert_eq!(results.len(), 1);
-    }
-
-    #[test]
-    fn execute_query_not_equals_filter() {
-        let events = vec![(
-            "stream-1".to_string(),
-            vec![
-                LogEvent {
-                    timestamp: 1000000,
-                    message: r#"{"level":"ERROR","msg":"fail"}"#.to_string(),
-                    ingestion_time: 1000000,
-                },
-                LogEvent {
-                    timestamp: 2000000,
-                    message: r#"{"level":"INFO","msg":"ok"}"#.to_string(),
-                    ingestion_time: 2000000,
-                },
-            ],
-        )];
-
-        let query = parse_query(r#"filter level != "ERROR""#);
-        let results = execute_query(&query, &events, 0, 10000);
-        assert_eq!(results.len(), 1);
-        let msg = results[0]
-            .as_array()
-            .unwrap()
-            .iter()
-            .find(|f| f["field"].as_str() == Some("@message"))
-            .unwrap();
-        assert!(msg["value"].as_str().unwrap().contains("INFO"));
+        let rows = execute_query(&q, &streams, 0, 10000);
+        let first = rows[0].as_array().unwrap();
+        let msg = first.iter().find(|f| f["field"] == "@message").unwrap();
+        assert_eq!(msg["value"], "third");
     }
 }

--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -137,8 +137,10 @@ impl LogsService {
         // Collect events by stream from every group/identifier the query
         // referenced, not just the legacy single `log_group_name`. ARNs are
         // resolved to bare group names so multi-group StartQuery requests
-        // actually scan every requested group.
-        let mut stream_events: Vec<(String, Vec<LogEvent>)> = Vec::new();
+        // actually scan every requested group. Each event keeps its original
+        // index in the stream's full event list so the `@ptr` it produces
+        // round-trips through GetLogRecord.
+        let mut streams: Vec<query::QueryStream> = Vec::new();
         let mut seen_groups: std::collections::HashSet<String> = Default::default();
         let identifiers: Vec<String> = if query_info.log_group_identifiers.is_empty() {
             vec![query_info.log_group_name.clone()]
@@ -162,30 +164,33 @@ impl LogsService {
                     .retention_in_days
                     .map(|d| Utc::now().timestamp_millis() - (d as i64) * 86_400_000);
                 for stream in group.log_streams.values() {
-                    let events: Vec<LogEvent> = if let Some(cutoff) = retention_cutoff {
-                        stream
-                            .events
-                            .iter()
-                            .filter(|e| e.timestamp >= cutoff)
-                            .cloned()
-                            .collect()
-                    } else {
-                        stream.events.clone()
-                    };
-                    stream_events.push((stream.name.clone(), events));
+                    let events: Vec<(usize, LogEvent)> = stream
+                        .events
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, e)| {
+                            retention_cutoff.is_none_or(|cutoff| e.timestamp >= cutoff)
+                        })
+                        .map(|(i, e)| (i, e.clone()))
+                        .collect();
+                    streams.push(query::QueryStream {
+                        group_name: group_name.clone(),
+                        stream_name: stream.name.clone(),
+                        events,
+                    });
                 }
             }
         }
 
         let results = query::execute_query(
             &parsed,
-            &stream_events,
+            &streams,
             query_info.start_time,
             query_info.end_time,
         );
 
         let records_matched = results.len() as f64;
-        let total_scanned: usize = stream_events.iter().map(|(_, e)| e.len()).sum();
+        let total_scanned: usize = streams.iter().map(|s| s.events.len()).sum();
 
         Ok(AwsResponse::json(
             StatusCode::OK,


### PR DESCRIPTION
Fixes a cluster of confirmed CloudWatch + CloudWatch Logs correctness/stub bugs.

## CloudWatch (crates/fakecloud-cloudwatch)
- **Exact dimension matching (HIGH).** GetMetricStatistics and GetMetricData matched dimensions as a subset, so an empty Dimensions filter aggregated every datum and a partial filter over-matched. Both now require exact dimension-set equality; an empty filter matches only data published with no dimensions (each unique dimension combination is a distinct metric, per AWS). ListMetrics keeps its containment-filter semantics (correct for that op).
- **Metric-math Expression queries (MEDIUM).** GetMetricData ignored `Expression` queries and returned empty. New `metric_math` module evaluates arithmetic over referenced metric ids + numeric literals (`m1+m2`, `m1/m2*100`) aligned by timestamp, plus `SUM/AVG/MIN/MAX/COUNT` (single series -> scalar, `[m1,m2]` array -> element-wise). `ReturnData=false` inputs are excluded from results. Genuinely unsupported syntax returns a real per-result error message + StatusCode, never a silent empty.
- **Percentiles (MEDIUM).** GetMetricStatistics `ExtendedStatistics` and GetMetricData `Stat=pNN` now compute `pNN` (linear interpolation) from each bucket's raw value samples. (Distributions published as StatisticValues don't retain raw values, so they don't contribute to percentiles.)
- **Pagination (MEDIUM).** DescribeAlarms honors MaxRecords (cap 100) and emits/round-trips a NextToken across the combined metric + composite result set; ListMetrics paginates at 500/page with a NextToken.
- **DescribeAlarmHistory (was a stub).** PutMetricAlarm records a ConfigurationUpdate item, SetAlarmState a StateUpdate item; DeleteAlarms clears history. DescribeAlarmHistory filters by AlarmName/HistoryItemType/date range, sorts by ScanBy, and paginates.
- **GetInsightRuleReport (was all-zero constants).** Now derives KeyLabels and AggregationStatistic from the rule's actual definition and validates the Metrics enum. Contributor data itself is **descoped (real reason)**: fakecloud has no log-ingestion -> Contributor Insights pipeline, so there are genuinely no contributors; the report stays honestly empty rather than fabricating values.

## CloudWatch Logs (crates/fakecloud-logs)
- **Insights stats/parse/display/dedup (MEDIUM).** The query engine is now an ordered pipeline. Adds `stats` (count/sum/avg/min/max/count_distinct, optional `by` grouping) returning aggregated rows, plus `parse` (glob `*` capture), `display`, and `dedup`, on top of the existing fields/filter/sort/limit.
- **@ptr fix.** `@ptr` is now `base64(group|stream|index)` so a result row resolves through GetLogRecord (previously `stream/timestamp`, which never decoded).

## Tests
Unit tests for the metric-math evaluator and the Logs query pipeline (stats/parse/dedup/@ptr). E2E (crates/fakecloud-e2e/tests):
- exact dimensions: dimensionless GetMetricStatistics(Sum) is empty, exact-set query returns only that set
- GetMetricData Expression `m1+m2` returns the sum series
- ExtendedStatistics p50 returns a value
- DescribeAlarms + ListMetrics paginate with NextToken
- DescribeAlarmHistory shows a StateUpdate after a transition
- Logs `stats count(*) by level` returns aggregated rows; raw-query `@ptr` resolves via GetLogRecord

## Validation
- cargo build, fmt --check, clippy (`-D warnings`) on both crates: clean
- cargo test for both crates: pass; new + existing CloudWatch/Logs E2E pass; CFN + persistence E2E for both services pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns CloudWatch and CloudWatch Logs with AWS behavior: exact dimension matching, metric-math and percentiles, real pagination and alarm history, plus a richer Logs Insights pipeline and a fixed `@ptr`. Improves query accuracy and makes alarms and Insights responses consistent.

- **New Features**
  - `GetMetricData` supports metric‑math `Expression` (arithmetic, `SUM/AVG/MIN/MAX/COUNT`; excludes `ReturnData=false`; clear errors on unsupported).
  - Percentiles (`pNN`) in `GetMetricStatistics` and `GetMetricData` computed from raw samples.
  - `DescribeAlarmHistory` returns real history from `PutMetricAlarm`, `SetAlarmState`, and `DeleteAlarms`.
  - Logs Insights adds `stats` (count/sum/avg/min/max/count_distinct with optional grouping), `parse` (glob), `display`, and `dedup`.
  - `GetInsightRuleReport` derives `KeyLabels` and `AggregationStatistic`, and validates the `Metrics` enum. Contributor data remains empty by design.

- **Bug Fixes**
  - Exact dimension‑set matching in `GetMetricStatistics` and `GetMetricData`; an empty filter matches only dimensionless data. `ListMetrics` keeps containment semantics.
  - Pagination: `DescribeAlarms` honors `MaxRecords` and `NextToken`; `ListMetrics` paginates at 500 per page with `NextToken`.
  - Logs `@ptr` now encodes `base64(group|stream|index)` so `GetLogRecord` resolves rows correctly.

<sup>Written for commit f876d02f9569004de871fe28345ebff86cde493c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

