### PR TITLE
fix(apigatewayv2): real ImportApi/ReimportApi/ExportApi + persist dropped route/stage/authorizer fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,6 +3290,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",

--- a/crates/fakecloud-apigatewayv2/Cargo.toml
+++ b/crates/fakecloud-apigatewayv2/Cargo.toml
@@ -22,6 +22,7 @@ parking_lot = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -5,12 +5,13 @@
 
 use http::StatusCode;
 use serde_json::{json, Value};
+use std::collections::BTreeMap;
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
-use crate::service::ApiGatewayV2Service;
-use crate::state::ApiGatewayV2State;
+use crate::service::{generate_id, ApiGatewayV2Service};
+use crate::state::{ApiGatewayV2State, HttpApi, Integration, Route};
 
 /// Lowercase the first letter of a key — Smithy's `@jsonName` default for
 /// apigatewayv2 shapes (e.g. `ApiId` -> `apiId`).
@@ -292,6 +293,194 @@ fn rand_id() -> String {
     )
 }
 
+/// Parse an OpenAPI/Swagger spec body as JSON, falling back to YAML. Both
+/// `ImportApi` and `ReimportApi` accept either representation.
+fn parse_openapi_spec(raw: &str) -> Result<Value, AwsServiceError> {
+    if let Ok(v) = serde_json::from_str::<Value>(raw) {
+        if v.is_object() {
+            return Ok(v);
+        }
+    }
+    serde_yaml::from_str::<Value>(raw)
+        .ok()
+        .filter(|v| v.is_object())
+        .ok_or_else(|| bad_request("Body", "not a valid OpenAPI/Swagger document"))
+}
+
+/// HTTP method keys recognized inside an OpenAPI `paths.<path>` object.
+const OPENAPI_HTTP_METHODS: &[&str] = &[
+    "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE", "ANY",
+];
+
+/// Build an `HttpApi` plus synthesized routes and integrations from an
+/// OpenAPI/Swagger document. Each `paths.<path>.<method>` entry becomes a
+/// route keyed `"<METHOD> <path>"`; an `x-amazon-apigateway-integration`
+/// extension on the operation becomes an `Integration` wired as the route
+/// target. Shared by `ImportApi` and `ReimportApi`.
+fn build_api_from_spec(
+    spec: &Value,
+    api_id: String,
+    region: &str,
+) -> (
+    HttpApi,
+    BTreeMap<String, Route>,
+    BTreeMap<String, Integration>,
+) {
+    let info = spec.get("info");
+    let name = info
+        .and_then(|i| i.get("title"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("imported-api")
+        .to_string();
+    let description = info
+        .and_then(|i| i.get("description"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let version = info
+        .and_then(|i| i.get("version"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let mut api = HttpApi::new(api_id, name, description, None, region);
+    api.version = version;
+
+    let mut routes = BTreeMap::new();
+    let mut integrations = BTreeMap::new();
+
+    if let Some(paths) = spec.get("paths").and_then(|p| p.as_object()) {
+        for (path, item) in paths {
+            let Some(methods) = item.as_object() else {
+                continue;
+            };
+            for (method, op) in methods {
+                let upper = method.to_ascii_uppercase();
+                let route_method = if upper == "X-AMAZON-APIGATEWAY-ANY-METHOD" {
+                    "ANY".to_string()
+                } else if OPENAPI_HTTP_METHODS.contains(&upper.as_str()) {
+                    upper
+                } else {
+                    // Skip non-operation keys (parameters, servers, $ref, ...).
+                    continue;
+                };
+                let route_id = generate_id("route");
+                let mut target = None;
+                if let Some(integ) = op.get("x-amazon-apigateway-integration") {
+                    let integration_id = generate_id("integ");
+                    let integration = Integration {
+                        integration_id: integration_id.clone(),
+                        integration_type: integ
+                            .get("type")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_ascii_uppercase())
+                            .unwrap_or_else(|| "HTTP_PROXY".to_string()),
+                        integration_uri: integ
+                            .get("uri")
+                            .and_then(|v| v.as_str())
+                            .map(String::from),
+                        payload_format_version: integ
+                            .get("payloadFormatVersion")
+                            .and_then(|v| v.as_str())
+                            .map(String::from),
+                        timeout_in_millis: integ.get("timeoutInMillis").and_then(|v| v.as_i64()),
+                        integration_method: integ
+                            .get("httpMethod")
+                            .and_then(|v| v.as_str())
+                            .map(String::from),
+                        integration_response_selection_expression: None,
+                        passthrough_behavior: integ
+                            .get("passthroughBehavior")
+                            .and_then(|v| v.as_str())
+                            .map(String::from),
+                        connection_type: integ
+                            .get("connectionType")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_ascii_uppercase())
+                            .unwrap_or_else(|| "INTERNET".to_string()),
+                    };
+                    integrations.insert(integration_id.clone(), integration);
+                    target = Some(format!("integrations/{integration_id}"));
+                }
+                let route = Route {
+                    route_id: route_id.clone(),
+                    route_key: format!("{route_method} {path}"),
+                    target,
+                    ..Default::default()
+                };
+                routes.insert(route_id, route);
+            }
+        }
+    }
+
+    (api, routes, integrations)
+}
+
+/// Generate an OpenAPI 3.0 document from an API and its routes. The inverse
+/// of `build_api_from_spec` for the parts that round-trip.
+fn export_openapi(api: &HttpApi, routes: &[Route]) -> Value {
+    let mut paths = serde_json::Map::new();
+    for route in routes {
+        // route_key is "<METHOD> <path>"; "$default" carries no method/path.
+        let Some((method, path)) = route.route_key.split_once(' ') else {
+            continue;
+        };
+        let method_key = if method.eq_ignore_ascii_case("ANY") {
+            "x-amazon-apigateway-any-method".to_string()
+        } else {
+            method.to_ascii_lowercase()
+        };
+        let entry = paths.entry(path.to_string()).or_insert_with(|| json!({}));
+        if let Some(obj) = entry.as_object_mut() {
+            obj.insert(
+                method_key,
+                json!({
+                    "responses": { "default": { "description": "Default response" } }
+                }),
+            );
+        }
+    }
+    json!({
+        "openapi": "3.0.1",
+        "info": {
+            "title": api.name,
+            "version": api.version.clone().unwrap_or_else(|| "1.0".to_string()),
+            "description": api.description.clone().unwrap_or_default(),
+        },
+        "paths": Value::Object(paths),
+    })
+}
+
+/// Produce a best-effort example JSON value from a (subset of) JSON schema,
+/// used to synthesize a `GetModelTemplate` mapping template.
+fn example_from_schema(schema: &Value) -> Value {
+    if let Some(example) = schema.get("example") {
+        return example.clone();
+    }
+    let ty = schema.get("type").and_then(|v| v.as_str());
+    match ty {
+        Some("object") | None if schema.get("properties").is_some() => {
+            let mut obj = serde_json::Map::new();
+            if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+                for (k, v) in props {
+                    obj.insert(k.clone(), example_from_schema(v));
+                }
+            }
+            Value::Object(obj)
+        }
+        Some("object") => Value::Object(serde_json::Map::new()),
+        Some("array") => {
+            let item = schema
+                .get("items")
+                .map(example_from_schema)
+                .unwrap_or(Value::Null);
+            json!([item])
+        }
+        Some("string") => json!(""),
+        Some("integer") | Some("number") => json!(0),
+        Some("boolean") => json!(false),
+        _ => json!({}),
+    }
+}
+
 impl ApiGatewayV2Service {
     pub(crate) fn handle_extra_action(
         &self,
@@ -524,9 +713,26 @@ impl ApiGatewayV2Service {
                 no_content()
             }
             "GetModelTemplate" => {
-                api_id.ok_or_else(|| missing("ApiId"))?;
-                resource_id.ok_or_else(|| missing("ModelId"))?;
-                ok(json!({"Value": "{}"}))
+                let api = api_id.ok_or_else(|| missing("ApiId"))?;
+                let model = resource_id.ok_or_else(|| missing("ModelId"))?;
+                self.read_state(aid, &region, |state| {
+                    let stored = state
+                        .models
+                        .get(api)
+                        .and_then(|m| m.get(model))
+                        .ok_or_else(|| not_found("Model", model))?;
+                    // Derive a mapping-template example from the model schema
+                    // rather than returning a fixed constant.
+                    let schema = stored
+                        .get("Schema")
+                        .or_else(|| stored.get("schema"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("{}");
+                    let schema_json: Value =
+                        serde_json::from_str(schema).unwrap_or_else(|_| json!({}));
+                    let template = example_from_schema(&schema_json);
+                    ok(json!({ "Value": template.to_string() }))
+                })
             }
 
             // ── Integration responses ──
@@ -989,22 +1195,43 @@ impl ApiGatewayV2Service {
             // ── Import / Export ──
             "ImportApi" => {
                 let body = body(req);
-                req_str(&body, "Body")?;
-                let api_id = format!("imported-{}", rand_id());
-                ok(json!({
-                    "ApiId": api_id,
-                    "Name": "imported-api",
-                    "ProtocolType": "HTTP",
-                }))
+                let spec_raw = req_str(&body, "Body")?.to_string();
+                let spec = parse_openapi_spec(&spec_raw)?;
+                let new_api_id = generate_id("api");
+                let (api, routes, integrations) =
+                    build_api_from_spec(&spec, new_api_id.clone(), &region);
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(aid);
+                state.apis.insert(new_api_id.clone(), api.clone());
+                state.routes.insert(new_api_id.clone(), routes);
+                state.integrations.insert(new_api_id.clone(), integrations);
+                ok(json!(api))
             }
             "ReimportApi" => {
-                let api = api_id.ok_or_else(|| missing("ApiId"))?;
+                let api = api_id.ok_or_else(|| missing("ApiId"))?.to_string();
                 let body = body(req);
-                req_str(&body, "Body")?;
-                ok(json!({"ApiId": api, "Name": "reimported"}))
+                let spec_raw = req_str(&body, "Body")?.to_string();
+                let spec = parse_openapi_spec(&spec_raw)?;
+                let (rebuilt, routes, integrations) =
+                    build_api_from_spec(&spec, api.clone(), &region);
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(aid);
+                let existing = state
+                    .apis
+                    .get_mut(&api)
+                    .ok_or_else(|| not_found("Api", &api))?;
+                // Preserve the existing endpoint/ids; overlay name/description/
+                // version and the synthesized surface from the new spec.
+                existing.name = rebuilt.name;
+                existing.description = rebuilt.description;
+                existing.version = rebuilt.version;
+                let updated = existing.clone();
+                state.routes.insert(api.clone(), routes);
+                state.integrations.insert(api.clone(), integrations);
+                ok(json!(updated))
             }
             "ExportApi" => {
-                let _api = api_id.ok_or_else(|| missing("ApiId"))?;
+                let api = api_id.ok_or_else(|| missing("ApiId"))?.to_string();
                 // Specification is an httpLabel (segs[4]) — already filtered
                 // to None for empty/placeholder path ids, so resource_id=None
                 // here means the caller omitted it.
@@ -1014,20 +1241,51 @@ impl ApiGatewayV2Service {
                     .iter()
                     .find(|(k, _)| *k == "outputType")
                     .map(|(_, v)| v.as_str());
-                if output_type.is_none() {
+                let Some(output_type) = output_type else {
                     return Err(missing("OutputType"));
-                }
-                ok(json!({"body": "openapi: 3.0.1\n"}))
+                };
+                let document = self.read_state(aid, &region, |state| {
+                    let api_obj = state.apis.get(&api).ok_or_else(|| not_found("Api", &api))?;
+                    let routes = state
+                        .routes
+                        .get(&api)
+                        .map(|r| r.values().cloned().collect::<Vec<_>>())
+                        .unwrap_or_default();
+                    Ok::<_, AwsServiceError>(export_openapi(api_obj, &routes))
+                })?;
+                // ExportApi returns the spec as a Blob body. Honor the requested
+                // OutputType (JSON default, YAML when asked).
+                let rendered = if output_type.eq_ignore_ascii_case("YAML") {
+                    serde_yaml::to_string(&document).unwrap_or_default()
+                } else {
+                    serde_json::to_string_pretty(&document).unwrap_or_default()
+                };
+                ok(json!({ "body": rendered }))
             }
 
             // ── Cleanup ops ──
             "DeleteCorsConfiguration" => {
-                api_id.ok_or_else(|| missing("ApiId"))?;
+                let api = api_id.ok_or_else(|| missing("ApiId"))?;
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(aid);
+                let api_obj = state
+                    .apis
+                    .get_mut(api)
+                    .ok_or_else(|| not_found("Api", api))?;
+                api_obj.cors_configuration = None;
                 no_content()
             }
             "DeleteAccessLogSettings" => {
-                api_id.ok_or_else(|| missing("ApiId"))?;
-                resource_id.ok_or_else(|| missing("StageName"))?;
+                let api = api_id.ok_or_else(|| missing("ApiId"))?;
+                let stage_name = resource_id.ok_or_else(|| missing("StageName"))?;
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(aid);
+                let stage = state
+                    .stages
+                    .get_mut(api)
+                    .and_then(|s| s.get_mut(stage_name))
+                    .ok_or_else(|| not_found("Stage", stage_name))?;
+                stage.access_log_settings = None;
                 no_content()
             }
             "DeleteRouteRequestParameter" => {
@@ -2042,13 +2300,43 @@ mod tests {
             Some("a1"),
             None,
         );
-        ok(
-            "GetModelTemplate",
-            "",
-            &["v2", "apis", "a1", "models", "m1", "template"],
-            Some("a1"),
-            Some("m1"),
-        );
+        {
+            // GetModelTemplate now derives a template from a real stored
+            // model schema, so seed one first.
+            let s = svc();
+            run(
+                &s,
+                "CreateModel",
+                r#"{"Name":"m","Schema":"{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"}}}"}"#,
+                &["v2", "apis", "a1", "models"],
+                Some("a1"),
+                None,
+            );
+            let model_id = {
+                let accounts = s.state.read();
+                accounts
+                    .get("000000000000")
+                    .and_then(|st| st.models.get("a1"))
+                    .and_then(|m| m.keys().next().cloned())
+                    .expect("model seeded")
+            };
+            let resp = s
+                .handle_extra_action(
+                    "GetModelTemplate",
+                    &req(
+                        "GetModelTemplate",
+                        "",
+                        &["v2", "apis", "a1", "models", &model_id, "template"],
+                    ),
+                    Some("a1"),
+                    Some(&model_id),
+                )
+                .expect("GetModelTemplate");
+            let b: serde_json::Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            let tmpl: serde_json::Value =
+                serde_json::from_str(b["value"].as_str().unwrap()).unwrap();
+            assert_eq!(tmpl["id"], "");
+        }
         ok(
             "CreateIntegrationResponse",
             r#"{"IntegrationResponseKey":"$default"}"#,
@@ -2095,46 +2383,162 @@ mod tests {
 
     #[test]
     fn import_export_cleanup() {
-        ok(
-            "ImportApi",
-            r#"{"Body":"openapi"}"#,
-            &["v2", "apis"],
-            None,
-            None,
-        );
-        ok(
-            "ReimportApi",
-            r#"{"Body":"openapi"}"#,
-            &["v2", "apis", "a1"],
-            Some("a1"),
-            None,
-        );
+        // A minimal-but-real OpenAPI document. ImportApi/ReimportApi now
+        // parse this and synthesize routes rather than echoing a constant.
+        let spec = r#"{"openapi":"3.0.1","info":{"title":"t","version":"1"},"paths":{"/p":{"get":{"responses":{"200":{"description":"ok"}}}}}}"#;
+
+        // ImportApi creates a real API on a fresh service.
         {
-            // ExportApi requires @httpQuery("outputType") + path Specification.
             let s = svc();
+            let import_body = serde_json::json!({ "Body": spec }).to_string();
+            let resp = s
+                .handle_extra_action(
+                    "ImportApi",
+                    &req("ImportApi", &import_body, &["v2", "apis"]),
+                    None,
+                    None,
+                )
+                .expect("ImportApi");
+            let b: serde_json::Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            let api = b["apiId"].as_str().unwrap().to_string();
+            // The synthesized route is readable back.
+            assert!(s
+                .state
+                .read()
+                .get("000000000000")
+                .and_then(|st| st.routes.get(&api))
+                .map(|r| r.values().any(|rt| rt.route_key == "GET /p"))
+                .unwrap_or(false));
+        }
+
+        // ExportApi / ReimportApi / cleanup ops all operate on a single
+        // service seeded with a real API + stage.
+        let s = svc();
+        let api = {
+            let import_body = serde_json::json!({ "Body": spec }).to_string();
+            let resp = s
+                .handle_extra_action(
+                    "ImportApi",
+                    &req("ImportApi", &import_body, &["v2", "apis"]),
+                    None,
+                    None,
+                )
+                .expect("ImportApi");
+            let b: serde_json::Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            b["apiId"].as_str().unwrap().to_string()
+        };
+
+        // Attach a CORS config + a stage with access log settings so the
+        // cleanup ops have something real to clear.
+        {
+            let mut accounts = s.state.write();
+            let state = accounts.get_or_create("000000000000");
+            if let Some(a) = state.apis.get_mut(&api) {
+                a.cors_configuration = Some(crate::state::CorsConfiguration {
+                    allow_credentials: None,
+                    allow_headers: None,
+                    allow_methods: Some(vec!["GET".to_string()]),
+                    allow_origins: Some(vec!["*".to_string()]),
+                    expose_headers: None,
+                    max_age: None,
+                });
+            }
+            state.stages.entry(api.clone()).or_default().insert(
+                "prod".to_string(),
+                crate::state::Stage {
+                    stage_name: "prod".to_string(),
+                    description: None,
+                    deployment_id: None,
+                    auto_deploy: false,
+                    created_date: chrono::Utc::now(),
+                    last_updated_date: None,
+                    web_acl_arn: None,
+                    stage_variables: None,
+                    access_log_settings: Some(crate::state::AccessLogSettings {
+                        destination_arn: "arn:aws:logs:us-east-1:0:log-group:g:*".to_string(),
+                        format: None,
+                    }),
+                    client_certificate_id: None,
+                    default_route_settings: None,
+                    route_settings: None,
+                    tags: None,
+                },
+            );
+        }
+
+        // ReimportApi replaces the surface of the existing API.
+        {
+            let spec2 = r#"{"openapi":"3.0.1","info":{"title":"t2","version":"2"},"paths":{"/q":{"get":{"responses":{"200":{"description":"ok"}}}}}}"#;
+            let reimport_body = serde_json::json!({ "Body": spec2 }).to_string();
+            run(
+                &s,
+                "ReimportApi",
+                &reimport_body,
+                &["v2", "apis", &api],
+                Some(&api),
+                None,
+            );
+            assert!(s
+                .state
+                .read()
+                .get("000000000000")
+                .and_then(|st| st.routes.get(&api))
+                .map(|r| r.values().all(|rt| rt.route_key == "GET /q"))
+                .unwrap_or(false));
+        }
+
+        // ExportApi generates a real document.
+        {
             let r = req_with_query(
                 "ExportApi",
                 "",
-                &["v2", "apis", "a1", "exports", "OAS30"],
+                &["v2", "apis", &api, "exports", "OAS30"],
                 &[("outputType", "JSON")],
             );
-            s.handle_extra_action("ExportApi", &r, Some("a1"), Some("OAS30"))
+            let resp = s
+                .handle_extra_action("ExportApi", &r, Some(&api), Some("OAS30"))
                 .expect("ExportApi");
+            let b: serde_json::Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            let doc: serde_json::Value = serde_json::from_str(b["body"].as_str().unwrap()).unwrap();
+            assert_eq!(doc["openapi"], "3.0.1");
+            assert!(doc["paths"]["/q"].get("get").is_some());
         }
-        ok(
+
+        // DeleteCorsConfiguration clears the config.
+        run(
+            &s,
             "DeleteCorsConfiguration",
             "",
-            &["v2", "apis", "a1", "cors"],
-            Some("a1"),
+            &["v2", "apis", &api, "cors"],
+            Some(&api),
             None,
         );
-        ok(
+        assert!(s
+            .state
+            .read()
+            .get("000000000000")
+            .and_then(|st| st.apis.get(&api))
+            .map(|a| a.cors_configuration.is_none())
+            .unwrap_or(false));
+
+        // DeleteAccessLogSettings clears the stage settings.
+        run(
+            &s,
             "DeleteAccessLogSettings",
             "",
-            &["v2", "apis", "a1", "stages", "prod", "accesslogsettings"],
-            Some("a1"),
+            &["v2", "apis", &api, "stages", "prod", "accesslogsettings"],
+            Some(&api),
             Some("prod"),
         );
+        assert!(s
+            .state
+            .read()
+            .get("000000000000")
+            .and_then(|st| st.stages.get(&api))
+            .and_then(|m| m.get("prod"))
+            .map(|st| st.access_log_settings.is_none())
+            .unwrap_or(false));
+
         ok(
             "DeleteRouteRequestParameter",
             "",

--- a/crates/fakecloud-apigatewayv2/src/router.rs
+++ b/crates/fakecloud-apigatewayv2/src/router.rs
@@ -174,9 +174,7 @@ mod tests {
         let routes = vec![Route {
             route_id: "r1".to_string(),
             route_key: "GET /pets".to_string(),
-            target: None,
-            authorization_type: None,
-            authorizer_id: None,
+            ..Default::default()
         }];
 
         let router = Router::new(routes);
@@ -192,9 +190,7 @@ mod tests {
         let routes = vec![Route {
             route_id: "r1".to_string(),
             route_key: "GET /pets/{id}".to_string(),
-            target: None,
-            authorization_type: None,
-            authorizer_id: None,
+            ..Default::default()
         }];
 
         let router = Router::new(routes);
@@ -213,9 +209,7 @@ mod tests {
         let routes = vec![Route {
             route_id: "r1".to_string(),
             route_key: "GET /api/{proxy+}".to_string(),
-            target: None,
-            authorization_type: None,
-            authorizer_id: None,
+            ..Default::default()
         }];
 
         let router = Router::new(routes);
@@ -235,16 +229,12 @@ mod tests {
             Route {
                 route_id: "r1".to_string(),
                 route_key: "GET /pets/{id}".to_string(),
-                target: None,
-                authorization_type: None,
-                authorizer_id: None,
+                ..Default::default()
             },
             Route {
                 route_id: "r2".to_string(),
                 route_key: "GET /pets/special".to_string(),
-                target: None,
-                authorization_type: None,
-                authorizer_id: None,
+                ..Default::default()
             },
         ];
 
@@ -261,16 +251,12 @@ mod tests {
             Route {
                 route_id: "r1".to_string(),
                 route_key: "GET /api/{proxy+}".to_string(),
-                target: None,
-                authorization_type: None,
-                authorizer_id: None,
+                ..Default::default()
             },
             Route {
                 route_id: "r2".to_string(),
                 route_key: "GET /api/{version}/users".to_string(),
-                target: None,
-                authorization_type: None,
-                authorizer_id: None,
+                ..Default::default()
             },
         ];
 
@@ -286,9 +272,7 @@ mod tests {
         let routes = vec![Route {
             route_id: "r1".to_string(),
             route_key: "ANY /pets".to_string(),
-            target: None,
-            authorization_type: None,
-            authorizer_id: None,
+            ..Default::default()
         }];
 
         let router = Router::new(routes);
@@ -303,16 +287,12 @@ mod tests {
             Route {
                 route_id: "any".to_string(),
                 route_key: "ANY /pets".to_string(),
-                target: None,
-                authorization_type: None,
-                authorizer_id: None,
+                ..Default::default()
             },
             Route {
                 route_id: "get".to_string(),
                 route_key: "GET /pets".to_string(),
-                target: None,
-                authorization_type: None,
-                authorizer_id: None,
+                ..Default::default()
             },
         ];
 
@@ -327,9 +307,7 @@ mod tests {
         let routes = vec![Route {
             route_id: "r1".to_string(),
             route_key: "GET /pets".to_string(),
-            target: None,
-            authorization_type: None,
-            authorizer_id: None,
+            ..Default::default()
         }];
 
         let router = Router::new(routes);
@@ -342,9 +320,7 @@ mod tests {
         let routes = vec![Route {
             route_id: "r1".to_string(),
             route_key: "GET /users/{userId}/posts/{postId}".to_string(),
-            target: None,
-            authorization_type: None,
-            authorizer_id: None,
+            ..Default::default()
         }];
 
         let router = Router::new(routes);

--- a/crates/fakecloud-apigatewayv2/src/service/apis.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/apis.rs
@@ -80,6 +80,7 @@ impl ApiGatewayV2Service {
         let mut api = HttpApi::new(api_id, name, description, tags, region);
         api.cors_configuration = cors_configuration;
         api.protocol_type = protocol_type.clone();
+        api.version = body["version"].as_str().map(|s| s.to_string());
         if let Some(ip) = requested_ip_type {
             api.ip_address_type = ip;
         }

--- a/crates/fakecloud-apigatewayv2/src/service/authorizers.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/authorizers.rs
@@ -77,6 +77,12 @@ impl ApiGatewayV2Service {
                 .map(|s| s.to_string()),
             authorizer_result_ttl_in_seconds: body["authorizerResultTtlInSeconds"].as_i64(),
             enable_simple_responses: body["enableSimpleResponses"].as_bool(),
+            authorizer_credentials_arn: body["authorizerCredentialsArn"]
+                .as_str()
+                .map(|s| s.to_string()),
+            identity_validation_expression: body["identityValidationExpression"]
+                .as_str()
+                .map(|s| s.to_string()),
         };
 
         let mut accounts = self.state.write();
@@ -272,6 +278,14 @@ impl ApiGatewayV2Service {
 
         if let Some(v) = body["enableSimpleResponses"].as_bool() {
             authorizer.enable_simple_responses = Some(v);
+        }
+
+        if let Some(v) = body["authorizerCredentialsArn"].as_str() {
+            authorizer.authorizer_credentials_arn = Some(v.to_string());
+        }
+
+        if let Some(v) = body["identityValidationExpression"].as_str() {
+            authorizer.identity_validation_expression = Some(v.to_string());
         }
 
         Ok(AwsResponse::ok_json(json!(authorizer)))

--- a/crates/fakecloud-apigatewayv2/src/service/mod.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/mod.rs
@@ -713,29 +713,75 @@ fn normalize_request_body_keys(mut req: AwsRequest) -> AwsRequest {
     req
 }
 
-/// Walk the body and, for every map key that starts with an uppercase
-/// ASCII letter, insert a sibling entry whose first letter is lowercased
-/// (and vice versa for camelCase keys). This is purely additive — the
-/// original key is preserved — so handlers that read either case keep
-/// working through the same body. The size cost is negligible compared
-/// to the wins in handler portability.
+/// Members whose values are maps with *arbitrary, user-supplied keys*
+/// (`map<string, ...>` in the Smithy model). The `@jsonName` first-letter
+/// normalization applies to modeled member names only — it must NOT rewrite
+/// the keys of these maps (content types, request-parameter expressions,
+/// route keys, tag names, ...), or a request like
+/// `requestModels: {"application/json": "M"}` would gain a corrupt
+/// `Application/json` sibling. Their *values* are still normalized so that a
+/// nested modeled struct (e.g. `requestParameters`'
+/// `ParameterConstraints.required`) keeps working in either case.
+const ARBITRARY_KEY_MAPS: &[&str] = &[
+    "requestModels",
+    "responseModels",
+    "requestParameters",
+    "responseParameters",
+    "requestTemplates",
+    "responseTemplates",
+    "routeSettings",
+    "stageVariables",
+    "tags",
+    "variables",
+];
+
+/// Whether `field` (in either case) names an arbitrary-key map member.
+fn is_arbitrary_key_map(field: &str) -> bool {
+    let mut chars = field.chars();
+    let camel = match chars.next() {
+        Some(c) => c.to_ascii_lowercase().to_string() + chars.as_str(),
+        None => return false,
+    };
+    ARBITRARY_KEY_MAPS.contains(&camel.as_str())
+}
+
+/// Walk the body and, for every *modeled* map key that starts with an
+/// uppercase ASCII letter, insert a sibling entry whose first letter is
+/// lowercased (and vice versa for camelCase keys). This is purely additive —
+/// the original key is preserved — so handlers that read either case keep
+/// working through the same body. Keys of arbitrary-key maps (see
+/// `ARBITRARY_KEY_MAPS`) are left exactly as sent.
 fn lowercase_first_letter_keys(v: serde_json::Value) -> serde_json::Value {
+    normalize_member_keys(v, false)
+}
+
+/// `keys_are_arbitrary` is true when the current object's own keys are
+/// user-supplied (a `map<string, ...>` value) and must be preserved verbatim.
+fn normalize_member_keys(v: serde_json::Value, keys_are_arbitrary: bool) -> serde_json::Value {
     match v {
         serde_json::Value::Object(map) => {
             let mut out = serde_json::Map::with_capacity(map.len() * 2);
             for (k, val) in map {
-                let normalized = lowercase_first_letter_keys(val);
-                let alt_key = swap_first_letter_case(&k);
-                if alt_key != k && !out.contains_key(&alt_key) {
-                    out.insert(alt_key, normalized.clone());
+                // A child is an arbitrary-key map iff *this* member name says
+                // so — regardless of the current level being arbitrary.
+                let child_arbitrary = is_arbitrary_key_map(&k);
+                let normalized = normalize_member_keys(val, child_arbitrary);
+                if !keys_are_arbitrary {
+                    let alt_key = swap_first_letter_case(&k);
+                    if alt_key != k && !out.contains_key(&alt_key) {
+                        out.insert(alt_key, normalized.clone());
+                    }
                 }
                 out.insert(k, normalized);
             }
             serde_json::Value::Object(out)
         }
-        serde_json::Value::Array(items) => {
-            serde_json::Value::Array(items.into_iter().map(lowercase_first_letter_keys).collect())
-        }
+        serde_json::Value::Array(items) => serde_json::Value::Array(
+            items
+                .into_iter()
+                .map(|x| normalize_member_keys(x, false))
+                .collect(),
+        ),
         other => other,
     }
 }

--- a/crates/fakecloud-apigatewayv2/src/service/mod.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/mod.rs
@@ -330,6 +330,9 @@ impl ApiGatewayV2Service {
         if let Some(b) = body["disableExecuteApiEndpoint"].as_bool() {
             api.disable_execute_api_endpoint = b;
         }
+        if let Some(v) = body["version"].as_str() {
+            api.version = Some(v.to_string());
+        }
 
         Ok(AwsResponse::ok_json(json!(api)))
     }
@@ -735,6 +738,38 @@ fn lowercase_first_letter_keys(v: serde_json::Value) -> serde_json::Value {
         }
         other => other,
     }
+}
+
+/// Parse a JSON array of strings into `Vec<String>`, or `None` when the
+/// value is not an array.
+pub(crate) fn parse_string_array(v: &serde_json::Value) -> Option<Vec<String>> {
+    v.as_array().map(|arr| {
+        arr.iter()
+            .filter_map(|x| x.as_str().map(|s| s.to_string()))
+            .collect()
+    })
+}
+
+/// Parse a JSON object of `string -> string` into a `BTreeMap`, or `None`
+/// when the value is not an object.
+pub(crate) fn parse_string_map(v: &serde_json::Value) -> Option<BTreeMap<String, String>> {
+    v.as_object().map(|obj| {
+        obj.iter()
+            .filter_map(|(k, val)| val.as_str().map(|s| (k.clone(), s.to_string())))
+            .collect()
+    })
+}
+
+/// Parse a JSON object of `string -> Value` into a `BTreeMap`, preserving
+/// each value verbatim, or `None` when the value is not an object.
+pub(crate) fn parse_value_map(
+    v: &serde_json::Value,
+) -> Option<BTreeMap<String, serde_json::Value>> {
+    v.as_object().map(|obj| {
+        obj.iter()
+            .map(|(k, val)| (k.clone(), val.clone()))
+            .collect()
+    })
 }
 
 fn swap_first_letter_case(s: &str) -> String {

--- a/crates/fakecloud-apigatewayv2/src/service/routes.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/routes.rs
@@ -44,6 +44,17 @@ impl ApiGatewayV2Service {
             target,
             authorization_type,
             authorizer_id,
+            api_key_required: body["apiKeyRequired"].as_bool(),
+            authorization_scopes: parse_string_array(&body["authorizationScopes"]),
+            model_selection_expression: body["modelSelectionExpression"]
+                .as_str()
+                .map(|s| s.to_string()),
+            operation_name: body["operationName"].as_str().map(|s| s.to_string()),
+            request_models: parse_string_map(&body["requestModels"]),
+            request_parameters: parse_value_map(&body["requestParameters"]),
+            route_response_selection_expression: body["routeResponseSelectionExpression"]
+                .as_str()
+                .map(|s| s.to_string()),
         };
 
         let mut accounts = self.state.write();
@@ -205,6 +216,34 @@ impl ApiGatewayV2Service {
 
         if let Some(authorizer_id) = body["authorizerId"].as_str() {
             route.authorizer_id = Some(authorizer_id.to_string());
+        }
+
+        if let Some(api_key_required) = body["apiKeyRequired"].as_bool() {
+            route.api_key_required = Some(api_key_required);
+        }
+
+        if let Some(scopes) = parse_string_array(&body["authorizationScopes"]) {
+            route.authorization_scopes = Some(scopes);
+        }
+
+        if let Some(expr) = body["modelSelectionExpression"].as_str() {
+            route.model_selection_expression = Some(expr.to_string());
+        }
+
+        if let Some(name) = body["operationName"].as_str() {
+            route.operation_name = Some(name.to_string());
+        }
+
+        if let Some(models) = parse_string_map(&body["requestModels"]) {
+            route.request_models = Some(models);
+        }
+
+        if let Some(params) = parse_value_map(&body["requestParameters"]) {
+            route.request_parameters = Some(params);
+        }
+
+        if let Some(expr) = body["routeResponseSelectionExpression"].as_str() {
+            route.route_response_selection_expression = Some(expr.to_string());
         }
 
         Ok(AwsResponse::ok_json(json!(route)))

--- a/crates/fakecloud-apigatewayv2/src/service/stages.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/stages.rs
@@ -55,6 +55,21 @@ impl ApiGatewayV2Service {
 
         let created_date = chrono::Utc::now();
 
+        let client_certificate_id = body["clientCertificateId"].as_str().map(|s| s.to_string());
+        let default_route_settings = body
+            .get("defaultRouteSettings")
+            .filter(|v| !v.is_null())
+            .cloned();
+        let route_settings = body
+            .get("routeSettings")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect::<BTreeMap<String, serde_json::Value>>()
+            });
+        let tags = parse_string_map(&body["tags"]);
+
         let stage = Stage {
             stage_name: stage_name.clone(),
             description,
@@ -65,6 +80,10 @@ impl ApiGatewayV2Service {
             web_acl_arn: None,
             stage_variables,
             access_log_settings,
+            client_certificate_id,
+            default_route_settings,
+            route_settings,
+            tags,
         };
 
         let mut accounts = self.state.write();
@@ -265,6 +284,31 @@ impl ApiGatewayV2Service {
             }
             // If accessLogSettings is present but destinationArn is missing,
             // preserve the existing settings (Cubic finding).
+        }
+
+        if let Some(cert) = body["clientCertificateId"].as_str() {
+            stage.client_certificate_id = Some(cert.to_string());
+        }
+
+        if let Some(settings) = body.get("defaultRouteSettings") {
+            if settings.is_null() {
+                stage.default_route_settings = None;
+            } else {
+                stage.default_route_settings = Some(settings.clone());
+            }
+        }
+
+        if let Some(settings) = body.get("routeSettings").and_then(|v| v.as_object()) {
+            stage.route_settings = Some(
+                settings
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect(),
+            );
+        }
+
+        if let Some(tags) = parse_string_map(&body["tags"]) {
+            stage.tags = Some(tags);
         }
 
         stage.last_updated_date = Some(chrono::Utc::now());

--- a/crates/fakecloud-apigatewayv2/src/service/stages.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/stages.rs
@@ -298,13 +298,15 @@ impl ApiGatewayV2Service {
             }
         }
 
-        if let Some(settings) = body.get("routeSettings").and_then(|v| v.as_object()) {
-            stage.route_settings = Some(
-                settings
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect(),
-            );
+        if let Some(settings) = body.get("routeSettings") {
+            // Distinguish an explicit null (clear) from an absent field
+            // (preserve), mirroring defaultRouteSettings above.
+            if settings.is_null() {
+                stage.route_settings = None;
+            } else if let Some(obj) = settings.as_object() {
+                stage.route_settings =
+                    Some(obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
+            }
         }
 
         if let Some(tags) = parse_string_map(&body["tags"]) {

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -2754,6 +2754,16 @@ async fn route_persists_extended_fields() {
     );
     assert_eq!(b["routeResponseSelectionExpression"], "$default");
 
+    // Arbitrary-key maps must be stored verbatim — no synthetic
+    // first-letter-swapped sibling keys ("Application/json", etc).
+    assert_eq!(b["requestModels"].as_object().unwrap().len(), 1);
+    assert!(b["requestModels"].get("Application/json").is_none());
+    let params = b["requestParameters"].as_object().unwrap();
+    assert_eq!(params.len(), 1);
+    assert!(params.get("Route.request.header.x").is_none());
+    // ...but the nested modeled struct's member is still case-normalized.
+    assert_eq!(params["route.request.header.x"]["required"], true);
+
     // Update one field; the rest must stay.
     let body = serde_json::json!({"operationName": "Renamed"});
     let req = make_request(
@@ -2817,6 +2827,35 @@ async fn stage_persists_extended_fields() {
     assert_eq!(b["clientCertificateId"], "cert-999");
     assert_eq!(b["tags"]["env"], "staging");
     // Untouched field preserved.
+    assert_eq!(b["defaultRouteSettings"]["throttlingBurstLimit"], 100);
+    // routeSettings map key ("GET /items") is arbitrary and kept verbatim.
+    let rs = b["routeSettings"].as_object().unwrap();
+    assert_eq!(rs.len(), 1);
+    assert!(rs.contains_key("GET /items"));
+
+    // Explicit null routeSettings clears them; absent field preserves.
+    let body = serde_json::json!({ "routeSettings": null });
+    let req = make_request(
+        Method::PATCH,
+        &format!("/v2/apis/{api_id}/stages/prod"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/stages/prod"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert!(b.get("routeSettings").is_none());
+    // A subsequent patch that omits routeSettings must not resurrect them.
+    let body = serde_json::json!({ "description": "d" });
+    let req = make_request(
+        Method::PATCH,
+        &format!("/v2/apis/{api_id}/stages/prod"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/stages/prod"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert!(b.get("routeSettings").is_none());
+    // defaultRouteSettings untouched by the routeSettings clears.
     assert_eq!(b["defaultRouteSettings"]["throttlingBurstLimit"], 100);
 }
 
@@ -3012,7 +3051,8 @@ async fn reimport_api_replaces_routes() {
     // Unknown API id 404s.
     let body = serde_json::json!({"body": petstore_spec()});
     let req = make_request(Method::PUT, "/v2/apis/does-not-exist", &body.to_string());
-    assert!(svc.handle(req).await.is_err());
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), http::StatusCode::NOT_FOUND);
 }
 
 /// ExportApi emits a real OpenAPI document derived from the API's routes.
@@ -3046,15 +3086,20 @@ async fn export_api_validates() {
     let svc = ApiGatewayV2Service::new(state);
     let api_id = create_api(&svc);
 
-    // Missing OutputType.
+    // Missing OutputType. The apigatewayv2 model marks OutputType
+    // @required (the clientOptional trait only nulls it in the generated
+    // SDK; the server still rejects it), so this is a 400 BadRequestException
+    // rather than a defaulted export.
     let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/exports/OAS30"), "");
-    assert!(svc.handle(req).await.is_err());
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
 
     // Unknown API.
     let mut req = make_request(Method::GET, "/v2/apis/nope/exports/OAS30", "");
     req.query_params
         .insert("outputType".to_string(), "JSON".to_string());
-    assert!(svc.handle(req).await.is_err());
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), http::StatusCode::NOT_FOUND);
 }
 
 /// DeleteCorsConfiguration clears the stored CORS config and persists it.
@@ -3086,7 +3131,8 @@ async fn delete_cors_configuration_clears_config() {
 
     // Unknown API 404s.
     let req = make_request(Method::DELETE, "/v2/apis/missing/cors", "");
-    assert!(svc.handle(req).await.is_err());
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), http::StatusCode::NOT_FOUND);
 }
 
 /// DeleteAccessLogSettings clears the stage's access log settings.

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -2706,3 +2706,461 @@ async fn create_domain_name_reports_available_status() {
     assert_eq!(cfg0["ipAddressType"], "ipv4");
     assert!(cfg0["apiGatewayDomainName"].as_str().is_some());
 }
+
+// ── Batch 6: field-drop + stub fixes ──
+
+/// Route Create/Update round-trips the previously dropped optional members.
+#[tokio::test]
+async fn route_persists_extended_fields() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "routeKey": "GET /items",
+        "apiKeyRequired": true,
+        "authorizationScopes": ["scope.a", "scope.b"],
+        "modelSelectionExpression": "$request.body.action",
+        "operationName": "ListItems",
+        "requestModels": {"application/json": "MyModel"},
+        "requestParameters": {"route.request.header.x": {"required": true}},
+        "routeResponseSelectionExpression": "$default",
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let b = body_json(&resp);
+    let route_id = b["routeId"].as_str().unwrap().to_string();
+    assert_eq!(b["apiKeyRequired"], true);
+
+    // Read back via GetRoute — the fields must survive the store.
+    let req = make_request(
+        Method::GET,
+        &format!("/v2/apis/{api_id}/routes/{route_id}"),
+        "",
+    );
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["apiKeyRequired"], true);
+    assert_eq!(b["authorizationScopes"][1], "scope.b");
+    assert_eq!(b["modelSelectionExpression"], "$request.body.action");
+    assert_eq!(b["operationName"], "ListItems");
+    assert_eq!(b["requestModels"]["application/json"], "MyModel");
+    assert_eq!(
+        b["requestParameters"]["route.request.header.x"]["required"],
+        true
+    );
+    assert_eq!(b["routeResponseSelectionExpression"], "$default");
+
+    // Update one field; the rest must stay.
+    let body = serde_json::json!({"operationName": "Renamed"});
+    let req = make_request(
+        Method::PATCH,
+        &format!("/v2/apis/{api_id}/routes/{route_id}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+    let req = make_request(
+        Method::GET,
+        &format!("/v2/apis/{api_id}/routes/{route_id}"),
+        "",
+    );
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["operationName"], "Renamed");
+    assert_eq!(b["apiKeyRequired"], true);
+}
+
+/// Stage Create/Update round-trips ClientCertificateId / DefaultRouteSettings /
+/// RouteSettings / Tags.
+#[tokio::test]
+async fn stage_persists_extended_fields() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "stageName": "prod",
+        "clientCertificateId": "cert-123",
+        "defaultRouteSettings": {"throttlingBurstLimit": 100, "throttlingRateLimit": 50.0},
+        "routeSettings": {"GET /items": {"throttlingBurstLimit": 5}},
+        "tags": {"team": "platform"},
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/stages/prod"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["clientCertificateId"], "cert-123");
+    assert_eq!(b["defaultRouteSettings"]["throttlingBurstLimit"], 100);
+    assert_eq!(b["routeSettings"]["GET /items"]["throttlingBurstLimit"], 5);
+    assert_eq!(b["tags"]["team"], "platform");
+
+    // Update tags + client cert.
+    let body = serde_json::json!({
+        "clientCertificateId": "cert-999",
+        "tags": {"env": "staging"},
+    });
+    let req = make_request(
+        Method::PATCH,
+        &format!("/v2/apis/{api_id}/stages/prod"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/stages/prod"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["clientCertificateId"], "cert-999");
+    assert_eq!(b["tags"]["env"], "staging");
+    // Untouched field preserved.
+    assert_eq!(b["defaultRouteSettings"]["throttlingBurstLimit"], 100);
+}
+
+/// Authorizer Create/Update round-trips AuthorizerCredentialsArn /
+/// IdentityValidationExpression.
+#[tokio::test]
+async fn authorizer_persists_extended_fields() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "name": "my-auth",
+        "authorizerType": "REQUEST",
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:auth/invocations",
+        "identitySource": ["$request.header.Authorization"],
+        "authorizerCredentialsArn": "arn:aws:iam::123456789012:role/invoke",
+        "identityValidationExpression": "^Bearer .+$",
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let b = body_json(&svc.handle(req).await.unwrap());
+    let auth_id = b["authorizerId"].as_str().unwrap().to_string();
+
+    let req = make_request(
+        Method::GET,
+        &format!("/v2/apis/{api_id}/authorizers/{auth_id}"),
+        "",
+    );
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(
+        b["authorizerCredentialsArn"],
+        "arn:aws:iam::123456789012:role/invoke"
+    );
+    assert_eq!(b["identityValidationExpression"], "^Bearer .+$");
+
+    let body = serde_json::json!({"identityValidationExpression": "^Token .+$"});
+    let req = make_request(
+        Method::PATCH,
+        &format!("/v2/apis/{api_id}/authorizers/{auth_id}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+    let req = make_request(
+        Method::GET,
+        &format!("/v2/apis/{api_id}/authorizers/{auth_id}"),
+        "",
+    );
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["identityValidationExpression"], "^Token .+$");
+    assert_eq!(
+        b["authorizerCredentialsArn"],
+        "arn:aws:iam::123456789012:role/invoke"
+    );
+}
+
+fn petstore_spec() -> String {
+    serde_json::json!({
+        "openapi": "3.0.1",
+        "info": {"title": "petstore", "version": "2.5", "description": "pets"},
+        "paths": {
+            "/pets": {
+                "get": {"responses": {"200": {"description": "ok"}}},
+                "post": {"responses": {"200": {"description": "ok"}}}
+            },
+            "/pets/{id}": {
+                "get": {
+                    "x-amazon-apigateway-integration": {
+                        "type": "http_proxy",
+                        "uri": "https://backend.example.com/pets",
+                        "httpMethod": "GET",
+                        "payloadFormatVersion": "1.0"
+                    },
+                    "responses": {"200": {"description": "ok"}}
+                }
+            }
+        }
+    })
+    .to_string()
+}
+
+/// ImportApi parses the spec, creates a real API, and synthesizes routes +
+/// integrations that GetApi/GetRoutes read back.
+#[tokio::test]
+async fn import_api_creates_real_api_and_routes() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+
+    let body = serde_json::json!({"body": petstore_spec()});
+    let req = make_request(Method::PUT, "/v2/apis", &body.to_string());
+    let b = body_json(&svc.handle(req).await.unwrap());
+    let api_id = b["apiId"].as_str().unwrap().to_string();
+    assert_eq!(b["name"], "petstore");
+    assert_eq!(b["version"], "2.5");
+    assert_eq!(b["protocolType"], "HTTP");
+
+    // GetApi must find it (not a discarded constant).
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["name"], "petstore");
+
+    // Three routes: GET/POST /pets and GET /pets/{id}.
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/routes"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    let keys: Vec<String> = b["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["routeKey"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(keys.len(), 3);
+    assert!(keys.contains(&"GET /pets".to_string()));
+    assert!(keys.contains(&"POST /pets".to_string()));
+    assert!(keys.contains(&"GET /pets/{id}".to_string()));
+
+    // The integration on GET /pets/{id} is wired as the route target.
+    let integrated = b["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["routeKey"] == "GET /pets/{id}")
+        .unwrap();
+    assert!(integrated["target"]
+        .as_str()
+        .unwrap()
+        .starts_with("integrations/"));
+
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/integrations"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["items"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        b["items"][0]["integrationUri"],
+        "https://backend.example.com/pets"
+    );
+}
+
+/// ImportApi accepts a YAML document too.
+#[tokio::test]
+async fn import_api_accepts_yaml() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let yaml = "openapi: 3.0.1\ninfo:\n  title: yamlapi\n  version: '1.0'\npaths:\n  /ping:\n    get:\n      responses:\n        '200':\n          description: ok\n";
+    let body = serde_json::json!({"body": yaml});
+    let req = make_request(Method::PUT, "/v2/apis", &body.to_string());
+    let b = body_json(&svc.handle(req).await.unwrap());
+    let api_id = b["apiId"].as_str().unwrap().to_string();
+    assert_eq!(b["name"], "yamlapi");
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/routes"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["items"][0]["routeKey"], "GET /ping");
+}
+
+/// ReimportApi replaces the routes of an existing API and 404s on unknown ids.
+#[tokio::test]
+async fn reimport_api_replaces_routes() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+
+    // Seed via import.
+    let body = serde_json::json!({"body": petstore_spec()});
+    let req = make_request(Method::PUT, "/v2/apis", &body.to_string());
+    let api_id = body_json(&svc.handle(req).await.unwrap())["apiId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Reimport a smaller spec.
+    let spec2 = serde_json::json!({
+        "openapi": "3.0.1",
+        "info": {"title": "petstore-v2", "version": "3.0"},
+        "paths": {"/health": {"get": {"responses": {"200": {"description": "ok"}}}}}
+    })
+    .to_string();
+    let body = serde_json::json!({"body": spec2});
+    let req = make_request(
+        Method::PUT,
+        &format!("/v2/apis/{api_id}"),
+        &body.to_string(),
+    );
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["name"], "petstore-v2");
+    assert_eq!(b["version"], "3.0");
+
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/routes"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    let items = b["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["routeKey"], "GET /health");
+
+    // Unknown API id 404s.
+    let body = serde_json::json!({"body": petstore_spec()});
+    let req = make_request(Method::PUT, "/v2/apis/does-not-exist", &body.to_string());
+    assert!(svc.handle(req).await.is_err());
+}
+
+/// ExportApi emits a real OpenAPI document derived from the API's routes.
+#[tokio::test]
+async fn export_api_generates_openapi_from_routes() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let body = serde_json::json!({"body": petstore_spec()});
+    let req = make_request(Method::PUT, "/v2/apis", &body.to_string());
+    let api_id = body_json(&svc.handle(req).await.unwrap())["apiId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let mut req = make_request(Method::GET, &format!("/v2/apis/{api_id}/exports/OAS30"), "");
+    req.query_params
+        .insert("outputType".to_string(), "JSON".to_string());
+    let b = body_json(&svc.handle(req).await.unwrap());
+    let doc: Value = serde_json::from_str(b["body"].as_str().unwrap()).unwrap();
+    assert_eq!(doc["openapi"], "3.0.1");
+    assert_eq!(doc["info"]["title"], "petstore");
+    assert!(doc["paths"]["/pets"].get("get").is_some());
+    assert!(doc["paths"]["/pets"].get("post").is_some());
+    assert!(doc["paths"]["/pets/{id}"].get("get").is_some());
+}
+
+/// ExportApi 404s on an unknown API and requires OutputType.
+#[tokio::test]
+async fn export_api_validates() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    // Missing OutputType.
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/exports/OAS30"), "");
+    assert!(svc.handle(req).await.is_err());
+
+    // Unknown API.
+    let mut req = make_request(Method::GET, "/v2/apis/nope/exports/OAS30", "");
+    req.query_params
+        .insert("outputType".to_string(), "JSON".to_string());
+    assert!(svc.handle(req).await.is_err());
+}
+
+/// DeleteCorsConfiguration clears the stored CORS config and persists it.
+#[tokio::test]
+async fn delete_cors_configuration_clears_config() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let body = serde_json::json!({
+        "name": "cors-api",
+        "protocolType": "HTTP",
+        "corsConfiguration": {"allowOrigins": ["*"], "allowMethods": ["GET"]},
+    });
+    let req = make_request(Method::POST, "/v2/apis", &body.to_string());
+    let api_id = body_json(&svc.create_api(&req).unwrap())["apiId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert!(b.get("corsConfiguration").is_some());
+
+    let req = make_request(Method::DELETE, &format!("/v2/apis/{api_id}/cors"), "");
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert!(b.get("corsConfiguration").is_none());
+
+    // Unknown API 404s.
+    let req = make_request(Method::DELETE, "/v2/apis/missing/cors", "");
+    assert!(svc.handle(req).await.is_err());
+}
+
+/// DeleteAccessLogSettings clears the stage's access log settings.
+#[tokio::test]
+async fn delete_access_log_settings_clears_settings() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "stageName": "prod",
+        "accessLogSettings": {
+            "destinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/apigw:*",
+            "format": "$context.requestId"
+        }
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/stages/prod"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert!(b.get("accessLogSettings").is_some());
+
+    let req = make_request(
+        Method::DELETE,
+        &format!("/v2/apis/{api_id}/stages/prod/accesslogsettings"),
+        "",
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/stages/prod"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert!(b.get("accessLogSettings").is_none());
+}
+
+/// GetModelTemplate derives a template from the model schema instead of a
+/// fixed constant.
+#[tokio::test]
+async fn get_model_template_derives_from_schema() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "id": {"type": "string"},
+            "count": {"type": "integer"},
+            "active": {"type": "boolean"}
+        }
+    })
+    .to_string();
+    let body = serde_json::json!({"name": "Widget", "schema": schema});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/models"),
+        &body.to_string(),
+    );
+    let b = body_json(&svc.handle(req).await.unwrap());
+    let model_id = b["modelId"].as_str().unwrap().to_string();
+
+    let req = make_request(
+        Method::GET,
+        &format!("/v2/apis/{api_id}/models/{model_id}/template"),
+        "",
+    );
+    let b = body_json(&svc.handle(req).await.unwrap());
+    // Not the old {"value":"{}"} constant — reflects the schema shape.
+    let tmpl: Value = serde_json::from_str(b["value"].as_str().unwrap()).unwrap();
+    assert_eq!(tmpl["id"], "");
+    assert_eq!(tmpl["count"], 0);
+    assert_eq!(tmpl["active"], false);
+}

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
@@ -217,6 +218,10 @@ pub struct HttpApi {
     /// `ipv4` (default) or `dualstack`. Real AWS always returns this on
     /// GetApi and Terraform's provider asserts on it.
     pub ip_address_type: String,
+    /// User-supplied API version string. AWS echoes it on GetApi and it is
+    /// carried through from an imported OpenAPI spec's `info.version`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
 }
 
 impl HttpApi {
@@ -243,6 +248,7 @@ impl HttpApi {
             route_selection_expression: "$request.method $request.path".to_string(),
             disable_execute_api_endpoint: false,
             ip_address_type: "ipv4".to_string(),
+            version: None,
         }
     }
 }
@@ -264,7 +270,7 @@ pub struct CorsConfiguration {
     pub max_age: Option<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Route {
     pub route_id: String,
@@ -275,6 +281,28 @@ pub struct Route {
     pub authorization_type: Option<String>, // "NONE", "JWT", "CUSTOM"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authorizer_id: Option<String>,
+    /// Whether an API key is required for this route.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key_required: Option<bool>,
+    /// OAuth scopes required when the route uses a JWT authorizer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization_scopes: Option<Vec<String>>,
+    /// Model selection expression (WebSocket APIs).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_selection_expression: Option<String>,
+    /// Friendly operation name for the route.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_name: Option<String>,
+    /// Request models keyed by content type (WebSocket APIs).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_models: Option<BTreeMap<String, String>>,
+    /// Request parameters keyed by `$request.*` expression; each value is a
+    /// `ParameterConstraints` object (`{"required": bool}`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_parameters: Option<BTreeMap<String, Value>>,
+    /// Route response selection expression (WebSocket APIs).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route_response_selection_expression: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -337,6 +365,19 @@ pub struct Stage {
     /// Access log destination + format for this stage.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub access_log_settings: Option<AccessLogSettings>,
+    /// Client certificate id used when calling backend integrations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_certificate_id: Option<String>,
+    /// Default throttling/logging settings applied to every route in the
+    /// stage. Stored verbatim as the Smithy `RouteSettings` shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_route_settings: Option<serde_json::Value>,
+    /// Per-route-key throttling/logging settings overriding the defaults.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route_settings: Option<BTreeMap<String, serde_json::Value>>,
+    /// Tags attached to the stage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -387,6 +428,13 @@ pub struct Authorizer {
     /// Whether a `2.0` Lambda authorizer returns a simple boolean response.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enable_simple_responses: Option<bool>,
+    /// IAM role ARN the gateway assumes when invoking a REQUEST authorizer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorizer_credentials_arn: Option<String>,
+    /// Regular expression the incoming identity source must match before the
+    /// authorizer is invoked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_validation_expression: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
@@ -5,6 +5,57 @@
 
 use super::*;
 
+/// Lowercase the first ASCII letter of a key.
+fn lower_first_ascii(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_ascii_lowercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// Convert a `RouteSettings` JSON object's PascalCase CloudFormation member
+/// names (`ThrottlingBurstLimit`, `LoggingLevel`, ...) to the camelCase
+/// wire/response names (`throttlingBurstLimit`, `loggingLevel`, ...) so that
+/// GetStage returns the modeled fields rather than PascalCase nested keys.
+fn route_settings_to_wire(v: &serde_json::Value) -> serde_json::Value {
+    match v {
+        serde_json::Value::Object(map) => serde_json::Value::Object(
+            map.iter()
+                .map(|(k, val)| (lower_first_ascii(k), val.clone()))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+/// Parse a CloudFormation `Tags` property in either the documented map form
+/// (`{"Key": "Value"}`) or the Key/Value array form
+/// (`[{"Key": .., "Value": ..}]`). Returns `None` when the property is absent
+/// or neither shape.
+fn parse_cfn_tag_map(v: Option<&serde_json::Value>) -> Option<BTreeMap<String, String>> {
+    let v = v?;
+    if let Some(obj) = v.as_object() {
+        return Some(
+            obj.iter()
+                .filter_map(|(k, val)| val.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect(),
+        );
+    }
+    if let Some(arr) = v.as_array() {
+        return Some(
+            arr.iter()
+                .filter_map(|entry| {
+                    let k = entry.get("Key").and_then(|x| x.as_str())?;
+                    let val = entry.get("Value").and_then(|x| x.as_str())?;
+                    Some((k.to_string(), val.to_string()))
+                })
+                .collect(),
+        );
+    }
+    None
+}
+
 impl ResourceProvisioner {
     // --- API Gateway v2 (HTTP/WebSocket APIs) ---
 
@@ -500,16 +551,18 @@ impl ResourceProvisioner {
                 .get("ClientCertificateId")
                 .and_then(|v| v.as_str())
                 .map(String::from),
-            default_route_settings: props.get("DefaultRouteSettings").cloned(),
+            default_route_settings: props
+                .get("DefaultRouteSettings")
+                .map(route_settings_to_wire),
             route_settings: props
                 .get("RouteSettings")
                 .and_then(|v| v.as_object())
-                .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()),
-            tags: props.get("Tags").and_then(|v| v.as_object()).map(|obj| {
-                obj.iter()
-                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                    .collect()
-            }),
+                .map(|obj| {
+                    obj.iter()
+                        .map(|(k, v)| (k.clone(), route_settings_to_wire(v)))
+                        .collect()
+                }),
+            tags: parse_cfn_tag_map(props.get("Tags")),
         };
 
         let mut accounts = self.apigatewayv2_state.write();
@@ -1447,5 +1500,58 @@ impl ResourceProvisioner {
         Ok(ProvisionResult::new(id.clone())
             .with("ModelId", id)
             .with("ApiId", api_id))
+    }
+}
+
+#[cfg(test)]
+mod apigwv2_helper_tests {
+    use super::{parse_cfn_tag_map, route_settings_to_wire};
+    use serde_json::json;
+
+    #[test]
+    fn route_settings_translated_to_camel_wire_names() {
+        // CloudFormation uses PascalCase RouteSettings members; GetStage must
+        // return the camelCase wire fields.
+        let cfn = json!({
+            "ThrottlingBurstLimit": 100,
+            "ThrottlingRateLimit": 50.0,
+            "DetailedMetricsEnabled": true,
+            "LoggingLevel": "INFO",
+            "DataTraceEnabled": false
+        });
+        let wire = route_settings_to_wire(&cfn);
+        assert_eq!(wire["throttlingBurstLimit"], 100);
+        assert_eq!(wire["throttlingRateLimit"], 50.0);
+        assert_eq!(wire["detailedMetricsEnabled"], true);
+        assert_eq!(wire["loggingLevel"], "INFO");
+        assert_eq!(wire["dataTraceEnabled"], false);
+        // No PascalCase members leak through.
+        assert!(wire.get("ThrottlingBurstLimit").is_none());
+    }
+
+    #[test]
+    fn cfn_tags_parsed_from_map_shape() {
+        let tags =
+            parse_cfn_tag_map(Some(&json!({"Environment": "prod", "team": "core"}))).unwrap();
+        assert_eq!(tags.get("Environment").map(String::as_str), Some("prod"));
+        assert_eq!(tags.get("team").map(String::as_str), Some("core"));
+    }
+
+    #[test]
+    fn cfn_tags_parsed_from_key_value_array_shape() {
+        // AWS templates may carry Tags as the [{Key, Value}] array form; these
+        // must not be silently dropped.
+        let tags = parse_cfn_tag_map(Some(&json!([
+            {"Key": "Environment", "Value": "prod"},
+            {"Key": "team", "Value": "core"}
+        ])))
+        .unwrap();
+        assert_eq!(tags.get("Environment").map(String::as_str), Some("prod"));
+        assert_eq!(tags.get("team").map(String::as_str), Some("core"));
+    }
+
+    #[test]
+    fn cfn_tags_absent_is_none() {
+        assert!(parse_cfn_tag_map(None).is_none());
     }
 }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
@@ -162,6 +162,39 @@ impl ResourceProvisioner {
                 .get("AuthorizerId")
                 .and_then(|v| v.as_str())
                 .map(String::from),
+            api_key_required: props.get("ApiKeyRequired").and_then(|v| v.as_bool()),
+            authorization_scopes: props
+                .get("AuthorizationScopes")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                }),
+            model_selection_expression: props
+                .get("ModelSelectionExpression")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            operation_name: props
+                .get("OperationName")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            request_models: props
+                .get("RequestModels")
+                .and_then(|v| v.as_object())
+                .map(|obj| {
+                    obj.iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                        .collect()
+                }),
+            request_parameters: props
+                .get("RequestParameters")
+                .and_then(|v| v.as_object())
+                .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()),
+            route_response_selection_expression: props
+                .get("RouteResponseSelectionExpression")
+                .and_then(|v| v.as_str())
+                .map(String::from),
         };
         state
             .routes
@@ -463,6 +496,20 @@ impl ResourceProvisioner {
             web_acl_arn: None,
             stage_variables,
             access_log_settings,
+            client_certificate_id: props
+                .get("ClientCertificateId")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            default_route_settings: props.get("DefaultRouteSettings").cloned(),
+            route_settings: props
+                .get("RouteSettings")
+                .and_then(|v| v.as_object())
+                .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()),
+            tags: props.get("Tags").and_then(|v| v.as_object()).map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            }),
         };
 
         let mut accounts = self.apigatewayv2_state.write();
@@ -620,6 +667,14 @@ impl ResourceProvisioner {
                 .get("AuthorizerResultTtlInSeconds")
                 .and_then(|v| v.as_i64()),
             enable_simple_responses: props.get("EnableSimpleResponses").and_then(|v| v.as_bool()),
+            authorizer_credentials_arn: props
+                .get("AuthorizerCredentialsArn")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            identity_validation_expression: props
+                .get("IdentityValidationExpression")
+                .and_then(|v| v.as_str())
+                .map(String::from),
         };
         let mut accounts = self.apigatewayv2_state.write();
         let state = accounts.get_or_create(&self.account_id);


### PR DESCRIPTION
## Summary

Bug-hunt batch 6 for the apigatewayv2 service: replaces stub handlers and silent field-drops with real, persisted behavior. Every Create/Update now persists what it receives and every Get/List reads it back.

HIGH
- ImportApi previously returned a hardcoded constant and never touched state. It now parses the OpenAPI/Swagger `Body` (JSON or YAML), creates a real Api, and synthesizes Routes + Integrations from the spec paths (each `path`+`method` becomes a route keyed `"METHOD path"`; an `x-amazon-apigateway-integration` extension becomes an Integration wired as the route target). GetApi/GetRoutes/GetIntegrations read it all back.
- ReimportApi now looks up the existing Api (404 on missing), re-parses the spec, and replaces the routes/integrations while preserving the endpoint/ids; name/description/version are updated from the spec.

MED
- CreateRoute/UpdateRoute persist ApiKeyRequired, AuthorizationScopes, ModelSelectionExpression, OperationName, RequestModels, RequestParameters, RouteResponseSelectionExpression.
- CreateStage/UpdateStage persist ClientCertificateId, DefaultRouteSettings, RouteSettings, Tags.
- DeleteCorsConfiguration clears `api.cors_configuration` and persists; DeleteAccessLogSettings clears `stage.access_log_settings` and persists. Both 404 on missing parents.
- ExportApi generates a real OpenAPI 3.0 document from the Api's routes, honoring the `outputType` query (JSON default, YAML on request), instead of a fixed one-liner.

LOW
- CreateAuthorizer/UpdateAuthorizer persist AuthorizerCredentialsArn and IdentityValidationExpression.
- GetModelTemplate derives a mapping template from the stored model schema (best-effort example from the JSON schema) instead of returning a fixed `{"Value":"{}"}`.

Also adds a `Version` field to the Api, carried from an imported spec's `info.version` and accepted on Create/UpdateApi.

### Notes
- All new struct fields are `#[serde(default)]` so existing snapshots deserialize unchanged.
- The CloudFormation apigwv2 provisioner constructs the apigatewayv2 Route/Stage/Authorizer structs directly (via re-export), so those three literals were updated to parse the corresponding CFN template properties. This keeps the workspace build green; it is the only change outside `crates/fakecloud-apigatewayv2`.
- No new API surface (all ops already existed in the Smithy model and SUPPORTED list), so SDKs/docs/website are unaffected.

## Test plan

- `cargo nextest run -p fakecloud-apigatewayv2` -> 158 passed, 0 skipped. New unit tests cover: route/stage/authorizer extended-field round-trip (create -> get, update -> get preserves untouched fields); ImportApi (JSON and YAML) creating real API + routes + integration; ReimportApi replacing routes and 404 on unknown id; ExportApi generating OpenAPI + validation errors; DeleteCorsConfiguration / DeleteAccessLogSettings clearing state; GetModelTemplate deriving from schema. Two pre-existing extras tests updated to assert the new real behavior.
- `cargo nextest run -p fakecloud-cloudformation` -> 248 passed, 0 skipped (provisioner literal changes).
- `cargo clippy -p fakecloud-apigatewayv2 --all-targets -- -D warnings` and same for fakecloud-cloudformation -> clean.
- `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces stubbed `apigatewayv2` Import/Reimport/Export with real OpenAPI handling and persists previously dropped Route/Stage/Authorizer fields so Create/Update round-trip correctly. Adds a schema‑aware body key normalizer and CloudFormation mapping fixes.

- **New Features**
  - ImportApi/ReimportApi parse OpenAPI (JSON or YAML), create/replace a real API, and synthesize Routes/Integrations; ReimportApi 404s on unknown ApiId.
  - ExportApi generates OpenAPI 3.0 from routes; honors `outputType` (JSON default, YAML when requested) and returns 400 when `outputType` is missing.
  - GetModelTemplate derives a template from the stored model schema.
  - Api accepts and returns `Version` (from `info.version` on import).

- **Bug Fixes**
  - Routes: persist ApiKeyRequired, AuthorizationScopes, ModelSelectionExpression, OperationName, RequestModels, RequestParameters, RouteResponseSelectionExpression.
  - Stages: persist ClientCertificateId, DefaultRouteSettings, RouteSettings, Tags; UpdateStage treats `routeSettings: null` as clear and an absent field as preserve.
  - Authorizers: persist AuthorizerCredentialsArn and IdentityValidationExpression.
  - DeleteCorsConfiguration and DeleteAccessLogSettings now clear stored fields and 404 on missing parents.
  - Body key normalizer is schema‑aware: preserves user keys in arbitrary‑key maps (requestModels, requestParameters, routeSettings, stageVariables, tags) while still normalizing modeled member names.
  - CloudFormation provisioner: parses the new Route/Stage/Authorizer props; converts PascalCase RouteSettings/DefaultRouteSettings to camelCase wire names; accepts Tags as a map or as [{Key,Value}].
  - New fields are `#[serde(default)]` for snapshot/backward compatibility.

<sup>Written for commit c5eb9a94b8451aa07d67ef3b06e1bfe42ef3e453. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

