### PR TITLE
fix(s3,elbv2,iam,cloudformation): copy-source-if-match, prober sibling-host, IAM pagination, CFN RDS port/attr + real EC2::Instance

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,17 +62,20 @@ jobs:
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
-      # Real artifact test: the published image must contain `nft`, or EC2
-      # security-group enforcement silently degrades even with CAP_NET_ADMIN
-      # (the #1539 Bug-4 / bug-hunt 2026-06-18 finding 0.1 class — "documented
-      # feature, missing binary"). Load the just-built native-arch image locally
-      # (reusing the gha cache) and assert the binary is present.
-      - name: Smoke-test image (nft present)
+      # Real artifact test: the published image must contain `nft` (EC2
+      # security-group enforcement) and the `docker` CLI (container-backed
+      # services spawn siblings via it), or those features silently degrade even
+      # with the right caps (the #1539 Bug-4 / bug-hunt 2026-06-18 finding 0.1
+      # class — "documented feature, missing binary"). Load the just-built
+      # native-arch image locally (reusing the gha cache) and assert the
+      # binaries are present.
+      - name: Smoke-test image (nft + docker CLI present)
         run: |
           docker buildx build --load \
             --cache-from type=gha,scope=${{ matrix.platform }} \
             -t fakecloud-smoke:test .
           docker run --rm --entrypoint nft fakecloud-smoke:test --version
+          docker run --rm --entrypoint docker fakecloud-smoke:test --version
 
       - name: Export digest
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -318,9 +318,24 @@ jobs:
           # rules, so the deny "bypasses" and every subsequent attempt fails
           # identically. Pruning before each attempt makes the retries genuinely
           # independent (the real fix for this job's intermittent failures).
