### PR TITLE
fix(wafv2,glue,athena,elasticache,acm): read-back stubs, full-replace updates, filter composition

### DIFF
--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -1307,52 +1307,149 @@ fn account_mut<'a>(state: &'a mut AcmAccounts, account_id: &str) -> &'a mut Acco
 }
 
 // Canonical EKU/KeyUsage sets carried by every fakecloud-issued cert (kept in
-// sync with certificate_search_result_json / describe output). A cert matches
-// a leaf filter when the requested values intersect its set; `ANY` is the AWS
-// wildcard sentinel.
+// sync with certificate_search_result_json / describe output). A cert matches a
+// single-valued X509AttributeFilter.ExtendedKeyUsage / KeyUsage when the
+// requested value is a member of its set.
 const CERT_EKUS: [&str; 2] = [
     "TLS_WEB_SERVER_AUTHENTICATION",
     "TLS_WEB_CLIENT_AUTHENTICATION",
 ];
 const CERT_KEY_USAGES: [&str; 2] = ["DIGITAL_SIGNATURE", "KEY_ENCIPHERMENT"];
 
-/// Read an uppercased list of string values from a leaf `Filter.<key>`.
-fn leaf_filter_values(filter: &Value, key: &str) -> Vec<String> {
-    filter
-        .get(key)
-        .and_then(Value::as_array)
-        .map(|v| {
-            v.iter()
-                .filter_map(|s| s.as_str().map(|s| s.to_ascii_uppercase()))
-                .collect()
-        })
-        .unwrap_or_default()
+/// Evaluate a `CommonNameFilter` / `DnsNameFilter` (a `{Value,
+/// ComparisonOperator}` struct where the operator is `EQUALS` or `CONTAINS`)
+/// against a candidate string.
+fn string_filter_matches(filter: &Value, value: &str) -> bool {
+    let Some(target) = filter.get("Value").and_then(Value::as_str) else {
+        return true;
+    };
+    match filter.get("ComparisonOperator").and_then(Value::as_str) {
+        Some("CONTAINS") => value.contains(target),
+        // EQUALS (the only other documented operator) and any default.
+        _ => value == target,
+    }
 }
 
-/// Evaluate a leaf `Filter` object (KeyTypes / ExtendedKeyUsages / KeyUsage)
-/// against a certificate. All present keys are AND'd; within a key a cert
-/// matches if it intersects any listed value.
+/// Certificate common name, with the `CN=` prefix stripped to match how the
+/// search result surfaces it.
+fn cert_common_name(cert: &StoredCertificate) -> &str {
+    cert.subject
+        .strip_prefix("CN=")
+        .unwrap_or(cert.subject.as_str())
+}
+
+/// Whether an epoch (or RFC3339) timestamp lands within a `TimestampRange`
+/// (`{Start, End}`, both inclusive; either bound may be omitted).
+fn ts_in_range(range: &Value, ts: chrono::DateTime<Utc>) -> bool {
+    let bound = |key: &str| -> Option<i64> {
+        range.get(key).and_then(|v| {
+            v.as_f64()
+                .map(|f| f as i64)
+                .or_else(|| {
+                    v.as_str()
+                        .and_then(|s| s.parse::<f64>().ok().map(|f| f as i64))
+                })
+                .or_else(|| {
+                    v.as_str()
+                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                        .map(|d| d.timestamp())
+                })
+        })
+    };
+    let epoch = ts.timestamp();
+    bound("Start").is_none_or(|s| epoch >= s) && bound("End").is_none_or(|e| epoch <= e)
+}
+
+/// Evaluate an `X509AttributeFilter` union (exactly one member set) against a
+/// certificate.
+fn cert_matches_x509(cert: &StoredCertificate, x: &Value) -> bool {
+    if let Some(cn) = x.get("Subject").and_then(|s| s.get("CommonName")) {
+        return string_filter_matches(cn, cert_common_name(cert));
+    }
+    if let Some(dns) = x
+        .get("SubjectAlternativeName")
+        .and_then(|s| s.get("DnsName"))
+    {
+        return cert
+            .subject_alternative_names
+            .iter()
+            .any(|san| string_filter_matches(dns, san));
+    }
+    if let Some(eku) = x.get("ExtendedKeyUsage").and_then(Value::as_str) {
+        return CERT_EKUS.contains(&eku.to_ascii_uppercase().as_str());
+    }
+    if let Some(ku) = x.get("KeyUsage").and_then(Value::as_str) {
+        return CERT_KEY_USAGES.contains(&ku.to_ascii_uppercase().as_str());
+    }
+    if let Some(alg) = x.get("KeyAlgorithm").and_then(Value::as_str) {
+        return cert.key_algorithm.eq_ignore_ascii_case(alg);
+    }
+    if let Some(serial) = x.get("SerialNumber").and_then(Value::as_str) {
+        return cert.serial == serial;
+    }
+    if let Some(range) = x.get("NotAfter") {
+        return ts_in_range(range, cert.not_after);
+    }
+    if let Some(range) = x.get("NotBefore") {
+        return ts_in_range(range, cert.not_before);
+    }
+    // No recognised member -> no constraint.
+    true
+}
+
+/// Evaluate an `AcmCertificateMetadataFilter` union against a certificate.
+fn cert_matches_metadata(cert: &StoredCertificate, md: &Value) -> bool {
+    if let Some(status) = md.get("Status").and_then(Value::as_str) {
+        return cert.status.eq_ignore_ascii_case(status);
+    }
+    if let Some(rs) = md.get("RenewalStatus").and_then(Value::as_str) {
+        return cert
+            .renewal_summary
+            .as_ref()
+            .is_some_and(|r| r.renewal_status.eq_ignore_ascii_case(rs));
+    }
+    if let Some(ty) = md.get("Type").and_then(Value::as_str) {
+        return cert.cert_type.eq_ignore_ascii_case(ty);
+    }
+    if let Some(in_use) = md.get("InUse").and_then(Value::as_bool) {
+        return cert.in_use_by.is_empty() != in_use;
+    }
+    if let Some(exported) = md.get("Exported").and_then(Value::as_bool) {
+        // fakecloud never exports certs (mirrored as Exported=false in output).
+        return !exported;
+    }
+    if let Some(opt) = md.get("ExportOption").and_then(Value::as_str) {
+        return cert.options.export.eq_ignore_ascii_case(opt);
+    }
+    if let Some(mb) = md.get("ManagedBy").and_then(Value::as_str) {
+        return cert
+            .managed_by
+            .as_deref()
+            .is_some_and(|m| m.eq_ignore_ascii_case(mb));
+    }
+    if let Some(vm) = md.get("ValidationMethod").and_then(Value::as_str) {
+        return cert
+            .validation_method
+            .as_deref()
+            .is_some_and(|m| m.eq_ignore_ascii_case(vm));
+    }
+    true
+}
+
+/// Evaluate a leaf `CertificateFilter` union (`CertificateArn` /
+/// `X509AttributeFilter` / `AcmCertificateMetadataFilter`) against a
+/// certificate, per the ACM SearchCertificates model.
 fn cert_matches_leaf(cert: &StoredCertificate, filter: &Value) -> bool {
-    let key_types = leaf_filter_values(filter, "KeyTypes");
-    if !key_types.is_empty() && !key_types.contains(&cert.key_algorithm.to_ascii_uppercase()) {
-        return false;
+    if let Some(arn) = filter.get("CertificateArn").and_then(Value::as_str) {
+        return cert.arn == arn;
     }
-    let eku = leaf_filter_values(filter, "ExtendedKeyUsages");
-    if !eku.is_empty()
-        && !eku
-            .iter()
-            .any(|f| f == "ANY" || CERT_EKUS.contains(&f.as_str()))
-    {
-        return false;
+    if let Some(x) = filter.get("X509AttributeFilter") {
+        return cert_matches_x509(cert, x);
     }
-    let key_usage = leaf_filter_values(filter, "KeyUsage");
-    if !key_usage.is_empty()
-        && !key_usage
-            .iter()
-            .any(|f| f == "ANY" || CERT_KEY_USAGES.contains(&f.as_str()))
-    {
-        return false;
+    if let Some(md) = filter.get("AcmCertificateMetadataFilter") {
+        return cert_matches_metadata(cert, md);
     }
+    // Empty/unknown leaf imposes no constraint.
     true
 }
 
@@ -2622,9 +2719,10 @@ mod tests {
 
     #[tokio::test]
     async fn search_certificates_extended_key_usage_filter() {
-        // EKU filtering was silently dropped (1.11). fakecloud certs carry
-        // the canonical TLS server/client auth EKUs, so a matching filter
-        // narrows to all certs and a non-matching one drops them all.
+        // EKU filtering uses the modeled X509AttributeFilter.ExtendedKeyUsage
+        // (a single value). fakecloud certs carry the canonical TLS
+        // server/client auth EKUs, so a matching filter keeps all certs and a
+        // non-matching one drops them all.
         let svc = AcmService::default();
         for d in ["a.example.com", "b.example.com"] {
             svc.handle(make_req("RequestCertificate", json!({ "DomainName": d })))
@@ -2640,7 +2738,11 @@ mod tests {
                 "SearchCertificates",
                 json!({
                     "FilterStatement": {
-                        "Filter": { "ExtendedKeyUsages": ["TLS_WEB_SERVER_AUTHENTICATION"] }
+                        "Filter": {
+                            "X509AttributeFilter": {
+                                "ExtendedKeyUsage": "TLS_WEB_SERVER_AUTHENTICATION"
+                            }
+                        }
                     }
                 }),
             ))
@@ -2655,7 +2757,9 @@ mod tests {
                 "SearchCertificates",
                 json!({
                     "FilterStatement": {
-                        "Filter": { "ExtendedKeyUsages": ["CODE_SIGNING"] }
+                        "Filter": {
+                            "X509AttributeFilter": { "ExtendedKeyUsage": "CODE_SIGNING" }
+                        }
                     }
                 }),
             ))
@@ -2708,37 +2812,111 @@ mod tests {
             }
         };
 
+        // Leaf uses the modeled X509AttributeFilter.KeyAlgorithm (single value).
+        let key_alg =
+            |alg: &str| json!({ "Filter": { "X509AttributeFilter": { "KeyAlgorithm": alg } } });
+
         // Not RSA -> only the EC cert.
-        let got = search(json!({ "Not": { "Filter": { "KeyTypes": ["RSA_2048"] } } })).await;
+        let got = search(json!({ "Not": key_alg("RSA_2048") })).await;
         assert_eq!(got, vec!["EC_prime256v1"]);
 
-        // Or of both key types -> both certs.
-        let mut got = search(json!({
-            "Or": [
-                { "Filter": { "KeyTypes": ["RSA_2048"] } },
-                { "Filter": { "KeyTypes": ["EC_prime256v1"] } },
-            ]
-        }))
-        .await;
+        // Or of both key algorithms -> both certs.
+        let mut got =
+            search(json!({ "Or": [key_alg("RSA_2048"), key_alg("EC_prime256v1")] })).await;
         got.sort();
         assert_eq!(got, vec!["EC_prime256v1", "RSA_2048"]);
 
-        // And of key type + matching EKU -> just the RSA cert.
+        // And of key algorithm + matching EKU -> just the RSA cert.
         let got = search(json!({
             "And": [
-                { "Filter": { "KeyTypes": ["RSA_2048"] } },
-                { "Filter": { "ExtendedKeyUsages": ["TLS_WEB_SERVER_AUTHENTICATION"] } },
+                key_alg("RSA_2048"),
+                { "Filter": { "X509AttributeFilter": { "ExtendedKeyUsage": "TLS_WEB_SERVER_AUTHENTICATION" } } },
             ]
         }))
         .await;
         assert_eq!(got, vec!["RSA_2048"]);
 
-        // And of two contradictory key types -> nothing.
-        let got = search(json!({
-            "And": [
-                { "Filter": { "KeyTypes": ["RSA_2048"] } },
-                { "Filter": { "KeyTypes": ["EC_prime256v1"] } },
-            ]
+        // And of two contradictory key algorithms -> nothing.
+        let got = search(json!({ "And": [key_alg("RSA_2048"), key_alg("EC_prime256v1")] })).await;
+        assert!(got.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_certificates_leaf_filter_shapes_apply() {
+        // Cover the real CertificateFilter union leaves: CertificateArn,
+        // X509AttributeFilter (CommonName / DnsName / SerialNumber), and
+        // AcmCertificateMetadataFilter (Status).
+        let svc = AcmService::default();
+        let resp = svc
+            .handle(make_req(
+                "RequestCertificate",
+                json!({
+                    "DomainName": "primary.example.com",
+                    "SubjectAlternativeNames": ["alt.example.org"],
+                }),
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let arn = body["CertificateArn"].as_str().unwrap().to_string();
+        svc.handle(make_req(
+            "RequestCertificate",
+            json!({ "DomainName": "other.example.com" }),
+        ))
+        .await
+        .unwrap();
+
+        let arns = |stmt: Value| {
+            let svc = &svc;
+            async move {
+                let resp = svc
+                    .handle(make_req(
+                        "SearchCertificates",
+                        json!({ "FilterStatement": stmt }),
+                    ))
+                    .await
+                    .unwrap();
+                let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+                body["Results"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|c| c["CertificateArn"].as_str().unwrap().to_string())
+                    .collect::<Vec<_>>()
+            }
+        };
+
+        // CertificateArn leaf -> exactly that cert.
+        let got = arns(json!({ "Filter": { "CertificateArn": arn } })).await;
+        assert_eq!(got.len(), 1);
+
+        // Subject.CommonName EQUALS -> the primary cert only.
+        let got = arns(json!({
+            "Filter": { "X509AttributeFilter": { "Subject": {
+                "CommonName": { "Value": "primary.example.com", "ComparisonOperator": "EQUALS" }
+            } } }
+        }))
+        .await;
+        assert_eq!(got.len(), 1);
+
+        // SubjectAlternativeName.DnsName CONTAINS -> the primary cert (its SAN).
+        let got = arns(json!({
+            "Filter": { "X509AttributeFilter": { "SubjectAlternativeName": {
+                "DnsName": { "Value": "example.org", "ComparisonOperator": "CONTAINS" }
+            } } }
+        }))
+        .await;
+        assert_eq!(got.len(), 1);
+
+        // Metadata Status filter: both start PENDING_VALIDATION, so both match;
+        // a bogus status matches none.
+        let got = arns(json!({
+            "Filter": { "AcmCertificateMetadataFilter": { "Status": "PENDING_VALIDATION" } }
+        }))
+        .await;
+        assert_eq!(got.len(), 2);
+        let got = arns(json!({
+            "Filter": { "AcmCertificateMetadataFilter": { "Status": "EXPIRED" } }
         }))
         .await;
         assert!(got.is_empty());

--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -1214,30 +1214,6 @@ impl AcmService {
                 return Err(validation_error("Invalid SortOrder"));
             }
         }
-        // Filter values live under FilterStatement.Filter.<Key>; AWS ANDs the
-        // leaf filters and, within each leaf, keeps certs that match ANY listed
-        // value. Only KeyTypes was applied before (bug-audit 2026-05-28, 1.5).
-        let filter_values = |key: &str| -> Vec<String> {
-            body.get("FilterStatement")
-                .and_then(|f| f.get("Filter"))
-                .and_then(|f| f.get(key))
-                .and_then(Value::as_array)
-                .map(|v| {
-                    v.iter()
-                        .filter_map(|s| s.as_str().map(|s| s.to_ascii_uppercase()))
-                        .collect()
-                })
-                .unwrap_or_default()
-        };
-        let key_types = filter_values("KeyTypes");
-        // ExtendedKeyUsages / KeyUsage were silently dropped before (the
-        // comment claimed pass-through but nothing applied them — bug-audit
-        // 2026-06-13, 1.11). fakecloud-issued certs carry the canonical ACM
-        // EKU/KeyUsage sets (mirrored in the response JSON below), so a cert
-        // matches a leaf filter when its set intersects the requested values.
-        let extended_key_usages = filter_values("ExtendedKeyUsages");
-        let key_usage = filter_values("KeyUsage");
-
         // CertificateStatuses is a top-level filter on the certificate status.
         let statuses: Vec<String> = body
             .get("CertificateStatuses")
@@ -1257,34 +1233,13 @@ impl AcmService {
             .unwrap_or_default();
         drop(state);
 
-        if !key_types.is_empty() {
-            all.retain(|c| key_types.contains(&c.key_algorithm.to_ascii_uppercase()));
-        }
         if !statuses.is_empty() {
             all.retain(|c| statuses.contains(&c.status.to_ascii_uppercase()));
         }
-        // Canonical EKU/KeyUsage sets carried by every fakecloud-issued
-        // cert (kept in sync with certificate_search_result_json /
-        // describe output). A cert matches when the requested filter
-        // intersects its set; `ANY` is the AWS wildcard sentinel.
-        const CERT_EKUS: [&str; 2] = [
-            "TLS_WEB_SERVER_AUTHENTICATION",
-            "TLS_WEB_CLIENT_AUTHENTICATION",
-        ];
-        const CERT_KEY_USAGES: [&str; 2] = ["DIGITAL_SIGNATURE", "KEY_ENCIPHERMENT"];
-        if !extended_key_usages.is_empty() {
-            all.retain(|_| {
-                extended_key_usages
-                    .iter()
-                    .any(|f| f == "ANY" || CERT_EKUS.contains(&f.as_str()))
-            });
-        }
-        if !key_usage.is_empty() {
-            all.retain(|_| {
-                key_usage
-                    .iter()
-                    .any(|f| f == "ANY" || CERT_KEY_USAGES.contains(&f.as_str()))
-            });
+        // FilterStatement is a recursive And/Or/Not/Filter tree; evaluate it
+        // against each cert so composed filters (not just bare leaves) apply.
+        if let Some(stmt) = body.get("FilterStatement") {
+            all.retain(|c| cert_matches_statement(c, stmt));
         }
 
         // Apply SortBy/SortOrder (validated above but previously never applied,
@@ -1349,6 +1304,82 @@ impl AcmService {
 
 fn account_mut<'a>(state: &'a mut AcmAccounts, account_id: &str) -> &'a mut AccountState {
     state.accounts.entry(account_id.to_string()).or_default()
+}
+
+// Canonical EKU/KeyUsage sets carried by every fakecloud-issued cert (kept in
+// sync with certificate_search_result_json / describe output). A cert matches
+// a leaf filter when the requested values intersect its set; `ANY` is the AWS
+// wildcard sentinel.
+const CERT_EKUS: [&str; 2] = [
+    "TLS_WEB_SERVER_AUTHENTICATION",
+    "TLS_WEB_CLIENT_AUTHENTICATION",
+];
+const CERT_KEY_USAGES: [&str; 2] = ["DIGITAL_SIGNATURE", "KEY_ENCIPHERMENT"];
+
+/// Read an uppercased list of string values from a leaf `Filter.<key>`.
+fn leaf_filter_values(filter: &Value, key: &str) -> Vec<String> {
+    filter
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|v| {
+            v.iter()
+                .filter_map(|s| s.as_str().map(|s| s.to_ascii_uppercase()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Evaluate a leaf `Filter` object (KeyTypes / ExtendedKeyUsages / KeyUsage)
+/// against a certificate. All present keys are AND'd; within a key a cert
+/// matches if it intersects any listed value.
+fn cert_matches_leaf(cert: &StoredCertificate, filter: &Value) -> bool {
+    let key_types = leaf_filter_values(filter, "KeyTypes");
+    if !key_types.is_empty() && !key_types.contains(&cert.key_algorithm.to_ascii_uppercase()) {
+        return false;
+    }
+    let eku = leaf_filter_values(filter, "ExtendedKeyUsages");
+    if !eku.is_empty()
+        && !eku
+            .iter()
+            .any(|f| f == "ANY" || CERT_EKUS.contains(&f.as_str()))
+    {
+        return false;
+    }
+    let key_usage = leaf_filter_values(filter, "KeyUsage");
+    if !key_usage.is_empty()
+        && !key_usage
+            .iter()
+            .any(|f| f == "ANY" || CERT_KEY_USAGES.contains(&f.as_str()))
+    {
+        return false;
+    }
+    true
+}
+
+/// Recursively evaluate a `FilterStatement` (And / Or / Not / Filter) against a
+/// certificate. Present composition keys are AND'd together.
+fn cert_matches_statement(cert: &StoredCertificate, stmt: &Value) -> bool {
+    if let Some(and) = stmt.get("And").and_then(Value::as_array) {
+        if !and.iter().all(|s| cert_matches_statement(cert, s)) {
+            return false;
+        }
+    }
+    if let Some(or) = stmt.get("Or").and_then(Value::as_array) {
+        if !or.is_empty() && !or.iter().any(|s| cert_matches_statement(cert, s)) {
+            return false;
+        }
+    }
+    if let Some(not) = stmt.get("Not") {
+        if cert_matches_statement(cert, not) {
+            return false;
+        }
+    }
+    if let Some(filter) = stmt.get("Filter") {
+        if !cert_matches_leaf(cert, filter) {
+            return false;
+        }
+    }
+    true
 }
 
 fn require_certificate_arn(req: &AwsRequest) -> Result<String, AwsServiceError> {
@@ -2632,5 +2663,84 @@ mod tests {
             .unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(count(&body), 0, "non-matching EKU should drop all certs");
+    }
+
+    #[tokio::test]
+    async fn search_certificates_honors_and_or_not_composition() {
+        // Two certs with distinct key algorithms let us exercise the recursive
+        // And/Or/Not FilterStatement composition (previously ignored).
+        let svc = AcmService::default();
+        svc.handle(make_req(
+            "RequestCertificate",
+            json!({ "DomainName": "rsa.example.com", "KeyAlgorithm": "RSA_2048" }),
+        ))
+        .await
+        .unwrap();
+        svc.handle(make_req(
+            "RequestCertificate",
+            json!({ "DomainName": "ec.example.com", "KeyAlgorithm": "EC_prime256v1" }),
+        ))
+        .await
+        .unwrap();
+
+        let search = |stmt: Value| {
+            let svc = &svc;
+            async move {
+                let resp = svc
+                    .handle(make_req(
+                        "SearchCertificates",
+                        json!({ "FilterStatement": stmt }),
+                    ))
+                    .await
+                    .unwrap();
+                let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+                body["Results"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|c| {
+                        c["X509Attributes"]["KeyAlgorithm"]
+                            .as_str()
+                            .unwrap()
+                            .to_string()
+                    })
+                    .collect::<Vec<_>>()
+            }
+        };
+
+        // Not RSA -> only the EC cert.
+        let got = search(json!({ "Not": { "Filter": { "KeyTypes": ["RSA_2048"] } } })).await;
+        assert_eq!(got, vec!["EC_prime256v1"]);
+
+        // Or of both key types -> both certs.
+        let mut got = search(json!({
+            "Or": [
+                { "Filter": { "KeyTypes": ["RSA_2048"] } },
+                { "Filter": { "KeyTypes": ["EC_prime256v1"] } },
+            ]
+        }))
+        .await;
+        got.sort();
+        assert_eq!(got, vec!["EC_prime256v1", "RSA_2048"]);
+
+        // And of key type + matching EKU -> just the RSA cert.
+        let got = search(json!({
+            "And": [
+                { "Filter": { "KeyTypes": ["RSA_2048"] } },
+                { "Filter": { "ExtendedKeyUsages": ["TLS_WEB_SERVER_AUTHENTICATION"] } },
+            ]
+        }))
+        .await;
+        assert_eq!(got, vec!["RSA_2048"]);
+
+        // And of two contradictory key types -> nothing.
+        let got = search(json!({
+            "And": [
+                { "Filter": { "KeyTypes": ["RSA_2048"] } },
+                { "Filter": { "KeyTypes": ["EC_prime256v1"] } },
+            ]
+        }))
+        .await;
+        assert!(got.is_empty());
     }
 }

--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -1376,10 +1376,20 @@ fn cert_matches_x509(cert: &StoredCertificate, x: &Value) -> bool {
             .any(|san| string_filter_matches(dns, san));
     }
     if let Some(eku) = x.get("ExtendedKeyUsage").and_then(Value::as_str) {
-        return CERT_EKUS.contains(&eku.to_ascii_uppercase().as_str());
+        let eku = eku.to_ascii_uppercase();
+        // The `ANY` sentinel matches any cert that has at least one EKU;
+        // otherwise the specific value must be one the cert carries.
+        return match eku.as_str() {
+            "ANY" => !CERT_EKUS.is_empty(),
+            v => CERT_EKUS.contains(&v),
+        };
     }
     if let Some(ku) = x.get("KeyUsage").and_then(Value::as_str) {
-        return CERT_KEY_USAGES.contains(&ku.to_ascii_uppercase().as_str());
+        let ku = ku.to_ascii_uppercase();
+        return match ku.as_str() {
+            "ANY" => !CERT_KEY_USAGES.is_empty(),
+            v => CERT_KEY_USAGES.contains(&v),
+        };
     }
     if let Some(alg) = x.get("KeyAlgorithm").and_then(Value::as_str) {
         return cert.key_algorithm.eq_ignore_ascii_case(alg);
@@ -2767,6 +2777,40 @@ mod tests {
             .unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(count(&body), 0, "non-matching EKU should drop all certs");
+
+        // The `ANY` sentinel matches any cert that has at least one EKU.
+        let resp = svc
+            .handle(make_req(
+                "SearchCertificates",
+                json!({
+                    "FilterStatement": {
+                        "Filter": { "X509AttributeFilter": { "ExtendedKeyUsage": "ANY" } }
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(count(&body), 2, "ANY EKU should match all certs with EKUs");
+
+        // Same `ANY` semantics for KeyUsage.
+        let resp = svc
+            .handle(make_req(
+                "SearchCertificates",
+                json!({
+                    "FilterStatement": {
+                        "Filter": { "X509AttributeFilter": { "KeyUsage": "ANY" } }
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            count(&body),
+            2,
+            "ANY KeyUsage should match all certs with key usages"
+        );
     }
 
     #[tokio::test]

--- a/crates/fakecloud-athena/src/service/mod.rs
+++ b/crates/fakecloud-athena/src/service/mod.rs
@@ -1647,6 +1647,52 @@ mod tests {
         assert_eq!(executors[0]["ExecutorType"], json!("COORDINATOR"));
         assert_eq!(executors[0]["ExecutorState"], json!("CREATED"));
     }
+
+    // ListWorkGroups' summary EngineVersion reflects the workgroup's real
+    // stored EngineVersion rather than a hardcoded "AUTO".
+    #[test]
+    fn list_work_groups_reports_real_engine_version() {
+        let svc = AthenaService::default();
+        svc.create_work_group(&req(
+            "CreateWorkGroup",
+            json!({
+                "Name": "wg3",
+                "Configuration": {
+                    "EngineVersion": {"SelectedEngineVersion": "Athena engine version 3"}
+                }
+            }),
+        ))
+        .unwrap();
+
+        let find_engine = |svc: &AthenaService, name: &str| -> String {
+            let body = parse_json(
+                &svc.list_work_groups(&req("ListWorkGroups", json!({})))
+                    .unwrap(),
+            );
+            body["WorkGroups"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|w| w["Name"] == json!(name))
+                .and_then(|w| w["EngineVersion"]["SelectedEngineVersion"].as_str())
+                .unwrap()
+                .to_string()
+        };
+        assert_eq!(find_engine(&svc, "wg3"), "Athena engine version 3");
+
+        // Updating the engine version via ConfigurationUpdates is reflected too.
+        svc.update_work_group(&req(
+            "UpdateWorkGroup",
+            json!({
+                "WorkGroup": "wg3",
+                "ConfigurationUpdates": {
+                    "EngineVersion": {"SelectedEngineVersion": "Athena engine version 2"}
+                }
+            }),
+        ))
+        .unwrap();
+        assert_eq!(find_engine(&svc, "wg3"), "Athena engine version 2");
+    }
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-athena/src/service/work_groups.rs
+++ b/crates/fakecloud-athena/src/service/work_groups.rs
@@ -14,6 +14,15 @@ impl AthenaService {
             .and_then(Value::as_str)
             .map(str::to_owned);
         let configuration = body.get("Configuration").cloned();
+        // The workgroup's EngineVersion comes from its Configuration; it must
+        // round-trip into ListWorkGroups' summary, not be hardcoded to AUTO.
+        let engine_version = configuration
+            .as_ref()
+            .and_then(|c| c.get("EngineVersion"))
+            .and_then(|ev| ev.get("SelectedEngineVersion"))
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .or_else(|| Some("AUTO".to_string()));
         let tags = parse_tags(body.get("Tags"))?;
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
@@ -26,7 +35,7 @@ impl AthenaService {
             description,
             configuration,
             creation_time: Utc::now(),
-            engine_version: Some("AUTO".to_string()),
+            engine_version,
         };
         let arn = workgroup_arn(&req.account_id, &req.region, &name);
         account.work_groups.insert(name, wg);
@@ -160,6 +169,14 @@ impl AthenaService {
                     }
                 }
                 config.insert("ResultConfiguration".to_string(), Value::Object(rc));
+            }
+            // Keep the summary's EngineVersion in sync with the merged config.
+            if let Some(sev) = config
+                .get("EngineVersion")
+                .and_then(|ev| ev.get("SelectedEngineVersion"))
+                .and_then(Value::as_str)
+            {
+                wg.engine_version = Some(sev.to_string());
             }
             wg.configuration = Some(Value::Object(config));
         }

--- a/crates/fakecloud-conformance/tests/wafv2.rs
+++ b/crates/fakecloud-conformance/tests/wafv2.rs
@@ -813,10 +813,26 @@ async fn waf_describe_managed_rule_group() {
 #[tokio::test]
 async fn waf_get_managed_rule_set() {
     let server = TestServer::start().await;
-    server
-        .wafv2_client()
+    let waf = server.wafv2_client().await;
+    // GetManagedRuleSet resolves a customer-managed rule set that was published
+    // via PutManagedRuleSetVersions; publish it first (with a version so the
+    // set carries published version detail) before reading it back.
+    waf.put_managed_rule_set_versions()
+        .name("MyManagedRuleSet")
+        .id("mrs-1")
+        .scope(Scope::Regional)
+        .lock_token("any")
+        .recommended_version("Version_1.0")
+        .versions_to_publish(
+            "Version_1.0",
+            aws_sdk_wafv2::types::VersionToPublish::builder()
+                .forecasted_lifetime(30)
+                .build(),
+        )
+        .send()
         .await
-        .get_managed_rule_set()
+        .unwrap();
+    waf.get_managed_rule_set()
         .name("MyManagedRuleSet")
         .id("mrs-1")
         .scope(Scope::Regional)

--- a/crates/fakecloud-elasticache/src/service/misc.rs
+++ b/crates/fakecloud-elasticache/src/service/misc.rs
@@ -723,13 +723,29 @@ impl ElastiCacheService {
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = "<ServiceUpdates/>";
+        let name_filter = optional_query_param(request, "ServiceUpdateName");
+        let status_filter = collect_indexed_strings(request, "ServiceUpdateStatus.member");
+        let accounts = self.state.read();
+        let empty = ElastiCacheState::new(&request.account_id, &request.region);
+        let state = accounts.get(&request.account_id).unwrap_or(&empty);
+        let members: String = state
+            .service_updates
+            .values()
+            .filter(|su| {
+                name_filter
+                    .as_ref()
+                    .is_none_or(|n| &su.service_update_name == n)
+                    && (status_filter.is_empty()
+                        || status_filter.contains(&su.service_update_status))
+            })
+            .map(render_service_update)
+            .collect();
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
                 "DescribeServiceUpdates",
                 ELASTICACHE_NS,
-                body,
+                &format!("<ServiceUpdates>{members}</ServiceUpdates>"),
                 &request.request_id,
             ),
         ))
@@ -739,13 +755,48 @@ impl ElastiCacheService {
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = "<UpdateActions/>";
+        let name_filter = optional_query_param(request, "ServiceUpdateName");
+        let cluster_filter = collect_indexed_strings(request, "CacheClusterIds.member");
+        let group_filter = collect_indexed_strings(request, "ReplicationGroupIds.member");
+        let status_filter = collect_indexed_strings(request, "UpdateActionStatus.member");
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        // Materialize the (service_update x target) actions before reading so
+        // callers see actions for their actual clusters/replication groups.
+        state.ensure_update_actions();
+        let members: String = state
+            .update_actions
+            .values()
+            .filter(|ua| {
+                let name_ok = name_filter
+                    .as_ref()
+                    .is_none_or(|n| &ua.service_update_name == n);
+                let status_ok =
+                    status_filter.is_empty() || status_filter.contains(&ua.update_action_status);
+                // CacheClusterIds and ReplicationGroupIds are OR'd; an empty
+                // pair means "all targets".
+                let target_ok = if cluster_filter.is_empty() && group_filter.is_empty() {
+                    true
+                } else {
+                    ua.cache_cluster_id
+                        .as_ref()
+                        .is_some_and(|c| cluster_filter.contains(c))
+                        || ua
+                            .replication_group_id
+                            .as_ref()
+                            .is_some_and(|g| group_filter.contains(g))
+                };
+                name_ok && status_ok && target_ok
+            })
+            .map(render_update_action)
+            .collect();
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
                 "DescribeUpdateActions",
                 ELASTICACHE_NS,
-                body,
+                &format!("<UpdateActions>{members}</UpdateActions>"),
                 &request.request_id,
             ),
         ))
@@ -755,14 +806,14 @@ impl ElastiCacheService {
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        self.batch_update_action(request, "BatchApplyUpdateAction", "stopping")
+        self.batch_update_action(request, "BatchApplyUpdateAction", "waiting-to-start")
     }
 
     pub(super) fn batch_stop_update_action(
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        self.batch_update_action(request, "BatchStopUpdateAction", "stopped")
+        self.batch_update_action(request, "BatchStopUpdateAction", "stopping")
     }
 
     pub(super) fn batch_update_action(
@@ -774,28 +825,120 @@ impl ElastiCacheService {
         let svc_update = required_query_param(request, "ServiceUpdateName")?;
         let cluster_ids = collect_indexed_strings(request, "CacheClusterIds.member");
         let group_ids = collect_indexed_strings(request, "ReplicationGroupIds.member");
-        let processed: Vec<String> = cluster_ids
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        state.ensure_update_actions();
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // (kind, id) where kind is "cc" or "rg"; processed = transitioned,
+        // unprocessed = no matching update action for that (service update, id).
+        let mut processed: Vec<(&str, String)> = Vec::new();
+        let mut unprocessed: Vec<(&str, String)> = Vec::new();
+        for (kind, id) in cluster_ids
             .iter()
-            .chain(group_ids.iter())
-            .cloned()
-            .collect();
+            .map(|c| ("cc", c))
+            .chain(group_ids.iter().map(|g| ("rg", g)))
+        {
+            let key = format!("{svc_update}#{kind}#{id}");
+            if let Some(ua) = state.update_actions.get_mut(&key) {
+                ua.update_action_status = new_status.to_string();
+                ua.update_action_status_modified_date = now.clone();
+                processed.push((kind, id.clone()));
+            } else {
+                unprocessed.push((kind, id.clone()));
+            }
+        }
+
         let processed_xml: String = processed
             .iter()
-            .map(|id| {
+            .map(|(kind, id)| {
+                let target = target_element(kind, id);
                 format!(
-                    "<member><ServiceUpdateName>{}</ServiceUpdateName><ReplicationGroupId>{}</ReplicationGroupId><UpdateActionStatus>{}</UpdateActionStatus></member>",
+                    "<member><ServiceUpdateName>{}</ServiceUpdateName>{target}<UpdateActionStatus>{}</UpdateActionStatus></member>",
                     xml_escape(&svc_update),
-                    xml_escape(id),
                     xml_escape(new_status),
                 )
             })
             .collect();
+        let unprocessed_xml: String = unprocessed
+            .iter()
+            .map(|(kind, id)| {
+                let target = target_element(kind, id);
+                format!(
+                    "<member><ServiceUpdateName>{}</ServiceUpdateName>{target}<ErrorType>UpdateActionNotFoundFault</ErrorType><ErrorMessage>No update action found for the given service update and target</ErrorMessage></member>",
+                    xml_escape(&svc_update),
+                )
+            })
+            .collect();
         let body = format!(
-            "<ProcessedUpdateActions>{processed_xml}</ProcessedUpdateActions><UnprocessedUpdateActions/>"
+            "<ProcessedUpdateActions>{processed_xml}</ProcessedUpdateActions><UnprocessedUpdateActions>{unprocessed_xml}</UnprocessedUpdateActions>"
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(action, ELASTICACHE_NS, &body, &request.request_id),
         ))
     }
+}
+
+/// Render `<ReplicationGroupId>` or `<CacheClusterId>` for a batch member.
+fn target_element(kind: &str, id: &str) -> String {
+    if kind == "rg" {
+        format!(
+            "<ReplicationGroupId>{}</ReplicationGroupId>",
+            xml_escape(id)
+        )
+    } else {
+        format!("<CacheClusterId>{}</CacheClusterId>", xml_escape(id))
+    }
+}
+
+fn render_service_update(su: &crate::state::ServiceUpdate) -> String {
+    format!(
+        "<member><ServiceUpdateName>{}</ServiceUpdateName><ServiceUpdateReleaseDate>{}</ServiceUpdateReleaseDate><ServiceUpdateEndDate>{}</ServiceUpdateEndDate><ServiceUpdateSeverity>{}</ServiceUpdateSeverity><ServiceUpdateStatus>{}</ServiceUpdateStatus><ServiceUpdateRecommendedApplyByDate>{}</ServiceUpdateRecommendedApplyByDate><ServiceUpdateType>{}</ServiceUpdateType><Engine>{}</Engine><EngineVersion>{}</EngineVersion><AutoUpdateAfterRecommendedApplyByDate>{}</AutoUpdateAfterRecommendedApplyByDate><EstimatedUpdateTime>{}</EstimatedUpdateTime><ServiceUpdateDescription>{}</ServiceUpdateDescription></member>",
+        xml_escape(&su.service_update_name),
+        xml_escape(&su.service_update_release_date),
+        xml_escape(&su.service_update_end_date),
+        xml_escape(&su.service_update_severity),
+        xml_escape(&su.service_update_status),
+        xml_escape(&su.service_update_recommended_apply_by_date),
+        xml_escape(&su.service_update_type),
+        xml_escape(&su.engine),
+        xml_escape(&su.engine_version),
+        su.auto_update_after_recommended_apply_by_date,
+        xml_escape(&su.estimated_update_time),
+        xml_escape(&su.service_update_description),
+    )
+}
+
+fn render_update_action(ua: &crate::state::UpdateAction) -> String {
+    let mut target = String::new();
+    if let Some(rg) = &ua.replication_group_id {
+        target.push_str(&format!(
+            "<ReplicationGroupId>{}</ReplicationGroupId>",
+            xml_escape(rg)
+        ));
+    }
+    if let Some(cc) = &ua.cache_cluster_id {
+        target.push_str(&format!(
+            "<CacheClusterId>{}</CacheClusterId>",
+            xml_escape(cc)
+        ));
+    }
+    format!(
+        "<member>{target}<ServiceUpdateName>{}</ServiceUpdateName><ServiceUpdateReleaseDate>{}</ServiceUpdateReleaseDate><ServiceUpdateSeverity>{}</ServiceUpdateSeverity><ServiceUpdateStatus>{}</ServiceUpdateStatus><ServiceUpdateRecommendedApplyByDate>{}</ServiceUpdateRecommendedApplyByDate><ServiceUpdateType>{}</ServiceUpdateType><UpdateActionAvailableDate>{}</UpdateActionAvailableDate><UpdateActionStatus>{}</UpdateActionStatus><NodesUpdated>{}</NodesUpdated><UpdateActionStatusModifiedDate>{}</UpdateActionStatusModifiedDate><SlaMet>{}</SlaMet><EstimatedUpdateTime>{}</EstimatedUpdateTime><Engine>{}</Engine></member>",
+        xml_escape(&ua.service_update_name),
+        xml_escape(&ua.service_update_release_date),
+        xml_escape(&ua.service_update_severity),
+        xml_escape(&ua.service_update_status),
+        xml_escape(&ua.service_update_recommended_apply_by_date),
+        xml_escape(&ua.service_update_type),
+        xml_escape(&ua.update_action_available_date),
+        xml_escape(&ua.update_action_status),
+        xml_escape(&ua.nodes_updated),
+        xml_escape(&ua.update_action_status_modified_date),
+        xml_escape(&ua.sla_met),
+        xml_escape(&ua.estimated_update_time),
+        xml_escape(&ua.engine),
+    )
 }

--- a/crates/fakecloud-elasticache/src/service/misc.rs
+++ b/crates/fakecloud-elasticache/src/service/misc.rs
@@ -758,7 +758,11 @@ impl ElastiCacheService {
         let name_filter = optional_query_param(request, "ServiceUpdateName");
         let cluster_filter = collect_indexed_strings(request, "CacheClusterIds.member");
         let group_filter = collect_indexed_strings(request, "ReplicationGroupIds.member");
-        let status_filter = collect_indexed_strings(request, "UpdateActionStatus.member");
+        let action_status_filter = collect_indexed_strings(request, "UpdateActionStatus.member");
+        // ServiceUpdateStatus filters on the *service update's* status
+        // (available/cancelled/expired); Engine filters on redis/memcached.
+        let su_status_filter = collect_indexed_strings(request, "ServiceUpdateStatus.member");
+        let engine_filter = optional_query_param(request, "Engine");
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
@@ -772,8 +776,11 @@ impl ElastiCacheService {
                 let name_ok = name_filter
                     .as_ref()
                     .is_none_or(|n| &ua.service_update_name == n);
-                let status_ok =
-                    status_filter.is_empty() || status_filter.contains(&ua.update_action_status);
+                let action_status_ok = action_status_filter.is_empty()
+                    || action_status_filter.contains(&ua.update_action_status);
+                let su_status_ok = su_status_filter.is_empty()
+                    || su_status_filter.contains(&ua.service_update_status);
+                let engine_ok = engine_filter.as_ref().is_none_or(|e| &ua.engine == e);
                 // CacheClusterIds and ReplicationGroupIds are OR'd; an empty
                 // pair means "all targets".
                 let target_ok = if cluster_filter.is_empty() && group_filter.is_empty() {
@@ -787,7 +794,7 @@ impl ElastiCacheService {
                             .as_ref()
                             .is_some_and(|g| group_filter.contains(g))
                 };
-                name_ok && status_ok && target_ok
+                name_ok && action_status_ok && su_status_ok && engine_ok && target_ok
             })
             .map(render_update_action)
             .collect();

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -4111,6 +4111,83 @@ fn batch_apply_update_action_transitions_state() {
 }
 
 #[test]
+fn describe_update_actions_filters_by_engine_and_service_update_status() {
+    let svc = fresh_service();
+    insert_test_cluster(&svc, "cc-1");
+
+    // Engine filter -> only the memcached service update's action.
+    let b = body(
+        svc.describe_update_actions(&request(
+            "DescribeUpdateActions",
+            &[("Engine", "memcached")],
+        ))
+        .unwrap(),
+    );
+    assert!(b.contains("elasticache-20240601-memcached-security"));
+    assert!(!b.contains("elasticache-20240301-redis-security"));
+
+    // ServiceUpdateStatus=available matches both seeded updates.
+    let b = body(
+        svc.describe_update_actions(&request(
+            "DescribeUpdateActions",
+            &[("ServiceUpdateStatus.member.1", "available")],
+        ))
+        .unwrap(),
+    );
+    assert!(b.contains("elasticache-20240601-memcached-security"));
+    assert!(b.contains("elasticache-20240301-redis-security"));
+
+    // A non-matching service-update status filters everything out.
+    let b = body(
+        svc.describe_update_actions(&request(
+            "DescribeUpdateActions",
+            &[("ServiceUpdateStatus.member.1", "expired")],
+        ))
+        .unwrap(),
+    );
+    assert!(!b.contains("<CacheClusterId>cc-1</CacheClusterId>"));
+}
+
+#[test]
+fn update_actions_pruned_when_target_deleted() {
+    let svc = fresh_service();
+    insert_test_cluster(&svc, "cc-1");
+
+    // Materialize the actions, then delete the target cluster from state.
+    let b = body(
+        svc.describe_update_actions(&request("DescribeUpdateActions", &[]))
+            .unwrap(),
+    );
+    assert!(b.contains("<CacheClusterId>cc-1</CacheClusterId>"));
+    {
+        let mut state = svc.state.write();
+        let account = state.get_or_create("123456789012");
+        account.cache_clusters.remove("cc-1");
+    }
+
+    // Describe now reconciles: no action for the deleted cluster remains.
+    let b = body(
+        svc.describe_update_actions(&request("DescribeUpdateActions", &[]))
+            .unwrap(),
+    );
+    assert!(!b.contains("<CacheClusterId>cc-1</CacheClusterId>"));
+
+    // BatchApply against the deleted target reports it unprocessed, not success.
+    let b = body(
+        svc.batch_apply_update_action(&request(
+            "BatchApplyUpdateAction",
+            &[
+                ("ServiceUpdateName", "elasticache-20240301-redis-security"),
+                ("CacheClusterIds.member.1", "cc-1"),
+            ],
+        ))
+        .unwrap(),
+    );
+    assert!(b.contains("<UnprocessedUpdateActions>"));
+    assert!(b.contains("UpdateActionNotFoundFault"));
+}
+
+#[test]
 fn copy_snapshot_unknown_source_errors() {
     let svc = fresh_service();
     let req = request(

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -3965,25 +3965,149 @@ fn describe_events_returns_empty() {
 }
 
 #[test]
-fn describe_service_updates_returns_empty() {
+fn describe_service_updates_returns_seeded_set() {
     let svc = fresh_service();
     let req = request("DescribeServiceUpdates", &[]);
     let resp = svc.describe_service_updates(&req).unwrap();
-    assert!(body(resp).contains("ServiceUpdates"));
+    let b = body(resp);
+    assert!(b.contains("<ServiceUpdates>"));
+    // Seeded, realistic service updates are returned (not an empty stub).
+    assert!(
+        b.contains("<ServiceUpdateName>elasticache-20240301-redis-security</ServiceUpdateName>")
+    );
+    assert!(b.contains("<ServiceUpdateStatus>available</ServiceUpdateStatus>"));
 }
 
 #[test]
-fn batch_apply_update_action_round_trip() {
+fn describe_service_updates_filters_by_name() {
     let svc = fresh_service();
+    let req = request(
+        "DescribeServiceUpdates",
+        &[(
+            "ServiceUpdateName",
+            "elasticache-20240601-memcached-security",
+        )],
+    );
+    let b = body(svc.describe_service_updates(&req).unwrap());
+    assert!(b.contains("elasticache-20240601-memcached-security"));
+    assert!(!b.contains("elasticache-20240301-redis-security"));
+}
+
+fn insert_test_cluster(svc: &ElastiCacheService, id: &str) {
+    let mut state = svc.state.write();
+    let account = state.get_or_create("123456789012");
+    account.cache_clusters.insert(
+        id.to_string(),
+        CacheCluster {
+            cache_cluster_id: id.to_string(),
+            cache_node_type: "cache.t4g.micro".to_string(),
+            engine: "redis".to_string(),
+            engine_version: "7.1".to_string(),
+            cache_cluster_status: "available".to_string(),
+            num_cache_nodes: 1,
+            preferred_availability_zone: "us-east-1a".to_string(),
+            cache_subnet_group_name: None,
+            auto_minor_version_upgrade: true,
+            arn: format!("arn:aws:elasticache:us-east-1:123456789012:cluster:{id}"),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            endpoint_address: "127.0.0.1".to_string(),
+            endpoint_port: 6379,
+            container_id: "abc123".to_string(),
+            host_port: 6379,
+            replication_group_id: None,
+            cache_parameter_group_name: None,
+            security_group_ids: Vec::new(),
+            log_delivery_configurations: Vec::new(),
+            transit_encryption_enabled: false,
+            at_rest_encryption_enabled: false,
+            auth_token_enabled: false,
+            port: 6379,
+            preferred_maintenance_window: None,
+            preferred_availability_zones: Vec::new(),
+            notification_topic_arn: None,
+            cache_security_group_names: Vec::new(),
+            snapshot_arns: Vec::new(),
+            snapshot_name: None,
+            snapshot_retention_limit: 0,
+            snapshot_window: None,
+            outpost_mode: None,
+            preferred_outpost_arn: None,
+            network_type: None,
+            ip_discovery: None,
+            az_mode: None,
+            auth_token: None,
+            kms_key_id: None,
+            transit_encryption_mode: None,
+            data_tiering_enabled: None,
+            cluster_mode: None,
+            preferred_outpost_arns: Vec::new(),
+        },
+    );
+}
+
+#[test]
+fn describe_update_actions_materializes_for_clusters() {
+    let svc = fresh_service();
+    insert_test_cluster(&svc, "cc-1");
+
+    let req = request("DescribeUpdateActions", &[]);
+    let b = body(svc.describe_update_actions(&req).unwrap());
+    // An action exists for the caller's cluster, initially not-applied.
+    assert!(b.contains("<CacheClusterId>cc-1</CacheClusterId>"));
+    assert!(b.contains("<UpdateActionStatus>not-applied</UpdateActionStatus>"));
+
+    // Filtering by an unrelated cluster id returns none.
+    let req = request(
+        "DescribeUpdateActions",
+        &[("CacheClusterIds.member.1", "other")],
+    );
+    let b = body(svc.describe_update_actions(&req).unwrap());
+    assert!(!b.contains("<CacheClusterId>cc-1</CacheClusterId>"));
+}
+
+#[test]
+fn batch_apply_update_action_transitions_state() {
+    let svc = fresh_service();
+    insert_test_cluster(&svc, "cc-1");
+    let su = "elasticache-20240301-redis-security";
+
+    // Apply the update action for the cluster.
     let req = request(
         "BatchApplyUpdateAction",
         &[
-            ("ServiceUpdateName", "svc-1"),
-            ("ReplicationGroupIds.member.1", "rg"),
+            ("ServiceUpdateName", su),
+            ("CacheClusterIds.member.1", "cc-1"),
         ],
     );
-    let resp = svc.batch_apply_update_action(&req).unwrap();
-    assert!(body(resp).contains("ProcessedUpdateActions"));
+    let b = body(svc.batch_apply_update_action(&req).unwrap());
+    assert!(b.contains("<ProcessedUpdateActions>"));
+    assert!(b.contains("<CacheClusterId>cc-1</CacheClusterId>"));
+    assert!(b.contains("<UpdateActionStatus>waiting-to-start</UpdateActionStatus>"));
+
+    // The transition persisted: DescribeUpdateActions scoped to this service
+    // update now shows the new status (the other seeded update is untouched).
+    let b = body(
+        svc.describe_update_actions(&request(
+            "DescribeUpdateActions",
+            &[("ServiceUpdateName", su)],
+        ))
+        .unwrap(),
+    );
+    assert!(b.contains("<UpdateActionStatus>waiting-to-start</UpdateActionStatus>"));
+    assert!(!b.contains("<UpdateActionStatus>not-applied</UpdateActionStatus>"));
+
+    // An unknown cluster is reported as unprocessed, not fake-success.
+    let req = request(
+        "BatchApplyUpdateAction",
+        &[
+            ("ServiceUpdateName", su),
+            ("CacheClusterIds.member.1", "ghost"),
+        ],
+    );
+    let b = body(svc.batch_apply_update_action(&req).unwrap());
+    assert!(b.contains("<UnprocessedUpdateActions>"));
+    assert!(b.contains("<CacheClusterId>ghost</CacheClusterId>"));
+    assert!(b.contains("UpdateActionNotFoundFault"));
 }
 
 #[test]

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -687,6 +687,18 @@ impl ElastiCacheState {
     pub fn ensure_update_actions(&mut self) {
         let cluster_ids: Vec<String> = self.cache_clusters.keys().cloned().collect();
         let group_ids: Vec<String> = self.replication_groups.keys().cloned().collect();
+        // Reconcile: drop actions whose target cluster/replication group (or
+        // service update) no longer exists, so deleted targets aren't treated
+        // as valid on subsequent Describe/BatchApply/BatchStop calls.
+        self.update_actions.retain(|_, ua| {
+            let su_exists = self.service_updates.contains_key(&ua.service_update_name);
+            let target_exists = match (&ua.cache_cluster_id, &ua.replication_group_id) {
+                (Some(cc), _) => cluster_ids.contains(cc),
+                (None, Some(rg)) => group_ids.contains(rg),
+                (None, None) => false,
+            };
+            su_exists && target_exists
+        });
         for su in self.service_updates.values() {
             for cc in &cluster_ids {
                 let key = format!("{}#cc#{}", su.service_update_name, cc);

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -597,6 +597,15 @@ pub struct ElastiCacheState {
     /// Active migrations keyed by replication group id.
     #[serde(default)]
     pub migrations: BTreeMap<String, Migration>,
+    /// Available service updates keyed by ServiceUpdateName, seeded with a
+    /// small realistic set and read by DescribeServiceUpdates.
+    #[serde(default)]
+    pub service_updates: BTreeMap<String, ServiceUpdate>,
+    /// Update actions keyed by "{service_update_name}#{target_kind}#{id}".
+    /// Materialized lazily from (service_updates x clusters/replication groups)
+    /// and transitioned by BatchApplyUpdateAction / BatchStopUpdateAction.
+    #[serde(default)]
+    pub update_actions: BTreeMap<String, UpdateAction>,
 }
 
 impl ElastiCacheState {
@@ -635,6 +644,8 @@ impl ElastiCacheState {
             parameter_group_parameters: BTreeMap::new(),
             events: Vec::new(),
             migrations: BTreeMap::new(),
+            service_updates: default_service_updates(),
+            update_actions: BTreeMap::new(),
         }
     }
 
@@ -665,6 +676,31 @@ impl ElastiCacheState {
         self.parameter_group_parameters.clear();
         self.events.clear();
         self.migrations.clear();
+        self.service_updates = default_service_updates();
+        self.update_actions.clear();
+    }
+
+    /// Ensure an UpdateAction exists for every (service_update, target) pair,
+    /// where targets are this account's cache clusters and replication groups.
+    /// AWS auto-creates these when a service update is released; we materialize
+    /// them lazily so DescribeUpdateActions and the batch ops share state.
+    pub fn ensure_update_actions(&mut self) {
+        let cluster_ids: Vec<String> = self.cache_clusters.keys().cloned().collect();
+        let group_ids: Vec<String> = self.replication_groups.keys().cloned().collect();
+        for su in self.service_updates.values() {
+            for cc in &cluster_ids {
+                let key = format!("{}#cc#{}", su.service_update_name, cc);
+                self.update_actions
+                    .entry(key)
+                    .or_insert_with(|| new_update_action(su, None, Some(cc.clone())));
+            }
+            for rg in &group_ids {
+                let key = format!("{}#rg#{}", su.service_update_name, rg);
+                self.update_actions
+                    .entry(key)
+                    .or_insert_with(|| new_update_action(su, Some(rg.clone()), None));
+            }
+        }
     }
 
     pub fn begin_cache_cluster_creation(&mut self, cache_cluster_id: &str) -> bool {
@@ -776,6 +812,80 @@ impl ElastiCacheState {
 
     pub fn has_arn(&self, arn: &str) -> bool {
         self.tags.contains_key(arn)
+    }
+}
+
+/// A small, realistic set of always-available service updates. AWS accounts
+/// always have some outstanding service updates; these are read by
+/// DescribeServiceUpdates and drive DescribeUpdateActions / batch ops.
+fn default_service_updates() -> BTreeMap<String, ServiceUpdate> {
+    let mut m = BTreeMap::new();
+    for (name, release, end, apply_by, severity, engine, desc) in [
+        (
+            "elasticache-20240301-redis-security",
+            "2024-03-01T00:00:00Z",
+            "2024-09-01T00:00:00Z",
+            "2024-04-01T00:00:00Z",
+            "important",
+            "redis",
+            "Security update for ElastiCache for Redis",
+        ),
+        (
+            "elasticache-20240601-memcached-security",
+            "2024-06-01T00:00:00Z",
+            "2024-12-01T00:00:00Z",
+            "2024-07-01T00:00:00Z",
+            "medium",
+            "memcached",
+            "Security update for ElastiCache for Memcached",
+        ),
+    ] {
+        m.insert(
+            name.to_string(),
+            ServiceUpdate {
+                service_update_name: name.to_string(),
+                service_update_release_date: release.to_string(),
+                service_update_end_date: end.to_string(),
+                service_update_severity: severity.to_string(),
+                service_update_status: "available".to_string(),
+                service_update_recommended_apply_by_date: apply_by.to_string(),
+                service_update_type: "security-update".to_string(),
+                engine: engine.to_string(),
+                engine_version: String::new(),
+                auto_update_after_recommended_apply_by_date: true,
+                estimated_update_time: "30 minutes".to_string(),
+                service_update_description: desc.to_string(),
+            },
+        );
+    }
+    m
+}
+
+/// Build a fresh, not-yet-applied UpdateAction for a service update against a
+/// single target (replication group or cache cluster).
+fn new_update_action(
+    su: &ServiceUpdate,
+    replication_group_id: Option<String>,
+    cache_cluster_id: Option<String>,
+) -> UpdateAction {
+    UpdateAction {
+        replication_group_id,
+        cache_cluster_id,
+        service_update_name: su.service_update_name.clone(),
+        service_update_release_date: su.service_update_release_date.clone(),
+        service_update_severity: su.service_update_severity.clone(),
+        service_update_status: su.service_update_status.clone(),
+        service_update_recommended_apply_by_date: su
+            .service_update_recommended_apply_by_date
+            .clone(),
+        service_update_type: su.service_update_type.clone(),
+        update_action_available_date: su.service_update_release_date.clone(),
+        update_action_status: "not-applied".to_string(),
+        nodes_updated: "0/0".to_string(),
+        update_action_status_modified_date: su.service_update_release_date.clone(),
+        sla_met: "n/a".to_string(),
+        estimated_update_time: su.estimated_update_time.clone(),
+        engine: su.engine.clone(),
     }
 }
 

--- a/crates/fakecloud-glue/src/service.rs
+++ b/crates/fakecloud-glue/src/service.rs
@@ -1211,6 +1211,17 @@ impl GlueService {
         if input["PartitionKeys"].is_array() {
             t.partition_keys = parse_columns(&input["PartitionKeys"]);
         }
+        // CreateTable persists these and GetTable reads them, but UpdateTable
+        // used to drop them silently (half fix) — apply them here too.
+        if let Some(v) = input["ViewOriginalText"].as_str() {
+            t.view_original_text = Some(v.to_string());
+        }
+        if let Some(v) = input["ViewExpandedText"].as_str() {
+            t.view_expanded_text = Some(v.to_string());
+        }
+        if let Some(r) = input["Retention"].as_i64() {
+            t.retention = r;
+        }
         Ok(AwsResponse::ok_json(json!({})))
     }
 

--- a/crates/fakecloud-glue/src/tests.rs
+++ b/crates/fakecloud-glue/src/tests.rs
@@ -463,3 +463,51 @@ fn constraint_validation_rejects_bad_input() {
     );
     assert!(ok.is_ok());
 }
+
+#[test]
+fn update_table_applies_view_text_and_retention() {
+    let svc = GlueService::default();
+    svc.create_database(&req(
+        "CreateDatabase",
+        json!({"DatabaseInput": {"Name": "db"}}),
+    ))
+    .unwrap();
+    svc.create_table(&req(
+        "CreateTable",
+        json!({
+            "DatabaseName": "db",
+            "TableInput": {
+                "Name": "v",
+                "TableType": "VIRTUAL_VIEW",
+                "ViewOriginalText": "SELECT 1",
+                "ViewExpandedText": "SELECT 1 FROM db.t",
+                "Retention": 5,
+            }
+        }),
+    ))
+    .unwrap();
+
+    // Update the view text and retention.
+    svc.update_table(&req(
+        "UpdateTable",
+        json!({
+            "DatabaseName": "db",
+            "TableInput": {
+                "Name": "v",
+                "TableType": "VIRTUAL_VIEW",
+                "ViewOriginalText": "SELECT 2",
+                "ViewExpandedText": "SELECT 2 FROM db.t",
+                "Retention": 9,
+            }
+        }),
+    ))
+    .unwrap();
+
+    let got = body_of(
+        svc.get_table(&req("GetTable", json!({"DatabaseName": "db", "Name": "v"})))
+            .unwrap(),
+    );
+    assert_eq!(got["Table"]["ViewOriginalText"], "SELECT 2");
+    assert_eq!(got["Table"]["ViewExpandedText"], "SELECT 2 FROM db.t");
+    assert_eq!(got["Table"]["Retention"], 9);
+}

--- a/crates/fakecloud-wafv2/src/service/mod.rs
+++ b/crates/fakecloud-wafv2/src/service/mod.rs
@@ -1315,4 +1315,102 @@ mod managed_rule_set_validation_tests {
         // TokenDomains cleared -> no ApplicationIntegrationURL surfaced.
         assert!(body.get("ApplicationIntegrationURL").is_none());
     }
+
+    // A snapshot written before published_version_details existed carries only
+    // the version names; GetManagedRuleSet must still surface those versions.
+    #[test]
+    fn get_managed_rule_set_synthesizes_detail_for_legacy_versions() {
+        let svc = Wafv2Service::default();
+        {
+            let mut state = svc.state.write();
+            let account = account_mut(&mut state, "123456789012");
+            account.managed_rule_sets.insert(
+                ("REGIONAL".to_string(), "Legacy".to_string()),
+                crate::state::ManagedRuleSet {
+                    id: "legacy-id".to_string(),
+                    name: "Legacy".to_string(),
+                    scope: "REGIONAL".to_string(),
+                    description: None,
+                    lock_token: "tok".to_string(),
+                    label_namespace: "awswaf:managed:Legacy".to_string(),
+                    recommended_version: Some("Version_1.0".to_string()),
+                    published_versions: vec!["Version_1.0".to_string()],
+                    // Legacy snapshot: names present, no per-version detail.
+                    published_version_details: std::collections::BTreeMap::new(),
+                    created_time: Utc::now(),
+                },
+            );
+        }
+        let resp = svc
+            .get_managed_rule_set(&req_json(
+                "GetManagedRuleSet",
+                json!({"Name": "Legacy", "Id": "legacy-id", "Scope": "REGIONAL"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let pv = &body["ManagedRuleSet"]["PublishedVersions"];
+        assert!(
+            pv.get("Version_1.0").is_some(),
+            "legacy published version must not be dropped, got {pv:?}"
+        );
+    }
+
+    // Republishing an existing version keeps its original PublishTimestamp and
+    // only advances LastUpdateTimestamp.
+    #[test]
+    fn republish_preserves_publish_timestamp() {
+        let svc = Wafv2Service::default();
+        svc.put_managed_rule_set_versions(&req_json(
+            "PutManagedRuleSetVersions",
+            json!({
+                "Name": "Rs", "Id": "id1", "Scope": "REGIONAL", "LockToken": "t",
+                "VersionsToPublish": {"Version_1.0": {"ForecastedLifetime": 30}},
+            }),
+        ))
+        .unwrap();
+        // Force a distinct, old PublishTimestamp on the stored detail.
+        {
+            let mut state = svc.state.write();
+            let account = account_mut(&mut state, "123456789012");
+            let set = account
+                .managed_rule_sets
+                .get_mut(&("REGIONAL".to_string(), "Rs".to_string()))
+                .unwrap();
+            let detail = set
+                .published_version_details
+                .get_mut("Version_1.0")
+                .unwrap()
+                .as_object_mut()
+                .unwrap();
+            detail.insert("PublishTimestamp".to_string(), json!(1000.0));
+            detail.insert("LastUpdateTimestamp".to_string(), json!(1000.0));
+        }
+        // Republish the same version.
+        svc.put_managed_rule_set_versions(&req_json(
+            "PutManagedRuleSetVersions",
+            json!({
+                "Name": "Rs", "Id": "id1", "Scope": "REGIONAL", "LockToken": "t",
+                "VersionsToPublish": {"Version_1.0": {"ForecastedLifetime": 60}},
+            }),
+        ))
+        .unwrap();
+        let resp = svc
+            .get_managed_rule_set(&req_json(
+                "GetManagedRuleSet",
+                json!({"Name": "Rs", "Id": "id1", "Scope": "REGIONAL"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let pv = &body["ManagedRuleSet"]["PublishedVersions"]["Version_1.0"];
+        assert_eq!(
+            pv["PublishTimestamp"].as_f64(),
+            Some(1000.0),
+            "PublishTimestamp must be preserved on republish"
+        );
+        assert_ne!(
+            pv["LastUpdateTimestamp"].as_f64(),
+            Some(1000.0),
+            "LastUpdateTimestamp must be refreshed on republish"
+        );
+    }
 }

--- a/crates/fakecloud-wafv2/src/service/mod.rs
+++ b/crates/fakecloud-wafv2/src/service/mod.rs
@@ -1188,4 +1188,131 @@ mod managed_rule_set_validation_tests {
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["ManagedRuleSets"].as_array().unwrap().len(), 0);
     }
+
+    // GetManagedRuleSet reads the set published via PutManagedRuleSetVersions
+    // rather than fabricating a 200 for a never-published set.
+    #[test]
+    fn get_managed_rule_set_reads_state() {
+        let svc = Wafv2Service::default();
+
+        // Unknown (scope, name) -> WAFNonexistentItemException.
+        let res = svc.get_managed_rule_set(&req_json(
+            "GetManagedRuleSet",
+            json!({"Name": "Nope", "Id": "abc123", "Scope": "REGIONAL"}),
+        ));
+        assert!(res.is_err());
+        assert_eq!(res.err().unwrap().code(), "WAFNonexistentItemException");
+
+        // Publish a set.
+        svc.put_managed_rule_set_versions(&req_json(
+            "PutManagedRuleSetVersions",
+            json!({
+                "Name": "MyRuleSet",
+                "Id": "abc123",
+                "Scope": "REGIONAL",
+                "LockToken": "tok",
+                "RecommendedVersion": "Version_1.0",
+                "VersionsToPublish": {
+                    "Version_1.0": {"ForecastedLifetime": 30, "AssociatedRuleGroupArn": "arn:aws:wafv2:us-east-1:123456789012:regional/rulegroup/rg/1"},
+                },
+            }),
+        ))
+        .unwrap();
+
+        // Mismatched Id -> still nonexistent.
+        let res = svc.get_managed_rule_set(&req_json(
+            "GetManagedRuleSet",
+            json!({"Name": "MyRuleSet", "Id": "wrong", "Scope": "REGIONAL"}),
+        ));
+        assert!(res.is_err());
+        assert_eq!(res.err().unwrap().code(), "WAFNonexistentItemException");
+
+        // Correct lookup returns the stored set and its published versions.
+        let resp = svc
+            .get_managed_rule_set(&req_json(
+                "GetManagedRuleSet",
+                json!({"Name": "MyRuleSet", "Id": "abc123", "Scope": "REGIONAL"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let set = &body["ManagedRuleSet"];
+        assert_eq!(set["Name"].as_str(), Some("MyRuleSet"));
+        assert_eq!(set["Id"].as_str(), Some("abc123"));
+        assert_eq!(set["RecommendedVersion"].as_str(), Some("Version_1.0"));
+        let pv = &set["PublishedVersions"]["Version_1.0"];
+        assert_eq!(pv["ForecastedLifetime"].as_i64(), Some(30));
+        assert_eq!(
+            pv["AssociatedRuleGroupArn"].as_str(),
+            Some("arn:aws:wafv2:us-east-1:123456789012:regional/rulegroup/rg/1")
+        );
+    }
+
+    // UpdateWebACL is full-replace: an optional member omitted from the update
+    // request is cleared, not carried over from the previous version.
+    #[test]
+    fn update_web_acl_clears_omitted_optional_members() {
+        let svc = Wafv2Service::default();
+        let create = svc
+            .create_web_acl(&req_json(
+                "CreateWebACL",
+                json!({
+                    "Name": "acl1",
+                    "Scope": "REGIONAL",
+                    "DefaultAction": {"Allow": {}},
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": true,
+                        "CloudWatchMetricsEnabled": true,
+                        "MetricName": "acl1",
+                    },
+                    "CustomResponseBodies": {
+                        "body1": {"ContentType": "TEXT_PLAIN", "Content": "hi"},
+                    },
+                    "TokenDomains": ["example.com"],
+                }),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(create.body.expect_bytes()).unwrap();
+        let id = body["Summary"]["Id"].as_str().unwrap().to_string();
+        let lock = body["Summary"]["LockToken"].as_str().unwrap().to_string();
+
+        // Update without CustomResponseBodies / TokenDomains -> both cleared.
+        svc.update_web_acl(&req_json(
+            "UpdateWebACL",
+            json!({
+                "Name": "acl1",
+                "Scope": "REGIONAL",
+                "Id": id,
+                "LockToken": lock,
+                "DefaultAction": {"Allow": {}},
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": true,
+                    "CloudWatchMetricsEnabled": true,
+                    "MetricName": "acl1",
+                },
+            }),
+        ))
+        .unwrap();
+
+        let resp = svc
+            .get_web_acl(&req_json(
+                "GetWebACL",
+                json!({"Name": "acl1", "Scope": "REGIONAL"}),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let acl = &body["WebACL"];
+        // CustomResponseBodies is now empty (either absent or {}).
+        let crb = acl.get("CustomResponseBodies");
+        assert!(
+            crb.is_none()
+                || crb
+                    .unwrap()
+                    .as_object()
+                    .map(|m| m.is_empty())
+                    .unwrap_or(true),
+            "CustomResponseBodies should be cleared, got {crb:?}"
+        );
+        // TokenDomains cleared -> no ApplicationIntegrationURL surfaced.
+        assert!(body.get("ApplicationIntegrationURL").is_none());
+    }
 }

--- a/crates/fakecloud-wafv2/src/service/rule_groups.rs
+++ b/crates/fakecloud-wafv2/src/service/rule_groups.rs
@@ -334,11 +334,23 @@ impl Wafv2Service {
             .filter(|s| s.id == id)
             .ok_or_else(|| not_found("ManagedRuleSet"))?;
 
-        let published: serde_json::Map<String, Value> = set
-            .published_version_details
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+        // Build PublishedVersions from the authoritative version-name list,
+        // using the per-version detail when present. Snapshots written before
+        // published_version_details existed only carry the names, so synthesize
+        // a minimal detail for those rather than dropping the version.
+        let mut published = serde_json::Map::new();
+        for v in &set.published_versions {
+            let detail = set
+                .published_version_details
+                .get(v)
+                .cloned()
+                .unwrap_or_else(|| json!({ "Capacity": 50 }));
+            published.insert(v.clone(), detail);
+        }
+        // Include any detail-only entries (defensive) not in the name list.
+        for (v, d) in &set.published_version_details {
+            published.entry(v.clone()).or_insert_with(|| d.clone());
+        }
         let mut managed = serde_json::Map::new();
         managed.insert("Name".to_string(), json!(set.name));
         managed.insert("Id".to_string(), json!(set.id));
@@ -542,7 +554,15 @@ impl Wafv2Service {
                 "Capacity".to_string(),
                 json!(cfg.get("Capacity").and_then(Value::as_i64).unwrap_or(50)),
             );
-            detail.insert("PublishTimestamp".to_string(), json!(now_ts));
+            // Preserve the original PublishTimestamp when republishing an
+            // existing version; only LastUpdateTimestamp advances.
+            let publish_ts = entry
+                .published_version_details
+                .get(vname)
+                .and_then(|d| d.get("PublishTimestamp"))
+                .and_then(Value::as_f64)
+                .unwrap_or(now_ts);
+            detail.insert("PublishTimestamp".to_string(), json!(publish_ts));
             detail.insert("LastUpdateTimestamp".to_string(), json!(now_ts));
             entry
                 .published_version_details

--- a/crates/fakecloud-wafv2/src/service/rule_groups.rs
+++ b/crates/fakecloud-wafv2/src/service/rule_groups.rs
@@ -213,9 +213,8 @@ impl Wafv2Service {
         rg.visibility_config = visibility_config;
         rg.rules = rules;
         rg.description = description;
-        if let Some(b) = body.get("CustomResponseBodies") {
-            rg.custom_response_bodies = parse_custom_response_bodies(Some(b));
-        }
+        // Update is full-replace: an omitted CustomResponseBodies clears it.
+        rg.custom_response_bodies = parse_custom_response_bodies(body.get("CustomResponseBodies"));
         rg.lock_token = synth_uuid();
         Ok(AwsResponse::ok_json(
             json!({ "NextLockToken": rg.lock_token }),
@@ -323,27 +322,47 @@ impl Wafv2Service {
         let body = req.json_body();
         let name = require_str_len(&body, "Name", 1, 128)?;
         let id = require_str_len(&body, "Id", 1, 36)?;
-        let _scope = require_scope(&body)?;
+        let scope = require_scope(&body)?;
+        // GetManagedRuleSet reads a set previously published via
+        // PutManagedRuleSetVersions. AWS returns WAFNonexistentItemException
+        // for an unknown (scope, name) or a mismatched Id.
+        let state = self.state.read();
+        let set = state
+            .accounts
+            .get(&req.account_id)
+            .and_then(|a| a.managed_rule_sets.get(&(scope, name.clone())))
+            .filter(|s| s.id == id)
+            .ok_or_else(|| not_found("ManagedRuleSet"))?;
+
+        let published: serde_json::Map<String, Value> = set
+            .published_version_details
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let mut managed = serde_json::Map::new();
+        managed.insert("Name".to_string(), json!(set.name));
+        managed.insert("Id".to_string(), json!(set.id));
+        managed.insert(
+            "ARN".to_string(),
+            json!(Arn::new(
+                "wafv2",
+                &req.region,
+                &req.account_id,
+                &format!("managedruleset/{}/{}", set.name, set.id)
+            )
+            .to_string()),
+        );
+        if let Some(d) = &set.description {
+            managed.insert("Description".to_string(), json!(d));
+        }
+        managed.insert("PublishedVersions".to_string(), Value::Object(published));
+        if let Some(rv) = &set.recommended_version {
+            managed.insert("RecommendedVersion".to_string(), json!(rv));
+        }
+        managed.insert("LabelNamespace".to_string(), json!(set.label_namespace));
         Ok(AwsResponse::ok_json(json!({
-            "ManagedRuleSet": {
-                "Name": name,
-                "Id": id,
-                "ARN": Arn::new("wafv2", &req.region, &req.account_id, &format!("managedruleset/{name}/{id}")).to_string(),
-                "Description": format!("Managed rule set {name}"),
-                "PublishedVersions": {
-                    "Version_1.0": {
-                        "AssociatedRuleGroupArn": Arn::new("wafv2", &req.region, "aws", &format!("managedrulegroup/{name}")).to_string(),
-                        "Capacity": 50,
-                        "ForecastedLifetime": 90,
-                        "PublishTimestamp": Utc::now().timestamp() as f64,
-                        "LastUpdateTimestamp": Utc::now().timestamp() as f64,
-                        "ExpiryTimestamp": (Utc::now() + chrono::Duration::days(365)).timestamp() as f64,
-                    }
-                },
-                "RecommendedVersion": "Version_1.0",
-                "LabelNamespace": format!("awswaf:managed::{name}:"),
-            },
-            "LockToken": synth_uuid(),
+            "ManagedRuleSet": Value::Object(managed),
+            "LockToken": set.lock_token,
         })))
     }
 
@@ -477,14 +496,15 @@ impl Wafv2Service {
             None => None,
         };
 
-        // Collect the version names being published (VersionsToPublish is a
-        // map of version-name -> {AssociatedRuleGroupArn, ForecastedLifetime}).
-        let mut published: Vec<String> = body
+        // VersionsToPublish is a map of version-name ->
+        // {AssociatedRuleGroupArn, ForecastedLifetime}. Persist both the
+        // version names and their detail so GetManagedRuleSet can read the
+        // full PublishedVersions back.
+        let versions_to_publish = body
             .get("VersionsToPublish")
             .and_then(Value::as_object)
-            .map(|m| m.keys().cloned().collect())
+            .cloned()
             .unwrap_or_default();
-        published.sort();
 
         let next_lock_token = synth_uuid();
         let mut state = self.state.write();
@@ -503,13 +523,32 @@ impl Wafv2Service {
                     label_namespace: format!("awswaf:managed:{name}"),
                     recommended_version: None,
                     published_versions: Vec::new(),
+                    published_version_details: std::collections::BTreeMap::new(),
                     created_time: Utc::now(),
                 });
-        for v in published {
-            if !entry.published_versions.contains(&v) {
-                entry.published_versions.push(v);
+        let now_ts = Utc::now().timestamp() as f64;
+        for (vname, cfg) in &versions_to_publish {
+            if !entry.published_versions.contains(vname) {
+                entry.published_versions.push(vname.clone());
             }
+            let mut detail = serde_json::Map::new();
+            if let Some(arn) = cfg.get("AssociatedRuleGroupArn") {
+                detail.insert("AssociatedRuleGroupArn".to_string(), arn.clone());
+            }
+            if let Some(fl) = cfg.get("ForecastedLifetime") {
+                detail.insert("ForecastedLifetime".to_string(), fl.clone());
+            }
+            detail.insert(
+                "Capacity".to_string(),
+                json!(cfg.get("Capacity").and_then(Value::as_i64).unwrap_or(50)),
+            );
+            detail.insert("PublishTimestamp".to_string(), json!(now_ts));
+            detail.insert("LastUpdateTimestamp".to_string(), json!(now_ts));
+            entry
+                .published_version_details
+                .insert(vname.clone(), Value::Object(detail));
         }
+        entry.published_versions.sort();
         if recommended_version.is_some() {
             entry.recommended_version = recommended_version;
         }

--- a/crates/fakecloud-wafv2/src/service/web_acls.rs
+++ b/crates/fakecloud-wafv2/src/service/web_acls.rs
@@ -209,31 +209,16 @@ impl Wafv2Service {
         acl.capacity = compute_capacity(&rules);
         acl.rules = rules;
         acl.description = description;
-        if let Some(b) = body.get("CustomResponseBodies") {
-            acl.custom_response_bodies = parse_custom_response_bodies(Some(b));
-        }
-        if body.get("CaptchaConfig").is_some() {
-            acl.captcha_config = body.get("CaptchaConfig").cloned();
-        }
-        if body.get("ChallengeConfig").is_some() {
-            acl.challenge_config = body.get("ChallengeConfig").cloned();
-        }
-        if let Some(td) = body.get("TokenDomains") {
-            acl.token_domains = parse_string_list(Some(td));
-        }
-        if body.get("AssociationConfig").is_some() {
-            acl.association_config = body.get("AssociationConfig").cloned();
-        }
-        if body.get("DataProtectionConfig").is_some() {
-            acl.data_protection_config = body.get("DataProtectionConfig").cloned();
-        }
-        if body.get("OnSourceDDoSProtectionConfig").is_some() {
-            acl.on_source_d_do_s_protection_config =
-                body.get("OnSourceDDoSProtectionConfig").cloned();
-        }
-        if body.get("ApplicationConfig").is_some() {
-            acl.application_config = body.get("ApplicationConfig").cloned();
-        }
+        // AWS Update ops are full-replace: every optional member omitted from
+        // the request is cleared (not left at its previous value).
+        acl.custom_response_bodies = parse_custom_response_bodies(body.get("CustomResponseBodies"));
+        acl.captcha_config = body.get("CaptchaConfig").cloned();
+        acl.challenge_config = body.get("ChallengeConfig").cloned();
+        acl.token_domains = parse_string_list(body.get("TokenDomains"));
+        acl.association_config = body.get("AssociationConfig").cloned();
+        acl.data_protection_config = body.get("DataProtectionConfig").cloned();
+        acl.on_source_d_do_s_protection_config = body.get("OnSourceDDoSProtectionConfig").cloned();
+        acl.application_config = body.get("ApplicationConfig").cloned();
         acl.lock_token = synth_uuid();
         Ok(AwsResponse::ok_json(
             json!({ "NextLockToken": acl.lock_token }),

--- a/crates/fakecloud-wafv2/src/state.rs
+++ b/crates/fakecloud-wafv2/src/state.rs
@@ -106,6 +106,11 @@ pub struct ManagedRuleSet {
     pub recommended_version: Option<String>,
     /// Published version names (e.g. "Version_1.0").
     pub published_versions: Vec<String>,
+    /// Per-version detail (AssociatedRuleGroupArn / Capacity / lifetime /
+    /// timestamps) keyed by version name, as published via
+    /// PutManagedRuleSetVersions and read back by GetManagedRuleSet.
+    #[serde(default)]
+    pub published_version_details: BTreeMap<String, Value>,
     pub created_time: DateTime<Utc>,
 }
 


### PR DESCRIPTION
## Summary

Batch 8b of the behavioral bug-hunt. Replaces hardcoded/stub responses with real state read-back, fixes full-replace update semantics, and implements filter composition. All changes are behavior fixes with no new API surface, so SDKs/docs are unaffected.

**wafv2**
- `GetManagedRuleSet` was fully hardcoded (always fabricated a 200 for a never-published set). It now reads from `state.managed_rule_sets`, returns `WAFNonexistentItemException` for an unknown `(scope, name)` or a mismatched `Id`, and returns the real stored set otherwise. `PutManagedRuleSetVersions` now persists per-version detail (AssociatedRuleGroupArn / Capacity / ForecastedLifetime / timestamps) so the read-back is faithful.
- `UpdateWebACL` now follows full-replace for ALL optional members (CustomResponseBodies, CaptchaConfig, ChallengeConfig, TokenDomains, AssociationConfig, DataProtectionConfig, OnSourceDDoSProtectionConfig, ApplicationConfig) -> an omitted member is cleared, matching AWS.
- `UpdateRuleGroup` now full-replaces `CustomResponseBodies` (cleared on omission).

**glue**
- `UpdateTable` now applies `ViewOriginalText`, `ViewExpandedText`, and `Retention` (CreateTable persisted them and GetTable read them, but UpdateTable dropped them).

**athena**
- `ListWorkGroups` summary now emits the workgroup's real stored `EngineVersion` (derived from its Configuration at create, kept in sync on ConfigurationUpdates) instead of a hardcoded "AUTO".

**elasticache**
- `DescribeServiceUpdates` returns a seeded, realistic set of service updates (filterable by name/status) instead of an empty stub.
- `DescribeUpdateActions` lazily materializes update actions for the caller's cache clusters and replication groups and returns them (filterable by name/target/status).
- `BatchApplyUpdateAction` / `BatchStopUpdateAction` now actually transition the named update actions in state and report processed vs unprocessed lists (unknown targets are reported as unprocessed with an error, not fake-success).

**acm**
- `SearchCertificates` now honors the recursive `And` / `Or` / `Not` `FilterStatement` composition over the existing leaf filters, not just bare leaf filters.

## Test plan

New/updated in-memory service unit tests, all green:
- wafv2: `get_managed_rule_set_reads_state` (unknown + mismatched Id -> WAFNonexistentItemException; correct lookup returns published versions), `update_web_acl_clears_omitted_optional_members`.
- glue: `update_table_applies_view_text_and_retention`.
- athena: `list_work_groups_reports_real_engine_version` (create + ConfigurationUpdates).
- elasticache: `describe_service_updates_returns_seeded_set`, `describe_service_updates_filters_by_name`, `describe_update_actions_materializes_for_clusters`, `batch_apply_update_action_transitions_state` (persisted transition + unprocessed unknown target).
- acm: `search_certificates_honors_and_or_not_composition` (Not / Or / And / contradictory And).

- `cargo nextest run` for all five crates: 357 passed, 0 failed.
- `cargo fmt` applied.
- `cargo clippy -p fakecloud-wafv2 -p fakecloud-glue -p fakecloud-athena -p fakecloud-elasticache -p fakecloud-acm --all-targets -- -D warnings`: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes read-back behavior, full-replace update semantics, and filter composition across `wafv2`, `glue`, `athena`, `elasticache`, and `acm` to better match AWS. No API changes; responses now reflect real stored state.

- **Bug Fixes**
  - `wafv2`: `GetManagedRuleSet` reads from state and returns `WAFNonexistentItemException` for unknown/mismatched Id; builds `PublishedVersions` from stored names and synthesizes detail for legacy snapshots; `PutManagedRuleSetVersions` stores per‑version detail and preserves the original `PublishTimestamp` on republish; `UpdateWebACL` and `UpdateRuleGroup` are full‑replace (omitted optionals are cleared).
  - `glue`: `UpdateTable` now applies `ViewOriginalText`, `ViewExpandedText`, and `Retention`.
  - `athena`: `ListWorkGroups` returns the stored `EngineVersion` and reflects `ConfigurationUpdates`.
  - `elasticache`: `DescribeServiceUpdates` returns seeded, realistic updates and supports name/status filters; `DescribeUpdateActions` materializes actions for existing clusters/replication groups and supports name/target/status plus `ServiceUpdateStatus` and `Engine`; state reconciles/prunes actions for deleted targets; batch apply/stop transition action status and report processed vs. unprocessed targets.
  - `acm`: `SearchCertificates` evaluates recursive `And`/`Or`/`Not` over the modeled `CertificateFilter` union (`CertificateArn`, `X509AttributeFilter`, `AcmCertificateMetadataFilter), covering CN/SAN (EQUALS/CONTAINS), EKU/KeyUsage (supports `ANY`), KeyAlgorithm, SerialNumber, NotBefore/NotAfter ranges, and metadata; applies `SortBy`/`SortOrder`.

<sup>Written for commit c7dda1beb15c5ca31e1753f59dc218bf472f120e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

