### PR TITLE
fix(sqs,s3): FIFO dedup scope + sequence-number shape, stable ListQueues token, v1 NextMarker

### DIFF
--- a/crates/fakecloud-s3/src/service/objects/list.rs
+++ b/crates/fakecloud-s3/src/service/objects/list.rs
@@ -132,7 +132,12 @@ impl S3Service {
             ));
         }
 
-        let next_marker = if is_truncated {
+        // Per the S3 ListObjects (v1) contract, NextMarker is only returned
+        // for a truncated listing when a Delimiter was supplied. Without a
+        // delimiter the client must resume from the last returned key itself,
+        // and AWS omits NextMarker entirely. Emitting it unconditionally
+        // misleads clients that key off its presence.
+        let next_marker = if is_truncated && delimiter.is_some() {
             format!("<NextMarker>{}</NextMarker>", xml_escape(&last_key))
         } else {
             String::new()

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -3690,6 +3690,56 @@ async fn list_objects_v1_basic() {
     assert!(body.contains("<Key>b</Key>"));
 }
 
+/// ListObjects v1: a truncated listing WITHOUT a delimiter must NOT emit
+/// NextMarker (the client resumes from the last key itself). AWS only
+/// returns NextMarker when a delimiter is supplied.
+#[tokio::test]
+async fn list_objects_v1_truncated_no_delimiter_omits_next_marker() {
+    let svc = make_service();
+    seed_bucket(&svc, "nm1");
+    for k in &["k0", "k1", "k2"] {
+        let req = make_request(Method::PUT, &format!("/nm1/{k}"), &[], b"x");
+        svc.put_object("123456789012", &req, "nm1", k)
+            .await
+            .unwrap();
+    }
+    let req = make_request(Method::GET, "/nm1", &[("max-keys", "1")], b"");
+    let resp = svc.list_objects_v1("123456789012", &req, "nm1").unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(body.contains("<IsTruncated>true</IsTruncated>"));
+    assert!(
+        !body.contains("<NextMarker>"),
+        "NextMarker must be omitted without a delimiter: {body}"
+    );
+}
+
+/// ListObjects v1: a truncated listing WITH a delimiter includes NextMarker
+/// so the client can resume past the whole common-prefix group.
+#[tokio::test]
+async fn list_objects_v1_truncated_with_delimiter_includes_next_marker() {
+    let svc = make_service();
+    seed_bucket(&svc, "nm2");
+    for k in &["p1/a", "p2/b", "p3/c"] {
+        let req = make_request(Method::PUT, &format!("/nm2/{k}"), &[], b"x");
+        svc.put_object("123456789012", &req, "nm2", k)
+            .await
+            .unwrap();
+    }
+    let req = make_request(
+        Method::GET,
+        "/nm2",
+        &[("max-keys", "1"), ("delimiter", "/")],
+        b"",
+    );
+    let resp = svc.list_objects_v1("123456789012", &req, "nm2").unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(body.contains("<IsTruncated>true</IsTruncated>"));
+    assert!(
+        body.contains("<NextMarker>p1/</NextMarker>"),
+        "NextMarker should carry the common-prefix cursor: {body}"
+    );
+}
+
 #[test]
 fn get_object_key_not_found() {
     let svc = make_service();

--- a/crates/fakecloud-sqs/src/helpers.rs
+++ b/crates/fakecloud-sqs/src/helpers.rs
@@ -280,8 +280,14 @@ pub(crate) fn process_batch_send_entry(
     } else {
         None
     };
+    // Scope the dedup cache key per message group when the queue's
+    // DeduplicationScope is `messageGroup`; queue-wide otherwise. The stored
+    // MessageDeduplicationId echoed to receivers stays the raw value.
+    let dedup_key = effective_dedup_id
+        .as_deref()
+        .map(|d| dedup_cache_key(queue, d, message_group_id.as_deref()));
     if cfg.is_fifo {
-        if let Some(ref dedup_id) = effective_dedup_id {
+        if let Some(ref dedup_id) = dedup_key {
             queue.dedup_cache.retain(|_, e| e.expiry > cfg.now);
             if let Some(existing) = queue.dedup_cache.get(dedup_id) {
                 let mut entry_resp = json!({
@@ -306,7 +312,7 @@ pub(crate) fn process_batch_send_entry(
     let sequence_number = if cfg.is_fifo {
         let seq = queue.next_sequence_number;
         queue.next_sequence_number += 1;
-        Some(seq.to_string())
+        Some(format_sequence_number(seq))
     } else {
         None
     };
@@ -346,7 +352,7 @@ pub(crate) fn process_batch_send_entry(
     queue.messages.push_back(msg);
 
     if cfg.is_fifo {
-        if let Some(dedup_id) = effective_dedup_id {
+        if let Some(dedup_id) = dedup_key {
             queue.dedup_cache.insert(
                 dedup_id,
                 crate::state::DedupEntry {
@@ -1277,6 +1283,75 @@ pub(crate) fn sha256_hex(input: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(input.as_bytes());
     format!("{:064x}", hasher.finalize())
+}
+
+/// Compute the key used to look up / store a FIFO dedup-cache entry.
+///
+/// AWS FIFO queues support two `DeduplicationScope` values:
+///  - `queue` (the default): deduplication is queue-wide — the same
+///    MessageDeduplicationId (or content hash) anywhere on the queue is a
+///    duplicate regardless of message group.
+///  - `messageGroup`: deduplication is scoped per message group — the same
+///    dedup id in two DIFFERENT groups is NOT a duplicate and both messages
+///    must be delivered.
+///
+/// The stored/echoed `MessageDeduplicationId` on the message is unchanged
+/// (callers still see the raw id); only the cache key is scoped. The group
+/// id is length-prefixed so `(group="a", dedup="b:c")` can't collide with
+/// `(group="a:b", dedup="c")`.
+pub(crate) fn dedup_cache_key(
+    queue: &SqsQueue,
+    dedup_id: &str,
+    message_group_id: Option<&str>,
+) -> String {
+    let per_group = queue
+        .attributes
+        .get("DeduplicationScope")
+        .map(String::as_str)
+        == Some("messageGroup");
+    if per_group {
+        let group = message_group_id.unwrap_or("");
+        format!("{}:{}:{}", group.len(), group, dedup_id)
+    } else {
+        dedup_id.to_string()
+    }
+}
+
+/// Base offset that projects the internal per-queue send counter onto the
+/// ~20-digit space AWS uses for FIFO `SequenceNumber` values. Real AWS
+/// returns large monotonic numbers (e.g. `18850381454051329024`), not the
+/// small consecutive integers a bare counter would produce.
+pub(crate) const SEQUENCE_NUMBER_BASE: u64 = 10_000_000_000_000_000_000;
+
+/// Render a FIFO sequence number: a fixed 20-digit base plus the queue's
+/// monotonic send counter. Strictly increasing per queue (each send bumps
+/// the counter), matching AWS's contract that SequenceNumber grows with
+/// send order while looking like a real AWS value.
+pub(crate) fn format_sequence_number(counter: u64) -> String {
+    (SEQUENCE_NUMBER_BASE + counter).to_string()
+}
+
+/// Encode a `ListQueues` pagination cursor. The token carries the last
+/// queue URL emitted on the page rather than a positional offset, so a
+/// concurrent create/delete between pages can't shift the window and cause
+/// the next page to skip or duplicate queues. Base64 keeps it opaque on the
+/// wire.
+pub(crate) fn encode_list_queues_token(marker: &str) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(marker.as_bytes())
+}
+
+/// Decode a `ListQueues` pagination cursor produced by
+/// [`encode_list_queues_token`]. Falls back to treating the token as a raw
+/// marker for forward-compat with any client that doesn't round-trip the
+/// opaque form.
+pub(crate) fn decode_list_queues_token(token: &str) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(token.as_bytes())
+        .ok()
+        .and_then(|b| String::from_utf8(b).ok())
+        .unwrap_or_else(|| token.to_string())
 }
 
 /// Find the message_id associated with a receipt handle by checking both the

--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -190,8 +190,15 @@ impl SqsService {
                 None
             };
 
+            // Cache key is scoped per message group when the queue's
+            // DeduplicationScope is `messageGroup`; queue-wide otherwise. The
+            // message's own dedup id (echoed to receivers) stays the raw value.
+            let dedup_key = effective_dedup_id
+                .as_deref()
+                .map(|d| dedup_cache_key(queue, d, message_group_id.as_deref()));
+
             if queue.is_fifo {
-                if let Some(ref dedup_id) = effective_dedup_id {
+                if let Some(ref dedup_id) = dedup_key {
                     let now = Utc::now();
                     queue.dedup_cache.retain(|_, e| e.expiry > now);
                     if let Some(entry) = queue.dedup_cache.get(dedup_id) {
@@ -257,7 +264,7 @@ impl SqsService {
             let sequence_number = if queue.is_fifo {
                 let seq = queue.next_sequence_number;
                 queue.next_sequence_number += 1;
-                Some(seq.to_string())
+                Some(format_sequence_number(seq))
             } else {
                 None
             };
@@ -300,9 +307,9 @@ impl SqsService {
             // the queue. Earlier failures (encryption, size limit) leave
             // the dedup_id un-cached so the caller's retry can succeed.
             if queue.is_fifo {
-                if let Some(ref dedup_id) = effective_dedup_id {
+                if let Some(dedup_id) = dedup_key {
                     queue.dedup_cache.insert(
-                        dedup_id.clone(),
+                        dedup_id,
                         crate::state::DedupEntry {
                             message_id: message_id.clone(),
                             sequence_number: sequence_number.clone(),

--- a/crates/fakecloud-sqs/src/service/queues.rs
+++ b/crates/fakecloud-sqs/src/service/queues.rs
@@ -249,10 +249,12 @@ impl SqsService {
             .map(|n| n.clamp(1, 1000) as usize)
             .unwrap_or(1000);
 
-        let offset = body["NextToken"]
-            .as_str()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(0);
+        // The pagination cursor carries the last queue URL emitted, not a
+        // positional offset. A positional offset shifts when a queue is
+        // created or deleted between page fetches, so the next page would
+        // skip or duplicate queues; a URL marker is stable across those
+        // mutations because the list is deterministically sorted.
+        let after_marker = body["NextToken"].as_str().map(decode_list_queues_token);
 
         let mut all_urls: Vec<String> = state
             .queues
@@ -262,17 +264,26 @@ impl SqsService {
             .collect();
         all_urls.sort();
 
-        let total = all_urls.len();
-        let page: Vec<String> = all_urls
-            .into_iter()
-            .skip(offset)
-            .take(max_results)
-            .collect();
-        let next_offset = offset + page.len();
+        // Resume just past the marker. `partition_point` finds the first URL
+        // strictly greater than the marker in O(log n).
+        let start_idx = match &after_marker {
+            Some(marker) => all_urls.partition_point(|u| u.as_str() <= marker.as_str()),
+            None => 0,
+        };
 
-        let mut result = json!({ "QueueUrls": page });
-        if next_offset < total {
-            result["NextToken"] = json!(next_offset.to_string());
+        let page: Vec<String> = all_urls
+            .iter()
+            .skip(start_idx)
+            .take(max_results)
+            .cloned()
+            .collect();
+        let has_more = start_idx + page.len() < all_urls.len();
+
+        let mut result = json!({ "QueueUrls": page.clone() });
+        if has_more {
+            if let Some(last) = page.last() {
+                result["NextToken"] = json!(encode_list_queues_token(last));
+            }
         }
 
         Ok(sqs_response(

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -2813,3 +2813,172 @@ async fn resume_message_move_tasks_drains_orphaned_running_task() {
     }
     assert!(completed, "orphaned move task should resume and complete");
 }
+
+// ── FIFO DeduplicationScope + SequenceNumber shape ──
+
+fn create_fifo_queue_with_attrs(svc: &SqsService, name: &str, attrs: Value) -> String {
+    let mut merged = serde_json::Map::new();
+    merged.insert("FifoQueue".to_string(), json!("true"));
+    if let Some(obj) = attrs.as_object() {
+        for (k, v) in obj {
+            merged.insert(k.clone(), v.clone());
+        }
+    }
+    let resp = svc
+        .create_queue(&make_request(
+            "CreateQueue",
+            json!({ "QueueName": name, "Attributes": Value::Object(merged) }),
+        ))
+        .unwrap();
+    body_json(resp)["QueueUrl"].as_str().unwrap().to_string()
+}
+
+fn send_fifo(svc: &SqsService, url: &str, body: &str, group: &str, dedup: &str) -> Value {
+    let resp = svc
+        .send_message(&make_request(
+            "SendMessage",
+            json!({
+                "QueueUrl": url,
+                "MessageBody": body,
+                "MessageGroupId": group,
+                "MessageDeduplicationId": dedup,
+            }),
+        ))
+        .unwrap();
+    body_json(resp)
+}
+
+/// DeduplicationScope=messageGroup scopes dedup per group: the SAME
+/// MessageDeduplicationId in two DIFFERENT groups is not a duplicate, so
+/// both messages must be delivered.
+#[test]
+fn fifo_dedup_scope_message_group_delivers_same_id_across_groups() {
+    let svc = make_service();
+    let url = create_fifo_queue_with_attrs(
+        &svc,
+        "scope-mg.fifo",
+        json!({ "DeduplicationScope": "messageGroup" }),
+    );
+
+    let first = send_fifo(&svc, &url, "from-g1", "g1", "shared-dedup");
+    let second = send_fifo(&svc, &url, "from-g2", "g2", "shared-dedup");
+    // Distinct groups -> distinct messages (no dedup replay).
+    assert_ne!(
+        first["MessageId"].as_str().unwrap(),
+        second["MessageId"].as_str().unwrap(),
+        "same dedup id in different groups must not be deduped under messageGroup scope"
+    );
+
+    let msgs = receive_msgs(&svc, &url, 10);
+    let bodies: std::collections::HashSet<&str> =
+        msgs.iter().filter_map(|m| m["Body"].as_str()).collect();
+    assert!(bodies.contains("from-g1"));
+    assert!(bodies.contains("from-g2"));
+    assert_eq!(bodies.len(), 2, "both group messages delivered");
+}
+
+/// Default (queue) DeduplicationScope still dedupes queue-wide: the same
+/// dedup id in different groups collapses to the first message.
+#[test]
+fn fifo_dedup_scope_queue_dedupes_across_groups() {
+    let svc = make_service();
+    // No DeduplicationScope attr -> AWS default "queue".
+    let url = create_fifo_queue_with_attrs(&svc, "scope-q.fifo", json!({}));
+
+    let first = send_fifo(&svc, &url, "from-g1", "g1", "shared-dedup");
+    let second = send_fifo(&svc, &url, "from-g2", "g2", "shared-dedup");
+    // Queue-wide dedup: the second send replays the first message id.
+    assert_eq!(
+        first["MessageId"].as_str().unwrap(),
+        second["MessageId"].as_str().unwrap(),
+        "same dedup id queue-wide replays the original message id"
+    );
+
+    let msgs = receive_msgs(&svc, &url, 10);
+    assert_eq!(msgs.len(), 1, "queue-scope dedup keeps only one message");
+    assert_eq!(msgs[0]["Body"].as_str().unwrap(), "from-g1");
+}
+
+/// FIFO SequenceNumber is a large ~20-digit value (like AWS), and strictly
+/// increases per queue with send order.
+#[test]
+fn fifo_sequence_number_is_20_digits_and_monotonic() {
+    let svc = make_service();
+    let url = create_fifo_queue_with_attrs(&svc, "seq.fifo", json!({}));
+
+    let a = send_fifo(&svc, &url, "a", "g1", "d1");
+    let b = send_fifo(&svc, &url, "b", "g1", "d2");
+
+    let seq_a = a["SequenceNumber"].as_str().unwrap();
+    let seq_b = b["SequenceNumber"].as_str().unwrap();
+
+    assert_eq!(
+        seq_a.len(),
+        20,
+        "SequenceNumber should be ~20 digits: {seq_a}"
+    );
+    assert_eq!(
+        seq_b.len(),
+        20,
+        "SequenceNumber should be ~20 digits: {seq_b}"
+    );
+    assert!(seq_a.chars().all(|c| c.is_ascii_digit()));
+    // Monotonic: parse as u128 and compare (lexical also works at equal len).
+    let na: u128 = seq_a.parse().unwrap();
+    let nb: u128 = seq_b.parse().unwrap();
+    assert!(nb > na, "SequenceNumber must increase: {na} -> {nb}");
+}
+
+/// ListQueues pagination cursor is stable across a concurrent delete
+/// between page fetches: it carries the last queue URL, not a positional
+/// offset, so the next page neither skips nor duplicates queues.
+#[test]
+fn list_queues_token_survives_interleaved_delete() {
+    let svc = make_service();
+    // Names sort as q0..q4 (URLs share a common prefix, so sort by suffix).
+    for i in 0..5 {
+        create_queue(&svc, &format!("q{i}"));
+    }
+
+    // Page 1: first two (q0, q1).
+    let resp = svc
+        .list_queues(&make_request("ListQueues", json!({ "MaxResults": 2 })))
+        .unwrap();
+    let page1 = body_json(resp);
+    let urls1: Vec<String> = page1["QueueUrls"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|u| u.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(urls1.len(), 2);
+    assert!(urls1[0].ends_with("/q0"));
+    assert!(urls1[1].ends_with("/q1"));
+    let token = page1["NextToken"].as_str().unwrap().to_string();
+
+    // Interleave: delete a queue BEFORE the marker (q0). A positional-offset
+    // token would now skip q2; the URL marker resumes correctly past q1.
+    svc.delete_queue(&make_request(
+        "DeleteQueue",
+        json!({ "QueueUrl": urls1[0].clone() }),
+    ))
+    .unwrap();
+
+    // Page 2 with the marker: must return q2, q3 (nothing skipped).
+    let resp = svc
+        .list_queues(&make_request(
+            "ListQueues",
+            json!({ "MaxResults": 2, "NextToken": token }),
+        ))
+        .unwrap();
+    let page2 = body_json(resp);
+    let urls2: Vec<String> = page2["QueueUrls"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|u| u.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(urls2.len(), 2, "no queues skipped after interleaved delete");
+    assert!(urls2[0].ends_with("/q2"), "resumed at q2, got {}", urls2[0]);
+    assert!(urls2[1].ends_with("/q3"));
+}


### PR DESCRIPTION
## Summary

Bug-hunt batch 8c: SQS + S3 correctness fixes. Touches only `crates/fakecloud-sqs` and `crates/fakecloud-s3`. No new API surface, so SDKs/docs/website are unaffected.

SQS:
- FIFO `DeduplicationScope=messageGroup` was ignored. The dedup cache was keyed by the dedup id alone, so the same `MessageDeduplicationId` (or content hash) sent to two DIFFERENT message groups was silently deduped -> cross-group message loss. The cache key is now scoped per message group when the queue's `DeduplicationScope` is `messageGroup`; the default `queue` scope keeps queue-wide dedup. Applied to both `SendMessage` and `SendMessageBatch`. The `MessageDeduplicationId` echoed to receivers is unchanged (the raw value); only the internal cache key is scoped.
- FIFO `SequenceNumber` was a small consecutive integer. AWS returns a large ~20-digit monotonic value. It is now rendered as a fixed 20-digit base offset plus the per-queue monotonic counter, so it looks like AWS while staying strictly increasing per queue. Both the single-send and batch-send paths reflect the new format.
- `ListQueues` `NextToken` was a plain decimal offset, which shifts when a queue is created or deleted between page fetches (skipping or duplicating queues). The token now carries the last queue URL emitted (base64, opaque). Pagination resumes just past the marker via `partition_point` over the sorted list, so it is stable across interleaved create/delete.

S3:
- `ListObjects` v1 emitted `NextMarker` even without a `Delimiter`. Per the S3 contract, `NextMarker` is only returned for a truncated v1 listing when a `Delimiter` is present; otherwise the client resumes from the last returned key. It is now only emitted when a delimiter was supplied and the result is truncated.

## Test plan

Added in-memory service unit tests:
- `fifo_dedup_scope_message_group_delivers_same_id_across_groups` -> same dedup id in two groups under `messageGroup` scope delivers both.
- `fifo_dedup_scope_queue_dedupes_across_groups` -> default `queue` scope still dedupes queue-wide (replays original MessageId, one message delivered).
- `fifo_sequence_number_is_20_digits_and_monotonic` -> SequenceNumber is 20 digits and strictly increases.
- `list_queues_token_survives_interleaved_delete` -> deleting a queue before the marker between pages does not skip/duplicate.
- `list_objects_v1_truncated_no_delimiter_omits_next_marker` and `list_objects_v1_truncated_with_delimiter_includes_next_marker`.

Results:
- `cargo nextest run -p fakecloud-sqs -p fakecloud-s3` -> 544 passed, 0 skipped.
- `cargo clippy -p fakecloud-sqs -p fakecloud-s3 --all-targets -- -D warnings` -> clean.
- `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SQS FIFO dedup scoping and sequence-number format, stabilizes `ListQueues` pagination, and aligns S3 `ListObjects` v1 `NextMarker` with AWS. No API changes.

- **Bug Fixes**
  - SQS: Scope FIFO dedup cache per message group when `DeduplicationScope=messageGroup`; default `queue` scope unchanged. Applies to `SendMessage` and `SendMessageBatch`.
  - SQS: Return ~20‑digit monotonic FIFO `SequenceNumber` (fixed base + per‑queue counter).
  - SQS: Make `ListQueues` `NextToken` an opaque base64 of the last queue URL; resume after marker to avoid skips/dupes across interleaved create/delete.
  - S3: `ListObjects` v1 only returns `NextMarker` when truncated and a `Delimiter` is provided; otherwise omit.

<sup>Written for commit fa07263db351dff3963acb29cb51095ef8e0d538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

