### PR TITLE
fix(cloudwatch): awsJson1_0 protocol support + persist alarm Metrics/Tags + anomaly Configuration

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudwatch.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudwatch.rs
@@ -131,6 +131,7 @@ impl ResourceProvisioner {
                 .map(String::from),
             configuration_updated_timestamp: now,
             alarm_configuration_updated_timestamp: now,
+            metrics: Vec::new(),
         };
         let region_alarms = state.alarms_in_mut(&self.region);
         if region_alarms.contains_key(&alarm_name) {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudwatch.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudwatch.rs
@@ -379,6 +379,10 @@ impl ResourceProvisioner {
         alarm.comparison_operator = comparison_operator;
         alarm.treat_missing_data = treat_missing_data;
         alarm.evaluate_low_sample_count_percentile = evaluate_low_sample_count_percentile;
+        alarm.threshold_metric_id = props
+            .get("ThresholdMetricId")
+            .and_then(|v| v.as_str())
+            .map(String::from);
         alarm.metrics = parse_cfn_alarm_metrics(props);
         alarm.configuration_updated_timestamp = now;
         alarm.alarm_configuration_updated_timestamp = now;

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudwatch.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudwatch.rs
@@ -5,6 +5,66 @@
 
 use super::*;
 
+/// Parse the `Metrics` property of an `AWS::CloudWatch::Alarm` template into the
+/// persisted [`AlarmMetricQuery`] form (metric-math / cross-account alarms).
+/// Returns an empty vec when the property is absent.
+fn parse_cfn_alarm_metrics(props: &serde_json::Value) -> Vec<AlarmMetricQuery> {
+    let Some(arr) = props.get("Metrics").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|m| {
+            let id = m.get("Id").and_then(|v| v.as_str())?.to_string();
+            let metric_stat = m.get("MetricStat").and_then(|v| v.as_object()).map(|ms| {
+                let metric = ms.get("Metric").and_then(|v| v.as_object());
+                let mut dimensions: BTreeMap<String, String> = BTreeMap::new();
+                if let Some(dims) = metric
+                    .and_then(|mo| mo.get("Dimensions"))
+                    .and_then(|v| v.as_array())
+                {
+                    for d in dims {
+                        if let (Some(k), Some(v)) = (
+                            d.get("Name").and_then(|x| x.as_str()),
+                            d.get("Value").and_then(|x| x.as_str()),
+                        ) {
+                            dimensions.insert(k.to_string(), v.to_string());
+                        }
+                    }
+                }
+                AlarmMetricStat {
+                    namespace: metric
+                        .and_then(|mo| mo.get("Namespace"))
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    metric_name: metric
+                        .and_then(|mo| mo.get("MetricName"))
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    dimensions,
+                    period: ms.get("Period").and_then(|v| v.as_i64()),
+                    stat: ms.get("Stat").and_then(|v| v.as_str()).map(String::from),
+                    unit: ms.get("Unit").and_then(|v| v.as_str()).map(String::from),
+                }
+            });
+            Some(AlarmMetricQuery {
+                id,
+                metric_stat,
+                expression: m
+                    .get("Expression")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                label: m.get("Label").and_then(|v| v.as_str()).map(String::from),
+                return_data: m.get("ReturnData").and_then(|v| v.as_bool()),
+                account_id: m
+                    .get("AccountId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                period: m.get("Period").and_then(|v| v.as_i64()),
+            })
+        })
+        .collect()
+}
+
 impl ResourceProvisioner {
     // --- CloudWatch ---
 
@@ -131,7 +191,7 @@ impl ResourceProvisioner {
                 .map(String::from),
             configuration_updated_timestamp: now,
             alarm_configuration_updated_timestamp: now,
-            metrics: Vec::new(),
+            metrics: parse_cfn_alarm_metrics(props),
         };
         let region_alarms = state.alarms_in_mut(&self.region);
         if region_alarms.contains_key(&alarm_name) {
@@ -319,6 +379,7 @@ impl ResourceProvisioner {
         alarm.comparison_operator = comparison_operator;
         alarm.treat_missing_data = treat_missing_data;
         alarm.evaluate_low_sample_count_percentile = evaluate_low_sample_count_percentile;
+        alarm.metrics = parse_cfn_alarm_metrics(props);
         alarm.configuration_updated_timestamp = now;
         alarm.alarm_configuration_updated_timestamp = now;
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -6385,9 +6385,9 @@ mod tests {
                 "A",
                 serde_json::json!({
                     "AlarmName": "math-alarm",
-                    "ComparisonOperator": "GreaterThanThreshold",
+                    "ComparisonOperator": "GreaterThanUpperThreshold",
                     "EvaluationPeriods": 1,
-                    "Threshold": 10,
+                    "ThresholdMetricId": "ad1",
                     "Metrics": [
                         {"Id": "e1", "Expression": "m1", "Label": "expr", "ReturnData": true},
                         {"Id": "m1", "ReturnData": false, "MetricStat": {
@@ -6416,6 +6416,7 @@ mod tests {
             assert_eq!(alarm.metrics[0].id, "e1");
             assert_eq!(alarm.metrics[0].expression.as_deref(), Some("m1"));
             assert_eq!(alarm.metrics[0].return_data, Some(true));
+            assert_eq!(alarm.threshold_metric_id.as_deref(), Some("ad1"));
             let stat = alarm.metrics[1].metric_stat.as_ref().unwrap();
             assert_eq!(stat.metric_name.as_deref(), Some("CPUUtilization"));
             assert_eq!(
@@ -6426,7 +6427,7 @@ mod tests {
             assert_eq!(stat.period, Some(300));
         }
 
-        // Update replaces the Metrics list on the update path.
+        // Update replaces the Metrics list AND refreshes ThresholdMetricId.
         prov.update_resource(
             &created,
             &make_resource(
@@ -6434,9 +6435,9 @@ mod tests {
                 "A",
                 serde_json::json!({
                     "AlarmName": "math-alarm",
-                    "ComparisonOperator": "GreaterThanThreshold",
+                    "ComparisonOperator": "GreaterThanUpperThreshold",
                     "EvaluationPeriods": 1,
-                    "Threshold": 20,
+                    "ThresholdMetricId": "ad2",
                     "Metrics": [{"Id": "e2", "Expression": "m1*2", "ReturnData": true}]
                 }),
             ),
@@ -6454,6 +6455,12 @@ mod tests {
         assert_eq!(alarm.metrics.len(), 1, "Metrics re-parsed on update");
         assert_eq!(alarm.metrics[0].id, "e2");
         assert_eq!(alarm.metrics[0].expression.as_deref(), Some("m1*2"));
+        // ThresholdMetricId reflects the updated definition, not the stale one.
+        assert_eq!(
+            alarm.threshold_metric_id.as_deref(),
+            Some("ad2"),
+            "ThresholdMetricId refreshed on update"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -44,7 +44,9 @@ use fakecloud_cloudfront::{
     },
     SharedCloudFrontState, StoredDistribution,
 };
-use fakecloud_cloudwatch::{AlarmState, Dashboard, MetricAlarm, SharedCloudWatchState};
+use fakecloud_cloudwatch::{
+    AlarmMetricQuery, AlarmMetricStat, AlarmState, Dashboard, MetricAlarm, SharedCloudWatchState,
+};
 use fakecloud_cognito::{
     default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig,
     CognitoIdentityProvider, CustomDomainConfig, EmailConfiguration, IdentityPool,
@@ -6372,6 +6374,86 @@ mod tests {
             resource_type: resource_type.to_string(),
             properties: props,
         }
+    }
+
+    #[test]
+    fn cloudwatch_alarm_provisions_and_updates_metrics() {
+        let prov = make_provisioner();
+        let created = prov
+            .create_resource(&make_resource(
+                "AWS::CloudWatch::Alarm",
+                "A",
+                serde_json::json!({
+                    "AlarmName": "math-alarm",
+                    "ComparisonOperator": "GreaterThanThreshold",
+                    "EvaluationPeriods": 1,
+                    "Threshold": 10,
+                    "Metrics": [
+                        {"Id": "e1", "Expression": "m1", "Label": "expr", "ReturnData": true},
+                        {"Id": "m1", "ReturnData": false, "MetricStat": {
+                            "Metric": {
+                                "Namespace": "AWS/EC2",
+                                "MetricName": "CPUUtilization",
+                                "Dimensions": [{"Name": "InstanceId", "Value": "i-123"}]
+                            },
+                            "Period": 300,
+                            "Stat": "Average"
+                        }}
+                    ]
+                }),
+            ))
+            .expect("alarm provisions");
+
+        {
+            let cw = prov.cloudwatch_state.read();
+            let acct = cw.get("123456789012").unwrap();
+            let alarm = acct
+                .alarms_in("us-east-1")
+                .unwrap()
+                .get("math-alarm")
+                .unwrap();
+            assert_eq!(alarm.metrics.len(), 2, "Metrics parsed on create");
+            assert_eq!(alarm.metrics[0].id, "e1");
+            assert_eq!(alarm.metrics[0].expression.as_deref(), Some("m1"));
+            assert_eq!(alarm.metrics[0].return_data, Some(true));
+            let stat = alarm.metrics[1].metric_stat.as_ref().unwrap();
+            assert_eq!(stat.metric_name.as_deref(), Some("CPUUtilization"));
+            assert_eq!(
+                stat.dimensions.get("InstanceId").map(String::as_str),
+                Some("i-123")
+            );
+            assert_eq!(stat.stat.as_deref(), Some("Average"));
+            assert_eq!(stat.period, Some(300));
+        }
+
+        // Update replaces the Metrics list on the update path.
+        prov.update_resource(
+            &created,
+            &make_resource(
+                "AWS::CloudWatch::Alarm",
+                "A",
+                serde_json::json!({
+                    "AlarmName": "math-alarm",
+                    "ComparisonOperator": "GreaterThanThreshold",
+                    "EvaluationPeriods": 1,
+                    "Threshold": 20,
+                    "Metrics": [{"Id": "e2", "Expression": "m1*2", "ReturnData": true}]
+                }),
+            ),
+        )
+        .expect("update succeeds")
+        .expect("AWS::CloudWatch::Alarm is updatable");
+
+        let cw = prov.cloudwatch_state.read();
+        let acct = cw.get("123456789012").unwrap();
+        let alarm = acct
+            .alarms_in("us-east-1")
+            .unwrap()
+            .get("math-alarm")
+            .unwrap();
+        assert_eq!(alarm.metrics.len(), 1, "Metrics re-parsed on update");
+        assert_eq!(alarm.metrics[0].id, "e2");
+        assert_eq!(alarm.metrics[0].expression.as_deref(), Some("m1*2"));
     }
 
     #[test]

--- a/crates/fakecloud-cloudwatch/src/anomaly_detectors.rs
+++ b/crates/fakecloud-cloudwatch/src/anomaly_detectors.rs
@@ -7,10 +7,32 @@ use fakecloud_core::query::optional_query_param;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::{
-    collect_member_values, invalid_param, parse_dimensions_query, render_dimensions, validate_len,
-    validate_range_i64, xml_escape, xml_response, CloudWatchService,
+    collect_indexed, collect_member_values, invalid_param, parse_dimensions_query,
+    render_dimensions, validate_len, validate_range_i64, xml_escape, xml_response,
+    CloudWatchService,
 };
-use crate::state::AnomalyDetector;
+use crate::state::{AnomalyDetector, AnomalyDetectorConfiguration, ExcludedTimeRange};
+
+/// Parse the optional `Configuration` (MetricTimezone + ExcludedTimeRanges)
+/// off a PutAnomalyDetector request, if present.
+fn parse_configuration(req: &AwsRequest) -> Option<AnomalyDetectorConfiguration> {
+    let metric_timezone = optional_query_param(req, "Configuration.MetricTimezone");
+    let excluded_time_ranges: Vec<ExcludedTimeRange> =
+        collect_indexed(req, "Configuration.ExcludedTimeRanges")
+            .into_iter()
+            .map(|m| ExcludedTimeRange {
+                start_time: m.get("StartTime").cloned(),
+                end_time: m.get("EndTime").cloned(),
+            })
+            .collect();
+    if metric_timezone.is_none() && excluded_time_ranges.is_empty() {
+        return None;
+    }
+    Some(AnomalyDetectorConfiguration {
+        excluded_time_ranges,
+        metric_timezone,
+    })
+}
 
 /// Build the stable key for a detector from its identifying fields. A
 /// metric-math detector keys off its serialized expression members; a
@@ -109,6 +131,9 @@ impl CloudWatchService {
             &id.dimensions,
             &id.math_id,
         );
+        let configuration = parse_configuration(req);
+        let periodic_spikes = optional_query_param(req, "MetricCharacteristics.PeriodicSpikes")
+            .map(|s| s.eq_ignore_ascii_case("true"));
         let detector = AnomalyDetector {
             key: key.clone(),
             namespace: id.namespace,
@@ -117,6 +142,8 @@ impl CloudWatchService {
             dimensions: id.dimensions,
             metric_math: id.math_id.is_some(),
             state_value: "TRAINED".to_string(),
+            configuration,
+            periodic_spikes,
         };
         let mut state = self.state.write();
         let acct = state.get_or_create(&req.account_id);
@@ -235,6 +262,35 @@ fn render_detector(d: &AnomalyDetector) -> String {
             s.push_str(&format!("<Stat>{}</Stat>", xml_escape(stat)));
         }
         s.push_str("</SingleMetricAnomalyDetector>");
+    }
+    if let Some(cfg) = &d.configuration {
+        s.push_str("<Configuration>");
+        if !cfg.excluded_time_ranges.is_empty() {
+            s.push_str("<ExcludedTimeRanges>");
+            for r in &cfg.excluded_time_ranges {
+                s.push_str("<member>");
+                if let Some(st) = &r.start_time {
+                    s.push_str(&format!("<StartTime>{}</StartTime>", xml_escape(st)));
+                }
+                if let Some(et) = &r.end_time {
+                    s.push_str(&format!("<EndTime>{}</EndTime>", xml_escape(et)));
+                }
+                s.push_str("</member>");
+            }
+            s.push_str("</ExcludedTimeRanges>");
+        }
+        if let Some(tz) = &cfg.metric_timezone {
+            s.push_str(&format!(
+                "<MetricTimezone>{}</MetricTimezone>",
+                xml_escape(tz)
+            ));
+        }
+        s.push_str("</Configuration>");
+    }
+    if let Some(ps) = d.periodic_spikes {
+        s.push_str(&format!(
+            "<MetricCharacteristics><PeriodicSpikes>{ps}</PeriodicSpikes></MetricCharacteristics>"
+        ));
     }
     s.push_str("</member>");
     s

--- a/crates/fakecloud-cloudwatch/src/json_protocol.rs
+++ b/crates/fakecloud-cloudwatch/src/json_protocol.rs
@@ -43,6 +43,38 @@ const NUMERIC_TAGS: &[&str] = &[
     "ExtendedStatistics",
 ];
 
+/// Output tags that wrap an awsQuery list. When such a container is present but
+/// empty (no `<member>` children), it must serialize as an empty JSON array
+/// `[]` rather than being omitted, so JSON callers don't see a missing field
+/// where the XML explicitly carried an empty list.
+const LIST_TAGS: &[&str] = &[
+    "Datapoints",
+    "Metrics",
+    "Dimensions",
+    "MetricAlarms",
+    "CompositeAlarms",
+    "AnomalyDetectors",
+    "AnomalyDetectorTypes",
+    "InsightRules",
+    "ManagedRules",
+    "MetricStreams",
+    "Entries",
+    "MetricDataResults",
+    "Values",
+    "Counts",
+    "Timestamps",
+    "Tags",
+    "Messages",
+    "AlarmHistoryItems",
+    "DashboardEntries",
+    "ExcludedTimeRanges",
+    "OKActions",
+    "AlarmActions",
+    "InsufficientDataActions",
+    "MetricDataQueries",
+    "Datasets",
+];
+
 /// Output tags whose leaf text is a boolean.
 const BOOL_TAGS: &[&str] = &[
     "ActionsEnabled",
@@ -187,6 +219,14 @@ fn convert(el: &El, parent_tag: &str) -> Option<Value> {
     if el.children.is_empty() {
         let text = el.text.trim();
         if text.is_empty() {
+            // An empty list container (`<Datapoints></Datapoints>`) carries no
+            // `<member>` children, so it lands here rather than the list branch
+            // below. Emit `[]` for known list tags so JSON callers see an empty
+            // array instead of a missing field; a genuinely empty scalar is
+            // still omitted (awsJson drops null fields).
+            if LIST_TAGS.contains(&el.name.as_str()) {
+                return Some(Value::Array(Vec::new()));
+            }
             return None;
         }
         // A leaf's own tag drives typing, except unnamed `member`/`value`
@@ -348,5 +388,33 @@ mod tests {
         let v = json("GetMetricData", inner);
         assert_eq!(v["MetricDataResults"][0]["Timestamps"][0], 1577836800.0);
         assert_eq!(v["MetricDataResults"][0]["Values"][0], 1.5);
+    }
+
+    #[test]
+    fn empty_list_container_becomes_empty_array() {
+        // An explicitly-empty list in the XML must serialize as [], not be
+        // dropped. A genuinely empty scalar (NextToken) stays omitted.
+        let inner = "<Label>cpu</Label><Datapoints></Datapoints><NextToken></NextToken>";
+        let v = json("GetMetricStatistics", inner);
+        assert_eq!(v["Label"], "cpu");
+        assert_eq!(v["Datapoints"], serde_json::json!([]));
+        assert!(v["Datapoints"].is_array());
+        assert!(
+            v.get("NextToken").is_none(),
+            "empty scalar should be omitted, got {v}"
+        );
+    }
+
+    #[test]
+    fn empty_tags_and_messages_lists_become_empty_arrays() {
+        let tags = json("ListTagsForResource", "<Tags></Tags>");
+        assert_eq!(tags["Tags"], serde_json::json!([]));
+
+        // Nested empty list inside a member.
+        let inner = "<MetricDataResults><member><Id>m1</Id>\
+            <Messages></Messages><Values></Values></member></MetricDataResults>";
+        let v = json("GetMetricData", inner);
+        assert_eq!(v["MetricDataResults"][0]["Messages"], serde_json::json!([]));
+        assert_eq!(v["MetricDataResults"][0]["Values"], serde_json::json!([]));
     }
 }

--- a/crates/fakecloud-cloudwatch/src/json_protocol.rs
+++ b/crates/fakecloud-cloudwatch/src/json_protocol.rs
@@ -1,0 +1,352 @@
+//! awsJson1_0 response support for CloudWatch.
+//!
+//! CloudWatch's Smithy model advertises `awsJson1_0` (target service shape
+//! `GraniteServiceVersion20100801`) alongside the legacy `awsQuery` protocol.
+//! Requests arriving over the JSON protocol are flattened into the awsQuery
+//! flat-key param map by the central dispatcher, so every handler runs
+//! unchanged and produces its usual awsQuery XML response.
+//!
+//! This module converts that XML response into the awsJson body a JSON client
+//! expects. The transform strips the `<{Action}Response>` / `<{Action}Result>`
+//! envelope and `ResponseMetadata`, turns awsQuery `<member>` lists into JSON
+//! arrays and `<entry><key>/<value>` maps into JSON objects, and types leaf
+//! values (numbers, booleans, epoch-second timestamps) so strict SDK
+//! deserializers accept the result.
+
+use fakecloud_core::service::{AwsResponse, ResponseBody};
+use serde_json::{Map, Value};
+
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+
+/// awsJson1_0 content type used by CloudWatch JSON responses.
+const JSON_CONTENT_TYPE: &str = "application/x-amz-json-1.0";
+
+/// Output tags whose leaf text is an integer or double.
+const NUMERIC_TAGS: &[&str] = &[
+    "Period",
+    "EvaluationPeriods",
+    "DatapointsToAlarm",
+    "Threshold",
+    "Duration",
+    "Size",
+    "ActionsSuppressorWaitPeriod",
+    "ActionsSuppressorExtensionPeriod",
+    "StorageResolution",
+    "SampleCount",
+    "Average",
+    "Sum",
+    "Minimum",
+    "Maximum",
+    "Values",
+    "Counts",
+    "ExtendedStatistics",
+];
+
+/// Output tags whose leaf text is a boolean.
+const BOOL_TAGS: &[&str] = &[
+    "ActionsEnabled",
+    "IncludeLinkedAccountsMetrics",
+    "ApplyOnTransformedLogs",
+    "ReturnData",
+    "PeriodicSpikes",
+];
+
+/// Output tags whose leaf text is an ISO-8601 timestamp that awsJson renders as
+/// epoch seconds.
+const TIMESTAMP_TAGS: &[&str] = &[
+    "Timestamp",
+    "Timestamps",
+    "AlarmConfigurationUpdatedTimestamp",
+    "StateUpdatedTimestamp",
+    "StateTransitionedTimestamp",
+    "LastModified",
+    "LastUpdateDate",
+    "LastUpdatedTimestamp",
+    "CreationDate",
+    "StartDate",
+    "ExpireDate",
+    "StartTime",
+    "EndTime",
+];
+
+/// Rebuild an XML awsQuery response as an awsJson1_0 response, preserving the
+/// original HTTP status.
+pub(crate) fn xml_response_to_json(resp: AwsResponse) -> AwsResponse {
+    let status = resp.status;
+    let ResponseBody::Bytes(bytes) = resp.body else {
+        // CloudWatch handlers never stream a file body; fall back untouched.
+        return resp;
+    };
+    let value = xml_to_json(&bytes);
+    let body = serde_json::to_vec(&value).unwrap_or_else(|_| b"{}".to_vec());
+    AwsResponse {
+        status,
+        content_type: JSON_CONTENT_TYPE.to_string(),
+        body: ResponseBody::Bytes(body.into()),
+        headers: resp.headers,
+    }
+}
+
+/// A minimal XML element tree.
+#[derive(Debug, Default)]
+struct El {
+    name: String,
+    text: String,
+    children: Vec<El>,
+}
+
+/// Parse the awsQuery XML envelope and convert its `<{Action}Result>` body to a
+/// JSON object. Returns an empty object when there is no result body (e.g.
+/// metadata-only responses like `PutMetricData`).
+fn xml_to_json(xml: &[u8]) -> Value {
+    let Some(root) = parse_xml(xml) else {
+        return Value::Object(Map::new());
+    };
+    // The result body lives in the `<{Action}Result>` child; `ResponseMetadata`
+    // is dropped.
+    let Some(result) = root.children.iter().find(|c| c.name.ends_with("Result")) else {
+        return Value::Object(Map::new());
+    };
+    match convert(result, "") {
+        Some(v @ Value::Object(_)) => v,
+        _ => Value::Object(Map::new()),
+    }
+}
+
+/// Build an [`El`] tree from XML text. Returns the single root element.
+fn parse_xml(xml: &[u8]) -> Option<El> {
+    let mut reader = Reader::from_reader(xml);
+    reader.config_mut().trim_text(true);
+    let mut stack: Vec<El> = Vec::new();
+    let mut root: Option<El> = None;
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) => {
+                let name = local_name(e.name().as_ref());
+                stack.push(El {
+                    name,
+                    ..Default::default()
+                });
+            }
+            Ok(Event::Empty(e)) => {
+                let name = local_name(e.name().as_ref());
+                let el = El {
+                    name,
+                    ..Default::default()
+                };
+                match stack.last_mut() {
+                    Some(parent) => parent.children.push(el),
+                    None => root = Some(el),
+                }
+            }
+            Ok(Event::Text(e)) => {
+                if let Some(top) = stack.last_mut() {
+                    if let Ok(text) = e.unescape() {
+                        top.text.push_str(text.as_ref());
+                    }
+                }
+            }
+            Ok(Event::CData(e)) => {
+                if let Some(top) = stack.last_mut() {
+                    if let Ok(s) = std::str::from_utf8(e.as_ref()) {
+                        top.text.push_str(s);
+                    }
+                }
+            }
+            Ok(Event::End(_)) => {
+                if let Some(done) = stack.pop() {
+                    match stack.last_mut() {
+                        Some(parent) => parent.children.push(done),
+                        None => root = Some(done),
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Ok(_) => {}
+            Err(_) => return None,
+        }
+        buf.clear();
+    }
+    root
+}
+
+/// Strip an XML namespace prefix (`ns:Tag` -> `Tag`).
+fn local_name(raw: &[u8]) -> String {
+    let s = String::from_utf8_lossy(raw);
+    match s.rsplit_once(':') {
+        Some((_, local)) => local.to_string(),
+        None => s.into_owned(),
+    }
+}
+
+/// Convert an element to JSON. `parent_tag` carries the enclosing list/map tag
+/// so scalar `<member>` leaves can be typed against the field they belong to.
+fn convert(el: &El, parent_tag: &str) -> Option<Value> {
+    if el.children.is_empty() {
+        let text = el.text.trim();
+        if text.is_empty() {
+            return None;
+        }
+        // A leaf's own tag drives typing, except unnamed `member`/`value`
+        // leaves which inherit the enclosing container's tag.
+        let typing_tag = if el.name == "member" || el.name == "value" {
+            parent_tag
+        } else {
+            &el.name
+        };
+        return Some(type_leaf(typing_tag, text));
+    }
+
+    // awsQuery list: every child is `<member>`.
+    if el.children.iter().all(|c| c.name == "member") {
+        let arr: Vec<Value> = el
+            .children
+            .iter()
+            .filter_map(|m| convert(m, &el.name))
+            .collect();
+        return Some(Value::Array(arr));
+    }
+
+    // awsQuery map: every child is `<entry>` with `<key>`/`<value>`.
+    if el.children.iter().all(|c| c.name == "entry") {
+        let mut obj = Map::new();
+        for entry in &el.children {
+            let key = entry
+                .children
+                .iter()
+                .find(|c| c.name == "key")
+                .map(|k| k.text.trim().to_string());
+            let val = entry
+                .children
+                .iter()
+                .find(|c| c.name == "value")
+                .and_then(|v| convert(v, &el.name));
+            if let (Some(k), Some(v)) = (key, val) {
+                obj.insert(k, v);
+            }
+        }
+        return Some(Value::Object(obj));
+    }
+
+    // Plain structure.
+    let mut obj = Map::new();
+    for child in &el.children {
+        if let Some(v) = convert(child, &el.name) {
+            obj.insert(child.name.clone(), v);
+        }
+    }
+    Some(Value::Object(obj))
+}
+
+/// Type a leaf value per the CloudWatch output schema.
+fn type_leaf(tag: &str, text: &str) -> Value {
+    if TIMESTAMP_TAGS.contains(&tag) {
+        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(text) {
+            let secs = dt.timestamp_millis() as f64 / 1000.0;
+            if let Some(n) = serde_json::Number::from_f64(secs) {
+                return Value::Number(n);
+            }
+        }
+        return Value::String(text.to_string());
+    }
+    if BOOL_TAGS.contains(&tag) {
+        return match text {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            other => Value::String(other.to_string()),
+        };
+    }
+    if NUMERIC_TAGS.contains(&tag) {
+        if !text.contains('.') && !text.contains('e') && !text.contains('E') {
+            if let Ok(i) = text.parse::<i64>() {
+                return Value::Number(i.into());
+            }
+        }
+        if let Ok(f) = text.parse::<f64>() {
+            if let Some(n) = serde_json::Number::from_f64(f) {
+                return Value::Number(n);
+            }
+        }
+        return Value::String(text.to_string());
+    }
+    Value::String(text.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn json(action: &str, inner: &str) -> Value {
+        let xml = fakecloud_core::query::query_response_xml(
+            action,
+            "http://monitoring.amazonaws.com/doc/2010-08-01/",
+            inner,
+            "req-1",
+        );
+        xml_to_json(xml.as_bytes())
+    }
+
+    #[test]
+    fn metadata_only_becomes_empty_object() {
+        let xml = fakecloud_core::query::query_metadata_only_xml(
+            "PutMetricData",
+            "http://monitoring.amazonaws.com/doc/2010-08-01/",
+            "req-1",
+        );
+        assert_eq!(xml_to_json(xml.as_bytes()), serde_json::json!({}));
+    }
+
+    #[test]
+    fn list_metrics_members_become_array() {
+        let inner = "<Metrics><member><Namespace>AWS/EC2</Namespace>\
+            <MetricName>CPUUtilization</MetricName>\
+            <Dimensions><member><Name>InstanceId</Name><Value>i-1</Value></member></Dimensions>\
+            </member></Metrics><NextToken>tok</NextToken>";
+        let v = json("ListMetrics", inner);
+        assert_eq!(v["Metrics"][0]["Namespace"], "AWS/EC2");
+        assert_eq!(v["Metrics"][0]["MetricName"], "CPUUtilization");
+        assert_eq!(v["Metrics"][0]["Dimensions"][0]["Name"], "InstanceId");
+        assert_eq!(v["Metrics"][0]["Dimensions"][0]["Value"], "i-1");
+        assert_eq!(v["NextToken"], "tok");
+        assert!(v["Metrics"].is_array());
+    }
+
+    #[test]
+    fn datapoints_are_typed() {
+        let inner = "<Label>CPUUtilization</Label><Datapoints><member>\
+            <Timestamp>2020-01-01T00:00:00.000Z</Timestamp>\
+            <Average>42.5</Average><SampleCount>3</SampleCount><Unit>Percent</Unit>\
+            </member></Datapoints>";
+        let v = json("GetMetricStatistics", inner);
+        assert_eq!(v["Label"], "CPUUtilization");
+        assert_eq!(v["Datapoints"][0]["Average"], 42.5);
+        assert_eq!(v["Datapoints"][0]["SampleCount"], 3);
+        assert_eq!(v["Datapoints"][0]["Unit"], "Percent");
+        // Epoch seconds for 2020-01-01T00:00:00Z.
+        assert_eq!(v["Datapoints"][0]["Timestamp"], 1577836800.0);
+    }
+
+    #[test]
+    fn alarm_flags_typed() {
+        let inner = "<MetricAlarms><member><AlarmName>cpu</AlarmName>\
+            <ActionsEnabled>true</ActionsEnabled><Threshold>80.0</Threshold>\
+            <EvaluationPeriods>2</EvaluationPeriods></member></MetricAlarms>";
+        let v = json("DescribeAlarms", inner);
+        assert_eq!(v["MetricAlarms"][0]["AlarmName"], "cpu");
+        assert_eq!(v["MetricAlarms"][0]["ActionsEnabled"], true);
+        assert_eq!(v["MetricAlarms"][0]["Threshold"], 80.0);
+        assert_eq!(v["MetricAlarms"][0]["EvaluationPeriods"], 2);
+    }
+
+    #[test]
+    fn timestamps_member_list_typed() {
+        let inner = "<MetricDataResults><member><Id>m1</Id>\
+            <Timestamps><member>2020-01-01T00:00:00.000Z</member></Timestamps>\
+            <Values><member>1.5</member></Values></member></MetricDataResults>";
+        let v = json("GetMetricData", inner);
+        assert_eq!(v["MetricDataResults"][0]["Timestamps"][0], 1577836800.0);
+        assert_eq!(v["MetricDataResults"][0]["Values"][0], 1.5);
+    }
+}

--- a/crates/fakecloud-cloudwatch/src/lib.rs
+++ b/crates/fakecloud-cloudwatch/src/lib.rs
@@ -19,6 +19,7 @@ mod tests;
 pub use delivery::CloudwatchDeliveryImpl;
 pub use service::CloudWatchService;
 pub use state::{
-    AlarmState, CloudWatchAccounts, CloudWatchSnapshot, CloudWatchState, Dashboard, MetricAlarm,
-    MetricDatum, SharedCloudWatchState, CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
+    AlarmMetricQuery, AlarmMetricStat, AlarmState, CloudWatchAccounts, CloudWatchSnapshot,
+    CloudWatchState, Dashboard, MetricAlarm, MetricDatum, SharedCloudWatchState,
+    CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-cloudwatch/src/lib.rs
+++ b/crates/fakecloud-cloudwatch/src/lib.rs
@@ -4,6 +4,7 @@ pub(crate) mod datasets;
 pub mod delivery;
 pub(crate) mod insight_rules;
 pub mod introspection;
+pub(crate) mod json_protocol;
 pub(crate) mod metric_math;
 pub(crate) mod metric_streams;
 pub(crate) mod mute_rules;

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -15,8 +15,9 @@ use fakecloud_persistence::SnapshotStore;
 use tokio::sync::Mutex;
 
 use crate::state::{
-    AlarmHistoryItem, AlarmState, CloudWatchSnapshot, Dashboard, MetricAlarm, MetricDatum,
-    SharedCloudWatchState, StatisticSet, CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
+    AlarmHistoryItem, AlarmMetricQuery, AlarmMetricStat, AlarmState, CloudWatchSnapshot, Dashboard,
+    MetricAlarm, MetricDatum, SharedCloudWatchState, StatisticSet,
+    CLOUDWATCH_SNAPSHOT_SCHEMA_VERSION,
 };
 
 pub(crate) const NS: &str = "http://monitoring.amazonaws.com/doc/2010-08-01/";
@@ -310,8 +311,20 @@ impl AwsService for CloudWatchService {
         if mutates && result.is_ok() {
             self.save_snapshot().await;
         }
+        // A JSON-protocol caller (awsJson1_0, identified by the X-Amz-Target
+        // header) expects a JSON response body; the handlers produce awsQuery
+        // XML, so convert it. Query-protocol callers keep the XML unchanged.
+        if request_is_json(&req) {
+            return result.map(crate::json_protocol::xml_response_to_json);
+        }
         result
     }
+}
+
+/// True when the request arrived over the awsJson1_0 protocol (CloudWatch
+/// advertises both awsJson1_0 and awsQuery). JSON callers set `X-Amz-Target`.
+fn request_is_json(req: &AwsRequest) -> bool {
+    req.headers.contains_key("x-amz-target")
 }
 
 pub(crate) fn xml_response(action: &str, inner: &str, request_id: &str) -> AwsResponse {
@@ -446,6 +459,44 @@ fn parse_dimensions(member: &HashMap<String, String>, prefix: &str) -> BTreeMap<
         if let (Some(n), Some(v)) = (name, value) {
             out.insert(n, v);
         }
+    }
+    out
+}
+
+/// Parse the `Metrics.member.N.*` list of a `PutMetricAlarm` request into the
+/// persisted [`AlarmMetricQuery`] form.
+fn parse_alarm_metrics(req: &AwsRequest) -> Vec<AlarmMetricQuery> {
+    let mut out = Vec::new();
+    for member in collect_indexed(req, "Metrics") {
+        let Some(id) = member.get("Id").cloned() else {
+            continue;
+        };
+        let metric_stat = if member.keys().any(|k| k.starts_with("MetricStat.")) {
+            let dimensions = parse_dimensions(&member, "MetricStat.Metric.Dimensions");
+            Some(AlarmMetricStat {
+                namespace: member.get("MetricStat.Metric.Namespace").cloned(),
+                metric_name: member.get("MetricStat.Metric.MetricName").cloned(),
+                dimensions,
+                period: member
+                    .get("MetricStat.Period")
+                    .and_then(|s| s.parse::<i64>().ok()),
+                stat: member.get("MetricStat.Stat").cloned(),
+                unit: member.get("MetricStat.Unit").cloned(),
+            })
+        } else {
+            None
+        };
+        out.push(AlarmMetricQuery {
+            id,
+            metric_stat,
+            expression: member.get("Expression").cloned(),
+            label: member.get("Label").cloned(),
+            return_data: member
+                .get("ReturnData")
+                .map(|s| s.eq_ignore_ascii_case("true")),
+            account_id: member.get("AccountId").cloned(),
+            period: member.get("Period").and_then(|s| s.parse::<i64>().ok()),
+        });
     }
     out
 }
@@ -1276,6 +1327,13 @@ impl CloudWatchService {
         // static Threshold; previously accepted then dropped (1.24).
         let threshold_metric_id = optional_query_param(req, "ThresholdMetricId");
         let dimensions = parse_dimensions_query(req, "Dimensions");
+        // `Metrics` — the metric-math / cross-account alarm definition. Parsed
+        // from the flat `Metrics.member.N.*` params and persisted so
+        // DescribeAlarms can echo it back (previously silently dropped).
+        let metrics = parse_alarm_metrics(req);
+        // Inline `Tags` on PutMetricAlarm land in the same ARN-keyed tag store
+        // as TagResource, so ListTagsForResource returns them.
+        let inline_tags = parse_tags(req, "Tags");
 
         let mut ok_actions = Vec::new();
         let mut alarm_actions = Vec::new();
@@ -1339,10 +1397,21 @@ impl CloudWatchService {
                 .map(|a| a.configuration_updated_timestamp)
                 .unwrap_or(now),
             alarm_configuration_updated_timestamp: now,
+            metrics,
         };
+        let alarm_arn = alarm.alarm_arn.clone();
         let history_name = alarm_name.clone();
         let created = existing.is_none();
         alarms.insert(alarm_name, alarm);
+
+        // Persist inline Tags into the ARN-keyed tag store (AWS applies inline
+        // tags on create; TagResource / UntagResource manage them thereafter).
+        if !inline_tags.is_empty() {
+            let bucket = acct.tags.entry(alarm_arn).or_default();
+            for (k, v) in inline_tags {
+                bucket.insert(k, v);
+            }
+        }
 
         let summary = if created {
             format!("Alarm \"{history_name}\" created")
@@ -2008,8 +2077,60 @@ fn render_alarm(alarm: &MetricAlarm) -> String {
             .alarm_configuration_updated_timestamp
             .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
     ));
+    render_alarm_metrics(&mut s, &alarm.metrics);
     s.push_str("</member>");
     s
+}
+
+/// Render the `Metrics` (metric-math / cross-account) list of a MetricAlarm.
+fn render_alarm_metrics(s: &mut String, metrics: &[AlarmMetricQuery]) {
+    if metrics.is_empty() {
+        return;
+    }
+    s.push_str("<Metrics>");
+    for q in metrics {
+        s.push_str("<member>");
+        s.push_str(&format!("<Id>{}</Id>", xml_escape(&q.id)));
+        if let Some(stat) = &q.metric_stat {
+            s.push_str("<MetricStat>");
+            s.push_str("<Metric>");
+            if let Some(ns) = &stat.namespace {
+                s.push_str(&format!("<Namespace>{}</Namespace>", xml_escape(ns)));
+            }
+            if let Some(mn) = &stat.metric_name {
+                s.push_str(&format!("<MetricName>{}</MetricName>", xml_escape(mn)));
+            }
+            s.push_str(&render_dimensions(&stat.dimensions));
+            s.push_str("</Metric>");
+            if let Some(p) = stat.period {
+                s.push_str(&format!("<Period>{p}</Period>"));
+            }
+            if let Some(st) = &stat.stat {
+                s.push_str(&format!("<Stat>{}</Stat>", xml_escape(st)));
+            }
+            if let Some(u) = &stat.unit {
+                s.push_str(&format!("<Unit>{}</Unit>", xml_escape(u)));
+            }
+            s.push_str("</MetricStat>");
+        }
+        if let Some(e) = &q.expression {
+            s.push_str(&format!("<Expression>{}</Expression>", xml_escape(e)));
+        }
+        if let Some(l) = &q.label {
+            s.push_str(&format!("<Label>{}</Label>", xml_escape(l)));
+        }
+        if let Some(rd) = q.return_data {
+            s.push_str(&format!("<ReturnData>{rd}</ReturnData>"));
+        }
+        if let Some(p) = q.period {
+            s.push_str(&format!("<Period>{p}</Period>"));
+        }
+        if let Some(acct) = &q.account_id {
+            s.push_str(&format!("<AccountId>{}</AccountId>", xml_escape(acct)));
+        }
+        s.push_str("</member>");
+    }
+    s.push_str("</Metrics>");
 }
 
 fn push_action_list(s: &mut String, name: &str, actions: &[String]) {

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -1404,9 +1404,11 @@ impl CloudWatchService {
         let created = existing.is_none();
         alarms.insert(alarm_name, alarm);
 
-        // Persist inline Tags into the ARN-keyed tag store (AWS applies inline
-        // tags on create; TagResource / UntagResource manage them thereafter).
-        if !inline_tags.is_empty() {
+        // Persist inline Tags into the ARN-keyed tag store, but ONLY on create.
+        // AWS ignores the inline Tags param when PutMetricAlarm updates an
+        // existing alarm; tags on an existing alarm are managed via
+        // TagResource / UntagResource.
+        if created && !inline_tags.is_empty() {
             let bucket = acct.tags.entry(alarm_arn).or_default();
             for (k, v) in inline_tags {
                 bucket.insert(k, v);

--- a/crates/fakecloud-cloudwatch/src/state.rs
+++ b/crates/fakecloud-cloudwatch/src/state.rs
@@ -268,6 +268,47 @@ pub struct MetricAlarm {
     pub threshold_metric_id: Option<String>,
     pub configuration_updated_timestamp: DateTime<Utc>,
     pub alarm_configuration_updated_timestamp: DateTime<Utc>,
+    /// `Metrics` — the metric-math / cross-account alarm definition (a list of
+    /// `MetricDataQuery`). Set instead of the single-metric fields when the
+    /// alarm evaluates an expression or a metric in another account.
+    #[serde(default)]
+    pub metrics: Vec<AlarmMetricQuery>,
+}
+
+/// A single `MetricDataQuery` entry in a `PutMetricAlarm` `Metrics` list.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AlarmMetricQuery {
+    pub id: String,
+    #[serde(default)]
+    pub metric_stat: Option<AlarmMetricStat>,
+    #[serde(default)]
+    pub expression: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub return_data: Option<bool>,
+    #[serde(default)]
+    pub account_id: Option<String>,
+    #[serde(default)]
+    pub period: Option<i64>,
+}
+
+/// The `MetricStat` of an [`AlarmMetricQuery`] (a metric plus how to aggregate
+/// it).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AlarmMetricStat {
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(default)]
+    pub metric_name: Option<String>,
+    #[serde(default)]
+    pub dimensions: BTreeMap<String, String>,
+    #[serde(default)]
+    pub period: Option<i64>,
+    #[serde(default)]
+    pub stat: Option<String>,
+    #[serde(default)]
+    pub unit: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -343,6 +384,31 @@ pub struct AnomalyDetector {
     pub dimensions: BTreeMap<String, String>,
     pub metric_math: bool,
     pub state_value: String,
+    /// `Configuration` (`MetricTimezone` + `ExcludedTimeRanges`) supplied on
+    /// PutAnomalyDetector; echoed back on DescribeAnomalyDetectors.
+    #[serde(default)]
+    pub configuration: Option<AnomalyDetectorConfiguration>,
+    /// `MetricCharacteristics.PeriodicSpikes`.
+    #[serde(default)]
+    pub periodic_spikes: Option<bool>,
+}
+
+/// The `Configuration` of an anomaly detector.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AnomalyDetectorConfiguration {
+    #[serde(default)]
+    pub excluded_time_ranges: Vec<ExcludedTimeRange>,
+    #[serde(default)]
+    pub metric_timezone: Option<String>,
+}
+
+/// A single `ExcludedTimeRanges` entry (`Range`).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExcludedTimeRange {
+    #[serde(default)]
+    pub start_time: Option<String>,
+    #[serde(default)]
+    pub end_time: Option<String>,
 }
 
 /// A Contributor Insights rule.

--- a/crates/fakecloud-cloudwatch/src/tests.rs
+++ b/crates/fakecloud-cloudwatch/src/tests.rs
@@ -716,6 +716,50 @@ async fn put_metric_alarm_persists_metrics_and_tags() {
     assert!(tag_xml.contains("<Value>obs</Value>"));
 }
 
+/// AWS ignores the inline `Tags` param when PutMetricAlarm updates an existing
+/// alarm; tags are only applied on create. TagResource/UntagResource manage
+/// tags on an existing alarm.
+#[tokio::test]
+async fn put_metric_alarm_update_ignores_inline_tags() {
+    let svc = service();
+    let base = &[
+        ("AlarmName", "cpu"),
+        ("ComparisonOperator", "GreaterThanThreshold"),
+        ("EvaluationPeriods", "1"),
+        ("Threshold", "10"),
+        ("MetricName", "CPUUtilization"),
+        ("Namespace", "AWS/EC2"),
+    ];
+    // Create with an inline tag.
+    let mut create = base.to_vec();
+    create.push(("Tags.member.1.Key", "team"));
+    create.push(("Tags.member.1.Value", "obs"));
+    call(&svc, "PutMetricAlarm", &create).await;
+
+    // Update the SAME alarm with different inline tags -> must be ignored.
+    let mut update = base.to_vec();
+    update.push(("Threshold", "20"));
+    update.push(("Tags.member.1.Key", "team"));
+    update.push(("Tags.member.1.Value", "changed"));
+    update.push(("Tags.member.2.Key", "env"));
+    update.push(("Tags.member.2.Value", "prod"));
+    call(&svc, "PutMetricAlarm", &update).await;
+
+    let arn = format!("arn:aws:cloudwatch:{REGION}:{ACCT}:alarm:cpu");
+    let tags = call(&svc, "ListTagsForResource", &[("ResourceARN", &arn)]).await;
+    let tag_xml = body_of(&tags);
+    // Original create-time tag survives unchanged; update tags are ignored.
+    assert!(tag_xml.contains("<Value>obs</Value>"), "tags: {tag_xml}");
+    assert!(
+        !tag_xml.contains("<Value>changed</Value>"),
+        "update inline tag must be ignored: {tag_xml}"
+    );
+    assert!(
+        !tag_xml.contains("<Key>env</Key>"),
+        "update inline tag must be ignored: {tag_xml}"
+    );
+}
+
 #[tokio::test]
 async fn put_anomaly_detector_persists_configuration() {
     let svc = service();

--- a/crates/fakecloud-cloudwatch/src/tests.rs
+++ b/crates/fakecloud-cloudwatch/src/tests.rs
@@ -483,3 +483,275 @@ async fn snapshot_hook_fires_with_store() {
         .expect("hook present when a store is set");
     hook().await;
 }
+
+// ---------------------------------------------------------------------------
+// awsJson1_0 protocol support (CloudWatch advertises awsJson1_0 alongside the
+// legacy awsQuery protocol). A JSON body is flattened into the same flat-key
+// param map the handlers consume, and the XML response is re-serialized as
+// JSON for the JSON caller.
+// ---------------------------------------------------------------------------
+
+/// Build a JSON-protocol request: flatten the JSON body the way the central
+/// dispatcher does, and set the `X-Amz-Target` header that identifies a JSON
+/// caller.
+fn json_req(action: &str, body: serde_json::Value) -> AwsRequest {
+    let bytes = Bytes::from(serde_json::to_vec(&body).unwrap());
+    let flat = fakecloud_core::protocol::flatten_json_to_query(&bytes);
+    let mut query_params = HashMap::new();
+    for (k, v) in flat {
+        query_params.insert(k, v);
+    }
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "x-amz-target",
+        format!("GraniteServiceVersion20100801.{action}")
+            .parse()
+            .unwrap(),
+    );
+    AwsRequest {
+        service: "monitoring".to_string(),
+        action: action.to_string(),
+        region: REGION.to_string(),
+        account_id: ACCT.to_string(),
+        request_id: "test-req".to_string(),
+        headers,
+        query_params,
+        body: bytes,
+        body_stream: Mutex::new(None),
+        path_segments: vec![],
+        raw_path: "/".to_string(),
+        raw_query: String::new(),
+        method: Method::POST,
+        is_query_protocol: false,
+        access_key_id: None,
+        principal: None,
+    }
+}
+
+async fn call_json(svc: &CloudWatchService, action: &str, body: serde_json::Value) -> AwsResponse {
+    svc.handle(json_req(action, body))
+        .await
+        .expect("handler ok")
+}
+
+fn json_body(resp: &AwsResponse) -> serde_json::Value {
+    serde_json::from_slice(resp.body.expect_bytes()).expect("valid json body")
+}
+
+#[tokio::test]
+async fn put_metric_data_json_and_query_roundtrip() {
+    let svc = service();
+    // JSON protocol PutMetricData.
+    let resp = call_json(
+        &svc,
+        "PutMetricData",
+        serde_json::json!({
+            "Namespace": "MyApp",
+            "MetricData": [{
+                "MetricName": "Latency",
+                "Value": 12.5,
+                "Dimensions": [{"Name": "Endpoint", "Value": "/api"}]
+            }]
+        }),
+    )
+    .await;
+    assert_eq!(resp.content_type, "application/x-amz-json-1.0");
+    assert_eq!(json_body(&resp), serde_json::json!({}));
+
+    // The data is readable back over BOTH protocols.
+    let json_list = call_json(
+        &svc,
+        "ListMetrics",
+        serde_json::json!({"Namespace": "MyApp"}),
+    )
+    .await;
+    let v = json_body(&json_list);
+    assert_eq!(v["Metrics"][0]["Namespace"], "MyApp");
+    assert_eq!(v["Metrics"][0]["MetricName"], "Latency");
+    assert_eq!(v["Metrics"][0]["Dimensions"][0]["Name"], "Endpoint");
+    assert_eq!(v["Metrics"][0]["Dimensions"][0]["Value"], "/api");
+
+    // Query protocol still returns XML for the same data.
+    let xml_list = call(&svc, "ListMetrics", &[("Namespace", "MyApp")]).await;
+    assert_eq!(xml_list.content_type, "text/xml");
+    assert!(body_of(&xml_list).contains("<MetricName>Latency</MetricName>"));
+}
+
+#[tokio::test]
+async fn get_metric_statistics_json_roundtrip() {
+    let svc = service();
+    // Publish a couple of points via JSON at a fixed timestamp so both land in
+    // the same 60s bucket deterministically.
+    for v in [10.0, 20.0] {
+        call_json(
+            &svc,
+            "PutMetricData",
+            serde_json::json!({
+                "Namespace": "MyApp",
+                "MetricData": [{
+                    "MetricName": "Latency",
+                    "Value": v,
+                    "Timestamp": "2020-06-01T12:00:00Z"
+                }]
+            }),
+        )
+        .await;
+    }
+    let resp = call_json(
+        &svc,
+        "GetMetricStatistics",
+        serde_json::json!({
+            "Namespace": "MyApp",
+            "MetricName": "Latency",
+            "StartTime": "2000-01-01T00:00:00Z",
+            "EndTime": "2100-01-01T00:00:00Z",
+            "Period": 60,
+            "Statistics": ["Average", "SampleCount"]
+        }),
+    )
+    .await;
+    assert_eq!(resp.content_type, "application/x-amz-json-1.0");
+    let v = json_body(&resp);
+    assert_eq!(v["Label"], "Latency");
+    // Average and SampleCount come back as JSON numbers, timestamp as epoch.
+    let dp = &v["Datapoints"][0];
+    assert_eq!(dp["Average"].as_f64(), Some(15.0));
+    assert_eq!(dp["SampleCount"].as_f64(), Some(2.0));
+    assert!(dp["Timestamp"].is_number());
+}
+
+#[tokio::test]
+async fn put_metric_alarm_json_roundtrip() {
+    let svc = service();
+    let resp = call_json(
+        &svc,
+        "PutMetricAlarm",
+        serde_json::json!({
+            "AlarmName": "cpu-high",
+            "ComparisonOperator": "GreaterThanThreshold",
+            "EvaluationPeriods": 2,
+            "Threshold": 80.0,
+            "MetricName": "CPUUtilization",
+            "Namespace": "AWS/EC2",
+            "Period": 60,
+            "Statistic": "Average"
+        }),
+    )
+    .await;
+    assert_eq!(resp.content_type, "application/x-amz-json-1.0");
+    assert_eq!(json_body(&resp), serde_json::json!({}));
+
+    let desc = call_json(
+        &svc,
+        "DescribeAlarms",
+        serde_json::json!({"AlarmNames": ["cpu-high"]}),
+    )
+    .await;
+    let v = json_body(&desc);
+    let alarm = &v["MetricAlarms"][0];
+    assert_eq!(alarm["AlarmName"], "cpu-high");
+    assert_eq!(alarm["Threshold"].as_f64(), Some(80.0));
+    assert_eq!(alarm["EvaluationPeriods"], 2);
+    assert_eq!(alarm["ActionsEnabled"], true);
+}
+
+#[tokio::test]
+async fn put_metric_alarm_persists_metrics_and_tags() {
+    let svc = service();
+    // Metric-math alarm with a Metrics list and inline Tags.
+    call(
+        &svc,
+        "PutMetricAlarm",
+        &[
+            ("AlarmName", "math-alarm"),
+            ("ComparisonOperator", "GreaterThanThreshold"),
+            ("EvaluationPeriods", "1"),
+            ("Threshold", "10"),
+            ("Metrics.member.1.Id", "e1"),
+            ("Metrics.member.1.Expression", "m1 + m2"),
+            ("Metrics.member.1.Label", "sum"),
+            ("Metrics.member.1.ReturnData", "true"),
+            ("Metrics.member.2.Id", "m1"),
+            ("Metrics.member.2.MetricStat.Metric.Namespace", "AWS/EC2"),
+            (
+                "Metrics.member.2.MetricStat.Metric.MetricName",
+                "CPUUtilization",
+            ),
+            (
+                "Metrics.member.2.MetricStat.Metric.Dimensions.member.1.Name",
+                "InstanceId",
+            ),
+            (
+                "Metrics.member.2.MetricStat.Metric.Dimensions.member.1.Value",
+                "i-123",
+            ),
+            ("Metrics.member.2.MetricStat.Period", "300"),
+            ("Metrics.member.2.MetricStat.Stat", "Average"),
+            ("Metrics.member.2.ReturnData", "false"),
+            ("Tags.member.1.Key", "team"),
+            ("Tags.member.1.Value", "obs"),
+        ],
+    )
+    .await;
+
+    let desc = call(
+        &svc,
+        "DescribeAlarms",
+        &[("AlarmNames.member.1", "math-alarm")],
+    )
+    .await;
+    let xml = body_of(&desc);
+    assert!(xml.contains("<Metrics>"), "Metrics echoed: {xml}");
+    assert!(xml.contains("<Id>e1</Id>"));
+    assert!(xml.contains("<Expression>m1 + m2</Expression>"));
+    assert!(xml.contains("<MetricName>CPUUtilization</MetricName>"));
+    assert!(xml.contains("<Stat>Average</Stat>"));
+    assert!(xml.contains("<Value>i-123</Value>"));
+
+    // Inline Tags are queryable via ListTagsForResource.
+    let arn = format!("arn:aws:cloudwatch:{REGION}:{ACCT}:alarm:math-alarm");
+    let tags = call(&svc, "ListTagsForResource", &[("ResourceARN", &arn)]).await;
+    let tag_xml = body_of(&tags);
+    assert!(tag_xml.contains("<Key>team</Key>"), "tags: {tag_xml}");
+    assert!(tag_xml.contains("<Value>obs</Value>"));
+}
+
+#[tokio::test]
+async fn put_anomaly_detector_persists_configuration() {
+    let svc = service();
+    call(
+        &svc,
+        "PutAnomalyDetector",
+        &[
+            ("Namespace", "AWS/EC2"),
+            ("MetricName", "CPU"),
+            ("Stat", "Average"),
+            ("Configuration.MetricTimezone", "America/New_York"),
+            (
+                "Configuration.ExcludedTimeRanges.member.1.StartTime",
+                "2020-01-01T00:00:00Z",
+            ),
+            (
+                "Configuration.ExcludedTimeRanges.member.1.EndTime",
+                "2020-01-02T00:00:00Z",
+            ),
+            ("MetricCharacteristics.PeriodicSpikes", "true"),
+        ],
+    )
+    .await;
+
+    let desc = call(
+        &svc,
+        "DescribeAnomalyDetectors",
+        &[("Namespace", "AWS/EC2")],
+    )
+    .await;
+    let xml = body_of(&desc);
+    assert!(
+        xml.contains("<MetricTimezone>America/New_York</MetricTimezone>"),
+        "config echoed: {xml}"
+    );
+    assert!(xml.contains("<ExcludedTimeRanges>"));
+    assert!(xml.contains("<StartTime>2020-01-01T00:00:00Z</StartTime>"));
+    assert!(xml.contains("<PeriodicSpikes>true</PeriodicSpikes>"));
+}

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -428,6 +428,17 @@ pub async fn dispatch(
         }
     }
 
+    // CloudWatch (`monitoring`) advertises awsJson1_0 alongside awsQuery. Its
+    // handlers all read the flat awsQuery param map, so when a client uses the
+    // JSON protocol we flatten the JSON body into that same map, leaving the
+    // handlers unchanged. The handler emits a JSON response for JSON callers.
+    if detected.protocol == AwsProtocol::Json && detected.service == "monitoring" {
+        let body_params = protocol::flatten_json_to_query(&body_bytes);
+        for (k, v) in body_params {
+            all_params.entry(k).or_insert(v);
+        }
+    }
+
     let aws_request = AwsRequest {
         service: detected.service.clone(),
         action: detected.action.clone(),

--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -441,6 +441,12 @@ fn parse_amz_target(target: &str) -> Option<DetectedRequest> {
         s if s.starts_with("Firehose_") => "firehose",
         "AWSGlue" => "glue",
         "CloudApiService" => "cloudcontrolapi",
+        // CloudWatch advertises awsJson1_0 (target service shape
+        // `GraniteServiceVersion20100801`) alongside the legacy awsQuery
+        // protocol. Newer SDKs (aws-sdk-rust / js-v3 / go-v2) POST with
+        // `X-Amz-Target: GraniteServiceVersion20100801.<Operation>` and a JSON
+        // body. The service registry key is `monitoring`.
+        s if s.starts_with("GraniteServiceVersion") => "monitoring",
         _ => return None,
     };
 
@@ -572,6 +578,64 @@ pub fn parse_query_body(body: &Bytes) -> HashMap<String, String> {
     decode_form_urlencoded(body)
 }
 
+/// Flatten an awsJson request body into the flat `awsQuery` key form that
+/// query-protocol handlers consume.
+///
+/// CloudWatch is served by handlers written against the awsQuery flat-key map
+/// (`MetricData.member.1.MetricName`, `StatisticValues.Sum`,
+/// `Dimensions.member.2.Value`, ...). Its Smithy model also advertises
+/// `awsJson1_0`, so modern SDKs send a nested JSON body instead. Rather than
+/// duplicate every parser, we flatten the JSON into the same map the awsQuery
+/// handlers already read:
+///
+/// - object field `K` -> key `K` (or `<parent>.K` when nested in a struct)
+/// - array element `i` (1-based) -> `<K>.member.<i>` (matching the awsQuery
+///   list wire convention)
+/// - scalars -> their string form (numbers/booleans stringified)
+///
+/// A body that is not a JSON object yields an empty map.
+pub fn flatten_json_to_query(body: &Bytes) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return out;
+    };
+    if value.is_object() {
+        flatten_json_value("", &value, &mut out);
+    }
+    out
+}
+
+fn flatten_json_value(prefix: &str, value: &serde_json::Value, out: &mut HashMap<String, String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (k, v) in map {
+                let child = if prefix.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{prefix}.{k}")
+                };
+                flatten_json_value(&child, v, out);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for (i, v) in items.iter().enumerate() {
+                let child = format!("{prefix}.member.{}", i + 1);
+                flatten_json_value(&child, v, out);
+            }
+        }
+        serde_json::Value::Null => {}
+        serde_json::Value::String(s) => {
+            out.insert(prefix.to_string(), s.clone());
+        }
+        serde_json::Value::Bool(b) => {
+            out.insert(prefix.to_string(), b.to_string());
+        }
+        serde_json::Value::Number(n) => {
+            out.insert(prefix.to_string(), n.to_string());
+        }
+    }
+}
+
 fn decode_form_urlencoded(input: &[u8]) -> HashMap<String, String> {
     let s = std::str::from_utf8(input).unwrap_or("");
     let mut result = HashMap::new();
@@ -686,6 +750,59 @@ mod tests {
     fn parse_amz_target_invalid_returns_none() {
         assert!(parse_amz_target("NoDotHere").is_none());
         assert!(parse_amz_target("").is_none());
+    }
+
+    #[test]
+    fn parse_amz_target_cloudwatch_json() {
+        // CloudWatch's awsJson1_0 target service shape.
+        let result = parse_amz_target("GraniteServiceVersion20100801.PutMetricData").unwrap();
+        assert_eq!(result.service, "monitoring");
+        assert_eq!(result.action, "PutMetricData");
+        assert_eq!(result.protocol, AwsProtocol::Json);
+    }
+
+    #[test]
+    fn flatten_json_to_query_nested() {
+        let body = Bytes::from(
+            serde_json::json!({
+                "Namespace": "MyApp",
+                "MetricData": [{
+                    "MetricName": "Latency",
+                    "Value": 12.5,
+                    "StatisticValues": {"SampleCount": 3, "Sum": 10},
+                    "Dimensions": [{"Name": "Endpoint", "Value": "/api"}]
+                }]
+            })
+            .to_string(),
+        );
+        let flat = flatten_json_to_query(&body);
+        assert_eq!(flat.get("Namespace").unwrap(), "MyApp");
+        assert_eq!(
+            flat.get("MetricData.member.1.MetricName").unwrap(),
+            "Latency"
+        );
+        assert_eq!(flat.get("MetricData.member.1.Value").unwrap(), "12.5");
+        assert_eq!(
+            flat.get("MetricData.member.1.StatisticValues.SampleCount")
+                .unwrap(),
+            "3"
+        );
+        assert_eq!(
+            flat.get("MetricData.member.1.Dimensions.member.1.Name")
+                .unwrap(),
+            "Endpoint"
+        );
+        assert_eq!(
+            flat.get("MetricData.member.1.Dimensions.member.1.Value")
+                .unwrap(),
+            "/api"
+        );
+    }
+
+    #[test]
+    fn flatten_json_to_query_non_object_is_empty() {
+        assert!(flatten_json_to_query(&Bytes::from_static(b"[]")).is_empty());
+        assert!(flatten_json_to_query(&Bytes::from_static(b"not json")).is_empty());
     }
 
     #[test]

--- a/website/content/docs/services/cloudwatch.md
+++ b/website/content/docs/services/cloudwatch.md
@@ -1,10 +1,10 @@
 +++
 title = "CloudWatch (Metrics & Alarms)"
-description = "Amazon CloudWatch metrics, alarms, dashboards, anomaly detectors, insight rules, and metric streams. awsQuery protocol."
+description = "Amazon CloudWatch metrics, alarms, dashboards, anomaly detectors, insight rules, and metric streams. awsQuery and awsJson1_0 protocols."
 weight = 33
 +++
 
-fakecloud implements Amazon CloudWatch's metrics-and-alarms surface (the `monitoring` SigV4 service, awsQuery protocol) — distinct from [CloudWatch Logs](/docs/services/logs/), which is a separate service. All 49 operations are implemented with persisted in-memory state.
+fakecloud implements Amazon CloudWatch's metrics-and-alarms surface (the `monitoring` SigV4 service) — distinct from [CloudWatch Logs](/docs/services/logs/), which is a separate service. CloudWatch's Smithy model advertises both the legacy `awsQuery` protocol (XML) and `awsJson1_0`; fakecloud accepts either, so older SDKs and newer SDKs (aws-sdk-rust / js-v3 / go-v2) that send `X-Amz-Target: GraniteServiceVersion20100801.<Operation>` with a JSON body both work, and each caller receives a response in the protocol it used. All 49 operations are implemented with persisted in-memory state.
 
 **Status: full control plane. Metrics are stored in memory and do not persist across server restarts; alarm evaluation is driven by the metric data you publish, not by a background sampling loop.**
 


### PR DESCRIPTION
## Summary

CloudWatch's Smithy model advertises `awsJson1_0` (target service shape `GraniteServiceVersion20100801`) and `awsQueryCompatible` alongside the legacy `awsQuery` protocol, but fakecloud only routed `awsQuery`. Modern SDKs (aws-sdk-rust / js-v3 / go-v2) that POST `X-Amz-Target: GraniteServiceVersion20100801.<Operation>` with a JSON body were unroutable and failed. This batch adds JSON-protocol support end to end and fixes three drop-on-persist bugs.

Findings addressed (bug-hunt 2026-07-01):

- HIGH: CloudWatch had no JSON-protocol routing.
  - `protocol.rs`: route the CloudWatch JSON target (`GraniteServiceVersion*`) to the `monitoring` service; new `flatten_json_to_query` flattens a nested awsJson body into the flat awsQuery key map the handlers already read (arrays -> `Member.N`, structs -> dotted keys, scalars stringified).
  - `dispatch.rs`: for `monitoring` JSON requests, flatten the JSON body into `query_params` so every existing handler runs unchanged.
  - `json_protocol.rs` (new): convert the handler's awsQuery XML back into an `awsJson1_0` response body (`<member>` lists -> JSON arrays, `<entry>` maps -> JSON objects, typed leaves incl. numbers, booleans, and epoch-second timestamps). Each caller gets a response in the protocol it used: JSON callers get JSON, query callers keep XML.
- MED: `PutMetricAlarm` dropped `Metrics`. The metric-math / cross-account `MetricDataQuery` list is now parsed, persisted on the alarm, and echoed on `DescribeAlarms`.
- LOW: `PutMetricAlarm` inline `Tags` dropped. Inline tags now land in the ARN-keyed tag store, so `ListTagsForResource` returns them.
- LOW: `PutAnomalyDetector` dropped `Configuration` + `MetricCharacteristics`. `Configuration` (`MetricTimezone` / `ExcludedTimeRanges`) and `MetricCharacteristics.PeriodicSpikes` are now parsed, persisted, and echoed on `DescribeAnomalyDetectors`.

The `parse_amz_target`/`dispatch` changes only add a CloudWatch branch; no other service's routing or response behavior changes.

## Test plan

- `cargo nextest run -p fakecloud-cloudwatch -p fakecloud-core`: 263 passed, 0 skipped. New tests:
  - JSON + query round-trip for `PutMetricData`, `GetMetricStatistics`, `ListMetrics`, `PutMetricAlarm` (asserts JSON content-type `application/x-amz-json-1.0`, typed numbers, epoch timestamps, and that query callers still get XML).
  - `PutMetricAlarm` persists `Metrics` (metric-math + MetricStat with dimensions) and inline `Tags` (via `ListTagsForResource`).
  - `PutAnomalyDetector` persists `Configuration` + `PeriodicSpikes`.
  - Unit tests for `parse_amz_target` CloudWatch JSON target, `flatten_json_to_query` nesting, and the XML->JSON converter (member lists, typed datapoints, alarm flags, timestamp member lists).
- `cargo clippy -p fakecloud-cloudwatch -p fakecloud-core --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `cargo build -p fakecloud-cloudformation`: clean (MetricAlarm struct gained a `metrics` field; the CFN provisioner ctor updated).

## Docs / SDK matrix

Updated `website/content/docs/services/cloudwatch.md` to note dual-protocol support (awsQuery + awsJson1_0). No SDK/client code changes are needed: the introspection SDKs are unaffected, and CloudWatch clients already ship in every AWS SDK.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudWatch awsJson1_0 support and fixes persistence for alarms and anomaly detectors. JSON callers now work end-to-end, CloudFormation alarms round‑trip `Metrics`, and `ThresholdMetricId` is refreshed on update.

- **New Features**
  - Support `X-Amz-Target: GraniteServiceVersion20100801.*` for CloudWatch: flatten JSON bodies into query params and return `application/x-amz-json-1.0` converted from existing XML with typed numbers/booleans/epoch-second timestamps; emit `[]` for empty list containers. Query callers still get XML.

- **Bug Fixes**
  - `PutMetricAlarm` persists `Metrics` (`MetricDataQuery`) and inline `Tags`; tags apply only on create; echoed via `DescribeAlarms` and `ListTagsForResource`.
  - `PutAnomalyDetector` persists `Configuration` (`MetricTimezone`, `ExcludedTimeRanges`) and `MetricCharacteristics.PeriodicSpikes`; echoed via `DescribeAnomalyDetectors`.
  - CloudFormation `AWS::CloudWatch::Alarm`: parse and persist `Metrics` on create and update; refresh `ThresholdMetricId` on update to avoid stale values.

<sup>Written for commit 23307aca4df0499166543d041f080a49730fce03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

