### PR TITLE
fix(sqs,kinesis,server): data-safety cluster — durable DDB-streams checkpoints, SQS redrive/visibility validation + move-task resume, Kinesis retention trim + shard pagination

### DIFF
--- a/crates/fakecloud-dynamodb/src/lib.rs
+++ b/crates/fakecloud-dynamodb/src/lib.rs
@@ -5,7 +5,7 @@ pub mod streams_dataplane;
 pub mod ttl;
 
 pub use service::helpers::schemas::{parse_gsi, parse_lsi, parse_tags};
-pub use service::DynamoDbService;
+pub use service::{save_dynamodb_snapshot, DynamoDbService};
 pub use state::{
     AttributeDefinition, DynamoDbSnapshot, DynamoDbState, DynamoTable, GlobalSecondaryIndex,
     KeySchemaElement, LocalSecondaryIndex, OnDemandThroughput, Projection, ProvisionedThroughput,

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -473,6 +473,15 @@ pub struct DynamoDbState {
     pub global_tables: BTreeMap<String, GlobalTableDescription>,
     pub exports: BTreeMap<String, ExportDescription>,
     pub imports: BTreeMap<String, ImportDescription>,
+    /// DynamoDB Streams -> Lambda event-source-mapping checkpoints: the
+    /// last stream sequence number delivered for each mapping
+    /// (keyed by ESM uuid). Persisted so the streams poller resumes from
+    /// where it left off after a restart instead of re-seeding TRIM_HORIZON
+    /// and re-invoking the target Lambda with the whole retained backlog
+    /// (duplicate side effects). Mirrors `KinesisState.lambda_checkpoints`.
+    /// `#[serde(default)]` keeps older snapshots loadable.
+    #[serde(default)]
+    pub lambda_stream_checkpoints: BTreeMap<String, String>,
 }
 
 /// On-disk snapshot envelope. The payload is the full [`DynamoDbState`];
@@ -501,6 +510,7 @@ impl DynamoDbState {
             global_tables: BTreeMap::new(),
             exports: BTreeMap::new(),
             imports: BTreeMap::new(),
+            lambda_stream_checkpoints: BTreeMap::new(),
         }
     }
 
