### PR TITLE
feat(pipes): CloudFormation AWS::Pipes::Pipe provisioner + GetAtt + persistence (batch 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,6 +3445,7 @@ dependencies = [
  "fakecloud-logs",
  "fakecloud-organizations",
  "fakecloud-persistence",
+ "fakecloud-pipes",
  "fakecloud-rds",
  "fakecloud-route53",
  "fakecloud-s3",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -44,6 +44,7 @@ fakecloud-ses = { workspace = true }
 fakecloud-application-autoscaling = { workspace = true }
 fakecloud-autoscaling = { workspace = true }
 fakecloud-batch = { workspace = true }
+fakecloud-pipes = { workspace = true }
 fakecloud-athena = { workspace = true }
 fakecloud-firehose = { workspace = true }
 fakecloud-glue = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -2567,6 +2567,9 @@ mod tests {
             batch: Arc::new(parking_lot::RwLock::new(
                 fakecloud_batch::BatchAccounts::new(),
             )),
+            pipes: Arc::new(parking_lot::RwLock::new(
+                fakecloud_pipes::PipesAccounts::new(),
+            )),
             ecs: shared::<fakecloud_ecs::EcsState>(),
             acm: Arc::new(RwLock::new(fakecloud_acm::AcmAccounts::new())),
             elasticache: shared::<fakecloud_elasticache::ElastiCacheState>(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
@@ -92,6 +92,7 @@ impl ResourceProvisioner {
             ec2_state: self.ec2_state.clone(),
             autoscaling_state: self.autoscaling_state.clone(),
             batch_state: self.batch_state.clone(),
+            pipes_state: self.pipes_state.clone(),
             ecs_state: self.ecs_state.clone(),
             acm_state: self.acm_state.clone(),
             elasticache_state: self.elasticache_state.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -882,6 +882,7 @@ pub struct ResourceProvisioner {
     pub ec2_state: fakecloud_ec2::SharedEc2State,
     pub autoscaling_state: fakecloud_autoscaling::SharedAutoScalingState,
     pub batch_state: fakecloud_batch::SharedBatchState,
+    pub pipes_state: fakecloud_pipes::SharedPipesState,
     pub ecs_state: SharedEcsState,
     pub acm_state: SharedAcmState,
     pub elasticache_state: SharedElastiCacheState,
@@ -1048,6 +1049,7 @@ mod kinesis;
 mod kms;
 mod lambda;
 mod logs;
+mod pipes;
 mod rds;
 mod route;
 mod s3;
@@ -1172,6 +1174,7 @@ impl ResourceProvisioner {
             "AWS::Batch::JobQueue" => self.create_batch_job_queue(resource),
             "AWS::Batch::JobDefinition" => self.create_batch_job_definition(resource),
             "AWS::Batch::SchedulingPolicy" => self.create_batch_scheduling_policy(resource),
+            "AWS::Pipes::Pipe" => self.create_pipes_pipe(resource),
             "AWS::EC2::VPC" => self.create_ec2_vpc(resource),
             "AWS::EC2::Instance" => self.create_ec2_instance(resource),
             "AWS::EC2::Subnet" => self.create_ec2_subnet(resource),
@@ -1769,6 +1772,10 @@ impl ResourceProvisioner {
             | "AWS::Batch::JobDefinition"
             | "AWS::Batch::SchedulingPolicy" => {
                 self.delete_batch(&resource.resource_type, &resource.physical_id);
+                Ok(())
+            }
+            "AWS::Pipes::Pipe" => {
+                self.delete_pipes_pipe(&resource.physical_id);
                 Ok(())
             }
             "AWS::ECS::Cluster" => self.delete_ecs_cluster(&resource.physical_id),
@@ -6263,6 +6270,7 @@ mod tests {
                 fakecloud_autoscaling::AutoScalingAccounts::new(),
             )),
             batch_state: Arc::new(RwLock::new(fakecloud_batch::BatchAccounts::new())),
+            pipes_state: Arc::new(RwLock::new(fakecloud_pipes::PipesAccounts::new())),
             ecs_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/pipes.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/pipes.rs
@@ -1,0 +1,146 @@
+//! `AWS::Pipes::Pipe` CloudFormation provisioning. Creates a pipe as a real
+//! record in the `pipes` service state — the same JSON shape the direct
+//! `CreatePipe` handler stores — so the background Pipes runner picks it up and
+//! a CFN-created pipe reads back identically to an API-created one on
+//! `DescribePipe`. The pipe is created already settled (`RUNNING`, or `STOPPED`
+//! when `DesiredState=STOPPED`) since CFN provisioning is synchronous. Persists
+//! through the `pipes` snapshot hook (keyed off the `Pipes` resource segment),
+//! so the resource survives a restart (the #1766 lesson).
+
+use serde_json::{json, Map, Value};
+
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+
+/// The optional `CreatePipe` input fields, copied verbatim from the CFN
+/// properties (Pipes uses PascalCase in both the API and CloudFormation, so the
+/// keys map 1:1).
+const PIPE_INPUT_FIELDS: &[&str] = &[
+    "Description",
+    "Source",
+    "SourceParameters",
+    "Enrichment",
+    "EnrichmentParameters",
+    "Target",
+    "TargetParameters",
+    "RoleArn",
+    "LogConfiguration",
+    "KmsKeyIdentifier",
+];
+
+impl ResourceProvisioner {
+    pub(super) fn create_pipes_pipe(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(Value::as_str)
+            .map(String::from)
+            .unwrap_or_else(|| resource.logical_id.clone());
+
+        let source = props
+            .get("Source")
+            .and_then(Value::as_str)
+            .ok_or("AWS::Pipes::Pipe requires Source")?
+            .to_string();
+        let target = props
+            .get("Target")
+            .and_then(Value::as_str)
+            .ok_or("AWS::Pipes::Pipe requires Target")?
+            .to_string();
+        let role_arn = props
+            .get("RoleArn")
+            .and_then(Value::as_str)
+            .ok_or("AWS::Pipes::Pipe requires RoleArn")?
+            .to_string();
+
+        let arn = format!(
+            "arn:aws:pipes:{}:{}:pipe/{name}",
+            self.region, self.account_id
+        );
+        // CFN provisioning is synchronous, so the pipe is born settled: RUNNING
+        // unless the template explicitly asks for STOPPED.
+        let desired = match props.get("DesiredState").and_then(Value::as_str) {
+            Some("STOPPED") => "STOPPED",
+            _ => "RUNNING",
+        };
+        let now = epoch_secs();
+
+        let mut pipe = Map::new();
+        pipe.insert("Name".into(), json!(name));
+        pipe.insert("Arn".into(), json!(arn));
+        pipe.insert("Source".into(), json!(source));
+        pipe.insert("Target".into(), json!(target));
+        pipe.insert("RoleArn".into(), json!(role_arn));
+        for field in PIPE_INPUT_FIELDS {
+            if let Some(v) = props.get(*field) {
+                pipe.insert((*field).into(), v.clone());
+            }
+        }
+        pipe.insert("DesiredState".into(), json!(desired));
+        pipe.insert("CurrentState".into(), json!(desired));
+        pipe.insert("StateReason".into(), json!("Pipe is healthy"));
+        pipe.insert("CreationTime".into(), json!(now));
+        pipe.insert("LastModifiedTime".into(), json!(now));
+
+        // Tags: AWS::Pipes::Pipe carries a JSON map; mirror the direct handler,
+        // which both embeds the Tags map on the pipe and indexes it in the tag
+        // store for ListTagsForResource.
+        if let Some(tags) = props.get("Tags").and_then(Value::as_object) {
+            let owned: Map<String, Value> = tags
+                .iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), json!(s))))
+                .collect();
+            if !owned.is_empty() {
+                pipe.insert("Tags".into(), Value::Object(owned.clone()));
+                let mut state = self.pipes_state.write();
+                let entry = state
+                    .get_or_create(&self.account_id)
+                    .tags
+                    .entry(arn.clone())
+                    .or_default();
+                for (k, v) in owned {
+                    if let Some(s) = v.as_str() {
+                        entry.insert(k, s.to_string());
+                    }
+                }
+            }
+        }
+
+        self.pipes_state
+            .write()
+            .get_or_create(&self.account_id)
+            .pipes
+            .insert(name.clone(), Value::Object(pipe));
+
+        // Ref returns the pipe name; GetAtt exposes Arn + the lifecycle fields.
+        Ok(ProvisionResult::new(name)
+            .with("Arn", arn)
+            .with("CurrentState", desired)
+            .with("StateReason", "Pipe is healthy")
+            .with("CreationTime", now.to_string())
+            .with("LastModifiedTime", now.to_string()))
+    }
+
+    /// Delete a pipe by physical id (its name). Also drops the tag-store entry
+    /// keyed by the pipe's ARN.
+    pub(super) fn delete_pipes_pipe(&self, physical_id: &str) {
+        let mut state = self.pipes_state.write();
+        let acct = state.get_or_create(&self.account_id);
+        if let Some(removed) = acct.pipes.remove(physical_id) {
+            if let Some(arn) = removed.get("Arn").and_then(Value::as_str) {
+                acct.tags.remove(arn);
+            }
+        }
+    }
+}
+
+/// Seconds since the Unix epoch. CloudFormation provisioning is not on the
+/// hot path, so a direct `SystemTime` read is fine here.
+fn epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -125,6 +125,7 @@ fn service_key_for_type(resource_type: &str) -> Option<&'static str> {
         "AutoScaling" => "autoscaling",
         "Batch" => "batch",
         "ApplicationAutoScaling" => "application-autoscaling",
+        "Pipes" => "pipes",
         _ => return None,
     })
 }
