### PR TITLE
feat(pipes): execution engine — SQS source delivery (batch 2)

### DIFF
--- a/crates/fakecloud-e2e/tests/pipes_execution.rs
+++ b/crates/fakecloud-e2e/tests/pipes_execution.rs
@@ -1,0 +1,198 @@
+//! EventBridge Pipes execution engine (batch 2): an SQS source pipe polls its
+//! source queue, applies the EventBridge-pattern filter, and delivers matching
+//! events to the target. Uses an SQS target so the whole path is observable
+//! through the SDK without a container runtime.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const ROLE: &str = "arn:aws:iam::000000000000:role/pipe-role";
+
+async fn make_queue(sqs: &aws_sdk_sqs::Client, name: &str) -> (String, String) {
+    let url = sqs
+        .create_queue()
+        .queue_name(name)
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let arn = sqs
+        .get_queue_attributes()
+        .queue_url(&url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+    (url, arn)
+}
+
+async fn wait_running(pipes: &aws_sdk_pipes::Client, name: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if let Ok(r) = pipes.describe_pipe().name(name).send().await {
+            if r.current_state() == Some(&aws_sdk_pipes::types::PipeState::Running) {
+                return;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("pipe {name} never reached RUNNING");
+}
+
+/// Poll a queue until one message arrives (up to `secs`), returning its body.
+async fn recv_one(sqs: &aws_sdk_sqs::Client, url: &str, secs: u64) -> Option<String> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+    while std::time::Instant::now() < deadline {
+        let r = sqs
+            .receive_message()
+            .queue_url(url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(0)
+            .send()
+            .await
+            .unwrap();
+        if let Some(m) = r.messages().first() {
+            return m.body().map(str::to_string);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    None
+}
+
+#[tokio::test]
+async fn pipe_sqs_source_to_sqs_target_delivers() {
+    let s = TestServer::start().await;
+    let cfg = s.aws_config().await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    let pipes = aws_sdk_pipes::Client::new(&cfg);
+
+    let (src_url, src_arn) = make_queue(&sqs, "pipe-src-deliver").await;
+    let (tgt_url, tgt_arn) = make_queue(&sqs, "pipe-tgt-deliver").await;
+
+    pipes
+        .create_pipe()
+        .name("deliver-pipe")
+        .source(&src_arn)
+        .target(&tgt_arn)
+        .role_arn(ROLE)
+        .send()
+        .await
+        .expect("create pipe");
+    wait_running(&pipes, "deliver-pipe").await;
+
+    sqs.send_message()
+        .queue_url(&src_url)
+        .message_body("hello-pipes")
+        .send()
+        .await
+        .unwrap();
+
+    // The runner forwards the SQS-source event JSON to the target queue.
+    let body = recv_one(&sqs, &tgt_url, 8)
+        .await
+        .expect("event delivered to target queue");
+    let event: serde_json::Value = serde_json::from_str(&body).expect("event is JSON");
+    assert_eq!(event["body"], "hello-pipes");
+    assert_eq!(event["eventSource"], "aws:sqs");
+    assert_eq!(event["eventSourceArn"], src_arn);
+
+    // Source queue is drained (the message was acked after delivery).
+    let leftover = sqs
+        .receive_message()
+        .queue_url(&src_url)
+        .visibility_timeout(0)
+        .send()
+        .await
+        .unwrap();
+    assert!(leftover.messages().is_empty(), "source not drained");
+}
+
+#[tokio::test]
+async fn pipe_filter_drops_non_matching_events() {
+    let s = TestServer::start().await;
+    let cfg = s.aws_config().await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    let pipes = aws_sdk_pipes::Client::new(&cfg);
+
+    let (src_url, src_arn) = make_queue(&sqs, "pipe-src-filter").await;
+    let (tgt_url, tgt_arn) = make_queue(&sqs, "pipe-tgt-filter").await;
+
+    // Only events whose body equals "keep" pass the filter.
+    let filter = aws_sdk_pipes::types::FilterCriteria::builder()
+        .filters(
+            aws_sdk_pipes::types::Filter::builder()
+                .pattern(r#"{"body":["keep"]}"#)
+                .build(),
+        )
+        .build();
+    let source_params = aws_sdk_pipes::types::PipeSourceParameters::builder()
+        .filter_criteria(filter)
+        .build();
+
+    pipes
+        .create_pipe()
+        .name("filter-pipe")
+        .source(&src_arn)
+        .target(&tgt_arn)
+        .role_arn(ROLE)
+        .source_parameters(source_params)
+        .send()
+        .await
+        .expect("create pipe");
+    wait_running(&pipes, "filter-pipe").await;
+
+    sqs.send_message()
+        .queue_url(&src_url)
+        .message_body("drop")
+        .send()
+        .await
+        .unwrap();
+    sqs.send_message()
+        .queue_url(&src_url)
+        .message_body("keep")
+        .send()
+        .await
+        .unwrap();
+
+    // The matching event arrives at the target.
+    let body = recv_one(&sqs, &tgt_url, 8)
+        .await
+        .expect("matching event delivered");
+    let event: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(event["body"], "keep");
+
+    // The non-matching event was dropped (acked), not delivered. Give the
+    // runner time to also process the dropped message, then confirm the target
+    // never receives a second message and the source is fully drained.
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let more = sqs
+        .receive_message()
+        .queue_url(&tgt_url)
+        .visibility_timeout(0)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        more.messages().is_empty(),
+        "filtered event should not have been delivered"
+    );
+    let src_left = sqs
+        .receive_message()
+        .queue_url(&src_url)
+        .visibility_timeout(0)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        src_left.messages().is_empty(),
+        "both messages should be acked from source (drop-as-ack)"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -20,6 +20,7 @@ mod dynamodb_streams_lambda_poller;
 mod introspection;
 mod kinesis_lambda_poller;
 mod lambda_delivery;
+mod pipes_runner;
 mod reaper;
 mod reset;
 mod runtime;
@@ -3884,6 +3885,24 @@ async fn main() {
         dynamodb_streams_poller = dynamodb_streams_poller.with_lambda_delivery(ld.clone());
     }
     tokio::spawn(Arc::new(dynamodb_streams_poller).run());
+    // EventBridge Pipes runner: executes RUNNING pipes with an SQS source,
+    // filtering events and delivering matches to Lambda/SQS/SNS targets via
+    // the shared delivery paths. Other sources/targets land in a later batch.
+    {
+        let mut pipes_bus = DeliveryBus::new()
+            .with_sqs(sqs_delivery.clone())
+            .with_sns(sns_delivery.clone());
+        if let Some(ref ld) = lambda_delivery {
+            pipes_bus = pipes_bus.with_lambda(ld.clone());
+        }
+        let runner = pipes_runner::PipesRunner::new(
+            pipes_state.clone(),
+            sqs_state.clone(),
+            Arc::new(pipes_bus),
+        )
+        .with_kms_hook(kms_hook_for_services.clone());
+        tokio::spawn(runner.run());
+    }
     if let Some(ref rt) = container_runtime {
         let rt = rt.clone();
         tokio::spawn(rt.run_cleanup_loop(std::time::Duration::from_secs(300)));

--- a/crates/fakecloud-server/src/pipes_runner.rs
+++ b/crates/fakecloud-server/src/pipes_runner.rs
@@ -1,0 +1,342 @@
+//! Background runner that executes EventBridge Pipes with an SQS source.
+//!
+//! For each RUNNING pipe whose `Source` is an SQS queue ARN, the runner polls
+//! the source queue, applies the pipe's EventBridge-pattern filter (matching
+//! events are forwarded, non-matching events are acked/deleted — "filter
+//! drop-as-ack", exactly as AWS Pipes does), and delivers the matching events
+//! to the pipe's target (Lambda / SQS / SNS) via the shared `DeliveryBus`,
+//! reusing the same cross-service delivery paths every other fakecloud feature
+//! uses. A message is deleted from the source only after it is either filtered
+//! out or successfully delivered; a delivery failure leaves it for redelivery.
+//!
+//! DynamoDB-stream / Kinesis sources, enrichment, the remaining target types
+//! (Step Functions / EventBridge bus / Kinesis), and InputTemplate transforms
+//! land in a later batch. Each unsupported source/target is left untouched
+//! (the pipe simply does no work) rather than faking delivery.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use base64::Engine;
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
+
+use fakecloud_core::delivery::{DeliveryBus, KmsHook};
+use fakecloud_lambda::filter::FilterSet;
+use fakecloud_pipes::SharedPipesState;
+use fakecloud_sqs::SharedSqsState;
+
+/// One RUNNING pipe with an SQS source, resolved for this tick.
+struct SqsSourcePipe {
+    source_arn: String,
+    target_arn: String,
+    filter: FilterSet,
+    batch_size: usize,
+}
+
+pub struct PipesRunner {
+    pipes_state: SharedPipesState,
+    sqs_state: SharedSqsState,
+    delivery: Arc<DeliveryBus>,
+    /// Decrypts at-rest SSE-KMS / SSE-SQS message bodies before forwarding,
+    /// mirroring the SQS->Lambda poller: AWS consumers see plaintext, so a
+    /// pipe must too rather than forward opaque envelope bytes.
+    kms_hook: Option<Arc<dyn KmsHook>>,
+}
+
+impl PipesRunner {
+    pub fn new(
+        pipes_state: SharedPipesState,
+        sqs_state: SharedSqsState,
+        delivery: Arc<DeliveryBus>,
+    ) -> Self {
+        Self {
+            pipes_state,
+            sqs_state,
+            delivery,
+            kms_hook: None,
+        }
+    }
+
+    pub fn with_kms_hook(mut self, hook: Arc<dyn KmsHook>) -> Self {
+        self.kms_hook = Some(hook);
+        self
+    }
+
+    pub async fn run(self) {
+        let mut interval = tokio::time::interval(Duration::from_millis(500));
+        loop {
+            interval.tick().await;
+            self.poll().await;
+        }
+    }
+
+    async fn poll(&self) {
+        let pipes = self.collect_sqs_source_pipes();
+        for pipe in pipes {
+            self.process_pipe(&pipe).await;
+        }
+    }
+
+    /// Snapshot every RUNNING pipe whose source is an SQS queue.
+    fn collect_sqs_source_pipes(&self) -> Vec<SqsSourcePipe> {
+        let accounts = self.pipes_state.read();
+        let mut out = Vec::new();
+        for state in accounts.accounts.values() {
+            for pipe in state.pipes.values() {
+                if pipe.get("CurrentState").and_then(Value::as_str) != Some("RUNNING") {
+                    continue;
+                }
+                let Some(source_arn) = pipe.get("Source").and_then(Value::as_str) else {
+                    continue;
+                };
+                if !source_arn.contains(":sqs:") {
+                    continue;
+                }
+                let Some(target_arn) = pipe.get("Target").and_then(Value::as_str) else {
+                    continue;
+                };
+                let source_params = pipe.get("SourceParameters");
+                let filter = build_filter(source_params);
+                let batch_size = source_params
+                    .and_then(|p| p.get("SqsQueueParameters"))
+                    .and_then(|p| p.get("BatchSize"))
+                    .and_then(Value::as_i64)
+                    .filter(|n| *n > 0)
+                    .unwrap_or(10)
+                    .min(10) as usize;
+                out.push(SqsSourcePipe {
+                    source_arn: source_arn.to_string(),
+                    target_arn: target_arn.to_string(),
+                    filter,
+                    batch_size,
+                });
+            }
+        }
+        out
+    }
+
+    async fn process_pipe(&self, pipe: &SqsSourcePipe) {
+        let now = Utc::now();
+        // Pull up to BatchSize visible messages and hide them for the queue's
+        // visibility window so a slow delivery doesn't re-pull the same batch.
+        let picked = self.pick_messages(&pipe.source_arn, pipe.batch_size, now);
+        if picked.is_empty() {
+            return;
+        }
+
+        // Partition by the filter: matching events are delivered, the rest are
+        // acked (deleted) immediately — AWS Pipes drops filtered events.
+        let mut to_deliver: Vec<(String, Value)> = Vec::new();
+        let mut ack_ids: Vec<String> = Vec::new();
+        for (id, event) in picked {
+            if pipe.filter.is_empty() || pipe.filter.matches(&event) {
+                to_deliver.push((id, event));
+            } else {
+                ack_ids.push(id);
+            }
+        }
+
+        if !to_deliver.is_empty() {
+            let delivered = self.deliver(&pipe.target_arn, &to_deliver).await;
+            if delivered {
+                ack_ids.extend(to_deliver.into_iter().map(|(id, _)| id));
+            }
+        }
+
+        if !ack_ids.is_empty() {
+            self.delete_messages(&pipe.source_arn, &ack_ids);
+        }
+    }
+
+    /// Pull up to `limit` currently-visible messages from the source queue and
+    /// mark them invisible for the queue's `VisibilityTimeout`. Returns
+    /// `(message_id, pipes-source-event)` pairs.
+    fn pick_messages(
+        &self,
+        source_arn: &str,
+        limit: usize,
+        now: DateTime<Utc>,
+    ) -> Vec<(String, Value)> {
+        let mut sqs_mas = self.sqs_state.write();
+        let default_acct = sqs_mas.default_account_id().to_string();
+        let acct = source_arn
+            .split(':')
+            .nth(4)
+            .unwrap_or(&default_acct)
+            .to_string();
+        let region = source_arn
+            .split(':')
+            .nth(3)
+            .unwrap_or("us-east-1")
+            .to_string();
+        let sqs = sqs_mas.get_or_create(&acct);
+        let Some(queue) = sqs.queues.values_mut().find(|q| q.arn == source_arn) else {
+            return Vec::new();
+        };
+        let visibility_timeout: i64 = queue
+            .attributes
+            .get("VisibilityTimeout")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(30);
+        let visible_at = now + chrono::Duration::seconds(visibility_timeout);
+        // Bodies are stored encrypted at rest on an SSE-KMS / managed-SSE
+        // queue; decrypt before forwarding so the target sees plaintext.
+        let encrypted = queue
+            .attributes
+            .get("KmsMasterKeyId")
+            .map(|k| !k.is_empty())
+            .unwrap_or(false)
+            || queue
+                .attributes
+                .get("SqsManagedSseEnabled")
+                .map(String::as_str)
+                == Some("true");
+
+        let mut out = Vec::new();
+        for msg in queue.messages.iter_mut() {
+            if out.len() >= limit {
+                break;
+            }
+            if let Some(vis) = msg.visible_at {
+                if vis > now {
+                    continue;
+                }
+            }
+            msg.visible_at = Some(visible_at);
+            let body = self.decrypt_body(&msg.body, source_arn, &acct, encrypted);
+            out.push((
+                msg.message_id.clone(),
+                sqs_source_event(msg, &body, source_arn, &region),
+            ));
+        }
+        out
+    }
+
+    /// Decrypt an at-rest SQS body when the queue is encrypted and the body
+    /// is a fakecloud KMS envelope. Falls back to the raw body otherwise.
+    fn decrypt_body(&self, body: &str, source_arn: &str, account: &str, encrypted: bool) -> String {
+        if !encrypted || !looks_like_fakecloud_envelope(body) {
+            return body.to_string();
+        }
+        let Some(hook) = self.kms_hook.as_ref() else {
+            return body.to_string();
+        };
+        let mut ctx = HashMap::new();
+        ctx.insert("aws:sqs:arn".to_string(), source_arn.to_string());
+        match hook.decrypt(account, body, "sqs.amazonaws.com", ctx) {
+            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+            Err(err) => {
+                tracing::warn!(%source_arn, %err, "pipes: KMS decrypt failed; forwarding opaque body");
+                body.to_string()
+            }
+        }
+    }
+
+    fn delete_messages(&self, source_arn: &str, ids: &[String]) {
+        let mut sqs_mas = self.sqs_state.write();
+        let default_acct = sqs_mas.default_account_id().to_string();
+        let acct = source_arn
+            .split(':')
+            .nth(4)
+            .unwrap_or(&default_acct)
+            .to_string();
+        let sqs = sqs_mas.get_or_create(&acct);
+        if let Some(queue) = sqs.queues.values_mut().find(|q| q.arn == source_arn) {
+            queue.messages.retain(|m| !ids.contains(&m.message_id));
+        }
+    }
+
+    /// Deliver the batch to the target. Returns true if delivery succeeded (and
+    /// the events may be acked). Lambda receives the whole batch as a JSON
+    /// array (Pipes batches to Lambda); SQS/SNS receive one message per event.
+    async fn deliver(&self, target_arn: &str, batch: &[(String, Value)]) -> bool {
+        if target_arn.contains(":lambda:") {
+            let payload = Value::Array(batch.iter().map(|(_, e)| e.clone()).collect());
+            let payload = serde_json::to_string(&payload).unwrap_or_else(|_| "[]".to_string());
+            match self.delivery.invoke_lambda(target_arn, &payload).await {
+                Some(Ok(_)) => true,
+                Some(Err(err)) => {
+                    tracing::warn!(%target_arn, %err, "pipes: Lambda target invocation failed; events will be retried");
+                    false
+                }
+                // No Lambda delivery wired (unit/no-runtime): leave events.
+                None => false,
+            }
+        } else if target_arn.contains(":sqs:") {
+            for (_, event) in batch {
+                let body = serde_json::to_string(event).unwrap_or_default();
+                self.delivery
+                    .send_to_sqs(target_arn, &body, &HashMap::new());
+            }
+            true
+        } else if target_arn.contains(":sns:") {
+            for (_, event) in batch {
+                let body = serde_json::to_string(event).unwrap_or_default();
+                self.delivery.publish_to_sns(target_arn, &body, None);
+            }
+            true
+        } else {
+            // Step Functions / EventBridge bus / Kinesis / etc. land in a later
+            // batch. Don't ack — leave the events so they're delivered once the
+            // target type is supported rather than silently dropped.
+            false
+        }
+    }
+}
+
+/// Build the pipe's source filter from `SourceParameters.FilterCriteria`.
+fn build_filter(source_params: Option<&Value>) -> FilterSet {
+    let patterns: Vec<String> = source_params
+        .and_then(|p| p.get("FilterCriteria"))
+        .and_then(|f| f.get("Filters"))
+        .and_then(Value::as_array)
+        .map(|filters| {
+            filters
+                .iter()
+                .filter_map(|f| f.get("Pattern").and_then(Value::as_str))
+                .map(|s| s.to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+    FilterSet::from_strings(patterns)
+}
+
+/// Build the AWS Pipes SQS-source event envelope for one message. `body` is the
+/// (already decrypted) message body.
+fn sqs_source_event(
+    msg: &fakecloud_sqs::SqsMessage,
+    body: &str,
+    source_arn: &str,
+    region: &str,
+) -> Value {
+    let attributes: serde_json::Map<String, Value> = msg
+        .attributes
+        .iter()
+        .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+        .collect();
+    json!({
+        "messageId": msg.message_id,
+        "receiptHandle": msg.receipt_handle.clone().unwrap_or_default(),
+        "body": body,
+        "attributes": attributes,
+        "messageAttributes": {},
+        "md5OfBody": msg.md5_of_body,
+        "eventSource": "aws:sqs",
+        "eventSourceArn": source_arn,
+        "awsRegion": region,
+    })
+}
+
+/// Detect a fakecloud KMS-at-rest envelope (matches the SQS service's own
+/// encryption format) so plaintext bodies are passed through untouched.
+fn looks_like_fakecloud_envelope(body: &str) -> bool {
+    if body.starts_with("fakecloud-kms:") {
+        return true;
+    }
+    match base64::engine::general_purpose::STANDARD.decode(body) {
+        Ok(bytes) => bytes.starts_with(&[0x01, 0x02, 0x02, 0x00]),
+        Err(_) => false,
+    }
+}

--- a/website/content/docs/services/pipes.md
+++ b/website/content/docs/services/pipes.md
@@ -38,12 +38,30 @@ machine and persistence:
   `Tags` on `CreatePipe`.
 - **Persistence** — pipes survive a restart in persistent mode.
 
+## Execution — SQS source (real delivery)
+
+A RUNNING pipe whose **source is an SQS queue** is executed for real by a
+background runner: it polls the source queue, applies the pipe's
+`FilterCriteria` (the same EventBridge event-pattern syntax used everywhere
+else in fakecloud), and delivers matching events to the target — reusing the
+exact cross-service delivery paths the rest of fakecloud uses. SSE-KMS /
+managed-SSE source bodies are decrypted before forwarding, so the target sees
+plaintext just like a real AWS consumer.
+
+- **Filtering** — events matching `SourceParameters.FilterCriteria.Filters[].Pattern`
+  are forwarded; non-matching events are acked (deleted) from the source, exactly
+  as AWS Pipes drops filtered events.
+- **Targets** — **Lambda** (the matching batch is invoked as a JSON array),
+  **SQS**, and **SNS** (one message per event). A message is deleted from the
+  source only after it is filtered out or successfully delivered; a delivery
+  failure leaves it for redelivery.
+
 ## Roadmap
 
-- **Execution engine** — real source polling (SQS / DynamoDB Streams / Kinesis)
-  with EventBridge-pattern filtering, optional enrichment (Lambda / Step
-  Functions / API destination), and target delivery (Lambda / SQS / SNS / Step
-  Functions / EventBridge bus / Kinesis) reusing fakecloud's existing invoke and
-  delivery paths.
+- **More sources** — DynamoDB Streams and Kinesis sources.
+- **More targets** — Step Functions `StartExecution`, EventBridge bus
+  `PutEvents`, and Kinesis.
+- **Enrichment + transforms** — optional enrichment (Lambda / Step Functions /
+  API destination) and `InputTemplate` target input transformers.
 - **CloudFormation** — `AWS::Pipes::Pipe` provisioning.
 - **Terraform** — `aws_pipes_pipe` acceptance coverage.


### PR DESCRIPTION
## Summary

Batch 2 of EventBridge Pipes: the **execution engine** for SQS-source pipes. A background runner (`pipes_runner`, mirroring the existing `sqs_lambda_poller`) executes every RUNNING pipe whose `Source` is an SQS queue — polling the source, applying the pipe's EventBridge-pattern filter, and delivering matching events to the target. This is the differentiation wedge: no free emulator runs Pipes with real cross-service delivery.

- **Filtering** via the existing EventBridge pattern matcher (`FilterSet`). Non-matching events are acked/deleted from the source (drop-as-ack), exactly as AWS Pipes does.
- **Targets**: Lambda (matching batch invoked as a JSON array), SQS, and SNS (one message per event), dispatched through the shared `DeliveryBus` — the same paths every other fakecloud feature uses.
- **At-rest decryption**: SSE-KMS / managed-SSE source bodies are decrypted (same `KmsHook` path as the SQS->Lambda poller) before forwarding, so targets see plaintext like a real consumer. (This was a real bug caught by the E2E — without it the target received opaque KMS envelope bytes.)
- **At-least-once**: a source message is deleted only after it is filtered out or successfully delivered; a delivery failure leaves it for redelivery.
- **No stubs**: unsupported sources (DynamoDB Streams / Kinesis) and targets (Step Functions / EventBridge bus / Kinesis) are left untouched — the pipe does no work rather than faking delivery — and land in batch 3.

## Test plan
- `cargo test -p fakecloud-e2e --test pipes_execution` — passes (2/2): SQS->SQS real delivery (asserts the Pipes SQS-source event envelope arrives at the target and the source drains) + EventBridge-pattern filter drop-as-ack (matching event delivered, non-matching dropped, both acked from source).
- `cargo clippy -p fakecloud --all-targets -- -D warnings` clean; server builds.

## Follow-ups (batch 3+)
DynamoDB Streams / Kinesis sources, Step Functions / EventBridge bus / Kinesis targets, enrichment (Lambda / SFN / API destination), and `InputTemplate` transforms; then CFN `AWS::Pipes::Pipe` and `aws_pipes_pipe` tfacc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an execution engine for EventBridge Pipes with SQS sources. A background runner polls queues, filters with EventBridge patterns, decrypts SSE bodies, and delivers matches to Lambda, SQS, or SNS with at-least-once behavior.

- **New Features**
  - Background `pipes_runner` in `fakecloud-server` executes RUNNING pipes whose source is an SQS queue.
  - Filtering via `FilterSet`; non-matching events are acked (drop-as-ack), matching events proceed.
  - Targets: Lambda (batch invoked as a JSON array), SQS, and SNS, all dispatched through `DeliveryBus`.
  - Decrypts SSE-KMS/managed-SSE source bodies via `KmsHook` so targets receive plaintext.
  - Deletes source messages only after filter-out or successful delivery; failures are retried.
  - Unsupported sources/targets (DynamoDB Streams/Kinesis, Step Functions/EventBridge/Kinesis) are left untouched for now.
  - E2E coverage for SQS->SQS delivery and filter behavior; service docs updated.

<sup>Written for commit b3ef92eacfed9bae4bc2484acb99b0e2fb91d2ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

