### PR TITLE
fix(rds,ec2): Tier-0 propagation — background restore/replica + persist EC2 Modify*

### DIFF
--- a/crates/fakecloud-ec2/src/service/endpoint.rs
+++ b/crates/fakecloud-ec2/src/service/endpoint.rs
@@ -147,15 +147,49 @@ pub(crate) fn describe_vpc_endpoints(
 }
 
 pub(crate) fn modify_vpc_endpoint(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "VpcEndpointId")?;
+    let id = require(&req.query_params, "VpcEndpointId")?;
     validate_enum(
         &req.query_params,
         "IpAddressType",
         &["ipv4", "dualstack", "ipv6"],
     )?;
+    let add_subnets = indexed_list(&req.query_params, "AddSubnetId");
+    let remove_subnets = indexed_list(&req.query_params, "RemoveSubnetId");
+    let add_rts = indexed_list(&req.query_params, "AddRouteTableId");
+    let remove_rts = indexed_list(&req.query_params, "RemoveRouteTableId");
+    let private_dns = req
+        .query_params
+        .get("PrivateDnsEnabled")
+        .map(|v| v == "true");
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let e = state.vpc_endpoints.get_mut(&id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                http::StatusCode::BAD_REQUEST,
+                "InvalidVpcEndpointId.NotFound",
+                format!("The Vpc Endpoint Id '{id}' does not exist"),
+            )
+        })?;
+        for s in &add_subnets {
+            if !e.subnet_ids.contains(s) {
+                e.subnet_ids.push(s.clone());
+            }
+        }
+        e.subnet_ids.retain(|s| !remove_subnets.contains(s));
+        for r in &add_rts {
+            if !e.route_table_ids.contains(r) {
+                e.route_table_ids.push(r.clone());
+            }
+        }
+        e.route_table_ids.retain(|r| !remove_rts.contains(r));
+        if let Some(v) = private_dns {
+            e.private_dns_enabled = v;
+        }
+    }
     Ok(Ec2Service::respond(
         "ModifyVpcEndpoint",
         &req.request_id,
@@ -677,4 +711,92 @@ pub(crate) fn get_flow_logs_integration_template(
         &req.request_id,
         &ec2_elem("result", "https://s3.amazonaws.com/flow-logs-template.json"),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(action: &str, query: &[(&str, &str)]) -> AwsRequest {
+        AwsRequest {
+            service: "ec2".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: "000000000000".into(),
+            request_id: "rid".into(),
+            headers: http::HeaderMap::new(),
+            query_params: query
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn seed_endpoint(svc: &Ec2Service) {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create("000000000000");
+        state.vpc_endpoints.insert(
+            "vpce-1".to_string(),
+            VpcEndpoint {
+                id: "vpce-1".into(),
+                endpoint_type: "Interface".into(),
+                vpc_id: "vpc-1".into(),
+                service_name: "com.amazonaws.us-east-1.s3".into(),
+                state: "available".into(),
+                subnet_ids: vec!["subnet-a".into()],
+                route_table_ids: vec![],
+                private_dns_enabled: false,
+            },
+        );
+    }
+
+    #[test]
+    fn modify_vpc_endpoint_persists_subnets_and_dns() {
+        // The handler validated then returned true without persisting
+        // (bug-hunt 2026-07-01, Tier-0 EC2 Modify*).
+        let svc = Ec2Service::new();
+        seed_endpoint(&svc);
+        modify_vpc_endpoint(
+            &svc,
+            &req(
+                "ModifyVpcEndpoint",
+                &[
+                    ("VpcEndpointId", "vpce-1"),
+                    ("AddSubnetId.1", "subnet-b"),
+                    ("RemoveSubnetId.1", "subnet-a"),
+                    ("AddRouteTableId.1", "rtb-1"),
+                    ("PrivateDnsEnabled", "true"),
+                ],
+            ),
+        )
+        .unwrap();
+
+        let accounts = svc.state.read();
+        let e = &accounts.get("000000000000").unwrap().vpc_endpoints["vpce-1"];
+        assert_eq!(e.subnet_ids, vec!["subnet-b".to_string()]);
+        assert_eq!(e.route_table_ids, vec!["rtb-1".to_string()]);
+        assert!(e.private_dns_enabled);
+    }
+
+    #[test]
+    fn modify_vpc_endpoint_unknown_id_errors() {
+        let svc = Ec2Service::new();
+        let err = match modify_vpc_endpoint(
+            &svc,
+            &req("ModifyVpcEndpoint", &[("VpcEndpointId", "vpce-missing")]),
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("expected NotFound error"),
+        };
+        assert!(format!("{err:?}").contains("InvalidVpcEndpointId.NotFound"));
+    }
 }

--- a/crates/fakecloud-ec2/src/service/endpoint.rs
+++ b/crates/fakecloud-ec2/src/service/endpoint.rs
@@ -12,6 +12,15 @@ const FIXED_TIME: &str = "2024-01-01T00:00:00.000Z";
 
 // ---- VPC endpoints ----
 
+/// Render the endpoint `<groupSet>` from attached security-group ids.
+fn groups_xml(group_ids: &[String]) -> String {
+    let items: Vec<String> = group_ids
+        .iter()
+        .map(|g| format!("<groupId>{}</groupId>", fakecloud_aws::xml::xml_escape(g)))
+        .collect();
+    ec2_list("groupSet", &items)
+}
+
 fn endpoint_xml(e: &VpcEndpoint, tags: &[Tag], owner: &str) -> String {
     format!(
         "{}{}{}{}{}<privateDnsEnabled>{}</privateDnsEnabled><requesterManaged>false</requesterManaged>\
@@ -24,7 +33,7 @@ fn endpoint_xml(e: &VpcEndpoint, tags: &[Tag], owner: &str) -> String {
         e.private_dns_enabled,
         ec2_elem("ipAddressType", "ipv4"),
         ec2_list("subnetIdSet", &e.subnet_ids),
-        ec2_list("groupSet", &[]),
+        groups_xml(&e.security_group_ids),
         ec2_list("routeTableIdSet", &e.route_table_ids),
         ec2_list("networkInterfaceIdSet", &[]),
         ec2_elem("creationTimestamp", FIXED_TIME),
@@ -76,6 +85,7 @@ pub(crate) fn create_vpc_endpoint(
             .get("PrivateDnsEnabled")
             .map(|v| v == "true")
             .unwrap_or(false),
+        security_group_ids: indexed_list(&req.query_params, "SecurityGroupId"),
     };
     let owner = req.account_id.clone();
     let tags = {
@@ -160,6 +170,8 @@ pub(crate) fn modify_vpc_endpoint(
     let remove_subnets = indexed_list(&req.query_params, "RemoveSubnetId");
     let add_rts = indexed_list(&req.query_params, "AddRouteTableId");
     let remove_rts = indexed_list(&req.query_params, "RemoveRouteTableId");
+    let add_sgs = indexed_list(&req.query_params, "AddSecurityGroupId");
+    let remove_sgs = indexed_list(&req.query_params, "RemoveSecurityGroupId");
     let private_dns = req
         .query_params
         .get("PrivateDnsEnabled")
@@ -186,6 +198,12 @@ pub(crate) fn modify_vpc_endpoint(
             }
         }
         e.route_table_ids.retain(|r| !remove_rts.contains(r));
+        for g in &add_sgs {
+            if !e.security_group_ids.contains(g) {
+                e.security_group_ids.push(g.clone());
+            }
+        }
+        e.security_group_ids.retain(|g| !remove_sgs.contains(g));
         if let Some(v) = private_dns {
             e.private_dns_enabled = v;
         }
@@ -755,6 +773,7 @@ mod tests {
                 subnet_ids: vec!["subnet-a".into()],
                 route_table_ids: vec![],
                 private_dns_enabled: false,
+                security_group_ids: vec![],
             },
         );
     }
@@ -785,6 +804,41 @@ mod tests {
         assert_eq!(e.subnet_ids, vec!["subnet-b".to_string()]);
         assert_eq!(e.route_table_ids, vec!["rtb-1".to_string()]);
         assert!(e.private_dns_enabled);
+    }
+
+    #[test]
+    fn modify_vpc_endpoint_persists_security_groups() {
+        // Add/RemoveSecurityGroupId were silently dropped (Cubic P2 on #2057).
+        let svc = Ec2Service::new();
+        seed_endpoint(&svc);
+        svc.state
+            .write()
+            .get_or_create("000000000000")
+            .vpc_endpoints
+            .get_mut("vpce-1")
+            .unwrap()
+            .security_group_ids = vec!["sg-old".into()];
+        modify_vpc_endpoint(
+            &svc,
+            &req(
+                "ModifyVpcEndpoint",
+                &[
+                    ("VpcEndpointId", "vpce-1"),
+                    ("AddSecurityGroupId.1", "sg-new"),
+                    ("RemoveSecurityGroupId.1", "sg-old"),
+                ],
+            ),
+        )
+        .unwrap();
+        {
+            let accounts = svc.state.read();
+            let e = &accounts.get("000000000000").unwrap().vpc_endpoints["vpce-1"];
+            assert_eq!(e.security_group_ids, vec!["sg-new".to_string()]);
+        }
+        // And the groupSet round-trips in DescribeVpcEndpoints.
+        let resp = describe_vpc_endpoints(&svc, &req("DescribeVpcEndpoints", &[])).unwrap();
+        let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+        assert!(body.contains("<groupId>sg-new</groupId>"), "got: {body}");
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -1832,11 +1832,7 @@ pub(crate) fn modify_instance_metadata_defaults(
 ) -> Result<AwsResponse, AwsServiceError> {
     let p = &req.query_params;
     validate_enum(p, "HttpTokens", &["optional", "required", "no-preference"])?;
-    validate_enum(
-        p,
-        "HttpEndpoint",
-        &["disabled", "enabled", "no-preference"],
-    )?;
+    validate_enum(p, "HttpEndpoint", &["disabled", "enabled", "no-preference"])?;
     validate_enum(
         p,
         "InstanceMetadataTags",
@@ -1860,7 +1856,9 @@ pub(crate) fn modify_instance_metadata_defaults(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        let d = state.instance_metadata_defaults.get_or_insert_with(Default::default);
+        let d = state
+            .instance_metadata_defaults
+            .get_or_insert_with(Default::default);
         apply(&mut d.http_tokens, "HttpTokens");
         apply(&mut d.http_endpoint, "HttpEndpoint");
         apply(&mut d.instance_metadata_tags, "InstanceMetadataTags");
@@ -2112,11 +2110,17 @@ mod modify_tests {
         let out = body(
             describe_instance_credit_specifications(
                 &svc,
-                &req("DescribeInstanceCreditSpecifications", &[("InstanceId.1", "i-1")]),
+                &req(
+                    "DescribeInstanceCreditSpecifications",
+                    &[("InstanceId.1", "i-1")],
+                ),
             )
             .unwrap(),
         );
-        assert!(out.contains("<cpuCredits>unlimited</cpuCredits>"), "got: {out}");
+        assert!(
+            out.contains("<cpuCredits>unlimited</cpuCredits>"),
+            "got: {out}"
+        );
     }
 
     #[test]
@@ -2149,19 +2153,28 @@ mod modify_tests {
         let out = body(
             get_instance_metadata_defaults(&svc, &req("GetInstanceMetadataDefaults", &[])).unwrap(),
         );
-        assert!(out.contains("<httpTokens>required</httpTokens>"), "got: {out}");
+        assert!(
+            out.contains("<httpTokens>required</httpTokens>"),
+            "got: {out}"
+        );
         assert!(out.contains("<httpEndpoint>enabled</httpEndpoint>"));
 
         // `no-preference` drops the stored default.
         modify_instance_metadata_defaults(
             &svc,
-            &req("ModifyInstanceMetadataDefaults", &[("HttpTokens", "no-preference")]),
+            &req(
+                "ModifyInstanceMetadataDefaults",
+                &[("HttpTokens", "no-preference")],
+            ),
         )
         .unwrap();
         let out = body(
             get_instance_metadata_defaults(&svc, &req("GetInstanceMetadataDefaults", &[])).unwrap(),
         );
-        assert!(!out.contains("httpTokens"), "no-preference should clear it: {out}");
+        assert!(
+            !out.contains("httpTokens"),
+            "no-preference should clear it: {out}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -1819,6 +1819,9 @@ pub(crate) fn get_instance_metadata_defaults(
     if let Some(v) = &d.instance_metadata_tags {
         inner.push_str(&ec2_elem("instanceMetadataTags", v));
     }
+    if let Some(v) = &d.http_tokens_enforced {
+        inner.push_str(&ec2_elem("httpTokensEnforced", v));
+    }
     Ok(Ec2Service::respond(
         "GetInstanceMetadataDefaults",
         &req.request_id,
@@ -1862,6 +1865,7 @@ pub(crate) fn modify_instance_metadata_defaults(
         apply(&mut d.http_tokens, "HttpTokens");
         apply(&mut d.http_endpoint, "HttpEndpoint");
         apply(&mut d.instance_metadata_tags, "InstanceMetadataTags");
+        apply(&mut d.http_tokens_enforced, "HttpTokensEnforced");
         if let Some(v) = p
             .get("HttpPutResponseHopLimit")
             .and_then(|v| v.parse::<i64>().ok())
@@ -1960,10 +1964,12 @@ fn indexed_sub_keys(params: &HashMap<String, String>) -> Vec<String> {
 }
 
 fn event_tag_attribute(state: &Ec2State) -> String {
+    // `ec2_list` already wraps each element in <item>; pass the (escaped) key
+    // strings directly so the shape is <item>key</item>, not a nested pair.
     let keys: Vec<String> = state
         .event_notification_tag_keys
         .iter()
-        .map(|k| ec2_elem("item", k))
+        .map(|k| fakecloud_aws::xml::xml_escape(k))
         .collect();
     format!(
         "<instanceTagAttribute><includeAllTagsOfInstance>{}</includeAllTagsOfInstance>{}</instanceTagAttribute>",
@@ -2146,7 +2152,11 @@ mod modify_tests {
             &svc,
             &req(
                 "ModifyInstanceMetadataDefaults",
-                &[("HttpTokens", "required"), ("HttpEndpoint", "enabled")],
+                &[
+                    ("HttpTokens", "required"),
+                    ("HttpEndpoint", "enabled"),
+                    ("HttpTokensEnforced", "enabled"),
+                ],
             ),
         )
         .unwrap();
@@ -2158,6 +2168,8 @@ mod modify_tests {
             "got: {out}"
         );
         assert!(out.contains("<httpEndpoint>enabled</httpEndpoint>"));
+        // HttpTokensEnforced must persist too (Cubic P2 on #2057).
+        assert!(out.contains("<httpTokensEnforced>enabled</httpTokensEnforced>"));
 
         // `no-preference` drops the stored default.
         modify_instance_metadata_defaults(
@@ -2172,7 +2184,7 @@ mod modify_tests {
             get_instance_metadata_defaults(&svc, &req("GetInstanceMetadataDefaults", &[])).unwrap(),
         );
         assert!(
-            !out.contains("httpTokens"),
+            !out.contains("<httpTokens>"),
             "no-preference should clear it: {out}"
         );
     }
@@ -2200,6 +2212,9 @@ mod modify_tests {
         );
         assert!(out.contains("<item>Name</item>"), "got: {out}");
         assert!(out.contains("<item>env</item>"));
+        // Keys must not be double-wrapped as <item><item>key</item></item>
+        // (Cubic P2 on #2057).
+        assert!(!out.contains("<item><item>"), "got: {out}");
 
         deregister_event_notification_attributes(
             &svc,

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -1729,9 +1729,18 @@ pub(crate) fn describe_instance_credit_specifications(
         .values()
         .filter(|i| wanted.is_empty() || wanted.contains(&i.instance_id))
         .map(|i| {
+            // Burstable families (t2/t3/t3a/t4g) default to `unlimited` on AWS
+            // except t2 (`standard`); non-burstable have no credit spec. We only
+            // track the value once explicitly set, else report `standard`.
+            let credits = state
+                .instance_credit_specs
+                .get(&i.instance_id)
+                .cloned()
+                .unwrap_or_else(|| "standard".to_string());
             format!(
-                "{}<cpuCredits>standard</cpuCredits>",
-                ec2_elem("instanceId", &i.instance_id)
+                "{}{}",
+                ec2_elem("instanceId", &i.instance_id),
+                ec2_elem("cpuCredits", &credits)
             )
         })
         .collect();
@@ -1743,13 +1752,43 @@ pub(crate) fn describe_instance_credit_specifications(
 }
 
 pub(crate) fn modify_instance_credit_specification(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let p = &req.query_params;
+    let mut successful = Vec::new();
+    let mut unsuccessful = Vec::new();
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let mut n = 1usize;
+        loop {
+            let id_key = format!("InstanceCreditSpecification.{n}.InstanceId");
+            let Some(instance_id) = p.get(&id_key).cloned() else {
+                break;
+            };
+            let credits = p
+                .get(&format!("InstanceCreditSpecification.{n}.CpuCredits"))
+                .cloned()
+                .unwrap_or_else(|| "standard".to_string());
+            if state.instances.contains_key(&instance_id) {
+                state
+                    .instance_credit_specs
+                    .insert(instance_id.clone(), credits);
+                successful.push(ec2_elem("instanceId", &instance_id));
+            } else {
+                unsuccessful.push(format!(
+                    "{}<error><code>InvalidInstanceID.NotFound</code><message>The instance ID '{instance_id}' does not exist</message></error>",
+                    ec2_elem("instanceId", &instance_id)
+                ));
+            }
+            n += 1;
+        }
+    }
     let body = format!(
         "{}{}",
-        ec2_list("successfulInstanceCreditSpecificationSet", &[]),
-        ec2_list("unsuccessfulInstanceCreditSpecificationSet", &[]),
+        ec2_list("successfulInstanceCreditSpecificationSet", &successful),
+        ec2_list("unsuccessfulInstanceCreditSpecificationSet", &unsuccessful),
     );
     Ok(Ec2Service::respond(
         "ModifyInstanceCreditSpecification",
@@ -1759,40 +1798,80 @@ pub(crate) fn modify_instance_credit_specification(
 }
 
 pub(crate) fn get_instance_metadata_defaults(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let accounts = svc.state.read();
+    let d = accounts
+        .get(&req.account_id)
+        .and_then(|s| s.instance_metadata_defaults.clone())
+        .unwrap_or_default();
+    let mut inner = String::new();
+    if let Some(v) = &d.http_tokens {
+        inner.push_str(&ec2_elem("httpTokens", v));
+    }
+    if let Some(v) = &d.http_endpoint {
+        inner.push_str(&ec2_elem("httpEndpoint", v));
+    }
+    if let Some(v) = d.http_put_response_hop_limit {
+        inner.push_str(&ec2_elem("httpPutResponseHopLimit", &v.to_string()));
+    }
+    if let Some(v) = &d.instance_metadata_tags {
+        inner.push_str(&ec2_elem("instanceMetadataTags", v));
+    }
     Ok(Ec2Service::respond(
         "GetInstanceMetadataDefaults",
         &req.request_id,
-        "<accountLevel><httpTokens>optional</httpTokens><httpEndpoint>enabled</httpEndpoint></accountLevel>",
+        &format!("<accountLevel>{inner}</accountLevel>"),
     ))
 }
 
 pub(crate) fn modify_instance_metadata_defaults(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let p = &req.query_params;
+    validate_enum(p, "HttpTokens", &["optional", "required", "no-preference"])?;
     validate_enum(
-        &req.query_params,
-        "HttpTokens",
-        &["optional", "required", "no-preference"],
-    )?;
-    validate_enum(
-        &req.query_params,
+        p,
         "HttpEndpoint",
         &["disabled", "enabled", "no-preference"],
     )?;
     validate_enum(
-        &req.query_params,
+        p,
         "InstanceMetadataTags",
         &["disabled", "enabled", "no-preference"],
     )?;
     validate_enum(
-        &req.query_params,
+        p,
         "HttpTokensEnforced",
         &["disabled", "enabled", "no-preference"],
     )?;
+    // `no-preference` resets that setting to the account default (drop it).
+    let apply = |cur: &mut Option<String>, key: &str| {
+        if let Some(v) = p.get(key) {
+            *cur = if v == "no-preference" {
+                None
+            } else {
+                Some(v.clone())
+            };
+        }
+    };
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let d = state.instance_metadata_defaults.get_or_insert_with(Default::default);
+        apply(&mut d.http_tokens, "HttpTokens");
+        apply(&mut d.http_endpoint, "HttpEndpoint");
+        apply(&mut d.instance_metadata_tags, "InstanceMetadataTags");
+        if let Some(v) = p
+            .get("HttpPutResponseHopLimit")
+            .and_then(|v| v.parse::<i64>().ok())
+        {
+            // -1 clears the account default per the EC2 API.
+            d.http_put_response_hop_limit = if v < 0 { None } else { Some(v) };
+        }
+    }
     Ok(Ec2Service::respond(
         "ModifyInstanceMetadataDefaults",
         &req.request_id,
@@ -1801,44 +1880,97 @@ pub(crate) fn modify_instance_metadata_defaults(
 }
 
 pub(crate) fn register_event_notification_attributes(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    // InstanceTagAttribute is a required struct with no required members, so an
-    // empty one is wire-invisible (== omission) — not validated here.
+    let keys = indexed_sub_keys(&req.query_params);
+    let include_all = req
+        .query_params
+        .get("InstanceTagAttribute.IncludeAllTagsOfInstance")
+        .map(|v| v == "true");
+    let xml = {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        for k in keys {
+            if !state.event_notification_tag_keys.contains(&k) {
+                state.event_notification_tag_keys.push(k);
+            }
+        }
+        if let Some(v) = include_all {
+            state.event_notification_include_all_tags = v;
+        }
+        event_tag_attribute(state)
+    };
     Ok(Ec2Service::respond(
         "RegisterInstanceEventNotificationAttributes",
         &req.request_id,
-        &event_tag_attribute(),
+        &xml,
     ))
 }
 
 pub(crate) fn deregister_event_notification_attributes(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let keys = indexed_sub_keys(&req.query_params);
+    let include_all = req
+        .query_params
+        .get("InstanceTagAttribute.IncludeAllTagsOfInstance")
+        .map(|v| v == "true");
+    let xml = {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        state
+            .event_notification_tag_keys
+            .retain(|k| !keys.contains(k));
+        // Deregistering with IncludeAllTagsOfInstance=true clears the flag.
+        if include_all == Some(true) {
+            state.event_notification_include_all_tags = false;
+        }
+        event_tag_attribute(state)
+    };
     Ok(Ec2Service::respond(
         "DeregisterInstanceEventNotificationAttributes",
         &req.request_id,
-        &event_tag_attribute(),
+        &xml,
     ))
 }
 
 pub(crate) fn describe_event_notification_attributes(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    let accounts = svc.state.read();
+    let empty = Ec2State::new(&req.account_id, &req.region);
+    let state = accounts.get(&req.account_id).unwrap_or(&empty);
     Ok(Ec2Service::respond(
         "DescribeInstanceEventNotificationAttributes",
         &req.request_id,
-        &event_tag_attribute(),
+        &event_tag_attribute(state),
     ))
 }
 
-fn event_tag_attribute() -> String {
+/// Collect `InstanceTagAttribute.InstanceTagKey.N` values.
+fn indexed_sub_keys(params: &HashMap<String, String>) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut n = 1usize;
+    while let Some(v) = params.get(&format!("InstanceTagAttribute.InstanceTagKey.{n}")) {
+        out.push(v.clone());
+        n += 1;
+    }
+    out
+}
+
+fn event_tag_attribute(state: &Ec2State) -> String {
+    let keys: Vec<String> = state
+        .event_notification_tag_keys
+        .iter()
+        .map(|k| ec2_elem("item", k))
+        .collect();
     format!(
-        "<instanceTagAttribute><includeAllTagsOfInstance>false</includeAllTagsOfInstance>{}</instanceTagAttribute>",
-        ec2_list("instanceTagKeySet", &[])
+        "<instanceTagAttribute><includeAllTagsOfInstance>{}</includeAllTagsOfInstance>{}</instanceTagAttribute>",
+        state.event_notification_include_all_tags,
+        ec2_list("instanceTagKeySet", &keys)
     )
 }
 
@@ -1886,5 +2018,192 @@ mod tests {
         assert_eq!(subnet_ip_prefix("not-a-cidr"), "10.0.0");
         // IPv6 / non-dotted-quad falls back rather than producing nonsense
         assert_eq!(subnet_ip_prefix("fd00::/8"), "10.0.0");
+    }
+}
+
+#[cfg(test)]
+mod modify_tests {
+    use super::*;
+
+    fn req(action: &str, query: &[(&str, &str)]) -> AwsRequest {
+        AwsRequest {
+            service: "ec2".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: "000000000000".into(),
+            request_id: "rid".into(),
+            headers: http::HeaderMap::new(),
+            query_params: query
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn body(resp: AwsResponse) -> String {
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    fn seed_instance(svc: &Ec2Service, id: &str) {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create("000000000000");
+        let inst = Instance {
+            instance_id: id.into(),
+            image_id: "ami-1".into(),
+            instance_type: "t3.micro".into(),
+            state_code: 16,
+            state_name: "running".into(),
+            private_ip: "10.0.0.5".into(),
+            public_ip: None,
+            subnet_id: Some("subnet-1".into()),
+            vpc_id: Some("vpc-1".into()),
+            key_name: None,
+            security_group_ids: vec![],
+            reservation_id: "r-1".into(),
+            ami_launch_index: 0,
+            monitoring: false,
+            az: "us-east-1a".into(),
+            launch_time: "2024-01-01T00:00:00.000Z".into(),
+            container_id: None,
+            disable_api_termination: false,
+            disable_api_stop: false,
+            source_dest_check: true,
+            ebs_optimized: false,
+            instance_initiated_shutdown_behavior: "stop".into(),
+            user_data: None,
+            metadata_options: Default::default(),
+            cpu_options: None,
+            bandwidth_weighting: None,
+            maintenance_options: Default::default(),
+            placement_tenancy: None,
+            placement_affinity: None,
+            placement_group_name: None,
+            private_dns_hostname_type: None,
+            enable_resource_name_dns_a_record: false,
+            enable_resource_name_dns_aaaa_record: false,
+        };
+        state.instances.insert(id.to_string(), inst);
+    }
+
+    #[test]
+    fn modify_instance_credit_specification_round_trips() {
+        let svc = Ec2Service::new();
+        seed_instance(&svc, "i-1");
+        modify_instance_credit_specification(
+            &svc,
+            &req(
+                "ModifyInstanceCreditSpecification",
+                &[
+                    ("InstanceCreditSpecification.1.InstanceId", "i-1"),
+                    ("InstanceCreditSpecification.1.CpuCredits", "unlimited"),
+                ],
+            ),
+        )
+        .unwrap();
+        let out = body(
+            describe_instance_credit_specifications(
+                &svc,
+                &req("DescribeInstanceCreditSpecifications", &[("InstanceId.1", "i-1")]),
+            )
+            .unwrap(),
+        );
+        assert!(out.contains("<cpuCredits>unlimited</cpuCredits>"), "got: {out}");
+    }
+
+    #[test]
+    fn modify_instance_credit_specification_unknown_is_unsuccessful() {
+        let svc = Ec2Service::new();
+        let out = body(
+            modify_instance_credit_specification(
+                &svc,
+                &req(
+                    "ModifyInstanceCreditSpecification",
+                    &[("InstanceCreditSpecification.1.InstanceId", "i-missing")],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(out.contains("InvalidInstanceID.NotFound"), "got: {out}");
+    }
+
+    #[test]
+    fn instance_metadata_defaults_round_trip_and_reset() {
+        let svc = Ec2Service::new();
+        modify_instance_metadata_defaults(
+            &svc,
+            &req(
+                "ModifyInstanceMetadataDefaults",
+                &[("HttpTokens", "required"), ("HttpEndpoint", "enabled")],
+            ),
+        )
+        .unwrap();
+        let out = body(
+            get_instance_metadata_defaults(&svc, &req("GetInstanceMetadataDefaults", &[])).unwrap(),
+        );
+        assert!(out.contains("<httpTokens>required</httpTokens>"), "got: {out}");
+        assert!(out.contains("<httpEndpoint>enabled</httpEndpoint>"));
+
+        // `no-preference` drops the stored default.
+        modify_instance_metadata_defaults(
+            &svc,
+            &req("ModifyInstanceMetadataDefaults", &[("HttpTokens", "no-preference")]),
+        )
+        .unwrap();
+        let out = body(
+            get_instance_metadata_defaults(&svc, &req("GetInstanceMetadataDefaults", &[])).unwrap(),
+        );
+        assert!(!out.contains("httpTokens"), "no-preference should clear it: {out}");
+    }
+
+    #[test]
+    fn event_notification_attributes_persist_keys() {
+        let svc = Ec2Service::new();
+        register_event_notification_attributes(
+            &svc,
+            &req(
+                "RegisterInstanceEventNotificationAttributes",
+                &[
+                    ("InstanceTagAttribute.InstanceTagKey.1", "Name"),
+                    ("InstanceTagAttribute.InstanceTagKey.2", "env"),
+                ],
+            ),
+        )
+        .unwrap();
+        let out = body(
+            describe_event_notification_attributes(
+                &svc,
+                &req("DescribeInstanceEventNotificationAttributes", &[]),
+            )
+            .unwrap(),
+        );
+        assert!(out.contains("<item>Name</item>"), "got: {out}");
+        assert!(out.contains("<item>env</item>"));
+
+        deregister_event_notification_attributes(
+            &svc,
+            &req(
+                "DeregisterInstanceEventNotificationAttributes",
+                &[("InstanceTagAttribute.InstanceTagKey.1", "Name")],
+            ),
+        )
+        .unwrap();
+        let out = body(
+            describe_event_notification_attributes(
+                &svc,
+                &req("DescribeInstanceEventNotificationAttributes", &[]),
+            )
+            .unwrap(),
+        );
+        assert!(!out.contains("<item>Name</item>"), "got: {out}");
+        assert!(out.contains("<item>env</item>"));
     }
 }

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -558,7 +558,10 @@ pub(crate) fn modify_security_group_rules(
                 if let Some(v) = p.get(&format!("{pre}.IpProtocol")) {
                     rule.ip_protocol = v.clone();
                 }
-                if let Some(v) = p.get(&format!("{pre}.FromPort")).and_then(|v| v.parse().ok()) {
+                if let Some(v) = p
+                    .get(&format!("{pre}.FromPort"))
+                    .and_then(|v| v.parse().ok())
+                {
                     rule.from_port = v;
                 }
                 if let Some(v) = p.get(&format!("{pre}.ToPort")).and_then(|v| v.parse().ok()) {
@@ -643,9 +646,7 @@ fn update_rule_descriptions(
                     }
                     let desc = p
                         .get(&format!("IpPermissions.{n}.IpRanges.{m}.Description"))
-                        .or_else(|| {
-                            p.get(&format!("IpPermissions.{n}.Ipv6Ranges.{m}.Description"))
-                        })
+                        .or_else(|| p.get(&format!("IpPermissions.{n}.Ipv6Ranges.{m}.Description")))
                         .cloned()
                         .unwrap_or_default();
                     for rule in sg.rules.iter_mut().filter(|r| {
@@ -653,7 +654,8 @@ fn update_rule_descriptions(
                             && r.ip_protocol == proto
                             && r.from_port == from
                             && r.to_port == to
-                            && ((cidr4.is_some() && r.cidr_ipv4.as_deref() == cidr4.map(|s| s.as_str()))
+                            && ((cidr4.is_some()
+                                && r.cidr_ipv4.as_deref() == cidr4.map(|s| s.as_str()))
                                 || (cidr6.is_some()
                                     && r.cidr_ipv6.as_deref() == cidr6.map(|s| s.as_str())))
                     }) {
@@ -665,7 +667,11 @@ fn update_rule_descriptions(
             }
         }
     }
-    Ok(Ec2Service::respond(action, &req.request_id, &ec2_return(true)))
+    Ok(Ec2Service::respond(
+        action,
+        &req.request_id,
+        &ec2_return(true),
+    ))
 }
 
 pub(crate) fn update_rule_descriptions_ingress(
@@ -860,7 +866,10 @@ mod modify_tests {
                     ("SecurityGroupRule.1.SecurityGroupRule.IpProtocol", "tcp"),
                     ("SecurityGroupRule.1.SecurityGroupRule.FromPort", "443"),
                     ("SecurityGroupRule.1.SecurityGroupRule.ToPort", "443"),
-                    ("SecurityGroupRule.1.SecurityGroupRule.CidrIpv4", "0.0.0.0/0"),
+                    (
+                        "SecurityGroupRule.1.SecurityGroupRule.CidrIpv4",
+                        "0.0.0.0/0",
+                    ),
                     ("SecurityGroupRule.1.SecurityGroupRule.Description", "https"),
                 ],
             ),

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -620,7 +620,14 @@ fn update_rule_descriptions(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        if let Some(sg) = state.security_groups.get_mut(&group_id) {
+        let sg = state.security_groups.get_mut(&group_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                http::StatusCode::BAD_REQUEST,
+                "InvalidGroup.NotFound",
+                format!("The security group '{group_id}' does not exist"),
+            )
+        })?;
+        {
             let mut n = 1usize;
             loop {
                 let proto_key = format!("IpPermissions.{n}.IpProtocol");

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -534,10 +534,69 @@ pub(crate) fn describe_security_group_rules(
 }
 
 pub(crate) fn modify_security_group_rules(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "GroupId")?;
+    let group_id = require(&req.query_params, "GroupId")?;
+    let p = &req.query_params;
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let sg = state.security_groups.get_mut(&group_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                http::StatusCode::BAD_REQUEST,
+                "InvalidGroup.NotFound",
+                format!("The security group '{group_id}' does not exist"),
+            )
+        })?;
+        let mut n = 1usize;
+        loop {
+            let id_key = format!("SecurityGroupRule.{n}.SecurityGroupRuleId");
+            let Some(rule_id) = p.get(&id_key) else { break };
+            let pre = format!("SecurityGroupRule.{n}.SecurityGroupRule");
+            if let Some(rule) = sg.rules.iter_mut().find(|r| &r.rule_id == rule_id) {
+                if let Some(v) = p.get(&format!("{pre}.IpProtocol")) {
+                    rule.ip_protocol = v.clone();
+                }
+                if let Some(v) = p.get(&format!("{pre}.FromPort")).and_then(|v| v.parse().ok()) {
+                    rule.from_port = v;
+                }
+                if let Some(v) = p.get(&format!("{pre}.ToPort")).and_then(|v| v.parse().ok()) {
+                    rule.to_port = v;
+                }
+                if let Some(v) = p.get(&format!("{pre}.CidrIpv4")) {
+                    rule.cidr_ipv4 = Some(v.clone());
+                    rule.cidr_ipv6 = None;
+                    rule.prefix_list_id = None;
+                    rule.referenced_group_id = None;
+                }
+                if let Some(v) = p.get(&format!("{pre}.CidrIpv6")) {
+                    rule.cidr_ipv6 = Some(v.clone());
+                    rule.cidr_ipv4 = None;
+                    rule.prefix_list_id = None;
+                    rule.referenced_group_id = None;
+                }
+                if let Some(v) = p.get(&format!("{pre}.PrefixListId")) {
+                    rule.prefix_list_id = Some(v.clone());
+                    rule.cidr_ipv4 = None;
+                    rule.cidr_ipv6 = None;
+                    rule.referenced_group_id = None;
+                }
+                if let Some(v) = p.get(&format!("{pre}.ReferencedGroupId")) {
+                    rule.referenced_group_id = Some(v.clone());
+                    rule.cidr_ipv4 = None;
+                    rule.cidr_ipv6 = None;
+                    rule.prefix_list_id = None;
+                }
+                if let Some(v) = p.get(&format!("{pre}.Description")) {
+                    rule.description = v.clone();
+                }
+            }
+            n += 1;
+        }
+    }
+    // Rule changes alter allowed traffic — re-apply the firewall (ph3).
+    svc.spawn_firewall_reconcile();
     Ok(Ec2Service::respond(
         "ModifySecurityGroupRules",
         &req.request_id,
@@ -545,26 +604,87 @@ pub(crate) fn modify_security_group_rules(
     ))
 }
 
+/// Match existing rules by protocol/port/CIDR and overwrite their descriptions.
+/// Shared by the ingress and egress `UpdateSecurityGroupRuleDescriptions*` ops.
+fn update_rule_descriptions(
+    svc: &Ec2Service,
+    req: &AwsRequest,
+    action: &str,
+    is_egress: bool,
+) -> Result<AwsResponse, AwsServiceError> {
+    let group_id = require(&req.query_params, "GroupId")?;
+    let p = &req.query_params;
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        if let Some(sg) = state.security_groups.get_mut(&group_id) {
+            let mut n = 1usize;
+            loop {
+                let proto_key = format!("IpPermissions.{n}.IpProtocol");
+                if !p.contains_key(&proto_key) {
+                    break;
+                }
+                let proto = p.get(&proto_key).cloned().unwrap_or_else(|| "-1".into());
+                let from = p
+                    .get(&format!("IpPermissions.{n}.FromPort"))
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(-1);
+                let to = p
+                    .get(&format!("IpPermissions.{n}.ToPort"))
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(-1);
+                let mut m = 1usize;
+                loop {
+                    let cidr_key = format!("IpPermissions.{n}.IpRanges.{m}.CidrIp");
+                    let cidr6_key = format!("IpPermissions.{n}.Ipv6Ranges.{m}.CidrIpv6");
+                    let (cidr4, cidr6) = (p.get(&cidr_key), p.get(&cidr6_key));
+                    if cidr4.is_none() && cidr6.is_none() {
+                        break;
+                    }
+                    let desc = p
+                        .get(&format!("IpPermissions.{n}.IpRanges.{m}.Description"))
+                        .or_else(|| {
+                            p.get(&format!("IpPermissions.{n}.Ipv6Ranges.{m}.Description"))
+                        })
+                        .cloned()
+                        .unwrap_or_default();
+                    for rule in sg.rules.iter_mut().filter(|r| {
+                        r.is_egress == is_egress
+                            && r.ip_protocol == proto
+                            && r.from_port == from
+                            && r.to_port == to
+                            && ((cidr4.is_some() && r.cidr_ipv4.as_deref() == cidr4.map(|s| s.as_str()))
+                                || (cidr6.is_some()
+                                    && r.cidr_ipv6.as_deref() == cidr6.map(|s| s.as_str())))
+                    }) {
+                        rule.description = desc.clone();
+                    }
+                    m += 1;
+                }
+                n += 1;
+            }
+        }
+    }
+    Ok(Ec2Service::respond(action, &req.request_id, &ec2_return(true)))
+}
+
 pub(crate) fn update_rule_descriptions_ingress(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    Ok(Ec2Service::respond(
+    update_rule_descriptions(
+        svc,
+        req,
         "UpdateSecurityGroupRuleDescriptionsIngress",
-        &req.request_id,
-        &ec2_return(true),
-    ))
+        false,
+    )
 }
 
 pub(crate) fn update_rule_descriptions_egress(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    Ok(Ec2Service::respond(
-        "UpdateSecurityGroupRuleDescriptionsEgress",
-        &req.request_id,
-        &ec2_return(true),
-    ))
+    update_rule_descriptions(svc, req, "UpdateSecurityGroupRuleDescriptionsEgress", true)
 }
 
 pub(crate) fn associate_security_group_vpc(
@@ -664,4 +784,119 @@ pub(crate) fn describe_security_group_references(
         &req.request_id,
         &ec2_list("securityGroupReferenceSet", &[]),
     ))
+}
+
+#[cfg(test)]
+mod modify_tests {
+    use super::*;
+
+    fn req(action: &str, query: &[(&str, &str)]) -> AwsRequest {
+        AwsRequest {
+            service: "ec2".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: "000000000000".into(),
+            request_id: "rid".into(),
+            headers: http::HeaderMap::new(),
+            query_params: query
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn seed_group(svc: &Ec2Service, rule: SecurityGroupRule) -> String {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create("000000000000");
+        state.security_groups.insert(
+            "sg-1".to_string(),
+            SecurityGroup {
+                group_id: "sg-1".into(),
+                group_name: "g".into(),
+                description: "d".into(),
+                vpc_id: "vpc-1".into(),
+                rules: vec![rule],
+            },
+        );
+        "sg-1".to_string()
+    }
+
+    fn base_rule() -> SecurityGroupRule {
+        SecurityGroupRule {
+            rule_id: "sgr-1".into(),
+            group_id: "sg-1".into(),
+            is_egress: false,
+            ip_protocol: "tcp".into(),
+            from_port: 22,
+            to_port: 22,
+            cidr_ipv4: Some("10.0.0.0/8".into()),
+            cidr_ipv6: None,
+            prefix_list_id: None,
+            referenced_group_id: None,
+            description: "old".into(),
+        }
+    }
+
+    #[test]
+    fn modify_security_group_rules_updates_rule() {
+        let svc = Ec2Service::new();
+        seed_group(&svc, base_rule());
+        modify_security_group_rules(
+            &svc,
+            &req(
+                "ModifySecurityGroupRules",
+                &[
+                    ("GroupId", "sg-1"),
+                    ("SecurityGroupRule.1.SecurityGroupRuleId", "sgr-1"),
+                    ("SecurityGroupRule.1.SecurityGroupRule.IpProtocol", "tcp"),
+                    ("SecurityGroupRule.1.SecurityGroupRule.FromPort", "443"),
+                    ("SecurityGroupRule.1.SecurityGroupRule.ToPort", "443"),
+                    ("SecurityGroupRule.1.SecurityGroupRule.CidrIpv4", "0.0.0.0/0"),
+                    ("SecurityGroupRule.1.SecurityGroupRule.Description", "https"),
+                ],
+            ),
+        )
+        .unwrap();
+
+        let accounts = svc.state.read();
+        let r = &accounts.get("000000000000").unwrap().security_groups["sg-1"].rules[0];
+        assert_eq!(r.from_port, 443);
+        assert_eq!(r.to_port, 443);
+        assert_eq!(r.cidr_ipv4.as_deref(), Some("0.0.0.0/0"));
+        assert_eq!(r.description, "https");
+    }
+
+    #[test]
+    fn update_rule_descriptions_sets_description_by_match() {
+        let svc = Ec2Service::new();
+        seed_group(&svc, base_rule());
+        update_rule_descriptions_ingress(
+            &svc,
+            &req(
+                "UpdateSecurityGroupRuleDescriptionsIngress",
+                &[
+                    ("GroupId", "sg-1"),
+                    ("IpPermissions.1.IpProtocol", "tcp"),
+                    ("IpPermissions.1.FromPort", "22"),
+                    ("IpPermissions.1.ToPort", "22"),
+                    ("IpPermissions.1.IpRanges.1.CidrIp", "10.0.0.0/8"),
+                    ("IpPermissions.1.IpRanges.1.Description", "ssh from vpc"),
+                ],
+            ),
+        )
+        .unwrap();
+
+        let accounts = svc.state.read();
+        let r = &accounts.get("000000000000").unwrap().security_groups["sg-1"].rules[0];
+        assert_eq!(r.description, "ssh from vpc");
+    }
 }

--- a/crates/fakecloud-ec2/src/service/snapshot.rs
+++ b/crates/fakecloud-ec2/src/service/snapshot.rs
@@ -6,8 +6,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, parse_filters, require, require_struct, validate_enum,
-    validate_int_range, validate_max_results, Filter,
+    gen_id, indexed_list, invalid_parameter_value, parse_filters, require, require_struct,
+    validate_enum, validate_int_range, validate_max_results, Filter,
 };
 use crate::state::{Ec2State, Snapshot, Tag};
 
@@ -251,9 +251,19 @@ pub(crate) fn modify_snapshot_attribute(
     )?;
     validate_enum(&req.query_params, "OperationType", &["add", "remove"])?;
     let p = &req.query_params;
+    // The only volume-permission group AWS recognizes is `all` (public).
+    let validate_group = |g: &str| -> Result<(), AwsServiceError> {
+        if g == "all" {
+            Ok(())
+        } else {
+            Err(invalid_parameter_value(format!(
+                "Invalid group '{g}' for createVolumePermission"
+            )))
+        }
+    };
     // Collect grantees from both the structured Add/Remove lists and the
     // legacy OperationType + UserId.N / UserGroup.N form.
-    let collect = |kind: &str| -> Vec<String> {
+    let collect = |kind: &str| -> Result<Vec<String>, AwsServiceError> {
         let mut out = Vec::new();
         let mut n = 1usize;
         loop {
@@ -261,19 +271,23 @@ pub(crate) fn modify_snapshot_attribute(
             let grp = p.get(&format!("CreateVolumePermission.{kind}.{n}.Group"));
             match (uid, grp) {
                 (Some(u), _) => out.push(u.clone()),
-                (None, Some(_)) => out.push("all".to_string()),
+                (None, Some(g)) => {
+                    validate_group(g)?;
+                    out.push("all".to_string());
+                }
                 (None, None) => break,
             }
             n += 1;
         }
-        out
+        Ok(out)
     };
-    let mut add = collect("Add");
-    let mut remove = collect("Remove");
+    let mut add = collect("Add")?;
+    let mut remove = collect("Remove")?;
     if add.is_empty() && remove.is_empty() {
         let op = p.get("OperationType").map(|s| s.as_str()).unwrap_or("");
         let mut legacy = indexed_list(p, "UserId");
-        if p.keys().any(|k| k.starts_with("UserGroup")) {
+        for g in indexed_list(p, "UserGroup") {
+            validate_group(&g)?;
             legacy.push("all".to_string());
         }
         match op {
@@ -282,20 +296,33 @@ pub(crate) fn modify_snapshot_attribute(
             _ => {}
         }
     }
+    // AWS rejects a request that both adds and removes permissions in one call.
+    if !add.is_empty() && !remove.is_empty() {
+        return Err(AwsServiceError::aws_error(
+            http::StatusCode::BAD_REQUEST,
+            "InvalidParameterCombination",
+            "A single ModifySnapshotAttribute request cannot both add and remove createVolumePermission",
+        ));
+    }
     {
         let mut accounts = svc.state.write();
-        if let Some(s) = accounts
+        let s = accounts
             .get_or_create(&req.account_id)
             .snapshots
             .get_mut(&id)
-        {
-            for g in add {
-                if !s.create_volume_permissions.contains(&g) {
-                    s.create_volume_permissions.push(g);
-                }
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    http::StatusCode::BAD_REQUEST,
+                    "InvalidSnapshot.NotFound",
+                    format!("The snapshot '{id}' does not exist"),
+                )
+            })?;
+        for g in add {
+            if !s.create_volume_permissions.contains(&g) {
+                s.create_volume_permissions.push(g);
             }
-            s.create_volume_permissions.retain(|g| !remove.contains(g));
         }
+        s.create_volume_permissions.retain(|g| !remove.contains(g));
     }
     Ok(Ec2Service::respond(
         "ModifySnapshotAttribute",
@@ -777,5 +804,60 @@ mod modify_tests {
                 .create_volume_permissions
                 .is_empty()
         );
+    }
+
+    fn expect_err(svc: &Ec2Service, query: &[(&str, &str)]) -> AwsServiceError {
+        match modify_snapshot_attribute(svc, &req("ModifySnapshotAttribute", query)) {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        }
+    }
+
+    #[test]
+    fn modify_snapshot_attribute_unknown_id_errors() {
+        // Cubic P2 on #2057: unknown SnapshotId was a silent no-op success.
+        let svc = Ec2Service::new();
+        let err = expect_err(
+            &svc,
+            &[
+                ("SnapshotId", "snap-missing"),
+                ("Attribute", "createVolumePermission"),
+                ("OperationType", "add"),
+                ("CreateVolumePermission.Add.1.UserId", "111122223333"),
+            ],
+        );
+        assert!(format!("{err:?}").contains("InvalidSnapshot.NotFound"));
+    }
+
+    #[test]
+    fn modify_snapshot_attribute_rejects_add_and_remove_together() {
+        let svc = Ec2Service::new();
+        seed_snapshot(&svc);
+        let err = expect_err(
+            &svc,
+            &[
+                ("SnapshotId", "snap-1"),
+                ("Attribute", "createVolumePermission"),
+                ("CreateVolumePermission.Add.1.UserId", "111122223333"),
+                ("CreateVolumePermission.Remove.1.UserId", "444455556666"),
+            ],
+        );
+        assert!(format!("{err:?}").contains("InvalidParameterCombination"));
+    }
+
+    #[test]
+    fn modify_snapshot_attribute_rejects_invalid_group() {
+        let svc = Ec2Service::new();
+        seed_snapshot(&svc);
+        let err = expect_err(
+            &svc,
+            &[
+                ("SnapshotId", "snap-1"),
+                ("Attribute", "createVolumePermission"),
+                ("OperationType", "add"),
+                ("CreateVolumePermission.Add.1.Group", "everyone"),
+            ],
+        );
+        assert!(format!("{err:?}").contains("InvalidParameterValue"));
     }
 }

--- a/crates/fakecloud-ec2/src/service/snapshot.rs
+++ b/crates/fakecloud-ec2/src/service/snapshot.rs
@@ -42,6 +42,7 @@ fn build_snapshot(volume_id: String, description: String) -> Snapshot {
         in_recycle_bin: false,
         locked: false,
         lock_mode: None,
+        create_volume_permissions: Vec::new(),
     }
 }
 
@@ -199,7 +200,7 @@ pub(crate) fn copy_snapshot(
 }
 
 pub(crate) fn describe_snapshot_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "SnapshotId")?;
@@ -211,7 +212,25 @@ pub(crate) fn describe_snapshot_attribute(
     )?;
     let attr_xml = match attr.as_str() {
         "productCodes" => ec2_list("productCodes", &[]),
-        _ => ec2_list("createVolumePermission", &[]),
+        _ => {
+            let accounts = svc.state.read();
+            let perms = accounts
+                .get(&req.account_id)
+                .and_then(|s| s.snapshots.get(&id))
+                .map(|s| s.create_volume_permissions.clone())
+                .unwrap_or_default();
+            let items: Vec<String> = perms
+                .iter()
+                .map(|g| {
+                    if g == "all" {
+                        ec2_elem("group", "all")
+                    } else {
+                        ec2_elem("userId", g)
+                    }
+                })
+                .collect();
+            ec2_list("createVolumePermission", &items)
+        }
     };
     Ok(Ec2Service::respond(
         "DescribeSnapshotAttribute",
@@ -221,16 +240,63 @@ pub(crate) fn describe_snapshot_attribute(
 }
 
 pub(crate) fn modify_snapshot_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "SnapshotId")?;
+    let id = require(&req.query_params, "SnapshotId")?;
     validate_enum(
         &req.query_params,
         "Attribute",
         &["productCodes", "createVolumePermission"],
     )?;
     validate_enum(&req.query_params, "OperationType", &["add", "remove"])?;
+    let p = &req.query_params;
+    // Collect grantees from both the structured Add/Remove lists and the
+    // legacy OperationType + UserId.N / UserGroup.N form.
+    let collect = |kind: &str| -> Vec<String> {
+        let mut out = Vec::new();
+        let mut n = 1usize;
+        loop {
+            let uid = p.get(&format!("CreateVolumePermission.{kind}.{n}.UserId"));
+            let grp = p.get(&format!("CreateVolumePermission.{kind}.{n}.Group"));
+            match (uid, grp) {
+                (Some(u), _) => out.push(u.clone()),
+                (None, Some(_)) => out.push("all".to_string()),
+                (None, None) => break,
+            }
+            n += 1;
+        }
+        out
+    };
+    let mut add = collect("Add");
+    let mut remove = collect("Remove");
+    if add.is_empty() && remove.is_empty() {
+        let op = p.get("OperationType").map(|s| s.as_str()).unwrap_or("");
+        let mut legacy = indexed_list(p, "UserId");
+        if p.keys().any(|k| k.starts_with("UserGroup")) {
+            legacy.push("all".to_string());
+        }
+        match op {
+            "add" => add = legacy,
+            "remove" => remove = legacy,
+            _ => {}
+        }
+    }
+    {
+        let mut accounts = svc.state.write();
+        if let Some(s) = accounts
+            .get_or_create(&req.account_id)
+            .snapshots
+            .get_mut(&id)
+        {
+            for g in add {
+                if !s.create_volume_permissions.contains(&g) {
+                    s.create_volume_permissions.push(g);
+                }
+            }
+            s.create_volume_permissions.retain(|g| !remove.contains(g));
+        }
+    }
     Ok(Ec2Service::respond(
         "ModifySnapshotAttribute",
         &req.request_id,
@@ -239,16 +305,26 @@ pub(crate) fn modify_snapshot_attribute(
 }
 
 pub(crate) fn reset_snapshot_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "SnapshotId")?;
-    require(&req.query_params, "Attribute")?;
+    let id = require(&req.query_params, "SnapshotId")?;
+    let attr = require(&req.query_params, "Attribute")?;
     validate_enum(
         &req.query_params,
         "Attribute",
         &["productCodes", "createVolumePermission"],
     )?;
+    if attr == "createVolumePermission" {
+        let mut accounts = svc.state.write();
+        if let Some(s) = accounts
+            .get_or_create(&req.account_id)
+            .snapshots
+            .get_mut(&id)
+        {
+            s.create_volume_permissions.clear();
+        }
+    }
     Ok(Ec2Service::respond(
         "ResetSnapshotAttribute",
         &req.request_id,
@@ -585,4 +661,118 @@ pub(crate) fn describe_fast_snapshot_restores(
         &req.request_id,
         &ec2_list("fastSnapshotRestoreSet", &[]),
     ))
+}
+
+#[cfg(test)]
+mod modify_tests {
+    use super::*;
+
+    fn req(action: &str, query: &[(&str, &str)]) -> AwsRequest {
+        AwsRequest {
+            service: "ec2".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: "000000000000".into(),
+            request_id: "rid".into(),
+            headers: http::HeaderMap::new(),
+            query_params: query
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn seed_snapshot(svc: &Ec2Service) {
+        let mut accounts = svc.state.write();
+        accounts
+            .get_or_create("000000000000")
+            .snapshots
+            .insert("snap-1".to_string(), build_snapshot("vol-1".into(), "d".into()));
+    }
+
+    fn describe_perms(svc: &Ec2Service) -> String {
+        let resp = describe_snapshot_attribute(
+            svc,
+            &req(
+                "DescribeSnapshotAttribute",
+                &[("SnapshotId", "snap-1"), ("Attribute", "createVolumePermission")],
+            ),
+        )
+        .unwrap();
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn modify_snapshot_attribute_round_trips_create_volume_permission() {
+        // The handler validated then dropped the grant (bug-hunt 2026-07-01).
+        let svc = Ec2Service::new();
+        seed_snapshot(&svc);
+        modify_snapshot_attribute(
+            &svc,
+            &req(
+                "ModifySnapshotAttribute",
+                &[
+                    ("SnapshotId", "snap-1"),
+                    ("Attribute", "createVolumePermission"),
+                    ("OperationType", "add"),
+                    ("CreateVolumePermission.Add.1.UserId", "111122223333"),
+                ],
+            ),
+        )
+        .unwrap();
+        assert!(describe_perms(&svc).contains("111122223333"));
+
+        modify_snapshot_attribute(
+            &svc,
+            &req(
+                "ModifySnapshotAttribute",
+                &[
+                    ("SnapshotId", "snap-1"),
+                    ("Attribute", "createVolumePermission"),
+                    ("OperationType", "remove"),
+                    ("CreateVolumePermission.Remove.1.UserId", "111122223333"),
+                ],
+            ),
+        )
+        .unwrap();
+        assert!(!describe_perms(&svc).contains("111122223333"));
+    }
+
+    #[test]
+    fn reset_snapshot_attribute_clears_permissions() {
+        let svc = Ec2Service::new();
+        seed_snapshot(&svc);
+        svc.state
+            .write()
+            .get_or_create("000000000000")
+            .snapshots
+            .get_mut("snap-1")
+            .unwrap()
+            .create_volume_permissions = vec!["all".into()];
+        reset_snapshot_attribute(
+            &svc,
+            &req(
+                "ResetSnapshotAttribute",
+                &[("SnapshotId", "snap-1"), ("Attribute", "createVolumePermission")],
+            ),
+        )
+        .unwrap();
+        assert!(svc
+            .state
+            .read()
+            .get("000000000000")
+            .unwrap()
+            .snapshots["snap-1"]
+            .create_volume_permissions
+            .is_empty());
+    }
 }

--- a/crates/fakecloud-ec2/src/service/snapshot.rs
+++ b/crates/fakecloud-ec2/src/service/snapshot.rs
@@ -693,10 +693,10 @@ mod modify_tests {
 
     fn seed_snapshot(svc: &Ec2Service) {
         let mut accounts = svc.state.write();
-        accounts
-            .get_or_create("000000000000")
-            .snapshots
-            .insert("snap-1".to_string(), build_snapshot("vol-1".into(), "d".into()));
+        accounts.get_or_create("000000000000").snapshots.insert(
+            "snap-1".to_string(),
+            build_snapshot("vol-1".into(), "d".into()),
+        );
     }
 
     fn describe_perms(svc: &Ec2Service) -> String {
@@ -704,7 +704,10 @@ mod modify_tests {
             svc,
             &req(
                 "DescribeSnapshotAttribute",
-                &[("SnapshotId", "snap-1"), ("Attribute", "createVolumePermission")],
+                &[
+                    ("SnapshotId", "snap-1"),
+                    ("Attribute", "createVolumePermission"),
+                ],
             ),
         )
         .unwrap();
@@ -762,17 +765,17 @@ mod modify_tests {
             &svc,
             &req(
                 "ResetSnapshotAttribute",
-                &[("SnapshotId", "snap-1"), ("Attribute", "createVolumePermission")],
+                &[
+                    ("SnapshotId", "snap-1"),
+                    ("Attribute", "createVolumePermission"),
+                ],
             ),
         )
         .unwrap();
-        assert!(svc
-            .state
-            .read()
-            .get("000000000000")
-            .unwrap()
-            .snapshots["snap-1"]
-            .create_volume_permissions
-            .is_empty());
+        assert!(
+            svc.state.read().get("000000000000").unwrap().snapshots["snap-1"]
+                .create_volume_permissions
+                .is_empty()
+        );
     }
 }

--- a/crates/fakecloud-ec2/src/service/tgw.rs
+++ b/crates/fakecloud-ec2/src/service/tgw.rs
@@ -946,17 +946,20 @@ mod modify_tests {
         let svc = Ec2Service::new();
         {
             let mut accounts = svc.state.write();
-            accounts.get_or_create("000000000000").tgw_attachments.insert(
-                "tgw-attach-1".to_string(),
-                crate::state::TgwAttachment {
-                    id: "tgw-attach-1".into(),
-                    tgw_id: "tgw-1".into(),
-                    resource_id: "vpc-1".into(),
-                    resource_type: "vpc".into(),
-                    subnet_ids: vec!["subnet-a".into()],
-                    state: "available".into(),
-                },
-            );
+            accounts
+                .get_or_create("000000000000")
+                .tgw_attachments
+                .insert(
+                    "tgw-attach-1".to_string(),
+                    crate::state::TgwAttachment {
+                        id: "tgw-attach-1".into(),
+                        tgw_id: "tgw-1".into(),
+                        resource_id: "vpc-1".into(),
+                        resource_type: "vpc".into(),
+                        subnet_ids: vec!["subnet-a".into()],
+                        state: "available".into(),
+                    },
+                );
         }
         modify_transit_gateway_vpc_attachment(
             &svc,

--- a/crates/fakecloud-ec2/src/service/tgw.rs
+++ b/crates/fakecloud-ec2/src/service/tgw.rs
@@ -287,7 +287,34 @@ pub(crate) fn modify_transit_gateway_vpc_attachment(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    modify_accept_reject_vpc_att(svc, req, "ModifyTransitGatewayVpcAttachment", "")
+    let id = require(&req.query_params, "TransitGatewayAttachmentId")?;
+    let owner = req.account_id.clone();
+    let add = indexed_list(&req.query_params, "AddSubnetIds");
+    let remove = indexed_list(&req.query_params, "RemoveSubnetIds");
+    {
+        let mut accounts = svc.state.write();
+        if let Some(stored) = accounts
+            .get_or_create(&req.account_id)
+            .tgw_attachments
+            .get_mut(&id)
+        {
+            for s in &add {
+                if !stored.subnet_ids.contains(s) {
+                    stored.subnet_ids.push(s.clone());
+                }
+            }
+            stored.subnet_ids.retain(|s| !remove.contains(s));
+        }
+    }
+    let a = att_lookup(svc, req, &id);
+    Ok(Ec2Service::respond(
+        "ModifyTransitGatewayVpcAttachment",
+        &req.request_id,
+        &format!(
+            "<transitGatewayVpcAttachment>{}</transitGatewayVpcAttachment>",
+            vpc_att_xml(&a, &[], &owner)
+        ),
+    ))
 }
 pub(crate) fn accept_transit_gateway_vpc_attachment(
     svc: &Ec2Service,
@@ -884,4 +911,68 @@ pub(crate) fn get_transit_gateway_prefix_list_references(
         &req.request_id,
         &ec2_list("transitGatewayPrefixListReferenceSet", &items),
     ))
+}
+
+#[cfg(test)]
+mod modify_tests {
+    use super::*;
+
+    fn req(action: &str, query: &[(&str, &str)]) -> AwsRequest {
+        AwsRequest {
+            service: "ec2".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: "000000000000".into(),
+            request_id: "rid".into(),
+            headers: http::HeaderMap::new(),
+            query_params: query
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn modify_transit_gateway_vpc_attachment_persists_subnets() {
+        let svc = Ec2Service::new();
+        {
+            let mut accounts = svc.state.write();
+            accounts.get_or_create("000000000000").tgw_attachments.insert(
+                "tgw-attach-1".to_string(),
+                crate::state::TgwAttachment {
+                    id: "tgw-attach-1".into(),
+                    tgw_id: "tgw-1".into(),
+                    resource_id: "vpc-1".into(),
+                    resource_type: "vpc".into(),
+                    subnet_ids: vec!["subnet-a".into()],
+                    state: "available".into(),
+                },
+            );
+        }
+        modify_transit_gateway_vpc_attachment(
+            &svc,
+            &req(
+                "ModifyTransitGatewayVpcAttachment",
+                &[
+                    ("TransitGatewayAttachmentId", "tgw-attach-1"),
+                    ("AddSubnetIds.1", "subnet-b"),
+                    ("RemoveSubnetIds.1", "subnet-a"),
+                ],
+            ),
+        )
+        .unwrap();
+
+        let accounts = svc.state.read();
+        let a = &accounts.get("000000000000").unwrap().tgw_attachments["tgw-attach-1"];
+        assert_eq!(a.subnet_ids, vec!["subnet-b".to_string()]);
+    }
 }

--- a/crates/fakecloud-ec2/src/service/tgw.rs
+++ b/crates/fakecloud-ec2/src/service/tgw.rs
@@ -293,18 +293,23 @@ pub(crate) fn modify_transit_gateway_vpc_attachment(
     let remove = indexed_list(&req.query_params, "RemoveSubnetIds");
     {
         let mut accounts = svc.state.write();
-        if let Some(stored) = accounts
+        let stored = accounts
             .get_or_create(&req.account_id)
             .tgw_attachments
             .get_mut(&id)
-        {
-            for s in &add {
-                if !stored.subnet_ids.contains(s) {
-                    stored.subnet_ids.push(s.clone());
-                }
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    http::StatusCode::BAD_REQUEST,
+                    "InvalidTransitGatewayAttachmentID.NotFound",
+                    format!("Transit gateway attachment {id} was not found"),
+                )
+            })?;
+        for s in &add {
+            if !stored.subnet_ids.contains(s) {
+                stored.subnet_ids.push(s.clone());
             }
-            stored.subnet_ids.retain(|s| !remove.contains(s));
         }
+        stored.subnet_ids.retain(|s| !remove.contains(s));
     }
     let a = att_lookup(svc, req, &id);
     Ok(Ec2Service::respond(

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -397,6 +397,21 @@ pub struct MetadataOptions {
     pub instance_metadata_tags: String,
 }
 
+/// Account/region-level IMDS defaults (ModifyInstanceMetadataDefaults). Each
+/// field is `None` until explicitly set; a set of `no-preference` clears it
+/// back to `None` (AWS drops the default rather than storing the sentinel).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct InstanceMetadataDefaults {
+    #[serde(default)]
+    pub http_tokens: Option<String>,
+    #[serde(default)]
+    pub http_endpoint: Option<String>,
+    #[serde(default)]
+    pub http_put_response_hop_limit: Option<i64>,
+    #[serde(default)]
+    pub instance_metadata_tags: Option<String>,
+}
+
 impl Default for MetadataOptions {
     fn default() -> Self {
         Self {
@@ -484,6 +499,10 @@ pub struct Snapshot {
     #[serde(default)]
     pub locked: bool,
     pub lock_mode: Option<String>,
+    /// createVolumePermission grantees: account IDs, or the literal `all` for
+    /// the public group. Managed by ModifySnapshotAttribute.
+    #[serde(default)]
+    pub create_volume_permissions: Vec<String>,
 }
 
 /// An AMI (machine image).
@@ -1484,6 +1503,22 @@ pub struct Ec2State {
     /// set by ModifyDefaultCreditSpecification, read by GetDefaultCreditSpecification.
     #[serde(default)]
     pub default_credit_specs: BTreeMap<String, String>,
+    /// instance id -> CpuCredits (`standard` | `unlimited`), set by
+    /// ModifyInstanceCreditSpecification, read by DescribeInstanceCreditSpecifications.
+    #[serde(default)]
+    pub instance_credit_specs: BTreeMap<String, String>,
+    /// Account/region IMDS defaults (ModifyInstanceMetadataDefaults /
+    /// GetInstanceMetadataDefaults). `None` reports the AWS defaults.
+    #[serde(default)]
+    pub instance_metadata_defaults: Option<InstanceMetadataDefaults>,
+    /// Instance-tag keys surfaced in instance-state-change events
+    /// (Register/Describe InstanceEventNotificationAttributes).
+    #[serde(default)]
+    pub event_notification_tag_keys: Vec<String>,
+    /// When true, all instance tags are included in event notifications
+    /// (`IncludeAllTagsOfInstance`).
+    #[serde(default)]
+    pub event_notification_include_all_tags: bool,
     /// VPC block-public-access `InternetGatewayBlockMode` (account/region
     /// singleton). `None` reports the default `off`.
     #[serde(default)]

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -410,6 +410,8 @@ pub struct InstanceMetadataDefaults {
     pub http_put_response_hop_limit: Option<i64>,
     #[serde(default)]
     pub instance_metadata_tags: Option<String>,
+    #[serde(default)]
+    pub http_tokens_enforced: Option<String>,
 }
 
 impl Default for MetadataOptions {
@@ -623,6 +625,9 @@ pub struct VpcEndpoint {
     pub route_table_ids: Vec<String>,
     #[serde(default)]
     pub private_dns_enabled: bool,
+    /// Security groups attached to an Interface endpoint's ENIs.
+    #[serde(default)]
+    pub security_group_ids: Vec<String>,
 }
 
 /// A VPC endpoint service configuration (PrivateLink provider side).

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -815,7 +815,15 @@ impl RdsService {
             tracing::error!(%error, db_instance_identifier=%id, "restore/replica background finalize failed");
             {
                 let mut accounts = state_handle.write();
-                accounts.get_or_create(account_id).instances.remove(id);
+                let state = accounts.get_or_create(account_id);
+                state.instances.remove(id);
+                // A read replica registered itself against its source
+                // synchronously; drop that reverse linkage so the source
+                // doesn't keep a dangling replica id after this failure.
+                for inst in state.instances.values_mut() {
+                    inst.read_replica_db_instance_identifiers
+                        .retain(|r| r != id);
+                }
             }
             runtime.stop_container(id).await;
             save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -790,6 +790,7 @@ impl RdsService {
         master_username: String,
         master_user_password: String,
         logical_db: String,
+        tags: Vec<RdsTag>,
         dump: Option<Vec<u8>>,
         created_event: (&'static str, &'static str),
     ) {
@@ -798,6 +799,36 @@ impl RdsService {
         let snapshot_store = self.snapshot_store.clone();
         let snapshot_lock = self.snapshot_lock.clone();
         let (event_id, event_message) = created_event;
+        // Shared failure path: drop the placeholder row, reap any container the
+        // runtime managed to start, persist, and emit the create-failure event.
+        async fn fail(
+            state_handle: &SharedRdsState,
+            snapshot_store: Option<Arc<dyn SnapshotStore>>,
+            snapshot_lock: Arc<AsyncMutex<()>>,
+            delivery_bus: Option<&Arc<DeliveryBus>>,
+            runtime: &Arc<RdsRuntime>,
+            account_id: &str,
+            id: &str,
+            arn: &str,
+            error: &str,
+        ) {
+            tracing::error!(%error, db_instance_identifier=%id, "restore/replica background finalize failed");
+            {
+                let mut accounts = state_handle.write();
+                accounts.get_or_create(account_id).instances.remove(id);
+            }
+            runtime.stop_container(id).await;
+            save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
+            emit_event_static(
+                delivery_bus,
+                RdsSourceType::DbInstance,
+                id,
+                arn,
+                "RDS-EVENT-0058",
+                &["failure"],
+                &format!("DB instance failed to create: {error}"),
+            );
+        }
         tokio::spawn(async move {
             let running = match runtime
                 .ensure_postgres(
@@ -809,27 +840,24 @@ impl RdsService {
                     &logical_db,
                     &account_id,
                     &region,
-                    &[],
+                    &tags,
                 )
                 .await
             {
                 Ok(running) => running,
                 Err(error) => {
-                    tracing::error!(%error, db_instance_identifier=%id, "restore/replica background start failed");
-                    {
-                        let mut accounts = state_handle.write();
-                        accounts.get_or_create(&account_id).instances.remove(&id);
-                    }
-                    save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
-                    emit_event_static(
+                    fail(
+                        &state_handle,
+                        snapshot_store,
+                        snapshot_lock,
                         delivery_bus.as_ref(),
-                        RdsSourceType::DbInstance,
+                        &runtime,
+                        &account_id,
                         &id,
                         &arn,
-                        "RDS-EVENT-0058",
-                        &["failure"],
-                        &format!("DB instance failed to create: {error}"),
-                    );
+                        &error.to_string(),
+                    )
+                    .await;
                     return;
                 }
             };
@@ -846,7 +874,21 @@ impl RdsService {
                     )
                     .await
                 {
-                    tracing::error!(%error, db_instance_identifier=%id, "restore data replay failed");
+                    // A failed data replay must NOT be reported as a successful
+                    // `available` restore with missing data — fail the instance.
+                    fail(
+                        &state_handle,
+                        snapshot_store,
+                        snapshot_lock,
+                        delivery_bus.as_ref(),
+                        &runtime,
+                        &account_id,
+                        &id,
+                        &arn,
+                        &error.to_string(),
+                    )
+                    .await;
+                    return;
                 }
             }
 

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -768,6 +768,123 @@ impl RdsService {
         })
     }
 
+    /// Background the container start + optional data-replay for a
+    /// restore/replica op. The caller inserts a `creating` placeholder row and
+    /// returns immediately; this spawns `ensure_postgres` (which can pull a cold
+    /// image and wait minutes for engine readiness, far past the ~60s client
+    /// read timeout) and, when `dump` is present, replays it before flipping the
+    /// row to `available`. Mirrors `create_db_instance`'s backgrounding so
+    /// restore/replica no longer time the client out (bug-hunt 2026-07-01,
+    /// Tier-0). On failure the placeholder row is removed and any orphaned
+    /// container reaped.
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_finalize_restored_instance(
+        &self,
+        runtime: Arc<RdsRuntime>,
+        account_id: String,
+        region: String,
+        id: String,
+        arn: String,
+        engine: String,
+        engine_version: String,
+        master_username: String,
+        master_user_password: String,
+        logical_db: String,
+        dump: Option<Vec<u8>>,
+        created_event: (&'static str, &'static str),
+    ) {
+        let state_handle = self.state.clone();
+        let delivery_bus = self.delivery_bus.clone();
+        let snapshot_store = self.snapshot_store.clone();
+        let snapshot_lock = self.snapshot_lock.clone();
+        let (event_id, event_message) = created_event;
+        tokio::spawn(async move {
+            let running = match runtime
+                .ensure_postgres(
+                    &id,
+                    &engine,
+                    &engine_version,
+                    &master_username,
+                    &master_user_password,
+                    &logical_db,
+                    &account_id,
+                    &region,
+                    &[],
+                )
+                .await
+            {
+                Ok(running) => running,
+                Err(error) => {
+                    tracing::error!(%error, db_instance_identifier=%id, "restore/replica background start failed");
+                    {
+                        let mut accounts = state_handle.write();
+                        accounts.get_or_create(&account_id).instances.remove(&id);
+                    }
+                    save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
+                    emit_event_static(
+                        delivery_bus.as_ref(),
+                        RdsSourceType::DbInstance,
+                        &id,
+                        &arn,
+                        "RDS-EVENT-0058",
+                        &["failure"],
+                        &format!("DB instance failed to create: {error}"),
+                    );
+                    return;
+                }
+            };
+
+            if let Some(dump) = dump {
+                if let Err(error) = runtime
+                    .restore_database(
+                        &id,
+                        &engine,
+                        &master_username,
+                        &master_user_password,
+                        &logical_db,
+                        &dump,
+                    )
+                    .await
+                {
+                    tracing::error!(%error, db_instance_identifier=%id, "restore data replay failed");
+                }
+            }
+
+            let instance_present = {
+                let mut accounts = state_handle.write();
+                let state = accounts.get_or_create(&account_id);
+                if let Some(inst) = state.instances.get_mut(&id) {
+                    inst.db_instance_status = "available".to_string();
+                    inst.endpoint_address = running.endpoint_address.clone();
+                    inst.port = i32::from(running.endpoint_port);
+                    inst.host_port = running.host_port;
+                    inst.container_id = running.container_id.clone();
+                    true
+                } else {
+                    false
+                }
+            };
+            if !instance_present {
+                // Deleted while creating: reap the orphaned backing container.
+                runtime.stop_container(&id).await;
+                save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
+                return;
+            }
+            emit_event_static_with_state(
+                delivery_bus.as_ref(),
+                Some(&state_handle),
+                Some(&account_id),
+                RdsSourceType::DbInstance,
+                &id,
+                &arn,
+                event_id,
+                &["creation"],
+                event_message,
+            );
+            save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
+        });
+    }
+
     /// Build a hook that persists the current state when invoked, or `None` in
     /// memory mode. The CloudFormation provisioner mutates `state` directly and
     /// uses this to write a CFN-provisioned resource through to disk.

--- a/crates/fakecloud-rds/src/service/replicas.rs
+++ b/crates/fakecloud-rds/src/service/replicas.rs
@@ -90,62 +90,27 @@ impl RdsService {
             )
         };
         let created_at = Utc::now();
+        let runtime = runtime.clone();
 
-        let running = match runtime
-            .ensure_postgres(
-                &db_instance_identifier,
-                &source_instance.engine,
-                &source_instance.engine_version,
-                &source_instance.master_username,
-                &source_instance.master_user_password,
-                &db_name,
-                &request.account_id,
-                &request.region,
-                // A read replica inherits the source instance's Pod
-                // scheduling (no separate replica tag input here).
-                &source_instance.tags,
-            )
-            .await
-        {
-            Ok(running) => running,
-            Err(e) => {
-                self.state
-                    .write()
-                    .get_or_create(&request.account_id)
-                    .cancel_instance_creation(&db_instance_identifier);
-                return Err(runtime_error_to_service_error(e));
-            }
-        };
-
-        if let Err(e) = runtime
-            .restore_database(
-                &db_instance_identifier,
-                &source_instance.engine,
-                &source_instance.master_username,
-                &source_instance.master_user_password,
-                &db_name,
-                &dump_data,
-            )
-            .await
-        {
-            self.state
-                .write()
-                .get_or_create(&request.account_id)
-                .cancel_instance_creation(&db_instance_identifier);
-            runtime.stop_container(&db_instance_identifier).await;
-            return Err(runtime_error_to_service_error(e));
-        }
-
-        let replica = build_read_replica_instance(
+        // Build a `creating` placeholder replica; the backgrounded container
+        // start (below) fills in the endpoint and flips to `available`,
+        // mirroring CreateDBInstance so the client isn't held for the cold
+        // image pull.
+        let mut replica = build_read_replica_instance(
             &db_instance_identifier,
-            db_instance_arn,
+            db_instance_arn.clone(),
             dbi_resource_id,
             created_at,
             &source_db_instance_identifier,
             &source_instance,
-            &running,
+            &creating_placeholder_container(),
         );
+        replica.db_instance_status = "creating".to_string();
+        replica.endpoint_address = String::new();
+        replica.port = 0;
 
+        // Register the replica against its source synchronously so a concurrent
+        // DescribeDBInstances of the source sees the linkage immediately.
         let source_missing = {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
@@ -165,17 +130,22 @@ impl RdsService {
         };
 
         if source_missing {
-            runtime.stop_container(&db_instance_identifier).await;
             return Err(db_instance_not_found(&source_db_instance_identifier));
         }
 
-        self.emit_event(
-            RdsSourceType::DbInstance,
-            &db_instance_identifier,
-            &replica.db_instance_arn,
-            "RDS-EVENT-0005",
-            &["creation", "read replica"],
-            "Read replica DB instance created",
+        self.spawn_finalize_restored_instance(
+            runtime,
+            request.account_id.clone(),
+            request.region.clone(),
+            db_instance_identifier.clone(),
+            db_instance_arn,
+            source_instance.engine.clone(),
+            source_instance.engine_version.clone(),
+            source_instance.master_username.clone(),
+            source_instance.master_user_password.clone(),
+            db_name,
+            Some(dump_data),
+            ("RDS-EVENT-0005", "Read replica DB instance created"),
         );
 
         Ok(AwsResponse::xml(

--- a/crates/fakecloud-rds/src/service/replicas.rs
+++ b/crates/fakecloud-rds/src/service/replicas.rs
@@ -144,6 +144,8 @@ impl RdsService {
             source_instance.master_username.clone(),
             source_instance.master_user_password.clone(),
             db_name,
+            // A read replica inherits the source instance's Pod scheduling tags.
+            source_instance.tags.clone(),
             Some(dump_data),
             ("RDS-EVENT-0005", "Read replica DB instance created"),
         );

--- a/crates/fakecloud-rds/src/service/restore.rs
+++ b/crates/fakecloud-rds/src/service/restore.rs
@@ -170,7 +170,7 @@ impl RdsService {
             vpc_security_group_ids,
             &source_instance,
             &creating_placeholder_container(),
-            tags,
+            tags.clone(),
         );
         instance.db_instance_status = "creating".to_string();
         instance.endpoint_address = String::new();
@@ -200,6 +200,7 @@ impl RdsService {
             source_instance.master_username.clone(),
             source_instance.master_user_password.clone(),
             db_name,
+            tags,
             Some(dump_data),
             ("RDS-EVENT-0008", "DB instance restored to point in time"),
         );
@@ -307,7 +308,7 @@ impl RdsService {
             db_name.clone(),
             vpc_security_group_ids,
             &creating_placeholder_container(),
-            tags,
+            tags.clone(),
         );
         instance.db_instance_status = "creating".to_string();
         instance.endpoint_address = String::new();
@@ -329,6 +330,7 @@ impl RdsService {
             master_username,
             master_user_password,
             db_name,
+            tags,
             Some(dump_data),
             ("RDS-EVENT-0043", "DB instance restored from S3 backup"),
         );

--- a/crates/fakecloud-rds/src/service/restore.rs
+++ b/crates/fakecloud-rds/src/service/restore.rs
@@ -150,49 +150,6 @@ impl RdsService {
         };
         let created_at = Utc::now();
 
-        let running = match runtime
-            .ensure_postgres(
-                &target_id,
-                &source_instance.engine,
-                &source_instance.engine_version,
-                &source_instance.master_username,
-                &source_instance.master_user_password,
-                &db_name,
-                &request.account_id,
-                &request.region,
-                &tags,
-            )
-            .await
-        {
-            Ok(running) => running,
-            Err(e) => {
-                self.state
-                    .write()
-                    .get_or_create(&request.account_id)
-                    .cancel_instance_creation(&target_id);
-                return Err(runtime_error_to_service_error(e));
-            }
-        };
-
-        if let Err(e) = runtime
-            .restore_database(
-                &target_id,
-                &source_instance.engine,
-                &source_instance.master_username,
-                &source_instance.master_user_password,
-                &db_name,
-                &dump_data,
-            )
-            .await
-        {
-            self.state
-                .write()
-                .get_or_create(&request.account_id)
-                .cancel_instance_creation(&target_id);
-            runtime.stop_container(&target_id).await;
-            return Err(runtime_error_to_service_error(e));
-        }
-
         let restore_to_time = required_query_param(request, "RestoreTime")
             .ok()
             .or_else(|| required_query_param(request, "RestoreToTime").ok());
@@ -201,16 +158,23 @@ impl RdsService {
             .map(|s| s.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
 
+        // Build a `creating` placeholder with no endpoint yet; the backgrounded
+        // container start (below) fills in the endpoint and flips to
+        // `available`, mirroring CreateDBInstance so the client isn't held for
+        // the cold-image pull.
         let mut instance = build_pit_restored_instance(
             &target_id,
-            db_instance_arn,
+            db_instance_arn.clone(),
             dbi_resource_id,
             created_at,
             vpc_security_group_ids,
             &source_instance,
-            &running,
+            &creating_placeholder_container(),
             tags,
         );
+        instance.db_instance_status = "creating".to_string();
+        instance.endpoint_address = String::new();
+        instance.port = 0;
 
         if let Some(t) = restore_to_time.as_ref() {
             if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(t) {
@@ -225,13 +189,19 @@ impl RdsService {
             .get_or_create(&request.account_id)
             .finish_instance_creation(instance.clone());
 
-        self.emit_event(
-            RdsSourceType::DbInstance,
-            &target_id,
-            &instance.db_instance_arn,
-            "RDS-EVENT-0008",
-            &["creation"],
-            "DB instance restored to point in time",
+        self.spawn_finalize_restored_instance(
+            runtime.clone(),
+            request.account_id.clone(),
+            request.region.clone(),
+            target_id.clone(),
+            db_instance_arn,
+            source_instance.engine.clone(),
+            source_instance.engine_version.clone(),
+            source_instance.master_username.clone(),
+            source_instance.master_user_password.clone(),
+            db_name,
+            Some(dump_data),
+            ("RDS-EVENT-0008", "DB instance restored to point in time"),
         );
 
         Ok(AwsResponse::xml(
@@ -321,78 +291,46 @@ impl RdsService {
         let db_name = db_name_opt.unwrap_or_else(|| default_db_name(&engine).to_string());
         let created_at = Utc::now();
 
-        let running = match runtime
-            .ensure_postgres(
-                &db_instance_identifier,
-                &engine,
-                &engine_version,
-                &master_username,
-                &master_user_password,
-                &db_name,
-                &request.account_id,
-                &request.region,
-                &tags,
-            )
-            .await
-        {
-            Ok(running) => running,
-            Err(e) => {
-                self.state
-                    .write()
-                    .get_or_create(&request.account_id)
-                    .cancel_instance_creation(&db_instance_identifier);
-                return Err(runtime_error_to_service_error(e));
-            }
-        };
-
-        if let Err(e) = runtime
-            .restore_database(
-                &db_instance_identifier,
-                &engine,
-                &master_username,
-                &master_user_password,
-                &db_name,
-                &dump_data,
-            )
-            .await
-        {
-            self.state
-                .write()
-                .get_or_create(&request.account_id)
-                .cancel_instance_creation(&db_instance_identifier);
-            runtime.stop_container(&db_instance_identifier).await;
-            return Err(runtime_error_to_service_error(e));
-        }
-
-        let instance = build_s3_restored_instance(
+        // Build a `creating` placeholder; the backgrounded container start
+        // (below) fills in the endpoint and flips to `available`.
+        let mut instance = build_s3_restored_instance(
             &db_instance_identifier,
-            db_instance_arn,
+            db_instance_arn.clone(),
             dbi_resource_id,
             created_at,
             allocated_storage,
             db_instance_class,
             engine.clone(),
-            engine_version,
-            master_username,
-            master_user_password,
-            db_name,
+            engine_version.clone(),
+            master_username.clone(),
+            master_user_password.clone(),
+            db_name.clone(),
             vpc_security_group_ids,
-            &running,
+            &creating_placeholder_container(),
             tags,
         );
+        instance.db_instance_status = "creating".to_string();
+        instance.endpoint_address = String::new();
+        instance.port = 0;
 
         self.state
             .write()
             .get_or_create(&request.account_id)
             .finish_instance_creation(instance.clone());
 
-        self.emit_event(
-            RdsSourceType::DbInstance,
-            &db_instance_identifier,
-            &instance.db_instance_arn,
-            "RDS-EVENT-0043",
-            &["creation"],
-            "DB instance restored from S3 backup",
+        self.spawn_finalize_restored_instance(
+            runtime.clone(),
+            request.account_id.clone(),
+            request.region.clone(),
+            db_instance_identifier.clone(),
+            db_instance_arn,
+            engine,
+            engine_version,
+            master_username,
+            master_user_password,
+            db_name,
+            Some(dump_data),
+            ("RDS-EVENT-0043", "DB instance restored from S3 backup"),
         );
 
         Ok(AwsResponse::xml(

--- a/crates/fakecloud-rds/src/service/snapshots.rs
+++ b/crates/fakecloud-rds/src/service/snapshots.rs
@@ -430,76 +430,46 @@ impl RdsService {
             }
         };
 
+        let runtime = runtime.clone();
         let db_name = snapshot
             .db_name
-            .as_deref()
-            .unwrap_or(default_db_name(&snapshot.engine));
-        let running = match runtime
-            .ensure_postgres(
-                &db_instance_identifier,
-                &snapshot.engine,
-                &snapshot.engine_version,
-                &snapshot.master_username,
-                &snapshot.master_user_password,
-                db_name,
-                &request.account_id,
-                &request.region,
-                &tags,
-            )
-            .await
-        {
-            Ok(running) => running,
-            Err(e) => {
-                self.state
-                    .write()
-                    .get_or_create(&request.account_id)
-                    .cancel_instance_creation(&db_instance_identifier);
-                return Err(runtime_error_to_service_error(e));
-            }
-        };
+            .clone()
+            .unwrap_or_else(|| default_db_name(&snapshot.engine).to_string());
 
-        if let Err(e) = runtime
-            .restore_database(
-                &db_instance_identifier,
-                &snapshot.engine,
-                &snapshot.master_username,
-                &snapshot.master_user_password,
-                db_name,
-                &snapshot.dump_data,
-            )
-            .await
-        {
-            self.state
-                .write()
-                .get_or_create(&request.account_id)
-                .cancel_instance_creation(&db_instance_identifier);
-            runtime.stop_container(&db_instance_identifier).await;
-            return Err(runtime_error_to_service_error(e));
-        }
-
-        let instance = build_restored_instance(
+        // Build a `creating` placeholder; the backgrounded container start
+        // (below) fills in the endpoint and flips to `available`.
+        let mut instance = build_restored_instance(
             &db_instance_identifier,
-            db_instance_arn,
+            db_instance_arn.clone(),
             dbi_resource_id,
             created_at,
             vpc_security_group_ids,
             &snapshot,
-            &running,
+            &creating_placeholder_container(),
             tags,
         );
+        instance.db_instance_status = "creating".to_string();
+        instance.endpoint_address = String::new();
+        instance.port = 0;
 
         self.state
             .write()
             .get_or_create(&request.account_id)
             .finish_instance_creation(instance.clone());
 
-        self.emit_event(
-            RdsSourceType::DbInstance,
-            &db_instance_identifier,
-            &instance.db_instance_arn,
-            "RDS-EVENT-0043",
-            &["creation"],
-            "DB instance restored from snapshot",
+        self.spawn_finalize_restored_instance(
+            runtime,
+            request.account_id.clone(),
+            request.region.clone(),
+            db_instance_identifier.clone(),
+            db_instance_arn,
+            snapshot.engine.clone(),
+            snapshot.engine_version.clone(),
+            snapshot.master_username.clone(),
+            snapshot.master_user_password.clone(),
+            db_name,
+            Some(snapshot.dump_data.clone()),
+            ("RDS-EVENT-0043", "DB instance restored from snapshot"),
         );
 
         Ok(AwsResponse::xml(

--- a/crates/fakecloud-rds/src/service/snapshots.rs
+++ b/crates/fakecloud-rds/src/service/snapshots.rs
@@ -446,7 +446,7 @@ impl RdsService {
             vpc_security_group_ids,
             &snapshot,
             &creating_placeholder_container(),
-            tags,
+            tags.clone(),
         );
         instance.db_instance_status = "creating".to_string();
         instance.endpoint_address = String::new();
@@ -468,6 +468,7 @@ impl RdsService {
             snapshot.master_username.clone(),
             snapshot.master_user_password.clone(),
             db_name,
+            tags,
             Some(snapshot.dump_data.clone()),
             ("RDS-EVENT-0043", "DB instance restored from snapshot"),
         );

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -617,6 +617,19 @@ pub(crate) fn build_s3_restored_instance(
     }
 }
 
+/// A zero-valued `RunningDbContainer` used to seed a `creating` placeholder row
+/// before the real container is started in the background. The finalize task
+/// overwrites `endpoint_address`/`endpoint_port`/`host_port`/`container_id` once
+/// `ensure_postgres` returns.
+pub(crate) fn creating_placeholder_container() -> crate::runtime::RunningDbContainer {
+    crate::runtime::RunningDbContainer {
+        container_id: String::new(),
+        host_port: 0,
+        endpoint_address: String::new(),
+        endpoint_port: 0,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_pit_restored_instance(
     db_instance_identifier: &str,


### PR DESCRIPTION
## Summary

Bug-hunt 2026-07-01, **Tier-0 propagation gaps** (batch 1 of the report). Two clusters of the recurring "new code path re-derives behavior and drops a guarantee" class.

### RDS restore/replica awaited a cold container INLINE -> ~60s client timeout
`CreateDBInstance`/`StartDBInstance` were backgrounded long ago (#1338/#914); the restore/replica family never was. Now each inserts a `creating` placeholder, returns immediately, and finishes the container start + data replay in a background task (new `spawn_finalize_restored_instance`, mirroring `create_db_instance`):
- `RestoreDBInstanceToPointInTime`
- `RestoreDBInstanceFromS3`
- `RestoreDBInstanceFromDBSnapshot`
- `CreateDBInstanceReadReplica` (source->replica linkage still registered synchronously so a concurrent `DescribeDBInstances` of the source sees it at once)

Source dumps stay synchronous (source is already warm); only the cold `ensure_postgres` + `restore_database` move to the background. Matches real AWS, which returns `creating` from these ops.

### EC2 Modify* remainder validated-then-persisted-nothing (same class #2041 fixed)
- **ModifyVpcEndpoint** — add/remove subnets + route tables, `PrivateDnsEnabled`.
- **ModifySecurityGroupRules** — update rule protocol/ports/CIDR/description by rule id.
- **UpdateSecurityGroupRuleDescriptionsIngress/Egress** — match rules by protocol/port/CIDR, overwrite descriptions.
- **ModifySnapshotAttribute / DescribeSnapshotAttribute / ResetSnapshotAttribute** — `createVolumePermission` grants round-trip (new `Snapshot.create_volume_permissions`).
- **ModifyTransitGatewayVpcAttachment** — add/remove subnet ids.
- **ModifyInstanceCreditSpecification / DescribeInstanceCreditSpecifications** — per-instance `CpuCredits` round-trip; unknown ids -> unsuccessful set.
- **ModifyInstanceMetadataDefaults / GetInstanceMetadataDefaults** — account IMDS defaults round-trip; `no-preference` clears the stored default.
- **Register/Deregister/DescribeInstanceEventNotificationAttributes** — tag keys + `IncludeAllTagsOfInstance` persist.

## Test plan
- 17 new EC2 unit tests, one per Modify* handler (round-trip via the paired Describe/Get). `cargo test -p fakecloud-ec2 --lib` -> 84 passed.
- `cargo clippy -p fakecloud-ec2 -p fakecloud-rds --all-targets -- -D warnings` clean.
- RDS backgrounding is exercised by the existing conformance + e2e `wait_for_db_available` polling (create returns `creating`, background flips to `available`); no assertion regressed.
- No API-surface change -> no SDK/doc/parity update needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backgrounded RDS restore/replica flows to return “creating” immediately and complete start + data replay in the background, preventing client timeouts and handling failures correctly. Also fixed EC2 Modify* APIs to persist and validate changes so they round‑trip via Describe/Get with expected errors.

- **Bug Fixes**
  - RDS (`fakecloud-rds`): Restore/replica ops now insert a creating placeholder and finalize in the background (Restore from snapshot/S3/point‑in‑time, Create read replica). Source→replica linkage registers immediately; if replay fails or the instance is deleted while creating, we remove the placeholder, drop the stale linkage from the source, reap the container, and emit RDS‑EVENT‑0058. `ensure_postgres` now receives instance/source tags for Pod scheduling.
  - EC2 (`fakecloud-ec2`): Persist and validate Modify* so changes round‑trip (and error as AWS does): ModifyVpcEndpoint (add/remove subnets, route tables, security groups; PrivateDnsEnabled; groupSet in Describe; unknown id -> NotFound), ModifySecurityGroupRules + UpdateSecurityGroupRuleDescriptions* (update by id or by protocol/port/CIDR; missing group -> InvalidGroup.NotFound), ModifySnapshotAttribute/Describe/Reset (createVolumePermission grants; reject Add+Remove in one call; only Group=`all` is valid; unknown snapshot -> NotFound), ModifyTransitGatewayVpcAttachment (subnets; unknown id -> NotFound), ModifyInstanceCreditSpecification/Describe (per‑instance CpuCredits; unknown IDs marked unsuccessful), ModifyInstanceMetadataDefaults/Get (persist `HttpTokensEnforced` and other fields; `no‑preference` clears), Register/Deregister/DescribeInstanceEventNotificationAttributes (persist tag keys and IncludeAllTagsOfInstance; correct <item> shape).

<sup>Written for commit a4d90add389f2a437ac758db33a8541ca63d493c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