+          # `docker network rm`/`prune` alone does NOT always reclaim Docker's
+          # default address pool once it gets wedged: a per-subnet bridge from a
+          # prior attempt can leave the pool in a state where the next
+          # `docker network create fakecloud-subnet-<id>` fails, and the runtime
+          # then falls back to docker0 (172.17.x). On docker0 same-subnet traffic
+          # never reaches fakecloud's per-subnet nft forward chain, so the deny
+          # silently bypasses and every later attempt fails identically on a
+          # 172.17.x instance IP (observed: attempt 1 on 172.18.x, attempts 2-3
+          # on 172.17.0.3). A full daemon restart is the only reliable way to
+          # recreate docker0 fresh and reclaim the pool; images (alpine:3) persist
+          # across the restart, so this is cheap. ensure_bridge_nf runs *after*
+          # this (docker recreating docker0 can reset bridge-nf-call-iptables).
           clean_docker() {
             sudo docker ps -aq --filter "label=fakecloud-ec2" | xargs -r sudo docker rm -f >/dev/null 2>&1 || true
             sudo docker network ls -q --filter "name=fakecloud-subnet-" | xargs -r sudo docker network rm >/dev/null 2>&1 || true
+            sudo docker network prune -f >/dev/null 2>&1 || true
+            sudo systemctl restart docker 2>/dev/null || sudo service docker restart 2>/dev/null || true
+            for _ in $(seq 1 30); do sudo docker info >/dev/null 2>&1 && break; sleep 1; done
             sudo docker network prune -f >/dev/null 2>&1 || true
           }
           run_once() {

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG TARGETARCH
 # Pin a docker CLI built with a current Go toolchain — the static build
 # bakes the Go stdlib into the binary, so a stale toolchain trips the
 # image's Trivy CRITICAL/HIGH gate (27.5.1 shipped go1.22.11, flagged by
-# CVE-2025-68121). 29.5.2 ships go1.26.3, which clears the gate.
+# CVE-2025-68121). 29.5.3 ships go1.26.3, which clears the gate.
 ARG DOCKER_CLI_VERSION=29.5.3
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates \

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
@@ -301,6 +301,93 @@ impl ResourceProvisioner {
         Ok(ProvisionResult::new(id.clone()).with("RouteTableId", id))
     }
 
+    /// `AWS::EC2::Instance` — create a REAL control-plane instance synchronously
+    /// (so `Ref` resolves to the `i-...` id and `Fn::GetAtt`
+    /// PrivateIp/PublicIp/AvailabilityZone resolve during provisioning), then
+    /// queue a spawn intent that backs it with a real container via the EC2
+    /// runtime — the same instance the direct `RunInstances` path launches.
+    /// Previously this fell through to the no-op `other =>` catch-all and `Ref`
+    /// resolved to the bare logical id, inconsistent with ASG launching real
+    /// instances.
+    pub(super) fn create_ec2_instance(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let security_group_ids: Vec<String> = props
+            .get("SecurityGroupIds")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|x| x.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let spec = fakecloud_ec2::cfn_provision::CfnInstanceSpec {
+            image_id: prop_str(props, "ImageId").map(String::from),
+            instance_type: prop_str(props, "InstanceType").map(String::from),
+            subnet_id: prop_str(props, "SubnetId").map(String::from),
+            availability_zone: props
+                .get("AvailabilityZone")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+                .or_else(|| {
+                    props
+                        .get("Placement")
+                        .and_then(|p| p.get("AvailabilityZone"))
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                }),
+            security_group_ids,
+            key_name: prop_str(props, "KeyName").map(String::from),
+            user_data: prop_str(props, "UserData").map(String::from),
+            private_ip: prop_str(props, "PrivateIpAddress").map(String::from),
+        };
+
+        let attrs = fakecloud_ec2::cfn_provision::cfn_create(
+            self.ec2_state.clone(),
+            &self.account_id,
+            &self.region,
+            &spec,
+        );
+
+        // Apply the template's Tags to the created instance (mirrors a direct
+        // CreateTags) so DescribeInstances / cost reports reflect them.
+        if let Some(tags) = props.get("Tags").and_then(|v| v.as_array()) {
+            if !tags.is_empty() {
+                let mut params = HashMap::new();
+                params.insert("ResourceId.1".to_string(), attrs.instance_id.clone());
+                for (i, t) in tags.iter().enumerate() {
+                    if let (Some(k), Some(v)) = (
+                        t.get("Key").and_then(|v| v.as_str()),
+                        t.get("Value").and_then(|v| v.as_str()),
+                    ) {
+                        let n = i + 1;
+                        params.insert(format!("Tag.{n}.Key"), k.to_string());
+                        params.insert(format!("Tag.{n}.Value"), v.to_string());
+                    }
+                }
+                let _ = self.ec2_dispatch("CreateTags", params);
+            }
+        }
+
+        // Background the container boot via the spawn-intent drain so stack
+        // creation never blocks on a cold image pull / Pod readiness.
+        self.pending_container_spawns
+            .lock()
+            .push(super::ContainerSpawnIntent::Ec2Instance {
+                instance_id: attrs.instance_id.clone(),
+            });
+
+        let mut result = ProvisionResult::new(attrs.instance_id.clone())
+            .with("PrivateIp", attrs.private_ip)
+            .with("AvailabilityZone", attrs.availability_zone);
+        if let Some(public_ip) = attrs.public_ip {
+            result = result.with("PublicIp", public_ip);
+        }
+        Ok(result)
+    }
+
     /// Delete an EC2 resource by its physical id, routing through the real
     /// handler so dependent default resources are cleaned up correctly.
     pub(super) fn delete_ec2_resource(

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -965,6 +965,10 @@ pub enum ContainerSpawnIntent {
     /// its desired capacity by launching real container-backed EC2 instances
     /// via the EC2 runtime, matching the direct `CreateAutoScalingGroup` path.
     AsgInstances { group_name: String },
+    /// `AWS::EC2::Instance` — back the inserted (control-plane `pending`)
+    /// instance with a real container via the EC2 runtime, matching the direct
+    /// `RunInstances` path.
+    Ec2Instance { instance_id: String },
     /// `AWS::ElastiCache::CacheCluster` — back the inserted CacheCluster with a
     /// real Redis/Memcached container via the ElastiCache runtime, matching the
     /// direct `CreateCacheCluster` path.
@@ -1008,6 +1012,9 @@ pub enum ContainerTeardownIntent {
     /// `AWS::AutoScaling::AutoScalingGroup` -- terminate the REAL EC2 instances
     /// the group launched (captured before the group record was removed).
     AsgInstances { instance_ids: Vec<String> },
+    /// `AWS::EC2::Instance` -- terminate the REAL EC2 instance + reap its
+    /// backing container when the stack is deleted.
+    Ec2Instance { instance_id: String },
 }
 
 /// A queued custom-resource (`Custom::*`) Lambda invocation. Built by
@@ -1166,6 +1173,7 @@ impl ResourceProvisioner {
             "AWS::Batch::JobDefinition" => self.create_batch_job_definition(resource),
             "AWS::Batch::SchedulingPolicy" => self.create_batch_scheduling_policy(resource),
             "AWS::EC2::VPC" => self.create_ec2_vpc(resource),
+            "AWS::EC2::Instance" => self.create_ec2_instance(resource),
             "AWS::EC2::Subnet" => self.create_ec2_subnet(resource),
             "AWS::EC2::SecurityGroup" => self.create_ec2_security_group(resource),
             "AWS::EC2::InternetGateway" => self.create_ec2_internet_gateway(resource),
@@ -1511,6 +1519,7 @@ impl ResourceProvisioner {
             | "AWS::EC2::Subnet"
             | "AWS::EC2::SecurityGroup"
             | "AWS::EC2::InternetGateway"
+            | "AWS::EC2::Instance"
             | "AWS::EC2::RouteTable" => self.get_att_ec2(resource, attribute),
             "AWS::ECS::CapacityProvider" => {
                 self.get_att_ecs_capacity_provider(&resource.physical_id, attribute)
@@ -1733,6 +1742,17 @@ impl ResourceProvisioner {
             "AWS::RDS::DBProxy" => self.delete_rds_db_proxy(&resource.physical_id),
             "AWS::RDS::DBInstance" => self.delete_rds_db_instance(&resource.physical_id),
             "AWS::RDS::DBCluster" => self.delete_rds_db_cluster(&resource.physical_id),
+            "AWS::EC2::Instance" => {
+                // Queue terminating the REAL instance + reaping its backing
+                // container so the stack delete drain doesn't leak an EC2
+                // container.
+                self.pending_container_teardowns.lock().push(
+                    ContainerTeardownIntent::Ec2Instance {
+                        instance_id: resource.physical_id.clone(),
+                    },
+                );
+                Ok(())
+            }
             "AWS::EC2::VPC"
             | "AWS::EC2::Subnet"
             | "AWS::EC2::SecurityGroup"

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
@@ -370,11 +370,14 @@ impl ResourceProvisioner {
             .get("DBName")
             .and_then(|v| v.as_str())
             .map(String::from);
+        // Default the port from the engine (MySQL/MariaDB -> 3306, Oracle ->
+        // 1521, SQL Server -> 1433, Db2 -> 50000, Postgres -> 5432) instead of
+        // hardcoding 5432 for every engine.
         let port = props
             .get("Port")
             .and_then(|v| v.as_i64())
             .map(|n| n as i32)
-            .unwrap_or(5432);
+            .unwrap_or_else(|| fakecloud_rds::default_port_for_engine(&engine));
         let allocated_storage = props
             .get("AllocatedStorage")
             .and_then(|v| {
@@ -468,6 +471,7 @@ impl ResourceProvisioner {
             state.region
         );
         let dbi_resource_id = format!("db-{}", Uuid::new_v4().simple());
+        let dbi_resource_id_attr = dbi_resource_id.clone();
         let inst = DbInstance {
             db_instance_identifier: identifier.clone(),
             db_instance_arn: arn.clone(),
@@ -628,7 +632,7 @@ impl ResourceProvisioner {
             .with("DBInstanceArn", arn)
             .with("Endpoint.Address", endpoint)
             .with("Endpoint.Port", endpoint_port.to_string())
-            .with("DbiResourceId", format!("db-{identifier}")))
+            .with("DbiResourceId", dbi_resource_id_attr))
     }
 
     pub(super) fn delete_rds_db_instance(&self, physical_id: &str) -> Result<(), String> {

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -456,6 +456,20 @@ impl ContainerBackingHandles {
                         .await;
                     });
                 }
+                ContainerSpawnIntent::Ec2Instance { instance_id } => {
+                    let ec2_state = self.ec2_state.clone();
+                    let ec2_runtime = self.ec2_runtime.clone();
+                    let account = self.account_id.clone();
+                    tokio::spawn(async move {
+                        fakecloud_ec2::cfn_provision::cfn_back_instance(
+                            ec2_state,
+                            ec2_runtime,
+                            account,
+                            instance_id,
+                        )
+                        .await;
+                    });
+                }
                 ContainerSpawnIntent::ElastiCacheCluster { cache_cluster_id } => {
                     if let Some(runtime) = self.elasticache_runtime.clone() {
                         let ec_state = self.elasticache_state.clone();
@@ -575,6 +589,22 @@ impl ContainerBackingHandles {
                             .await;
                         });
                     }
+                }
+                ContainerTeardownIntent::Ec2Instance { instance_id } => {
+                    let ec2_state = self.ec2_state.clone();
+                    let ec2_runtime = self.ec2_runtime.clone();
+                    let account = self.account_id.clone();
+                    let region = self.region.clone();
+                    tokio::spawn(async move {
+                        fakecloud_ec2::cfn_provision::cfn_terminate(
+                            ec2_state,
+                            ec2_runtime,
+                            account,
+                            region,
+                            instance_id,
+                        )
+                        .await;
+                    });
                 }
                 ContainerTeardownIntent::AsgInstances { instance_ids } => {
                     let asg_state = self.autoscaling_state.clone();

--- a/crates/fakecloud-e2e/tests/cloudformation_rds_port_and_ec2_instance.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_rds_port_and_ec2_instance.rs
@@ -1,0 +1,123 @@
+//! CloudFormation provisioner fixes:
+//! - An RDS DBInstance with no Port defaults the port from the engine
+//!   (MySQL -> 3306) via Fn::GetAtt Endpoint.Port, not a hardcoded 5432.
+//! - Fn::GetAtt DbiResourceId matches the value DescribeDBInstances returns
+//!   (previously the GetAtt refabricated `db-<identifier>` while the record
+//!   stored a real `db-<uuid>`).
+//! - AWS::EC2::Instance provisions a REAL instance: Ref resolves to the
+//!   `i-...` id and DescribeInstances finds it (previously it fell to the
+//!   accept-and-ignore catch-all and Ref returned the bare logical id).
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::Capability;
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Db": {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "DBInstanceIdentifier": "mysql-noport",
+        "DBInstanceClass": "db.t4g.micro",
+        "Engine": "mysql",
+        "EngineVersion": "8.0",
+        "MasterUsername": "admin",
+        "MasterUserPassword": "hunter2-secret",
+        "AllocatedStorage": "20"
+      }
+    },
+    "Instance": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "ImageId": "ami-0123456789abcdef0",
+        "InstanceType": "t3.micro"
+      }
+    }
+  },
+  "Outputs": {
+    "DbPort": {"Value": {"Fn::GetAtt": ["Db", "Endpoint.Port"]}},
+    "DbResourceId": {"Value": {"Fn::GetAtt": ["Db", "DbiResourceId"]}},
+    "InstanceRef": {"Value": {"Ref": "Instance"}},
+    "InstanceAz": {"Value": {"Fn::GetAtt": ["Instance", "AvailabilityZone"]}}
+  }
+}"#;
+
+fn output<'a>(stack: &'a aws_sdk_cloudformation::types::Stack, key: &str) -> &'a str {
+    stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some(key))
+        .and_then(|o| o.output_value())
+        .unwrap_or_else(|| panic!("output {key} present"))
+}
+
+#[tokio::test]
+async fn cfn_rds_engine_port_and_real_ec2_instance() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let rds = server.rds_client().await;
+    let ec2 = server.ec2_client().await;
+
+    cfn.create_stack()
+        .stack_name("port-ec2-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("port-ec2-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    // MySQL with no Port -> 3306, not 5432.
+    assert_eq!(output(stack, "DbPort"), "3306");
+
+    // DbiResourceId GetAtt matches DescribeDBInstances.
+    let getatt_resource_id = output(stack, "DbResourceId");
+    let inst = rds
+        .describe_db_instances()
+        .db_instance_identifier("mysql-noport")
+        .send()
+        .await
+        .expect("describe_db_instances");
+    let db = inst.db_instances().first().expect("db present");
+    assert_eq!(db.dbi_resource_id(), Some(getatt_resource_id));
+    assert!(
+        getatt_resource_id.starts_with("db-"),
+        "resource id should be db-<uuid>: {getatt_resource_id}"
+    );
+    // Stored DescribeDBInstances port also reflects the engine default.
+    assert_eq!(db.endpoint().and_then(|e| e.port()), Some(3306));
+
+    // EC2::Instance Ref resolves to a real i- id and DescribeInstances finds it.
+    let instance_ref = output(stack, "InstanceRef");
+    assert!(
+        instance_ref.starts_with("i-"),
+        "Ref should resolve to an instance id: {instance_ref}"
+    );
+    assert!(!output(stack, "InstanceAz").is_empty(), "AZ GetAtt present");
+
+    let di = ec2
+        .describe_instances()
+        .instance_ids(instance_ref)
+        .send()
+        .await
+        .expect("describe_instances");
+    let found = di
+        .reservations()
+        .iter()
+        .flat_map(|r| r.instances())
+        .any(|i| i.instance_id() == Some(instance_ref));
+    assert!(
+        found,
+        "CFN-created instance {instance_ref} must be described"
+    );
+}

