### PR TITLE
feat(pipes): execution engine — SFN, EventBridge-bus, Kinesis targets (batch 3)

### DIFF
--- a/crates/fakecloud-e2e/tests/pipes_targets.rs
+++ b/crates/fakecloud-e2e/tests/pipes_targets.rs
@@ -1,0 +1,205 @@
+//! EventBridge Pipes additional targets (batch 3): an SQS-source pipe delivers
+//! matching events to Step Functions and Kinesis targets, observed through the
+//! respective SDKs.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const ROLE: &str = "arn:aws:iam::000000000000:role/pipe-role";
+
+async fn make_queue(sqs: &aws_sdk_sqs::Client, name: &str) -> (String, String) {
+    let url = sqs
+        .create_queue()
+        .queue_name(name)
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let arn = sqs
+        .get_queue_attributes()
+        .queue_url(&url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+    (url, arn)
+}
+
+async fn wait_running(pipes: &aws_sdk_pipes::Client, name: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if let Ok(r) = pipes.describe_pipe().name(name).send().await {
+            if r.current_state() == Some(&aws_sdk_pipes::types::PipeState::Running) {
+                return;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("pipe {name} never reached RUNNING");
+}
+
+#[tokio::test]
+async fn pipe_sqs_source_to_kinesis_target() {
+    let s = TestServer::start().await;
+    let cfg = s.aws_config().await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    let kinesis = aws_sdk_kinesis::Client::new(&cfg);
+    let pipes = aws_sdk_pipes::Client::new(&cfg);
+
+    let (src_url, src_arn) = make_queue(&sqs, "pipe-src-kinesis").await;
+
+    kinesis
+        .create_stream()
+        .stream_name("pipe-target-stream")
+        .shard_count(1)
+        .send()
+        .await
+        .expect("create stream");
+    let stream_arn = kinesis
+        .describe_stream_summary()
+        .stream_name("pipe-target-stream")
+        .send()
+        .await
+        .unwrap()
+        .stream_description_summary()
+        .unwrap()
+        .stream_arn()
+        .to_string();
+
+    pipes
+        .create_pipe()
+        .name("kinesis-pipe")
+        .source(&src_arn)
+        .target(&stream_arn)
+        .role_arn(ROLE)
+        .send()
+        .await
+        .expect("create pipe");
+    wait_running(&pipes, "kinesis-pipe").await;
+
+    sqs.send_message()
+        .queue_url(&src_url)
+        .message_body("to-kinesis")
+        .send()
+        .await
+        .unwrap();
+
+    // Read the stream until the forwarded event record shows up.
+    let shard_id = kinesis
+        .describe_stream()
+        .stream_name("pipe-target-stream")
+        .send()
+        .await
+        .unwrap()
+        .stream_description()
+        .unwrap()
+        .shards()[0]
+        .shard_id()
+        .to_string();
+    let mut iter = kinesis
+        .get_shard_iterator()
+        .stream_name("pipe-target-stream")
+        .shard_id(&shard_id)
+        .shard_iterator_type(aws_sdk_kinesis::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap()
+        .shard_iterator()
+        .unwrap()
+        .to_string();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(8);
+    let mut found = None;
+    while std::time::Instant::now() < deadline {
+        let resp = kinesis
+            .get_records()
+            .shard_iterator(&iter)
+            .send()
+            .await
+            .unwrap();
+        for rec in resp.records() {
+            let data = rec.data().as_ref();
+            let event: serde_json::Value = serde_json::from_slice(data).unwrap();
+            if event["body"] == "to-kinesis" {
+                found = Some(event);
+                break;
+            }
+        }
+        if found.is_some() {
+            break;
+        }
+        if let Some(next) = resp.next_shard_iterator() {
+            iter = next.to_string();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    let event = found.expect("event delivered to Kinesis target");
+    assert_eq!(event["eventSource"], "aws:sqs");
+}
+
+#[tokio::test]
+async fn pipe_sqs_source_to_stepfunctions_target() {
+    let s = TestServer::start().await;
+    let cfg = s.aws_config().await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    let sfn = aws_sdk_sfn::Client::new(&cfg);
+    let pipes = aws_sdk_pipes::Client::new(&cfg);
+
+    let (src_url, src_arn) = make_queue(&sqs, "pipe-src-sfn").await;
+
+    let definition = r#"{"StartAt":"P","States":{"P":{"Type":"Pass","End":true}}}"#;
+    let sm_arn = sfn
+        .create_state_machine()
+        .name("pipe-target-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::000000000000:role/sfn-role")
+        .send()
+        .await
+        .expect("create state machine")
+        .state_machine_arn()
+        .to_string();
+
+    pipes
+        .create_pipe()
+        .name("sfn-pipe")
+        .source(&src_arn)
+        .target(&sm_arn)
+        .role_arn(ROLE)
+        .send()
+        .await
+        .expect("create pipe");
+    wait_running(&pipes, "sfn-pipe").await;
+
+    sqs.send_message()
+        .queue_url(&src_url)
+        .message_body("to-sfn")
+        .send()
+        .await
+        .unwrap();
+
+    // The pipe starts a Step Functions execution per event.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(8);
+    let mut started = false;
+    while std::time::Instant::now() < deadline {
+        let execs = sfn
+            .list_executions()
+            .state_machine_arn(&sm_arn)
+            .send()
+            .await
+            .unwrap();
+        if !execs.executions().is_empty() {
+            started = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    assert!(started, "pipe did not start a Step Functions execution");
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3874,7 +3874,7 @@ async fn main() {
     }
     tokio::spawn(sqs_lambda_poller.run());
     let mut kinesis_lambda_poller =
-        KinesisLambdaPoller::new(kinesis_state, lambda_invocations_state.clone());
+        KinesisLambdaPoller::new(kinesis_state.clone(), lambda_invocations_state.clone());
     if let Some(ref ld) = lambda_delivery {
         kinesis_lambda_poller = kinesis_lambda_poller.with_lambda_delivery(ld.clone());
     }
@@ -3886,12 +3886,49 @@ async fn main() {
     }
     tokio::spawn(Arc::new(dynamodb_streams_poller).run());
     // EventBridge Pipes runner: executes RUNNING pipes with an SQS source,
-    // filtering events and delivering matches to Lambda/SQS/SNS targets via
-    // the shared delivery paths. Other sources/targets land in a later batch.
+    // filtering events and delivering matches to Lambda/SQS/SNS/Step
+    // Functions/EventBridge-bus/Kinesis targets via the shared delivery
+    // paths. DynamoDB-stream/Kinesis sources + enrichment land in a later
+    // batch.
     {
+        // EventBridge-bus + Step Functions target senders need their own
+        // delivery impls (mirroring the scheduler/EB wiring); a minimal inner
+        // bus suffices because a pipe delivers *to* these targets rather than
+        // driving their downstream fan-out.
+        let pipes_eb_delivery = {
+            let mut inner = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+            if let Some(ref ld) = lambda_delivery {
+                inner = inner.with_lambda(ld.clone());
+            }
+            Arc::new(
+                fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
+                    eb_state.clone(),
+                    Arc::new(inner),
+                ),
+            )
+        };
+        let pipes_sfn_delivery = {
+            let mut sfn_bus = DeliveryBus::new().with_sqs(sqs_delivery.clone());
+            if let Some(ref ld) = lambda_delivery {
+                sfn_bus = sfn_bus.with_lambda(ld.clone());
+            }
+            Arc::new(
+                stepfunctions_delivery::StepFunctionsDeliveryImpl::new(
+                    stepfunctions_state.clone(),
+                    Some(Arc::new(sfn_bus)),
+                    Some(dynamodb_state.clone()),
+                )
+                .with_registry(sfn_registry_handle.clone()),
+            )
+        };
+        let pipes_kinesis_delivery =
+            fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
         let mut pipes_bus = DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())
-            .with_sns(sns_delivery.clone());
+            .with_sns(sns_delivery.clone())
+            .with_eventbridge(pipes_eb_delivery)
+            .with_stepfunctions(pipes_sfn_delivery)
+            .with_kinesis(pipes_kinesis_delivery);
         if let Some(ref ld) = lambda_delivery {
             pipes_bus = pipes_bus.with_lambda(ld.clone());
         }

--- a/crates/fakecloud-server/src/pipes_runner.rs
+++ b/crates/fakecloud-server/src/pipes_runner.rs
@@ -4,15 +4,16 @@
 //! the source queue, applies the pipe's EventBridge-pattern filter (matching
 //! events are forwarded, non-matching events are acked/deleted — "filter
 //! drop-as-ack", exactly as AWS Pipes does), and delivers the matching events
-//! to the pipe's target (Lambda / SQS / SNS) via the shared `DeliveryBus`,
-//! reusing the same cross-service delivery paths every other fakecloud feature
-//! uses. A message is deleted from the source only after it is either filtered
-//! out or successfully delivered; a delivery failure leaves it for redelivery.
+//! to the pipe's target (Lambda / SQS / SNS / Step Functions / EventBridge bus
+//! / Kinesis) via the shared `DeliveryBus`, reusing the same cross-service
+//! delivery paths every other fakecloud feature uses. A message is deleted
+//! from the source only after it is either filtered out or successfully
+//! delivered; a delivery failure leaves it for redelivery.
 //!
-//! DynamoDB-stream / Kinesis sources, enrichment, the remaining target types
-//! (Step Functions / EventBridge bus / Kinesis), and InputTemplate transforms
-//! land in a later batch. Each unsupported source/target is left untouched
-//! (the pipe simply does no work) rather than faking delivery.
+//! DynamoDB-stream / Kinesis sources, enrichment, InputTemplate transforms,
+//! and the remaining target types (ECS / Batch / Redshift / HTTP / …) land in
+//! a later batch. Each unsupported source/target is left untouched (the pipe
+//! simply does no work) rather than faking delivery.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -31,6 +32,7 @@ use fakecloud_sqs::SharedSqsState;
 struct SqsSourcePipe {
     source_arn: String,
     target_arn: String,
+    target_params: Option<Value>,
     filter: FilterSet,
     batch_size: usize,
 }
@@ -109,6 +111,7 @@ impl PipesRunner {
                 out.push(SqsSourcePipe {
                     source_arn: source_arn.to_string(),
                     target_arn: target_arn.to_string(),
+                    target_params: pipe.get("TargetParameters").cloned(),
                     filter,
                     batch_size,
                 });
@@ -139,7 +142,9 @@ impl PipesRunner {
         }
 
         if !to_deliver.is_empty() {
-            let delivered = self.deliver(&pipe.target_arn, &to_deliver).await;
+            let delivered = self
+                .deliver(&pipe.target_arn, pipe.target_params.as_ref(), &to_deliver)
+                .await;
             if delivered {
                 ack_ids.extend(to_deliver.into_iter().map(|(id, _)| id));
             }
@@ -251,7 +256,12 @@ impl PipesRunner {
     /// Deliver the batch to the target. Returns true if delivery succeeded (and
     /// the events may be acked). Lambda receives the whole batch as a JSON
     /// array (Pipes batches to Lambda); SQS/SNS receive one message per event.
-    async fn deliver(&self, target_arn: &str, batch: &[(String, Value)]) -> bool {
+    async fn deliver(
+        &self,
+        target_arn: &str,
+        target_params: Option<&Value>,
+        batch: &[(String, Value)],
+    ) -> bool {
         if target_arn.contains(":lambda:") {
             let payload = Value::Array(batch.iter().map(|(_, e)| e.clone()).collect());
             let payload = serde_json::to_string(&payload).unwrap_or_else(|_| "[]".to_string());
@@ -277,10 +287,57 @@ impl PipesRunner {
                 self.delivery.publish_to_sns(target_arn, &body, None);
             }
             true
+        } else if target_arn.contains(":states:") {
+            // Step Functions: start one execution per event with the event as
+            // input (Pipes invokes standard state machines per record).
+            for (_, event) in batch {
+                let input = serde_json::to_string(event).unwrap_or_default();
+                self.delivery
+                    .start_stepfunctions_execution(target_arn, &input);
+            }
+            true
+        } else if target_arn.contains(":events:") {
+            // EventBridge bus: PutEvents one entry per event. Source/DetailType
+            // come from the target's EventBridgeEventBusParameters (AWS
+            // requires them), defaulting to Pipes' conventional values.
+            let bus_name = target_arn
+                .rsplit_once("event-bus/")
+                .map(|(_, n)| n)
+                .unwrap_or("default");
+            let eb_params = target_params.and_then(|p| p.get("EventBridgeEventBusParameters"));
+            let source = eb_params
+                .and_then(|p| p.get("Source"))
+                .and_then(Value::as_str)
+                .unwrap_or("Pipes");
+            let detail_type = eb_params
+                .and_then(|p| p.get("DetailType"))
+                .and_then(Value::as_str)
+                .unwrap_or("Event");
+            for (_, event) in batch {
+                let detail = serde_json::to_string(event).unwrap_or_default();
+                self.delivery
+                    .put_event_to_eventbridge(source, detail_type, &detail, bus_name);
+            }
+            true
+        } else if target_arn.contains(":kinesis:") {
+            // Kinesis: one record per event. PartitionKey comes from the
+            // target's KinesisStreamParameters (a literal here), falling back
+            // to the source message id so records still spread across shards.
+            let configured_pk = target_params
+                .and_then(|p| p.get("KinesisStreamParameters"))
+                .and_then(|p| p.get("PartitionKey"))
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty());
+            for (id, event) in batch {
+                let data = serde_json::to_string(event).unwrap_or_default();
+                let pk = configured_pk.unwrap_or(id.as_str());
+                self.delivery.send_to_kinesis(target_arn, &data, pk);
+            }
+            true
         } else {
-            // Step Functions / EventBridge bus / Kinesis / etc. land in a later
-            // batch. Don't ack — leave the events so they're delivered once the
-            // target type is supported rather than silently dropped.
+            // Other targets (ECS / Batch / Redshift / HTTP / SageMaker / …)
+            // land in a later batch. Don't ack — leave the events so they're
+            // delivered once the target type is supported, never faked.
             false
         }
     }

--- a/website/content/docs/services/pipes.md
+++ b/website/content/docs/services/pipes.md
@@ -52,16 +52,20 @@ plaintext just like a real AWS consumer.
   are forwarded; non-matching events are acked (deleted) from the source, exactly
   as AWS Pipes drops filtered events.
 - **Targets** — **Lambda** (the matching batch is invoked as a JSON array),
-  **SQS**, and **SNS** (one message per event). A message is deleted from the
+  **SQS** and **SNS** (one message per event), **Step Functions**
+  (`StartExecution` per event), **EventBridge bus** (`PutEvents`, with
+  `Source`/`DetailType` from `TargetParameters.EventBridgeEventBusParameters`),
+  and **Kinesis** (one record per event, partition key from
+  `TargetParameters.KinesisStreamParameters`). A message is deleted from the
   source only after it is filtered out or successfully delivered; a delivery
   failure leaves it for redelivery.
 
 ## Roadmap
 
 - **More sources** — DynamoDB Streams and Kinesis sources.
-- **More targets** — Step Functions `StartExecution`, EventBridge bus
-  `PutEvents`, and Kinesis.
 - **Enrichment + transforms** — optional enrichment (Lambda / Step Functions /
   API destination) and `InputTemplate` target input transformers.
+- **More targets** — ECS, Batch, Redshift Data, HTTP/API destination,
+  SageMaker, CloudWatch Logs, Timestream.
 - **CloudFormation** — `AWS::Pipes::Pipe` provisioning.
 - **Terraform** — `aws_pipes_pipe` acceptance coverage.


### PR DESCRIPTION
## Batch 3 of EventBridge Pipes: Step Functions / EventBridge-bus / Kinesis targets

Extends the Pipes runner with three additional target types:

- **Step Functions** — `StartExecution` via `DeliveryBus.start_stepfunctions_execution`
- **EventBridge bus** — `PutEvents` via `DeliveryBus.put_event_to_eventbridge`
- **Kinesis** — `PutRecord` via `DeliveryBus.send_to_kinesis`

`target_params` is threaded through `deliver()` so per-target settings reach each sender. `pipes_bus` in `main.rs` now wires the eventbridge/stepfunctions/kinesis senders.

### Tests
`crates/fakecloud-e2e/tests/pipes_targets.rs` — SQS-source -> SFN target and SQS-source -> Kinesis target round-trips. Both pass.

### Docs
`website/content/docs/services/pipes.md` updated with the new supported targets.

Follows batch-1 (#2046 control plane) and batch-2 (#2047 SQS-source execution + filter).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Step Functions, EventBridge bus, and Kinesis as EventBridge Pipes targets. Pipes now deliver SQS-sourced events to these services via the shared `DeliveryBus`, with per-target settings and proper acking.

- New Features
  - Targets: Step Functions (StartExecution per event), EventBridge bus (PutEvents; bus from ARN; `Source`/`DetailType` from `TargetParameters.EventBridgeEventBusParameters`), Kinesis (PutRecord per event; partition key from `TargetParameters.KinesisStreamParameters.PartitionKey` or the message id).
  - Thread `target_params` through `deliver()` so per-target settings reach senders; wire EB/SFN/Kinesis into `pipes_bus` in `main.rs`.
  - E2E: SQS → Step Functions and SQS → Kinesis round-trips; docs updated.

<sup>Written for commit 9ea3f5647d93db7ee0a05e80bb76dc10a81e3782. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

