### PR TITLE
feat(pipes): execution engine — Kinesis + DynamoDB-stream sources, enrichment, InputTemplate (batch 4)

### DIFF
--- a/crates/fakecloud-dynamodb/src/lib.rs
+++ b/crates/fakecloud-dynamodb/src/lib.rs
@@ -9,6 +9,6 @@ pub use service::{save_dynamodb_snapshot, DynamoDbService};
 pub use state::{
     AttributeDefinition, DynamoDbSnapshot, DynamoDbState, DynamoTable, GlobalSecondaryIndex,
     KeySchemaElement, LocalSecondaryIndex, OnDemandThroughput, Projection, ProvisionedThroughput,
-    SharedDynamoDbState, DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
+    SharedDynamoDbState, StreamRecord, DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
 };
 pub use streams_dataplane::DynamoDbStreamsService;

--- a/crates/fakecloud-e2e/tests/pipes_enrichment.rs
+++ b/crates/fakecloud-e2e/tests/pipes_enrichment.rs
@@ -1,0 +1,153 @@
+//! EventBridge Pipes enrichment (batch 4): an SQS-source pipe runs each matched
+//! batch through a Lambda *enrichment* whose JSON return replaces the batch,
+//! then delivers the enriched events to the target. Uses a real Python Lambda
+//! (container runtime) for the enrichment round-trip and an SQS target so the
+//! result is observable through the SDK.
+
+mod helpers;
+
+use std::io::Write;
+
+use aws_sdk_lambda::primitives::Blob;
+use aws_sdk_lambda::types::{FunctionCode, Runtime};
+use helpers::TestServer;
+
+const ROLE: &str = "arn:aws:iam::000000000000:role/pipe-role";
+
+fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let cursor = std::io::Cursor::new(Vec::new());
+    let mut writer = zip::ZipWriter::new(cursor);
+    for (name, content) in entries {
+        let options = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+        writer.start_file(*name, options).unwrap();
+        writer.write_all(content).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
+async fn make_queue(sqs: &aws_sdk_sqs::Client, name: &str) -> (String, String) {
+    let url = sqs
+        .create_queue()
+        .queue_name(name)
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let arn = sqs
+        .get_queue_attributes()
+        .queue_url(&url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+    (url, arn)
+}
+
+async fn wait_running(pipes: &aws_sdk_pipes::Client, name: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if let Ok(r) = pipes.describe_pipe().name(name).send().await {
+            if r.current_state() == Some(&aws_sdk_pipes::types::PipeState::Running) {
+                return;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("pipe {name} never reached RUNNING");
+}
+
+async fn recv_one(sqs: &aws_sdk_sqs::Client, url: &str, secs: u64) -> Option<String> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+    while std::time::Instant::now() < deadline {
+        let r = sqs
+            .receive_message()
+            .queue_url(url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(0)
+            .send()
+            .await
+            .unwrap();
+        if let Some(m) = r.messages().first() {
+            return m.body().map(str::to_string);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    None
+}
+
+// The enrichment receives the matched batch as a JSON array and returns a new
+// array; Pipes forwards exactly what it returns to the target.
+const ENRICH_HANDLER: &str = r#"
+def handler(event, context):
+    # event is the array of source events
+    return [{"enriched": True, "count": len(event), "first_body": event[0]["body"]}]
+"#;
+
+#[tokio::test]
+async fn pipe_lambda_enrichment_rewrites_batch() {
+    let s = TestServer::start().await;
+    let cfg = s.aws_config().await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    let lambda = aws_sdk_lambda::Client::new(&cfg);
+    let pipes = aws_sdk_pipes::Client::new(&cfg);
+
+    let (src_url, src_arn) = make_queue(&sqs, "pipe-src-enrich").await;
+    let (tgt_url, tgt_arn) = make_queue(&sqs, "pipe-tgt-enrich").await;
+
+    let zip = make_zip(&[("index.py", ENRICH_HANDLER.as_bytes())]);
+    lambda
+        .create_function()
+        .function_name("pipe-enricher")
+        .runtime(Runtime::Python313)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .expect("create enrichment function");
+    let enrich_arn = lambda
+        .get_function()
+        .function_name("pipe-enricher")
+        .send()
+        .await
+        .unwrap()
+        .configuration()
+        .unwrap()
+        .function_arn()
+        .unwrap()
+        .to_string();
+
+    pipes
+        .create_pipe()
+        .name("enrich-pipe")
+        .source(&src_arn)
+        .target(&tgt_arn)
+        .enrichment(&enrich_arn)
+        .role_arn(ROLE)
+        .send()
+        .await
+        .expect("create pipe");
+    wait_running(&pipes, "enrich-pipe").await;
+
+    sqs.send_message()
+        .queue_url(&src_url)
+        .message_body("raw-event")
+        .send()
+        .await
+        .unwrap();
+
+    let body = recv_one(&sqs, &tgt_url, 30)
+        .await
+        .expect("enriched event delivered to target queue");
+    let event: serde_json::Value = serde_json::from_str(&body).expect("event is JSON");
+    assert_eq!(event["enriched"], true);
+    assert_eq!(event["count"], 1);
+    assert_eq!(event["first_body"], "raw-event");
+}

--- a/crates/fakecloud-e2e/tests/pipes_sources.rs
+++ b/crates/fakecloud-e2e/tests/pipes_sources.rs
@@ -1,0 +1,277 @@
+//! EventBridge Pipes additional sources (batch 4): pipes read from Kinesis
+//! streams and DynamoDB streams (not just SQS), and the target `InputTemplate`
+//! transforms each event before delivery. An SQS target keeps the whole path
+//! observable through the SDK without a container runtime.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const ROLE: &str = "arn:aws:iam::000000000000:role/pipe-role";
+
+async fn make_queue(sqs: &aws_sdk_sqs::Client, name: &str) -> (String, String) {
+    let url = sqs
+        .create_queue()
+        .queue_name(name)
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let arn = sqs
+        .get_queue_attributes()
+        .queue_url(&url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+    (url, arn)
+}
+
+async fn wait_running(pipes: &aws_sdk_pipes::Client, name: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if let Ok(r) = pipes.describe_pipe().name(name).send().await {
+            if r.current_state() == Some(&aws_sdk_pipes::types::PipeState::Running) {
+                return;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("pipe {name} never reached RUNNING");
+}
+
+/// Poll a queue until one message arrives (up to `secs`), returning its body.
+async fn recv_one(sqs: &aws_sdk_sqs::Client, url: &str, secs: u64) -> Option<String> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+    while std::time::Instant::now() < deadline {
+        let r = sqs
+            .receive_message()
+            .queue_url(url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(0)
+            .send()
+            .await
+            .unwrap();
+        if let Some(m) = r.messages().first() {
+            return m.body().map(str::to_string);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    None
+}
+
+#[tokio::test]
+async fn pipe_kinesis_source_to_sqs_target() {
+    let s = TestServer::start().await;
+    let cfg = s.aws_config().await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    let kinesis = aws_sdk_kinesis::Client::new(&cfg);
+    let pipes = aws_sdk_pipes::Client::new(&cfg);
+
+    kinesis
+        .create_stream()
+        .stream_name("pipe-kinesis-src")
+        .shard_count(1)
+        .send()
+        .await
+        .expect("create stream");
+    let stream_arn = kinesis
+        .describe_stream_summary()
+        .stream_name("pipe-kinesis-src")
+        .send()
+        .await
+        .unwrap()
+        .stream_description_summary()
+        .unwrap()
+        .stream_arn()
+        .to_string();
+
+    let (tgt_url, tgt_arn) = make_queue(&sqs, "pipe-tgt-from-kinesis").await;
+
+    let source_params = aws_sdk_pipes::types::PipeSourceParameters::builder()
+        .kinesis_stream_parameters(
+            aws_sdk_pipes::types::PipeSourceKinesisStreamParameters::builder()
+                .starting_position(aws_sdk_pipes::types::KinesisStreamStartPosition::TrimHorizon)
+                .batch_size(10)
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    pipes
+        .create_pipe()
+        .name("kinesis-src-pipe")
+        .source(&stream_arn)
+        .target(&tgt_arn)
+        .role_arn(ROLE)
+        .source_parameters(source_params)
+        .send()
+        .await
+        .expect("create pipe");
+    wait_running(&pipes, "kinesis-src-pipe").await;
+
+    kinesis
+        .put_record()
+        .stream_name("pipe-kinesis-src")
+        .partition_key("pk-1")
+        .data(aws_sdk_kinesis::primitives::Blob::new(
+            b"from-kinesis".to_vec(),
+        ))
+        .send()
+        .await
+        .expect("put record");
+
+    let body = recv_one(&sqs, &tgt_url, 10)
+        .await
+        .expect("kinesis record delivered to target queue");
+    let event: serde_json::Value = serde_json::from_str(&body).expect("event is JSON");
+    assert_eq!(event["eventSource"], "aws:kinesis");
+    assert_eq!(event["eventSourceARN"], stream_arn);
+    // The record data rides through base64-encoded in the Pipes envelope.
+    let data_b64 = event["kinesis"]["data"].as_str().unwrap();
+    let decoded = base64_decode(data_b64);
+    assert_eq!(decoded, b"from-kinesis");
+}
+
+#[tokio::test]
+async fn pipe_dynamodb_stream_source_to_sqs_target() {
+    let s = TestServer::start().await;
+    let cfg = s.aws_config().await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    let ddb = aws_sdk_dynamodb::Client::new(&cfg);
+    let pipes = aws_sdk_pipes::Client::new(&cfg);
+
+    use aws_sdk_dynamodb::types as dt;
+    ddb.create_table()
+        .table_name("pipe-ddb-src")
+        .attribute_definitions(
+            dt::AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(dt::ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            dt::KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(dt::KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(dt::BillingMode::PayPerRequest)
+        .stream_specification(
+            dt::StreamSpecification::builder()
+                .stream_enabled(true)
+                .stream_view_type(dt::StreamViewType::NewAndOldImages)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create table");
+
+    let stream_arn = ddb
+        .describe_table()
+        .table_name("pipe-ddb-src")
+        .send()
+        .await
+        .unwrap()
+        .table()
+        .unwrap()
+        .latest_stream_arn()
+        .expect("stream arn")
+        .to_string();
+
+    let (tgt_url, tgt_arn) = make_queue(&sqs, "pipe-tgt-from-ddb").await;
+
+    let source_params = aws_sdk_pipes::types::PipeSourceParameters::builder()
+        .dynamo_db_stream_parameters(
+            aws_sdk_pipes::types::PipeSourceDynamoDbStreamParameters::builder()
+                .starting_position(aws_sdk_pipes::types::DynamoDbStreamStartPosition::TrimHorizon)
+                .batch_size(10)
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    pipes
+        .create_pipe()
+        .name("ddb-src-pipe")
+        .source(&stream_arn)
+        .target(&tgt_arn)
+        .role_arn(ROLE)
+        .source_parameters(source_params)
+        .send()
+        .await
+        .expect("create pipe");
+    wait_running(&pipes, "ddb-src-pipe").await;
+
+    ddb.put_item()
+        .table_name("pipe-ddb-src")
+        .item("pk", dt::AttributeValue::S("row-1".into()))
+        .send()
+        .await
+        .expect("put item");
+
+    let body = recv_one(&sqs, &tgt_url, 10)
+        .await
+        .expect("ddb stream record delivered to target queue");
+    let event: serde_json::Value = serde_json::from_str(&body).expect("event is JSON");
+    assert_eq!(event["eventSource"], "aws:dynamodb");
+    assert_eq!(event["eventName"], "INSERT");
+    assert_eq!(event["dynamodb"]["NewImage"]["pk"]["S"], "row-1");
+}
+
+#[tokio::test]
+async fn pipe_input_template_transforms_event() {
+    let s = TestServer::start().await;
+    let cfg = s.aws_config().await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    let pipes = aws_sdk_pipes::Client::new(&cfg);
+
+    let (src_url, src_arn) = make_queue(&sqs, "pipe-src-tmpl").await;
+    let (tgt_url, tgt_arn) = make_queue(&sqs, "pipe-tgt-tmpl").await;
+
+    let target_params = aws_sdk_pipes::types::PipeTargetParameters::builder()
+        .input_template(r#"{"transformed": "<$.body>", "src": "<$.eventSource>"}"#)
+        .build();
+
+    pipes
+        .create_pipe()
+        .name("tmpl-pipe")
+        .source(&src_arn)
+        .target(&tgt_arn)
+        .role_arn(ROLE)
+        .target_parameters(target_params)
+        .send()
+        .await
+        .expect("create pipe");
+    wait_running(&pipes, "tmpl-pipe").await;
+
+    sqs.send_message()
+        .queue_url(&src_url)
+        .message_body("payload")
+        .send()
+        .await
+        .unwrap();
+
+    let body = recv_one(&sqs, &tgt_url, 8)
+        .await
+        .expect("transformed event delivered");
+    let event: serde_json::Value = serde_json::from_str(&body).expect("template produced JSON");
+    // <$.body> resolves to the source message body, <$.eventSource> to "aws:sqs".
+    assert_eq!(event["transformed"], "payload");
+    assert_eq!(event["src"], "aws:sqs");
+}
+
+fn base64_decode(s: &str) -> Vec<u8> {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.decode(s).unwrap()
+}

--- a/crates/fakecloud-kinesis/src/lib.rs
+++ b/crates/fakecloud-kinesis/src/lib.rs
@@ -5,6 +5,6 @@ pub(crate) mod state;
 
 pub use service::{build_stream_shards, KinesisService};
 pub use state::{
-    KinesisConsumer, KinesisShard, KinesisSnapshot, KinesisState, KinesisStream,
+    KinesisConsumer, KinesisRecord, KinesisShard, KinesisSnapshot, KinesisState, KinesisStream,
     SharedKinesisState, KINESIS_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-pipes/src/state.rs
+++ b/crates/fakecloud-pipes/src/state.rs
@@ -29,6 +29,14 @@ pub struct PipesState {
     /// Tags keyed by resource ARN -> { key: value }.
     #[serde(default)]
     pub tags: BTreeMap<String, BTreeMap<String, String>>,
+    /// Source checkpoints for streaming sources, so a restart resumes
+    /// instead of re-replaying the retained backlog. Keyed by
+    /// `"<pipeArn>#<shardId>"` for a Kinesis source (value = the next
+    /// record index in that shard) and `"<pipeArn>"` for a DynamoDB-stream
+    /// source (value = the last delivered sequence number). SQS sources
+    /// don't checkpoint — they ack by deleting the source message.
+    #[serde(default)]
+    pub source_checkpoints: BTreeMap<String, String>,
 }
 
 impl PipesAccounts {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3885,11 +3885,11 @@ async fn main() {
         dynamodb_streams_poller = dynamodb_streams_poller.with_lambda_delivery(ld.clone());
     }
     tokio::spawn(Arc::new(dynamodb_streams_poller).run());
-    // EventBridge Pipes runner: executes RUNNING pipes with an SQS source,
-    // filtering events and delivering matches to Lambda/SQS/SNS/Step
-    // Functions/EventBridge-bus/Kinesis targets via the shared delivery
-    // paths. DynamoDB-stream/Kinesis sources + enrichment land in a later
-    // batch.
+    // EventBridge Pipes runner: executes RUNNING pipes with an SQS / Kinesis /
+    // DynamoDB-stream source, filtering events, optionally running them through
+    // a Lambda enrichment, applying the target InputTemplate, and delivering
+    // matches to Lambda/SQS/SNS/Step Functions/EventBridge-bus/Kinesis targets
+    // via the shared delivery paths.
     {
         // EventBridge-bus + Step Functions target senders need their own
         // delivery impls (mirroring the scheduler/EB wiring); a minimal inner
@@ -3937,6 +3937,8 @@ async fn main() {
             sqs_state.clone(),
             Arc::new(pipes_bus),
         )
+        .with_kinesis_state(kinesis_state.clone())
+        .with_dynamodb_state(dynamodb_state.clone())
         .with_kms_hook(kms_hook_for_services.clone());
         tokio::spawn(runner.run());
     }

--- a/crates/fakecloud-server/src/pipes_runner.rs
+++ b/crates/fakecloud-server/src/pipes_runner.rs
@@ -1,19 +1,26 @@
-//! Background runner that executes EventBridge Pipes with an SQS source.
+//! Background runner that executes EventBridge Pipes.
 //!
-//! For each RUNNING pipe whose `Source` is an SQS queue ARN, the runner polls
-//! the source queue, applies the pipe's EventBridge-pattern filter (matching
-//! events are forwarded, non-matching events are acked/deleted — "filter
-//! drop-as-ack", exactly as AWS Pipes does), and delivers the matching events
-//! to the pipe's target (Lambda / SQS / SNS / Step Functions / EventBridge bus
-//! / Kinesis) via the shared `DeliveryBus`, reusing the same cross-service
-//! delivery paths every other fakecloud feature uses. A message is deleted
-//! from the source only after it is either filtered out or successfully
-//! delivered; a delivery failure leaves it for redelivery.
+//! For each RUNNING pipe the runner polls its source, applies the pipe's
+//! EventBridge-pattern filter (matching events are forwarded, non-matching
+//! events are acked — "filter drop-as-ack", exactly as AWS Pipes does),
+//! optionally runs the matched batch through an *enrichment* (a Lambda
+//! round-trip whose JSON return replaces the batch), applies the target
+//! `InputTemplate` transform per event, and delivers the result to the pipe's
+//! target via the shared `DeliveryBus`, reusing the same cross-service
+//! delivery paths every other fakecloud feature uses.
 //!
-//! DynamoDB-stream / Kinesis sources, enrichment, InputTemplate transforms,
-//! and the remaining target types (ECS / Batch / Redshift / HTTP / …) land in
-//! a later batch. Each unsupported source/target is left untouched (the pipe
-//! simply does no work) rather than faking delivery.
+//! Sources: SQS queues, Kinesis streams, and DynamoDB streams. SQS acks by
+//! deleting the source message only after it is filtered out or successfully
+//! delivered; the stream sources keep a durable per-pipe checkpoint (in the
+//! Pipes state, so it survives a restart) and advance it only past records
+//! that are filtered out or successfully delivered — a delivery failure
+//! leaves the window for redelivery (at-least-once, like AWS).
+//!
+//! Targets: Lambda / SQS / SNS / Step Functions / EventBridge bus / Kinesis.
+//! Other targets (ECS / Batch / Redshift / HTTP / …) and non-Lambda
+//! enrichment land in a later batch; an unsupported source/target/enrichment
+//! is left untouched (the pipe simply does no work and never acks) rather
+//! than faking delivery.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -24,22 +31,48 @@ use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
 
 use fakecloud_core::delivery::{DeliveryBus, KmsHook};
+use fakecloud_dynamodb::SharedDynamoDbState;
+use fakecloud_kinesis::SharedKinesisState;
 use fakecloud_lambda::filter::FilterSet;
 use fakecloud_pipes::SharedPipesState;
 use fakecloud_sqs::SharedSqsState;
 
-/// One RUNNING pipe with an SQS source, resolved for this tick.
-struct SqsSourcePipe {
+/// What kind of source a RUNNING pipe reads from.
+enum SourceKind {
+    Sqs,
+    Kinesis,
+    DynamoDbStream,
+}
+
+/// One RUNNING pipe resolved for this tick.
+struct RunningPipe {
+    /// The pipe's own ARN — used to key stream checkpoints.
+    arn: String,
     source_arn: String,
+    source_kind: SourceKind,
     target_arn: String,
     target_params: Option<Value>,
+    /// `TargetParameters.InputTemplate`, applied per event before delivery.
+    input_template: Option<String>,
+    /// `Enrichment` ARN (a Lambda, this batch); the matched batch is sent to
+    /// it and its JSON return replaces the batch before target delivery.
+    enrichment: Option<String>,
+    /// `EnrichmentParameters.InputTemplate`, applied per event before the
+    /// enrichment invocation.
+    enrichment_input_template: Option<String>,
     filter: FilterSet,
     batch_size: usize,
+    /// `StartingPosition` for a stream source (TRIM_HORIZON / LATEST /
+    /// AT_TIMESTAMP); ignored for SQS.
+    starting_position: Option<String>,
+    starting_position_timestamp: Option<f64>,
 }
 
 pub struct PipesRunner {
     pipes_state: SharedPipesState,
     sqs_state: SharedSqsState,
+    kinesis_state: Option<SharedKinesisState>,
+    dynamodb_state: Option<SharedDynamoDbState>,
     delivery: Arc<DeliveryBus>,
     /// Decrypts at-rest SSE-KMS / SSE-SQS message bodies before forwarding,
     /// mirroring the SQS->Lambda poller: AWS consumers see plaintext, so a
@@ -56,9 +89,21 @@ impl PipesRunner {
         Self {
             pipes_state,
             sqs_state,
+            kinesis_state: None,
+            dynamodb_state: None,
             delivery,
             kms_hook: None,
         }
+    }
+
+    pub fn with_kinesis_state(mut self, state: SharedKinesisState) -> Self {
+        self.kinesis_state = Some(state);
+        self
+    }
+
+    pub fn with_dynamodb_state(mut self, state: SharedDynamoDbState) -> Self {
+        self.dynamodb_state = Some(state);
+        self
     }
 
     pub fn with_kms_hook(mut self, hook: Arc<dyn KmsHook>) -> Self {
@@ -75,14 +120,18 @@ impl PipesRunner {
     }
 
     async fn poll(&self) {
-        let pipes = self.collect_sqs_source_pipes();
+        let pipes = self.collect_running_pipes();
         for pipe in pipes {
-            self.process_pipe(&pipe).await;
+            match pipe.source_kind {
+                SourceKind::Sqs => self.process_sqs_pipe(&pipe).await,
+                SourceKind::Kinesis => self.process_kinesis_pipe(&pipe).await,
+                SourceKind::DynamoDbStream => self.process_ddb_pipe(&pipe).await,
+            }
         }
     }
 
-    /// Snapshot every RUNNING pipe whose source is an SQS queue.
-    fn collect_sqs_source_pipes(&self) -> Vec<SqsSourcePipe> {
+    /// Snapshot every RUNNING pipe whose source is one we execute.
+    fn collect_running_pipes(&self) -> Vec<RunningPipe> {
         let accounts = self.pipes_state.read();
         let mut out = Vec::new();
         for state in accounts.accounts.values() {
@@ -93,34 +142,68 @@ impl PipesRunner {
                 let Some(source_arn) = pipe.get("Source").and_then(Value::as_str) else {
                     continue;
                 };
-                if !source_arn.contains(":sqs:") {
+                let source_kind = if source_arn.contains(":sqs:") {
+                    SourceKind::Sqs
+                } else if source_arn.contains(":kinesis:") {
+                    SourceKind::Kinesis
+                } else if source_arn.contains(":dynamodb:") && source_arn.contains("/stream/") {
+                    SourceKind::DynamoDbStream
+                } else {
                     continue;
-                }
+                };
                 let Some(target_arn) = pipe.get("Target").and_then(Value::as_str) else {
                     continue;
                 };
                 let source_params = pipe.get("SourceParameters");
                 let filter = build_filter(source_params);
-                let batch_size = source_params
-                    .and_then(|p| p.get("SqsQueueParameters"))
-                    .and_then(|p| p.get("BatchSize"))
-                    .and_then(Value::as_i64)
-                    .filter(|n| *n > 0)
-                    .unwrap_or(10)
-                    .min(10) as usize;
-                out.push(SqsSourcePipe {
+                let batch_size = source_batch_size(source_params, &source_kind);
+                let (starting_position, starting_position_timestamp) =
+                    starting_position(source_params, &source_kind);
+                let target_params = pipe.get("TargetParameters").cloned();
+                let input_template = target_params
+                    .as_ref()
+                    .and_then(|p| p.get("InputTemplate"))
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+                let enrichment = pipe
+                    .get("Enrichment")
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+                let enrichment_input_template = pipe
+                    .get("EnrichmentParameters")
+                    .and_then(|p| p.get("InputTemplate"))
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+                let arn = pipe
+                    .get("Arn")
+                    .and_then(Value::as_str)
+                    .unwrap_or(source_arn)
+                    .to_string();
+                out.push(RunningPipe {
+                    arn,
                     source_arn: source_arn.to_string(),
+                    source_kind,
                     target_arn: target_arn.to_string(),
-                    target_params: pipe.get("TargetParameters").cloned(),
+                    target_params,
+                    input_template,
+                    enrichment,
+                    enrichment_input_template,
                     filter,
                     batch_size,
+                    starting_position,
+                    starting_position_timestamp,
                 });
             }
         }
         out
     }
 
-    async fn process_pipe(&self, pipe: &SqsSourcePipe) {
+    // --- SQS source ---------------------------------------------------------
+
+    async fn process_sqs_pipe(&self, pipe: &RunningPipe) {
         let now = Utc::now();
         // Pull up to BatchSize visible messages and hide them for the queue's
         // visibility window so a slow delivery doesn't re-pull the same batch.
@@ -131,22 +214,20 @@ impl PipesRunner {
 
         // Partition by the filter: matching events are delivered, the rest are
         // acked (deleted) immediately — AWS Pipes drops filtered events.
-        let mut to_deliver: Vec<(String, Value)> = Vec::new();
+        let mut matched: Vec<(String, Value)> = Vec::new();
         let mut ack_ids: Vec<String> = Vec::new();
         for (id, event) in picked {
             if pipe.filter.is_empty() || pipe.filter.matches(&event) {
-                to_deliver.push((id, event));
+                matched.push((id, event));
             } else {
                 ack_ids.push(id);
             }
         }
 
-        if !to_deliver.is_empty() {
-            let delivered = self
-                .deliver(&pipe.target_arn, pipe.target_params.as_ref(), &to_deliver)
-                .await;
-            if delivered {
-                ack_ids.extend(to_deliver.into_iter().map(|(id, _)| id));
+        if !matched.is_empty() {
+            let events: Vec<Value> = matched.iter().map(|(_, e)| e.clone()).collect();
+            if self.enrich_and_deliver(pipe, events).await {
+                ack_ids.extend(matched.into_iter().map(|(id, _)| id));
             }
         }
 
@@ -253,18 +334,257 @@ impl PipesRunner {
         }
     }
 
+    // --- Kinesis source -----------------------------------------------------
+
+    async fn process_kinesis_pipe(&self, pipe: &RunningPipe) {
+        let Some(kinesis_state) = self.kinesis_state.as_ref() else {
+            return;
+        };
+        let account = arn_account(&pipe.source_arn);
+        let region = arn_region(&pipe.source_arn);
+
+        // Snapshot each shard's pending window and seed missing checkpoints.
+        struct ShardWindow {
+            shard_id: String,
+            end: usize,
+            records: Vec<fakecloud_kinesis::KinesisRecord>,
+        }
+        let windows: Vec<ShardWindow> = {
+            let ks = kinesis_state.read();
+            let Some(kinesis) = ks.get(&account) else {
+                return;
+            };
+            let Some(stream) = kinesis
+                .streams
+                .values()
+                .find(|s| s.stream_arn == pipe.source_arn)
+            else {
+                return;
+            };
+            let mut seeds: Vec<(String, usize)> = Vec::new();
+            let mut windows = Vec::new();
+            for shard in &stream.shards {
+                let key = format!("{}#{}", pipe.arn, shard.shard_id);
+                let start = match self.checkpoint(&account, &key) {
+                    Some(s) => s.parse::<usize>().unwrap_or(0),
+                    None => {
+                        let init = kinesis_start_index(
+                            &shard.records,
+                            pipe.starting_position.as_deref(),
+                            pipe.starting_position_timestamp,
+                        );
+                        seeds.push((key.clone(), init));
+                        init
+                    }
+                };
+                if start >= shard.records.len() {
+                    continue;
+                }
+                let end = shard
+                    .records
+                    .len()
+                    .min(start.saturating_add(pipe.batch_size));
+                windows.push(ShardWindow {
+                    shard_id: shard.shard_id.clone(),
+                    end,
+                    records: shard.records[start..end].to_vec(),
+                });
+            }
+            drop(ks);
+            // Persist the first-seen checkpoints so LATEST/AT_TIMESTAMP don't
+            // re-resolve (and re-skip) on every subsequent tick.
+            for (key, init) in seeds {
+                self.set_checkpoint(&account, &key, init.to_string());
+            }
+            windows
+        };
+
+        for window in windows {
+            let events: Vec<Value> = window
+                .records
+                .iter()
+                .map(|r| kinesis_source_event(r, &window.shard_id, &pipe.source_arn, &region))
+                .collect();
+            let key = format!("{}#{}", pipe.arn, window.shard_id);
+            if self.process_stream_window(pipe, events).await {
+                self.set_checkpoint(&account, &key, window.end.to_string());
+            }
+        }
+    }
+
+    // --- DynamoDB stream source --------------------------------------------
+
+    async fn process_ddb_pipe(&self, pipe: &RunningPipe) {
+        let Some(dynamodb_state) = self.dynamodb_state.as_ref() else {
+            return;
+        };
+        let account = arn_account(&pipe.source_arn);
+        let Some(table_name) = pipe
+            .source_arn
+            .split(":table/")
+            .nth(1)
+            .and_then(|t| t.split('/').next())
+            .map(str::to_string)
+        else {
+            return;
+        };
+
+        // Seed the checkpoint the first time we see this pipe.
+        if self.checkpoint(&account, &pipe.arn).is_none() {
+            let init = {
+                let ds = dynamodb_state.read();
+                let Some(dynamodb) = ds.get(&account) else {
+                    return;
+                };
+                let Some(table) = dynamodb.tables.get(&table_name) else {
+                    return;
+                };
+                // DDB streams only accept TRIM_HORIZON (replay) and LATEST
+                // (skip the existing backlog).
+                if pipe.starting_position.as_deref() == Some("LATEST") {
+                    let records = table.stream_records.read();
+                    records
+                        .iter()
+                        .map(|r| r.dynamodb.sequence_number.clone())
+                        .max()
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                }
+            };
+            self.set_checkpoint(&account, &pipe.arn, init);
+        }
+        let checkpoint = self.checkpoint(&account, &pipe.arn).unwrap_or_default();
+
+        let (last_seq, events) = {
+            let ds = dynamodb_state.read();
+            let Some(dynamodb) = ds.get(&account) else {
+                return;
+            };
+            let Some(table) = dynamodb.tables.get(&table_name) else {
+                return;
+            };
+            if !table.stream_enabled {
+                return;
+            }
+            let stream_records = table.stream_records.read();
+            let mut window: Vec<_> = stream_records
+                .iter()
+                .filter(|r| {
+                    checkpoint.is_empty()
+                        || r.dynamodb.sequence_number.as_str() > checkpoint.as_str()
+                })
+                .take(pipe.batch_size)
+                .cloned()
+                .collect();
+            window.sort_by(|a, b| a.dynamodb.sequence_number.cmp(&b.dynamodb.sequence_number));
+            let last_seq = window.last().map(|r| r.dynamodb.sequence_number.clone());
+            let events: Vec<Value> = window.iter().map(ddb_source_event).collect();
+            (last_seq, events)
+        };
+
+        let Some(last_seq) = last_seq else {
+            return;
+        };
+        if self.process_stream_window(pipe, events).await {
+            self.set_checkpoint(&account, &pipe.arn, last_seq);
+        }
+    }
+
+    /// Filter, enrich, transform and deliver one stream window. Returns true
+    /// when the window may be checkpointed past (filtered-only windows count
+    /// as success; a delivery failure returns false so the window is retried).
+    async fn process_stream_window(&self, pipe: &RunningPipe, events: Vec<Value>) -> bool {
+        let matched: Vec<Value> = if pipe.filter.is_empty() {
+            events
+        } else {
+            events
+                .into_iter()
+                .filter(|e| pipe.filter.matches(e))
+                .collect()
+        };
+        // Every record in the window is filtered out: nothing to deliver, but
+        // the checkpoint must still advance past them (AWS consumes them).
+        if matched.is_empty() {
+            return true;
+        }
+        self.enrich_and_deliver(pipe, matched).await
+    }
+
+    // --- Shared enrichment + transform + delivery --------------------------
+
+    /// Run the matched batch through the optional enrichment, apply the target
+    /// `InputTemplate` per resulting event, and deliver. Returns true when the
+    /// batch may be acked/checkpointed (delivered, or the enrichment dropped
+    /// every event).
+    async fn enrich_and_deliver(&self, pipe: &RunningPipe, events: Vec<Value>) -> bool {
+        let enriched = match self.enrich(pipe, events).await {
+            Some(events) => events,
+            // Enrichment failed or is unsupported: don't ack, retry later.
+            None => return false,
+        };
+        if enriched.is_empty() {
+            // Enrichment legitimately dropped every event — consume them.
+            return true;
+        }
+        let transformed: Vec<Value> = enriched
+            .iter()
+            .map(|e| apply_input_template(pipe.input_template.as_deref(), e))
+            .collect();
+        self.deliver(&pipe.target_arn, pipe.target_params.as_ref(), &transformed)
+            .await
+    }
+
+    /// Send the batch through the pipe's enrichment (a Lambda) and return the
+    /// events its JSON response yields. `Some(events)` on success (possibly
+    /// empty — the enrichment dropped everything); `None` when the enrichment
+    /// failed, isn't wired, or is an unsupported type (so the caller retries
+    /// rather than fakes delivery). With no enrichment configured the batch
+    /// passes through unchanged.
+    async fn enrich(&self, pipe: &RunningPipe, events: Vec<Value>) -> Option<Vec<Value>> {
+        let Some(enr_arn) = pipe.enrichment.as_deref() else {
+            return Some(events);
+        };
+        // The enrichment receives the batch as an array, each event first run
+        // through the enrichment InputTemplate when one is configured.
+        let input: Vec<Value> = events
+            .iter()
+            .map(|e| apply_input_template(pipe.enrichment_input_template.as_deref(), e))
+            .collect();
+        if enr_arn.contains(":lambda:") {
+            let payload =
+                serde_json::to_string(&Value::Array(input)).unwrap_or_else(|_| "[]".into());
+            match self.delivery.invoke_lambda(enr_arn, &payload).await {
+                Some(Ok(bytes)) => Some(enrichment_output(&bytes)),
+                Some(Err(err)) => {
+                    tracing::warn!(%enr_arn, %err, "pipes: enrichment Lambda failed; events will be retried");
+                    None
+                }
+                // No Lambda runtime wired (unit/no-runtime): leave events.
+                None => None,
+            }
+        } else {
+            // Non-Lambda enrichment (Step Functions sync / API destination /
+            // API Gateway) needs a synchronous round-trip not yet wired; don't
+            // fake it — leave the events so they deliver once supported.
+            tracing::warn!(%enr_arn, "pipes: unsupported enrichment type; events held");
+            None
+        }
+    }
+
     /// Deliver the batch to the target. Returns true if delivery succeeded (and
     /// the events may be acked). Lambda receives the whole batch as a JSON
-    /// array (Pipes batches to Lambda); SQS/SNS receive one message per event.
+    /// array (Pipes batches to Lambda); SQS/SNS/SFN/Kinesis receive one
+    /// message per event.
     async fn deliver(
         &self,
         target_arn: &str,
         target_params: Option<&Value>,
-        batch: &[(String, Value)],
+        batch: &[Value],
     ) -> bool {
         if target_arn.contains(":lambda:") {
-            let payload = Value::Array(batch.iter().map(|(_, e)| e.clone()).collect());
-            let payload = serde_json::to_string(&payload).unwrap_or_else(|_| "[]".to_string());
+            let payload = serde_json::to_string(&Value::Array(batch.to_vec()))
+                .unwrap_or_else(|_| "[]".to_string());
             match self.delivery.invoke_lambda(target_arn, &payload).await {
                 Some(Ok(_)) => true,
                 Some(Err(err)) => {
@@ -275,23 +595,23 @@ impl PipesRunner {
                 None => false,
             }
         } else if target_arn.contains(":sqs:") {
-            for (_, event) in batch {
-                let body = serde_json::to_string(event).unwrap_or_default();
+            for event in batch {
+                let body = event_to_payload(event);
                 self.delivery
                     .send_to_sqs(target_arn, &body, &HashMap::new());
             }
             true
         } else if target_arn.contains(":sns:") {
-            for (_, event) in batch {
-                let body = serde_json::to_string(event).unwrap_or_default();
+            for event in batch {
+                let body = event_to_payload(event);
                 self.delivery.publish_to_sns(target_arn, &body, None);
             }
             true
         } else if target_arn.contains(":states:") {
             // Step Functions: start one execution per event with the event as
             // input (Pipes invokes standard state machines per record).
-            for (_, event) in batch {
-                let input = serde_json::to_string(event).unwrap_or_default();
+            for event in batch {
+                let input = event_to_payload(event);
                 self.delivery
                     .start_stepfunctions_execution(target_arn, &input);
             }
@@ -313,8 +633,8 @@ impl PipesRunner {
                 .and_then(|p| p.get("DetailType"))
                 .and_then(Value::as_str)
                 .unwrap_or("Event");
-            for (_, event) in batch {
-                let detail = serde_json::to_string(event).unwrap_or_default();
+            for event in batch {
+                let detail = event_to_payload(event);
                 self.delivery
                     .put_event_to_eventbridge(source, detail_type, &detail, bus_name);
             }
@@ -322,15 +642,16 @@ impl PipesRunner {
         } else if target_arn.contains(":kinesis:") {
             // Kinesis: one record per event. PartitionKey comes from the
             // target's KinesisStreamParameters (a literal here), falling back
-            // to the source message id so records still spread across shards.
+            // to the event's index so records still spread across shards.
             let configured_pk = target_params
                 .and_then(|p| p.get("KinesisStreamParameters"))
                 .and_then(|p| p.get("PartitionKey"))
                 .and_then(Value::as_str)
                 .filter(|s| !s.is_empty());
-            for (id, event) in batch {
-                let data = serde_json::to_string(event).unwrap_or_default();
-                let pk = configured_pk.unwrap_or(id.as_str());
+            for (idx, event) in batch.iter().enumerate() {
+                let data = event_to_payload(event);
+                let fallback = idx.to_string();
+                let pk = configured_pk.unwrap_or(fallback.as_str());
                 self.delivery.send_to_kinesis(target_arn, &data, pk);
             }
             true
@@ -340,6 +661,23 @@ impl PipesRunner {
             // delivered once the target type is supported, never faked.
             false
         }
+    }
+
+    // --- Checkpoint helpers -------------------------------------------------
+
+    fn checkpoint(&self, account: &str, key: &str) -> Option<String> {
+        self.pipes_state
+            .read()
+            .get(account)
+            .and_then(|s| s.source_checkpoints.get(key).cloned())
+    }
+
+    fn set_checkpoint(&self, account: &str, key: &str, value: String) {
+        self.pipes_state
+            .write()
+            .get_or_create(account)
+            .source_checkpoints
+            .insert(key.to_string(), value);
     }
 }
 
@@ -358,6 +696,159 @@ fn build_filter(source_params: Option<&Value>) -> FilterSet {
         })
         .unwrap_or_default();
     FilterSet::from_strings(patterns)
+}
+
+/// Resolve the per-source `BatchSize` (clamped to each source's AWS ceiling).
+fn source_batch_size(source_params: Option<&Value>, kind: &SourceKind) -> usize {
+    let (param_key, default, max) = match kind {
+        SourceKind::Sqs => ("SqsQueueParameters", 10, 10),
+        SourceKind::Kinesis => ("KinesisStreamParameters", 100, 10_000),
+        SourceKind::DynamoDbStream => ("DynamoDBStreamParameters", 100, 10_000),
+    };
+    source_params
+        .and_then(|p| p.get(param_key))
+        .and_then(|p| p.get("BatchSize"))
+        .and_then(Value::as_i64)
+        .filter(|n| *n > 0)
+        .unwrap_or(default)
+        .min(max) as usize
+}
+
+/// Resolve `StartingPosition` (+ timestamp) for a stream source.
+fn starting_position(
+    source_params: Option<&Value>,
+    kind: &SourceKind,
+) -> (Option<String>, Option<f64>) {
+    let param_key = match kind {
+        SourceKind::Kinesis => "KinesisStreamParameters",
+        SourceKind::DynamoDbStream => "DynamoDBStreamParameters",
+        SourceKind::Sqs => return (None, None),
+    };
+    let params = source_params.and_then(|p| p.get(param_key));
+    let pos = params
+        .and_then(|p| p.get("StartingPosition"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let ts = params
+        .and_then(|p| p.get("StartingPositionTimestamp"))
+        .and_then(Value::as_f64);
+    (pos, ts)
+}
+
+/// First record index a Kinesis pipe should read given its StartingPosition.
+fn kinesis_start_index(
+    records: &[fakecloud_kinesis::KinesisRecord],
+    starting_position: Option<&str>,
+    starting_position_timestamp: Option<f64>,
+) -> usize {
+    match starting_position.unwrap_or("TRIM_HORIZON") {
+        "LATEST" => records.len(),
+        "AT_TIMESTAMP" => {
+            let target = starting_position_timestamp.map(|t| t as i64).unwrap_or(0);
+            records
+                .iter()
+                .position(|r| r.approximate_arrival_timestamp.timestamp() >= target)
+                .unwrap_or(records.len())
+        }
+        _ => 0, // TRIM_HORIZON
+    }
+}
+
+fn arn_account(arn: &str) -> String {
+    arn.split(':').nth(4).unwrap_or("").to_string()
+}
+
+fn arn_region(arn: &str) -> String {
+    arn.split(':').nth(3).unwrap_or("us-east-1").to_string()
+}
+
+/// Serialize a (possibly already-transformed) event for a one-per-record
+/// target. A string event is sent as-is (it was rendered by an InputTemplate);
+/// anything else is JSON-serialized.
+fn event_to_payload(event: &Value) -> String {
+    match event {
+        Value::String(s) => s.clone(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+/// Normalize an enrichment Lambda's JSON response into a list of events. An
+/// array becomes its elements; a single object becomes a one-element batch;
+/// null / empty drops the batch. Pipes enrichment may return 0..N events.
+fn enrichment_output(bytes: &[u8]) -> Vec<Value> {
+    match serde_json::from_slice::<Value>(bytes) {
+        Ok(Value::Array(items)) => items,
+        Ok(Value::Null) => Vec::new(),
+        Ok(Value::String(s)) if s.is_empty() => Vec::new(),
+        Ok(other) => vec![other],
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Apply an AWS Pipes `InputTemplate` to one event. With no template the event
+/// passes through unchanged. Otherwise every `<$.json.path>` placeholder is
+/// resolved against the event (and `<aws.pipes.event.json>` expands to the
+/// whole event); the rendered string is returned parsed as JSON when it parses
+/// and as a JSON string otherwise — matching how AWS treats a template that
+/// produces a JSON object versus free text.
+fn apply_input_template(template: Option<&str>, event: &Value) -> Value {
+    let Some(template) = template else {
+        return event.clone();
+    };
+    let rendered = render_template(template, event);
+    match serde_json::from_str::<Value>(&rendered) {
+        Ok(value) => value,
+        Err(_) => Value::String(rendered),
+    }
+}
+
+/// Substitute `<...>` placeholders in a Pipes InputTemplate.
+fn render_template(template: &str, event: &Value) -> String {
+    let mut out = String::new();
+    let mut rest = template;
+    while let Some(open) = rest.find('<') {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 1..];
+        if let Some(close) = after.find('>') {
+            out.push_str(&resolve_token(after[..close].trim(), event));
+            rest = &after[close + 1..];
+        } else {
+            // Unterminated '<' — emit literally and stop scanning.
+            out.push('<');
+            rest = after;
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Resolve one InputTemplate token to its replacement text.
+fn resolve_token(token: &str, event: &Value) -> String {
+    if token == "aws.pipes.event.json" {
+        return serde_json::to_string(event).unwrap_or_default();
+    }
+    if let Some(path) = token.strip_prefix('$') {
+        return match resolve_json_path(event, path) {
+            Some(Value::String(s)) => s,
+            Some(other) => serde_json::to_string(&other).unwrap_or_default(),
+            // Unresolved path -> empty, as AWS substitutes nothing.
+            None => String::new(),
+        };
+    }
+    // Unknown token: leave it intact rather than silently blanking it.
+    format!("<{token}>")
+}
+
+/// Resolve a simple JSON path like `.detail.name` against an event.
+fn resolve_json_path(event: &Value, path: &str) -> Option<Value> {
+    let mut current = event;
+    for segment in path.split('.') {
+        if segment.is_empty() {
+            continue;
+        }
+        current = current.get(segment)?;
+    }
+    Some(current.clone())
 }
 
 /// Build the AWS Pipes SQS-source event envelope for one message. `body` is the
@@ -386,6 +877,57 @@ fn sqs_source_event(
     })
 }
 
+/// Build the AWS Pipes Kinesis-source event envelope for one record.
+fn kinesis_source_event(
+    record: &fakecloud_kinesis::KinesisRecord,
+    shard_id: &str,
+    source_arn: &str,
+    region: &str,
+) -> Value {
+    json!({
+        "eventSource": "aws:kinesis",
+        "eventVersion": "1.0",
+        "eventID": format!("{}:{}", shard_id, record.sequence_number),
+        "eventName": "aws:kinesis:record",
+        "invokeIdentityArn": "arn:aws:iam::123456789012:role/pipes-role",
+        "awsRegion": region,
+        "eventSourceARN": source_arn,
+        "kinesis": {
+            "kinesisSchemaVersion": "1.0",
+            "partitionKey": record.partition_key,
+            "sequenceNumber": record.sequence_number,
+            "data": base64::engine::general_purpose::STANDARD.encode(&record.data),
+            "approximateArrivalTimestamp":
+                record.approximate_arrival_timestamp.timestamp_millis() as f64 / 1000.0,
+        }
+    })
+}
+
+/// Build the AWS Pipes DynamoDB-stream-source event envelope for one record.
+fn ddb_source_event(record: &fakecloud_dynamodb::StreamRecord) -> Value {
+    let mut event = json!({
+        "eventID": record.event_id,
+        "eventName": record.event_name,
+        "eventVersion": record.event_version,
+        "eventSource": record.event_source,
+        "awsRegion": record.aws_region,
+        "dynamodb": {
+            "Keys": record.dynamodb.keys,
+            "SequenceNumber": record.dynamodb.sequence_number,
+            "SizeBytes": record.dynamodb.size_bytes,
+            "StreamViewType": record.dynamodb.stream_view_type,
+        },
+        "eventSourceARN": record.event_source_arn,
+    });
+    if let Some(ref new_img) = record.dynamodb.new_image {
+        event["dynamodb"]["NewImage"] = json!(new_img);
+    }
+    if let Some(ref old_img) = record.dynamodb.old_image {
+        event["dynamodb"]["OldImage"] = json!(old_img);
+    }
+    event
+}
+
 /// Detect a fakecloud KMS-at-rest envelope (matches the SQS service's own
 /// encryption format) so plaintext bodies are passed through untouched.
 fn looks_like_fakecloud_envelope(body: &str) -> bool {
@@ -395,5 +937,88 @@ fn looks_like_fakecloud_envelope(body: &str) -> bool {
     match base64::engine::general_purpose::STANDARD.decode(body) {
         Ok(bytes) => bytes.starts_with(&[0x01, 0x02, 0x02, 0x00]),
         Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_template_renders_json_object() {
+        let event = json!({"body": "hello", "messageId": "m-1"});
+        let tmpl = r#"{"text": "<$.body>", "id": "<$.messageId>"}"#;
+        let out = apply_input_template(Some(tmpl), &event);
+        assert_eq!(out, json!({"text": "hello", "id": "m-1"}));
+    }
+
+    #[test]
+    fn input_template_whole_event_token() {
+        let event = json!({"a": 1});
+        let out = apply_input_template(Some("<aws.pipes.event.json>"), &event);
+        assert_eq!(out, event);
+    }
+
+    #[test]
+    fn input_template_non_string_value_is_injected_raw() {
+        let event = json!({"count": 5, "nested": {"k": "v"}});
+        let tmpl = r#"{"n": <$.count>, "obj": <$.nested>}"#;
+        let out = apply_input_template(Some(tmpl), &event);
+        assert_eq!(out, json!({"n": 5, "obj": {"k": "v"}}));
+    }
+
+    #[test]
+    fn input_template_freeform_text_stays_string() {
+        let event = json!({"name": "ada"});
+        let out = apply_input_template(Some("hello <$.name>"), &event);
+        assert_eq!(out, Value::String("hello ada".into()));
+    }
+
+    #[test]
+    fn input_template_missing_path_substitutes_empty() {
+        let event = json!({"a": 1});
+        let out = apply_input_template(Some("x<$.missing>y"), &event);
+        assert_eq!(out, Value::String("xy".into()));
+    }
+
+    #[test]
+    fn no_template_passes_event_through() {
+        let event = json!({"a": 1});
+        assert_eq!(apply_input_template(None, &event), event);
+    }
+
+    #[test]
+    fn enrichment_output_array_passthrough() {
+        let bytes = br#"[{"a":1},{"a":2}]"#;
+        assert_eq!(enrichment_output(bytes).len(), 2);
+    }
+
+    #[test]
+    fn enrichment_output_single_object_wraps() {
+        let bytes = br#"{"a":1}"#;
+        assert_eq!(enrichment_output(bytes), vec![json!({"a": 1})]);
+    }
+
+    #[test]
+    fn enrichment_output_null_drops() {
+        assert!(enrichment_output(b"null").is_empty());
+        assert!(enrichment_output(b"\"\"").is_empty());
+        assert!(enrichment_output(b"not json").is_empty());
+    }
+
+    #[test]
+    fn kinesis_start_index_respects_starting_position() {
+        let records: Vec<fakecloud_kinesis::KinesisRecord> = Vec::new();
+        assert_eq!(kinesis_start_index(&records, Some("LATEST"), None), 0);
+        assert_eq!(kinesis_start_index(&records, Some("TRIM_HORIZON"), None), 0);
+        assert_eq!(kinesis_start_index(&records, None, None), 0);
+    }
+
+    #[test]
+    fn batch_size_clamps_per_source() {
+        let params = json!({"SqsQueueParameters": {"BatchSize": 50}});
+        assert_eq!(source_batch_size(Some(&params), &SourceKind::Sqs), 10);
+        let params = json!({"KinesisStreamParameters": {"BatchSize": 500}});
+        assert_eq!(source_batch_size(Some(&params), &SourceKind::Kinesis), 500);
     }
 }

--- a/website/content/docs/services/pipes.md
+++ b/website/content/docs/services/pipes.md
@@ -38,33 +38,44 @@ machine and persistence:
   `Tags` on `CreatePipe`.
 - **Persistence** — pipes survive a restart in persistent mode.
 
-## Execution — SQS source (real delivery)
+## Execution — real source → enrichment → target
 
-A RUNNING pipe whose **source is an SQS queue** is executed for real by a
-background runner: it polls the source queue, applies the pipe's
-`FilterCriteria` (the same EventBridge event-pattern syntax used everywhere
-else in fakecloud), and delivers matching events to the target — reusing the
-exact cross-service delivery paths the rest of fakecloud uses. SSE-KMS /
-managed-SSE source bodies are decrypted before forwarding, so the target sees
-plaintext just like a real AWS consumer.
+A RUNNING pipe is executed for real by a background runner: it polls the
+source, applies the pipe's `FilterCriteria` (the same EventBridge event-pattern
+syntax used everywhere else in fakecloud), optionally runs the matched batch
+through an enrichment, applies the target `InputTemplate`, and delivers the
+result to the target — reusing the exact cross-service delivery paths the rest
+of fakecloud uses.
 
+- **Sources** — **SQS queues**, **Kinesis streams**, and **DynamoDB streams**.
+  SQS acks by deleting the source message once it is filtered out or
+  successfully delivered; SSE-KMS / managed-SSE source bodies are decrypted
+  before forwarding, so the target sees plaintext just like a real AWS consumer.
+  The stream sources keep a durable per-pipe checkpoint (persisted with the
+  Pipes state, so a restart resumes instead of re-replaying the backlog) and
+  honor `StartingPosition` (`TRIM_HORIZON` / `LATEST`, plus `AT_TIMESTAMP` for
+  Kinesis). A delivery failure leaves the window for redelivery (at-least-once).
 - **Filtering** — events matching `SourceParameters.FilterCriteria.Filters[].Pattern`
-  are forwarded; non-matching events are acked (deleted) from the source, exactly
-  as AWS Pipes drops filtered events.
-- **Targets** — **Lambda** (the matching batch is invoked as a JSON array),
-  **SQS** and **SNS** (one message per event), **Step Functions**
-  (`StartExecution` per event), **EventBridge bus** (`PutEvents`, with
-  `Source`/`DetailType` from `TargetParameters.EventBridgeEventBusParameters`),
-  and **Kinesis** (one record per event, partition key from
-  `TargetParameters.KinesisStreamParameters`). A message is deleted from the
-  source only after it is filtered out or successfully delivered; a delivery
-  failure leaves it for redelivery.
+  are forwarded; non-matching events are dropped (acked), exactly as AWS Pipes
+  drops filtered events.
+- **Enrichment** — when `Enrichment` is a **Lambda** ARN, the matched batch is
+  sent to it as a JSON array and the function's JSON return *replaces* the batch
+  (0..N events) before target delivery; an enrichment that returns an empty
+  array drops the batch. `EnrichmentParameters.InputTemplate` transforms each
+  event before the enrichment call.
+- **Input transform** — `TargetParameters.InputTemplate` is applied per event
+  before delivery: `<$.json.path>` placeholders resolve against the event and
+  `<aws.pipes.event.json>` expands to the whole event; a template that renders
+  valid JSON is delivered as that JSON, otherwise as a string.
+- **Targets** — **Lambda** (the batch is invoked as a JSON array), **SQS** and
+  **SNS** (one message per event), **Step Functions** (`StartExecution` per
+  event), **EventBridge bus** (`PutEvents`, with `Source`/`DetailType` from
+  `TargetParameters.EventBridgeEventBusParameters`), and **Kinesis** (one record
+  per event, partition key from `TargetParameters.KinesisStreamParameters`).
 
 ## Roadmap
 
-- **More sources** — DynamoDB Streams and Kinesis sources.
-- **Enrichment + transforms** — optional enrichment (Lambda / Step Functions /
-  API destination) and `InputTemplate` target input transformers.
+- **More enrichment** — Step Functions (sync), API destination, API Gateway.
 - **More targets** — ECS, Batch, Redshift Data, HTTP/API destination,
   SageMaker, CloudWatch Logs, Timestream.
 - **CloudFormation** — `AWS::Pipes::Pipe` provisioning.


### PR DESCRIPTION
## Batch 4 of EventBridge Pipes: more sources + enrichment + input transform

Generalizes the Pipes runner beyond SQS and fills in the middle of the `source -> enrichment -> target` path.

### Sources
- **Kinesis streams** and **DynamoDB streams**, alongside SQS.
- Each stream source keeps a **durable per-pipe checkpoint** in the Pipes state, so a restart resumes instead of re-replaying the retained backlog.
- Honors `StartingPosition` (`TRIM_HORIZON` / `LATEST`, plus `AT_TIMESTAMP` for Kinesis). The checkpoint advances only past filtered-out or successfully-delivered records; a delivery failure retries the window (at-least-once).

### Enrichment
- A **Lambda** `Enrichment` ARN is invoked with the matched batch as a JSON array; its JSON return *replaces* the batch (0..N events) before target delivery. An empty array drops the batch.
- `EnrichmentParameters.InputTemplate` transforms each event before the enrichment call.
- Non-Lambda enrichment (Step Functions sync / API destination / API Gateway) is **held, not faked**, until a synchronous round-trip is wired.

### Input transform
- `TargetParameters.InputTemplate` applied per event: `<$.json.path>` resolves against the event, `<aws.pipes.event.json>` expands to the whole event; a template that renders valid JSON is delivered as JSON, otherwise as a string.

### State / wiring
- Adds `source_checkpoints` to `PipesState` (persisted with the snapshot).
- Re-exports `KinesisRecord` and `StreamRecord` so the runner can build the source-event envelopes.
- Wires Kinesis + DynamoDB state into the runner in `main.rs`.

### Tests
- Unit (`pipes_runner`): InputTemplate rendering, enrichment-output normalization, batch-size clamps.
- E2E `pipes_sources.rs`: Kinesis-source and DynamoDB-stream-source -> SQS target, InputTemplate transform.
- E2E `pipes_enrichment.rs`: real Python-Lambda enrichment rewrites the batch.

### Docs
- `website/content/docs/services/pipes.md` updated for the new sources, enrichment, and input transform.

Follows batch-1 (#2046), batch-2 (#2047), batch-3 (#2048).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the EventBridge Pipes runner with Kinesis and DynamoDB stream sources, Lambda enrichment, and per-event `InputTemplate` transforms. Adds durable checkpoints to resume after restarts and preserves at-least-once delivery.

- **New Features**
  - Sources: Kinesis and DynamoDB streams alongside SQS, with per-pipe durable checkpoints and `StartingPosition` support (`TRIM_HORIZON` / `LATEST`, plus `AT_TIMESTAMP` for Kinesis). Checkpoints advance only for filtered-out or successfully delivered records; failures retry the window.
  - Enrichment: Lambda `Enrichment` receives the matched batch (JSON array) and its JSON return replaces the batch (0..N events). Supports `EnrichmentParameters.InputTemplate` per event before the call. Non-Lambda enrichment is held for a later sync round-trip (not faked).
  - Input transform: Applies `TargetParameters.InputTemplate` per event before delivery. `<$.json.path>` resolves against the event; `<aws.pipes.event.json>` expands to the whole event. If the template renders valid JSON, it’s delivered as JSON; otherwise as a string.
  - Delivery targets: Lambda (batch array) and SQS/SNS/Step Functions/EventBridge bus/Kinesis (one record per event) via existing delivery paths.
  - State/wiring: Adds `source_checkpoints` to the Pipes state, re-exports `KinesisRecord` and `StreamRecord`, and wires Kinesis + DynamoDB state into the runner.
  - Tests/docs: E2E for Kinesis/DynamoDB sources and `InputTemplate`; E2E Lambda enrichment; unit tests for template/enrichment; docs updated.

<sup>Written for commit f513e02437fff5e97702918133b1ed9a5536cc53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

