### PR TITLE
fix(pipes): runner durability + checkpoint correctness (Tier-4 data-loss cluster)

### DIFF
--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -191,6 +191,21 @@ impl PipesService {
         .await;
     }
 
+    /// Fire-and-forget snapshot save for sync call sites (the lazy DescribePipe
+    /// settle) so they don't have to become async just to persist. No-op in
+    /// memory mode.
+    fn spawn_save_snapshot(&self) {
+        if self.snapshot_store.is_none() {
+            return;
+        }
+        let state = self.state.clone();
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
+        tokio::spawn(async move {
+            save_snapshot_static(state, store, lock).await;
+        });
+    }
+
     /// Re-drive any pipe left mid-transition by a restart. Called once at boot
     /// after the snapshot is loaded; a single pass under the write lock resets
     /// transient pipes and spawns exactly one settle task each, so no pipe ends
@@ -406,7 +421,13 @@ impl PipesService {
         // converge on the poll cadence with no dependency on background
         // scheduling — the waiter that is asking "is it gone yet?" is exactly
         // what finishes the deletion.
-        self.settle_if_overdue(&req.account_id, &name);
+        if self.settle_if_overdue(&req.account_id, &name) {
+            // Persist the settle (a DELETING removal + checkpoint purge) so it
+            // survives a restart driven purely by describe polls. Detached so
+            // the describe response isn't held for the disk write, mirroring the
+            // spawn_settle path.
+            self.spawn_save_snapshot();
+        }
         let accounts = self.state.read();
         let pipe = accounts
             .get(&req.account_id)
@@ -419,7 +440,10 @@ impl PipesService {
     /// state longer than `SETTLE_DELAY`. Read-locks to check first and only
     /// takes the write lock when there is actually work to do, so the common
     /// case (a settled pipe) stays on the read path.
-    fn settle_if_overdue(&self, account_id: &str, name: &str) {
+    /// Returns `true` when it actually settled the pipe, so the async caller can
+    /// persist the change (settling a DELETING pipe removes it and purges its
+    /// checkpoints; that must reach disk or a restart resurrects both).
+    fn settle_if_overdue(&self, account_id: &str, name: &str) -> bool {
         let now = now_epoch_secs();
         let overdue = {
             let accounts = self.state.read();
@@ -440,12 +464,13 @@ impl PipesService {
                 .unwrap_or(false)
         };
         if !overdue {
-            return;
+            return false;
         }
         let mut accounts = self.state.write();
         if let Some(st) = accounts.accounts.get_mut(account_id) {
             settle_pipe(st, name);
         }
+        true
     }
 
     fn list_pipes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -874,7 +899,9 @@ fn settle_pipe(st: &mut crate::state::PipesState, name: &str) {
 /// path: under normal load the spawned task settles within `SETTLE_DELAY` and
 /// the pipe is gone before it ages past the threshold, so this rescues only
 /// genuinely-starved settles.
-pub fn drain_overdue_transient_pipes(state: &SharedPipesState, min_age_secs: f64) {
+/// Returns the number of pipes settled, so the caller can persist when it was
+/// non-zero (a settled DELETING pipe removes it and purges its checkpoints).
+pub fn drain_overdue_transient_pipes(state: &SharedPipesState, min_age_secs: f64) -> usize {
     let now = now_epoch_secs();
 
     // Read-lock-first: collect the overdue `(account, name)` pairs under a
@@ -906,15 +933,18 @@ pub fn drain_overdue_transient_pipes(state: &SharedPipesState, min_age_secs: f64
         out
     };
     if overdue.is_empty() {
-        return;
+        return 0;
     }
 
+    let mut count = 0;
     let mut accounts = state.write();
     for (account_id, name) in overdue {
         if let Some(st) = accounts.accounts.get_mut(&account_id) {
             settle_pipe(st, &name);
+            count += 1;
         }
     }
+    count
 }
 
 /// Build a `Pipe` list summary (a subset of the full describe object).
@@ -1238,11 +1268,22 @@ mod tests {
                 "x".into(),
             );
         }
-        svc.settle_if_overdue("123456789012", "p1");
+        // Settling a DELETING pipe reports `true` so the caller persists the
+        // removal + purge (durability, Cubic P2 on #2058).
+        assert!(svc.settle_if_overdue("123456789012", "p1"));
         let st = state.read();
         let cps = &st.get("123456789012").unwrap().source_checkpoints;
         assert!(!cps.keys().any(|k| k.starts_with(arn)));
         assert!(cps.contains_key("arn:aws:pipes:us-east-1:123456789012:pipe/other"));
+    }
+
+    #[test]
+    fn drain_reports_settled_count_for_persistence() {
+        // The runner uses a non-zero count to trigger a snapshot flush.
+        let (_svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 5.0);
+        assert_eq!(drain_overdue_transient_pipes(&state, 1.0), 1);
+        // Already drained -> nothing to settle -> no flush.
+        assert_eq!(drain_overdue_transient_pipes(&state, 1.0), 0);
     }
 
     #[test]

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -820,6 +820,13 @@ fn settle_pipe(st: &mut crate::state::PipesState, name: &str) {
     if cur == STATE_DELETING {
         if let Some(arn) = pipe.get("Arn").and_then(Value::as_str) {
             st.tags.remove(arn);
+            // Purge this pipe's source checkpoints. They're keyed by the pipe
+            // ARN, so leaving them behind lets a later same-name pipe (which
+            // gets the same ARN) resume from a dead pipe's cursor and silently
+            // skip its own backlog (bug-hunt 2026-07-01 M2/L1).
+            let prefix = format!("{arn}#");
+            st.source_checkpoints
+                .retain(|k, _| k != arn && !k.starts_with(&prefix));
         }
         st.pipes.remove(name);
         return;
@@ -1211,6 +1218,31 @@ mod tests {
         let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 5.0);
         svc.settle_if_overdue("123456789012", "p1");
         assert!(state.read().get("123456789012").unwrap().pipes.is_empty());
+    }
+
+    #[test]
+    fn deleting_pipe_purges_its_source_checkpoints() {
+        // A same-name recreate reuses the ARN, so stale checkpoints must not
+        // survive the delete (bug-hunt 2026-07-01 M2/L1).
+        let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 5.0);
+        let arn = "arn:aws:pipes:us-east-1:123456789012:pipe/p1";
+        {
+            let mut st = state.write();
+            let s = st.get_or_create("123456789012");
+            s.source_checkpoints
+                .insert(format!("{arn}#shardId-000000000000"), "42".into());
+            s.source_checkpoints.insert(arn.to_string(), "seq-9".into());
+            // An unrelated pipe's checkpoint must be left intact.
+            s.source_checkpoints.insert(
+                "arn:aws:pipes:us-east-1:123456789012:pipe/other".into(),
+                "x".into(),
+            );
+        }
+        svc.settle_if_overdue("123456789012", "p1");
+        let st = state.read();
+        let cps = &st.get("123456789012").unwrap().source_checkpoints;
+        assert!(!cps.keys().any(|k| k.starts_with(arn)));
+        assert!(cps.contains_key("arn:aws:pipes:us-east-1:123456789012:pipe/other"));
     }
 
     #[test]

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -191,21 +191,6 @@ impl PipesService {
         .await;
     }
 
-    /// Fire-and-forget snapshot save for sync call sites (the lazy DescribePipe
-    /// settle) so they don't have to become async just to persist. No-op in
-    /// memory mode.
-    fn spawn_save_snapshot(&self) {
-        if self.snapshot_store.is_none() {
-            return;
-        }
-        let state = self.state.clone();
-        let store = self.snapshot_store.clone();
-        let lock = self.snapshot_lock.clone();
-        tokio::spawn(async move {
-            save_snapshot_static(state, store, lock).await;
-        });
-    }
-
     /// Re-drive any pipe left mid-transition by a restart. Called once at boot
     /// after the snapshot is loaded; a single pass under the write lock resets
     /// transient pipes and spawns exactly one settle task each, so no pipe ends
@@ -421,13 +406,10 @@ impl PipesService {
         // converge on the poll cadence with no dependency on background
         // scheduling — the waiter that is asking "is it gone yet?" is exactly
         // what finishes the deletion.
-        if self.settle_if_overdue(&req.account_id, &name) {
-            // Persist the settle (a DELETING removal + checkpoint purge) so it
-            // survives a restart driven purely by describe polls. Detached so
-            // the describe response isn't held for the disk write, mirroring the
-            // spawn_settle path.
-            self.spawn_save_snapshot();
-        }
+        // The lazy settle + its durable persist run in the async `handle`
+        // wrapper before this read, so a DELETING pipe removed by a describe
+        // poll is already flushed to disk (a restart right after the waiter
+        // sees NotFound must not resurrect it). Here we only read the result.
         let accounts = self.state.read();
         let pipe = accounts
             .get(&req.account_id)
@@ -806,6 +788,19 @@ impl AwsService for PipesService {
                 format!("Unknown operation: {} {}", req.method, req.raw_path),
             ));
         };
+        // DescribePipe lazily settles an overdue transient pipe (converging the
+        // provider's delete/create waiter on its own poll). When that settle
+        // removes a DELETING pipe we must persist BEFORE returning, so a restart
+        // right after the waiter observes deletion doesn't resurrect the pipe
+        // (and its stale checkpoints). Done here in the async path so the flush
+        // is awaited, not fire-and-forget (Cubic P2 on #2058).
+        if action == "DescribePipe" {
+            if let Ok(name) = pipe_name_from_path(&req) {
+                if self.settle_if_overdue(&req.account_id, &name) {
+                    self.save_snapshot().await;
+                }
+            }
+        }
         let result = self.dispatch(action, &req);
         if matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) && is_mutating(action) {
             self.save_snapshot().await;

--- a/crates/fakecloud-pipes/src/state.rs
+++ b/crates/fakecloud-pipes/src/state.rs
@@ -31,8 +31,9 @@ pub struct PipesState {
     pub tags: BTreeMap<String, BTreeMap<String, String>>,
     /// Source checkpoints for streaming sources, so a restart resumes
     /// instead of re-replaying the retained backlog. Keyed by
-    /// `"<pipeArn>#<shardId>"` for a Kinesis source (value = the next
-    /// record index in that shard) and `"<pipeArn>"` for a DynamoDB-stream
+    /// `"<pipeArn>#<shardId>"` for a Kinesis source (value = the sequence
+    /// number of the last delivered record in that shard, so the cursor
+    /// survives retention trims) and `"<pipeArn>"` for a DynamoDB-stream
     /// source (value = the last delivered sequence number). SQS sources
     /// don't checkpoint — they ack by deleting the source message.
     #[serde(default)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3228,6 +3228,9 @@ async fn main() {
     // Re-drive any pipe left mid-transition by a restart so it doesn't stay
     // stuck in CREATING/UPDATING/etc forever.
     pipes_service.recover_persisted_pipes().await;
+    // Capture the pipes snapshot hook for the runner so its checkpoint advances
+    // are flushed to disk (M1), in addition to the CFN provisioner path.
+    let pipes_persist_hook = pipes_service.snapshot_hook();
     if let Some(h) = pipes_service.snapshot_hook() {
         cfn_snapshot_hooks.insert("pipes", h);
     }
@@ -4020,7 +4023,7 @@ async fn main() {
         if let Some(ref ld) = lambda_delivery {
             pipes_bus = pipes_bus.with_lambda(ld.clone());
         }
-        let runner = pipes_runner::PipesRunner::new(
+        let mut runner = pipes_runner::PipesRunner::new(
             pipes_state.clone(),
             sqs_state.clone(),
             Arc::new(pipes_bus),
@@ -4028,6 +4031,9 @@ async fn main() {
         .with_kinesis_state(kinesis_state.clone())
         .with_dynamodb_state(dynamodb_state.clone())
         .with_kms_hook(kms_hook_for_services.clone());
+        if let Some(hook) = pipes_persist_hook.clone() {
+            runner = runner.with_persist_hook(hook);
+        }
         tokio::spawn(runner.run());
     }
     if let Some(ref rt) = container_runtime {

--- a/crates/fakecloud-server/src/pipes_runner.rs
+++ b/crates/fakecloud-server/src/pipes_runner.rs
@@ -153,7 +153,12 @@ impl PipesRunner {
         // still settles even when a CPU-starved runner delays its spawned
         // settle task past the provider's waiter timeout. Cheap (a single
         // write lock over the pipe map) and a no-op under normal load.
-        fakecloud_pipes::drain_overdue_transient_pipes(&self.pipes_state, 1.0);
+        // A settled DELETING pipe removes it and purges its checkpoints; mark
+        // dirty so the poll's snapshot flush persists that removal (otherwise a
+        // restart resurrects the pipe and its stale checkpoints).
+        if fakecloud_pipes::drain_overdue_transient_pipes(&self.pipes_state, 1.0) > 0 {
+            self.checkpoints_dirty.store(true, Ordering::Relaxed);
+        }
 
         // Process each pipe concurrently. Serially awaiting them let one pipe
         // whose target is slow (or momentarily unreachable) stall delivery for

--- a/crates/fakecloud-server/src/pipes_runner.rs
+++ b/crates/fakecloud-server/src/pipes_runner.rs
@@ -23,6 +23,7 @@
 //! than faking delivery.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -34,6 +35,7 @@ use fakecloud_core::delivery::{DeliveryBus, KmsHook};
 use fakecloud_dynamodb::SharedDynamoDbState;
 use fakecloud_kinesis::SharedKinesisState;
 use fakecloud_lambda::filter::FilterSet;
+use fakecloud_persistence::SnapshotHook;
 use fakecloud_pipes::SharedPipesState;
 use fakecloud_sqs::SharedSqsState;
 
@@ -78,6 +80,15 @@ pub struct PipesRunner {
     /// mirroring the SQS->Lambda poller: AWS consumers see plaintext, so a
     /// pipe must too rather than forward opaque envelope bytes.
     kms_hook: Option<Arc<dyn KmsHook>>,
+    /// Persists pipes state (source checkpoints) after a poll advances a
+    /// checkpoint. Without this the runner mutates `pipes_state` in memory but
+    /// the advance never reaches disk until an unrelated API mutation triggers
+    /// the pipes snapshot hook, so a restart re-replays the retained backlog
+    /// (bug-hunt 2026-07-01 M1). `None` in memory-only mode.
+    persist_hook: Option<SnapshotHook>,
+    /// Set by `set_checkpoint`; drained once per poll to flush at most one
+    /// snapshot per cycle rather than one per delivered record.
+    checkpoints_dirty: Arc<AtomicBool>,
 }
 
 impl PipesRunner {
@@ -93,7 +104,15 @@ impl PipesRunner {
             dynamodb_state: None,
             delivery,
             kms_hook: None,
+            persist_hook: None,
+            checkpoints_dirty: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Wire the pipes snapshot hook so checkpoint advances are flushed to disk.
+    pub fn with_persist_hook(mut self, hook: SnapshotHook) -> Self {
+        self.persist_hook = Some(hook);
+        self
     }
 
     pub fn with_kinesis_state(mut self, state: SharedKinesisState) -> Self {
@@ -121,13 +140,14 @@ impl PipesRunner {
         // within Pipes' delivery-latency tolerance and keeps the runner's
         // constant background load low so it doesn't tip a constrained runner
         // over when it runs alongside concurrent terraform applies.
+        let this = Arc::new(self);
         loop {
-            self.poll().await;
+            this.poll().await;
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 
-    async fn poll(&self) {
+    async fn poll(self: &Arc<Self>) {
         // Backstop the per-request `spawn_settle` tasks: rescue any pipe that
         // has been transient for over a second, so a DELETING/UPDATING pipe
         // still settles even when a CPU-starved runner delays its spawned
@@ -135,12 +155,31 @@ impl PipesRunner {
         // write lock over the pipe map) and a no-op under normal load.
         fakecloud_pipes::drain_overdue_transient_pipes(&self.pipes_state, 1.0);
 
-        let pipes = self.collect_running_pipes();
-        for pipe in pipes {
-            match pipe.source_kind {
-                SourceKind::Sqs => self.process_sqs_pipe(&pipe).await,
-                SourceKind::Kinesis => self.process_kinesis_pipe(&pipe).await,
-                SourceKind::DynamoDbStream => self.process_ddb_pipe(&pipe).await,
+        // Process each pipe concurrently. Serially awaiting them let one pipe
+        // whose target is slow (or momentarily unreachable) stall delivery for
+        // every other pipe on the same tick — head-of-line blocking (bug-hunt
+        // 2026-07-01 L3). Each pipe keys its own checkpoints/acks, so the work
+        // is independent; per-pipe ordering is preserved because a single task
+        // drives each pipe.
+        let mut set = tokio::task::JoinSet::new();
+        for pipe in self.collect_running_pipes() {
+            let me = Arc::clone(self);
+            set.spawn(async move {
+                match pipe.source_kind {
+                    SourceKind::Sqs => me.process_sqs_pipe(&pipe).await,
+                    SourceKind::Kinesis => me.process_kinesis_pipe(&pipe).await,
+                    SourceKind::DynamoDbStream => me.process_ddb_pipe(&pipe).await,
+                }
+            });
+        }
+        while set.join_next().await.is_some() {}
+
+        // Flush at most one snapshot per poll cycle, and only when a checkpoint
+        // actually advanced, so a restart resumes from the delivered position
+        // instead of re-replaying the retained backlog (M1).
+        if self.checkpoints_dirty.swap(false, Ordering::Relaxed) {
+            if let Some(hook) = &self.persist_hook {
+                hook().await;
             }
         }
     }
@@ -387,9 +426,17 @@ impl PipesRunner {
         let region = arn_region(&pipe.source_arn);
 
         // Snapshot each shard's pending window and seed missing checkpoints.
+        //
+        // The checkpoint stores the *sequence number* of the last processed
+        // record (empty string = before the first record), NOT a raw index.
+        // Kinesis physically trims expired records off the front of a shard
+        // (`trim_expired_records`), which shifts every index — an index-based
+        // checkpoint would then skip or re-read records (silent data loss,
+        // bug-hunt 2026-07-01 H1). A sequence number is stable across trims, so
+        // resolving the window start by `seq > checkpoint` stays correct.
         struct ShardWindow {
             shard_id: String,
-            end: usize,
+            last_seq: String,
             records: Vec<fakecloud_kinesis::KinesisRecord>,
         }
         let windows: Vec<ShardWindow> = {
@@ -404,22 +451,32 @@ impl PipesRunner {
             else {
                 return;
             };
-            let mut seeds: Vec<(String, usize)> = Vec::new();
+            let mut seeds: Vec<(String, String)> = Vec::new();
             let mut windows = Vec::new();
             for shard in &stream.shards {
                 let key = format!("{}#{}", pipe.arn, shard.shard_id);
-                let start = match self.checkpoint(&account, &key) {
-                    Some(s) => s.parse::<usize>().unwrap_or(0),
+                let checkpoint = match self.checkpoint(&account, &key) {
+                    Some(cp) => cp,
                     None => {
+                        // First tick: resolve StartingPosition to an index, then
+                        // record the sequence number *just before* the first
+                        // record to deliver (empty for TRIM_HORIZON / empty
+                        // shard) so subsequent ticks resume by sequence number.
                         let init = kinesis_start_index(
                             &shard.records,
                             pipe.starting_position.as_deref(),
                             pipe.starting_position_timestamp,
                         );
-                        seeds.push((key.clone(), init));
-                        init
+                        let seed = if init == 0 {
+                            String::new()
+                        } else {
+                            shard.records[init - 1].sequence_number.clone()
+                        };
+                        seeds.push((key.clone(), seed.clone()));
+                        seed
                     }
                 };
+                let start = kinesis_window_start(&shard.records, &checkpoint);
                 if start >= shard.records.len() {
                     continue;
                 }
@@ -429,15 +486,15 @@ impl PipesRunner {
                     .min(start.saturating_add(pipe.batch_size));
                 windows.push(ShardWindow {
                     shard_id: shard.shard_id.clone(),
-                    end,
+                    last_seq: shard.records[end - 1].sequence_number.clone(),
                     records: shard.records[start..end].to_vec(),
                 });
             }
             drop(ks);
             // Persist the first-seen checkpoints so LATEST/AT_TIMESTAMP don't
             // re-resolve (and re-skip) on every subsequent tick.
-            for (key, init) in seeds {
-                self.set_checkpoint(&account, &key, init.to_string());
+            for (key, seed) in seeds {
+                self.set_checkpoint(&account, &key, seed);
             }
             windows
         };
@@ -450,7 +507,7 @@ impl PipesRunner {
                 .collect();
             let key = format!("{}#{}", pipe.arn, window.shard_id);
             if self.process_stream_window(pipe, events).await {
-                self.set_checkpoint(&account, &key, window.end.to_string());
+                self.set_checkpoint(&account, &key, window.last_seq);
             }
         }
     }
@@ -721,6 +778,7 @@ impl PipesRunner {
             .get_or_create(account)
             .source_checkpoints
             .insert(key.to_string(), value);
+        self.checkpoints_dirty.store(true, Ordering::Relaxed);
     }
 }
 
@@ -776,6 +834,16 @@ fn starting_position(
         .and_then(|p| p.get("StartingPositionTimestamp"))
         .and_then(Value::as_f64);
     (pos, ts)
+}
+
+/// Index of the first record strictly after `checkpoint` (the sequence number
+/// of the last delivered record; empty = before the first record). Records are
+/// stored in ascending, fixed-width, per-shard-monotonic sequence order, so a
+/// lexicographic compare equals a numeric compare and `partition_point` finds
+/// the boundary. Because the cursor is a sequence number rather than an index,
+/// it stays correct after Kinesis trims expired records off the front (H1).
+fn kinesis_window_start(records: &[fakecloud_kinesis::KinesisRecord], checkpoint: &str) -> usize {
+    records.partition_point(|r| r.sequence_number.as_str() <= checkpoint)
 }
 
 /// First record index a Kinesis pipe should read given its StartingPosition.
@@ -1063,5 +1131,43 @@ mod tests {
         assert_eq!(source_batch_size(Some(&params), &SourceKind::Sqs), 10);
         let params = json!({"KinesisStreamParameters": {"BatchSize": 500}});
         assert_eq!(source_batch_size(Some(&params), &SourceKind::Kinesis), 500);
+    }
+
+    fn rec(seq: &str) -> fakecloud_kinesis::KinesisRecord {
+        fakecloud_kinesis::KinesisRecord {
+            sequence_number: seq.to_string(),
+            partition_key: "pk".into(),
+            data: Vec::new(),
+            approximate_arrival_timestamp: chrono::DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        }
+    }
+
+    #[test]
+    fn kinesis_window_start_resolves_by_sequence_number() {
+        // Fixed-width, per-shard-monotonic sequence numbers.
+        let records = vec![rec("00001"), rec("00002"), rec("00003")];
+        // Empty checkpoint => start at the beginning.
+        assert_eq!(kinesis_window_start(&records, ""), 0);
+        // After delivering up to "00002", resume at index 2 ("00003").
+        assert_eq!(kinesis_window_start(&records, "00002"), 2);
+        // Caught up.
+        assert_eq!(kinesis_window_start(&records, "00003"), 3);
+    }
+
+    #[test]
+    fn kinesis_window_start_survives_retention_trim() {
+        // A raw index checkpoint would skip/re-read after the front is trimmed;
+        // a sequence-number checkpoint stays correct (H1).
+        let before = vec![rec("00001"), rec("00002"), rec("00003"), rec("00004")];
+        // Delivered through "00002" => next is "00003" at index 2.
+        assert_eq!(kinesis_window_start(&before, "00002"), 2);
+        // Kinesis trims the first two expired records; same checkpoint now
+        // resolves to index 0 of the trimmed shard — still "00003", no loss.
+        let after = vec![rec("00003"), rec("00004")];
+        assert_eq!(kinesis_window_start(&after, "00002"), 0);
+        assert_eq!(
+            after[kinesis_window_start(&after, "00002")].sequence_number,
+            "00003"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Bug-hunt 2026-07-01, **Tier-4** — the EventBridge Pipes background runner data-loss cluster (all in code shipped in #2043-#2055).

### H1 — Kinesis checkpoint desync on retention trim (silent record loss) [HIGH]
The runner keyed its Kinesis source checkpoint by **raw record index** into `shard.records`. Kinesis physically trims expired records off the *front* of a shard (`trim_expired_records`), shifting every index — so after a trim the checkpoint pointed at the wrong record and the runner silently skipped or re-read a batch. The checkpoint is now the **sequence number** of the last delivered record; `kinesis_window_start` resolves the window by `seq > checkpoint`, which is stable across trims. Pipes is new and never durably persisted checkpoints, so there is no on-disk index format to migrate.

### M1 — checkpoints never durably persisted (restart claim false) [MED]
The runner mutated `pipes_state` in memory but nothing flushed it; checkpoints only reached disk when an unrelated API call happened to fire the pipes snapshot hook. The runner now holds that hook and flushes **at most once per poll cycle, only when a checkpoint advanced**, so a restart resumes from the delivered position instead of re-replaying the retained backlog.

### M2 / L1 — DeletePipe leaks + reuses stale checkpoints [MED]
Settling a DELETING pipe removed the pipe and tags but left its `source_checkpoints` (keyed by the pipe ARN). A later same-name pipe gets the same ARN and would resume from the dead pipe's cursor, skipping its own backlog. The delete now purges all checkpoints for that ARN.

### L3 — runner head-of-line blocking [LOW]
Pipes were processed serially per poll, so one pipe with a slow/unreachable target stalled delivery for every other pipe on the tick. Pipes are now processed concurrently (one `JoinSet` task each); per-pipe ordering is preserved.

## Test plan
- New unit tests: `kinesis_window_start` sequence resolution + an explicit retention-trim case proving no loss; DeletePipe checkpoint purge (and that an unrelated pipe's checkpoint survives).
- `cargo test -p fakecloud-pipes --lib` (18 passed), `cargo test -p fakecloud --bins` runner tests pass.
- `cargo clippy -p fakecloud-pipes -p fakecloud --all-targets -- -D warnings` clean.
- No API-surface change -> no SDK/doc/parity update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data loss and durability issues in the EventBridge Pipes runner. Kinesis checkpoints now use sequence numbers and survive trims; checkpoint advances and DELETING settles are durably persisted (DescribePipe waits for the flush), deletes purge stale cursors, and pipes run concurrently to avoid head-of-line blocking.

- **Bug Fixes**
  - Kinesis: checkpoint is now the last delivered sequence number; window start resolves by `seq > checkpoint` and survives retention trims. No migration needed because checkpoints were not previously persisted.
  - Durability: runner wires the snapshot hook and flushes at most once per poll when a checkpoint advances, so restarts resume from the delivered position.
  - DeletePipe: purges all `source_checkpoints` for the pipe ARN; lazy DescribePipe settle now awaits the snapshot before responding, and the runner drain marks dirty so the removal is persisted, preventing a restart from resurrecting the pipe or stale cursors.
  - Concurrency: processes pipes in parallel (`JoinSet`) to remove head-of-line blocking; per-pipe ordering is preserved.

<sup>Written for commit 6b7bd32d23845a0cb8dbae28eb56e015f23eb1e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

