### PR TITLE
fix(rds-data,pipes,cloudformation): data-infra correctness cluster (bug-hunt batch 8a)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1487,6 +1487,7 @@ impl ResourceProvisioner {
             "AWS::SNS::Topic" => Some(self.update_sns_topic(existing, new_def)?),
             "AWS::SNS::TopicPolicy" => Some(self.update_sns_topic_policy(existing, new_def)?),
             "AWS::S3::BucketPolicy" => Some(self.update_s3_bucket_policy(existing, new_def)?),
+            "AWS::Pipes::Pipe" => Some(self.update_pipes_pipe(existing, new_def)?),
             _ => None,
         };
 
@@ -1600,6 +1601,7 @@ impl ResourceProvisioner {
             "AWS::CloudFormation::Stack" => {
                 self.get_att_cloudformation_stack(&resource.physical_id, attribute)
             }
+            "AWS::Pipes::Pipe" => self.get_att_pipes_pipe(&resource.physical_id, attribute),
             _ => None,
         }
     }
@@ -6455,6 +6457,130 @@ mod tests {
         assert_eq!(policy.default_version_id, "v2");
         let default = policy.versions.iter().find(|v| v.is_default).unwrap();
         assert!(default.document.contains("Deny"));
+    }
+
+    fn pipe_props(name: &str, target: &str, description: Option<&str>) -> serde_json::Value {
+        let mut m = serde_json::json!({
+            "Name": name,
+            "Source": "arn:aws:sqs:us-east-1:123456789012:src",
+            "Target": target,
+            "RoleArn": "arn:aws:iam::123456789012:role/pipe",
+        });
+        if let Some(d) = description {
+            m["Description"] = serde_json::json!(d);
+        }
+        m
+    }
+
+    #[test]
+    fn update_stack_applies_pipes_pipe_change() {
+        let prov = make_provisioner();
+        let created = prov
+            .create_resource(&make_resource(
+                "AWS::Pipes::Pipe",
+                "P",
+                pipe_props(
+                    "my-pipe",
+                    "arn:aws:sqs:us-east-1:123456789012:dst",
+                    Some("v1"),
+                ),
+            ))
+            .expect("pipe provisions");
+
+        // UpdateStack on a Pipes resource previously fell through to `_ => None`,
+        // so CFN reported UPDATE_COMPLETE while discarding the change.
+        let updated = prov
+            .update_resource(
+                &created,
+                &make_resource(
+                    "AWS::Pipes::Pipe",
+                    "P",
+                    pipe_props(
+                        "my-pipe",
+                        "arn:aws:sqs:us-east-1:123456789012:dst2",
+                        Some("v2"),
+                    ),
+                ),
+            )
+            .expect("update succeeds")
+            .expect("Pipes::Pipe is updatable (not a silent no-op)");
+        assert_eq!(updated.status, "UPDATE_COMPLETE");
+
+        // The change is actually applied to the pipes service state.
+        let pipes = prov.pipes_state.read();
+        let pipe = pipes
+            .get("123456789012")
+            .unwrap()
+            .pipes
+            .get("my-pipe")
+            .unwrap();
+        assert_eq!(pipe["Description"], "v2");
+        assert_eq!(pipe["Target"], "arn:aws:sqs:us-east-1:123456789012:dst2");
+        // CFN provisioning is synchronous, so the pipe stays settled.
+        assert_eq!(pipe["CurrentState"], "RUNNING");
+    }
+
+    #[test]
+    fn update_stack_clears_omitted_pipe_field() {
+        let prov = make_provisioner();
+        let created = prov
+            .create_resource(&make_resource(
+                "AWS::Pipes::Pipe",
+                "P",
+                pipe_props(
+                    "p2",
+                    "arn:aws:sqs:us-east-1:123456789012:dst",
+                    Some("drop-me"),
+                ),
+            ))
+            .expect("pipe provisions");
+        prov.update_resource(
+            &created,
+            &make_resource(
+                "AWS::Pipes::Pipe",
+                "P",
+                pipe_props("p2", "arn:aws:sqs:us-east-1:123456789012:dst", None),
+            ),
+        )
+        .expect("update succeeds")
+        .expect("updatable");
+        let pipes = prov.pipes_state.read();
+        let pipe = pipes.get("123456789012").unwrap().pipes.get("p2").unwrap();
+        assert!(
+            pipe.get("Description").is_none(),
+            "an omitted updatable field is cleared (full-replace semantics)"
+        );
+    }
+
+    #[test]
+    fn create_pipe_rejects_empty_required_field() {
+        let prov = make_provisioner();
+        let err = prov
+            .create_resource(&make_resource(
+                "AWS::Pipes::Pipe",
+                "P",
+                serde_json::json!({
+                    "Name": "p3",
+                    "Source": "",
+                    "Target": "arn:aws:sqs:us-east-1:123456789012:dst",
+                    "RoleArn": "arn:aws:iam::123456789012:role/pipe",
+                }),
+            ))
+            .unwrap_err();
+        assert!(err.contains("Source"), "empty Source rejected: {err}");
+    }
+
+    #[test]
+    fn create_pipe_rejects_duplicate_name() {
+        let prov = make_provisioner();
+        let props = pipe_props("dup", "arn:aws:sqs:us-east-1:123456789012:dst", None);
+        prov.create_resource(&make_resource("AWS::Pipes::Pipe", "P", props.clone()))
+            .expect("first create ok");
+        // A second resource with the same Name must conflict, not overwrite.
+        let err = prov
+            .create_resource(&make_resource("AWS::Pipes::Pipe", "P2", props))
+            .unwrap_err();
+        assert!(err.contains("already exists"), "duplicate rejected: {err}");
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -6521,6 +6521,50 @@ mod tests {
     }
 
     #[test]
+    fn update_stack_replaces_pipe_on_source_change() {
+        // Source is replacement-required on AWS::Pipes::Pipe: a changed Source
+        // must actually take effect (via delete+recreate), not be silently
+        // dropped by an in-place update that only touches the mutable fields.
+        let prov = make_provisioner();
+        let created = prov
+            .create_resource(&make_resource(
+                "AWS::Pipes::Pipe",
+                "P",
+                serde_json::json!({
+                    "Name": "src-pipe",
+                    "Source": "arn:aws:sqs:us-east-1:123456789012:src-old",
+                    "Target": "arn:aws:sqs:us-east-1:123456789012:dst",
+                    "RoleArn": "arn:aws:iam::123456789012:role/pipe",
+                }),
+            ))
+            .expect("pipe provisions");
+        prov.update_resource(
+            &created,
+            &make_resource(
+                "AWS::Pipes::Pipe",
+                "P",
+                serde_json::json!({
+                    "Name": "src-pipe",
+                    "Source": "arn:aws:sqs:us-east-1:123456789012:src-new",
+                    "Target": "arn:aws:sqs:us-east-1:123456789012:dst",
+                    "RoleArn": "arn:aws:iam::123456789012:role/pipe",
+                }),
+            ),
+        )
+        .expect("update succeeds")
+        .expect("Pipes::Pipe is updatable");
+        let pipes = prov.pipes_state.read();
+        let acct = pipes.get("123456789012").unwrap();
+        // Exactly one pipe (the recreate reused the same Name after deleting).
+        assert_eq!(acct.pipes.len(), 1);
+        let pipe = acct.pipes.get("src-pipe").unwrap();
+        assert_eq!(
+            pipe["Source"], "arn:aws:sqs:us-east-1:123456789012:src-new",
+            "changed Source is applied via replacement, not silently dropped"
+        );
+    }
+
+    #[test]
     fn update_stack_clears_omitted_pipe_field() {
         let prov = make_provisioner();
         let created = prov

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/pipes.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/pipes.rs
@@ -155,6 +155,13 @@ impl ResourceProvisioner {
     /// generic `update_resource` dispatcher returns `Ok(None)` for
     /// `AWS::Pipes::Pipe`, so CloudFormation reports `UPDATE_COMPLETE` while
     /// silently discarding the property change.
+    ///
+    /// `Source` is replacement-required on `AWS::Pipes::Pipe` (the CFN resource
+    /// schema marks Source create-only: "Update requires: Replacement"). A
+    /// changed Source therefore cannot be applied in place — doing so would leave
+    /// the pipe reading from the old source while reporting success. When Source
+    /// changes we perform a replacement (delete the old record + recreate from
+    /// the new properties) so the new Source actually takes effect.
     pub(super) fn update_pipes_pipe(
         &self,
         existing: &super::StackResource,
@@ -165,9 +172,26 @@ impl ResourceProvisioner {
         let name = existing.physical_id.clone();
         let now = epoch_secs();
 
+        // Replacement-required Source change: recreate instead of in-place update.
+        let old_source = self
+            .pipes_state
+            .read()
+            .get(&self.account_id)
+            .and_then(|st| st.pipes.get(&name))
+            .and_then(|p| p.get("Source").and_then(Value::as_str).map(String::from));
+        let new_source = props.get("Source").and_then(Value::as_str);
+        if let (Some(old), Some(new)) = (old_source.as_deref(), new_source) {
+            if new != old {
+                // Drop the old record so the recreate's same-name conflict check
+                // passes, then rebuild the pipe from scratch with the new Source.
+                self.delete_pipes_pipe(&name);
+                return self.create_pipes_pipe(resource);
+            }
+        }
+
         // Target/RoleArn stay required and non-empty on update; Source is
-        // immutable so it is not re-validated here. Called for validation only —
-        // the applied value flows through PIPE_UPDATE_FIELDS below.
+        // unchanged here (a change took the replacement path above). Called for
+        // validation only — the applied value flows through PIPE_UPDATE_FIELDS.
         require_arn_field(props, "Target")?;
         require_arn_field(props, "RoleArn")?;
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/pipes.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/pipes.rs
@@ -27,6 +27,21 @@ const PIPE_INPUT_FIELDS: &[&str] = &[
     "KmsKeyIdentifier",
 ];
 
+/// The updatable `UpdatePipe` fields. `Source` is intentionally absent: it is
+/// immutable on a pipe (a change forces a CloudFormation replacement), so an
+/// in-place update never rewrites it. Mirrors the direct `UpdatePipe` handler.
+const PIPE_UPDATE_FIELDS: &[&str] = &[
+    "Description",
+    "SourceParameters",
+    "Enrichment",
+    "EnrichmentParameters",
+    "Target",
+    "TargetParameters",
+    "RoleArn",
+    "LogConfiguration",
+    "KmsKeyIdentifier",
+];
+
 impl ResourceProvisioner {
     pub(super) fn create_pipes_pipe(
         &self,
@@ -38,22 +53,15 @@ impl ResourceProvisioner {
             .and_then(Value::as_str)
             .map(String::from)
             .unwrap_or_else(|| resource.logical_id.clone());
+        // Apply the same validation the direct CreatePipe handler enforces, so a
+        // CFN-created pipe can't slip past name/ARN constraints the API rejects.
+        fakecloud_pipes::validate_pipe_name(&name).map_err(|e| e.message())?;
 
-        let source = props
-            .get("Source")
-            .and_then(Value::as_str)
-            .ok_or("AWS::Pipes::Pipe requires Source")?
-            .to_string();
-        let target = props
-            .get("Target")
-            .and_then(Value::as_str)
-            .ok_or("AWS::Pipes::Pipe requires Target")?
-            .to_string();
-        let role_arn = props
-            .get("RoleArn")
-            .and_then(Value::as_str)
-            .ok_or("AWS::Pipes::Pipe requires RoleArn")?
-            .to_string();
+        // Source/Target/RoleArn are required and must be non-empty (a bare
+        // `as_str` would accept `""`), and are bounded to the 1-1600 ARN length.
+        let source = require_arn_field(props, "Source")?;
+        let target = require_arn_field(props, "Target")?;
+        let role_arn = require_arn_field(props, "RoleArn")?;
 
         let arn = format!(
             "arn:aws:pipes:{}:{}:pipe/{name}",
@@ -66,6 +74,19 @@ impl ResourceProvisioner {
             _ => "RUNNING",
         };
         let now = epoch_secs();
+
+        // Reject a same-name collision instead of silently overwriting an
+        // existing pipe (the direct CreatePipe handler returns ConflictException
+        // here). CloudFormation provisions a stack single-threaded, so a plain
+        // read-then-write is race-free.
+        if self
+            .pipes_state
+            .read()
+            .get(&self.account_id)
+            .is_some_and(|st| st.pipes.contains_key(&name))
+        {
+            return Err(format!("Pipe with Name {name} already exists."));
+        }
 
         let mut pipe = Map::new();
         pipe.insert("Name".into(), json!(name));
@@ -128,6 +149,90 @@ impl ResourceProvisioner {
             .with("LastModifiedTime", now.to_string()))
     }
 
+    /// Apply a stack UpdateStack change to an existing pipe: re-write the
+    /// updatable fields (full replace — an omitted field is cleared, matching
+    /// the direct `UpdatePipe` handler) and re-settle it. Without this arm the
+    /// generic `update_resource` dispatcher returns `Ok(None)` for
+    /// `AWS::Pipes::Pipe`, so CloudFormation reports `UPDATE_COMPLETE` while
+    /// silently discarding the property change.
+    pub(super) fn update_pipes_pipe(
+        &self,
+        existing: &super::StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        // The physical id of a pipe is its Name.
+        let name = existing.physical_id.clone();
+        let now = epoch_secs();
+
+        // Target/RoleArn stay required and non-empty on update; Source is
+        // immutable so it is not re-validated here. Called for validation only —
+        // the applied value flows through PIPE_UPDATE_FIELDS below.
+        require_arn_field(props, "Target")?;
+        require_arn_field(props, "RoleArn")?;
+
+        let desired = match props.get("DesiredState").and_then(Value::as_str) {
+            Some("STOPPED") => "STOPPED",
+            _ => "RUNNING",
+        };
+
+        let mut state = self.pipes_state.write();
+        let acct = state.get_or_create(&self.account_id);
+        let pipe = acct
+            .pipes
+            .get_mut(&name)
+            .ok_or_else(|| format!("AWS::Pipes::Pipe {name} not yet provisioned"))?;
+        let obj = pipe
+            .as_object_mut()
+            .ok_or_else(|| format!("corrupt pipe state for {name}"))?;
+
+        for field in PIPE_UPDATE_FIELDS {
+            match props.get(*field) {
+                Some(v) => {
+                    obj.insert((*field).to_string(), v.clone());
+                }
+                None => {
+                    obj.remove(*field);
+                }
+            }
+        }
+        obj.insert("DesiredState".into(), json!(desired));
+        // CFN provisioning is synchronous, so the pipe stays settled.
+        obj.insert("CurrentState".into(), json!(desired));
+        obj.insert("StateReason".into(), json!("Pipe is healthy"));
+        obj.insert("LastModifiedTime".into(), json!(now));
+        let source = obj
+            .get("Source")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        fakecloud_pipes::ensure_source_param_defaults(obj, &source);
+        fakecloud_pipes::normalize_empty_input_templates(obj);
+        let arn = obj
+            .get("Arn")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        Ok(ProvisionResult::new(name)
+            .with("Arn", arn)
+            .with("CurrentState", desired)
+            .with("StateReason", "Pipe is healthy")
+            .with("LastModifiedTime", now.to_string()))
+    }
+
+    /// Live-state `Fn::GetAtt` for a pipe: resolves `Arn` from the pipes service
+    /// state (the create path also pre-captures it, so this is the consistency
+    /// overlay used when reading back a persisted stack).
+    pub(super) fn get_att_pipes_pipe(&self, physical_id: &str, attribute: &str) -> Option<String> {
+        let state = self.pipes_state.read();
+        let pipe = state.get(&self.account_id)?.pipes.get(physical_id)?;
+        match attribute {
+            "Arn" => pipe.get("Arn").and_then(Value::as_str).map(String::from),
+            _ => None,
+        }
+    }
+
     /// Delete a pipe by physical id (its name). Also drops the tag-store entry
     /// keyed by the pipe's ARN.
     pub(super) fn delete_pipes_pipe(&self, physical_id: &str) {
@@ -139,6 +244,19 @@ impl ResourceProvisioner {
             }
         }
     }
+}
+
+/// Extract a required ARN-shaped property (`Source`/`Target`/`RoleArn`),
+/// rejecting a missing, empty, or oversize value with the same non-empty +
+/// 1-1600 length bound the direct CreatePipe/UpdatePipe handler enforces.
+fn require_arn_field(props: &Value, field: &str) -> Result<String, String> {
+    let value = props
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| format!("AWS::Pipes::Pipe requires a non-empty {field}"))?;
+    fakecloud_pipes::validate_resource_arn_len(field, value).map_err(|e| e.message())?;
+    Ok(value.to_string())
 }
 
 /// Seconds since the Unix epoch. CloudFormation provisioning is not on the

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -52,6 +52,7 @@ fn well_known_attributes_for(resource_type: &str) -> &'static [&'static str] {
         "AWS::EC2::SecurityGroup" => &["GroupId", "VpcId"],
         "AWS::EC2::InternetGateway" => &["InternetGatewayId"],
         "AWS::EC2::RouteTable" => &["RouteTableId"],
+        "AWS::Pipes::Pipe" => &["Arn"],
         _ => &[],
     }
 }

--- a/crates/fakecloud-pipes/src/lib.rs
+++ b/crates/fakecloud-pipes/src/lib.rs
@@ -14,7 +14,7 @@ pub mod state;
 
 pub use service::{
     drain_overdue_transient_pipes, ensure_source_param_defaults, normalize_empty_input_templates,
-    PipesService,
+    validate_pipe_name, validate_resource_arn_len, PipesService,
 };
 pub use state::{
     PipesAccounts, PipesSnapshot, PipesState, SharedPipesState, PIPES_SNAPSHOT_SCHEMA_VERSION,

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -567,15 +567,11 @@ impl PipesService {
 
     fn update_pipe(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let name = pipe_name_from_path(req)?;
-        // Advance an overdue transient pipe first (its own lock) so a pipe that
-        // already finished its transition isn't wrongly rejected; the
-        // authoritative, race-free transient check runs under the write lock
-        // below, in the same critical section as the mutation.
-        self.settle_if_overdue(&req.account_id, &name);
         let body = req.json_body();
-        // Validate the request BEFORE touching any state, so a rejected
-        // UpdatePipe leaves the pipe untouched — otherwise force-settling a fresh
-        // transient pipe below would be a side effect of a failed call.
+        // Validate the request body at the VERY START, before any state is read
+        // or mutated — including before `settle_if_overdue`, which can settle or
+        // even remove an overdue transient pipe. A rejected UpdatePipe must leave
+        // state completely untouched for both fresh and overdue pipes.
         if body
             .get("RoleArn")
             .and_then(Value::as_str)
@@ -584,6 +580,11 @@ impl PipesService {
         {
             return Err(validation_error("RoleArn is required"));
         }
+        // Advance an overdue transient pipe (its own lock) so a pipe that already
+        // finished its transition isn't wrongly rejected; the authoritative,
+        // race-free transient check runs under the write lock below, in the same
+        // critical section as the mutation.
+        self.settle_if_overdue(&req.account_id, &name);
         let now = now_epoch_secs();
 
         let response = {
@@ -1528,6 +1529,46 @@ mod tests {
             state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
             STATE_CREATING,
             "a rejected UpdatePipe must not force-settle (state unchanged)"
+        );
+    }
+
+    #[test]
+    fn invalid_update_leaves_overdue_transient_pipe_untouched() {
+        // Request validation runs before settle_if_overdue, so an invalid
+        // UpdatePipe on an OVERDUE CREATING pipe returns ValidationException
+        // without settling it to RUNNING.
+        let (svc, state) = service_with_pipe(STATE_CREATING, STATE_RUNNING, 5.0);
+        let req = make_request(Method::PUT, "/v1/pipes/p1");
+        let Err(err) = svc.update_pipe(&req) else {
+            panic!("UpdatePipe with no RoleArn must error");
+        };
+        assert_eq!(err.code(), "ValidationException");
+        assert_eq!(
+            state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
+            STATE_CREATING,
+            "a rejected UpdatePipe must not settle an overdue pipe"
+        );
+    }
+
+    #[test]
+    fn invalid_update_does_not_remove_overdue_deleting_pipe() {
+        // The most damaging case: an overdue DELETING pipe would be REMOVED by
+        // settle_if_overdue. Request validation must run first, so a missing
+        // RoleArn returns ValidationException and the pipe still exists.
+        let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 5.0);
+        let req = make_request(Method::PUT, "/v1/pipes/p1");
+        let Err(err) = svc.update_pipe(&req) else {
+            panic!("UpdatePipe with no RoleArn must error");
+        };
+        assert_eq!(err.code(), "ValidationException");
+        assert!(
+            state
+                .read()
+                .get("123456789012")
+                .unwrap()
+                .pipes
+                .contains_key("p1"),
+            "a rejected UpdatePipe must not remove an overdue DELETING pipe"
         );
     }
 

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -568,23 +568,14 @@ impl PipesService {
     fn update_pipe(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let name = pipe_name_from_path(req)?;
         let body = req.json_body();
-        // Validate the request body at the VERY START, before any state is read
-        // or mutated — including before `settle_if_overdue`, which can settle or
-        // even remove an overdue transient pipe. A rejected UpdatePipe must leave
-        // state completely untouched for both fresh and overdue pipes.
-        if body
-            .get("RoleArn")
-            .and_then(Value::as_str)
-            .filter(|s| !s.is_empty())
-            .is_none()
-        {
+        // Validate the request body first, before any state is read or mutated.
+        // The overdue lazy-settle for this op runs in the async `handle` wrapper
+        // (so its persist can be awaited even when this dispatch then errors),
+        // and the wrapper gates that settle on the same validity check — so an
+        // invalid UpdatePipe never settles/removes a pipe.
+        if !has_valid_role_arn(&body) {
             return Err(validation_error("RoleArn is required"));
         }
-        // Advance an overdue transient pipe (its own lock) so a pipe that already
-        // finished its transition isn't wrongly rejected; the authoritative,
-        // race-free transient check runs under the write lock below, in the same
-        // critical section as the mutation.
-        self.settle_if_overdue(&req.account_id, &name);
         let now = now_epoch_secs();
 
         let response = {
@@ -680,9 +671,10 @@ impl PipesService {
         desired: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let name = pipe_name_from_path(req)?;
-        // Settle an overdue transient pipe first; the authoritative transient
-        // check runs under the write lock below, atomically with the mutation.
-        self.settle_if_overdue(&req.account_id, &name);
+        // The overdue lazy-settle for Start/Stop runs in the async `handle`
+        // wrapper (so a removed overdue-DELETING pipe is persisted before this
+        // dispatch returns NotFound). The authoritative transient check runs
+        // under the write lock below, atomically with the mutation.
         let now = now_epoch_secs();
         let response = {
             let mut accounts = self.state.write();
@@ -823,13 +815,24 @@ impl AwsService for PipesService {
                 format!("Unknown operation: {} {}", req.method, req.raw_path),
             ));
         };
-        // DescribePipe lazily settles an overdue transient pipe (converging the
-        // provider's delete/create waiter on its own poll). When that settle
-        // removes a DELETING pipe we must persist BEFORE returning, so a restart
-        // right after the waiter observes deletion doesn't resurrect the pipe
-        // (and its stale checkpoints). Done here in the async path so the flush
-        // is awaited, not fire-and-forget (Cubic P2 on #2058).
-        if action == "DescribePipe" {
+        // Lazily settle an overdue transient pipe for the ops that depend on
+        // lifecycle convergence, and persist the settle here — BEFORE dispatch —
+        // so the flush is awaited, not fire-and-forget (the #2058 DescribePipe
+        // fix). This also covers the case where the settle *removes* an overdue
+        // DELETING pipe and the subsequent dispatch then returns NotFound: doing
+        // the settle+persist in this wrapper means the removal reaches disk even
+        // though the dispatch errors, so a restart can't resurrect the pipe (and
+        // its stale checkpoints).
+        //
+        // For UpdatePipe the settle is gated on a valid request body, so an
+        // invalid update never settles or removes a pipe (leaves state
+        // untouched); Start/Stop/Describe have no such body validation.
+        let settle_before_dispatch = match action {
+            "DescribePipe" | "StartPipe" | "StopPipe" => true,
+            "UpdatePipe" => has_valid_role_arn(&req.json_body()),
+            _ => false,
+        };
+        if settle_before_dispatch {
             if let Ok(name) = pipe_name_from_path(&req) {
                 if self.settle_if_overdue(&req.account_id, &name) {
                     self.save_snapshot().await;
@@ -1202,6 +1205,16 @@ fn not_found(name: &str) -> AwsServiceError {
         "NotFoundException",
         format!("Pipe {name} does not exist."),
     )
+}
+
+/// Does the UpdatePipe request body carry a non-empty `RoleArn` (the one
+/// required field)? Used both to reject an invalid UpdatePipe and to gate the
+/// pre-dispatch overdue settle in `handle`, so an invalid update never mutates
+/// state.
+fn has_valid_role_arn(body: &Value) -> bool {
+    body.get("RoleArn")
+        .and_then(Value::as_str)
+        .is_some_and(|s| !s.is_empty())
 }
 
 /// If a pipe object is mid-transition, produce the `ConflictException` a
@@ -1588,18 +1601,64 @@ mod tests {
         );
     }
 
-    #[test]
-    fn update_settles_overdue_deleting_then_reports_not_found() {
-        // An overdue DELETING pipe is settled (removed) before the write-lock
-        // guard runs, so UpdatePipe sees NotFound rather than a spurious Conflict.
-        // A valid RoleArn ensures request validation passes and the lookup runs.
+    #[tokio::test]
+    async fn update_settles_overdue_deleting_then_reports_not_found() {
+        // Through the full `handle` path: an overdue DELETING pipe is settled
+        // (removed) by the pre-dispatch wrapper, so a valid UpdatePipe sees
+        // NotFound rather than a spurious Conflict, and the pipe is gone.
         let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 5.0);
-        let req = update_request_with_role();
-        let Err(err) = svc.update_pipe(&req) else {
+        let Err(err) = svc.handle(update_request_with_role()).await else {
             panic!("UpdatePipe on a removed pipe must error");
         };
         assert_eq!(err.code(), "NotFoundException");
         assert!(state.read().get("123456789012").unwrap().pipes.is_empty());
+    }
+
+    /// A test `SnapshotStore` that retains the last saved bytes so a test can
+    /// assert what was persisted (the real `MemorySnapshotStore` is a no-op).
+    #[derive(Default)]
+    struct CapturingStore {
+        saved: std::sync::Mutex<Option<Vec<u8>>>,
+    }
+    impl fakecloud_persistence::SnapshotStore for CapturingStore {
+        fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+            Ok(self.saved.lock().unwrap().clone())
+        }
+        fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+            *self.saved.lock().unwrap() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_update_on_overdue_deleting_pipe_persists_removal() {
+        // The resurrection bug: a valid UpdatePipe against an overdue DELETING
+        // pipe removes it in memory, then returns NotFound. That removal must be
+        // flushed to the snapshot store (awaited) so a restart from the snapshot
+        // doesn't bring the deleted pipe back.
+        let (svc, _state) = service_with_pipe(STATE_DELETING, "STOPPED", 5.0);
+        let store = Arc::new(CapturingStore::default());
+        let svc = svc.with_snapshot_store(store.clone());
+
+        let Err(err) = svc.handle(update_request_with_role()).await else {
+            panic!("UpdatePipe on a removed pipe must error");
+        };
+        assert_eq!(err.code(), "NotFoundException");
+
+        // Deserialize the persisted snapshot and assert the pipe is gone.
+        let bytes = store
+            .load()
+            .unwrap()
+            .expect("the settle/removal was flushed to the snapshot store");
+        let snapshot: PipesSnapshot = serde_json::from_slice(&bytes).unwrap();
+        let accounts = snapshot.accounts.expect("snapshot carries account state");
+        let still_present = accounts
+            .get("123456789012")
+            .is_some_and(|st| st.pipes.contains_key("p1"));
+        assert!(
+            !still_present,
+            "the removed DELETING pipe must not survive in the snapshot (no resurrection)"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -455,35 +455,6 @@ impl PipesService {
         true
     }
 
-    /// Reject a mutating lifecycle op (Update/Start/Stop) while the pipe is
-    /// mid-transition. AWS returns `ConflictException` for these until the pipe
-    /// settles, so a racing Update/Start/Stop can't resurrect a `DELETING` pipe
-    /// (settling it back to `RUNNING`) or clobber an in-flight `CREATING`/
-    /// `UPDATING`/`STARTING`/`STOPPING` one. Settles an overdue pipe first, so a
-    /// pipe that has already finished its transition — but whose background
-    /// settle task hasn't fired yet — is not wrongly rejected. A pipe that no
-    /// longer exists (a completed delete) passes through here and is handled as
-    /// a NotFound by the caller.
-    fn ensure_not_transient(&self, account_id: &str, name: &str) -> Result<(), AwsServiceError> {
-        self.settle_if_overdue(account_id, name);
-        let accounts = self.state.read();
-        if let Some(pipe) = accounts.get(account_id).and_then(|st| st.pipes.get(name)) {
-            let cur = pipe
-                .get("CurrentState")
-                .and_then(Value::as_str)
-                .unwrap_or("");
-            if is_transient_state(cur) {
-                return Err(conflict_error(
-                    format!(
-                        "Pipe '{name}' is in state {cur} and cannot be modified until it stabilizes."
-                    ),
-                    name,
-                ));
-            }
-        }
-        Ok(())
-    }
-
     fn list_pipes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let q = &req.query_params;
         let name_prefix = q.get("NamePrefix").map(String::as_str);
@@ -596,16 +567,12 @@ impl PipesService {
 
     fn update_pipe(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let name = pipe_name_from_path(req)?;
-        self.ensure_not_transient(&req.account_id, &name)?;
+        // Advance an overdue transient pipe first (its own lock) so a pipe that
+        // already finished its transition isn't wrongly rejected; the
+        // authoritative, race-free transient check runs under the write lock
+        // below, in the same critical section as the mutation.
+        self.settle_if_overdue(&req.account_id, &name);
         let body = req.json_body();
-        if body
-            .get("RoleArn")
-            .and_then(Value::as_str)
-            .filter(|s| !s.is_empty())
-            .is_none()
-        {
-            return Err(validation_error("RoleArn is required"));
-        }
         let now = now_epoch_secs();
 
         let response = {
@@ -615,6 +582,20 @@ impl PipesService {
             let obj = pipe
                 .as_object_mut()
                 .ok_or_else(|| validation_error("corrupt pipe state"))?;
+            // Atomic guard: reject a mutation while the pipe is mid-transition,
+            // holding the write lock so a concurrent DeletePipe/Start/Stop can't
+            // flip the state between this check and the write below.
+            if let Some(err) = transient_conflict(obj, &name) {
+                return Err(err);
+            }
+            if body
+                .get("RoleArn")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .is_none()
+            {
+                return Err(validation_error("RoleArn is required"));
+            }
             // UpdatePipe is a full replace of the updatable fields: a field the
             // client omits is cleared, not left at its previous value. AWS does
             // this (e.g. dropping `TargetParameters.InputTemplate` on a later
@@ -688,7 +669,9 @@ impl PipesService {
         desired: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let name = pipe_name_from_path(req)?;
-        self.ensure_not_transient(&req.account_id, &name)?;
+        // Settle an overdue transient pipe first; the authoritative transient
+        // check runs under the write lock below, atomically with the mutation.
+        self.settle_if_overdue(&req.account_id, &name);
         let now = now_epoch_secs();
         let response = {
             let mut accounts = self.state.write();
@@ -697,6 +680,11 @@ impl PipesService {
             let obj = pipe
                 .as_object_mut()
                 .ok_or_else(|| validation_error("corrupt pipe state"))?;
+            // Atomic guard in the same critical section as the mutation: a
+            // concurrent DeletePipe can't flip the state between check and write.
+            if let Some(err) = transient_conflict(obj, &name) {
+                return Err(err);
+            }
             obj.insert("DesiredState".into(), json!(desired));
             obj.insert("CurrentState".into(), json!(transient));
             obj.insert("LastModifiedTime".into(), json!(now));
@@ -1156,6 +1144,26 @@ fn not_found(name: &str) -> AwsServiceError {
     )
 }
 
+/// If a pipe object is mid-transition, produce the `ConflictException` a
+/// mutating lifecycle op (Update/Start/Stop) must return. Callers invoke this
+/// while holding the state write lock, in the same critical section as the
+/// mutation, so a concurrent Delete/Start/Stop can't flip the state between the
+/// check and the write.
+fn transient_conflict(obj: &Map<String, Value>, name: &str) -> Option<AwsServiceError> {
+    let cur = obj
+        .get("CurrentState")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if is_transient_state(cur) {
+        Some(conflict_error(
+            format!("Pipe '{name}' is in state {cur} and cannot be modified until it stabilizes."),
+            name,
+        ))
+    } else {
+        None
+    }
+}
+
 fn conflict_error(msg: impl Into<String>, resource_id: &str) -> AwsServiceError {
     AwsServiceError::aws_error_with_fields(
         StatusCode::CONFLICT,
@@ -1371,18 +1379,52 @@ mod tests {
     }
 
     #[test]
-    fn ensure_not_transient_allows_settled_pipe() {
-        // A RUNNING pipe is modifiable, so the guard passes cleanly.
-        let (svc, _state) = service_with_pipe(STATE_RUNNING, STATE_RUNNING, 0.0);
-        assert!(svc.ensure_not_transient("123456789012", "p1").is_ok());
+    fn transient_conflict_flags_only_transient_states() {
+        // The in-lock guard treats settled states as modifiable and every
+        // transient state as a ConflictException.
+        let mut obj = Map::new();
+        obj.insert("CurrentState".into(), json!(STATE_RUNNING));
+        assert!(transient_conflict(&obj, "p1").is_none());
+        obj.insert("CurrentState".into(), json!(STATE_STOPPED));
+        assert!(transient_conflict(&obj, "p1").is_none());
+        for st in [
+            STATE_CREATING,
+            STATE_UPDATING,
+            STATE_STARTING,
+            STATE_STOPPING,
+            STATE_DELETING,
+        ] {
+            obj.insert("CurrentState".into(), json!(st));
+            assert_eq!(
+                transient_conflict(&obj, "p1").unwrap().code(),
+                "ConflictException",
+                "{st} must conflict"
+            );
+        }
     }
 
     #[test]
-    fn ensure_not_transient_settles_overdue_deleting_then_allows() {
-        // An overdue DELETING pipe is settled (removed) before the guard checks,
-        // so a following op sees NotFound rather than a spurious Conflict.
+    fn update_allows_settled_pipe_past_the_guard() {
+        // A RUNNING pipe passes the transient guard: UpdatePipe then fails on the
+        // missing RoleArn (ValidationException), proving it was NOT a Conflict.
+        let (svc, _state) = service_with_pipe(STATE_RUNNING, STATE_RUNNING, 0.0);
+        let req = make_request(Method::PUT, "/v1/pipes/p1");
+        let Err(err) = svc.update_pipe(&req) else {
+            panic!("UpdatePipe with no RoleArn must error");
+        };
+        assert_eq!(err.code(), "ValidationException");
+    }
+
+    #[test]
+    fn update_settles_overdue_deleting_then_reports_not_found() {
+        // An overdue DELETING pipe is settled (removed) before the write-lock
+        // guard runs, so UpdatePipe sees NotFound rather than a spurious Conflict.
         let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 5.0);
-        assert!(svc.ensure_not_transient("123456789012", "p1").is_ok());
+        let req = make_request(Method::PUT, "/v1/pipes/p1");
+        let Err(err) = svc.update_pipe(&req) else {
+            panic!("UpdatePipe on a removed pipe must error");
+        };
+        assert_eq!(err.code(), "NotFoundException");
         assert!(state.read().get("123456789012").unwrap().pipes.is_empty());
     }
 

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -455,6 +455,35 @@ impl PipesService {
         true
     }
 
+    /// Reject a mutating lifecycle op (Update/Start/Stop) while the pipe is
+    /// mid-transition. AWS returns `ConflictException` for these until the pipe
+    /// settles, so a racing Update/Start/Stop can't resurrect a `DELETING` pipe
+    /// (settling it back to `RUNNING`) or clobber an in-flight `CREATING`/
+    /// `UPDATING`/`STARTING`/`STOPPING` one. Settles an overdue pipe first, so a
+    /// pipe that has already finished its transition — but whose background
+    /// settle task hasn't fired yet — is not wrongly rejected. A pipe that no
+    /// longer exists (a completed delete) passes through here and is handled as
+    /// a NotFound by the caller.
+    fn ensure_not_transient(&self, account_id: &str, name: &str) -> Result<(), AwsServiceError> {
+        self.settle_if_overdue(account_id, name);
+        let accounts = self.state.read();
+        if let Some(pipe) = accounts.get(account_id).and_then(|st| st.pipes.get(name)) {
+            let cur = pipe
+                .get("CurrentState")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            if is_transient_state(cur) {
+                return Err(conflict_error(
+                    format!(
+                        "Pipe '{name}' is in state {cur} and cannot be modified until it stabilizes."
+                    ),
+                    name,
+                ));
+            }
+        }
+        Ok(())
+    }
+
     fn list_pipes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let q = &req.query_params;
         let name_prefix = q.get("NamePrefix").map(String::as_str);
@@ -567,6 +596,7 @@ impl PipesService {
 
     fn update_pipe(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let name = pipe_name_from_path(req)?;
+        self.ensure_not_transient(&req.account_id, &name)?;
         let body = req.json_body();
         if body
             .get("RoleArn")
@@ -658,6 +688,7 @@ impl PipesService {
         desired: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let name = pipe_name_from_path(req)?;
+        self.ensure_not_transient(&req.account_id, &name)?;
         let now = now_epoch_secs();
         let response = {
             let mut accounts = self.state.write();
@@ -1024,7 +1055,7 @@ fn resource_arn_from_path(req: &AwsRequest) -> Result<String, AwsServiceError> {
 
 /// Validate a `ResourceArn`-shaped value (length 1..1600). Shared by the
 /// ListPipes `SourcePrefix` / `TargetPrefix` query filters.
-fn validate_resource_arn_len(field: &str, value: &str) -> Result<(), AwsServiceError> {
+pub fn validate_resource_arn_len(field: &str, value: &str) -> Result<(), AwsServiceError> {
     if value.is_empty() || value.len() > 1600 {
         return Err(validation_error(format!(
             "{field} must be 1-1600 characters"
@@ -1074,7 +1105,7 @@ fn validate_requested_pipe_state(value: &str) -> Result<(), AwsServiceError> {
     }
 }
 
-fn validate_pipe_name(name: &str) -> Result<(), AwsServiceError> {
+pub fn validate_pipe_name(name: &str) -> Result<(), AwsServiceError> {
     if name.is_empty() || name.len() > 64 {
         return Err(validation_error(
             "Pipe name must be between 1 and 64 characters",
@@ -1300,6 +1331,59 @@ mod tests {
             state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
             STATE_CREATING
         );
+    }
+
+    #[test]
+    fn update_rejects_deleting_pipe_with_conflict() {
+        // A racing UpdatePipe must not resurrect a fresh DELETING pipe: AWS
+        // returns ConflictException while the pipe is mid-transition.
+        let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 0.0);
+        let req = make_request(Method::PUT, "/v1/pipes/p1");
+        let Err(err) = svc.update_pipe(&req) else {
+            panic!("UpdatePipe on a DELETING pipe must be rejected");
+        };
+        assert_eq!(err.code(), "ConflictException");
+        // The pipe is untouched — still DELETING, not flipped back to UPDATING.
+        assert_eq!(
+            state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
+            STATE_DELETING
+        );
+    }
+
+    #[test]
+    fn start_rejects_creating_pipe_with_conflict() {
+        let (svc, _state) = service_with_pipe(STATE_CREATING, STATE_RUNNING, 0.0);
+        let req = make_request(Method::POST, "/v1/pipes/p1/start");
+        let Err(err) = svc.start_pipe(&req) else {
+            panic!("StartPipe on a CREATING pipe must be rejected");
+        };
+        assert_eq!(err.code(), "ConflictException");
+    }
+
+    #[test]
+    fn stop_rejects_updating_pipe_with_conflict() {
+        let (svc, _state) = service_with_pipe(STATE_UPDATING, STATE_RUNNING, 0.0);
+        let req = make_request(Method::POST, "/v1/pipes/p1/stop");
+        let Err(err) = svc.stop_pipe(&req) else {
+            panic!("StopPipe on an UPDATING pipe must be rejected");
+        };
+        assert_eq!(err.code(), "ConflictException");
+    }
+
+    #[test]
+    fn ensure_not_transient_allows_settled_pipe() {
+        // A RUNNING pipe is modifiable, so the guard passes cleanly.
+        let (svc, _state) = service_with_pipe(STATE_RUNNING, STATE_RUNNING, 0.0);
+        assert!(svc.ensure_not_transient("123456789012", "p1").is_ok());
+    }
+
+    #[test]
+    fn ensure_not_transient_settles_overdue_deleting_then_allows() {
+        // An overdue DELETING pipe is settled (removed) before the guard checks,
+        // so a following op sees NotFound rather than a spurious Conflict.
+        let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 5.0);
+        assert!(svc.ensure_not_transient("123456789012", "p1").is_ok());
+        assert!(state.read().get("123456789012").unwrap().pipes.is_empty());
     }
 
     #[test]

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -573,6 +573,17 @@ impl PipesService {
         // below, in the same critical section as the mutation.
         self.settle_if_overdue(&req.account_id, &name);
         let body = req.json_body();
+        // Validate the request BEFORE touching any state, so a rejected
+        // UpdatePipe leaves the pipe untouched — otherwise force-settling a fresh
+        // transient pipe below would be a side effect of a failed call.
+        if body
+            .get("RoleArn")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .is_none()
+        {
+            return Err(validation_error("RoleArn is required"));
+        }
         let now = now_epoch_secs();
 
         let response = {
@@ -584,7 +595,9 @@ impl PipesService {
                 .ok_or_else(|| validation_error("corrupt pipe state"))?;
             // Stabilize a fresh transient pipe on demand (CREATING/STARTING/
             // STOPPING/UPDATING -> steady state) so Update on a just-created pipe
-            // succeeds like real AWS; DELETING is left for the guard below.
+            // succeeds like real AWS; DELETING is left for the guard below. Runs
+            // only after request validation has passed, so a rejected update
+            // never mutates state.
             settle_transient_obj(obj);
             // Atomic guard: reject a mutation only while the pipe is DELETING
             // (the sole remaining transient state after the settle above),
@@ -592,14 +605,6 @@ impl PipesService {
             // state between this check and the write below.
             if let Some(err) = transient_conflict(obj, &name) {
                 return Err(err);
-            }
-            if body
-                .get("RoleArn")
-                .and_then(Value::as_str)
-                .filter(|s| !s.is_empty())
-                .is_none()
-            {
-                return Err(validation_error("RoleArn is required"));
             }
             // UpdatePipe is a full replace of the updatable fields: a field the
             // client omits is cleared, not left at its previous value. AWS does
@@ -1395,12 +1400,26 @@ mod tests {
         );
     }
 
+    /// A PUT /v1/pipes/p1 request carrying a valid RoleArn body, so UpdatePipe
+    /// passes request validation and reaches the transient/conflict logic.
+    fn update_request_with_role() -> AwsRequest {
+        let mut req = make_request(Method::PUT, "/v1/pipes/p1");
+        req.body = serde_json::to_vec(&json!({
+            "RoleArn": "arn:aws:iam::123456789012:role/p"
+        }))
+        .unwrap()
+        .into();
+        req
+    }
+
     #[test]
     fn update_rejects_deleting_pipe_with_conflict() {
         // A racing UpdatePipe must not resurrect a fresh DELETING pipe: AWS
-        // returns ConflictException while the pipe is mid-transition.
+        // returns ConflictException while the pipe is mid-transition. The request
+        // carries a valid RoleArn so it reaches the guard rather than failing
+        // request validation first.
         let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 0.0);
-        let req = make_request(Method::PUT, "/v1/pipes/p1");
+        let req = update_request_with_role();
         let Err(err) = svc.update_pipe(&req) else {
             panic!("UpdatePipe on a DELETING pipe must be rejected");
         };
@@ -1495,23 +1514,46 @@ mod tests {
     }
 
     #[test]
-    fn update_allows_settled_pipe_past_the_guard() {
-        // A RUNNING pipe passes the transient guard: UpdatePipe then fails on the
-        // missing RoleArn (ValidationException), proving it was NOT a Conflict.
-        let (svc, _state) = service_with_pipe(STATE_RUNNING, STATE_RUNNING, 0.0);
+    fn invalid_update_leaves_fresh_transient_pipe_untouched() {
+        // A missing RoleArn is rejected BEFORE the on-demand settle, so an
+        // invalid UpdatePipe on a fresh CREATING pipe returns ValidationException
+        // without force-settling it (no failed-update side effect).
+        let (svc, state) = service_with_pipe(STATE_CREATING, STATE_RUNNING, 0.0);
         let req = make_request(Method::PUT, "/v1/pipes/p1");
         let Err(err) = svc.update_pipe(&req) else {
             panic!("UpdatePipe with no RoleArn must error");
         };
         assert_eq!(err.code(), "ValidationException");
+        assert_eq!(
+            state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
+            STATE_CREATING,
+            "a rejected UpdatePipe must not force-settle (state unchanged)"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_allows_settled_pipe() {
+        // A RUNNING pipe with a valid request passes the transient guard and is
+        // updated (CurrentState -> UPDATING), rather than being rejected.
+        let (svc, state) = service_with_pipe(STATE_RUNNING, STATE_RUNNING, 0.0);
+        let req = update_request_with_role();
+        assert!(
+            svc.update_pipe(&req).is_ok(),
+            "UpdatePipe on a RUNNING pipe must succeed"
+        );
+        assert_eq!(
+            state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
+            STATE_UPDATING
+        );
     }
 
     #[test]
     fn update_settles_overdue_deleting_then_reports_not_found() {
         // An overdue DELETING pipe is settled (removed) before the write-lock
         // guard runs, so UpdatePipe sees NotFound rather than a spurious Conflict.
+        // A valid RoleArn ensures request validation passes and the lookup runs.
         let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 5.0);
-        let req = make_request(Method::PUT, "/v1/pipes/p1");
+        let req = update_request_with_role();
         let Err(err) = svc.update_pipe(&req) else {
             panic!("UpdatePipe on a removed pipe must error");
         };

--- a/crates/fakecloud-pipes/src/service.rs
+++ b/crates/fakecloud-pipes/src/service.rs
@@ -582,9 +582,14 @@ impl PipesService {
             let obj = pipe
                 .as_object_mut()
                 .ok_or_else(|| validation_error("corrupt pipe state"))?;
-            // Atomic guard: reject a mutation while the pipe is mid-transition,
-            // holding the write lock so a concurrent DeletePipe/Start/Stop can't
-            // flip the state between this check and the write below.
+            // Stabilize a fresh transient pipe on demand (CREATING/STARTING/
+            // STOPPING/UPDATING -> steady state) so Update on a just-created pipe
+            // succeeds like real AWS; DELETING is left for the guard below.
+            settle_transient_obj(obj);
+            // Atomic guard: reject a mutation only while the pipe is DELETING
+            // (the sole remaining transient state after the settle above),
+            // holding the write lock so a concurrent DeletePipe can't flip the
+            // state between this check and the write below.
             if let Some(err) = transient_conflict(obj, &name) {
                 return Err(err);
             }
@@ -680,8 +685,13 @@ impl PipesService {
             let obj = pipe
                 .as_object_mut()
                 .ok_or_else(|| validation_error("corrupt pipe state"))?;
-            // Atomic guard in the same critical section as the mutation: a
-            // concurrent DeletePipe can't flip the state between check and write.
+            // Stabilize a fresh transient pipe on demand so Start/Stop on a
+            // just-created pipe succeeds like real AWS; DELETING is left for the
+            // guard below.
+            settle_transient_obj(obj);
+            // Atomic guard in the same critical section as the mutation: reject
+            // only a DELETING pipe, so a concurrent DeletePipe can't be raced
+            // between check and write.
             if let Some(err) = transient_conflict(obj, &name) {
                 return Err(err);
             }
@@ -848,6 +858,50 @@ fn is_mutating(action: &str) -> bool {
 /// Advance a transient pipe to its settled state. Removes the pipe (and tags)
 /// when it was DELETING; otherwise resolves to its DesiredState or the natural
 /// terminus of the in-flight transition.
+/// Force a *non-DELETING* transient pipe to its steady state in place, ignoring
+/// the `SETTLE_DELAY` window. fakecloud has no real provisioning latency, so a
+/// just-created `CREATING` pipe (and `STARTING`/`STOPPING`/`UPDATING`)
+/// stabilizes on demand — real AWS lets Start/Stop/Update on a freshly-created
+/// pipe succeed with 200 because the pipe stabilizes almost instantly. Called
+/// under the state write lock immediately before the transient guard, so a
+/// fresh pipe becomes RUNNING/STOPPED and the guard only ever rejects a pipe
+/// that is genuinely `DELETING` (preserving the anti-resurrection fix).
+fn settle_transient_obj(obj: &mut Map<String, Value>) {
+    let cur = obj
+        .get("CurrentState")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    // DELETING is left untouched so the guard can still reject it; a settled
+    // state needs no work.
+    if cur == STATE_DELETING || !is_transient_state(cur) {
+        return;
+    }
+    let desired = obj
+        .get("DesiredState")
+        .and_then(Value::as_str)
+        .unwrap_or(STATE_RUNNING)
+        .to_string();
+    let settled = match cur {
+        STATE_STARTING => STATE_RUNNING,
+        STATE_STOPPING => STATE_STOPPED,
+        // CREATING / UPDATING resolve to whatever the client asked for.
+        _ => {
+            if desired == STATE_STOPPED {
+                STATE_STOPPED
+            } else {
+                STATE_RUNNING
+            }
+        }
+    };
+    obj.insert("CurrentState".into(), json!(settled));
+    let reason = if settled == STATE_RUNNING {
+        "Pipe is running"
+    } else {
+        "Pipe is stopped"
+    };
+    obj.insert("StateReason".into(), json!(reason));
+}
+
 fn settle_pipe(st: &mut crate::state::PipesState, name: &str) {
     let Some(pipe) = st.pipes.get(name) else {
         return;
@@ -1358,30 +1412,67 @@ mod tests {
         );
     }
 
-    #[test]
-    fn start_rejects_creating_pipe_with_conflict() {
-        let (svc, _state) = service_with_pipe(STATE_CREATING, STATE_RUNNING, 0.0);
+    #[tokio::test]
+    async fn start_settles_fresh_creating_pipe_then_succeeds() {
+        // Real AWS lets StartPipe on a just-created (CREATING) pipe succeed —
+        // the pipe stabilizes almost instantly. fakecloud force-settles it to
+        // RUNNING on demand, so Start proceeds (200) and moves it to STARTING.
+        let (svc, state) = service_with_pipe(STATE_CREATING, STATE_RUNNING, 0.0);
         let req = make_request(Method::POST, "/v1/pipes/p1/start");
-        let Err(err) = svc.start_pipe(&req) else {
-            panic!("StartPipe on a CREATING pipe must be rejected");
-        };
-        assert_eq!(err.code(), "ConflictException");
+        assert!(
+            svc.start_pipe(&req).is_ok(),
+            "StartPipe on a fresh CREATING pipe must succeed, not 409"
+        );
+        assert_eq!(
+            state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
+            STATE_STARTING
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_settles_fresh_updating_pipe_then_succeeds() {
+        let (svc, state) = service_with_pipe(STATE_UPDATING, STATE_RUNNING, 0.0);
+        let req = make_request(Method::POST, "/v1/pipes/p1/stop");
+        assert!(
+            svc.stop_pipe(&req).is_ok(),
+            "StopPipe on a fresh UPDATING pipe must succeed, not 409"
+        );
+        assert_eq!(
+            state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
+            STATE_STOPPING
+        );
     }
 
     #[test]
-    fn stop_rejects_updating_pipe_with_conflict() {
-        let (svc, _state) = service_with_pipe(STATE_UPDATING, STATE_RUNNING, 0.0);
-        let req = make_request(Method::POST, "/v1/pipes/p1/stop");
-        let Err(err) = svc.stop_pipe(&req) else {
-            panic!("StopPipe on an UPDATING pipe must be rejected");
-        };
-        assert_eq!(err.code(), "ConflictException");
+    fn start_and_stop_reject_deleting_pipe_with_conflict() {
+        // The anti-resurrection guard: Start/Stop on a DELETING pipe still 409s
+        // and does not flip it out of DELETING.
+        for op in ["start", "stop"] {
+            let (svc, state) = service_with_pipe(STATE_DELETING, "STOPPED", 0.0);
+            let req = make_request(Method::POST, &format!("/v1/pipes/p1/{op}"));
+            let res = if op == "start" {
+                svc.start_pipe(&req)
+            } else {
+                svc.stop_pipe(&req)
+            };
+            let Err(err) = res else {
+                panic!("{op} on a DELETING pipe must be rejected");
+            };
+            assert_eq!(err.code(), "ConflictException", "{op} must conflict");
+            assert_eq!(
+                state.read().get("123456789012").unwrap().pipes["p1"]["CurrentState"],
+                STATE_DELETING,
+                "{op} must not resurrect the DELETING pipe"
+            );
+        }
     }
 
     #[test]
     fn transient_conflict_flags_only_transient_states() {
-        // The in-lock guard treats settled states as modifiable and every
-        // transient state as a ConflictException.
+        // Raw helper contract: settled states are modifiable, every transient
+        // state maps to ConflictException. In the live Update/Start/Stop path a
+        // non-DELETING transient is force-settled *before* this runs, so only
+        // DELETING actually reaches it — but the helper itself flags all of them.
         let mut obj = Map::new();
         obj.insert("CurrentState".into(), json!(STATE_RUNNING));
         assert!(transient_conflict(&obj, "p1").is_none());

--- a/crates/fakecloud-rds-data/Cargo.toml
+++ b/crates/fakecloud-rds-data/Cargo.toml
@@ -29,4 +29,4 @@ uuid = { workspace = true }
 rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/fakecloud-rds-data/src/service.rs
+++ b/crates/fakecloud-rds-data/src/service.rs
@@ -67,6 +67,16 @@ impl TxnEntry {
             *t = Instant::now();
         }
     }
+
+    /// Has this transaction been idle longer than [`TXN_IDLE_TIMEOUT`] as of
+    /// `now`? A poisoned `last_used` lock is treated as not-stale so a spurious
+    /// panic elsewhere can never trigger a rollback.
+    fn is_stale(&self, now: Instant) -> bool {
+        self.last_used
+            .lock()
+            .map(|t| now.duration_since(*t) > TXN_IDLE_TIMEOUT)
+            .unwrap_or(false)
+    }
 }
 
 type TxnMap = Arc<Mutex<HashMap<String, Arc<TxnEntry>>>>;
@@ -327,14 +337,14 @@ impl RdsDataService {
             match held {
                 HeldConn::Pg(client) => {
                     for set in run_each(&sets) {
-                        pg_run(client, sql, set, false, false).await?;
-                        results.push(json!({ "generatedFields": [] }));
+                        let v = pg_run(client, sql, set, false, false).await?;
+                        results.push(batch_update_result(&v));
                     }
                 }
                 HeldConn::MySql(conn) => {
                     for set in run_each(&sets) {
-                        my_run(conn, sql, set, false, false).await?;
-                        results.push(json!({ "generatedFields": [] }));
+                        let v = my_run(conn, sql, set, false, false).await?;
+                        results.push(batch_update_result(&v));
                     }
                 }
             }
@@ -347,17 +357,19 @@ impl RdsDataService {
         if engine.contains("postgres") {
             let client = pg_connect(&conn).await?;
             for set in run_each(&sets) {
-                pg_run(&client, sql, set, false, false).await?;
-                results.push(json!({ "generatedFields": [] }));
+                let v = pg_run(&client, sql, set, false, false).await?;
+                results.push(batch_update_result(&v));
             }
         } else if is_mysql(&engine) {
             let mut c = my_connect(&conn).await?;
             for set in run_each(&sets) {
-                if let Err(e) = my_run(&mut c, sql, set, false, false).await {
-                    let _ = c.disconnect().await;
-                    return Err(e);
+                match my_run(&mut c, sql, set, false, false).await {
+                    Ok(v) => results.push(batch_update_result(&v)),
+                    Err(e) => {
+                        let _ = c.disconnect().await;
+                        return Err(e);
+                    }
                 }
-                results.push(json!({ "generatedFields": [] }));
             }
             let _ = c.disconnect().await;
         } else {
@@ -465,26 +477,46 @@ async fn reap_idle_transactions(transactions: TxnMap) {
     let mut tick = tokio::time::interval(Duration::from_secs(30));
     loop {
         tick.tick().await;
-        let now = Instant::now();
-        let stale: Vec<(String, Arc<TxnEntry>)> = {
-            let map = transactions.lock().await;
-            map.iter()
-                .filter(|(_, e)| {
-                    e.last_used
-                        .lock()
-                        .map(|t| now.duration_since(*t) > TXN_IDLE_TIMEOUT)
-                        .unwrap_or(false)
-                })
-                .map(|(id, e)| (id.clone(), e.clone()))
-                .collect()
-        };
-        for (id, entry) in stale {
-            transactions.lock().await.remove(&id);
-            if let Some(held) = entry.conn.lock().await.take() {
-                let _ = finish_held(held, "ROLLBACK").await;
-            }
+        reap_once(&transactions).await;
+    }
+}
+
+/// Sample the transactions that look idle as of `now`, cloning the `Arc`s so the
+/// map lock is dropped before any connection is touched.
+async fn collect_stale(transactions: &TxnMap, now: Instant) -> Vec<(String, Arc<TxnEntry>)> {
+    let map = transactions.lock().await;
+    map.iter()
+        .filter(|(_, e)| e.is_stale(now))
+        .map(|(id, e)| (id.clone(), e.clone()))
+        .collect()
+}
+
+/// Roll back and release each sampled-stale transaction — but only after
+/// re-verifying, under the map lock, that it is *still* idle and still the same
+/// entry. Without this recheck a statement that reactivated the transaction
+/// between the sample and the removal (`touch()` on an in-flight
+/// `ExecuteStatement`) would have its live connection rolled back out from under
+/// it — a TOCTOU that silently corrupts an active transaction.
+async fn reap_stale(transactions: &TxnMap, stale: Vec<(String, Arc<TxnEntry>)>) {
+    for (id, entry) in stale {
+        let mut map = transactions.lock().await;
+        let still_stale =
+            entry.is_stale(Instant::now()) && map.get(&id).is_some_and(|e| Arc::ptr_eq(e, &entry));
+        if !still_stale {
+            continue;
+        }
+        map.remove(&id);
+        drop(map);
+        if let Some(held) = entry.conn.lock().await.take() {
+            let _ = finish_held(held, "ROLLBACK").await;
         }
     }
+}
+
+/// One reaper sweep: sample the idle set, then roll back each after a re-check.
+async fn reap_once(transactions: &TxnMap) {
+    let stale = collect_stale(transactions, Instant::now()).await;
+    reap_stale(transactions, stale).await;
 }
 
 /// A single positional SQL parameter resolved from an AWS `SqlParameter`.
@@ -622,6 +654,59 @@ fn mysql_literal(v: &SqlValue) -> String {
     }
 }
 
+/// Is the statement a data-modifying `INSERT`/`UPDATE`/`DELETE ... RETURNING`?
+/// These come back through the row-returning path (they have a result set) but,
+/// unlike a plain `SELECT`, they also change rows — so `numberOfRecordsUpdated`
+/// must reflect the affected count rather than 0.
+fn is_returning_dml(sql: &str) -> bool {
+    let head = sql.trim_start().to_ascii_uppercase();
+    (head.starts_with("INSERT") || head.starts_with("UPDATE") || head.starts_with("DELETE"))
+        && head.contains(" RETURNING ")
+}
+
+/// Build one `updateResults[]` entry for BatchExecuteStatement from a single
+/// statement's run output, carrying through any `generatedFields` the write
+/// produced (e.g. a MySQL auto-increment id) rather than always emitting `[]`.
+fn batch_update_result(run_output: &Value) -> Value {
+    let generated = run_output
+        .get("generatedFields")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+    json!({ "generatedFields": generated })
+}
+
+/// AWS-shaped `columnMetadata` for a Postgres result description.
+fn pg_column_metadata(cols: &[tokio_postgres::Column]) -> Value {
+    Value::Array(
+        cols.iter()
+            .map(|c| {
+                json!({
+                    "name": c.name(),
+                    "label": c.name(),
+                    "typeName": c.type_().name(),
+                    "nullable": 2, // unknown
+                })
+            })
+            .collect(),
+    )
+}
+
+/// AWS-shaped `columnMetadata` for a MySQL result description.
+fn my_column_metadata(cols: &[mysql_async::Column]) -> Value {
+    Value::Array(
+        cols.iter()
+            .map(|c| {
+                json!({
+                    "name": c.name_str().to_string(),
+                    "label": c.name_str().to_string(),
+                    "typeName": format!("{:?}", c.column_type()),
+                    "nullable": 2,
+                })
+            })
+            .collect(),
+    )
+}
+
 /// Does the SQL statement return a result set (vs. an affected-rows write)?
 fn returns_rows(sql: &str) -> bool {
     let head = sql.trim_start().to_ascii_uppercase();
@@ -693,34 +778,43 @@ async fn pg_run(
         return Ok(Value::Object(out));
     }
 
-    let rows = client
-        .query(stmt.as_str(), no_params)
+    // Prepare first, then run the prepared statement: the `Statement`'s column
+    // description is available even when the query returns zero rows, so a
+    // `SELECT ... WHERE 1=0` still reports its columns under
+    // `includeResultMetadata` (a bare `client.query()` would leave us with no
+    // row to read columns from).
+    let statement = client
+        .prepare(stmt.as_str())
         .await
         .map_err(|e| bad_request(format!("{e}")))?;
+    let rows = client
+        .query(&statement, no_params)
+        .await
+        .map_err(|e| bad_request(format!("{e}")))?;
+    let cols = statement.columns();
+
+    // A pure SELECT never updates rows (numberOfRecordsUpdated = 0); a DML
+    // `... RETURNING` (INSERT/UPDATE/DELETE) reports the affected count, which
+    // equals the number of returned rows. Emit the field unconditionally so
+    // typed SDKs read a present value rather than defaulting it silently.
+    let updated = if is_returning_dml(&stmt) {
+        rows.len() as i64
+    } else {
+        0
+    };
+    out.insert("numberOfRecordsUpdated".into(), json!(updated));
+
+    if include_metadata {
+        out.insert("columnMetadata".into(), pg_column_metadata(cols));
+    }
+
     if rows.is_empty() {
-        out.insert("numberOfRecordsUpdated".into(), json!(0));
         if format_json {
             out.insert("formattedRecords".into(), json!("[]"));
         } else {
             out.insert("records".into(), json!([]));
         }
         return Ok(Value::Object(out));
-    }
-
-    let cols = rows[0].columns();
-    if include_metadata {
-        let md: Vec<Value> = cols
-            .iter()
-            .map(|c| {
-                json!({
-                    "name": c.name(),
-                    "label": c.name(),
-                    "typeName": c.type_().name(),
-                    "nullable": 2, // unknown
-                })
-            })
-            .collect();
-        out.insert("columnMetadata".into(), Value::Array(md));
     }
 
     let mut records: Vec<Value> = Vec::with_capacity(rows.len());
@@ -886,36 +980,44 @@ async fn my_run(
         return Ok(Value::Object(out));
     }
 
-    let rows: Vec<Row> = c
-        .query(stmt.as_str())
+    // Run through `query_iter` so the result-set column definitions are read off
+    // the wire (and captured) before the rows are drained — a zero-row result
+    // (`WHERE 1=0`) therefore still exposes its columns under
+    // `includeResultMetadata`, which `rows[0].columns()` cannot do when there is
+    // no row 0.
+    let result = c
+        .query_iter(stmt.as_str())
+        .await
+        .map_err(|e| bad_request(format!("{e}")))?;
+    let cols: std::sync::Arc<[Column]> = result
+        .columns()
+        .unwrap_or_else(|| std::sync::Arc::from(Vec::<Column>::new()));
+    let rows: Vec<Row> = result
+        .collect_and_drop::<Row>()
         .await
         .map_err(|e| bad_request(format!("{e}")))?;
     let affected = c.affected_rows();
 
+    // A pure SELECT never updates rows; a DML `... RETURNING` (MariaDB) reports
+    // the affected count. Keep the field consistent with the Postgres arm.
+    let updated = if is_returning_dml(&stmt) {
+        affected as i64
+    } else {
+        0
+    };
+    out.insert("numberOfRecordsUpdated".into(), json!(updated));
+
+    if include_metadata {
+        out.insert("columnMetadata".into(), my_column_metadata(&cols));
+    }
+
     if rows.is_empty() {
-        out.insert("numberOfRecordsUpdated".into(), json!(affected));
         if format_json {
             out.insert("formattedRecords".into(), json!("[]"));
         } else {
             out.insert("records".into(), json!([]));
         }
         return Ok(Value::Object(out));
-    }
-
-    let cols: std::sync::Arc<[Column]> = rows[0].columns();
-    if include_metadata {
-        let md: Vec<Value> = cols
-            .iter()
-            .map(|c| {
-                json!({
-                    "name": c.name_str().to_string(),
-                    "label": c.name_str().to_string(),
-                    "typeName": format!("{:?}", c.column_type()),
-                    "nullable": 2,
-                })
-            })
-            .collect();
-        out.insert("columnMetadata".into(), Value::Array(md));
     }
 
     let mut records: Vec<Value> = Vec::with_capacity(rows.len());
@@ -1060,4 +1162,91 @@ fn b64_decode(s: &str) -> Vec<u8> {
     base64::engine::general_purpose::STANDARD
         .decode(s)
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_returning_dml_matches_only_dml_returning() {
+        assert!(is_returning_dml("INSERT INTO t VALUES (1) RETURNING id"));
+        assert!(is_returning_dml("  update t set x = 1 returning *"));
+        assert!(is_returning_dml("DELETE FROM t WHERE id = 1 RETURNING id"));
+        // A plain SELECT is not a write, even when a column is named `returning`.
+        assert!(!is_returning_dml("SELECT 1"));
+        assert!(!is_returning_dml("SELECT returning_col FROM t"));
+        // An INSERT without RETURNING goes through the affected-rows write path.
+        assert!(!is_returning_dml("INSERT INTO t VALUES (1)"));
+    }
+
+    #[test]
+    fn batch_update_result_carries_generated_fields() {
+        // The MySQL write path populates generatedFields; the batch entry must
+        // surface it rather than discarding it for an empty list.
+        let out = json!({
+            "numberOfRecordsUpdated": 1,
+            "generatedFields": [{ "longValue": 42 }],
+            "records": [],
+        });
+        assert_eq!(
+            batch_update_result(&out),
+            json!({ "generatedFields": [{ "longValue": 42 }] })
+        );
+    }
+
+    #[test]
+    fn batch_update_result_defaults_to_empty_generated_fields() {
+        // A statement that produced no generated key (e.g. Postgres, or a
+        // non-auto-increment INSERT) still yields a well-formed entry.
+        let out = json!({ "numberOfRecordsUpdated": 1, "records": [] });
+        assert_eq!(batch_update_result(&out), json!({ "generatedFields": [] }));
+    }
+
+    fn idle_entry(last_used: Instant) -> Arc<TxnEntry> {
+        // conn = None so the reaper never tries to touch a real database.
+        Arc::new(TxnEntry {
+            conn: Mutex::new(None),
+            last_used: StdMutex::new(last_used),
+        })
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reaper_rolls_back_idle_transaction() {
+        let transactions: TxnMap = Arc::new(Mutex::new(HashMap::new()));
+        let base = Instant::now();
+        transactions
+            .lock()
+            .await
+            .insert("tx1".to_string(), idle_entry(base));
+        // Advance past the idle window, then sweep.
+        tokio::time::advance(TXN_IDLE_TIMEOUT + Duration::from_secs(1)).await;
+        reap_once(&transactions).await;
+        assert!(
+            transactions.lock().await.is_empty(),
+            "a genuinely idle transaction is reaped"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reaper_rechecks_staleness_before_rollback() {
+        let transactions: TxnMap = Arc::new(Mutex::new(HashMap::new()));
+        let base = Instant::now();
+        let entry = idle_entry(base);
+        transactions
+            .lock()
+            .await
+            .insert("tx1".to_string(), entry.clone());
+        tokio::time::advance(TXN_IDLE_TIMEOUT + Duration::from_secs(1)).await;
+        // The reaper samples the entry as stale...
+        let stale = collect_stale(&transactions, Instant::now()).await;
+        assert_eq!(stale.len(), 1, "entry sampled as stale");
+        // ...but an in-flight ExecuteStatement reactivates it before removal.
+        entry.touch();
+        reap_stale(&transactions, stale).await;
+        assert!(
+            transactions.lock().await.contains_key("tx1"),
+            "a reactivated transaction is NOT rolled back (TOCTOU guarded)"
+        );
+    }
 }

--- a/crates/fakecloud-rds-data/src/service.rs
+++ b/crates/fakecloud-rds-data/src/service.rs
@@ -1,6 +1,7 @@
 //! RDS Data API (`rds-data`) restJson1 dispatch + real SQL execution.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 
@@ -59,6 +60,12 @@ struct TxnEntry {
     /// `None` once the transaction has been committed/rolled-back or reaped.
     conn: Mutex<Option<HeldConn>>,
     last_used: StdMutex<Instant>,
+    /// Number of statements currently executing against this transaction. Bumped
+    /// while the transactions-map lock is held (so the reaper, which samples
+    /// under the same lock, can never see a live in-flight transaction as
+    /// reapable) and cleared when the statement finishes. A transaction is only
+    /// reapable when this is zero.
+    in_flight: AtomicU64,
 }
 
 impl TxnEntry {
@@ -76,6 +83,40 @@ impl TxnEntry {
             .lock()
             .map(|t| now.duration_since(*t) > TXN_IDLE_TIMEOUT)
             .unwrap_or(false)
+    }
+
+    /// May the reaper roll this transaction back? Only when no statement is
+    /// in-flight *and* it has been idle past the timeout. The `in_flight` check
+    /// closes the window where a statement has taken a reference to the entry but
+    /// has not yet refreshed `last_used`.
+    fn is_reapable(&self, now: Instant) -> bool {
+        self.in_flight.load(Ordering::SeqCst) == 0 && self.is_stale(now)
+    }
+}
+
+/// RAII marker that keeps a transaction pinned against the idle reaper for the
+/// duration of a statement. Incremented under the transactions-map lock in
+/// [`RdsDataService::acquire_txn`]; on drop it refreshes the idle clock and then
+/// releases the pin, so the moment the pin is gone `last_used` is already fresh.
+struct InFlightGuard {
+    entry: Arc<TxnEntry>,
+}
+
+impl InFlightGuard {
+    fn pin(entry: Arc<TxnEntry>) -> Self {
+        entry.in_flight.fetch_add(1, Ordering::SeqCst);
+        entry.touch();
+        Self { entry }
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        // Refresh the idle clock *before* dropping the pin: once `in_flight`
+        // reaches zero the reaper may observe the entry, and it must then see an
+        // up-to-date `last_used` rather than the stale pre-statement value.
+        self.entry.touch();
+        self.entry.in_flight.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -207,11 +248,11 @@ impl RdsDataService {
             // Validate the resource still resolves (AWS still checks it), but the
             // actual execution rides the held connection.
             self.require_conn(req, &body)?;
-            let entry = self.txn_entry(txid).await?;
-            entry.touch();
+            let pin = self.acquire_txn(txid).await?;
             // Lock only this transaction's connection, not the whole map, so a
-            // slow statement here can't block other transactions.
-            let mut guard = entry.conn.lock().await;
+            // slow statement here can't block other transactions. The pin keeps
+            // the reaper off this transaction for the whole statement.
+            let mut guard = pin.entry.conn.lock().await;
             let held = guard.as_mut().ok_or_else(|| not_found_txn(txid))?;
             let value = match held {
                 HeldConn::Pg(client) => {
@@ -267,20 +308,22 @@ impl RdsDataService {
         let entry = Arc::new(TxnEntry {
             conn: Mutex::new(Some(held)),
             last_used: StdMutex::new(Instant::now()),
+            in_flight: AtomicU64::new(0),
         });
         self.transactions.lock().await.insert(txid.clone(), entry);
         Ok(AwsResponse::ok_json(json!({ "transactionId": txid })))
     }
 
-    /// Look up an open transaction's entry, cloning the `Arc` so the map lock is
-    /// released before the caller locks the connection itself.
-    async fn txn_entry(&self, txid: &str) -> Result<Arc<TxnEntry>, AwsServiceError> {
-        self.transactions
-            .lock()
-            .await
-            .get(txid)
-            .cloned()
-            .ok_or_else(|| not_found_txn(txid))
+    /// Look up an open transaction and pin it against the idle reaper for the
+    /// duration of a statement. The `in_flight` bump happens while the
+    /// transactions-map lock is still held, so the reaper (which samples under
+    /// that same lock) can never observe this transaction as reapable between the
+    /// lookup and the pin — closing the clone-then-touch race. The returned guard
+    /// refreshes `last_used` and releases the pin on drop.
+    async fn acquire_txn(&self, txid: &str) -> Result<InFlightGuard, AwsServiceError> {
+        let map = self.transactions.lock().await;
+        let entry = map.get(txid).cloned().ok_or_else(|| not_found_txn(txid))?;
+        Ok(InFlightGuard::pin(entry))
     }
 
     /// Shared body for Commit/Rollback: pull the held connection out of the map
@@ -329,9 +372,8 @@ impl RdsDataService {
         // transaction when `transactionId` is given.
         if let Some(txid) = body.get("transactionId").and_then(Value::as_str) {
             self.require_conn(req, &body)?;
-            let entry = self.txn_entry(txid).await?;
-            entry.touch();
-            let mut guard = entry.conn.lock().await;
+            let pin = self.acquire_txn(txid).await?;
+            let mut guard = pin.entry.conn.lock().await;
             let held = guard.as_mut().ok_or_else(|| not_found_txn(txid))?;
             let mut results = Vec::with_capacity(sets.len().max(1));
             match held {
@@ -486,23 +528,24 @@ async fn reap_idle_transactions(transactions: TxnMap) {
 async fn collect_stale(transactions: &TxnMap, now: Instant) -> Vec<(String, Arc<TxnEntry>)> {
     let map = transactions.lock().await;
     map.iter()
-        .filter(|(_, e)| e.is_stale(now))
+        .filter(|(_, e)| e.is_reapable(now))
         .map(|(id, e)| (id.clone(), e.clone()))
         .collect()
 }
 
-/// Roll back and release each sampled-stale transaction — but only after
-/// re-verifying, under the map lock, that it is *still* idle and still the same
-/// entry. Without this recheck a statement that reactivated the transaction
-/// between the sample and the removal (`touch()` on an in-flight
-/// `ExecuteStatement`) would have its live connection rolled back out from under
-/// it — a TOCTOU that silently corrupts an active transaction.
+/// Roll back and release each sampled transaction — but only after re-verifying,
+/// under the map lock, that it is *still* reapable and still the same entry.
+/// `is_reapable` rejects a transaction that a statement has pinned in-flight
+/// since the sample (the statement bumps `in_flight` under this same lock, so
+/// there is no window where a live statement's transaction looks idle), and the
+/// `ptr_eq` guard rejects one that was removed and replaced by a new
+/// BeginTransaction reusing the id.
 async fn reap_stale(transactions: &TxnMap, stale: Vec<(String, Arc<TxnEntry>)>) {
     for (id, entry) in stale {
         let mut map = transactions.lock().await;
-        let still_stale =
-            entry.is_stale(Instant::now()) && map.get(&id).is_some_and(|e| Arc::ptr_eq(e, &entry));
-        if !still_stale {
+        let still_reapable = entry.is_reapable(Instant::now())
+            && map.get(&id).is_some_and(|e| Arc::ptr_eq(e, &entry));
+        if !still_reapable {
             continue;
         }
         map.remove(&id);
@@ -1208,6 +1251,7 @@ mod tests {
         Arc::new(TxnEntry {
             conn: Mutex::new(None),
             last_used: StdMutex::new(last_used),
+            in_flight: AtomicU64::new(0),
         })
     }
 
@@ -1225,6 +1269,30 @@ mod tests {
         assert!(
             transactions.lock().await.is_empty(),
             "a genuinely idle transaction is reaped"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reaper_spares_transaction_with_in_flight_statement() {
+        // Reproduces the Cubic P1 race: a statement has taken a reference to the
+        // entry (pin) but has NOT yet refreshed last_used (it is a slow query
+        // still running). Even though last_used is stale, the in-flight pin must
+        // keep the reaper from rolling the live transaction back.
+        let transactions: TxnMap = Arc::new(Mutex::new(HashMap::new()));
+        let base = Instant::now();
+        let entry = idle_entry(base);
+        transactions
+            .lock()
+            .await
+            .insert("tx1".to_string(), entry.clone());
+        tokio::time::advance(TXN_IDLE_TIMEOUT + Duration::from_secs(1)).await;
+        // A statement is now in-flight: pinned, but last_used still points at the
+        // pre-statement (stale) instant.
+        entry.in_flight.fetch_add(1, Ordering::SeqCst);
+        reap_once(&transactions).await;
+        assert!(
+            transactions.lock().await.contains_key("tx1"),
+            "a transaction with an in-flight statement is not reaped despite a stale last_used"
         );
     }
 


### PR DESCRIPTION
## Summary

Bug-hunt batch 8a: correctness fixes across the rds-data, pipes, and CloudFormation-orchestration surfaces. No new API surface (SDK/docs unaffected).

### rds-data (`crates/fakecloud-rds-data/src/service.rs`)
- **columnMetadata on a zero-row result.** `ExecuteStatement` with `includeResultMetadata=true` now returns `columnMetadata` even when the query yields no rows. The column description is read off the prepared statement (Postgres) / the `query_iter` result set (MySQL) instead of `rows[0].columns()`, so `SELECT ... WHERE 1=0` reports its columns like real AWS.
- **numberOfRecordsUpdated is present + correct for row-returning statements.** A pure `SELECT` reports `0`; an `INSERT`/`UPDATE`/`DELETE ... RETURNING` reports the affected-row count (equal to the returned-row count). Previously the non-empty SELECT path omitted the field entirely.
- **BatchExecuteStatement generatedFields.** Each `updateResults[]` entry now carries the `generatedFields` produced by that statement (e.g. a MySQL auto-increment id) instead of always emitting `[]`. The single-statement path was already correct; the batch path discarded the run output.
- **Idle-transaction reaper TOCTOU.** The reaper collected stale transactions, dropped the map lock, then removed + rolled back without re-checking. It now re-verifies staleness and entry identity under the map lock immediately before rollback, so a statement that reactivated the transaction between the sample and the removal is not rolled back out from under the client.

### pipes (`crates/fakecloud-pipes/src/service.rs`)
- **Lifecycle guard.** `UpdatePipe`/`StartPipe`/`StopPipe` now return `ConflictException` while the pipe is in a transient state (`CREATING`/`UPDATING`/`STARTING`/`STOPPING`/`DELETING`), matching AWS. An overdue pipe is settled first so a pipe that has already finished its transition is not wrongly rejected. This closes the race where a `DELETING` pipe could be resurrected to `RUNNING` by a racing Update/Start/Stop.

### cloudformation (`crates/fakecloud-cloudformation/src`)
- **UpdateStack for AWS::Pipes::Pipe.** Added the missing `update_resource` arm; previously it fell through to `Ok(None)`, so CloudFormation reported `UPDATE_COMPLETE` while silently discarding the property change. The new arm applies the updatable fields (full-replace semantics matching the direct `UpdatePipe` handler) to the live pipe and keeps it settled.
- **CFN Pipe create validation.** The provisioner now enforces the same checks as the direct `CreatePipe` handler: non-empty `Source`/`Target`/`RoleArn`, `validate_pipe_name` + `validate_resource_arn_len` (reused from the pipes crate, now `pub`), and a same-name conflict instead of a silent overwrite.
- **GetAtt consistency.** Added `AWS::Pipes::Pipe` to `well_known_attributes_for` and a `get_att` overlay resolving `Arn` from live pipes state.

## Test plan
- `cargo nextest run -p fakecloud-rds-data -p fakecloud-pipes -p fakecloud-cloudformation` -> all green (274 CFN/pipes tests + 5 rds-data unit tests).
- `cargo clippy -p fakecloud-rds-data -p fakecloud-pipes -p fakecloud-cloudformation --all-targets -- -D warnings` -> clean.
- `cargo fmt` applied.

New tests:
- rds-data: `is_returning_dml` classification; `batch_update_result` carries/derives `generatedFields`; reaper removes a genuinely idle txn and (via a paused tokio clock) spares a reactivated one (TOCTOU recheck).
- pipes: Update on `DELETING`, Start on `CREATING`, Stop on `UPDATING` all return `ConflictException`; a settled pipe passes; an overdue `DELETING` pipe is settled (removed) rather than conflicting.
- cloudformation: UpdateStack applies a Pipes property change and clears an omitted field; create rejects an empty required field and a duplicate name.

Notes:
- The DB-backed columnMetadata-on-empty and MySQL `query_iter` paths require a live Postgres/MySQL container (existing Docker e2e partition) and were not exercised locally; the change is structural (prepared-statement / result-set column description) and the plumbing is covered by unit tests. Scope was restricted to the three crates, so no e2e test file was added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AWS-behavior mismatches and race conditions across `rds-data`, `pipes`, and CloudFormation Pipes orchestration, and persists overdue deletions to prevent resurrection. No new API surface or migrations.

- **Bug Fixes**
  - `rds-data`
    - `includeResultMetadata=true` returns `columnMetadata` for zero-row results (pg via prepared statement; mysql via `query_iter`).
    - Always emit `numberOfRecordsUpdated`: 0 for pure SELECT; affected count for `INSERT`/`UPDATE`/`DELETE ... RETURNING`.
    - `BatchExecuteStatement` preserves per-statement `generatedFields`.
    - Idle-transaction reaper uses an in-flight pin (bumped under the map lock) and rechecks staleness/identity under lock to avoid mid-flight/TOCTOU rollbacks.
  - `pipes`
    - `StartPipe`/`StopPipe` force-settle non-`DELETING` transient states under the write lock so fresh `CREATING`/`UPDATING` calls succeed; only `DELETING` returns `ConflictException`.
    - Overdue settle now runs in the async handler and is awaited; an overdue `DELETING` pipe is removed and the removal is persisted even if the subsequent `UpdatePipe`/`StartPipe`/`StopPipe` returns `NotFound` (no resurrection on restart). For `UpdatePipe`, this pre-dispatch settle is gated on a valid body (`RoleArn`) so invalid updates never settle or remove a pipe.
    - In `UpdatePipe`, body validation runs before any settle, and the transient-state guard runs under the same write lock as the mutation to avoid races with `DeletePipe`.
  - CloudFormation for `AWS::Pipes::Pipe`
    - `UpdateStack` applies updatable fields with full-replace semantics; a `Source` change triggers replacement; the pipe remains settled.
    - `Create` validates `Name`/`Source`/`Target`/`RoleArn` (non-empty, bounds via `validate_pipe_name` and `validate_resource_arn_len`) and rejects duplicates.
    - `Fn::GetAtt` supports `Arn`.

<sup>Written for commit 919ffc7d220be45992f9b58f91585c564289df8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