@@ -300,6 +301,7 @@ pub struct CloudFormationDeps {
     pub ec2: fakecloud_ec2::SharedEc2State,
     pub autoscaling: fakecloud_autoscaling::SharedAutoScalingState,
     pub batch: fakecloud_batch::SharedBatchState,
+    pub pipes: fakecloud_pipes::SharedPipesState,
     pub ecs: fakecloud_ecs::SharedEcsState,
     pub acm: fakecloud_acm::SharedAcmState,
     pub elasticache: fakecloud_elasticache::SharedElastiCacheState,
@@ -746,6 +748,7 @@ impl CloudFormationService {
             ec2_state: self.deps.ec2.clone(),
             autoscaling_state: self.deps.autoscaling.clone(),
             batch_state: self.deps.batch.clone(),
+            pipes_state: self.deps.pipes.clone(),
             ecs_state: self.deps.ecs.clone(),
             acm_state: self.deps.acm.clone(),
             elasticache_state: self.deps.elasticache.clone(),
@@ -2834,6 +2837,7 @@ mod tests {
                 fakecloud_autoscaling::AutoScalingAccounts::new(),
             )),
             batch: Arc::new(RwLock::new(fakecloud_batch::BatchAccounts::new())),
+            pipes: Arc::new(RwLock::new(fakecloud_pipes::PipesAccounts::new())),
             ecs: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",

--- a/crates/fakecloud-e2e/tests/cloudformation_pipes.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_pipes.rs
@@ -1,0 +1,128 @@
+//! CloudFormation provisions an AWS::Pipes::Pipe as a real record in the
+//! `pipes` service control plane: it reads back through DescribePipe as RUNNING,
+//! exposes its ARN via GetAtt, and is actually executed by the Pipes runner
+//! (a source message reaches the target). Deleting the stack removes the pipe.
+
+mod helpers;
+
+use helpers::TestServer;
+
+// Two SQS queues and a pipe wiring source -> target. The pipe's Source/Target
+// resolve to the queues' ARNs via GetAtt; the stack output surfaces the pipe
+// ARN so the test can assert GetAtt works.
+const TEMPLATE: &str = r#"{
+  "Resources": {
+    "SrcQ": { "Type": "AWS::SQS::Queue", "Properties": { "QueueName": "cfn-pipe-src" } },
+    "TgtQ": { "Type": "AWS::SQS::Queue", "Properties": { "QueueName": "cfn-pipe-tgt" } },
+    "Pipe": {
+      "Type": "AWS::Pipes::Pipe",
+      "Properties": {
+        "Name": "cfn-pipe",
+        "RoleArn": "arn:aws:iam::000000000000:role/pipe-role",
+        "Source": { "Fn::GetAtt": ["SrcQ", "Arn"] },
+        "Target": { "Fn::GetAtt": ["TgtQ", "Arn"] }
+      }
+    }
+  },
+  "Outputs": {
+    "PipeArn": { "Value": { "Fn::GetAtt": ["Pipe", "Arn"] } }
+  }
+}"#;
+
+async fn queue_url(sqs: &aws_sdk_sqs::Client, name: &str) -> String {
+    sqs.get_queue_url()
+        .queue_name(name)
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string()
+}
+
+#[tokio::test]
+async fn cfn_provisions_and_runs_pipe() {
+    let s = TestServer::start().await;
+    let cfg = s.aws_config().await;
+    let cfn = s.cloudformation_client().await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    let pipes = aws_sdk_pipes::Client::new(&cfg);
+
+    cfn.create_stack()
+        .stack_name("pipe-stack")
+        .template_body(TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("pipe-stack")
+        .send()
+        .await
+        .unwrap();
+    let stack = &described.stacks()[0];
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    // GetAtt Arn surfaced as a stack output.
+    let pipe_arn = stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some("PipeArn"))
+        .and_then(|o| o.output_value())
+        .expect("PipeArn output");
+    assert!(pipe_arn.contains(":pipe/cfn-pipe"), "got {pipe_arn}");
+
+    // The pipe exists in the pipes service and settled to RUNNING.
+    let described_pipe = pipes
+        .describe_pipe()
+        .name("cfn-pipe")
+        .send()
+        .await
+        .expect("DescribePipe");
+    assert_eq!(
+        described_pipe.current_state(),
+        Some(&aws_sdk_pipes::types::PipeState::Running)
+    );
+    assert_eq!(described_pipe.arn(), Some(pipe_arn));
+
+    // The provisioned pipe is actually executed: a source message reaches the
+    // target queue.
+    let src_url = queue_url(&sqs, "cfn-pipe-src").await;
+    let tgt_url = queue_url(&sqs, "cfn-pipe-tgt").await;
+    sqs.send_message()
+        .queue_url(&src_url)
+        .message_body("cfn-routed")
+        .send()
+        .await
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(8);
+    let mut delivered = None;
+    while std::time::Instant::now() < deadline {
+        let r = sqs
+            .receive_message()
+            .queue_url(&tgt_url)
+            .wait_time_seconds(0)
+            .send()
+            .await
+            .unwrap();
+        if let Some(m) = r.messages().first() {
+            delivered = m.body().map(str::to_string);
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    let body = delivered.expect("CFN-provisioned pipe delivered to target");
+    let event: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(event["body"], "cfn-routed");
+
+    // Deleting the stack removes the pipe.
+    cfn.delete_stack()
+        .stack_name("pipe-stack")
+        .send()
+        .await
+        .unwrap();
+    let gone = pipes.describe_pipe().name("cfn-pipe").send().await;
+    assert!(gone.is_err(), "stack delete should remove the pipe");
+}

--- a/crates/fakecloud-e2e/tests/cloudformation_pipes_persistence.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_pipes_persistence.rs
@@ -1,0 +1,52 @@
+//! A CloudFormation-provisioned AWS::Pipes::Pipe survives a restart in
+//! persistent mode. Regression for the #1766-class gap: the CFN provisioner
+//! writes straight into `pipes_state`, so without a `cfn_snapshot_hooks` entry
+//! for "pipes" the pipe would vanish on restart.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "Resources": {
+    "SrcQ": { "Type": "AWS::SQS::Queue", "Properties": { "QueueName": "persist-pipe-src" } },
+    "TgtQ": { "Type": "AWS::SQS::Queue", "Properties": { "QueueName": "persist-pipe-tgt" } },
+    "Pipe": {
+      "Type": "AWS::Pipes::Pipe",
+      "Properties": {
+        "Name": "persist-pipe",
+        "RoleArn": "arn:aws:iam::000000000000:role/pipe-role",
+        "Source": { "Fn::GetAtt": ["SrcQ", "Arn"] },
+        "Target": { "Fn::GetAtt": ["TgtQ", "Arn"] }
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisioned_pipe_survives_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let cfn = server.cloudformation_client().await;
+
+    cfn.create_stack()
+        .stack_name("pipe-persist")
+        .template_body(TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    server.restart().await;
+    let pipes = aws_sdk_pipes::Client::new(&server.aws_config().await);
+
+    let described = pipes
+        .describe_pipe()
+        .name("persist-pipe")
+        .send()
+        .await
+        .expect("CFN-provisioned pipe should survive restart");
+    assert_eq!(
+        described.current_state(),
+        Some(&aws_sdk_pipes::types::PipeState::Running)
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -932,6 +932,7 @@ async fn main() {
             ec2: ec2_state.clone(),
             autoscaling: autoscaling_state.clone(),
             batch: batch_state.clone(),
+            pipes: pipes_state.clone(),
             ecs: ecs_state.clone(),
             acm: acm_state.clone(),
             elasticache: elasticache_state.clone(),

--- a/website/content/docs/services/pipes.md
+++ b/website/content/docs/services/pipes.md
@@ -73,10 +73,19 @@ of fakecloud uses.
   `TargetParameters.EventBridgeEventBusParameters`), and **Kinesis** (one record
   per event, partition key from `TargetParameters.KinesisStreamParameters`).
 
+## CloudFormation
+
+`AWS::Pipes::Pipe` is provisioned as a real pipe in the control plane: the
+provisioner stores the same JSON shape as the direct `CreatePipe`, so the
+background runner picks it up and it reads back identically on `DescribePipe`.
+A CFN-created pipe is born settled (`RUNNING`, or `STOPPED` when
+`DesiredState=STOPPED`); `Ref` returns the pipe name and `Fn::GetAtt` exposes
+`Arn`, `CurrentState`, `StateReason`, `CreationTime`, and `LastModifiedTime`.
+The pipe survives a restart in persistent mode and is removed on stack delete.
+
 ## Roadmap
 
 - **More enrichment** — Step Functions (sync), API destination, API Gateway.
 - **More targets** — ECS, Batch, Redshift Data, HTTP/API destination,
   SageMaker, CloudWatch Logs, Timestream.
-- **CloudFormation** — `AWS::Pipes::Pipe` provisioning.
 - **Terraform** — `aws_pipes_pipe` acceptance coverage.


### PR DESCRIPTION
## Batch 5 of EventBridge Pipes: CloudFormation provisioning

Provisions `AWS::Pipes::Pipe` as a real record in the `pipes` service control plane.

- The provisioner stores the same JSON shape as the direct `CreatePipe` handler, so the **background runner picks it up** and a CFN-created pipe reads back identically on `DescribePipe`.
- CFN provisioning is synchronous, so the pipe is **born settled** — `RUNNING`, or `STOPPED` when `DesiredState=STOPPED`.
- **`Ref`** returns the pipe name; **`Fn::GetAtt`** exposes `Arn`, `CurrentState`, `StateReason`, `CreationTime`, `LastModifiedTime`.
- **Stack delete** removes the pipe (and its tag-store entry).

### Persistence
- Maps the `Pipes` resource segment to the `pipes` snapshot-hook key (already registered in the server), so a CFN-provisioned pipe **survives a restart** (the #1766 lesson).

### Wiring
- Adds `pipes_state` to `ResourceProvisioner` and a `pipes` handle to `CloudFormationDeps`, threaded through every constructor (service build, nested CFN provisioner, both test deps builders) plus `main.rs`.

### Tests
- `cloudformation_pipes.rs`: provisions an SQS-source -> SQS-target pipe, asserts `DescribePipe` RUNNING + the `GetAtt Arn` stack output + a source message actually routing to the target, then stack delete removes it.
- `cloudformation_pipes_persistence.rs`: a CFN-provisioned pipe survives a restart.

### Docs
- `website/content/docs/services/pipes.md` documents the CloudFormation support.

Follows batch-1 (#2046), batch-2 (#2047), batch-3 (#2048), batch-4 (#2049).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for `AWS::Pipes::Pipe`, provisioning real pipes that the background runner executes and that read back the same on `DescribePipe`. Pipes are created settled (RUNNING or STOPPED), support `Ref`/`Fn::GetAtt`, persist across restarts, and are removed on stack delete.

- New Features
  - Provision `AWS::Pipes::Pipe` with the same JSON shape as `CreatePipe`; runner picks it up and parity on `DescribePipe`.
  - Synchronous state: `RUNNING` by default or `STOPPED` when `DesiredState=STOPPED`.
  - `Ref` returns the pipe name; `Fn::GetAtt` exposes `Arn`, `CurrentState`, `StateReason`, `CreationTime`, `LastModifiedTime`.
  - Stack delete removes the pipe and its tag-store entry; resources persist via the `pipes` snapshot hook.
  - Updated docs for Pipes CloudFormation behavior.

- Tests
  - E2E: SQS→SQS pipe runs; `GetAtt Arn` surfaced via stack output; stack delete removes the pipe.
  - Persistence: CFN-provisioned pipe survives a server restart.

<sup>Written for commit 0737a868d28535b90d23768a0b9f385060c06fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