--- a/crates/fakecloud-e2e/tests/iam_pagination_filters.rs
+++ b/crates/fakecloud-e2e/tests/iam_pagination_filters.rs
@@ -1,0 +1,125 @@
+//! IAM pagination / filter fidelity:
+//! - ListPolicies honors OnlyAttached.
+//! - GetGroup honors Marker/MaxItems and reports IsTruncated.
+//! - ListAccessKeys raises NoSuchEntity for a nonexistent user.
+
+mod helpers;
+
+use aws_sdk_iam::types::PolicyScopeType;
+use helpers::TestServer;
+
+const POLICY_DOC: &str = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#;
+
+#[tokio::test]
+async fn list_policies_only_attached_filters_unattached() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    let attached = iam
+        .create_policy()
+        .policy_name("attached-pol")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .expect("create attached policy");
+    let attached_arn = attached.policy().unwrap().arn().unwrap().to_string();
+
+    iam.create_policy()
+        .policy_name("lonely-pol")
+        .policy_document(POLICY_DOC)
+        .send()
+        .await
+        .expect("create unattached policy");
+
+    iam.create_user()
+        .user_name("pol-user")
+        .send()
+        .await
+        .expect("create user");
+    iam.attach_user_policy()
+        .user_name("pol-user")
+        .policy_arn(&attached_arn)
+        .send()
+        .await
+        .expect("attach policy");
+
+    let listed = iam
+        .list_policies()
+        .scope(PolicyScopeType::Local)
+        .only_attached(true)
+        .send()
+        .await
+        .expect("list_policies only_attached");
+    let names: Vec<&str> = listed
+        .policies()
+        .iter()
+        .filter_map(|p| p.policy_name())
+        .collect();
+    assert!(
+        names.contains(&"attached-pol"),
+        "attached policy must be listed: {names:?}"
+    );
+    assert!(
+        !names.contains(&"lonely-pol"),
+        "unattached policy must be filtered out: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn get_group_paginates_members() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    iam.create_group()
+        .group_name("paged-group")
+        .send()
+        .await
+        .expect("create group");
+    for u in ["m-alice", "m-bob", "m-carol"] {
+        iam.create_user().user_name(u).send().await.expect("user");
+        iam.add_user_to_group()
+            .group_name("paged-group")
+            .user_name(u)
+            .send()
+            .await
+            .expect("add to group");
+    }
+
+    let page1 = iam
+        .get_group()
+        .group_name("paged-group")
+        .max_items(2)
+        .send()
+        .await
+        .expect("get_group page1");
+    assert_eq!(page1.users().len(), 2, "first page should hold MaxItems=2");
+    assert!(page1.is_truncated(), "first page must be truncated");
+    let marker = page1.marker().expect("truncated page returns a marker");
+
+    let page2 = iam
+        .get_group()
+        .group_name("paged-group")
+        .marker(marker)
+        .send()
+        .await
+        .expect("get_group page2");
+    assert_eq!(page2.users().len(), 1, "second page should hold remainder");
+    assert!(!page2.is_truncated(), "second page must not be truncated");
+}
+
+#[tokio::test]
+async fn list_access_keys_missing_user_is_no_such_entity() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    let err = iam
+        .list_access_keys()
+        .user_name("ghost-user")
+        .send()
+        .await
+        .expect_err("missing user must error");
+    assert!(
+        err.into_service_error().is_no_such_entity_exception(),
+        "expected NoSuchEntity for a nonexistent user"
+    );
+}

--- a/crates/fakecloud-e2e/tests/s3_copy_source_if_match.rs
+++ b/crates/fakecloud-e2e/tests/s3_copy_source_if_match.rs
@@ -1,0 +1,76 @@
+//! S3 CopyObject must honor `x-amz-copy-source-if-match`: a mismatched source
+//! ETag returns 412 PreconditionFailed (previously the header was never read,
+//! so the copy succeeded with a 200).
+
+mod helpers;
+
+use aws_sdk_s3::primitives::ByteStream;
+use helpers::TestServer;
+
+#[tokio::test]
+async fn copy_object_enforces_copy_source_if_match() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket()
+        .bucket("cp-bucket")
+        .send()
+        .await
+        .expect("create_bucket");
+
+    let put = s3
+        .put_object()
+        .bucket("cp-bucket")
+        .key("src.txt")
+        .body(ByteStream::from_static(b"hello copy source"))
+        .send()
+        .await
+        .expect("put_object");
+    let src_etag = put.e_tag().expect("etag").to_string();
+
+    // Mismatched copy-source-if-match -> 412 PreconditionFailed, no copy.
+    let err = s3
+        .copy_object()
+        .bucket("cp-bucket")
+        .key("dst-bad.txt")
+        .copy_source("cp-bucket/src.txt")
+        .copy_source_if_match("\"deadbeefdeadbeefdeadbeefdeadbeef\"")
+        .send()
+        .await
+        .expect_err("mismatched copy-source-if-match must fail");
+    let raw = err.into_service_error();
+    let msg = format!("{raw:?}");
+    assert!(
+        msg.contains("PreconditionFailed") || msg.contains("412"),
+        "expected PreconditionFailed, got: {msg}"
+    );
+
+    // The bad copy must not have created the destination object.
+    let head_bad = s3
+        .head_object()
+        .bucket("cp-bucket")
+        .key("dst-bad.txt")
+        .send()
+        .await;
+    assert!(head_bad.is_err(), "412 copy must not create the object");
+
+    // Matching copy-source-if-match -> 200, copy succeeds.
+    s3.copy_object()
+        .bucket("cp-bucket")
+        .key("dst-ok.txt")
+        .copy_source("cp-bucket/src.txt")
+        .copy_source_if_match(&src_etag)
+        .send()
+        .await
+        .expect("matching copy-source-if-match must succeed");
+
+    let got = s3
+        .get_object()
+        .bucket("cp-bucket")
+        .key("dst-ok.txt")
+        .send()
+        .await
+        .expect("get copied object");
+    let body = got.body.collect().await.expect("body").into_bytes();
+    assert_eq!(&body[..], b"hello copy source");
+}

--- a/crates/fakecloud-ec2/src/cfn_provision.rs
+++ b/crates/fakecloud-ec2/src/cfn_provision.rs
@@ -1,0 +1,56 @@
+//! CloudFormation-driven provisioning for `AWS::EC2::Instance`.
+//!
+//! The CFN provisioner inserts the instance record synchronously (control plane
+//! only, status `pending`, so `Ref`/`GetAtt` resolve to a real `i-...` id and
+//! its IPs during provisioning), then asks EC2 to back it with a REAL container
+//! in a background task -- the same container the direct `RunInstances` path
+//! spawns -- so a CFN-provisioned instance is genuinely backed, not phantom
+//! metadata. With no EC2 runtime wired (CI / metadata-only) the instance still
+//! reaches `running` via the metadata-only path, matching the direct API.
+
+use std::sync::Arc;
+
+use crate::service::instance::{cfn_boot_instance, cfn_create_instance, cfn_terminate_instance};
+use crate::{Ec2Runtime, Ec2Service, SharedEc2State};
+
+pub use crate::service::instance::{CfnInstanceAttrs, CfnInstanceSpec};
+
+/// Synchronously create a control-plane `AWS::EC2::Instance` record and return
+/// its Ref/GetAtt attributes (instance id, private/public IP, AZ).
+pub fn cfn_create(
+    state: SharedEc2State,
+    account_id: &str,
+    region: &str,
+    spec: &CfnInstanceSpec,
+) -> CfnInstanceAttrs {
+    let svc = Ec2Service::with_state(state);
+    cfn_create_instance(&svc, account_id, region, spec)
+}
+
+/// Boot the REAL backing container for a CFN-created instance and reconcile it
+/// to `running`. No-op if the instance is gone (e.g. the stack was deleted
+/// before this ran). Intended to be `tokio::spawn`ed by the CloudFormation
+/// `CreateStack` drain.
+pub async fn cfn_back_instance(
+    state: SharedEc2State,
+    runtime: Option<Arc<Ec2Runtime>>,
+    account_id: String,
+    instance_id: String,
+) {
+    let svc = Ec2Service::with_state(state).with_runtime(runtime);
+    cfn_boot_instance(&svc, &account_id, &instance_id).await;
+}
+
+/// Terminate a CFN-created instance and reap its REAL backing container when its
+/// stack is deleted. Intended to be `tokio::spawn`ed by the CloudFormation
+/// delete drain.
+pub async fn cfn_terminate(
+    state: SharedEc2State,
+    runtime: Option<Arc<Ec2Runtime>>,
+    account_id: String,
+    region: String,
+    instance_id: String,
+) {
+    let svc = Ec2Service::with_state(state).with_runtime(runtime);
+    cfn_terminate_instance(&svc, &account_id, &region, &instance_id).await;
+}