@@ -510,6 +520,22 @@ impl DynamoDbState {
         self.global_tables.clear();
         self.exports.clear();
         self.imports.clear();
+        self.lambda_stream_checkpoints.clear();
+    }
+
+    /// Last stream sequence number delivered for the given DynamoDB
+    /// Streams -> Lambda event source mapping, or `None` if the mapping
+    /// has never delivered (so the poller seeds from StartingPosition).
+    pub fn lambda_stream_checkpoint(&self, mapping_uuid: &str) -> Option<String> {
+        self.lambda_stream_checkpoints.get(mapping_uuid).cloned()
+    }
+
+    /// Record the last stream sequence number delivered for a mapping. The
+    /// value rides along with the next DynamoDB snapshot save, exactly the
+    /// way Kinesis lambda checkpoints persist through their snapshot.
+    pub fn set_lambda_stream_checkpoint(&mut self, mapping_uuid: &str, sequence_number: String) {
+        self.lambda_stream_checkpoints
+            .insert(mapping_uuid.to_string(), sequence_number);
     }
 }
 

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -293,6 +293,10 @@ impl KinesisService {
 
     fn describe_stream(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
+        // Limit is 1..=10000 in the model but a single DescribeStream call
+        // returns at most 100 shards; anything above is capped to 100 and
+        // `HasMoreShards` signals the caller to page with ExclusiveStartShardId.
+        validate_optional_json_range("Limit", &body["Limit"], 1, 10000)?;
         let accounts = self.state.read();
         let empty = KinesisState::new(&request.account_id, &request.region);
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
@@ -304,14 +308,33 @@ impl KinesisService {
             json!([{ "ShardLevelMetrics": stream.enhanced_metrics }])
         };
 
+        let limit = body["Limit"]
+            .as_i64()
+            .map(|n| n.clamp(1, 100))
+            .unwrap_or(100) as usize;
+        let exclusive_start = body["ExclusiveStartShardId"].as_str();
+        let mut shards: Vec<Value> = stream
+            .shards
+            .iter()
+            .filter(|s| {
+                exclusive_start
+                    .map(|start| s.shard_id.as_str() > start)
+                    .unwrap_or(true)
+            })
+            .take(limit + 1)
+            .map(shard_to_json)
+            .collect();
+        let has_more = shards.len() > limit;
+        shards.truncate(limit);
+
         Ok(AwsResponse::ok_json(json!({
             "StreamDescription": {
                 "EncryptionType": stream.encryption_type,
                 "EnhancedMonitoring": enhanced_monitoring,
-                "HasMoreShards": false,
+                "HasMoreShards": has_more,
                 "KeyId": stream.key_id,
                 "RetentionPeriodHours": stream.retention_period_hours,
-                "Shards": stream.shards.iter().map(shard_to_json).collect::<Vec<_>>(),
+                "Shards": shards,
                 "StreamARN": stream.stream_arn,
                 "StreamCreationTimestamp": stream.stream_creation_timestamp.timestamp_millis() as f64 / 1000.0,
                 "StreamModeDetails": {
@@ -671,6 +694,9 @@ impl KinesisService {
         let body = request.json_body();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
+        // Drop records past retention on write so they don't accumulate in
+        // memory (and in every snapshot) unbounded.
+        state.trim_expired_records();
         let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
@@ -697,6 +723,9 @@ impl KinesisService {
         let body = request.json_body();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
+        // Drop records past retention on write so they don't accumulate in
+        // memory (and in every snapshot) unbounded.
+        state.trim_expired_records();
         let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
         let stream = state
@@ -1525,9 +1554,22 @@ impl KinesisService {
             None => body["ExclusiveStartShardId"].as_str().map(str::to_string),
         };
 
-        let mut shards: Vec<Value> = stream
-            .shards
-            .iter()
+        // Apply an optional ShardFilter (AT_LATEST / AT_TRIM_HORIZON /
+        // AT_TIMESTAMP / AFTER_SHARD_ID / FROM_*) before paginating. KCL
+        // relies on this to fan out only to the relevant shards.
+        let shard_filter = body.get("ShardFilter").filter(|f| f.is_object());
+        let mut filtered_shards: Vec<&KinesisShard> = Vec::new();
+        for shard in &stream.shards {
+            if let Some(filter) = shard_filter {
+                if !shard_matches_filter(shard, filter)? {
+                    continue;
+                }
+            }
+            filtered_shards.push(shard);
+        }
+
+        let mut shards: Vec<Value> = filtered_shards
+            .into_iter()
             .filter(|s| {
                 if let Some(start_id) = exclusive_start.as_deref() {
                     s.shard_id.as_str() > start_id

--- a/crates/fakecloud-kinesis/src/service_helpers.rs
+++ b/crates/fakecloud-kinesis/src/service_helpers.rs
@@ -370,6 +370,68 @@ pub(crate) fn validate_stream_id(body: &Value) -> Result<(), AwsServiceError> {
     validate_optional_string_length("StreamId", body["StreamId"].as_str(), 1, 24)
 }
 
+/// Evaluate a `ListShards` `ShardFilter` against a single shard. Returns
+/// whether the shard should be included.
+///
+/// - `AT_LATEST`: only currently-open shards.
+/// - `AT_TRIM_HORIZON` / `FROM_TRIM_HORIZON`: every shard (data is still
+///   within the retention window in this model).
+/// - `AFTER_SHARD_ID`: shards whose id sorts after the filter's `ShardId`.
+/// - `AT_TIMESTAMP` / `FROM_TIMESTAMP`: shards that are still open or that
+///   hold at least one record at/after the filter `Timestamp`.
+///
+/// Required companion fields (`ShardId` / `Timestamp`) are validated, matching
+/// the `InvalidArgumentException` AWS raises when they're missing.
+pub(crate) fn shard_matches_filter(
+    shard: &KinesisShard,
+    filter: &Value,
+) -> Result<bool, AwsServiceError> {
+    let filter_type = filter["Type"]
+        .as_str()
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| invalid_argument("ShardFilter.Type is required"))?;
+
+    match filter_type {
+        "AT_LATEST" => Ok(shard.is_open),
+        "AT_TRIM_HORIZON" | "FROM_TRIM_HORIZON" => Ok(true),
+        "AFTER_SHARD_ID" => {
+            let after = filter["ShardId"]
+                .as_str()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    invalid_argument("ShardFilter.ShardId is required for AFTER_SHARD_ID")
+                })?;
+            Ok(shard.shard_id.as_str() > after)
+        }
+        "AT_TIMESTAMP" | "FROM_TIMESTAMP" => {
+            let ts_value = filter["Timestamp"].as_f64().ok_or_else(|| {
+                invalid_argument(
+                    "ShardFilter.Timestamp is required for AT_TIMESTAMP/FROM_TIMESTAMP",
+                )
+            })?;
+            if !ts_value.is_finite() || ts_value < 0.0 {
+                return Err(invalid_argument(
+                    "ShardFilter.Timestamp must be a non-negative epoch",
+                ));
+            }
+            let secs = ts_value.trunc() as i64;
+            let nanos = ((ts_value - ts_value.trunc()) * 1_000_000_000.0) as u32;
+            let target = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, nanos)
+                .ok_or_else(|| invalid_argument("ShardFilter.Timestamp is invalid"))?;
+            if shard.is_open {
+                return Ok(true);
+            }
+            Ok(shard
+                .records
+                .iter()
+                .any(|r| r.approximate_arrival_timestamp >= target))
+        }
+        other => Err(invalid_argument(format!(
+            "Unsupported ShardFilter.Type: {other}"
+        ))),
+    }
+}
+
 pub(crate) fn resource_not_found_arn(arn: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -345,6 +345,91 @@ fn describe_stream_returns_shard_descriptions() {
 }
 
 #[test]
+fn describe_stream_paginates_with_limit_and_exclusive_start() {
+    let (svc, _) = make_service();
+    create_stream_action(&svc, "orders", 5);
+
+    // First page: cap at Limit=2 and report HasMoreShards.
+    let resp = svc
+        .describe_stream(&request(
+            "DescribeStream",
+            json!({ "StreamName": "orders", "Limit": 2 }),
+        ))
+        .unwrap();
+    let body = json_response(resp);
+    let desc = &body["StreamDescription"];
+    let page1 = desc["Shards"].as_array().unwrap();
+    assert_eq!(page1.len(), 2, "Limit honored");
+    assert_eq!(desc["HasMoreShards"], json!(true), "more shards remain");
+    let last_id = page1.last().unwrap()["ShardId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Second page: resume after the last returned shard id.
+    let resp = svc
+        .describe_stream(&request(
+            "DescribeStream",
+            json!({ "StreamName": "orders", "ExclusiveStartShardId": last_id }),
+        ))
+        .unwrap();
+    let body = json_response(resp);
+    let desc = &body["StreamDescription"];
+    let page2 = desc["Shards"].as_array().unwrap();
+    assert_eq!(page2.len(), 3, "remaining shards returned");
+    assert_eq!(desc["HasMoreShards"], json!(false), "no more shards");
+}
+
+#[test]
+fn list_shards_honors_shard_filter() {
+    let (svc, _) = make_service();
+    create_stream_action(&svc, "orders", 3);
+
+    // AFTER_SHARD_ID drops the named shard and everything before it.
+    let resp = svc
+        .list_shards(&request(
+            "ListShards",
+            json!({
+                "StreamName": "orders",
+                "ShardFilter": { "Type": "AFTER_SHARD_ID", "ShardId": "shardId-000000000000" }
+            }),
+        ))
+        .unwrap();
+    let body = json_response(resp);
+    let shards = body["Shards"].as_array().unwrap();
+    assert_eq!(
+        shards.len(),
+        2,
+        "two shards sort after shardId-000000000000"
+    );
+    assert!(
+        shards
+            .iter()
+            .all(|s| s["ShardId"].as_str().unwrap() != "shardId-000000000000"),
+        "the filtered shard is excluded"
+    );
+
+    // AT_LATEST returns the currently-open shards (all of them here).
+    let resp = svc
+        .list_shards(&request(
+            "ListShards",
+            json!({ "StreamName": "orders", "ShardFilter": { "Type": "AT_LATEST" } }),
+        ))
+        .unwrap();
+    let body = json_response(resp);
+    assert_eq!(body["Shards"].as_array().unwrap().len(), 3);
+
+    // A ShardFilter that requires ShardId but omits it is rejected.
+    assert_code_kinesis(
+        svc.list_shards(&request(
+            "ListShards",
+            json!({ "StreamName": "orders", "ShardFilter": { "Type": "AFTER_SHARD_ID" } }),
+        )),
+        "InvalidArgumentException",
+    );
+}
+
+#[test]
 fn describe_stream_unknown_errors() {
     let (svc, _) = make_service();
     assert_code_kinesis(

--- a/crates/fakecloud-kinesis/src/state.rs
+++ b/crates/fakecloud-kinesis/src/state.rs
@@ -174,6 +174,53 @@ impl KinesisState {
         self.lambda_checkpoints
             .insert(format!("{mapping_uuid}:{shard_id}"), offset);
     }
+
+    /// Physically drop shard records older than each stream's retention
+    /// period. `get_records` only advanced the read cursor past expired
+    /// records, so they lived in memory (and in every snapshot) forever.
+    /// Removing them from the front of a shard shifts all index-based
+    /// offsets, so we decrement the Lambda checkpoints and shard-iterator
+    /// leases that point into the trimmed shard by the same amount, keeping
+    /// sequence/iterator correctness intact.
+    pub fn trim_expired_records(&mut self) {
+        self.trim_expired_records_at(Utc::now());
+    }
+
+    /// [`trim_expired_records`] with an explicit "now", for deterministic tests.
+    pub fn trim_expired_records_at(&mut self, now: DateTime<Utc>) {
+        for (stream_name, stream) in self.streams.iter_mut() {
+            let cutoff = now - Duration::hours(stream.retention_period_hours as i64);
+            for shard in stream.shards.iter_mut() {
+                // Records are stored in arrival order, so the expired ones
+                // are a contiguous prefix.
+                let trim = shard
+                    .records
+                    .iter()
+                    .take_while(|r| r.approximate_arrival_timestamp < cutoff)
+                    .count();
+                if trim == 0 {
+                    continue;
+                }
+                shard.records.drain(0..trim);
+
+                // Shift index-based offsets that referenced this shard.
+                for (key, offset) in self.lambda_checkpoints.iter_mut() {
+                    if key
+                        .rsplit_once(':')
+                        .map(|(_, sid)| sid == shard.shard_id)
+                        .unwrap_or(false)
+                    {
+                        *offset = offset.saturating_sub(trim);
+                    }
+                }
+                for lease in self.iterators.values_mut() {
+                    if lease.stream_name == *stream_name && lease.shard_id == shard.shard_id {
+                        lease.next_record_index = lease.next_record_index.saturating_sub(trim);
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// On-disk snapshot envelope for Kinesis state. Versioned so format
@@ -257,5 +304,78 @@ mod tests {
         let mut state = KinesisState::new("123456789012", "us-east-1");
         state.set_lambda_checkpoint("uuid-1", "shard-0", 42);
         assert_eq!(state.lambda_checkpoint("uuid-1", "shard-0"), 42);
+    }
+
+    fn record_at(seq: &str, age_hours: i64) -> KinesisRecord {
+        KinesisRecord {
+            sequence_number: seq.to_string(),
+            partition_key: "pk".to_string(),
+            data: vec![1, 2, 3],
+            approximate_arrival_timestamp: Utc::now() - Duration::hours(age_hours),
+        }
+    }
+
+    #[test]
+    fn trim_expired_records_drops_old_and_shifts_offsets() {
+        let mut state = KinesisState::new("123456789012", "us-east-1");
+        let shard_id = "shardId-000000000000".to_string();
+        let stream = KinesisStream {
+            stream_name: "s".to_string(),
+            stream_arn: state.stream_arn("s"),
+            stream_status: "ACTIVE".to_string(),
+            stream_creation_timestamp: Utc::now(),
+            retention_period_hours: 24,
+            stream_mode: "PROVISIONED".to_string(),
+            encryption_type: "NONE".to_string(),
+            key_id: None,
+            shard_count: 1,
+            open_shard_count: 1,
+            tags: BTreeMap::new(),
+            shards: vec![KinesisShard {
+                shard_id: shard_id.clone(),
+                starting_hash_key: "0".to_string(),
+                ending_hash_key: "1".to_string(),
+                parent_shard_id: None,
+                adjacent_parent_shard_id: None,
+                is_open: true,
+                next_sequence_number: 3,
+                // Two records aged past the 24h window, one fresh.
+                records: vec![record_at("0", 48), record_at("1", 48), record_at("2", 1)],
+            }],
+            next_shard_index: 1,
+            enhanced_metrics: Vec::new(),
+            warm_throughput_mibps: None,
+            max_record_size_kib: None,
+        };
+        state.streams.insert("s".to_string(), stream);
+
+        // A consumer checkpoint that has read all 3, and a live iterator
+        // pointing past all 3 — both index-based.
+        state.set_lambda_checkpoint("uuid-1", &shard_id, 3);
+        state.iterators.insert(
+            "tok".to_string(),
+            ShardIteratorLease {
+                iterator_token: "tok".to_string(),
+                stream_name: "s".to_string(),
+                shard_id: shard_id.clone(),
+                next_record_index: 3,
+                expires_at: Utc::now() + Duration::minutes(5),
+            },
+        );
+
+        state.trim_expired_records();
+
+        let shard = &state.streams["s"].shards[0];
+        assert_eq!(shard.records.len(), 1, "two expired records trimmed");
+        assert_eq!(shard.records[0].sequence_number, "2", "fresh record kept");
+        assert_eq!(
+            state.lambda_checkpoint("uuid-1", &shard_id),
+            1,
+            "checkpoint shifted down by the trimmed prefix"
+        );
+        assert_eq!(
+            state.iterators["tok"].next_record_index, 1,
+            "iterator offset shifted down by the trimmed prefix"
+        );
     }
 }

--- a/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
+++ b/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
@@ -4,7 +4,6 @@
 //! pointing to DynamoDB streams, reads stream records, and invokes Lambda
 //! functions with batches of records.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -21,8 +20,6 @@ pub struct DynamoDbStreamsLambdaPoller {
     dynamodb_state: SharedDynamoDbState,
     lambda_state: SharedLambdaState,
     lambda_delivery: Option<Arc<dyn LambdaDelivery>>,
-    /// Track the last processed sequence number per mapping
-    checkpoints: parking_lot::RwLock<HashMap<String, String>>,
 }
 
 impl DynamoDbStreamsLambdaPoller {
@@ -31,7 +28,6 @@ impl DynamoDbStreamsLambdaPoller {
             dynamodb_state,
             lambda_state,
             lambda_delivery: None,
-            checkpoints: parking_lot::RwLock::new(HashMap::new()),
         }
     }
 
@@ -59,26 +55,32 @@ impl DynamoDbStreamsLambdaPoller {
             starting_position_timestamp: Option<f64>,
         }
 
-        // Collect enabled mappings that point to DynamoDB streams
+        // Collect enabled mappings that point to DynamoDB streams across
+        // ALL accounts — a non-default/cross-account ESM must fire too, the
+        // same way the Kinesis poller iterates every account.
         let mappings: Vec<DdbMapping> = {
             let lambda_accounts = self.lambda_state.read();
-            let lambda = lambda_accounts.default_ref();
-            lambda
-                .event_source_mappings
-                .values()
-                .filter(|m| {
-                    m.enabled
-                        && m.event_source_arn.contains(":dynamodb:")
-                        && m.event_source_arn.contains("/stream/")
-                })
-                .map(|m| DdbMapping {
-                    uuid: m.uuid.clone(),
-                    stream_arn: m.event_source_arn.clone(),
-                    function_arn: m.function_arn.clone(),
-                    batch_size: m.batch_size,
-                    filter: FilterSet::from_strings(m.filter_patterns.iter()),
-                    starting_position: m.starting_position.clone(),
-                    starting_position_timestamp: m.starting_position_timestamp,
+            lambda_accounts
+                .iter()
+                .flat_map(|(_, lambda)| {
+                    lambda
+                        .event_source_mappings
+                        .values()
+                        .filter(|m| {
+                            m.enabled
+                                && m.event_source_arn.contains(":dynamodb:")
+                                && m.event_source_arn.contains("/stream/")
+                        })
+                        .map(|m| DdbMapping {
+                            uuid: m.uuid.clone(),
+                            stream_arn: m.event_source_arn.clone(),
+                            function_arn: m.function_arn.clone(),
+                            batch_size: m.batch_size,
+                            filter: FilterSet::from_strings(m.filter_patterns.iter()),
+                            starting_position: m.starting_position.clone(),
+                            starting_position_timestamp: m.starting_position_timestamp,
+                        })
+                        .collect::<Vec<_>>()
                 })
                 .collect()
         };
@@ -104,6 +106,9 @@ impl DynamoDbStreamsLambdaPoller {
             } else {
                 continue;
             };
+            // The DynamoDB state holding the table lives in the stream ARN's
+            // own account, which is not necessarily the default account.
+            let ddb_account = stream_arn.split(':').nth(4).unwrap_or("").to_string();
 
             // AT_TIMESTAMP isn't valid for DDB streams in real AWS;
             // suppress the field if the user supplied it.
@@ -113,11 +118,19 @@ impl DynamoDbStreamsLambdaPoller {
             // first time we see this mapping. For DDB streams AWS only
             // accepts TRIM_HORIZON (default — replays existing records)
             // and LATEST (skip whatever is already in the stream).
+            //
+            // The checkpoint lives in the (persisted) DynamoDB state so it
+            // survives a restart: on reload the key is already present, so
+            // we resume from the last delivered sequence number instead of
+            // re-seeding TRIM_HORIZON and re-invoking the target Lambda
+            // with the whole retained backlog (duplicate side effects).
             let checkpoint = {
-                let mut cps = self.checkpoints.write();
-                if !cps.contains_key(&mapping_id) {
-                    let dynamodb_mas = self.dynamodb_state.read();
-                    let dynamodb = dynamodb_mas.default_ref();
+                let mut ddb_accounts = self.dynamodb_state.write();
+                let dynamodb = match ddb_accounts.get_mut(&ddb_account) {
+                    Some(d) => d,
+                    None => continue,
+                };
+                if dynamodb.lambda_stream_checkpoint(&mapping_id).is_none() {
                     if let Some(table) = dynamodb.tables.get(table_name) {
                         let stream_records = table.stream_records.read();
                         let init = match starting_position.as_deref().unwrap_or("TRIM_HORIZON") {
@@ -128,16 +141,20 @@ impl DynamoDbStreamsLambdaPoller {
                                 .unwrap_or_default(),
                             _ => String::new(),
                         };
-                        cps.insert(mapping_id.clone(), init);
+                        drop(stream_records);
+                        dynamodb.set_lambda_stream_checkpoint(&mapping_id, init);
                     }
                 }
-                cps.get(&mapping_id).cloned()
+                dynamodb.lambda_stream_checkpoint(&mapping_id)
             };
 
             // Read stream records from DynamoDB
             let records = {
-                let dynamodb_mas = self.dynamodb_state.read();
-                let dynamodb = dynamodb_mas.default_ref();
+                let ddb_accounts = self.dynamodb_state.read();
+                let dynamodb = match ddb_accounts.get(&ddb_account) {
+                    Some(d) => d,
+                    None => continue,
+                };
                 let table = match dynamodb.tables.get(table_name) {
                     Some(t) => t,
                     None => continue,
@@ -215,7 +232,7 @@ impl DynamoDbStreamsLambdaPoller {
             // successful invoke so failures retry on the next poll.
             if event_records.is_empty() {
                 if let Some(seq) = last_seq.clone() {
-                    self.checkpoints.write().insert(mapping_id.clone(), seq);
+                    self.advance_checkpoint(&ddb_account, &mapping_id, seq);
                 }
                 continue;
             }
@@ -252,12 +269,13 @@ impl DynamoDbStreamsLambdaPoller {
             // Successful invoke — advance the checkpoint and record
             // the invocation when no real Lambda runtime is wired.
             if let Some(seq) = last_seq.clone() {
-                self.checkpoints.write().insert(mapping_id.clone(), seq);
+                self.advance_checkpoint(&ddb_account, &mapping_id, seq);
             }
 
             if self.lambda_delivery.is_none() {
+                let fn_account = function_arn.split(':').nth(4).unwrap_or("");
                 let mut lambda_accounts = self.lambda_state.write();
-                let lambda = lambda_accounts.default_mut();
+                let lambda = lambda_accounts.get_or_create(fn_account);
                 lambda.invocations.push(LambdaInvocation {
                     function_arn: function_arn.clone(),
                     payload: payload.clone(),
@@ -266,5 +284,230 @@ impl DynamoDbStreamsLambdaPoller {
                 });
             }
         }
+    }
+
+    /// Persist the last-delivered sequence number for a mapping into the
+    /// DynamoDB state. The value rides along with the next DynamoDB
+    /// snapshot save, so it survives a restart (mirrors how Kinesis lambda
+    /// checkpoints persist through their snapshot).
+    fn advance_checkpoint(&self, ddb_account: &str, mapping_id: &str, sequence_number: String) {
+        let mut ddb_accounts = self.dynamodb_state.write();
+        if let Some(dynamodb) = ddb_accounts.get_mut(ddb_account) {
+            dynamodb.set_lambda_stream_checkpoint(mapping_id, sequence_number);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use fakecloud_core::multi_account::MultiAccountState;
+    use fakecloud_core::service::{AwsRequest, AwsService};
+    use fakecloud_dynamodb::{DynamoDbService, DynamoDbState};
+    use fakecloud_lambda::{EventSourceMapping, LambdaState};
+    use parking_lot::RwLock;
+    use serde_json::Value;
+
+    const DEFAULT_ACCOUNT: &str = "123456789012";
+    const REGION: &str = "us-east-1";
+    const ENDPOINT: &str = "http://localhost:4566";
+
+    fn make_request(account: &str, action: &str, body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "dynamodb".to_string(),
+            action: action.to_string(),
+            region: REGION.to_string(),
+            account_id: account.to_string(),
+            request_id: "test-id".to_string(),
+            headers: axum::http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: serde_json::to_vec(&body).unwrap().into(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: axum::http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    async fn create_streamed_table(svc: &DynamoDbService, account: &str, table: &str) {
+        svc.handle(make_request(
+            account,
+            "CreateTable",
+            serde_json::json!({
+                "TableName": table,
+                "KeySchema": [{ "AttributeName": "pk", "KeyType": "HASH" }],
+                "AttributeDefinitions": [{ "AttributeName": "pk", "AttributeType": "S" }],
+                "BillingMode": "PAY_PER_REQUEST",
+                "StreamSpecification": {
+                    "StreamEnabled": true,
+                    "StreamViewType": "NEW_AND_OLD_IMAGES"
+                }
+            }),
+        ))
+        .await
+        .expect("CreateTable should succeed");
+    }
+
+    async fn put_item(svc: &DynamoDbService, account: &str, table: &str, pk: &str) {
+        svc.handle(make_request(
+            account,
+            "PutItem",
+            serde_json::json!({
+                "TableName": table,
+                "Item": { "pk": { "S": pk } }
+            }),
+        ))
+        .await
+        .expect("PutItem should succeed");
+    }
+
+    fn stream_arn(state: &SharedDynamoDbState, account: &str, table: &str) -> String {
+        state
+            .read()
+            .get(account)
+            .expect("account exists")
+            .tables
+            .get(table)
+            .expect("table exists")
+            .stream_arn
+            .clone()
+            .expect("stream enabled")
+    }
+
+    fn esm(uuid: &str, account: &str, stream_arn: &str) -> EventSourceMapping {
+        EventSourceMapping {
+            uuid: uuid.to_string(),
+            function_arn: format!("arn:aws:lambda:{REGION}:{account}:function:streamed-fn"),
+            event_source_arn: stream_arn.to_string(),
+            batch_size: 10,
+            enabled: true,
+            state: "Enabled".to_string(),
+            last_modified: Utc::now(),
+            filter_patterns: Vec::new(),
+            maximum_batching_window_in_seconds: None,
+            starting_position: Some("TRIM_HORIZON".to_string()),
+            starting_position_timestamp: None,
+            parallelization_factor: None,
+            function_response_types: Vec::new(),
+            kms_key_arn: None,
+            metrics_config: None,
+            destination_config: None,
+            maximum_retry_attempts: None,
+            maximum_record_age_in_seconds: None,
+            bisect_batch_on_function_error: None,
+            tumbling_window_in_seconds: None,
+            topics: Vec::new(),
+            queues: Vec::new(),
+            source_access_configurations: Vec::new(),
+        }
+    }
+
+    fn lambda_state_with(account: &str, mapping: EventSourceMapping) -> SharedLambdaState {
+        let mut lambda: MultiAccountState<LambdaState> =
+            MultiAccountState::new(DEFAULT_ACCOUNT, REGION, ENDPOINT);
+        lambda
+            .get_or_create(account)
+            .event_source_mappings
+            .insert(mapping.uuid.clone(), mapping);
+        Arc::new(RwLock::new(lambda))
+    }
+
+    fn invocation_count(lambda_state: &SharedLambdaState, account: &str) -> usize {
+        lambda_state
+            .read()
+            .get(account)
+            .map(|l| l.invocations.len())
+            .unwrap_or(0)
+    }
+
+    /// Deliver a batch, then "restart" by round-tripping the DynamoDB state
+    /// through serde and rebuilding the poller against the restored state +
+    /// a fresh Lambda state. The durable checkpoint must prevent the whole
+    /// retained backlog from being re-replayed to the target Lambda.
+    #[tokio::test]
+    async fn checkpoint_survives_restart_no_replay() {
+        let dynamodb_state: SharedDynamoDbState = Arc::new(RwLock::new(MultiAccountState::new(
+            DEFAULT_ACCOUNT,
+            REGION,
+            ENDPOINT,
+        )));
+        let svc = DynamoDbService::new(dynamodb_state.clone());
+        create_streamed_table(&svc, DEFAULT_ACCOUNT, "t").await;
+        put_item(&svc, DEFAULT_ACCOUNT, "t", "a").await;
+        put_item(&svc, DEFAULT_ACCOUNT, "t", "b").await;
+
+        let arn = stream_arn(&dynamodb_state, DEFAULT_ACCOUNT, "t");
+        let lambda_state = lambda_state_with(DEFAULT_ACCOUNT, esm("esm-1", DEFAULT_ACCOUNT, &arn));
+
+        let poller = DynamoDbStreamsLambdaPoller::new(dynamodb_state.clone(), lambda_state.clone());
+        poller.poll().await;
+        assert_eq!(
+            invocation_count(&lambda_state, DEFAULT_ACCOUNT),
+            1,
+            "first poll delivers the backlog as one batch"
+        );
+        // A second poll on the same process must not re-deliver.
+        poller.poll().await;
+        assert_eq!(
+            invocation_count(&lambda_state, DEFAULT_ACCOUNT),
+            1,
+            "no re-delivery while checkpoint is current"
+        );
+
+        // "Restart": persist + reload the DynamoDB state, fresh Lambda state.
+        let serialized = serde_json::to_string(&*dynamodb_state.read()).unwrap();
+        let restored: MultiAccountState<DynamoDbState> = serde_json::from_str(&serialized).unwrap();
+        let restored_state: SharedDynamoDbState = Arc::new(RwLock::new(restored));
+        // The checkpoint must have survived the round-trip.
+        assert!(
+            restored_state
+                .read()
+                .get(DEFAULT_ACCOUNT)
+                .unwrap()
+                .lambda_stream_checkpoint("esm-1")
+                .is_some(),
+            "checkpoint persisted through snapshot"
+        );
+
+        let lambda_state2 = lambda_state_with(DEFAULT_ACCOUNT, esm("esm-1", DEFAULT_ACCOUNT, &arn));
+        let poller2 = DynamoDbStreamsLambdaPoller::new(restored_state, lambda_state2.clone());
+        poller2.poll().await;
+        assert_eq!(
+            invocation_count(&lambda_state2, DEFAULT_ACCOUNT),
+            0,
+            "restart must resume from the durable checkpoint, not re-replay TRIM_HORIZON"
+        );
+    }
+
+    /// An event source mapping on a non-default / cross-account stream must
+    /// still fire — the poller used to serve only the default account.
+    #[tokio::test]
+    async fn non_default_account_mapping_fires() {
+        const OTHER: &str = "999999999999";
+        let dynamodb_state: SharedDynamoDbState = Arc::new(RwLock::new(MultiAccountState::new(
+            DEFAULT_ACCOUNT,
+            REGION,
+            ENDPOINT,
+        )));
+        let svc = DynamoDbService::new(dynamodb_state.clone());
+        create_streamed_table(&svc, OTHER, "t").await;
+        put_item(&svc, OTHER, "t", "a").await;
+
+        let arn = stream_arn(&dynamodb_state, OTHER, "t");
+        assert!(arn.contains(OTHER), "stream arn carries the other account");
+        let lambda_state = lambda_state_with(OTHER, esm("esm-x", OTHER, &arn));
+
+        let poller = DynamoDbStreamsLambdaPoller::new(dynamodb_state.clone(), lambda_state.clone());
+        poller.poll().await;
+        assert_eq!(
+            invocation_count(&lambda_state, OTHER),
+            1,
+            "cross-account mapping must fire"
+        );
     }
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1027,7 +1027,11 @@ async fn main() {
     if let Some(h) = sqs_service.snapshot_hook() {
         cfn_snapshot_hooks.insert("sqs", h);
     }
-    registry.register(Arc::new(sqs_service));
+    // Resume any in-progress message-move task left RUNNING/CANCELLING by a
+    // previous process so it doesn't hang forever and the DLQ drain continues.
+    let sqs_service = Arc::new(sqs_service);
+    sqs_service.resume_message_move_tasks();
+    registry.register(sqs_service);
     // Flush cross-service SQS deliveries (SNS/EventBridge/S3/Scheduler fan-out)
     // that the sync delivery trait cannot persist itself. bug-audit 4.8.
     if let Some(store) = sqs_snapshot_store {
@@ -1924,6 +1928,12 @@ async fn main() {
         } else {
             None
         };
+    // Keep a clone of the snapshot store (and a dedicated write lock) for the
+    // `/_fakecloud/dynamodb/ttl-processor/tick` admin route, which mutates
+    // state outside any handler and must persist the result the same way the
+    // normal mutating API path does.
+    let dynamodb_ttl_snapshot_store = dynamodb_snapshot_store.clone();
+    let dynamodb_ttl_snapshot_lock = Arc::new(tokio::sync::Mutex::new(()));
     let mut dynamodb_service = DynamoDbService::new(dynamodb_state_for_register)
         .with_s3(s3_state.clone())
         .with_s3_store(s3_store.clone())
@@ -5508,11 +5518,19 @@ async fn main() {
             axum::routing::post({
                 let ds = dynamodb_ttl_state;
                 let delivery = dynamodb_ttl_delivery;
+                let store = dynamodb_ttl_snapshot_store;
+                let lock = dynamodb_ttl_snapshot_lock;
                 move || async move {
                     let count = fakecloud_dynamodb::ttl::process_ttl_expirations_with(
                         &ds,
                         Some(&delivery),
                     );
+                    // Persist the deletions: the tick mutates state outside any
+                    // handler, so without this the expired items reappear on the
+                    // next restart (the normal mutating API path saves here).
+                    if count > 0 {
+                        fakecloud_dynamodb::save_dynamodb_snapshot(&ds, store.clone(), &lock).await;
+                    }
                     axum::Json(types::TtlTickResponse {
                         expired_items: count as u64,
                     })

--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -371,6 +371,22 @@ impl SqsService {
         let max_messages = max_messages_raw.unwrap_or(1).min(10) as usize;
 
         let visibility_timeout = val_as_i64(&body["VisibilityTimeout"]);
+        // Range-validate the request-level VisibilityTimeout (0..=43200) the
+        // same way ChangeMessageVisibility does. Without this a near-i64::MAX
+        // value overflows `now + Duration::seconds(v)` and PANICS the worker
+        // thread (dropping the connection), and a negative value would make
+        // the message immediately visible. AWS returns InvalidParameterValue.
+        if let Some(vt) = visibility_timeout {
+            if !(0..=43200).contains(&vt) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!(
+                        "Value {vt} for parameter VisibilityTimeout is invalid. Reason: Must be between 0 and 43200 seconds."
+                    ),
+                ));
+            }
+        }
 
         // FIFO receive de-dup: a retried receive carrying the same
         // ReceiveRequestAttemptId within the visibility window replays the

--- a/crates/fakecloud-sqs/src/service/moves.rs
+++ b/crates/fakecloud-sqs/src/service/moves.rs
@@ -354,6 +354,157 @@ impl SqsService {
             req.is_query_protocol,
         ))
     }
+
+    /// Re-spawn the background mover for any message-move task left in a
+    /// non-terminal state (RUNNING / CANCELLING) by a previous process.
+    ///
+    /// On restart the task row persists but the tokio task driving it is
+    /// gone, so without this `ListMessageMoveTasks` would report RUNNING
+    /// forever and the DLQ drain would never finish. We reclaim each
+    /// orphaned task under the current pid and continue draining from where
+    /// it left off (the persisted `messages_moved` count is preserved). A
+    /// task that was CANCELLING keeps its cancel intent so the resumed
+    /// mover finalizes it as CANCELLED; a task whose source queue no longer
+    /// exists is finalized as FAILED. Call once at startup.
+    pub fn resume_message_move_tasks(&self) {
+        let pid = std::process::id();
+
+        struct Resume {
+            account_id: String,
+            region: String,
+            task_handle: String,
+            source_url: String,
+            destination_arn: Option<String>,
+            dlq_targets: Vec<String>,
+            rate: u64,
+            cancel_flag: Arc<AtomicBool>,
+        }
+
+        /// Fields snapshotted from an orphaned task before re-borrowing state.
+        struct Orphan {
+            task_handle: String,
+            source_arn: String,
+            destination_arn: Option<String>,
+            max_per_sec: Option<i32>,
+            cancelling: bool,
+        }
+
+        let mut to_resume: Vec<Resume> = Vec::new();
+        {
+            let mut accounts = self.state.write();
+            for (account_id, state) in accounts.iter_mut() {
+                let account_id = account_id.to_string();
+                // Snapshot the orphaned tasks first (immutable read), then
+                // mutate each one below — avoids overlapping borrows of
+                // `state.queues` and `state.message_move_tasks`.
+                let orphans: Vec<Orphan> = state
+                    .message_move_tasks
+                    .iter()
+                    .filter(|t| {
+                        matches!(
+                            t.status,
+                            MessageMoveTaskStatus::Running | MessageMoveTaskStatus::Cancelling
+                        ) && t.driver_pid != pid
+                    })
+                    .map(|t| Orphan {
+                        task_handle: t.task_handle.clone(),
+                        source_arn: t.source_arn.clone(),
+                        destination_arn: t.destination_arn.clone(),
+                        max_per_sec: t.max_messages_per_second,
+                        cancelling: t.status == MessageMoveTaskStatus::Cancelling,
+                    })
+                    .collect();
+
+                for Orphan {
+                    task_handle,
+                    source_arn,
+                    destination_arn,
+                    max_per_sec,
+                    cancelling,
+                } in orphans
+                {
+                    let source_url = state
+                        .queues
+                        .values()
+                        .find(|q| q.arn == source_arn)
+                        .map(|q| q.queue_url.clone());
+
+                    let Some(source_url) = source_url else {
+                        // Source queue is gone — finalize Failed so the task
+                        // doesn't hang at RUNNING forever.
+                        if let Some(task) = state
+                            .message_move_tasks
+                            .iter_mut()
+                            .find(|t| t.task_handle == task_handle)
+                        {
+                            task.driver_pid = pid;
+                            task.status = MessageMoveTaskStatus::Failed;
+                            task.failure_reason =
+                                Some("Source queue no longer exists after restart.".to_string());
+                        }
+                        continue;
+                    };
+
+                    let dlq_targets: Vec<String> = state
+                        .queues
+                        .values()
+                        .filter(|q| {
+                            q.redrive_policy
+                                .as_ref()
+                                .map(|rp| rp.dead_letter_target_arn == source_arn)
+                                .unwrap_or(false)
+                        })
+                        .map(|q| q.queue_url.clone())
+                        .collect();
+
+                    let cancel_flag = Arc::new(AtomicBool::new(cancelling));
+                    if let Some(task) = state
+                        .message_move_tasks
+                        .iter_mut()
+                        .find(|t| t.task_handle == task_handle)
+                    {
+                        task.driver_pid = pid;
+                        task.cancel_flag = cancel_flag.clone();
+                    }
+
+                    let rate = max_per_sec.unwrap_or(1).max(1) as u64;
+                    to_resume.push(Resume {
+                        account_id: account_id.clone(),
+                        region: state.region.clone(),
+                        task_handle,
+                        source_url,
+                        destination_arn,
+                        dlq_targets,
+                        rate,
+                        cancel_flag,
+                    });
+                }
+            }
+        }
+
+        for r in to_resume {
+            let state_handle = self.state.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            let interval = std::time::Duration::from_nanos(1_000_000_000 / r.rate);
+            tokio::spawn(async move {
+                run_message_move_task(
+                    state_handle,
+                    r.account_id,
+                    r.region,
+                    r.task_handle,
+                    r.source_url,
+                    r.destination_arn,
+                    r.dlq_targets,
+                    interval,
+                    r.cancel_flag,
+                    snapshot_store,
+                    snapshot_lock,
+                )
+                .await;
+            });
+        }
+    }
 }
 
 /// A persisted move task blocks a new StartMessageMoveTask for its source queue

--- a/crates/fakecloud-sqs/src/service/queues.rs
+++ b/crates/fakecloud-sqs/src/service/queues.rs
@@ -472,6 +472,29 @@ impl SqsService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
         let resolved_url = resolve_queue_url(queue_url, state).ok_or_else(queue_not_found)?;
+
+        // Validate the redrive DLQ target the same way CreateQueue does,
+        // before storing it. Terraform's `aws_sqs_redrive_policy` resource
+        // configures the DLQ via SetQueueAttributes, and an unchecked
+        // bad/nonexistent DLQ ARN makes failed messages churn on the source
+        // forever instead of being dead-lettered. Done with immutable borrows
+        // before the mutable `get_mut` below.
+        if let Some(rp_str) = body["Attributes"]
+            .as_object()
+            .and_then(|a| a.get("RedrivePolicy"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            if let Some(rp) = parse_redrive_policy(rp_str) {
+                let is_fifo = state
+                    .queues
+                    .get(&resolved_url)
+                    .map(|q| q.is_fifo)
+                    .unwrap_or(false);
+                validate_redrive_policy_target(state, &rp, is_fifo)?;
+            }
+        }
+
         let queue = state
             .queues
             .get_mut(&resolved_url)

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -1355,13 +1355,18 @@ fn list_dead_letter_source_queues_finds_sources() {
 
 #[test]
 fn redrive_with_unresolvable_dlq_arn_keeps_message_on_source_queue() {
-    // A RedrivePolicy whose deadLetterTargetArn doesn't resolve (DLQ deleted,
-    // ARN typo) must not destroy over-limit messages: real SQS keeps them on
-    // the source queue. Previously the redrive move silently dropped them.
+    // A RedrivePolicy whose deadLetterTargetArn no longer resolves at runtime
+    // (the DLQ was deleted after being configured) must not destroy over-limit
+    // messages: real SQS keeps them on the source queue. Previously the redrive
+    // move silently dropped them. (The DLQ is created + configured first, since
+    // SetQueueAttributes now validates the target at config time, then deleted
+    // to recreate the unresolvable-at-runtime condition.)
     let svc = make_service();
     let src_url = create_queue_url(&svc, "bad-dlq-src");
+    let dlq_url = create_queue_url(&svc, "transient-dlq");
+    let dlq_arn = "arn:aws:sqs:us-east-1:123456789012:transient-dlq";
     let redrive = json!({
-        "deadLetterTargetArn": "arn:aws:sqs:us-east-1:000000000000:no-such-dlq",
+        "deadLetterTargetArn": dlq_arn,
         "maxReceiveCount": "1"
     })
     .to_string();
@@ -1370,6 +1375,9 @@ fn redrive_with_unresolvable_dlq_arn_keeps_message_on_source_queue() {
         json!({ "QueueUrl": src_url, "Attributes": { "RedrivePolicy": redrive } }),
     ))
     .unwrap();
+    // Delete the DLQ so the redrive target no longer resolves at runtime.
+    svc.delete_queue(&make_request("DeleteQueue", json!({ "QueueUrl": dlq_url })))
+        .unwrap();
     send_msg(&svc, &src_url, "survivor");
 
     // First receive delivers (receive_count 1 == max); the second crosses
@@ -2667,4 +2675,141 @@ async fn snapshot_hook_fires_with_store() {
         .snapshot_hook()
         .expect("hook present when a store is set");
     hook().await;
+}
+
+/// A request-level VisibilityTimeout outside 0..=43200 must be rejected with
+/// InvalidParameterValue instead of panicking the worker thread (a near-i64::MAX
+/// value overflows `now + Duration::seconds(v)`).
+#[tokio::test]
+async fn receive_message_rejects_out_of_range_visibility_timeout() {
+    let svc = make_service();
+    let url = create_queue(&svc, "vt-q");
+    send_msg(&svc, &url, "hello");
+
+    let huge = make_request(
+        "ReceiveMessage",
+        json!({ "QueueUrl": url, "VisibilityTimeout": i64::MAX }),
+    );
+    let err = expect_err(svc.receive_message(&huge).await);
+    assert_eq!(err.code(), "InvalidParameterValue");
+
+    let negative = make_request(
+        "ReceiveMessage",
+        json!({ "QueueUrl": url, "VisibilityTimeout": -1 }),
+    );
+    let err = expect_err(svc.receive_message(&negative).await);
+    assert_eq!(err.code(), "InvalidParameterValue");
+}
+
+/// SetQueueAttributes must validate the redrive DLQ target the same way
+/// CreateQueue does — Terraform's `aws_sqs_redrive_policy` configures the DLQ
+/// through SetQueueAttributes, and an unchecked bad ARN churns messages forever.
+#[test]
+fn set_queue_attributes_rejects_nonexistent_redrive_target() {
+    let svc = make_service();
+    let url = create_queue(&svc, "src-q");
+
+    let bad = make_request(
+        "SetQueueAttributes",
+        json!({
+            "QueueUrl": url,
+            "Attributes": {
+                "RedrivePolicy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:123456789012:ghost-dlq\",\"maxReceiveCount\":3}"
+            }
+        }),
+    );
+    let err = expect_err(svc.set_queue_attributes(&bad));
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
+
+    // A real DLQ is accepted.
+    let dlq_url = create_queue(&svc, "real-dlq");
+    let dlq_arn = "arn:aws:sqs:us-east-1:123456789012:real-dlq";
+    assert!(dlq_url.ends_with("real-dlq"));
+    let good = make_request(
+        "SetQueueAttributes",
+        json!({
+            "QueueUrl": url,
+            "Attributes": {
+                "RedrivePolicy": format!("{{\"deadLetterTargetArn\":\"{dlq_arn}\",\"maxReceiveCount\":3}}")
+            }
+        }),
+    );
+    svc.set_queue_attributes(&good).expect("valid DLQ accepted");
+}
+
+/// A message-move task left RUNNING by a previous process (stale driver pid)
+/// must be resumed at startup so it doesn't hang forever and the DLQ drain
+/// completes.
+#[tokio::test]
+async fn resume_message_move_tasks_drains_orphaned_running_task() {
+    let svc = make_service();
+    let dlq_url = create_queue(&svc, "drain-dlq");
+    let main_url = create_queue(&svc, "drain-main");
+    let dlq_arn = "arn:aws:sqs:us-east-1:123456789012:drain-dlq".to_string();
+
+    // main references dlq as its DLQ, so dlq is a valid move source.
+    let set_redrive = make_request(
+        "SetQueueAttributes",
+        json!({
+            "QueueUrl": main_url,
+            "Attributes": {
+                "RedrivePolicy": format!("{{\"deadLetterTargetArn\":\"{dlq_arn}\",\"maxReceiveCount\":1}}")
+            }
+        }),
+    );
+    svc.set_queue_attributes(&set_redrive).unwrap();
+
+    send_msg(&svc, &dlq_url, "m1");
+    send_msg(&svc, &dlq_url, "m2");
+
+    // Inject an orphaned RUNNING task (stale pid => left by a prior process).
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create("123456789012");
+        state.message_move_tasks.push(MessageMoveTask {
+            task_handle: "FakeCloudMessageMoveTask-orphan".to_string(),
+            source_arn: dlq_arn.clone(),
+            destination_arn: None,
+            max_messages_per_second: Some(500),
+            status: MessageMoveTaskStatus::Running,
+            messages_moved: 0,
+            messages_to_move: 2,
+            started_timestamp: Utc::now().timestamp_millis(),
+            failure_reason: None,
+            driver_pid: std::process::id().wrapping_add(1), // not us
+            cancel_flag: Arc::new(AtomicBool::new(false)),
+        });
+    }
+
+    svc.resume_message_move_tasks();
+
+    // Wait for the resumed mover to drain the DLQ into main.
+    let mut completed = false;
+    for _ in 0..200 {
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let accounts = svc.state.read();
+        let state = accounts.get("123456789012").unwrap();
+        let task = state
+            .message_move_tasks
+            .iter()
+            .find(|t| t.task_handle == "FakeCloudMessageMoveTask-orphan")
+            .unwrap();
+        if task.status == MessageMoveTaskStatus::Completed {
+            completed = true;
+            assert_eq!(task.messages_moved, 2);
+            assert_eq!(
+                state
+                    .queues
+                    .values()
+                    .find(|q| q.arn == dlq_arn)
+                    .unwrap()
+                    .messages
+                    .len(),
+                0,
+                "source DLQ drained"
+            );
+            break;
+        }
+    }
+    assert!(completed, "orphaned move task should resume and complete");
 }


### PR DESCRIPTION
Fixes a cluster of confirmed data-safety / persistence / pagination bugs.

## Fixes
1. HIGH - DynamoDB Streams -> Lambda checkpoints are now durable. They live in `DynamoDbState` (persisted via the snapshot, `#[serde(default)]` for back-compat) instead of an in-memory `RwLock`, so a restart resumes from the last delivered sequence number rather than re-seeding TRIM_HORIZON and re-invoking the target Lambda with the whole retained backlog (duplicate side effects). Mirrors `KinesisState.lambda_checkpoints`.
2. MEDIUM - That poller now iterates ALL Lambda accounts and resolves the table from the stream ARN's own account, so non-default / cross-account ESMs fire (was default-account-only).
3. MEDIUM - SQS `ReceiveMessage` range-validates the request-level `VisibilityTimeout` (0..=43200) and returns `InvalidParameterValue`. A near-`i64::MAX` value previously overflowed `now + Duration::seconds(v)` and panicked the worker thread; a negative value made the message immediately visible.
4. MEDIUM - SQS `SetQueueAttributes` validates the redrive DLQ target the same way `CreateQueue` does (Terraform's `aws_sqs_redrive_policy` uses SetQueueAttributes). A bad/nonexistent DLQ ARN no longer churns messages on the source forever.
5. MEDIUM - SQS resumes in-progress message-move tasks left RUNNING/CANCELLING by a previous process at startup, so `ListMessageMoveTasks` no longer hangs at RUNNING forever and the DLQ drain continues. A task whose source queue is gone is finalized FAILED.
6. MEDIUM - Kinesis shard records past retention are now trimmed on write (shifting index-based Lambda checkpoints and shard-iterator offsets so sequence/iterator correctness is preserved), instead of living in memory + every snapshot forever.
7. MEDIUM - Kinesis `DescribeStream` honors `Limit` (capped at 100) / `ExclusiveStartShardId` and reports a real `HasMoreShards`; `ListShards` honors `ShardFilter` (AT_LATEST / AT_TRIM_HORIZON / AT_TIMESTAMP / AFTER_SHARD_ID / FROM_*).
8. LOW - The `/_fakecloud/dynamodb/ttl-processor/tick` admin route saves the snapshot after expiring items, so the deletions survive a restart (the normal mutating path already persists).

## Tests
- DDB poller: deliver, "restart" (rebuild from the serde-round-tripped state), assert NO re-replay; a cross-account ESM fires.
- SQS: huge + negative `VisibilityTimeout` rejected (no panic); `SetQueueAttributes` with a bad redrive ARN rejected; an orphaned RUNNING move task resumes and drains. Updated the prior unresolvable-DLQ test to delete the DLQ after config (config-time validation now applies; the runtime safety-net still holds).
- Kinesis: records past retention trimmed with offsets shifted; `DescribeStream` paginates; `ListShards` honors a `ShardFilter` (incl. missing-ShardId rejection).

## Validation
- cargo build (all touched crates + server)
- cargo fmt --all -- --check: clean
- cargo clippy -p fakecloud-sqs -p fakecloud-kinesis -p fakecloud -p fakecloud-dynamodb --all-targets -- -D warnings: clean
- cargo test -p fakecloud-sqs (170) / fakecloud-kinesis (123) / fakecloud-dynamodb (328): pass
- cargo test -p fakecloud-e2e --no-run: compiles

## Notes
Checkpoint durability mirrors the Kinesis poller: the checkpoint lives in the persisted state and is flushed by the next snapshot save, so there remains a small window (advance not yet snapshotted before a crash) identical to the accepted Kinesis behavior. This eliminates the catastrophic full-backlog re-replay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiple data-safety and pagination gaps across DynamoDB Streams, SQS, and Kinesis to prevent replays, panics, and unbounded growth. Restarts now resume correctly, SQS params are validated, Kinesis data is trimmed, and APIs align better with AWS behavior.

- Bug Fixes
  - DynamoDB Streams → Lambda: Persist per-mapping checkpoints in `DynamoDbState` (snapshot-backed) so restarts resume instead of replaying TRIM_HORIZON; iterate all Lambda accounts and use the stream ARN’s account so cross-account mappings fire.
  - SQS: `ReceiveMessage` validates `VisibilityTimeout` (0..=43200) to avoid panics/early visibility; `SetQueueAttributes` validates redrive DLQ targets like `CreateQueue`; resume orphaned RUNNING/CANCELLING message-move tasks at startup and finalize FAILED when the source queue is gone.
  - Kinesis: Trim records past retention on write and shift Lambda checkpoints and shard-iterator offsets to keep them correct; `DescribeStream` paginates with `Limit` (capped at 100) and `ExclusiveStartShardId`; `ListShards` honors `ShardFilter` (AT_LATEST/TRIM_HORIZON/TIMESTAMP/AFTER_SHARD_ID/FROM_*).
  - Server: `/_fakecloud/dynamodb/ttl-processor/tick` now saves a snapshot after expirations so deletions persist across restarts.

<sup>Written for commit e193edb017e88f9c91fbe9f4c97e45c0b0af2263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

