### PR TITLE
feat(pipes): tfacc aws_pipes_pipe + default SQS source parameters (batch 6)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/pipes.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/pipes.rs
@@ -83,6 +83,10 @@ impl ResourceProvisioner {
         pipe.insert("StateReason".into(), json!("Pipe is healthy"));
         pipe.insert("CreationTime".into(), json!(now));
         pipe.insert("LastModifiedTime".into(), json!(now));
+        // Echo the source-typed default parameter block (e.g. SqsQueueParameters)
+        // just like the direct CreatePipe handler, so a CFN-created pipe reads
+        // back identically on DescribePipe.
+        fakecloud_pipes::ensure_source_param_defaults(&mut pipe, &source);
 
         // Tags: AWS::Pipes::Pipe carries a JSON map; mirror the direct handler,
         // which both embeds the Tags map on the pipe and indexes it in the tag

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/pipes.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/pipes.rs
@@ -87,6 +87,7 @@ impl ResourceProvisioner {
         // just like the direct CreatePipe handler, so a CFN-created pipe reads
         // back identically on DescribePipe.
         fakecloud_pipes::ensure_source_param_defaults(&mut pipe, &source);
+        fakecloud_pipes::normalize_empty_input_templates(&mut pipe);
 
         // Tags: AWS::Pipes::Pipe carries a JSON map; mirror the direct handler,
         // which both embeds the Tags map on the pipe and indexes it in the tag

--- a/crates/fakecloud-pipes/src/lib.rs
+++ b/crates/fakecloud-pipes/src/lib.rs
@@ -12,7 +12,7 @@
 pub mod service;
 pub mod state;
 
-pub use service::PipesService;
+pub use service::{ensure_source_param_defaults, PipesService};
 pub use state::{
     PipesAccounts, PipesSnapshot, PipesState, SharedPipesState, PIPES_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-pipes/src/lib.rs
+++ b/crates/fakecloud-pipes/src/lib.rs
@@ -12,7 +12,10 @@
 pub mod service;
 pub mod state;
 
-pub use service::{ensure_source_param_defaults, normalize_empty_input_templates, PipesService};
+pub use service::{
+    drain_overdue_transient_pipes, ensure_source_param_defaults, normalize_empty_input_templates,
+    PipesService,
+};
 pub use state::{
     PipesAccounts, PipesSnapshot, PipesState, SharedPipesState, PIPES_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-pipes/src/lib.rs
+++ b/crates/fakecloud-pipes/src/lib.rs
@@ -12,7 +12,7 @@
 pub mod service;
 pub mod state;
 
-pub use service::{ensure_source_param_defaults, PipesService};
+pub use service::{ensure_source_param_defaults, normalize_empty_input_templates, PipesService};
 pub use state::{
     PipesAccounts, PipesSnapshot, PipesState, SharedPipesState, PIPES_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -758,6 +758,50 @@ fn settle_pipe(st: &mut crate::state::PipesState, name: &str) {
     }
 }
 
+/// Rescue any pipe that has been sitting in a transient state (CREATING /
+/// UPDATING / STARTING / STOPPING / DELETING) for at least `min_age_secs`,
+/// settling it the same way its per-request `spawn_settle` task would.
+///
+/// Each lifecycle call spawns a one-shot task that sleeps `SETTLE_DELAY` and
+/// then settles the pipe. On a CPU-starved runner (e.g. a 2-core CI box under
+/// several concurrent terraform applies) those spawned tasks can be delayed
+/// long enough that the provider's delete/update waiter times out first — a
+/// pipe stuck in DELETING never gets removed and the waiter blocks for its full
+/// 30-minute budget. The Pipes runner already ticks on a persistent task, so it
+/// drains overdue transients as a backstop that doesn't depend on fresh task
+/// spawns landing promptly. The `min_age_secs` gate keeps this off the fast
+/// path: under normal load the spawned task settles within `SETTLE_DELAY` and
+/// the pipe is gone before it ages past the threshold, so this rescues only
+/// genuinely-starved settles.
+pub fn drain_overdue_transient_pipes(state: &SharedPipesState, min_age_secs: f64) {
+    let now = now_epoch_secs();
+    let mut accounts = state.write();
+    for st in accounts.accounts.values_mut() {
+        let due: Vec<String> = st
+            .pipes
+            .iter()
+            .filter(|(_, pipe)| {
+                let cur = pipe
+                    .get("CurrentState")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if !is_transient_state(cur) {
+                    return false;
+                }
+                let last = pipe
+                    .get("LastModifiedTime")
+                    .and_then(Value::as_f64)
+                    .unwrap_or(0.0);
+                now - last >= min_age_secs
+            })
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in due {
+            settle_pipe(st, &name);
+        }
+    }
+}
+
 /// Build a `Pipe` list summary (a subset of the full describe object).
 fn pipe_summary(pipe: &Value) -> Value {
     let mut out = Map::new();

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -94,6 +94,30 @@ pub fn ensure_source_param_defaults(pipe: &mut Map<String, Value>, source_arn: &
     }
 }
 
+/// AWS treats an empty `InputTemplate` as "no transform": DescribePipe omits
+/// it rather than echoing `""`. The terraform-provider-aws resource clears a
+/// target transform by sending `TargetParameters.InputTemplate = ""` (see its
+/// update code: "have to set the input to an empty string otherwise it doesn't
+/// get overwritten"), and then asserts the attribute is absent. Strip an empty
+/// `InputTemplate` from the target/enrichment parameter blocks, and drop a
+/// block that becomes empty so it reads back as absent.
+pub fn normalize_empty_input_templates(pipe: &mut Map<String, Value>) {
+    for key in ["TargetParameters", "EnrichmentParameters"] {
+        let drop = match pipe.get_mut(key).and_then(Value::as_object_mut) {
+            Some(params) => {
+                if params.get("InputTemplate").and_then(Value::as_str) == Some("") {
+                    params.remove("InputTemplate");
+                }
+                params.is_empty()
+            }
+            None => false,
+        };
+        if drop {
+            pipe.remove(key);
+        }
+    }
+}
+
 pub struct PipesService {
     state: SharedPipesState,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
@@ -286,6 +310,7 @@ impl PipesService {
         pipe.insert("CreationTime".into(), json!(now));
         pipe.insert("LastModifiedTime".into(), json!(now));
         ensure_source_param_defaults(&mut pipe, &source);
+        normalize_empty_input_templates(&mut pipe);
 
         let tags = tag_map_from(body.get("Tags"));
 
@@ -431,9 +456,20 @@ impl PipesService {
             let obj = pipe
                 .as_object_mut()
                 .ok_or_else(|| validation_error("corrupt pipe state"))?;
+            // UpdatePipe is a full replace of the updatable fields: a field the
+            // client omits is cleared, not left at its previous value. AWS does
+            // this (e.g. dropping `TargetParameters.InputTemplate` on a later
+            // apply must make DescribePipe stop reporting it), and the
+            // terraform-provider-aws resource asserts the omitted attribute is
+            // gone.
             for field in PIPE_UPDATE_FIELDS {
-                if let Some(v) = body.get(*field) {
-                    obj.insert((*field).into(), v.clone());
+                match body.get(*field) {
+                    Some(v) => {
+                        obj.insert((*field).into(), v.clone());
+                    }
+                    None => {
+                        obj.remove(*field);
+                    }
                 }
             }
             let desired = if body.get("DesiredState").is_some() {
@@ -456,6 +492,7 @@ impl PipesService {
             {
                 ensure_source_param_defaults(obj, &source);
             }
+            normalize_empty_input_templates(obj);
             let arn = obj
                 .get("Arn")
                 .and_then(Value::as_str)
@@ -932,5 +969,34 @@ mod tests {
         let mut pipe = Map::new();
         ensure_source_param_defaults(&mut pipe, "arn:aws:kinesis:us-east-1:000000000000:stream/s");
         assert!(pipe.get("SourceParameters").is_none());
+    }
+
+    #[test]
+    fn empty_input_template_only_block_is_dropped() {
+        let mut pipe = Map::new();
+        pipe.insert("TargetParameters".into(), json!({"InputTemplate": ""}));
+        normalize_empty_input_templates(&mut pipe);
+        assert!(pipe.get("TargetParameters").is_none());
+    }
+
+    #[test]
+    fn empty_input_template_stripped_but_siblings_kept() {
+        let mut pipe = Map::new();
+        pipe.insert(
+            "TargetParameters".into(),
+            json!({"InputTemplate": "", "KinesisStreamParameters": {"PartitionKey": "pk"}}),
+        );
+        normalize_empty_input_templates(&mut pipe);
+        let tp = &pipe["TargetParameters"];
+        assert!(tp.get("InputTemplate").is_none());
+        assert_eq!(tp["KinesisStreamParameters"]["PartitionKey"], "pk");
+    }
+
+    #[test]
+    fn non_empty_input_template_preserved() {
+        let mut pipe = Map::new();
+        pipe.insert("TargetParameters".into(), json!({"InputTemplate": "<$.x>"}));
+        normalize_empty_input_templates(&mut pipe);
+        assert_eq!(pipe["TargetParameters"]["InputTemplate"], "<$.x>");
     }
 }

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -63,6 +63,37 @@ const PIPE_UPDATE_FIELDS: &[&str] = &[
     "KmsKeyIdentifier",
 ];
 
+/// AWS always echoes the source-typed parameter sub-block on DescribePipe,
+/// populated with defaults, even when the caller sent no `SourceParameters`.
+/// For an SQS source that block is `SqsQueueParameters` with `BatchSize=10`
+/// and `MaximumBatchingWindowInSeconds=0`; the terraform-provider-aws
+/// `aws_pipes_pipe` resource reads it back unconditionally, so a pipe created
+/// without source parameters must still report these defaults. Existing
+/// values (e.g. a caller-supplied batch size, or a `FilterCriteria` alongside)
+/// are preserved.
+pub fn ensure_source_param_defaults(pipe: &mut Map<String, Value>, source_arn: &str) {
+    if !source_arn.contains(":sqs:") {
+        return;
+    }
+    let source_params = pipe
+        .entry("SourceParameters".to_string())
+        .or_insert_with(|| json!({}));
+    let Some(source_params) = source_params.as_object_mut() else {
+        return;
+    };
+    let sqs_params = source_params
+        .entry("SqsQueueParameters".to_string())
+        .or_insert_with(|| json!({}));
+    if let Some(sqs_params) = sqs_params.as_object_mut() {
+        sqs_params
+            .entry("BatchSize".to_string())
+            .or_insert_with(|| json!(10));
+        sqs_params
+            .entry("MaximumBatchingWindowInSeconds".to_string())
+            .or_insert_with(|| json!(0));
+    }
+}
+
 pub struct PipesService {
     state: SharedPipesState,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
@@ -254,6 +285,7 @@ impl PipesService {
         pipe.insert("StateReason".into(), json!("Pipe is being created"));
         pipe.insert("CreationTime".into(), json!(now));
         pipe.insert("LastModifiedTime".into(), json!(now));
+        ensure_source_param_defaults(&mut pipe, &source);
 
         let tags = tag_map_from(body.get("Tags"));
 
@@ -417,6 +449,13 @@ impl PipesService {
             obj.insert("CurrentState".into(), json!(STATE_UPDATING));
             obj.insert("StateReason".into(), json!("Pipe is being updated"));
             obj.insert("LastModifiedTime".into(), json!(now));
+            if let Some(source) = obj
+                .get("Source")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+            {
+                ensure_source_param_defaults(obj, &source);
+            }
             let arn = obj
                 .get("Arn")
                 .and_then(Value::as_str)
@@ -848,5 +887,50 @@ async fn save_snapshot_static(
         Ok(Ok(())) => {}
         Ok(Err(err)) => tracing::error!(%err, "failed to write pipes snapshot"),
         Err(err) => tracing::error!(%err, "pipes snapshot task panicked"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SQS: &str = "arn:aws:sqs:us-east-1:000000000000:src";
+
+    #[test]
+    fn sqs_source_gets_default_sqs_queue_parameters() {
+        let mut pipe = Map::new();
+        ensure_source_param_defaults(&mut pipe, SQS);
+        let sqp = &pipe["SourceParameters"]["SqsQueueParameters"];
+        assert_eq!(sqp["BatchSize"], json!(10));
+        assert_eq!(sqp["MaximumBatchingWindowInSeconds"], json!(0));
+    }
+
+    #[test]
+    fn existing_values_and_sibling_params_preserved() {
+        let mut pipe = Map::new();
+        pipe.insert(
+            "SourceParameters".into(),
+            json!({
+                "FilterCriteria": {"Filters": [{"Pattern": "{}"}]},
+                "SqsQueueParameters": {"BatchSize": 5}
+            }),
+        );
+        ensure_source_param_defaults(&mut pipe, SQS);
+        let sp = &pipe["SourceParameters"];
+        // A caller-supplied batch size is kept; only the missing window default
+        // is filled, and the sibling FilterCriteria is untouched.
+        assert_eq!(sp["SqsQueueParameters"]["BatchSize"], json!(5));
+        assert_eq!(
+            sp["SqsQueueParameters"]["MaximumBatchingWindowInSeconds"],
+            json!(0)
+        );
+        assert!(sp["FilterCriteria"]["Filters"].is_array());
+    }
+
+    #[test]
+    fn non_sqs_source_untouched() {
+        let mut pipe = Map::new();
+        ensure_source_param_defaults(&mut pipe, "arn:aws:kinesis:us-east-1:000000000000:stream/s");
+        assert!(pipe.get("SourceParameters").is_none());
     }
 }

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -377,12 +377,56 @@ impl PipesService {
 
     fn describe_pipe(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let name = pipe_name_from_path(req)?;
+        // Lazy settle: if the pipe is transient and has been so for longer than
+        // SETTLE_DELAY, advance it now (removing it if it was DELETING). The
+        // per-request `spawn_settle` task and the runner drain normally do this,
+        // but both depend on a background task getting scheduled promptly; on a
+        // heavily oversubscribed CI runner that can lag past the provider's
+        // delete/create waiter budget, hanging a pipe in DELETING. Driving the
+        // settle from the client's own DescribePipe poll makes the lifecycle
+        // converge on the poll cadence with no dependency on background
+        // scheduling — the waiter that is asking "is it gone yet?" is exactly
+        // what finishes the deletion.
+        self.settle_if_overdue(&req.account_id, &name);
         let accounts = self.state.read();
         let pipe = accounts
             .get(&req.account_id)
             .and_then(|st| st.pipes.get(&name))
             .ok_or_else(|| not_found(&name))?;
         Ok(AwsResponse::ok_json(pipe.clone()))
+    }
+
+    /// Advance a single pipe to its settled state if it has sat in a transient
+    /// state longer than `SETTLE_DELAY`. Read-locks to check first and only
+    /// takes the write lock when there is actually work to do, so the common
+    /// case (a settled pipe) stays on the read path.
+    fn settle_if_overdue(&self, account_id: &str, name: &str) {
+        let now = now_epoch_secs();
+        let overdue = {
+            let accounts = self.state.read();
+            accounts
+                .get(account_id)
+                .and_then(|st| st.pipes.get(name))
+                .map(|pipe| {
+                    let cur = pipe
+                        .get("CurrentState")
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    let last = pipe
+                        .get("LastModifiedTime")
+                        .and_then(Value::as_f64)
+                        .unwrap_or(0.0);
+                    is_transient_state(cur) && now - last >= SETTLE_DELAY.as_secs_f64()
+                })
+                .unwrap_or(false)
+        };
+        if !overdue {
+            return;
+        }
+        let mut accounts = self.state.write();
+        if let Some(st) = accounts.accounts.get_mut(account_id) {
+            settle_pipe(st, name);
+        }
     }
 
     fn list_pipes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1018,6 +1062,62 @@ mod tests {
     use super::*;
 
     const SQS: &str = "arn:aws:sqs:us-east-1:000000000000:src";
+
+    /// A `PipesService` whose account holds one pipe in `state` with the given
+    /// CurrentState/DesiredState and a LastModifiedTime `age_secs` in the past.
+    fn service_with_pipe(
+        current: &str,
+        desired: &str,
+        age_secs: f64,
+    ) -> (PipesService, SharedPipesState) {
+        use parking_lot::RwLock;
+        let state: SharedPipesState = Arc::new(RwLock::new(crate::state::PipesAccounts::new()));
+        {
+            let mut acc = state.write();
+            let st = acc.get_or_create("123456789012");
+            st.pipes.insert(
+                "p1".into(),
+                json!({
+                    "Name": "p1",
+                    "Arn": "arn:aws:pipes:us-east-1:123456789012:pipe/p1",
+                    "CurrentState": current,
+                    "DesiredState": desired,
+                    "LastModifiedTime": now_epoch_secs() - age_secs,
+                }),
+            );
+        }
+        (PipesService::new(state.clone()), state)
+    }
+
+    #[test]
+    fn lazy_settle_removes_overdue_deleting_pipe() {
+        // A DELETING pipe older than SETTLE_DELAY is removed by a describe-time
+        // settle, so the provider's delete waiter converges on its own poll.
+        let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 5.0);
+        svc.settle_if_overdue("123456789012", "p1");
+        assert!(state.read().get("123456789012").unwrap().pipes.is_empty());
+    }
+
+    #[test]
+    fn lazy_settle_advances_overdue_creating_pipe() {
+        let (svc, state) = service_with_pipe(STATE_CREATING, STATE_RUNNING, 5.0);
+        svc.settle_if_overdue("123456789012", "p1");
+        assert_eq!(
+            state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
+            STATE_RUNNING
+        );
+    }
+
+    #[test]
+    fn lazy_settle_leaves_fresh_transient_pipe() {
+        // Within SETTLE_DELAY the transient state is still observable.
+        let (svc, state) = service_with_pipe(STATE_CREATING, STATE_RUNNING, 0.0);
+        svc.settle_if_overdue("123456789012", "p1");
+        assert_eq!(
+            state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
+            STATE_CREATING
+        );
+    }
 
     #[test]
     fn sqs_source_gets_default_sqs_queue_parameters() {

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -101,6 +101,13 @@ pub fn ensure_source_param_defaults(pipe: &mut Map<String, Value>, source_arn: &
 /// get overwritten"), and then asserts the attribute is absent. Strip an empty
 /// `InputTemplate` from the target/enrichment parameter blocks, and drop a
 /// block that becomes empty so it reads back as absent.
+///
+/// The same "empty to overwrite" pattern applies to the source filter: to clear
+/// `filter_criteria` the provider sends `SourceParameters.FilterCriteria = {}`
+/// (an empty `FilterCriteria` with no `Filters`; see `expandUpdatePipeSourceParameters`),
+/// and AWS's flatten emits a `filter_criteria` block only when `FilterCriteria`
+/// is non-nil. So a FilterCriteria carrying no filters must read back as absent —
+/// strip it, or the provider sees one (empty) block where it expects zero.
 pub fn normalize_empty_input_templates(pipe: &mut Map<String, Value>) {
     for key in ["TargetParameters", "EnrichmentParameters"] {
         let drop = match pipe.get_mut(key).and_then(Value::as_object_mut) {
@@ -114,6 +121,24 @@ pub fn normalize_empty_input_templates(pipe: &mut Map<String, Value>) {
         };
         if drop {
             pipe.remove(key);
+        }
+    }
+
+    // Drop an empty `SourceParameters.FilterCriteria` (Filters absent or empty)
+    // so it reads back as no filter at all. Leave the surrounding
+    // SourceParameters block in place — it still carries the source-typed
+    // parameter defaults (e.g. SqsQueueParameters).
+    if let Some(sp) = pipe.get_mut("SourceParameters").and_then(Value::as_object_mut) {
+        let drop_fc = match sp.get("FilterCriteria").and_then(Value::as_object) {
+            Some(fc) => fc
+                .get("Filters")
+                .and_then(Value::as_array)
+                .map(|f| f.is_empty())
+                .unwrap_or(true),
+            None => false,
+        };
+        if drop_fc {
+            sp.remove("FilterCriteria");
         }
     }
 }
@@ -998,5 +1023,51 @@ mod tests {
         pipe.insert("TargetParameters".into(), json!({"InputTemplate": "<$.x>"}));
         normalize_empty_input_templates(&mut pipe);
         assert_eq!(pipe["TargetParameters"]["InputTemplate"], "<$.x>");
+    }
+
+    #[test]
+    fn empty_filter_criteria_stripped_defaults_kept() {
+        // Clearing a source filter sends FilterCriteria = {} alongside the
+        // source-typed defaults. The empty FilterCriteria must be dropped so it
+        // reads back as absent, but SqsQueueParameters must survive.
+        let mut pipe = Map::new();
+        pipe.insert(
+            "SourceParameters".into(),
+            json!({
+                "SqsQueueParameters": {"BatchSize": 10, "MaximumBatchingWindowInSeconds": 0},
+                "FilterCriteria": {},
+            }),
+        );
+        normalize_empty_input_templates(&mut pipe);
+        assert!(pipe["SourceParameters"].get("FilterCriteria").is_none());
+        assert_eq!(
+            pipe["SourceParameters"]["SqsQueueParameters"]["BatchSize"],
+            10
+        );
+    }
+
+    #[test]
+    fn empty_filters_array_filter_criteria_stripped() {
+        let mut pipe = Map::new();
+        pipe.insert(
+            "SourceParameters".into(),
+            json!({"FilterCriteria": {"Filters": []}}),
+        );
+        normalize_empty_input_templates(&mut pipe);
+        assert!(pipe["SourceParameters"].get("FilterCriteria").is_none());
+    }
+
+    #[test]
+    fn non_empty_filter_criteria_preserved() {
+        let mut pipe = Map::new();
+        pipe.insert(
+            "SourceParameters".into(),
+            json!({"FilterCriteria": {"Filters": [{"Pattern": "{\"x\":[1]}"}]}}),
+        );
+        normalize_empty_input_templates(&mut pipe);
+        assert_eq!(
+            pipe["SourceParameters"]["FilterCriteria"]["Filters"][0]["Pattern"],
+            "{\"x\":[1]}"
+        );
     }
 }

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -775,28 +775,42 @@ fn settle_pipe(st: &mut crate::state::PipesState, name: &str) {
 /// genuinely-starved settles.
 pub fn drain_overdue_transient_pipes(state: &SharedPipesState, min_age_secs: f64) {
     let now = now_epoch_secs();
-    let mut accounts = state.write();
-    for st in accounts.accounts.values_mut() {
-        let due: Vec<String> = st
-            .pipes
-            .iter()
-            .filter(|(_, pipe)| {
+
+    // Read-lock-first: collect the overdue `(account, name)` pairs under a
+    // shared read lock, and only escalate to the write lock when there is
+    // actually something to settle. The common case — no transient pipe past
+    // the age gate — takes only the read lock, so the runner's per-tick drain
+    // does not convoy against the provider's DescribePipe read flood.
+    let overdue: Vec<(String, String)> = {
+        let accounts = state.read();
+        let mut out = Vec::new();
+        for (account_id, st) in &accounts.accounts {
+            for (name, pipe) in &st.pipes {
                 let cur = pipe
                     .get("CurrentState")
                     .and_then(Value::as_str)
                     .unwrap_or("");
                 if !is_transient_state(cur) {
-                    return false;
+                    continue;
                 }
                 let last = pipe
                     .get("LastModifiedTime")
                     .and_then(Value::as_f64)
                     .unwrap_or(0.0);
-                now - last >= min_age_secs
-            })
-            .map(|(name, _)| name.clone())
-            .collect();
-        for name in due {
+                if now - last >= min_age_secs {
+                    out.push((account_id.clone(), name.clone()));
+                }
+            }
+        }
+        out
+    };
+    if overdue.is_empty() {
+        return;
+    }
+
+    let mut accounts = state.write();
+    for (account_id, name) in overdue {
+        if let Some(st) = accounts.accounts.get_mut(&account_id) {
             settle_pipe(st, &name);
         }
     }

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -128,7 +128,10 @@ pub fn normalize_empty_input_templates(pipe: &mut Map<String, Value>) {
     // so it reads back as no filter at all. Leave the surrounding
     // SourceParameters block in place — it still carries the source-typed
     // parameter defaults (e.g. SqsQueueParameters).
-    if let Some(sp) = pipe.get_mut("SourceParameters").and_then(Value::as_object_mut) {
+    if let Some(sp) = pipe
+        .get_mut("SourceParameters")
+        .and_then(Value::as_object_mut)
+    {
         let drop_fc = match sp.get("FilterCriteria").and_then(Value::as_object) {
             Some(fc) => fc
                 .get("Filters")

--- a/crates/fakecloud-server/src/pipes_runner.rs
+++ b/crates/fakecloud-server/src/pipes_runner.rs
@@ -112,10 +112,18 @@ impl PipesRunner {
     }
 
     pub async fn run(self) {
-        let mut interval = tokio::time::interval(Duration::from_millis(500));
+        // Sleep *after* each poll rather than using a fixed-rate `interval`:
+        // `interval` with the default Burst behaviour fires back-to-back to
+        // "catch up" whenever a poll runs long, which on an oversubscribed
+        // 2-core CI runner turns the runner into a busy loop that starves the
+        // request handlers. A trailing sleep guarantees at least this gap
+        // between polls no matter how long a poll took. One second is well
+        // within Pipes' delivery-latency tolerance and keeps the runner's
+        // constant background load low so it doesn't tip a constrained runner
+        // over when it runs alongside concurrent terraform applies.
         loop {
-            interval.tick().await;
             self.poll().await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 

--- a/crates/fakecloud-server/src/pipes_runner.rs
+++ b/crates/fakecloud-server/src/pipes_runner.rs
@@ -205,6 +205,16 @@ impl PipesRunner {
 
     async fn process_sqs_pipe(&self, pipe: &RunningPipe) {
         let now = Utc::now();
+        // Cheap read-locked pre-check: only escalate to the SQS *write* lock
+        // (which `pick_messages` takes, and which contends with every SQS
+        // request handler) when the source queue actually has a visible
+        // message. An idle SQS-source pipe is the common case — polled every
+        // 500ms — and a per-pipe write-lock storm on the global SQS state
+        // starves the request loop under load (SQS/DescribePipe calls time out,
+        // the tfacc suite hangs). With no work to do, take only the read lock.
+        if !self.sqs_source_has_visible_messages(&pipe.source_arn, now) {
+            return;
+        }
         // Pull up to BatchSize visible messages and hide them for the queue's
         // visibility window so a slow delivery doesn't re-pull the same batch.
         let picked = self.pick_messages(&pipe.source_arn, pipe.batch_size, now);
@@ -234,6 +244,24 @@ impl PipesRunner {
         if !ack_ids.is_empty() {
             self.delete_messages(&pipe.source_arn, &ack_ids);
         }
+    }
+
+    /// Read-locked check for whether the source queue has at least one visible
+    /// message right now. Used to gate the write-locking `pick_messages` so an
+    /// idle pipe never contends on the global SQS write lock.
+    fn sqs_source_has_visible_messages(&self, source_arn: &str, now: DateTime<Utc>) -> bool {
+        let sqs_mas = self.sqs_state.read();
+        let acct = source_arn.split(':').nth(4).unwrap_or("");
+        let Some(sqs) = sqs_mas.get(acct) else {
+            return false;
+        };
+        let Some(queue) = sqs.queues.values().find(|q| q.arn == source_arn) else {
+            return false;
+        };
+        queue
+            .messages
+            .iter()
+            .any(|m| m.visible_at.map(|v| v <= now).unwrap_or(true))
     }
 
     /// Pull up to `limit` currently-visible messages from the source queue and

--- a/crates/fakecloud-server/src/pipes_runner.rs
+++ b/crates/fakecloud-server/src/pipes_runner.rs
@@ -120,6 +120,13 @@ impl PipesRunner {
     }
 
     async fn poll(&self) {
+        // Backstop the per-request `spawn_settle` tasks: rescue any pipe that
+        // has been transient for over a second, so a DELETING/UPDATING pipe
+        // still settles even when a CPU-starved runner delays its spawned
+        // settle task past the provider's waiter timeout. Cheap (a single
+        // write lock over the pipe map) and a no-op under normal load.
+        fakecloud_pipes::drain_overdue_transient_pipes(&self.pipes_state, 1.0);
+
         let pipes = self.collect_running_pipes();
         for pipe in pipes {
             match pipe.source_kind {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -603,6 +603,17 @@ pub const SERVICES: &[Service] = &[
         deny: &[],
     },
     Service {
+        name: "pipes",
+        // EventBridge Pipes: the control-plane smokes for aws_pipes_pipe — basic
+        // SQS source->target, disappears, description, desired_state, role ARN,
+        // generated/prefixed names, target update, source filter criteria, and
+        // the target InputTemplate transform. Real-only surfaces (Kafka/MSK/MQ
+        // sources, Redshift/SageMaker/Batch/ECS targets, KMS, CloudWatch-Logs
+        // log configuration) are left out of the smoke.
+        run_regex: "^TestAccPipesPipe_(basicSQS|disappears|description|desiredState|roleARN|nameGenerated|namePrefix|tags|targetUpdate|sourceParameters_filterCriteria|targetParameters_inputTemplate)$",
+        deny: &[],
+    },
+    Service {
         name: "sesv2",
         // SES v2: the `_basic` smoke for configuration sets (+ event destination
         // + data source), dedicated IP pools (+ data source), and email identity
@@ -1143,6 +1154,12 @@ pub const SHARDS: &[Shard] = &[
         name: "scheduler",
         service: "scheduler",
         run_regex: "^TestAccScheduler[A-Za-z0-9]+_basic$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "pipes",
+        service: "pipes",
+        run_regex: "^TestAccPipesPipe_(basicSQS|disappears|description|desiredState|roleARN|nameGenerated|namePrefix|tags|targetUpdate|sourceParameters_filterCriteria|targetParameters_inputTemplate)$",
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -1156,10 +1156,30 @@ pub const SHARDS: &[Shard] = &[
         run_regex: "^TestAccScheduler[A-Za-z0-9]+_basic$",
         extra_deny: &[],
     },
+    // EventBridge Pipes is split across three shards, each a fresh fakecloud
+    // handling at most four pipe-lifecycle tests. Pipes is the only service that
+    // runs a persistent execution loop, and a single process that drives ~6+ of
+    // these create/transition/destroy tests back-to-back on a constrained 2-core
+    // CI runner degrades until the provider's delete/"gone" waiters stop
+    // converging (a pipe or its SQS source/target queue lingers past the waiter
+    // budget). Keeping each shard small holds every run well under that point;
+    // the union of the three equals the original single-shard selection.
     Shard {
-        name: "pipes",
+        name: "pipes-a",
         service: "pipes",
-        run_regex: "^TestAccPipesPipe_(basicSQS|disappears|description|desiredState|roleARN|nameGenerated|namePrefix|tags|targetUpdate|sourceParameters_filterCriteria|targetParameters_inputTemplate)$",
+        run_regex: "^TestAccPipesPipe_(basicSQS|disappears|description|desiredState)$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "pipes-b",
+        service: "pipes",
+        run_regex: "^TestAccPipesPipe_(roleARN|nameGenerated|namePrefix|tags)$",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "pipes-c",
+        service: "pipes",
+        run_regex: "^TestAccPipesPipe_(targetUpdate|sourceParameters_filterCriteria|targetParameters_inputTemplate)$",
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -309,6 +309,7 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_BATCH", "batch"),
     ("AWS_ENDPOINT_URL_COGNITO_IDENTITY", "cognito-identity"),
     ("AWS_ENDPOINT_URL_SCHEDULER", "scheduler"),
+    ("AWS_ENDPOINT_URL_PIPES", "pipes"),
     ("AWS_ENDPOINT_URL_WAFV2", "wafv2"),
     ("AWS_ENDPOINT_URL_FIREHOSE", "firehose"),
     ("AWS_ENDPOINT_URL_CLOUDWATCH", "monitoring"),

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -11,6 +11,7 @@
 //! an *allow*-list rather than a deny-list to match fakecloud's
 //! parity-per-implemented-service invariant.
 
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
@@ -209,12 +210,59 @@ impl<'a> GoTestRunner<'a> {
             cmd.env(key, &self.endpoint);
         }
 
-        let output = cmd.output().expect("run go test");
+        // Stream `go test` output live (echo each line to our own stdout/stderr
+        // as it arrives) instead of buffering until exit. `go test -v` can run
+        // for many minutes; if a single subtest hangs and CI kills the job on
+        // its timeout, a buffered `cmd.output()` would discard everything and
+        // the CI log would show no `=== RUN` / `--- PASS` lines — leaving the
+        // culprit invisible (exactly the blind spot a pipes-shard hang hit).
+        // Streaming means the last un-paired `=== RUN` in the job log names the
+        // hung test even when the process is killed mid-run. We still collect
+        // the bytes so `assert_pass` can parse the failure summary.
+        let mut child = cmd.spawn().expect("spawn go test");
+        let child_stdout = child.stdout.take().expect("piped stdout");
+        let child_stderr = child.stderr.take().expect("piped stderr");
+        let stdout_handle = std::thread::spawn(move || tee(child_stdout, false));
+        let stderr_handle = std::thread::spawn(move || tee(child_stderr, true));
+        let status = child.wait().expect("wait for go test");
+        let stdout = stdout_handle.join().unwrap_or_default();
+        let stderr = stderr_handle.join().unwrap_or_default();
         GoTestResult {
-            success: output.status.success(),
-            output,
+            success: status.success(),
+            output: Output {
+                status,
+                stdout,
+                stderr,
+            },
         }
     }
+}
+
+/// Read a child pipe line by line, echoing each line to the parent's stdout
+/// (or stderr) as it arrives so the output survives a timeout-kill, while
+/// accumulating the raw bytes for later parsing.
+fn tee<R: std::io::Read>(pipe: R, is_stderr: bool) -> Vec<u8> {
+    let mut collected = Vec::new();
+    let mut reader = BufReader::new(pipe);
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        match reader.read_until(b'\n', &mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                collected.extend_from_slice(&line);
+                if is_stderr {
+                    let _ = std::io::stderr().write_all(&line);
+                    let _ = std::io::stderr().flush();
+                } else {
+                    let _ = std::io::stdout().write_all(&line);
+                    let _ = std::io::stdout().flush();
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    collected
 }
 
 pub struct GoTestResult {

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -148,6 +148,18 @@ pub struct GoTestRunner<'a> {
     pub endpoint: String,
 }
 
+/// Go `-parallel` degree for a service's `go test` invocation. Defaults to 4;
+/// a few background-loop + waiter-heavy services drop to 2 so their lifecycle
+/// settle tasks don't starve for CPU under four concurrent terraform applies on
+/// a 2-core CI runner. `pipes` runs a 500ms source-poll loop alongside
+/// create/import/update/delete waiters and is the clearest such case.
+fn parallelism_for(service: &str) -> u32 {
+    match service {
+        "pipes" => 2,
+        _ => 4,
+    }
+}
+
 impl<'a> GoTestRunner<'a> {
     pub fn run_service(&self, service: &Service) -> GoTestResult {
         self.run_go_tests(service.name, service.run_regex, service.deny)
@@ -169,13 +181,21 @@ impl<'a> GoTestRunner<'a> {
             format!("^({})$", deny.join("|"))
         };
 
-        // `-parallel 4` lets Go's test runner execute up to 4 `t.Parallel()`
+        // `-parallel N` lets Go's test runner execute up to N `t.Parallel()`
         // subtests concurrently within a single `go test` invocation. We use 4
         // (rather than 8 or runner core count) because some upstream tests
         // poll fakecloud aggressively under parallel load and can starve the
         // request loop, surfacing as suite-wide hangs. CI fan-out across
         // services is handled by the GitHub Actions matrix, so wall time
         // scales with the slowest single service, not their sum.
+        //
+        // A few services drive a fakecloud-side background loop plus multi-step
+        // create/update/delete lifecycle waiters, and on a constrained 2-core CI
+        // runner four of those in parallel saturate the CPU enough that the
+        // lifecycle settle tasks starve and the provider's delete/update waiters
+        // time out (observed as a 30-minute stuck DELETING pipe). Those run at a
+        // lower parallelism; see `parallelism_for`.
+        let parallel = parallelism_for(service);
         let mut cmd = Command::new("go");
         let mut args: Vec<String> = vec![
             "test".into(),
@@ -187,7 +207,7 @@ impl<'a> GoTestRunner<'a> {
             "90m".into(),
             "-count=1".into(),
             "-parallel".into(),
-            "4".into(),
+            parallel.to_string(),
         ];
         if !skip_re.is_empty() {
             args.push("-skip".into());

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -148,14 +148,20 @@ pub struct GoTestRunner<'a> {
     pub endpoint: String,
 }
 
-/// Go `-parallel` degree for a service's `go test` invocation. Defaults to 4;
-/// a few background-loop + waiter-heavy services drop to 2 so their lifecycle
-/// settle tasks don't starve for CPU under four concurrent terraform applies on
-/// a 2-core CI runner. `pipes` runs a 500ms source-poll loop alongside
-/// create/import/update/delete waiters and is the clearest such case.
+/// Go `-parallel` degree for a service's `go test` invocation. Defaults to 4.
+///
+/// `pipes` is special: unlike every other service it runs a persistent
+/// background execution loop (the Pipes runner) on the fakecloud side. That
+/// constant load *on top of* four concurrent terraform applies oversubscribes a
+/// 2-core CI runner badly enough that the server stops serving the provider's
+/// delete/`gone` poll requests promptly — a pipe hangs in DELETING and even
+/// unrelated SQS DeleteQueue waiters time out. Other services have no such loop,
+/// so parallel-4 is fine for them. Run the pipes acceptance tests serially so
+/// they don't oversubscribe the box; the suite is small and its behaviour is
+/// unchanged, this only bounds concurrency on constrained runners.
 fn parallelism_for(service: &str) -> u32 {
     match service {
-        "pipes" => 2,
+        "pipes" => 1,
         _ => 4,
     }
 }

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -253,6 +253,11 @@ async fn scheduler_acceptance() {
 }
 
 #[tokio::test]
+async fn pipes_acceptance() {
+    run_shard("pipes").await;
+}
+
+#[tokio::test]
 async fn sesv2_acceptance() {
     run_shard("sesv2").await;
 }

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -253,8 +253,18 @@ async fn scheduler_acceptance() {
 }
 
 #[tokio::test]
-async fn pipes_acceptance() {
-    run_shard("pipes").await;
+async fn pipes_a_acceptance() {
+    run_shard("pipes-a").await;
+}
+
+#[tokio::test]
+async fn pipes_b_acceptance() {
+    run_shard("pipes-b").await;
+}
+
+#[tokio::test]
+async fn pipes_c_acceptance() {
+    run_shard("pipes-c").await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Batch 6 of EventBridge Pipes: terraform-provider-aws acceptance coverage

Wires `aws_pipes_pipe` into the tfacc harness and fixes the one fidelity gap the suite surfaced.

### tfacc wiring
- `AWS_ENDPOINT_URL_PIPES` endpoint mapping.
- `Service` + `Shard` allowlist entries for `pipes`.
- `pipes_acceptance` shard test.

Covers the `aws_pipes_pipe` control-plane smokes: `basicSQS`, `disappears`, `description`, `desiredState`, `roleARN`, `nameGenerated`, `namePrefix`, `tags`, `targetUpdate`, `sourceParameters_filterCriteria`, `targetParameters_inputTemplate`. Real-only surfaces (Kafka/MSK/MQ sources, Redshift/SageMaker/Batch/ECS targets, KMS, CloudWatch-Logs log config) are left out of the smoke.

### Fidelity fix
AWS always echoes the source-typed parameter sub-block on `DescribePipe` with defaults, even when the caller sent no `SourceParameters`. For an SQS source that is `SqsQueueParameters` with `BatchSize=10` and `MaximumBatchingWindowInSeconds=0`, which the resource reads unconditionally (the smoke asserts `source_parameters.0.sqs_queue_parameters.0.*`, which was `#=0` before).

`CreatePipe` and `UpdatePipe` now populate these defaults (preserving any caller-supplied values and a sibling `FilterCriteria`), and the CloudFormation provisioner does the same via a shared `ensure_source_param_defaults` helper so a CFN-created pipe reads back identically.

### Tests
- Pipes unit tests for the defaulting helper (defaults, preserve-existing, non-SQS untouched).
- The full 11-test pipes tfacc shard passes locally (~73s).

Follows batch-1 (#2046) … batch-5 (#2050).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `aws_pipes_pipe` to `tfacc` and aligns behavior with AWS (default SQS source params, empty `InputTemplate`/`FilterCriteria` handling, and replace‑semantics `UpdatePipe`). Also settles overdue transients via the runner and on `DescribePipe`, and splits the pipes acceptance into three serialized shards to avoid CI starvation.

- **New Features**
  - Wired `aws_pipes_pipe` into `tfacc`: `AWS_ENDPOINT_URL_PIPES`, allowlist, and three shards (`pipes-a`, `pipes-b`, `pipes-c`) with acceptance tests; runs with `-parallel 1`.

- **Bug Fixes**
  - Fidelity: default SQS `SqsQueueParameters` (`BatchSize=10`, `MaximumBatchingWindowInSeconds=0`), strip empty `Target/Enrichment InputTemplate`, drop empty `SourceParameters.FilterCriteria`, and clear omitted fields on `UpdatePipe`; applied on create/update and CloudFormation.
  - Robustness/CI: lazy‑settle overdue transients on `DescribePipe`; runner also drains overdue transients, gates SQS pulls with a read‑locked visible‑message check, and switches to poll‑then‑sleep (1s). Streams `go test` output live so timeout‑kills still show the hung subtest.

<sup>Written for commit 653f68090e8badd1d4003df9f91b6bfed8b3c077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

