### PR TITLE
test(cloudformation): widen changeset-backing poll window for CI cold-container boot

### DIFF
--- a/crates/fakecloud-e2e/tests/cloudformation_changeset_backing.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_changeset_backing.rs
@@ -84,7 +84,7 @@ async fn execute_change_set_provisions_and_deletes_rds_instance() {
     // The instance must reach `available` -- this is the bug: before the
     // changeset-side drain it stayed `creating` forever whenever a runtime was
     // wired (and was never backed by a real container).
-    let available = helpers::wait_until(std::time::Duration::from_secs(15), || {
+    let available = helpers::wait_until(std::time::Duration::from_secs(120), || {
         let rds = rds.clone();
         async move {
             let out = rds
@@ -112,7 +112,7 @@ async fn execute_change_set_provisions_and_deletes_rds_instance() {
         .await
         .expect("delete_stack");
 
-    let gone = helpers::wait_until(std::time::Duration::from_secs(15), || {
+    let gone = helpers::wait_until(std::time::Duration::from_secs(120), || {
         let rds = rds.clone();
         async move {
             match rds
@@ -181,7 +181,7 @@ async fn create_change_set_provisions_and_deletes_elasticache_cluster() {
         .await
         .expect("execute_change_set");
 
-    let available = helpers::wait_until(std::time::Duration::from_secs(15), || {
+    let available = helpers::wait_until(std::time::Duration::from_secs(120), || {
         let ec = ec.clone();
         async move {
             let out = ec
@@ -207,7 +207,7 @@ async fn create_change_set_provisions_and_deletes_elasticache_cluster() {
         .await
         .expect("delete_stack");
 
-    let gone = helpers::wait_until(std::time::Duration::from_secs(15), || {
+    let gone = helpers::wait_until(std::time::Duration::from_secs(120), || {
         let ec = ec.clone();
         async move {
             match ec


### PR DESCRIPTION
The changeset-backing e2e test (added in #2035) polled only 15s for a CFN-changeset-provisioned RDS instance to reach `available`. A real Postgres container cold-boot in CI can exceed that, so the assertion 'changeset-provisioned RDS instance must reach available' flaked on the E2E general partition. Widened all four poll ceilings (RDS + ElastiCache available/gone) to 120s; `wait_until` returns as soon as the condition holds, so green runs are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase polling timeouts in the CloudFormation changeset-backing e2e tests from 15s to 120s for RDS and ElastiCache reaching available and being deleted, reducing CI flakes from cold-container boots. `wait_until` returns early when the condition is met, so successful runs are unaffected.

<sup>Written for commit fc93bf9ea091c96c05d5c733f6ac7b0509782301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