--- a/crates/fakecloud-ec2/src/lib.rs
+++ b/crates/fakecloud-ec2/src/lib.rs
@@ -7,6 +7,7 @@
 //! tagging subsystem, and the region/AZ/account-attribute describe primitives
 //! that almost every SDK client calls implicitly.
 
+pub mod cfn_provision;
 pub mod defaults;
 pub mod runtime;
 pub mod service;

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -485,6 +485,262 @@ fn reconcile_started(
     }
 }
 
+/// Inputs for a CloudFormation-driven `AWS::EC2::Instance` launch.
+#[derive(Debug, Clone, Default)]
+pub struct CfnInstanceSpec {
+    pub image_id: Option<String>,
+    pub instance_type: Option<String>,
+    pub subnet_id: Option<String>,
+    pub availability_zone: Option<String>,
+    pub security_group_ids: Vec<String>,
+    pub key_name: Option<String>,
+    pub user_data: Option<String>,
+    pub private_ip: Option<String>,
+}
+
+/// The Ref / GetAtt-resolvable attributes of a CFN-launched instance.
+#[derive(Debug, Clone)]
+pub struct CfnInstanceAttrs {
+    pub instance_id: String,
+    pub private_ip: String,
+    pub public_ip: Option<String>,
+    pub availability_zone: String,
+}
+
+/// Synchronously insert a control-plane `AWS::EC2::Instance` record (status
+/// `pending`) and return its Ref/GetAtt attributes. Mirrors the control-plane
+/// half of [`run_instances`] for a single instance so a CFN-provisioned
+/// instance resolves `Ref` to a real `i-...` id and `GetAtt`
+/// PrivateIp/PublicIp/AvailabilityZone immediately. The backing container is
+/// booted afterwards by [`cfn_boot_instance`] (drained off the request path).
+pub(crate) fn cfn_create_instance(
+    svc: &Ec2Service,
+    account_id: &str,
+    region: &str,
+    spec: &CfnInstanceSpec,
+) -> CfnInstanceAttrs {
+    let image_id = spec
+        .image_id
+        .clone()
+        .unwrap_or_else(|| "ami-00000000000000000".to_string());
+    let instance_type = spec
+        .instance_type
+        .clone()
+        .unwrap_or_else(|| "t3.micro".to_string());
+    let region = if region.is_empty() {
+        "us-east-1"
+    } else {
+        region
+    };
+    let mut subnet_id = spec.subnet_id.clone();
+    let mut sg_ids = spec.security_group_ids.clone();
+
+    let (vpc_id, subnet_auto_public, ip_prefix, az) = {
+        let accounts = svc.state.read();
+        let empty = Ec2State::new(account_id, region);
+        let state = accounts.get(account_id).unwrap_or(&empty);
+        // Resolve a default subnet when none is given, preferring the requested
+        // AZ, exactly like `run_instances`.
+        if subnet_id.is_none() {
+            let want_az = spec.availability_zone.clone();
+            if let Some(s) = state
+                .subnets
+                .values()
+                .filter(|s| s.default_for_az)
+                .find(|s| want_az.as_deref().is_none_or(|a| s.availability_zone == a))
+                .or_else(|| state.subnets.values().find(|s| s.default_for_az))
+            {
+                subnet_id = Some(s.subnet_id.clone());
+            }
+        }
+        let resolved_vpc = subnet_id
+            .as_ref()
+            .and_then(|sid| state.subnets.get(sid))
+            .map(|s| s.vpc_id.clone());
+        if sg_ids.is_empty() {
+            let vpc = resolved_vpc
+                .clone()
+                .unwrap_or_else(|| crate::defaults::default_vpc_id(account_id));
+            if let Some(sg) = state
+                .security_groups
+                .values()
+                .find(|g| g.vpc_id == vpc && g.group_name == "default")
+            {
+                sg_ids = vec![sg.group_id.clone()];
+            }
+        }
+        let (vpc, auto_public, az) = match subnet_id.as_ref() {
+            Some(sid) => state
+                .subnets
+                .get(sid)
+                .map(|s| {
+                    (
+                        Some(s.vpc_id.clone()),
+                        s.map_public_ip_on_launch || s.default_for_az,
+                        s.availability_zone.clone(),
+                    )
+                })
+                .unwrap_or((None, false, format!("{region}a"))),
+            None => (
+                Some(crate::defaults::default_vpc_id(account_id)),
+                true,
+                format!("{region}a"),
+            ),
+        };
+        let az = spec.availability_zone.clone().unwrap_or(az);
+        let ip_prefix = subnet_id
+            .as_ref()
+            .and_then(|sid| state.subnets.get(sid))
+            .map(|s| subnet_ip_prefix(&s.cidr_block))
+            .unwrap_or_else(|| "10.0.0".to_string());
+        (vpc, auto_public, ip_prefix, az)
+    };
+
+    let assign_public = subnet_auto_public;
+    let id = gen_id("i");
+    let private_ip = spec
+        .private_ip
+        .clone()
+        .unwrap_or_else(|| format!("{ip_prefix}.10"));
+    let public_ip = if assign_public {
+        Some("52.0.0.10".to_string())
+    } else {
+        None
+    };
+
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(account_id);
+        let inst = Instance {
+            instance_id: id.clone(),
+            image_id,
+            instance_type,
+            state_code: 0,
+            state_name: "pending".to_string(),
+            private_ip: private_ip.clone(),
+            public_ip: public_ip.clone(),
+            subnet_id: subnet_id.clone(),
+            vpc_id: vpc_id.clone(),
+            key_name: spec.key_name.clone(),
+            security_group_ids: sg_ids,
+            reservation_id: gen_id("r"),
+            ami_launch_index: 0,
+            monitoring: false,
+            az: az.clone(),
+            launch_time: LAUNCH_TIME.to_string(),
+            container_id: None,
+            disable_api_termination: false,
+            disable_api_stop: false,
+            source_dest_check: true,
+            ebs_optimized: false,
+            instance_initiated_shutdown_behavior: "stop".to_string(),
+            user_data: spec.user_data.clone().filter(|s| !s.is_empty()),
+            metadata_options: crate::state::MetadataOptions::default(),
+            cpu_options: None,
+            bandwidth_weighting: None,
+            maintenance_options: crate::state::MaintenanceOptions::default(),
+            placement_tenancy: None,
+            placement_affinity: None,
+            placement_group_name: None,
+        };
+        state.instances.insert(id.clone(), inst);
+    }
+
+    CfnInstanceAttrs {
+        instance_id: id,
+        private_ip,
+        public_ip,
+        availability_zone: az,
+    }
+}
+
+/// Boot the backing container for a CFN-created instance and reconcile it to
+/// `running` (or metadata-only `running` when no runtime is wired). Mirrors the
+/// background-boot half of [`run_instances`]. Intended to be `tokio::spawn`ed by
+/// the CloudFormation create drain so stack creation never blocks on a cold
+/// image pull / Pod readiness.
+pub(crate) async fn cfn_boot_instance(svc: &Ec2Service, account_id: &str, id: &str) {
+    let (user_data, instance_network) = {
+        let accounts = svc.state.read();
+        let Some(state) = accounts.get(account_id) else {
+            return;
+        };
+        let Some(inst) = state.instances.get(id) else {
+            return;
+        };
+        let network = inst
+            .subnet_id
+            .as_ref()
+            .map(|sid| crate::runtime::InstanceNetwork {
+                subnet_id: sid.clone(),
+                internal: !crate::defaults::subnet_is_public(state, sid),
+            });
+        (inst.user_data.clone(), network)
+    };
+
+    let empty_tags = std::collections::BTreeMap::new();
+    let running = if let Some(rt) = &svc.runtime {
+        match rt
+            .run_instance(
+                account_id,
+                id,
+                user_data.as_deref(),
+                &empty_tags,
+                instance_network.as_ref(),
+            )
+            .await
+        {
+            Ok(r) => Some(r),
+            Err(e) => {
+                tracing::warn!(instance_id = %id, error = %e, "CFN EC2 instance container failed to start; serving metadata-only");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    reconcile_started(&svc.state, account_id, id, running);
+
+    if let Some(rt) = &svc.runtime {
+        if rt.network_isolation_enforced() {
+            super::firewall_model::reconcile(&svc.state, rt).await;
+        }
+    }
+}
+
+/// Terminate a CFN-created instance (reaping its real backing container) when
+/// its stack is deleted. Routes through the real `TerminateInstances` handler so
+/// the container/Pod is stopped and the firewall re-reconciled, instead of
+/// leaking a running EC2 container. No-op if the instance is already gone.
+pub(crate) async fn cfn_terminate_instance(
+    svc: &Ec2Service,
+    account_id: &str,
+    region: &str,
+    instance_id: &str,
+) {
+    let mut query_params = std::collections::HashMap::new();
+    query_params.insert("InstanceId.1".to_string(), instance_id.to_string());
+    let req = AwsRequest {
+        service: "ec2".to_string(),
+        action: "TerminateInstances".to_string(),
+        region: region.to_string(),
+        account_id: account_id.to_string(),
+        request_id: gen_id("req"),
+        headers: http::HeaderMap::new(),
+        query_params,
+        body: bytes::Bytes::new(),
+        body_stream: parking_lot::Mutex::new(None),
+        path_segments: Vec::new(),
+        raw_path: "/".to_string(),
+        raw_query: String::new(),
+        method: http::Method::POST,
+        is_query_protocol: true,
+        access_key_id: None,
+        principal: None,
+    };
+    let _ = terminate_instances(svc, &req).await;
+}
+
 fn validate_enum_instance_type(req: &AwsRequest) -> Result<(), AwsServiceError> {
     // InstanceType has ~850 enum members; accept any non-empty value that looks
     // like a `family.size` token rather than enumerating them all.

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -10,7 +10,7 @@ mod firewall_model;
 mod fleet;
 mod ice;
 mod image;
-mod instance;
+pub(crate) mod instance;
 mod ipam;
 mod ipam_discovery;
 mod ipam_policy;

--- a/crates/fakecloud-elbv2/src/prober.rs
+++ b/crates/fakecloud-elbv2/src/prober.rs
@@ -23,6 +23,15 @@ pub fn spawn_prober(state: SharedElbv2State) {
         debug!("ELBv2 health probes disabled via {ENV_DISABLE}");
         return;
     }
+    // Detect once: EC2-instance (`i-*`) and ECS bridge-mode (`127.0.0.1`)
+    // targets publish their ports on the host daemon's loopback, reached via
+    // `sibling_host` (`127.0.0.1` on the host, or the host alias when fakecloud
+    // is itself containerized). This mirrors the data plane's
+    // `resolve_upstream_host` so probes succeed under FAKECLOUD_IN_CONTAINER=1
+    // instead of hitting fakecloud's own loopback and 503'ing every target.
+    let sibling_host = fakecloud_core::container_net::detect_container_cli()
+        .map(|cli| fakecloud_core::container_net::HostNetworking::detect(&cli).sibling_host)
+        .unwrap_or_else(|| "127.0.0.1".to_string());
     tokio::spawn(async move {
         // No client-level timeout: each probe wraps the request in a
         // `tokio::time::timeout` keyed off the target group's
@@ -38,7 +47,7 @@ pub fn spawn_prober(state: SharedElbv2State) {
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tick.tick().await;
-            run_one_pass(&state, &client).await;
+            run_one_pass(&state, &client, &sibling_host).await;
         }
     });
 }
@@ -58,7 +67,7 @@ struct ProbeJob {
     unhealthy_threshold: u32,
 }
 
-async fn run_one_pass(state: &SharedElbv2State, client: &Client) {
+async fn run_one_pass(state: &SharedElbv2State, client: &Client, sibling_host: &str) {
     let now = Utc::now();
     let jobs: Vec<ProbeJob> = {
         let accounts = state.read();
@@ -89,7 +98,7 @@ async fn run_one_pass(state: &SharedElbv2State, client: &Client) {
         return;
     }
 
-    let results = futures_concurrent(jobs, client).await;
+    let results = futures_concurrent(jobs, client, sibling_host).await;
 
     let mut accounts = state.write();
     for (job, ok) in results {
@@ -174,12 +183,17 @@ fn build_job(
     })
 }
 
-async fn futures_concurrent(jobs: Vec<ProbeJob>, client: &Client) -> Vec<(ProbeJob, bool)> {
+async fn futures_concurrent(
+    jobs: Vec<ProbeJob>,
+    client: &Client,
+    sibling_host: &str,
+) -> Vec<(ProbeJob, bool)> {
     let mut handles = Vec::with_capacity(jobs.len());
     for job in jobs {
         let client = client.clone();
+        let sibling_host = sibling_host.to_string();
         handles.push(tokio::spawn(async move {
-            let ok = probe(&client, &job).await;
+            let ok = probe(&client, &job, &sibling_host).await;
             (job, ok)
         }));
     }
@@ -192,12 +206,20 @@ async fn futures_concurrent(jobs: Vec<ProbeJob>, client: &Client) -> Vec<(ProbeJ
     out
 }
 
-async fn probe(client: &Client, job: &ProbeJob) -> bool {
-    let host = if job.target_id.starts_with("i-") {
-        "127.0.0.1".to_string()
+/// Resolve the host to probe for a target. EC2-instance (`i-*`) and ECS
+/// bridge-mode (`127.0.0.1`) targets publish on the host daemon's loopback and
+/// are reached via `sibling_host`; any other id (a real container IP/DNS) is
+/// used verbatim. Mirrors the data plane's `resolve_upstream_host`.
+fn resolve_probe_host(target_id: &str, sibling_host: &str) -> String {
+    if target_id.starts_with("i-") || target_id == "127.0.0.1" {
+        sibling_host.to_string()
     } else {
-        job.target_id.clone()
-    };
+        target_id.to_string()
+    }
+}
+
+async fn probe(client: &Client, job: &ProbeJob, sibling_host: &str) -> bool {
+    let host = resolve_probe_host(&job.target_id, sibling_host);
     let probe_timeout = Duration::from_secs(job.timeout_secs);
 
     match job.protocol.as_str() {
@@ -283,5 +305,34 @@ mod tests {
         assert!(matcher_matches("200,300-399", 350));
         assert!(matcher_matches("200,300-399", 200));
         assert!(!matcher_matches("200,300-399", 400));
+    }
+
+    #[test]
+    fn resolve_probe_host_uses_sibling_for_ec2_and_bridge() {
+        // EC2 instance ids resolve to the sibling host (host alias when
+        // fakecloud is itself containerized), not fakecloud's own loopback.
+        assert_eq!(
+            resolve_probe_host("i-0123456789abcdef0", "host.docker.internal"),
+            "host.docker.internal"
+        );
+        // ECS bridge-mode tasks register as 127.0.0.1 and resolve the same way.
+        assert_eq!(
+            resolve_probe_host("127.0.0.1", "host.docker.internal"),
+            "host.docker.internal"
+        );
+        // On the host, sibling_host is plain loopback.
+        assert_eq!(resolve_probe_host("i-abc", "127.0.0.1"), "127.0.0.1");
+    }
+
+    #[test]
+    fn resolve_probe_host_passes_real_container_ip_verbatim() {
+        assert_eq!(
+            resolve_probe_host("10.0.1.5", "host.docker.internal"),
+            "10.0.1.5"
+        );
+        assert_eq!(
+            resolve_probe_host("ip-10-0-1-5.ec2.internal", "host.docker.internal"),
+            "ip-10-0-1-5.ec2.internal"
+        );
     }
 }

--- a/crates/fakecloud-iam/src/iam_service/groups.rs
+++ b/crates/fakecloud-iam/src/iam_service/groups.rs
@@ -93,19 +93,75 @@ impl IamService {
             )
         })?;
 
-        let user_members: String = group
+        // Marker/MaxItems pagination over the group's members (the cursor is
+        // the member user name). Previously both were ignored and IsTruncated
+        // was hardcoded false, so large groups never paged.
+        validate_optional_string_length(
+            "marker",
+            req.query_params.get("Marker").map(|s| s.as_str()),
+            1,
+            320,
+        )?;
+        validate_optional_range_i64(
+            "maxItems",
+            parse_optional_i64_param(
+                "maxItems",
+                req.query_params.get("MaxItems").map(|s| s.as_str()),
+            )?,
+            1,
+            1000,
+        )?;
+        let max_items: usize = req
+            .query_params
+            .get("MaxItems")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(100);
+        let marker = req.query_params.get("Marker").cloned();
+
+        // Resolve members (skipping any whose user record vanished) preserving
+        // membership order, then page after the marker.
+        let resolved: Vec<&crate::state::IamUser> = group
             .members
             .iter()
-            .filter_map(|uname| {
-                state.users.get(uname).map(|u| {
-                    format!(
-                        "      <member>\n        <Path>{}</Path>\n        <UserName>{}</UserName>\n        <UserId>{}</UserId>\n        <Arn>{}</Arn>\n        <CreateDate>{}</CreateDate>\n      </member>",
-                        u.path, u.user_name, u.user_id, u.arn, u.created_at.format("%Y-%m-%dT%H:%M:%SZ")
-                    )
-                })
+            .filter_map(|uname| state.users.get(uname))
+            .collect();
+        let start_idx = marker
+            .as_ref()
+            .and_then(|m| {
+                resolved
+                    .iter()
+                    .position(|u| u.user_name == *m)
+                    .map(|p| p + 1)
+            })
+            .unwrap_or(0);
+        let rest = resolved.get(start_idx..).unwrap_or(&[]);
+        let is_truncated = rest.len() > max_items;
+        let page = if is_truncated {
+            &rest[..max_items]
+        } else {
+            rest
+        };
+        let next_marker = if is_truncated {
+            page.last().map(|u| u.user_name.clone())
+        } else {
+            None
+        };
+
+        let user_members: String = page
+            .iter()
+            .map(|u| {
+                format!(
+                    "      <member>\n        <Path>{}</Path>\n        <UserName>{}</UserName>\n        <UserId>{}</UserId>\n        <Arn>{}</Arn>\n        <CreateDate>{}</CreateDate>\n      </member>",
+                    u.path, u.user_name, u.user_id, u.arn, u.created_at.format("%Y-%m-%dT%H:%M:%SZ")
+                )
             })
             .collect::<Vec<_>>()
             .join("\n");
+
+        let marker_xml = next_marker
+            .as_deref()
+            .map(|m| format!("    <Marker>{m}</Marker>\n"))
+            .unwrap_or_default();
 
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -118,8 +174,8 @@ impl IamService {
       <Arn>{}</Arn>
       <CreateDate>{}</CreateDate>
     </Group>
-    <IsTruncated>false</IsTruncated>
-    <Users>
+    <IsTruncated>{is_truncated}</IsTruncated>
+{marker_xml}    <Users>
 {user_members}
     </Users>
   </GetGroupResult>

--- a/crates/fakecloud-iam/src/iam_service/policies.rs
+++ b/crates/fakecloud-iam/src/iam_service/policies.rs
@@ -202,6 +202,32 @@ impl IamService {
         if let Some(prefix) = path_prefix {
             policies.retain(|p| p.path.starts_with(&prefix));
         }
+
+        // PolicyUsageFilter selects which attachment relationship counts as
+        // "in use": permissions policies (default) vs permissions boundaries.
+        let usage_filter = req
+            .query_params
+            .get("PolicyUsageFilter")
+            .map(|s| s.as_str())
+            .unwrap_or("PermissionsPolicy");
+        // OnlyAttached: drop policies that are not attached (in the selected
+        // usage sense). Both were previously ignored, so unattached policies
+        // always came back.
+        let only_attached = req
+            .query_params
+            .get("OnlyAttached")
+            .map(|v| v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        if only_attached {
+            policies.retain(|p| {
+                if usage_filter.eq_ignore_ascii_case("PermissionsBoundary") {
+                    count_boundary_attachments(state, &p.arn) > 0
+                } else {
+                    count_managed_attachments(state, &p.arn) > 0
+                }
+            });
+        }
+
         policies.sort_by(|a, b| a.policy_name.cmp(&b.policy_name));
 
         // Marker-based pagination: resume after the marked item (by ARN, the
@@ -617,6 +643,34 @@ impl IamService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let policy_arn = required_param(&req.query_params, "PolicyArn")?;
         let entity_filter = req.query_params.get("EntityFilter").cloned();
+        validate_optional_string_length(
+            "pathPrefix",
+            req.query_params.get("PathPrefix").map(|s| s.as_str()),
+            1,
+            512,
+        )?;
+        validate_optional_string_length(
+            "marker",
+            req.query_params.get("Marker").map(|s| s.as_str()),
+            1,
+            320,
+        )?;
+        validate_optional_range_i64(
+            "maxItems",
+            parse_optional_i64_param(
+                "maxItems",
+                req.query_params.get("MaxItems").map(|s| s.as_str()),
+            )?,
+            1,
+            1000,
+        )?;
+        validate_optional_enum(
+            "policyUsageFilter",
+            req.query_params
+                .get("PolicyUsageFilter")
+                .map(|s| s.as_str()),
+            &["PermissionsPolicy", "PermissionsBoundary"],
+        )?;
         let accounts = self.state.read();
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -644,70 +698,160 @@ impl IamService {
             None | Some("Group") | Some("LocalManagedPolicy") | Some("AWSManagedPolicy")
         );
 
-        // Find roles attached to this policy
-        let role_members: String = if !include_roles {
-            String::new()
-        } else {
-            state
-            .role_policies
-            .iter()
-            .filter(|(_, arns)| arns.contains(&policy_arn))
-            .filter_map(|(role_name, _)| {
-                state.roles.get(role_name).map(|r| {
-                    format!(
-                        "      <member>\n        <RoleName>{}</RoleName>\n        <RoleId>{}</RoleId>\n      </member>",
-                        r.role_name, r.role_id
-                    )
-                })
+        let path_prefix = req.query_params.get("PathPrefix").cloned();
+        // PermissionsBoundary usage lists entities that reference the policy as
+        // their boundary (users/roles only); the default lists attachments.
+        let boundary_usage = req
+            .query_params
+            .get("PolicyUsageFilter")
+            .map(|v| v.eq_ignore_ascii_case("PermissionsBoundary"))
+            .unwrap_or(false);
+
+        // Build a unified, ordered entity list so pagination spans all three
+        // member kinds with a single Marker (cursor = "kind:name"). Previously
+        // Marker/MaxItems/PathPrefix/PolicyUsageFilter were all ignored.
+        #[derive(Clone, Copy, PartialEq)]
+        enum Kind {
+            Role,
+            User,
+            Group,
+        }
+        let path_ok = |p: &str| path_prefix.as_deref().is_none_or(|pre| p.starts_with(pre));
+        let mut entities: Vec<(Kind, String, String)> = Vec::new();
+
+        if include_roles {
+            for r in state.roles.values() {
+                let matches_policy = if boundary_usage {
+                    r.permissions_boundary.as_deref() == Some(policy_arn.as_str())
+                } else {
+                    state
+                        .role_policies
+                        .get(&r.role_name)
+                        .is_some_and(|arns| arns.contains(&policy_arn))
+                };
+                if matches_policy && path_ok(&r.path) {
+                    entities.push((Kind::Role, r.role_name.clone(), r.role_id.clone()));
+                }
+            }
+        }
+        if include_users {
+            for u in state.users.values() {
+                let matches_policy = if boundary_usage {
+                    u.permissions_boundary.as_deref() == Some(policy_arn.as_str())
+                } else {
+                    state
+                        .user_policies
+                        .get(&u.user_name)
+                        .is_some_and(|arns| arns.contains(&policy_arn))
+                };
+                if matches_policy && path_ok(&u.path) {
+                    entities.push((Kind::User, u.user_name.clone(), u.user_id.clone()));
+                }
+            }
+        }
+        // Groups cannot have permissions boundaries, so they never appear under
+        // the PermissionsBoundary usage filter.
+        if include_groups && !boundary_usage {
+            for g in state.groups.values() {
+                if g.attached_policies.contains(&policy_arn) && path_ok(&g.path) {
+                    entities.push((Kind::Group, g.group_name.clone(), g.group_id.clone()));
+                }
+            }
+        }
+
+        let cursor = |k: Kind, name: &str| {
+            let prefix = match k {
+                Kind::Role => "role",
+                Kind::User => "user",
+                Kind::Group => "group",
+            };
+            format!("{prefix}:{name}")
+        };
+        // Stable order: by kind (role, user, group) then name.
+        entities.sort_by(|a, b| {
+            let ka = match a.0 {
+                Kind::Role => 0,
+                Kind::User => 1,
+                Kind::Group => 2,
+            };
+            let kb = match b.0 {
+                Kind::Role => 0,
+                Kind::User => 1,
+                Kind::Group => 2,
+            };
+            ka.cmp(&kb).then_with(|| a.1.cmp(&b.1))
+        });
+
+        let max_items: usize = req
+            .query_params
+            .get("MaxItems")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(100);
+        let marker = req.query_params.get("Marker").cloned();
+        let start_idx = marker
+            .as_ref()
+            .and_then(|m| {
+                entities
+                    .iter()
+                    .position(|(k, name, _)| cursor(*k, name) == *m)
+                    .map(|p| p + 1)
             })
-            .collect::<Vec<_>>()
-            .join("\n")
+            .unwrap_or(0);
+        let rest = entities.get(start_idx..).unwrap_or(&[]);
+        let is_truncated = rest.len() > max_items;
+        let page = if is_truncated {
+            &rest[..max_items]
+        } else {
+            rest
+        };
+        let next_marker = if is_truncated {
+            page.last().map(|(k, name, _)| cursor(*k, name))
+        } else {
+            None
         };
 
-        // Find users attached to this policy
-        let user_members: String = if !include_users {
-            String::new()
-        } else {
-            state
-            .user_policies
+        let role_members = page
             .iter()
-            .filter(|(_, arns)| arns.contains(&policy_arn))
-            .filter_map(|(user_name, _)| {
-                state.users.get(user_name).map(|u| {
-                    format!(
-                        "      <member>\n        <UserName>{}</UserName>\n        <UserId>{}</UserId>\n      </member>",
-                        u.user_name, u.user_id
-                    )
-                })
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-        };
-
-        // Find groups attached to this policy
-        let group_members: String = if !include_groups {
-            String::new()
-        } else {
-            state
-            .groups
-            .values()
-            .filter(|g| g.attached_policies.contains(&policy_arn))
-            .map(|g| {
+            .filter(|(k, ..)| *k == Kind::Role)
+            .map(|(_, name, id)| {
                 format!(
-                    "      <member>\n        <GroupName>{}</GroupName>\n        <GroupId>{}</GroupId>\n      </member>",
-                    g.group_name, g.group_id
+                    "      <member>\n        <RoleName>{name}</RoleName>\n        <RoleId>{id}</RoleId>\n      </member>"
                 )
             })
             .collect::<Vec<_>>()
-            .join("\n")
-        };
+            .join("\n");
+        let user_members = page
+            .iter()
+            .filter(|(k, ..)| *k == Kind::User)
+            .map(|(_, name, id)| {
+                format!(
+                    "      <member>\n        <UserName>{name}</UserName>\n        <UserId>{id}</UserId>\n      </member>"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let group_members = page
+            .iter()
+            .filter(|(k, ..)| *k == Kind::Group)
+            .map(|(_, name, id)| {
+                format!(
+                    "      <member>\n        <GroupName>{name}</GroupName>\n        <GroupId>{id}</GroupId>\n      </member>"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let marker_xml = next_marker
+            .as_deref()
+            .map(|m| format!("    <Marker>{m}</Marker>\n"))
+            .unwrap_or_default();
 
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListEntitiesForPolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListEntitiesForPolicyResult>
-    <IsTruncated>false</IsTruncated>
-    <PolicyRoles>
+    <IsTruncated>{is_truncated}</IsTruncated>
+{marker_xml}    <PolicyRoles>
 {role_members}
     </PolicyRoles>
     <PolicyUsers>
@@ -795,6 +939,24 @@ fn count_managed_attachments(state: &crate::state::IamState, arn: &str) -> u32 {
     }
     for group in state.groups.values() {
         if group.attached_policies.iter().any(|a| a == arn) {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Count how many users/roles reference this policy ARN as their permissions
+/// boundary. Used by ListPolicies/ListEntitiesForPolicy with
+/// `PolicyUsageFilter=PermissionsBoundary`.
+fn count_boundary_attachments(state: &crate::state::IamState, arn: &str) -> u32 {
+    let mut count = 0u32;
+    for user in state.users.values() {
+        if user.permissions_boundary.as_deref() == Some(arn) {
+            count += 1;
+        }
+    }
+    for role in state.roles.values() {
+        if role.permissions_boundary.as_deref() == Some(arn) {
             count += 1;
         }
     }

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -660,6 +660,15 @@ impl IamService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        // A nonexistent user must raise NoSuchEntity, not return an empty 200
+        // (matches ListSigningCertificates).
+        if !state.users.contains_key(&user_name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchEntity",
+                format!("The user with name {user_name} cannot be found."),
+            ));
+        }
         let mut keys = state
             .access_keys
             .get(&user_name)
@@ -1351,6 +1360,15 @@ impl IamService {
             .cloned()
             .filter(|v| !v.is_empty())
             .unwrap_or_else(|| resolve_calling_user(state, &req.account_id));
+
+        // A nonexistent user must raise NoSuchEntity, not return an empty 200.
+        if !state.users.contains_key(&user_name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchEntity",
+                format!("The user with name {user_name} cannot be found."),
+            ));
+        }
 
         let keys = state.ssh_public_keys.get(&user_name);
         let members: String = keys

--- a/crates/fakecloud-rds/src/lib.rs
+++ b/crates/fakecloud-rds/src/lib.rs
@@ -5,6 +5,7 @@ pub(crate) mod service;
 pub(crate) mod state;
 pub(crate) mod validation;
 
+pub use service::service_helpers::default_port_for_engine;
 pub use service::RdsService;
 pub use state::{
     DbInstance, DbParameterGroup, DbSubnetGroup, RdsSnapshot, RdsState, RdsTag, SharedRdsState,

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -997,7 +997,7 @@ fn attach_cluster_member(state: &mut RdsState, cluster_id: &str, instance_id: &s
 }
 
 #[path = "../service_helpers.rs"]
-mod service_helpers;
+pub(crate) mod service_helpers;
 pub(crate) use service_helpers::*;
 
 #[cfg(test)]

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -1988,7 +1988,7 @@ pub(crate) fn default_db_name(engine: &str) -> &'static str {
 /// Pick the port AWS defaults to for a freshly-created instance of
 /// `engine`. Mirrors the AWS RDS defaults so client SDKs that connect
 /// without an explicit `--port` flag hit the right listener.
-pub(crate) fn default_port_for_engine(engine: &str) -> i32 {
+pub fn default_port_for_engine(engine: &str) -> i32 {
     match engine {
         "postgres" => 5432,
         "mysql" | "mariadb" => 3306,

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -356,6 +356,29 @@ impl S3Service {
             .get("x-amz-copy-source-range")
             .and_then(|v| v.to_str().ok());
 
+        // Copy-source preconditions (x-amz-copy-source-if-*). These were never
+        // read on the part-copy path, so a mismatched source still copied + 200'd.
+        let cs_if_match = req
+            .headers
+            .get("x-amz-copy-source-if-match")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let cs_if_none_match = req
+            .headers
+            .get("x-amz-copy-source-if-none-match")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let cs_if_modified_since = req
+            .headers
+            .get("x-amz-copy-source-if-modified-since")
+            .and_then(|v| v.to_str().ok())
+            .and_then(super::parse_http_date);
+        let cs_if_unmodified_since = req
+            .headers
+            .get("x-amz-copy-source-if-unmodified-since")
+            .and_then(|v| v.to_str().ok())
+            .and_then(super::parse_http_date);
+
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);
         let src_body_ref = {
@@ -371,6 +394,34 @@ impl S3Service {
                     .get(src_key)
                     .ok_or_else(|| no_such_key(src_key))?
             };
+            let precondition_412 = || {
+                AwsServiceError::aws_error(
+                    StatusCode::PRECONDITION_FAILED,
+                    "PreconditionFailed",
+                    "At least one of the pre-conditions you specified did not hold",
+                )
+            };
+            let src_etag = format!("\"{}\"", src_obj.etag);
+            if let Some(ref im) = cs_if_match {
+                if !super::etag_matches(im, &src_etag) {
+                    return Err(precondition_412());
+                }
+            }
+            if let Some(ref inm) = cs_if_none_match {
+                if super::etag_matches(inm, &src_etag) {
+                    return Err(precondition_412());
+                }
+            }
+            if let Some(since) = cs_if_unmodified_since {
+                if src_obj.last_modified > since {
+                    return Err(precondition_412());
+                }
+            }
+            if let Some(since) = cs_if_modified_since {
+                if src_obj.last_modified <= since {
+                    return Err(precondition_412());
+                }
+            }
             src_obj.body.clone()
         };
         let src_bytes = state.read_body(&src_body_ref).map_err(super::io_to_aws)?;

--- a/crates/fakecloud-s3/src/service/objects/read.rs
+++ b/crates/fakecloud-s3/src/service/objects/read.rs
@@ -151,7 +151,7 @@ impl S3Service {
             }
         }
         if let Some(ref redirect) = obj.website_redirect_location {
-            headers.insert("x-amz-website-redirect-location", redirect.parse().unwrap());
+            insert_str_header(&mut headers, "x-amz-website-redirect-location", redirect);
         }
         if !obj.tags.is_empty() {
             headers.insert(
@@ -532,7 +532,7 @@ impl S3Service {
             }
         }
         if let Some(ref redirect) = obj.website_redirect_location {
-            headers.insert("x-amz-website-redirect-location", redirect.parse().unwrap());
+            insert_str_header(&mut headers, "x-amz-website-redirect-location", redirect);
         }
         if !obj.tags.is_empty() {
             headers.insert(

--- a/crates/fakecloud-s3/src/service/objects/write.rs
+++ b/crates/fakecloud-s3/src/service/objects/write.rs
@@ -728,6 +728,12 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
+        let if_match = req
+            .headers
+            .get("x-amz-copy-source-if-match")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
         let if_none_match = req
             .headers
             .get("x-amz-copy-source-if-none-match")
@@ -769,6 +775,23 @@ impl S3Service {
             ));
         }
 
+        // x-amz-copy-source-if-match: fail with 412 when the source ETag does
+        // NOT match (bug-audit — this header was never read, so a mismatched
+        // source still copied + 200'd).
+        if let Some(ref im) = if_match {
+            let src_etag = format!("\"{}\"", src_obj.etag);
+            if !etag_matches(im, &src_etag) {
+                return Err(AwsServiceError::aws_error_with_fields(
+                    StatusCode::PRECONDITION_FAILED,
+                    "PreconditionFailed",
+                    "At least one of the pre-conditions you specified did not hold",
+                    vec![(
+                        "Condition".to_string(),
+                        "x-amz-copy-source-If-Match".to_string(),
+                    )],
+                ));
+            }
+        }
         if let Some(ref inm) = if_none_match {
             let src_etag = format!("\"{}\"", src_obj.etag);
             if etag_matches(inm, &src_etag) {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3899,10 +3899,13 @@ async fn main() {
     }
     if iam_mode.is_enabled() {
         let (enforced, skipped) = registry.iam_enforcement_split();
-        tracing::info!(
+        // warn (not info): the `skipped` services accept any authorized caller
+        // even under --iam, a security-relevant gap that should be as loud as
+        // the SigV4 caveat above rather than buried at info level.
+        tracing::warn!(
             enforced = ?enforced,
             skipped = ?skipped,
-            "IAM enforcement surface: listed `enforced` services evaluate policies; `skipped` services are not yet wired for enforcement"
+            "IAM enforcement surface: listed `enforced` services evaluate policies; `skipped` services are NOT yet wired for enforcement and allow any authorized caller"
         );
     }
     let config = DispatchConfig {


### PR DESCRIPTION
Cluster of confirmed correctness/compat/portability bug fixes.

## S3
- **CopyObject / UploadPartCopy honor `x-amz-copy-source-if-match`** (the crate never read it). A mismatched source ETag now returns 412 PreconditionFailed instead of copying + 200. UploadPartCopy also gains the if-none-match / if-(un)modified-since copy-source preconditions it was missing. (`write.rs`, `multipart.rs`)
- **GetObject/HeadObject `x-amz-website-redirect-location`** now set via the skip-if-invalid `insert_str_header` helper instead of `.parse().unwrap()` (no longer panics on a control-char value). (`read.rs`)

## ELBv2
- **Health prober resolves `i-*` / ECS-bridge targets via `sibling_host`** (`detect_container_cli` + `HostNetworking::detect`), mirroring the data plane's `resolve_upstream_host`. Under `FAKECLOUD_IN_CONTAINER=1` probes no longer hit fakecloud's own loopback and 503 every EC2/bridge target. (`prober.rs`)

## IAM
- **ListPolicies** honors `OnlyAttached` + `PolicyUsageFilter`.
- **GetGroup** honors `Marker`/`MaxItems` and reports `IsTruncated` + `Marker`.
- **ListEntitiesForPolicy** honors pagination + `PathPrefix` + `PolicyUsageFilter`.
- **ListAccessKeys / ListSSHPublicKeys** raise `NoSuchEntity` for a nonexistent user instead of an empty 200 (matching ListSigningCertificates).

## CloudFormation
- **RDS provisioner** defaults the port from the engine (reuses RDS's `default_port_for_engine`; MySQL -> 3306, Oracle -> 1521, etc.) and publishes the SAME `DbiResourceId` stored on the record (was refabricating `db-<identifier>` while DescribeDBInstances returned `db-<uuid>`).
- **`AWS::EC2::Instance`** is now a real provisioner instead of the accept-and-ignore catch-all: creates a control-plane instance synchronously so `Ref` resolves to the `i-...` id and `Fn::GetAtt` PrivateIp/PublicIp/AvailabilityZone resolve, then backs it with a real container via a new EC2 `cfn_provision` spawn-intent (mirroring ASG), with a matching teardown intent on stack delete.

## Distribution / auth
- `docker.yml` image smoke-test also asserts the `docker` CLI is present (the #1539 Bug-4 regression vector), alongside the existing `nft` check.
- `Dockerfile` comment corrected to the pinned `29.5.3`.
- `main.rs` IAM-enforcement-skipped startup log promoted `info!` -> `warn!` so the "skipped services allow any authorized caller" gap is as loud as the SigV4 caveat.

## Tests
- e2e: S3 copy-source-if-match (412 mismatch / 200 match, no object on 412); IAM only-attached filter, GetGroup pagination, ListAccessKeys NoSuchEntity; CFN MySQL port (Endpoint.Port = 3306), DbiResourceId GetAtt == DescribeDBInstances, AWS::EC2::Instance Ref -> real i- id resolvable via DescribeInstances.
- unit: ELBv2 prober `resolve_probe_host` (i-*/127.0.0.1 -> sibling, real IP verbatim).

## Validation
- cargo build (affected crates + binary), cargo fmt --check, clippy -D warnings (s3/elbv2/iam/cloudformation/ec2/rds), unit tests for those crates, and the 5 new e2e tests all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes correctness and compatibility gaps across S3, ELBv2, IAM, and CloudFormation, and makes CloudFormation `AWS::EC2::Instance` create real instances backed by containers. Also improves RDS defaults and tightens distribution checks and IAM enforcement warnings.

- **New Features**
  - CloudFormation `AWS::EC2::Instance`: creates a real instance (Ref/GetAtt resolve to `i-*`, IPs, AZ) and then backs it with a container; matching teardown on stack delete.

- **Bug Fixes**
  - S3: honor `x-amz-copy-source-if-match` (412 on ETag mismatch); add copy-source preconditions to `UploadPartCopy`; avoid panic when setting `x-amz-website-redirect-location`.
  - ELBv2: prober resolves `i-*` and `127.0.0.1` targets via sibling host, fixing probes in containerized runs.
  - IAM: `ListPolicies` respects `OnlyAttached` and `PolicyUsageFilter`; `GetGroup` paginates with `Marker`/`MaxItems`; `ListEntitiesForPolicy` adds pagination, `PathPrefix`, and `PolicyUsageFilter`; `ListAccessKeys`/`ListSSHPublicKeys` return `NoSuchEntity` for missing users.
  - CloudFormation RDS: default port from engine (e.g., MySQL → 3306) and `DbiResourceId` matches `DescribeDBInstances`.
  - Distribution/auth/CI: CI smoke-test asserts both `nft` and `docker` CLIs are in the image; startup logs promote skipped IAM enforcement to `warn`; e2e job restarts Docker per attempt to avoid docker0 fallback and make retries independent.

<sup>Written for commit 7d6c4ecb6dfd17e6fcac365db43a4155848daa48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

