### PR TITLE
fix(ssm,secretsmanager,ses,eventbridge,firehose,apigateway,iam): persist dropped inputs + match AWS response shapes

### DIFF
--- a/crates/fakecloud-apigateway/src/service_stages.rs
+++ b/crates/fakecloud-apigateway/src/service_stages.rs
@@ -177,19 +177,31 @@ impl ApiGatewayService {
                 "/webAclArn" => s.web_acl_arn = value.as_str().map(String::from),
                 // Per-method settings: AWS PATCHes them at
                 // `/{resourcePath}/{httpMethod}/{setting}` (e.g.
-                // `/~1pets/GET/throttling/rateLimit`). Store each under
-                // method_settings keyed by its path so DescribeStage reflects
-                // the change instead of silently dropping it.
+                // `/~1pets/GET/throttling/rateLimit`, or `/*/*/logging/loglevel`
+                // for all methods). AWS's GetStage returns `methodSettings` as a
+                // map keyed by `"{resourcePath}/{httpMethod}"` whose value is a
+                // MethodSetting object (metricsEnabled / loggingLevel /
+                // throttlingRateLimit / ...). Storing the raw patch path with the
+                // raw string value produced the wrong shape and a perpetual
+                // Terraform diff on aws_api_gateway_method_settings.
                 _ if path.contains("/throttling/")
                     || path.contains("/logging/")
                     || path.contains("/metrics/")
                     || path.contains("/caching/") =>
                 {
-                    let key = path.trim_start_matches('/').to_string();
-                    if op == "remove" {
-                        s.method_settings.remove(&key);
-                    } else {
-                        s.method_settings.insert(key, value.clone());
+                    if let Some((map_key, field)) = method_setting_key_and_field(path) {
+                        let entry = s
+                            .method_settings
+                            .entry(map_key)
+                            .or_insert_with(|| serde_json::json!({}));
+                        if let Some(m) = entry.as_object_mut() {
+                            if op == "remove" {
+                                m.remove(&field);
+                            } else if let Some(coerced) = coerce_method_setting_value(&field, value)
+                            {
+                                m.insert(field, coerced);
+                            }
+                        }
                     }
                 }
                 _ if path.starts_with("/variables/") => {
@@ -234,6 +246,76 @@ impl ApiGatewayService {
         });
         s.last_updated_date = chrono::Utc::now();
         ok(stage_to_json(s))
+    }
+}
+
+/// Map a method-settings PATCH setting sub-path to its AWS MethodSetting field
+/// name. Returns `None` for unrecognized setting paths.
+fn method_setting_field(setting: &str) -> Option<&'static str> {
+    Some(match setting {
+        "metrics/enabled" => "metricsEnabled",
+        "logging/loglevel" => "loggingLevel",
+        "logging/dataTrace" => "dataTraceEnabled",
+        "throttling/burstLimit" => "throttlingBurstLimit",
+        "throttling/rateLimit" => "throttlingRateLimit",
+        "caching/enabled" => "cachingEnabled",
+        "caching/ttlInSeconds" => "cacheTtlInSeconds",
+        "caching/dataEncrypted" => "cacheDataEncrypted",
+        "caching/requireAuthorizationForCacheControl" => "requireAuthorizationForCacheControl",
+        "caching/unauthorizedCacheControlHeaderStrategy" => {
+            "unauthorizedCacheControlHeaderStrategy"
+        }
+        _ => return None,
+    })
+}
+
+/// Parse a stage method-settings PATCH path (e.g. `/~1pets/GET/throttling/rateLimit`
+/// or `/*/*/logging/loglevel`) into the AWS `methodSettings` map key
+/// (`pets/GET`, `*/*`) plus the MethodSetting field name. API Gateway escapes
+/// `/` as `~1` and `~` as `~0` in the resource-path segment.
+fn method_setting_key_and_field(path: &str) -> Option<(String, String)> {
+    let trimmed = path.trim_start_matches('/');
+    let mut parts = trimmed.splitn(3, '/');
+    let resource_token = parts.next()?;
+    let http_method = parts.next()?;
+    let setting = parts.next()?;
+    let field = method_setting_field(setting)?;
+    let resource_path = resource_token.replace("~1", "/").replace("~0", "~");
+    let resource_path = resource_path.trim_start_matches('/');
+    Some((format!("{resource_path}/{http_method}"), field.to_string()))
+}
+
+/// Coerce a PATCH string value into the JSON type AWS reports for the given
+/// MethodSetting field. Patch operation values arrive as strings, so numeric
+/// and boolean fields must be parsed.
+fn coerce_method_setting_value(field: &str, value: &Value) -> Option<Value> {
+    match field {
+        "metricsEnabled"
+        | "dataTraceEnabled"
+        | "cachingEnabled"
+        | "cacheDataEncrypted"
+        | "requireAuthorizationForCacheControl" => {
+            let b = value
+                .as_bool()
+                .or_else(|| value.as_str().and_then(|s| s.parse::<bool>().ok()))?;
+            Some(Value::Bool(b))
+        }
+        "throttlingBurstLimit" | "cacheTtlInSeconds" => {
+            let n = value
+                .as_i64()
+                .or_else(|| value.as_str().and_then(|s| s.parse::<i64>().ok()))?;
+            Some(serde_json::json!(n))
+        }
+        "throttlingRateLimit" => {
+            let n = value
+                .as_f64()
+                .or_else(|| value.as_str().and_then(|s| s.parse::<f64>().ok()))?;
+            Some(serde_json::json!(n))
+        }
+        "loggingLevel" | "unauthorizedCacheControlHeaderStrategy" => {
+            value.as_str().map(|s| Value::String(s.to_string()))
+        }
+        _ => None,
     }
 }
 
@@ -323,8 +405,89 @@ mod patch_tests {
         assert!(s.cache_cluster_enabled);
         assert_eq!(s.cache_cluster_size.as_deref(), Some("0.5"));
         assert_eq!(s.web_acl_arn.as_deref(), Some("arn:aws:wafv2:::webacl/x"));
-        assert!(s
-            .method_settings
-            .contains_key("~1pets/GET/throttling/rateLimit"));
+        // Method settings are keyed by "{resourcePath}/{httpMethod}" with a
+        // MethodSetting object value (not the raw patch path / raw string).
+        let ms = s.method_settings.get("pets/GET").expect("pets/GET key");
+        assert_eq!(ms["throttlingRateLimit"], serde_json::json!(10.0));
+    }
+
+    #[test]
+    fn update_stage_method_settings_use_aws_shape() {
+        let state =
+            std::sync::Arc::new(
+                parking_lot::RwLock::new(fakecloud_core::multi_account::MultiAccountState::<
+                    crate::state::ApiGatewayState,
+                >::new("123456789012", "us-east-1", "")),
+            );
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create("123456789012");
+            st.stages.entry("api1".to_string()).or_default().insert(
+                "prod".to_string(),
+                Stage {
+                    stage_name: "prod".into(),
+                    deployment_id: "d1".into(),
+                    description: None,
+                    cache_cluster_enabled: false,
+                    cache_cluster_size: None,
+                    variables: Default::default(),
+                    method_settings: Default::default(),
+                    created_date: chrono::Utc::now(),
+                    last_updated_date: chrono::Utc::now(),
+                    tracing_enabled: false,
+                    web_acl_arn: None,
+                    canary_settings: None,
+                    access_log_settings: None,
+                    tags: Default::default(),
+                },
+            );
+        }
+        let svc = ApiGatewayService::new(state.clone());
+        let params: BTreeMap<String, String> = [
+            ("restApiId".to_string(), "api1".to_string()),
+            ("stageName".to_string(), "prod".to_string()),
+        ]
+        .into_iter()
+        .collect();
+
+        // Apply a full set of `*/*` (all-methods) settings, the exact shape
+        // Terraform's aws_api_gateway_method_settings sends.
+        let resp = svc
+            .update_stage(
+                &patch_req(json!([
+                    { "op": "replace", "path": "/*/*/metrics/enabled", "value": "true" },
+                    { "op": "replace", "path": "/*/*/logging/loglevel", "value": "INFO" },
+                    { "op": "replace", "path": "/*/*/logging/dataTrace", "value": "true" },
+                    { "op": "replace", "path": "/*/*/throttling/burstLimit", "value": "5000" },
+                    { "op": "replace", "path": "/*/*/throttling/rateLimit", "value": "10000" },
+                    { "op": "replace", "path": "/*/*/caching/ttlInSeconds", "value": "300" },
+                ])),
+                &params,
+            )
+            .unwrap();
+
+        // GetStage / UpdateStage round-trip the correct MethodSetting shape.
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let ms = &body["methodSettings"]["*/*"];
+        assert_eq!(ms["metricsEnabled"], json!(true));
+        assert_eq!(ms["loggingLevel"], json!("INFO"));
+        assert_eq!(ms["dataTraceEnabled"], json!(true));
+        assert_eq!(ms["throttlingBurstLimit"], json!(5000));
+        assert_eq!(ms["throttlingRateLimit"], json!(10000.0));
+        assert_eq!(ms["cacheTtlInSeconds"], json!(300));
+
+        // A subsequent remove drops just that field, keeping the rest.
+        svc.update_stage(
+            &patch_req(json!([
+                { "op": "remove", "path": "/*/*/logging/loglevel" },
+            ])),
+            &params,
+        )
+        .unwrap();
+        let accounts = state.read();
+        let s = &accounts.get("123456789012").unwrap().stages["api1"]["prod"];
+        let ms = s.method_settings.get("*/*").unwrap();
+        assert!(ms.get("loggingLevel").is_none());
+        assert_eq!(ms["metricsEnabled"], json!(true));
     }
 }

--- a/crates/fakecloud-apigateway/src/service_stages.rs
+++ b/crates/fakecloud-apigateway/src/service_stages.rs
@@ -190,15 +190,27 @@ impl ApiGatewayService {
                     || path.contains("/caching/") =>
                 {
                     if let Some((map_key, field)) = method_setting_key_and_field(path) {
-                        let entry = s
-                            .method_settings
-                            .entry(map_key)
-                            .or_insert_with(|| serde_json::json!({}));
-                        if let Some(m) = entry.as_object_mut() {
-                            if op == "remove" {
-                                m.remove(&field);
-                            } else if let Some(coerced) = coerce_method_setting_value(&field, value)
-                            {
+                        if op == "remove" {
+                            // Remove just the field; if that empties the
+                            // MethodSetting object, drop the whole map entry so
+                            // GetStage doesn't return an empty settings block
+                            // (which reintroduces a perpetual Terraform diff).
+                            if let Some(entry) = s.method_settings.get_mut(&map_key) {
+                                if let Some(m) = entry.as_object_mut() {
+                                    m.remove(&field);
+                                }
+                                let now_empty =
+                                    entry.as_object().map(|m| m.is_empty()).unwrap_or(true);
+                                if now_empty {
+                                    s.method_settings.remove(&map_key);
+                                }
+                            }
+                        } else if let Some(coerced) = coerce_method_setting_value(&field, value) {
+                            let entry = s
+                                .method_settings
+                                .entry(map_key)
+                                .or_insert_with(|| serde_json::json!({}));
+                            if let Some(m) = entry.as_object_mut() {
                                 m.insert(field, coerced);
                             }
                         }
@@ -484,10 +496,42 @@ mod patch_tests {
             &params,
         )
         .unwrap();
+        {
+            let accounts = state.read();
+            let s = &accounts.get("123456789012").unwrap().stages["api1"]["prod"];
+            let ms = s.method_settings.get("*/*").unwrap();
+            assert!(ms.get("loggingLevel").is_none());
+            assert_eq!(ms["metricsEnabled"], json!(true));
+        }
+
+        // Removing every remaining field drops the whole map entry (no empty
+        // methodSettings block left behind to cause a perpetual diff).
+        let resp = svc
+            .update_stage(
+                &patch_req(json!([
+                    { "op": "remove", "path": "/*/*/metrics/enabled" },
+                    { "op": "remove", "path": "/*/*/logging/dataTrace" },
+                    { "op": "remove", "path": "/*/*/throttling/burstLimit" },
+                    { "op": "remove", "path": "/*/*/throttling/rateLimit" },
+                    { "op": "remove", "path": "/*/*/caching/ttlInSeconds" },
+                ])),
+                &params,
+            )
+            .unwrap();
         let accounts = state.read();
         let s = &accounts.get("123456789012").unwrap().stages["api1"]["prod"];
-        let ms = s.method_settings.get("*/*").unwrap();
-        assert!(ms.get("loggingLevel").is_none());
-        assert_eq!(ms["metricsEnabled"], json!(true));
+        assert!(
+            !s.method_settings.contains_key("*/*"),
+            "emptied method settings entry must be removed"
+        );
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(
+            body["methodSettings"]
+                .as_object()
+                .map(|m| m.is_empty())
+                .unwrap_or(true),
+            "methodSettings must not contain an empty entry, got: {}",
+            body["methodSettings"]
+        );
     }
 }

--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -303,7 +303,7 @@ pub(crate) fn validate_pattern_values(value: &Value, path: &str) -> Result<(), A
 }
 
 pub(crate) fn build_auth_params_response(auth_type: &str, params: &Value) -> Value {
-    match auth_type {
+    let mut resp = match auth_type {
         "API_KEY" => {
             let mut resp = json!({});
             if let Some(api_key) = params.get("ApiKeyAuthParameters") {
@@ -335,8 +335,54 @@ pub(crate) fn build_auth_params_response(auth_type: &str, params: &Value) -> Val
             }
             resp
         }
-        _ => params.clone(),
+        _ => return params.clone(),
+    };
+
+    // Echo the connection-level InvocationHttpParameters (additional custom
+    // headers / query-string / body parameters merged into every invocation).
+    // Previously dropped, which made DescribeConnection lose everything the
+    // caller configured beyond the auth block. Secret values are hidden on
+    // describe (matching AWS), but keys + IsValueSecret flags round-trip.
+    if let Some(inv) = params.get("InvocationHttpParameters") {
+        resp["InvocationHttpParameters"] = sanitize_invocation_http_params(inv);
     }
+    resp
+}
+
+/// Redact secret values from a connection's `InvocationHttpParameters` for
+/// read responses. Each parameter keeps its `Key` and `IsValueSecret` flag;
+/// the `Value` is only echoed when the parameter is explicitly non-secret.
+fn sanitize_invocation_http_params(inv: &Value) -> Value {
+    let mut out = json!({});
+    for field in [
+        "HeaderParameters",
+        "QueryStringParameters",
+        "BodyParameters",
+    ] {
+        if let Some(arr) = inv.get(field).and_then(|v| v.as_array()) {
+            let sanitized: Vec<Value> = arr
+                .iter()
+                .map(|p| {
+                    let is_secret = p
+                        .get("IsValueSecret")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true);
+                    let mut entry = json!({
+                        "Key": p.get("Key").cloned().unwrap_or(Value::Null),
+                        "IsValueSecret": is_secret,
+                    });
+                    if !is_secret {
+                        if let Some(val) = p.get("Value") {
+                            entry["Value"] = val.clone();
+                        }
+                    }
+                    entry
+                })
+                .collect();
+            out[field] = json!(sanitized);
+        }
+    }
+    out
 }
 
 /// Match an event against an EventBridge event pattern.

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -2474,6 +2474,53 @@ fn connection_create_list_describe_deauthorize() {
     .unwrap();
 }
 
+#[test]
+fn describe_connection_echoes_invocation_http_parameters() {
+    let svc = make_service();
+
+    svc.create_connection(&make_request(
+        "CreateConnection",
+        json!({
+            "Name": "conn-http",
+            "AuthorizationType": "API_KEY",
+            "AuthParameters": {
+                "ApiKeyAuthParameters": {"ApiKeyName": "x-key", "ApiKeyValue": "secret"},
+                "InvocationHttpParameters": {
+                    "HeaderParameters": [
+                        {"Key": "X-Custom", "Value": "public", "IsValueSecret": false},
+                        {"Key": "X-Token", "Value": "hush", "IsValueSecret": true}
+                    ],
+                    "QueryStringParameters": [
+                        {"Key": "q", "Value": "v", "IsValueSecret": false}
+                    ]
+                }
+            }
+        }),
+    ))
+    .unwrap();
+
+    let resp = svc
+        .describe_connection(&make_request(
+            "DescribeConnection",
+            json!({"Name": "conn-http"}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let inv = &body["AuthParameters"]["InvocationHttpParameters"];
+    let headers = inv["HeaderParameters"].as_array().unwrap();
+    assert_eq!(headers.len(), 2);
+    // Non-secret header echoes its value; keys + IsValueSecret always present.
+    let public = headers.iter().find(|h| h["Key"] == "X-Custom").unwrap();
+    assert_eq!(public["Value"], "public");
+    assert_eq!(public["IsValueSecret"], false);
+    // Secret header keeps its key + flag but hides the value.
+    let secret = headers.iter().find(|h| h["Key"] == "X-Token").unwrap();
+    assert_eq!(secret["IsValueSecret"], true);
+    assert!(secret.get("Value").is_none(), "secret value must be hidden");
+    // Query string parameters echoed too.
+    assert_eq!(inv["QueryStringParameters"][0]["Key"], "q");
+}
+
 // ── Event bus list ──
 
 #[test]

--- a/crates/fakecloud-firehose/src/service.rs
+++ b/crates/fakecloud-firehose/src/service.rs
@@ -779,7 +779,14 @@ impl FirehoseService {
         let name = body["DeliveryStreamName"]
             .as_str()
             .ok_or_else(|| missing("DeliveryStreamName"))?;
-        let current_version = body["CurrentDeliveryStreamVersionId"].as_str();
+        // CurrentDeliveryStreamVersionId and DestinationId are both REQUIRED
+        // by AWS UpdateDestination.
+        let current_version = body["CurrentDeliveryStreamVersionId"]
+            .as_str()
+            .ok_or_else(|| missing("CurrentDeliveryStreamVersionId"))?;
+        let destination_id = body["DestinationId"]
+            .as_str()
+            .ok_or_else(|| missing("DestinationId"))?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id, &req.region);
         let stream = state
@@ -789,19 +796,30 @@ impl FirehoseService {
 
         // AWS requires CurrentDeliveryStreamVersionId to match the stream's
         // current version and rejects a mismatch with a concurrent-modification
-        // error. Validate only when supplied so callers that omit it still work.
-        if let Some(cur) = current_version {
-            if cur != stream.version_id {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ConcurrentModificationException",
-                    format!(
-                        "The current delivery stream version {} does not match \
-                         the supplied version {cur}.",
-                        stream.version_id
-                    ),
-                ));
-            }
+        // error (this is the optimistic-concurrency guard).
+        if current_version != stream.version_id {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ConcurrentModificationException",
+                format!(
+                    "The current delivery stream version {} does not match \
+                     the supplied version {current_version}.",
+                    stream.version_id
+                ),
+            ));
+        }
+
+        // DestinationId must identify the stream's current destination.
+        let current_dest_id = stream
+            .destination
+            .as_ref()
+            .map(|d| d.destination_id.clone())
+            .unwrap_or_else(|| "destinationId-000000000001".to_string());
+        if destination_id != current_dest_id {
+            return Err(invalid_argument(format!(
+                "DestinationId {destination_id} does not match the current \
+                 destination {current_dest_id} for delivery stream {name}."
+            )));
         }
 
         // Apply the S3 / ExtendedS3 update. The `*Update` shapes make every
@@ -1272,9 +1290,7 @@ mod tests {
         assert_eq!(after["VersionId"], "2");
     }
 
-    #[test]
-    fn update_destination_rejects_stale_version() {
-        let svc = service();
+    fn create_ver_stream(svc: &FirehoseService) -> String {
         svc.create_delivery_stream(&request(
             "CreateDeliveryStream",
             json!({
@@ -1286,6 +1302,16 @@ mod tests {
             }),
         ))
         .unwrap();
+        describe(svc, "ver-stream")["Destinations"][0]["DestinationId"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn update_destination_rejects_stale_version() {
+        let svc = service();
+        let dest_id = create_ver_stream(&svc);
 
         // Wrong CurrentDeliveryStreamVersionId -> ConcurrentModificationException.
         let err = match svc.update_destination(&request(
@@ -1293,6 +1319,7 @@ mod tests {
             json!({
                 "DeliveryStreamName": "ver-stream",
                 "CurrentDeliveryStreamVersionId": "99",
+                "DestinationId": dest_id,
                 "ExtendedS3DestinationUpdate": { "Prefix": "x/" }
             }),
         )) {
@@ -1300,5 +1327,59 @@ mod tests {
             Ok(_) => panic!("stale version must be rejected"),
         };
         assert_eq!(err.code(), "ConcurrentModificationException");
+    }
+
+    #[test]
+    fn update_destination_requires_current_version_and_destination_id() {
+        let svc = service();
+        let dest_id = create_ver_stream(&svc);
+
+        // Missing CurrentDeliveryStreamVersionId -> rejected.
+        let err = match svc.update_destination(&request(
+            "UpdateDestination",
+            json!({
+                "DeliveryStreamName": "ver-stream",
+                "DestinationId": dest_id,
+                "ExtendedS3DestinationUpdate": { "Prefix": "x/" }
+            }),
+        )) {
+            Err(e) => e,
+            Ok(_) => panic!("missing CurrentDeliveryStreamVersionId must be rejected"),
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+
+        // Missing DestinationId -> rejected.
+        let err = match svc.update_destination(&request(
+            "UpdateDestination",
+            json!({
+                "DeliveryStreamName": "ver-stream",
+                "CurrentDeliveryStreamVersionId": "1",
+                "ExtendedS3DestinationUpdate": { "Prefix": "x/" }
+            }),
+        )) {
+            Err(e) => e,
+            Ok(_) => panic!("missing DestinationId must be rejected"),
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn update_destination_rejects_mismatched_destination_id() {
+        let svc = service();
+        create_ver_stream(&svc);
+
+        let err = match svc.update_destination(&request(
+            "UpdateDestination",
+            json!({
+                "DeliveryStreamName": "ver-stream",
+                "CurrentDeliveryStreamVersionId": "1",
+                "DestinationId": "destinationId-wrong",
+                "ExtendedS3DestinationUpdate": { "Prefix": "x/" }
+            }),
+        )) {
+            Err(e) => e,
+            Ok(_) => panic!("mismatched DestinationId must be rejected"),
+        };
+        assert_eq!(err.code(), "InvalidArgumentException");
     }
 }

--- a/crates/fakecloud-firehose/src/service.rs
+++ b/crates/fakecloud-firehose/src/service.rs
@@ -262,6 +262,69 @@ fn invalid_argument(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "InvalidArgumentException", msg)
 }
 
+/// Apply a partial `*S3DestinationUpdate` block onto an existing destination.
+/// Every field in the `*Update` shape is optional, so only the members the
+/// caller supplied are changed; the destination's stable `DestinationId` is
+/// preserved. Buffering values are validated when present.
+fn apply_s3_update(dest: &mut S3Destination, val: &Value) -> Result<(), AwsServiceError> {
+    let buf = &val["BufferingHints"];
+    let size = buf["SizeInMBs"].as_i64();
+    let interval = buf["IntervalInSeconds"].as_i64();
+    validate_buffering(size, interval)?;
+
+    if let Some(v) = val["RoleARN"].as_str() {
+        dest.role_arn = v.to_string();
+    }
+    if let Some(v) = val["BucketARN"].as_str() {
+        dest.bucket_arn = v.to_string();
+    }
+    if let Some(v) = val["Prefix"].as_str() {
+        dest.prefix = Some(v.to_string());
+    }
+    if let Some(v) = val["ErrorOutputPrefix"].as_str() {
+        dest.error_output_prefix = Some(v.to_string());
+    }
+    if size.is_some() {
+        dest.buffering_size_mb = size;
+    }
+    if interval.is_some() {
+        dest.buffering_interval_seconds = interval;
+    }
+    if let Some(v) = val["CompressionFormat"].as_str() {
+        dest.compression_format = Some(v.to_string());
+    }
+    if val["ProcessingConfiguration"].is_object() {
+        dest.processing_configuration = Some(val["ProcessingConfiguration"].clone());
+    }
+    if val["DataFormatConversionConfiguration"].is_object() {
+        dest.data_format_conversion_configuration =
+            Some(val["DataFormatConversionConfiguration"].clone());
+    }
+    if val["CloudWatchLoggingOptions"].is_object() {
+        dest.cloudwatch_logging_options = Some(val["CloudWatchLoggingOptions"].clone());
+    }
+    if let Some(v) = val["CustomTimeZone"].as_str() {
+        dest.custom_time_zone = Some(v.to_string());
+    }
+    if let Some(v) = val["S3BackupMode"].as_str() {
+        dest.s3_backup_mode = Some(v.to_string());
+    }
+    if let Some(v) = val["FileExtension"].as_str() {
+        dest.file_extension = Some(v.to_string());
+    }
+    Ok(())
+}
+
+/// Increment a Firehose delivery-stream version id. AWS version ids are
+/// numeric strings that advance by one on every successful configuration
+/// change (UpdateDestination, Start/StopEncryption, ...).
+fn next_version_id(current: &str) -> String {
+    current
+        .parse::<u64>()
+        .map(|n| (n + 1).to_string())
+        .unwrap_or_else(|_| current.to_string())
+}
+
 /// Validate a delivery-stream name against the Firehose model constraints:
 /// length 1..=64 and pattern `^[a-zA-Z0-9_.-]+$`. AWS rejects violations with
 /// an InvalidArgumentException before any resource lookup.
@@ -716,24 +779,63 @@ impl FirehoseService {
         let name = body["DeliveryStreamName"]
             .as_str()
             .ok_or_else(|| missing("DeliveryStreamName"))?;
+        let current_version = body["CurrentDeliveryStreamVersionId"].as_str();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id, &req.region);
         let stream = state
             .streams_mut(&req.region)
             .get_mut(name)
             .ok_or_else(|| not_found(name))?;
-        let updated = match parse_s3_destination(&body["S3DestinationUpdate"])? {
-            Some(d) => Some(d),
-            None => parse_s3_destination(&body["ExtendedS3DestinationUpdate"])?,
-        };
-        if let Some(d) = updated {
-            stream.destination = Some(d);
+
+        // AWS requires CurrentDeliveryStreamVersionId to match the stream's
+        // current version and rejects a mismatch with a concurrent-modification
+        // error. Validate only when supplied so callers that omit it still work.
+        if let Some(cur) = current_version {
+            if cur != stream.version_id {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ConcurrentModificationException",
+                    format!(
+                        "The current delivery stream version {} does not match \
+                         the supplied version {cur}.",
+                        stream.version_id
+                    ),
+                ));
+            }
         }
+
+        // Apply the S3 / ExtendedS3 update. The `*Update` shapes make every
+        // member optional, so a partial update (e.g. only BufferingHints) must
+        // merge onto the existing destination rather than being dropped, and
+        // the destination keeps its stable DestinationId across updates.
+        let s3_update = if body["S3DestinationUpdate"].is_object() {
+            Some(&body["S3DestinationUpdate"])
+        } else if body["ExtendedS3DestinationUpdate"].is_object() {
+            Some(&body["ExtendedS3DestinationUpdate"])
+        } else {
+            None
+        };
+        if let Some(update) = s3_update {
+            match stream.destination.as_mut() {
+                Some(existing) => apply_s3_update(existing, update)?,
+                // No existing S3 destination: fall back to a full parse
+                // (RoleARN + BucketARN required to materialize one).
+                None => {
+                    if let Some(d) = parse_s3_destination(update)? {
+                        stream.destination = Some(d);
+                    }
+                }
+            }
+        }
+
         // Non-S3 destinations (Redshift/OpenSearch/Splunk/HTTP/...) were
         // previously dropped on update; merge any supplied ones in.
         for (key, value) in extract_extra_destinations(&body, "Update") {
             stream.extra_destinations.insert(key, value);
         }
+
+        // A successful update advances the stream version.
+        stream.version_id = next_version_id(&stream.version_id);
         stream.last_update = Utc::now();
         Ok(AwsResponse::ok_json(json!({})))
     }
@@ -1102,5 +1204,101 @@ mod tests {
             ext["ProcessingConfiguration"]["Processors"][0]["Type"],
             "Lambda"
         );
+    }
+
+    fn describe(svc: &FirehoseService, name: &str) -> Value {
+        let resp = svc
+            .describe_delivery_stream(&request(
+                "DescribeDeliveryStream",
+                json!({ "DeliveryStreamName": name }),
+            ))
+            .unwrap();
+        serde_json::from_slice::<Value>(resp.body.expect_bytes()).unwrap()
+            ["DeliveryStreamDescription"]
+            .clone()
+    }
+
+    #[test]
+    fn update_destination_keeps_destination_id_stable_and_bumps_version() {
+        let svc = service();
+        svc.create_delivery_stream(&request(
+            "CreateDeliveryStream",
+            json!({
+                "DeliveryStreamName": "upd-stream",
+                "ExtendedS3DestinationConfiguration": {
+                    "RoleARN": "arn:aws:iam::123456789012:role/fh",
+                    "BucketARN": "arn:aws:s3:::bucket",
+                    "Prefix": "before/"
+                }
+            }),
+        ))
+        .unwrap();
+
+        let before = describe(&svc, "upd-stream");
+        let original_dest_id = before["Destinations"][0]["DestinationId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(before["VersionId"], "1");
+
+        // Partial update: only change the Prefix (no RoleARN/BucketARN).
+        svc.update_destination(&request(
+            "UpdateDestination",
+            json!({
+                "DeliveryStreamName": "upd-stream",
+                "CurrentDeliveryStreamVersionId": "1",
+                "DestinationId": original_dest_id,
+                "ExtendedS3DestinationUpdate": { "Prefix": "after/" }
+            }),
+        ))
+        .unwrap();
+
+        let after = describe(&svc, "upd-stream");
+        // DestinationId is stable across the update.
+        assert_eq!(
+            after["Destinations"][0]["DestinationId"].as_str().unwrap(),
+            original_dest_id
+        );
+        // Partial update applied: Prefix changed, BucketARN preserved.
+        assert_eq!(
+            after["Destinations"][0]["ExtendedS3DestinationDescription"]["Prefix"],
+            "after/"
+        );
+        assert_eq!(
+            after["Destinations"][0]["ExtendedS3DestinationDescription"]["BucketARN"],
+            "arn:aws:s3:::bucket"
+        );
+        // Version advanced from 1 -> 2.
+        assert_eq!(after["VersionId"], "2");
+    }
+
+    #[test]
+    fn update_destination_rejects_stale_version() {
+        let svc = service();
+        svc.create_delivery_stream(&request(
+            "CreateDeliveryStream",
+            json!({
+                "DeliveryStreamName": "ver-stream",
+                "ExtendedS3DestinationConfiguration": {
+                    "RoleARN": "arn:aws:iam::123456789012:role/fh",
+                    "BucketARN": "arn:aws:s3:::bucket"
+                }
+            }),
+        ))
+        .unwrap();
+
+        // Wrong CurrentDeliveryStreamVersionId -> ConcurrentModificationException.
+        let err = match svc.update_destination(&request(
+            "UpdateDestination",
+            json!({
+                "DeliveryStreamName": "ver-stream",
+                "CurrentDeliveryStreamVersionId": "99",
+                "ExtendedS3DestinationUpdate": { "Prefix": "x/" }
+            }),
+        )) {
+            Err(e) => e,
+            Ok(_) => panic!("stale version must be rejected"),
+        };
+        assert_eq!(err.code(), "ConcurrentModificationException");
     }
 }

--- a/crates/fakecloud-iam/src/iam_service/helpers.rs
+++ b/crates/fakecloud-iam/src/iam_service/helpers.rs
@@ -4,6 +4,8 @@ use super::*;
 pub(crate) fn partition_for_region(region: &str) -> &str {
     if region.starts_with("cn-") {
         "aws-cn"
+    } else if region.starts_with("us-gov-") {
+        "aws-us-gov"
     } else if region.starts_with("us-iso-") {
         "aws-iso"
     } else if region.starts_with("us-isob-") {

--- a/crates/fakecloud-iam/src/iam_service/policies.rs
+++ b/crates/fakecloud-iam/src/iam_service/policies.rs
@@ -13,8 +13,6 @@ use super::{
 };
 use fakecloud_core::query::required_param;
 
-use fakecloud_aws::xml::xml_escape;
-
 use crate::policy_validation::validate_policy_document;
 
 /// IAM ``ListPolicies`` ``Scope`` filter.
@@ -390,6 +388,9 @@ impl IamService {
 
         policy.versions.push(version.clone());
 
+        // AWS omits the policy Document from the CreatePolicyVersion response;
+        // only GetPolicyVersion returns it. Emitting it here diverged from the
+        // real API's PolicyVersion shape.
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <CreatePolicyVersionResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
@@ -397,7 +398,6 @@ impl IamService {
     <PolicyVersion>
       <VersionId>{}</VersionId>
       <IsDefaultVersion>{}</IsDefaultVersion>
-      <Document>{}</Document>
       <CreateDate>{}</CreateDate>
     </PolicyVersion>
   </CreatePolicyVersionResult>
@@ -407,7 +407,6 @@ impl IamService {
 </CreatePolicyVersionResponse>"#,
             version.version_id,
             version.is_default,
-            xml_escape(&version.document),
             version.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
             req.request_id
         );
@@ -487,15 +486,17 @@ impl IamService {
             )
         })?;
 
+        // AWS omits the policy Document from ListPolicyVersions members; the
+        // document is only returned by GetPolicyVersion. Emitting it here
+        // caused clients to see a document where the real API sends none.
         let members: String = policy
             .versions
             .iter()
             .map(|v| {
                 format!(
-                    "      <member>\n        <VersionId>{}</VersionId>\n        <IsDefaultVersion>{}</IsDefaultVersion>\n        <Document>{}</Document>\n        <CreateDate>{}</CreateDate>\n      </member>",
+                    "      <member>\n        <VersionId>{}</VersionId>\n        <IsDefaultVersion>{}</IsDefaultVersion>\n        <CreateDate>{}</CreateDate>\n      </member>",
                     v.version_id,
                     v.is_default,
-                    url_encode(&v.document),
                     v.created_at.format("%Y-%m-%dT%H:%M:%SZ")
                 )
             })

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -914,11 +914,15 @@ impl IamService {
             ));
         }
 
+        // Derive the ARN partition from the request region so gov/cn/iso
+        // deployments get the right partition (aws-us-gov / aws-cn / ...)
+        // instead of a hardcoded `aws`.
+        let partition = partition_for_region(&req.region);
         let role = IamRole {
             role_id: format!("AROA{}", generate_id()),
             arn: format!(
-                "arn:aws:iam::{}:role{}{}",
-                state.account_id, path, role_name
+                "arn:{}:iam::{}:role{}{}",
+                partition, state.account_id, path, role_name
             ),
             role_name: role_name.clone(),
             path,

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -803,6 +803,53 @@ fn list_policy_versions() {
     // Should have v1 and v2
     assert!(body.contains("<VersionId>v1</VersionId>"));
     assert!(body.contains("<VersionId>v2</VersionId>"));
+    // AWS omits the Document from ListPolicyVersions; only GetPolicyVersion
+    // returns it.
+    assert!(
+        !body.contains("<Document>"),
+        "ListPolicyVersions must not include Document, got: {body}"
+    );
+}
+
+#[test]
+fn create_policy_version_omits_document_but_get_returns_it() {
+    let svc = make_service();
+    let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}"#;
+    let resp = svc
+        .create_policy(&make_request(
+            "CreatePolicy",
+            vec![("PolicyName", "doc-pol"), ("PolicyDocument", policy_doc)],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes());
+    let policy_arn = extract_xml_tag(&body, "Arn").to_string();
+
+    // CreatePolicyVersion must NOT echo the Document (AWS omits it).
+    let resp = svc
+        .create_policy_version(&make_request(
+            "CreatePolicyVersion",
+            vec![("PolicyArn", &policy_arn), ("PolicyDocument", policy_doc)],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes());
+    assert!(body.contains("<VersionId>v2</VersionId>"));
+    assert!(
+        !body.contains("<Document>"),
+        "CreatePolicyVersion must not include Document, got: {body}"
+    );
+
+    // GetPolicyVersion still returns the (URL-encoded) Document.
+    let resp = svc
+        .get_policy_version(&make_request(
+            "GetPolicyVersion",
+            vec![("PolicyArn", &policy_arn), ("VersionId", "v2")],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes());
+    assert!(
+        body.contains("<Document>"),
+        "GetPolicyVersion must include Document"
+    );
 }
 
 #[test]
@@ -1165,6 +1212,24 @@ fn service_linked_role_lifecycle() {
     let resp = svc.get_service_linked_role_deletion_status(&req).unwrap();
     let body = String::from_utf8_lossy(resp.body.expect_bytes());
     assert!(body.contains("<Status>SUCCEEDED</Status>"));
+}
+
+#[test]
+fn create_service_linked_role_uses_region_partition() {
+    let svc = make_service();
+    // GovCloud region -> aws-us-gov partition in the role ARN.
+    let mut req = make_request(
+        "CreateServiceLinkedRole",
+        vec![("AWSServiceName", "elasticloadbalancing.amazonaws.com")],
+    );
+    req.region = "us-gov-west-1".to_string();
+    let resp = svc.create_service_linked_role(&req).unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes());
+    assert!(
+        body.contains("arn:aws-us-gov:iam::"),
+        "SLR ARN must use the gov partition, got: {body}"
+    );
+    assert!(!body.contains("arn:aws:iam::"));
 }
 
 // ---- Permission Boundary Tests ----

--- a/crates/fakecloud-iam/src/sts_service/mod.rs
+++ b/crates/fakecloud-iam/src/sts_service/mod.rs
@@ -223,6 +223,8 @@ pub(super) fn sts_issuer_url(region: &str) -> String {
 fn partition_for_region(region: &str) -> &str {
     if region.starts_with("cn-") {
         "aws-cn"
+    } else if region.starts_with("us-gov-") {
+        "aws-us-gov"
     } else if region.starts_with("us-iso-") {
         "aws-iso"
     } else if region.starts_with("us-isob-") {
@@ -593,6 +595,8 @@ mod tests {
         assert_eq!(partition_for_region("eu-west-1"), "aws");
         assert_eq!(partition_for_region("cn-north-1"), "aws-cn");
         assert_eq!(partition_for_region("cn-northwest-1"), "aws-cn");
+        assert_eq!(partition_for_region("us-gov-west-1"), "aws-us-gov");
+        assert_eq!(partition_for_region("us-gov-east-1"), "aws-us-gov");
         assert_eq!(partition_for_region("us-isob-east-1"), "aws-iso-b");
         assert_eq!(partition_for_region("us-iso-east-1"), "aws-iso");
     }

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -28,6 +28,29 @@ struct RotationInvocation {
     /// createSecret/setSecret/testSecret/finishSecret; RotateImmediately=false
     /// with a Lambda runs only testSecret to validate the configuration.
     steps: Vec<&'static str>,
+    /// A temporary AWSPENDING version created purely so a test-only
+    /// (RotateImmediately=false) invocation has something for the Lambda's
+    /// testSecret step to read. Removed once the steps complete.
+    cleanup_pending: Option<PendingCleanup>,
+}
+
+/// Locates a temporary AWSPENDING version to delete after a test-only rotation.
+struct PendingCleanup {
+    account_id: String,
+    secret_name: String,
+    version_id: String,
+}
+
+/// Remove the temporary AWSPENDING version created for a test-only rotation.
+fn remove_rotation_test_pending(state: &SharedSecretsManagerState, cleanup: &PendingCleanup) {
+    let mut accounts = state.write();
+    if let Some(secret) = accounts
+        .get_or_create(&cleanup.account_id)
+        .secrets
+        .get_mut(&cleanup.secret_name)
+    {
+        secret.versions.remove(&cleanup.version_id);
+    }
 }
 
 /// Result of an idempotency check against an existing
@@ -1427,6 +1450,7 @@ impl SecretsManagerService {
                                     "testSecret",
                                     "finishSecret",
                                 ],
+                                cleanup_pending: None,
                             });
                         }
                     } else {
@@ -1451,16 +1475,39 @@ impl SecretsManagerService {
                 }
             }
         } else if has_lambda {
-            // RotateImmediately=false with a Lambda: validate the rotation
-            // configuration by running only the testSecret step. The value is
-            // not rotated and LastRotatedDate is left untouched.
-            if let Some(ref arn) = lambda_arn {
-                invocation = Some(RotationInvocation {
-                    lambda_arn: arn.clone(),
-                    secret_id: secret.arn.clone(),
-                    client_request_token: version_id.clone(),
-                    steps: vec!["testSecret"],
-                });
+            // RotateImmediately=false with a Lambda: AWS validates the rotation
+            // configuration by running only the testSecret step. The current
+            // value is NOT rotated and LastRotatedDate is left untouched, but
+            // the Lambda's testSecret step needs an AWSPENDING version to read.
+            // Mirror AWS by staging a temporary AWSPENDING copy of the current
+            // value (keyed by the rotation token) and removing it once the test
+            // completes.
+            if let (Some(arn), Some(current_vid)) =
+                (lambda_arn.as_ref(), secret.current_version_id.clone())
+            {
+                if let Some(cv) = secret.versions.get(&current_vid).cloned() {
+                    secret.versions.insert(
+                        version_id.clone(),
+                        SecretVersion {
+                            version_id: version_id.clone(),
+                            secret_string: cv.secret_string.clone(),
+                            secret_binary: cv.secret_binary.clone(),
+                            stages: vec!["AWSPENDING".to_string()],
+                            created_at: now,
+                        },
+                    );
+                    invocation = Some(RotationInvocation {
+                        lambda_arn: arn.clone(),
+                        secret_id: secret.arn.clone(),
+                        client_request_token: version_id.clone(),
+                        steps: vec!["testSecret"],
+                        cleanup_pending: Some(PendingCleanup {
+                            account_id: req.account_id.clone(),
+                            secret_name: secret.name.clone(),
+                            version_id: version_id.clone(),
+                        }),
+                    });
+                }
             }
         }
 
@@ -2153,10 +2200,13 @@ impl AwsService for SecretsManagerService {
             "RotateSecret" => {
                 let (response, invocation) = self.rotate_secret(&req)?;
                 if let Some(inv) = invocation {
-                    if let Some(ref bus) = self.delivery_bus {
-                        let bus = bus.clone();
-                        // AWS invokes the rotation Lambda asynchronously for each step.
-                        tokio::spawn(async move {
+                    let bus = self.delivery_bus.clone();
+                    let state = self.state.clone();
+                    // AWS invokes the rotation Lambda asynchronously for each
+                    // step, then (for a test-only invocation) removes the
+                    // temporary AWSPENDING version.
+                    tokio::spawn(async move {
+                        if let Some(bus) = bus {
                             for step in &inv.steps {
                                 let payload = serde_json::json!({
                                     "SecretId": inv.secret_id,
@@ -2184,8 +2234,13 @@ impl AwsService for SecretsManagerService {
                                     }
                                 }
                             }
-                        });
-                    }
+                        }
+                        // Clean up the temporary AWSPENDING version even when no
+                        // delivery bus is wired, so it never lingers.
+                        if let Some(cleanup) = inv.cleanup_pending {
+                            remove_rotation_test_pending(&state, &cleanup);
+                        }
+                    });
                 }
                 Ok(response)
             }

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -53,6 +53,35 @@ fn remove_rotation_test_pending(state: &SharedSecretsManagerState, cleanup: &Pen
     }
 }
 
+/// Invoke the rotation Lambda once per step, in order. Stops early if delivery
+/// is not configured for the target function.
+async fn run_rotation_steps(bus: &DeliveryBus, inv: &RotationInvocation) {
+    for step in &inv.steps {
+        let payload = serde_json::json!({
+            "SecretId": inv.secret_id,
+            "ClientRequestToken": inv.client_request_token,
+            "Step": step,
+        });
+        match bus
+            .invoke_lambda(&inv.lambda_arn, &payload.to_string())
+            .await
+        {
+            Some(Ok(_)) => {}
+            Some(Err(e)) => {
+                tracing::warn!(step = step, error = %e, "rotation Lambda invocation failed");
+            }
+            None => {
+                tracing::warn!(
+                    lambda_arn = %inv.lambda_arn,
+                    step = step,
+                    "rotation Lambda delivery not configured; Lambda invocation skipped"
+                );
+                break;
+            }
+        }
+    }
+}
+
 /// Result of an idempotency check against an existing
 /// `ClientRequestToken` / version id.
 pub(crate) enum VersionIdempotency {
@@ -2200,47 +2229,28 @@ impl AwsService for SecretsManagerService {
             "RotateSecret" => {
                 let (response, invocation) = self.rotate_secret(&req)?;
                 if let Some(inv) = invocation {
-                    let bus = self.delivery_bus.clone();
-                    let state = self.state.clone();
-                    // AWS invokes the rotation Lambda asynchronously for each
-                    // step, then (for a test-only invocation) removes the
-                    // temporary AWSPENDING version.
-                    tokio::spawn(async move {
-                        if let Some(bus) = bus {
-                            for step in &inv.steps {
-                                let payload = serde_json::json!({
-                                    "SecretId": inv.secret_id,
-                                    "ClientRequestToken": inv.client_request_token,
-                                    "Step": step,
-                                });
-                                let payload_str = payload.to_string();
-                                match bus.invoke_lambda(&inv.lambda_arn, &payload_str).await {
-                                    Some(Ok(_)) => {}
-                                    Some(Err(e)) => {
-                                        tracing::warn!(
-                                            step = step,
-                                            error = %e,
-                                            "rotation Lambda invocation failed"
-                                        );
-                                    }
-                                    None => {
-                                        tracing::warn!(
-                                            lambda_arn = %inv.lambda_arn,
-                                            step = step,
-                                            "rotation Lambda delivery not configured; \
-                                             Lambda invocation skipped"
-                                        );
-                                        break;
-                                    }
-                                }
+                    if let Some(cleanup) = inv.cleanup_pending.as_ref() {
+                        // Test-only rotation (RotateImmediately=false): run the
+                        // testSecret invocation and remove the temporary
+                        // AWSPENDING version SYNCHRONOUSLY, inside the handler's
+                        // critical section, so the mutating-action snapshot
+                        // taken at the end of `handle` never captures (and can't
+                        // restore) the temporary version.
+                        if let Some(ref bus) = self.delivery_bus {
+                            run_rotation_steps(bus, &inv).await;
+                        }
+                        remove_rotation_test_pending(&self.state, cleanup);
+                    } else {
+                        // Full rotation: AWS invokes the rotation Lambda
+                        // asynchronously for each step. The Lambda's own
+                        // PutSecretValue calls persist their own snapshots.
+                        let bus = self.delivery_bus.clone();
+                        tokio::spawn(async move {
+                            if let Some(bus) = bus {
+                                run_rotation_steps(&bus, &inv).await;
                             }
-                        }
-                        // Clean up the temporary AWSPENDING version even when no
-                        // delivery bus is wired, so it never lingers.
-                        if let Some(cleanup) = inv.cleanup_pending {
-                            remove_rotation_test_pending(&state, &cleanup);
-                        }
-                    });
+                        });
+                    }
                 }
                 Ok(response)
             }

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -24,6 +24,10 @@ struct RotationInvocation {
     lambda_arn: String,
     secret_id: String,
     client_request_token: String,
+    /// The rotation steps to invoke, in order. A full rotation runs
+    /// createSecret/setSecret/testSecret/finishSecret; RotateImmediately=false
+    /// with a Lambda runs only testSecret to validate the configuration.
+    steps: Vec<&'static str>,
 }
 
 /// Result of an idempotency check against an existing
@@ -1390,9 +1394,14 @@ impl SecretsManagerService {
             body["RotationLambdaARN"].as_str().is_some() || secret.rotation_lambda_arn.is_some();
         let lambda_arn = secret.rotation_lambda_arn.clone();
 
-        // If the secret has a value, perform rotation (only when
-        // RotateImmediately is true; otherwise the config is saved and the
-        // value is left untouched until the next scheduled window).
+        // Rotation behavior:
+        // - RotateImmediately (default): a full rotation. With a Lambda, the
+        //   Lambda runs all four steps; without one, the value is rotated
+        //   in-place (new AWSCURRENT, old -> AWSPREVIOUS).
+        // - RotateImmediately=false: the value is NOT rotated now. But when a
+        //   rotation Lambda is configured, AWS still validates the rotation
+        //   configuration by running ONLY the testSecret step (matching real
+        //   Secrets Manager). LastRotatedDate is only set on an actual rotation.
         let mut invocation = None;
         if rotate_immediately {
             secret.last_rotated_at = Some(now);
@@ -1406,12 +1415,18 @@ impl SecretsManagerService {
                         // PutSecretValue with VersionStages=[AWSPENDING] during the
                         // createSecret step (matching real AWS Secrets Manager behavior).
 
-                        // Schedule Lambda invocation
+                        // Schedule Lambda invocation (full rotation steps).
                         if let Some(ref arn) = lambda_arn {
                             invocation = Some(RotationInvocation {
                                 lambda_arn: arn.clone(),
                                 secret_id: secret.arn.clone(),
                                 client_request_token: version_id.clone(),
+                                steps: vec![
+                                    "createSecret",
+                                    "setSecret",
+                                    "testSecret",
+                                    "finishSecret",
+                                ],
                             });
                         }
                     } else {
@@ -1434,6 +1449,18 @@ impl SecretsManagerService {
                         secret.current_version_id = Some(version_id.clone());
                     }
                 }
+            }
+        } else if has_lambda {
+            // RotateImmediately=false with a Lambda: validate the rotation
+            // configuration by running only the testSecret step. The value is
+            // not rotated and LastRotatedDate is left untouched.
+            if let Some(ref arn) = lambda_arn {
+                invocation = Some(RotationInvocation {
+                    lambda_arn: arn.clone(),
+                    secret_id: secret.arn.clone(),
+                    client_request_token: version_id.clone(),
+                    steps: vec!["testSecret"],
+                });
             }
         }
 
@@ -2130,8 +2157,7 @@ impl AwsService for SecretsManagerService {
                         let bus = bus.clone();
                         // AWS invokes the rotation Lambda asynchronously for each step.
                         tokio::spawn(async move {
-                            for step in &["createSecret", "setSecret", "testSecret", "finishSecret"]
-                            {
+                            for step in &inv.steps {
                                 let payload = serde_json::json!({
                                     "SecretId": inv.secret_id,
                                     "ClientRequestToken": inv.client_request_token,

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -264,6 +264,7 @@ impl SecretsManagerService {
         };
 
         let tags_ever_set = !input.tags.is_empty();
+        let replica_regions = input.add_replica_regions.clone();
         let secret = Secret {
             name: input.name.clone(),
             arn: arn.clone(),
@@ -283,7 +284,7 @@ impl SecretsManagerService {
             rotation_rules: None,
             last_rotated_at: None,
             resource_policy: None,
-            replica_regions: Vec::new(),
+            replica_regions,
         };
 
         state.secrets.insert(input.name.clone(), secret);
@@ -294,6 +295,11 @@ impl SecretsManagerService {
         });
         if let Some(vid) = version_id_for_response {
             response["VersionId"] = json!(vid);
+        }
+        // CreateSecret echoes ReplicationStatus when replica regions were
+        // requested via AddReplicaRegions.
+        if !input.add_replica_regions.is_empty() {
+            response["ReplicationStatus"] = replication_status_json(&input.add_replica_regions);
         }
 
         Ok(AwsResponse::ok_json(response))
@@ -1366,8 +1372,14 @@ impl SecretsManagerService {
 
         secret.rotation_enabled = Some(true);
         let now = Utc::now();
-        secret.last_rotated_at = Some(now);
         secret.last_changed_at = now;
+
+        // RotateImmediately defaults to true. When false, Secrets Manager
+        // saves the rotation configuration and schedules the next rotation
+        // for the upcoming window WITHOUT rotating the value now (and
+        // without invoking the rotation Lambda). LastRotatedDate is only
+        // set when a rotation actually happens.
+        let rotate_immediately = body["RotateImmediately"].as_bool().unwrap_or(true);
 
         let version_id = body["ClientRequestToken"]
             .as_str()
@@ -1378,44 +1390,49 @@ impl SecretsManagerService {
             body["RotationLambdaARN"].as_str().is_some() || secret.rotation_lambda_arn.is_some();
         let lambda_arn = secret.rotation_lambda_arn.clone();
 
-        // If the secret has a value, perform rotation
+        // If the secret has a value, perform rotation (only when
+        // RotateImmediately is true; otherwise the config is saved and the
+        // value is left untouched until the next scheduled window).
         let mut invocation = None;
-        if let Some(current_vid) = secret.current_version_id.clone() {
-            let current_value = secret.versions.get(&current_vid).cloned();
+        if rotate_immediately {
+            secret.last_rotated_at = Some(now);
+            if let Some(current_vid) = secret.current_version_id.clone() {
+                let current_value = secret.versions.get(&current_vid).cloned();
 
-            if let Some(cv) = current_value {
-                if has_lambda {
-                    // With Lambda: do NOT pre-create the AWSPENDING version. The
-                    // rotation Lambda is responsible for putting the new value via
-                    // PutSecretValue with VersionStages=[AWSPENDING] during the
-                    // createSecret step (matching real AWS Secrets Manager behavior).
+                if let Some(cv) = current_value {
+                    if has_lambda {
+                        // With Lambda: do NOT pre-create the AWSPENDING version. The
+                        // rotation Lambda is responsible for putting the new value via
+                        // PutSecretValue with VersionStages=[AWSPENDING] during the
+                        // createSecret step (matching real AWS Secrets Manager behavior).
 
-                    // Schedule Lambda invocation
-                    if let Some(ref arn) = lambda_arn {
-                        invocation = Some(RotationInvocation {
-                            lambda_arn: arn.clone(),
-                            secret_id: secret.arn.clone(),
-                            client_request_token: version_id.clone(),
-                        });
-                    }
-                } else {
-                    // Without Lambda: simple rotation - new version becomes AWSCURRENT
-                    // Move old version to AWSPREVIOUS
-                    if let Some(old_v) = secret.versions.get_mut(&current_vid) {
-                        old_v.stages.retain(|s| s != "AWSCURRENT");
-                        if !old_v.stages.contains(&"AWSPREVIOUS".to_string()) {
-                            old_v.stages.push("AWSPREVIOUS".to_string());
+                        // Schedule Lambda invocation
+                        if let Some(ref arn) = lambda_arn {
+                            invocation = Some(RotationInvocation {
+                                lambda_arn: arn.clone(),
+                                secret_id: secret.arn.clone(),
+                                client_request_token: version_id.clone(),
+                            });
                         }
+                    } else {
+                        // Without Lambda: simple rotation - new version becomes AWSCURRENT
+                        // Move old version to AWSPREVIOUS
+                        if let Some(old_v) = secret.versions.get_mut(&current_vid) {
+                            old_v.stages.retain(|s| s != "AWSCURRENT");
+                            if !old_v.stages.contains(&"AWSPREVIOUS".to_string()) {
+                                old_v.stages.push("AWSPREVIOUS".to_string());
+                            }
+                        }
+                        let version = SecretVersion {
+                            version_id: version_id.clone(),
+                            secret_string: cv.secret_string.clone(),
+                            secret_binary: cv.secret_binary.clone(),
+                            stages: vec!["AWSCURRENT".to_string()],
+                            created_at: now,
+                        };
+                        secret.versions.insert(version_id.clone(), version);
+                        secret.current_version_id = Some(version_id.clone());
                     }
-                    let version = SecretVersion {
-                        version_id: version_id.clone(),
-                        secret_string: cv.secret_string.clone(),
-                        secret_binary: cv.secret_binary.clone(),
-                        stages: vec!["AWSCURRENT".to_string()],
-                        created_at: now,
-                    };
-                    secret.versions.insert(version_id.clone(), version);
-                    secret.current_version_id = Some(version_id.clone());
                 }
             }
         }
@@ -2035,6 +2052,10 @@ struct CreateSecretInput {
     secret_string: Option<String>,
     secret_binary: Option<Vec<u8>>,
     tags: Vec<(String, String)>,
+    /// Regions requested via CreateSecret's `AddReplicaRegions`. Persisted
+    /// as replica regions so DescribeSecret and the CreateSecret response
+    /// both report `ReplicationStatus`.
+    add_replica_regions: Vec<String>,
 }
 
 impl CreateSecretInput {
@@ -2069,6 +2090,14 @@ impl CreateSecretInput {
             secret_string: body["SecretString"].as_str().map(|s| s.to_string()),
             secret_binary: body["SecretBinary"].as_str().and_then(base64_decode),
             tags: parse_tags(&body["Tags"]),
+            add_replica_regions: body["AddReplicaRegions"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|r| r["Region"].as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default(),
         })
     }
 }

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -2458,3 +2458,106 @@ async fn batch_get_secret_value_returns_plaintext_not_ciphertext() {
         "BatchGetSecretValue must return plaintext, not ciphertext"
     );
 }
+
+#[tokio::test]
+async fn test_rotate_secret_rotate_immediately_false_does_not_rotate_value() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    let req = make_request(
+        "CreateSecret",
+        r#"{"Name": "rot-defer", "SecretString": "original"}"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let original_vid = body["VersionId"].as_str().unwrap().to_string();
+
+    // Rotate with RotateImmediately=false: config saved, value untouched.
+    let token = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    let rot = serde_json::json!({
+        "SecretId": "rot-defer",
+        "RotationRules": { "AutomaticallyAfterDays": 30 },
+        "ClientRequestToken": token,
+        "RotateImmediately": false,
+    });
+    let req = make_request("RotateSecret", &rot.to_string());
+    svc.handle(req).await.unwrap();
+
+    let accts = state.read();
+    let s = accts.default_ref();
+    let secret = s.secrets.get("rot-defer").unwrap();
+    // Rotation config is saved and enabled.
+    assert_eq!(secret.rotation_enabled, Some(true));
+    assert!(secret.rotation_rules.is_some());
+    // But the value was NOT rotated: no new version, current unchanged,
+    // and LastRotatedDate is not set (no rotation happened).
+    assert!(!secret.versions.contains_key(token));
+    assert_eq!(
+        secret.current_version_id.as_deref(),
+        Some(original_vid.as_str())
+    );
+    assert!(secret.last_rotated_at.is_none());
+}
+
+#[tokio::test]
+async fn test_rotate_secret_rotate_immediately_default_true_rotates() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "rot-now", "SecretString": "original"}"#,
+    ))
+    .await
+    .unwrap();
+
+    let token = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    let rot = serde_json::json!({
+        "SecretId": "rot-now",
+        "ClientRequestToken": token,
+    });
+    svc.handle(make_request("RotateSecret", &rot.to_string()))
+        .await
+        .unwrap();
+
+    let accts = state.read();
+    let s = accts.default_ref();
+    let secret = s.secrets.get("rot-now").unwrap();
+    // Default (RotateImmediately omitted == true): value rotated.
+    assert_eq!(secret.current_version_id.as_deref(), Some(token));
+    assert!(secret.last_rotated_at.is_some());
+}
+
+#[tokio::test]
+async fn test_create_secret_with_add_replica_regions() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    let req = make_request(
+        "CreateSecret",
+        r#"{"Name": "replicated", "SecretString": "v1",
+            "AddReplicaRegions": [{"Region": "us-west-2"}, {"Region": "eu-west-1"}]}"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let statuses = body["ReplicationStatus"].as_array().unwrap();
+    let regions: Vec<&str> = statuses
+        .iter()
+        .map(|s| s["Region"].as_str().unwrap())
+        .collect();
+    assert!(regions.contains(&"us-west-2"));
+    assert!(regions.contains(&"eu-west-1"));
+
+    // Persisted: DescribeSecret echoes ReplicationStatus too.
+    let req = make_request("DescribeSecret", r#"{"SecretId": "replicated"}"#);
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let dregions: Vec<&str> = body["ReplicationStatus"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["Region"].as_str().unwrap())
+        .collect();
+    assert!(dregions.contains(&"us-west-2"));
+    assert!(dregions.contains(&"eu-west-1"));
+}

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -2568,6 +2568,84 @@ async fn test_rotate_secret_immediately_false_with_lambda_runs_test_step_only() 
     );
 }
 
+/// A RotateImmediately=false rotation must NOT persist the temporary
+/// AWSPENDING test version: the mutating-action snapshot taken by `handle`
+/// must capture the post-cleanup state so a restart never restores a stale
+/// AWSPENDING version.
+#[tokio::test]
+async fn test_rotate_immediately_false_pending_not_persisted() {
+    #[derive(Default)]
+    struct RecordingStore {
+        bytes: std::sync::Mutex<Option<Vec<u8>>>,
+    }
+    impl fakecloud_persistence::SnapshotStore for RecordingStore {
+        fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+            Ok(self.bytes.lock().unwrap().clone())
+        }
+        fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+            *self.bytes.lock().unwrap() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    let state = make_state();
+    let store = Arc::new(RecordingStore::default());
+    let svc = SecretsManagerService::new(state.clone())
+        .with_snapshot_store(store.clone() as Arc<dyn fakecloud_persistence::SnapshotStore>);
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "rot-persist", "SecretString": "original"}"#,
+    ))
+    .await
+    .unwrap();
+
+    // RotateImmediately=false with a Lambda but no delivery bus: the testSecret
+    // step is skipped, but the temporary AWSPENDING version is staged and then
+    // cleaned up synchronously before the snapshot is taken.
+    let token = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    let rot = serde_json::json!({
+        "SecretId": "rot-persist",
+        "RotationLambdaARN": "arn:aws:lambda:us-east-1:123456789012:function:rotator",
+        "ClientRequestToken": token,
+        "RotateImmediately": false,
+    });
+    svc.handle(make_request("RotateSecret", &rot.to_string()))
+        .await
+        .unwrap();
+
+    // In-memory state is already clean.
+    {
+        let accts = state.read();
+        let secret = accts.default_ref().secrets.get("rot-persist").unwrap();
+        assert!(!secret.versions.contains_key(token));
+        assert!(secret
+            .versions
+            .values()
+            .all(|v| !v.stages.contains(&"AWSPENDING".to_string())));
+    }
+
+    // The persisted snapshot (taken by the mutating-action save at the end of
+    // `handle`) must also be free of the temporary AWSPENDING version.
+    let bytes = fakecloud_persistence::SnapshotStore::load(store.as_ref())
+        .unwrap()
+        .expect("RotateSecret must persist a snapshot");
+    let snap: crate::SecretsManagerSnapshot = serde_json::from_slice(&bytes).unwrap();
+    let accounts = snap.accounts.expect("multi-account snapshot");
+    let persisted = &accounts.default_ref().secrets["rot-persist"];
+    assert!(
+        !persisted.versions.contains_key(token),
+        "temporary AWSPENDING version must not be persisted"
+    );
+    assert!(
+        persisted
+            .versions
+            .values()
+            .all(|v| !v.stages.contains(&"AWSPENDING".to_string())),
+        "no AWSPENDING version may remain in the persisted snapshot"
+    );
+}
+
 #[tokio::test]
 async fn test_rotate_secret_immediately_with_lambda_runs_full_steps() {
     let state = make_state();

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -2633,6 +2633,19 @@ async fn test_rotate_immediately_false_pending_not_persisted() {
     let snap: crate::SecretsManagerSnapshot = serde_json::from_slice(&bytes).unwrap();
     let accounts = snap.accounts.expect("multi-account snapshot");
     let persisted = &accounts.default_ref().secrets["rot-persist"];
+    // First prove we're inspecting the POST-RotateSecret snapshot (not the
+    // earlier CreateSecret one): the rotation config set by this RotateSecret
+    // call must be present. Otherwise "no AWSPENDING" would prove nothing.
+    assert_eq!(
+        persisted.rotation_enabled,
+        Some(true),
+        "snapshot must be the post-RotateSecret one (rotation enabled)"
+    );
+    assert_eq!(
+        persisted.rotation_lambda_arn.as_deref(),
+        Some("arn:aws:lambda:us-east-1:123456789012:function:rotator"),
+        "snapshot must be the post-RotateSecret one (rotation Lambda configured)"
+    );
     assert!(
         !persisted.versions.contains_key(token),
         "temporary AWSPENDING version must not be persisted"

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -2521,18 +2521,51 @@ async fn test_rotate_secret_immediately_false_with_lambda_runs_test_step_only() 
         "ClientRequestToken": token,
         "RotateImmediately": false,
     });
+    // Capture the AWSCURRENT version id before rotation.
+    let original_current = {
+        let accts = state.read();
+        accts
+            .default_ref()
+            .secrets
+            .get("rot-test-step")
+            .unwrap()
+            .current_version_id
+            .clone()
+    };
+
     let (_resp, invocation) = svc
         .rotate_secret(&make_request("RotateSecret", &rot.to_string()))
         .unwrap();
     let inv = invocation.expect("a Lambda invocation must be scheduled to test the config");
     assert_eq!(inv.steps, vec!["testSecret"]);
+    let cleanup = inv
+        .cleanup_pending
+        .expect("test-only rotation must stage a temporary AWSPENDING version to clean up");
 
-    // Value not rotated: no new version, current version unchanged, no
-    // LastRotatedDate.
+    {
+        let accts = state.read();
+        let secret = accts.default_ref().secrets.get("rot-test-step").unwrap();
+        // A temporary AWSPENDING version was staged for the testSecret step,
+        // carrying a copy of the current value.
+        let pending = secret
+            .versions
+            .get(token)
+            .expect("AWSPENDING test version must exist for the Lambda to read");
+        assert!(pending.stages.contains(&"AWSPENDING".to_string()));
+        assert_eq!(pending.secret_string.as_deref(), Some("original"));
+        // The current value is NOT rotated and LastRotatedDate is untouched.
+        assert_eq!(secret.current_version_id, original_current);
+        assert!(secret.last_rotated_at.is_none());
+    }
+
+    // The cleanup removes the temporary AWSPENDING version.
+    super::remove_rotation_test_pending(&state, &cleanup);
     let accts = state.read();
     let secret = accts.default_ref().secrets.get("rot-test-step").unwrap();
-    assert!(!secret.versions.contains_key(token));
-    assert!(secret.last_rotated_at.is_none());
+    assert!(
+        !secret.versions.contains_key(token),
+        "temporary AWSPENDING version must be cleaned up after the test step"
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -2500,6 +2500,70 @@ async fn test_rotate_secret_rotate_immediately_false_does_not_rotate_value() {
 }
 
 #[tokio::test]
+async fn test_rotate_secret_immediately_false_with_lambda_runs_test_step_only() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "rot-test-step", "SecretString": "original"}"#,
+    ))
+    .await
+    .unwrap();
+
+    // RotateImmediately=false with a Lambda: AWS still validates the config by
+    // running ONLY the testSecret step. The value is not rotated.
+    let token = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    let rot = serde_json::json!({
+        "SecretId": "rot-test-step",
+        "RotationLambdaARN": "arn:aws:lambda:us-east-1:123456789012:function:rotator",
+        "RotationRules": { "AutomaticallyAfterDays": 30 },
+        "ClientRequestToken": token,
+        "RotateImmediately": false,
+    });
+    let (_resp, invocation) = svc
+        .rotate_secret(&make_request("RotateSecret", &rot.to_string()))
+        .unwrap();
+    let inv = invocation.expect("a Lambda invocation must be scheduled to test the config");
+    assert_eq!(inv.steps, vec!["testSecret"]);
+
+    // Value not rotated: no new version, current version unchanged, no
+    // LastRotatedDate.
+    let accts = state.read();
+    let secret = accts.default_ref().secrets.get("rot-test-step").unwrap();
+    assert!(!secret.versions.contains_key(token));
+    assert!(secret.last_rotated_at.is_none());
+}
+
+#[tokio::test]
+async fn test_rotate_secret_immediately_with_lambda_runs_full_steps() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "rot-full", "SecretString": "original"}"#,
+    ))
+    .await
+    .unwrap();
+
+    let token = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    let rot = serde_json::json!({
+        "SecretId": "rot-full",
+        "RotationLambdaARN": "arn:aws:lambda:us-east-1:123456789012:function:rotator",
+        "ClientRequestToken": token,
+    });
+    let (_resp, invocation) = svc
+        .rotate_secret(&make_request("RotateSecret", &rot.to_string()))
+        .unwrap();
+    let inv = invocation.expect("full rotation must schedule a Lambda invocation");
+    assert_eq!(
+        inv.steps,
+        vec!["createSecret", "setSecret", "testSecret", "finishSecret"]
+    );
+}
+
+#[tokio::test]
 async fn test_rotate_secret_rotate_immediately_default_true_rotates() {
     let state = make_state();
     let svc = SecretsManagerService::new(state.clone());

--- a/crates/fakecloud-ses/src/dkim.rs
+++ b/crates/fakecloud-ses/src/dkim.rs
@@ -55,6 +55,30 @@ pub fn generate_easy_dkim_keypair() -> (String, String) {
     cached_easy_dkim_keypair().clone()
 }
 
+/// Normalize a BYODKIM `DomainSigningPrivateKey` for storage. AWS supplies
+/// the key as base64-encoded DER (PKCS#8 or PKCS#1), so it must be decoded and
+/// re-encoded to the PEM form the signer ([`sign_message`] via
+/// [`parse_private_key`]) expects — otherwise valid AWS keys fail to parse and
+/// no DKIM signatures are ever produced. Values already in PEM form, or that
+/// can't be decoded/parsed, are returned unchanged as a best-effort fallback.
+pub fn normalize_byodkim_private_key(raw: &str) -> String {
+    if raw.contains("-----BEGIN") {
+        return raw.to_string();
+    }
+    // AWS base64 material may carry wrapping whitespace/newlines; strip them.
+    let compact: String = raw.split_whitespace().collect();
+    let Ok(der) = base64::engine::general_purpose::STANDARD.decode(compact.as_bytes()) else {
+        return raw.to_string();
+    };
+    let key = RsaPrivateKey::from_pkcs8_der(&der)
+        .ok()
+        .or_else(|| RsaPrivateKey::from_pkcs1_der(&der).ok());
+    match key.and_then(|k| k.to_pkcs8_pem(LineEnding::LF).ok()) {
+        Some(pem) => pem.to_string(),
+        None => raw.to_string(),
+    }
+}
+
 /// Sign the given message and return a fully-formed `DKIM-Signature`
 /// header value (without the leading `DKIM-Signature: ` prefix). Returns
 /// `None` when the private key cannot be parsed. Uses relaxed/relaxed
@@ -297,6 +321,38 @@ mod tests {
     fn sign_returns_none_for_garbage_pem() {
         let headers = vec![("From".to_string(), "x".to_string())];
         assert!(sign_message("not a key", "d", "s", &headers, "body").is_none());
+    }
+
+    #[test]
+    fn normalize_byodkim_decodes_base64_der_to_signable_pem() {
+        // AWS supplies BYODKIM keys as base64-encoded DER. Build one from the
+        // Easy-DKIM PEM: decode the PEM, re-encode to DER, base64 it.
+        let (pem, _) = generate_easy_dkim_keypair();
+        let key = parse_private_key(&pem).unwrap();
+        let der = key.to_pkcs8_der().unwrap();
+        let b64 = base64::engine::general_purpose::STANDARD.encode(der.as_bytes());
+
+        // Base64 DER -> normalized PEM that the signer can parse and use.
+        let normalized = normalize_byodkim_private_key(&b64);
+        assert!(
+            normalized.contains("-----BEGIN"),
+            "normalized BYODKIM key must be PEM, got: {normalized}"
+        );
+        assert!(
+            parse_private_key(&normalized).is_some(),
+            "normalized BYODKIM key must be parseable by the signer"
+        );
+        let headers = vec![("From".to_string(), "alice@example.com".to_string())];
+        assert!(
+            sign_message(&normalized, "example.com", "byo", &headers, "body").is_some(),
+            "signer must produce a DKIM signature from the normalized key"
+        );
+    }
+
+    #[test]
+    fn normalize_byodkim_passes_pem_through_unchanged() {
+        let (pem, _) = generate_easy_dkim_keypair();
+        assert_eq!(normalize_byodkim_private_key(&pem), pem);
     }
 
     #[test]

--- a/crates/fakecloud-ses/src/service/identities.rs
+++ b/crates/fakecloud-ses/src/service/identities.rs
@@ -76,21 +76,57 @@ impl SesV2Service {
         // here is a real input-drop bug.
         let configuration_set_name = body["ConfigurationSetName"].as_str().map(|s| s.to_string());
 
-        // Easy DKIM auto-provisions a fresh RSA-2048 keypair when the
-        // identity is created so SendEmail can stamp DKIM-Signature
-        // headers without a follow-up PutEmailIdentityDkimSigningAttributes.
-        let (priv_pem, pub_b64) = crate::dkim::generate_easy_dkim_keypair();
+        // DKIM configuration. CreateEmailIdentity's DkimSigningAttributes
+        // selects between Easy DKIM (AWS-managed keypair, optionally with a
+        // requested NextSigningKeyLength) and BYODKIM (the caller supplies
+        // their own selector + private key, origin EXTERNAL). Previously
+        // this was hardcoded to Easy DKIM, silently dropping BYODKIM.
+        let dkim = &body["DkimSigningAttributes"];
+        let byo_selector = dkim["DomainSigningSelector"].as_str();
+        let byo_private_key = dkim["DomainSigningPrivateKey"].as_str();
+        let (dkim_origin, dkim_private_key, dkim_selector, dkim_key_length, dkim_public_key) =
+            if let (Some(selector), Some(private_key)) = (byo_selector, byo_private_key) {
+                // BYODKIM: honor the caller's selector + private key. There
+                // is no AWS-generated public key in this mode.
+                (
+                    "EXTERNAL".to_string(),
+                    Some(private_key.to_string()),
+                    Some(selector.to_string()),
+                    None,
+                    None,
+                )
+            } else {
+                // Easy DKIM: auto-provision a fresh keypair so SendEmail can
+                // stamp DKIM-Signature headers without a follow-up
+                // PutEmailIdentityDkimSigningAttributes. NextSigningKeyLength
+                // (if supplied) selects the reported key length.
+                let key_length = dkim["NextSigningKeyLength"]
+                    .as_str()
+                    .unwrap_or("RSA_2048_BIT")
+                    .to_string();
+                let (priv_pem, pub_b64) = crate::dkim::generate_easy_dkim_keypair();
+                (
+                    "AWS_SES".to_string(),
+                    Some(priv_pem),
+                    Some("fakecloudses".to_string()),
+                    Some(key_length),
+                    Some(pub_b64),
+                )
+            };
+        let dkim_origin_resp = dkim_origin.clone();
+        let dkim_selector_resp = dkim_selector.clone();
+        let dkim_key_length_resp = dkim_key_length.clone();
         let identity = EmailIdentity {
             identity_name: identity_name.clone(),
             identity_type: identity_type.to_string(),
             verified: true,
             created_at: Utc::now(),
             dkim_signing_enabled: true,
-            dkim_signing_attributes_origin: "AWS_SES".to_string(),
-            dkim_domain_signing_private_key: Some(priv_pem),
-            dkim_domain_signing_selector: Some("fakecloudses".to_string()),
-            dkim_next_signing_key_length: Some("RSA_2048_BIT".to_string()),
-            dkim_public_key_b64: Some(pub_b64),
+            dkim_signing_attributes_origin: dkim_origin,
+            dkim_domain_signing_private_key: dkim_private_key,
+            dkim_domain_signing_selector: dkim_selector,
+            dkim_next_signing_key_length: dkim_key_length,
+            dkim_public_key_b64: dkim_public_key,
             email_forwarding_enabled: true,
             mail_from_domain: None,
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
@@ -125,18 +161,27 @@ impl SesV2Service {
             state.tags.remove(&arn);
         }
 
+        let mut dkim_attrs = json!({
+            "SigningEnabled": true,
+            "Status": "SUCCESS",
+            "SigningAttributesOrigin": dkim_origin_resp,
+            "Tokens": [
+                "token1",
+                "token2",
+                "token3",
+            ],
+        });
+        if let Some(ref selector) = dkim_selector_resp {
+            dkim_attrs["DomainSigningSelector"] = json!(selector);
+        }
+        if let Some(ref len) = dkim_key_length_resp {
+            dkim_attrs["CurrentSigningKeyLength"] = json!(len);
+            dkim_attrs["NextSigningKeyLength"] = json!(len);
+        }
         let response = json!({
             "IdentityType": identity_type,
             "VerifiedForSendingStatus": true,
-            "DkimAttributes": {
-                "SigningEnabled": true,
-                "Status": "SUCCESS",
-                "Tokens": [
-                    "token1",
-                    "token2",
-                    "token3",
-                ],
-            },
+            "DkimAttributes": dkim_attrs,
         });
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))

--- a/crates/fakecloud-ses/src/service/identities.rs
+++ b/crates/fakecloud-ses/src/service/identities.rs
@@ -86,11 +86,13 @@ impl SesV2Service {
         let byo_private_key = dkim["DomainSigningPrivateKey"].as_str();
         let (dkim_origin, dkim_private_key, dkim_selector, dkim_key_length, dkim_public_key) =
             if let (Some(selector), Some(private_key)) = (byo_selector, byo_private_key) {
-                // BYODKIM: honor the caller's selector + private key. There
-                // is no AWS-generated public key in this mode.
+                // BYODKIM: honor the caller's selector + private key. AWS
+                // supplies the key as base64-encoded DER, so normalize it to
+                // the PEM form the signer expects before storing. There is no
+                // AWS-generated public key in this mode.
                 (
                     "EXTERNAL".to_string(),
-                    Some(private_key.to_string()),
+                    Some(crate::dkim::normalize_byodkim_private_key(private_key)),
                     Some(selector.to_string()),
                     None,
                     None,
@@ -600,7 +602,10 @@ impl SesV2Service {
 
         if let Some(attrs) = body.get("SigningAttributes") {
             if let Some(key) = attrs["DomainSigningPrivateKey"].as_str() {
-                identity.dkim_domain_signing_private_key = Some(key.to_string());
+                // AWS supplies BYODKIM keys as base64-encoded DER; normalize to
+                // the PEM form the signer expects so signing actually works.
+                identity.dkim_domain_signing_private_key =
+                    Some(crate::dkim::normalize_byodkim_private_key(key));
                 identity.dkim_public_key_b64 = None;
             }
             if let Some(selector) = attrs["DomainSigningSelector"].as_str() {

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -4556,3 +4556,92 @@ async fn snapshot_hook_fires_with_store() {
         .expect("hook present when a store is set");
     hook().await;
 }
+
+#[tokio::test]
+async fn test_create_email_identity_byodkim() {
+    let state = make_state();
+    let svc = SesV2Service::new(state.clone());
+
+    // BYODKIM: caller supplies selector + private key.
+    let req = make_request(
+        Method::POST,
+        "/v2/email/identities",
+        r#"{"EmailIdentity": "byo.example.com",
+            "DkimSigningAttributes": {
+                "DomainSigningSelector": "myselector",
+                "DomainSigningPrivateKey": "myprivatekeybase64"
+            }}"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        body["DkimAttributes"]["SigningAttributesOrigin"], "EXTERNAL",
+        "BYODKIM must report EXTERNAL origin"
+    );
+    assert_eq!(
+        body["DkimAttributes"]["DomainSigningSelector"],
+        "myselector"
+    );
+
+    // Persisted: the caller's private key + selector are stored, not a
+    // freshly generated Easy-DKIM keypair.
+    {
+        let accts = state.read();
+        let s = accts.default_ref();
+        let id = s.identities.get("byo.example.com").unwrap();
+        assert_eq!(id.dkim_signing_attributes_origin, "EXTERNAL");
+        assert_eq!(
+            id.dkim_domain_signing_selector.as_deref(),
+            Some("myselector")
+        );
+        assert_eq!(
+            id.dkim_domain_signing_private_key.as_deref(),
+            Some("myprivatekeybase64")
+        );
+    }
+
+    // GetEmailIdentity round-trips EXTERNAL origin + selector.
+    let req = make_request(Method::GET, "/v2/email/identities/byo.example.com", "");
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        body["DkimAttributes"]["SigningAttributesOrigin"],
+        "EXTERNAL"
+    );
+    assert_eq!(
+        body["DkimAttributes"]["DomainSigningSelector"],
+        "myselector"
+    );
+}
+
+#[tokio::test]
+async fn test_create_email_identity_easy_dkim_key_length() {
+    let state = make_state();
+    let svc = SesV2Service::new(state.clone());
+
+    // Easy DKIM with an explicit NextSigningKeyLength.
+    let req = make_request(
+        Method::POST,
+        "/v2/email/identities",
+        r#"{"EmailIdentity": "easy.example.com",
+            "DkimSigningAttributes": { "NextSigningKeyLength": "RSA_1024_BIT" }}"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["DkimAttributes"]["SigningAttributesOrigin"], "AWS_SES");
+    assert_eq!(
+        body["DkimAttributes"]["NextSigningKeyLength"],
+        "RSA_1024_BIT"
+    );
+
+    let accts = state.read();
+    let s = accts.default_ref();
+    let id = s.identities.get("easy.example.com").unwrap();
+    assert_eq!(
+        id.dkim_next_signing_key_length.as_deref(),
+        Some("RSA_1024_BIT")
+    );
+    // Easy DKIM still auto-provisions a keypair.
+    assert!(id.dkim_domain_signing_private_key.is_some());
+}

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -2281,6 +2281,12 @@ pub(crate) fn update_configuration_set_event_destination(
     let config_set_name = required_param(&req.query_params, "ConfigurationSetName")?;
     let dest_name = required_param(&req.query_params, "EventDestination.Name")?;
 
+    // Parse + validate the (optional) target BEFORE mutating any state so a
+    // rejected request (multiple targets) leaves the destination untouched
+    // rather than persisting partial Enabled / MatchingEventTypes changes.
+    let target = parse_event_destination_target(&req.query_params)?;
+    let event_types = parse_member_list(&req.query_params, "EventDestination.MatchingEventTypes");
+
     let mut accounts = state.write();
     let st = accounts.get_or_create(&req.account_id);
     let dests = st
@@ -2307,7 +2313,6 @@ pub(crate) fn update_configuration_set_event_destination(
     if let Some(v) = req.query_params.get("EventDestination.Enabled") {
         dest.enabled = v == "true";
     }
-    let event_types = parse_member_list(&req.query_params, "EventDestination.MatchingEventTypes");
     if !event_types.is_empty() {
         dest.matching_event_types = event_types;
     }
@@ -2316,7 +2321,7 @@ pub(crate) fn update_configuration_set_event_destination(
     // Applying a new target clears the other two so a destination never ends
     // up with more than one target type (which would make
     // DescribeConfigurationSet report multiple targets).
-    if let Some(target) = parse_event_destination_target(&req.query_params)? {
+    if let Some(target) = target {
         dest.kinesis_firehose_destination = None;
         dest.cloud_watch_destination = None;
         dest.sns_destination = None;

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -1373,6 +1373,41 @@ fn parse_cloudwatch_destination(params: &HashMap<String, String>) -> Option<serd
     }
 }
 
+/// The three mutually-exclusive SES v1 event-destination targets. AWS allows
+/// exactly one target type per event destination.
+enum EventDestinationTarget {
+    Kinesis(serde_json::Value),
+    CloudWatch(serde_json::Value),
+    Sns(serde_json::Value),
+}
+
+/// Parse the single event-destination target from the request query params.
+/// Returns an error if more than one of Kinesis/CloudWatch/SNS is supplied
+/// (AWS permits only one), and `Ok(None)` when none is supplied.
+fn parse_event_destination_target(
+    params: &HashMap<String, String>,
+) -> Result<Option<EventDestinationTarget>, AwsServiceError> {
+    let kinesis = parse_kinesis_firehose_destination(params);
+    let cloudwatch = parse_cloudwatch_destination(params);
+    let sns = params
+        .get("EventDestination.SNSDestination.TopicARN")
+        .map(|arn| serde_json::json!({ "TopicArn": arn }));
+
+    let count = kinesis.is_some() as u8 + cloudwatch.is_some() as u8 + sns.is_some() as u8;
+    if count > 1 {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterValue",
+            "An event destination must specify exactly one destination type \
+             (KinesisFirehoseDestination, CloudWatchDestination, or SNSDestination).",
+        ));
+    }
+    Ok(kinesis
+        .map(EventDestinationTarget::Kinesis)
+        .or_else(|| cloudwatch.map(EventDestinationTarget::CloudWatch))
+        .or_else(|| sns.map(EventDestinationTarget::Sns)))
+}
+
 pub(crate) fn send_email(
     state: &SharedSesState,
     req: &AwsRequest,
@@ -2201,16 +2236,28 @@ pub(crate) fn create_configuration_set_event_destination(
         }
     }
 
+    // AWS requires exactly one destination target per event destination.
+    let target = parse_event_destination_target(&req.query_params)?.ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterValue",
+            "An event destination must specify exactly one destination type \
+             (KinesisFirehoseDestination, CloudWatchDestination, or SNSDestination).",
+        )
+    })?;
+    let (kinesis, cloudwatch, sns) = match target {
+        EventDestinationTarget::Kinesis(v) => (Some(v), None, None),
+        EventDestinationTarget::CloudWatch(v) => (None, Some(v), None),
+        EventDestinationTarget::Sns(v) => (None, None, Some(v)),
+    };
+
     let dest = EventDestination {
         name: dest_name.to_string(),
         enabled,
         matching_event_types: event_types,
-        kinesis_firehose_destination: parse_kinesis_firehose_destination(&req.query_params),
-        cloud_watch_destination: parse_cloudwatch_destination(&req.query_params),
-        sns_destination: req
-            .query_params
-            .get("EventDestination.SNSDestination.TopicARN")
-            .map(|arn| serde_json::json!({ "TopicArn": arn })),
+        kinesis_firehose_destination: kinesis,
+        cloud_watch_destination: cloudwatch,
+        sns_destination: sns,
         event_bridge_destination: None,
         pinpoint_destination: None,
     };
@@ -2265,19 +2312,19 @@ pub(crate) fn update_configuration_set_event_destination(
         dest.matching_event_types = event_types;
     }
     // Apply destination-target changes when supplied so an update that
-    // switches or (re)configures Kinesis/CloudWatch/SNS destinations is
-    // reflected on the read side.
-    if let Some(k) = parse_kinesis_firehose_destination(&req.query_params) {
-        dest.kinesis_firehose_destination = Some(k);
-    }
-    if let Some(cw) = parse_cloudwatch_destination(&req.query_params) {
-        dest.cloud_watch_destination = Some(cw);
-    }
-    if let Some(arn) = req
-        .query_params
-        .get("EventDestination.SNSDestination.TopicARN")
-    {
-        dest.sns_destination = Some(serde_json::json!({ "TopicArn": arn }));
+    // switches or (re)configures the target is reflected on the read side.
+    // Applying a new target clears the other two so a destination never ends
+    // up with more than one target type (which would make
+    // DescribeConfigurationSet report multiple targets).
+    if let Some(target) = parse_event_destination_target(&req.query_params)? {
+        dest.kinesis_firehose_destination = None;
+        dest.cloud_watch_destination = None;
+        dest.sns_destination = None;
+        match target {
+            EventDestinationTarget::Kinesis(v) => dest.kinesis_firehose_destination = Some(v),
+            EventDestinationTarget::CloudWatch(v) => dest.cloud_watch_destination = Some(v),
+            EventDestinationTarget::Sns(v) => dest.sns_destination = Some(v),
+        }
     }
 
     Ok(xml_metadata_only(

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -1329,6 +1329,50 @@ pub(crate) fn parse_member_list(params: &HashMap<String, String>, prefix: &str) 
     result
 }
 
+/// Parse the `EventDestination.KinesisFirehoseDestination.*` query params (SES
+/// v1 CreateConfigurationSetEventDestination). Returns `None` when neither
+/// field is present so we don't attach an empty destination.
+fn parse_kinesis_firehose_destination(
+    params: &HashMap<String, String>,
+) -> Option<serde_json::Value> {
+    let role = params.get("EventDestination.KinesisFirehoseDestination.IAMRoleARN");
+    let stream = params.get("EventDestination.KinesisFirehoseDestination.DeliveryStreamARN");
+    if role.is_none() && stream.is_none() {
+        return None;
+    }
+    Some(serde_json::json!({
+        "IAMRoleARN": role.cloned().unwrap_or_default(),
+        "DeliveryStreamARN": stream.cloned().unwrap_or_default(),
+    }))
+}
+
+/// Parse the `EventDestination.CloudWatchDestination.DimensionConfigurations.*`
+/// query params (SES v1). Returns `None` when no dimension configurations were
+/// supplied.
+fn parse_cloudwatch_destination(params: &HashMap<String, String>) -> Option<serde_json::Value> {
+    let mut configs = Vec::new();
+    for i in 1.. {
+        let prefix =
+            format!("EventDestination.CloudWatchDestination.DimensionConfigurations.member.{i}");
+        let name = params.get(&format!("{prefix}.DimensionName"));
+        let source = params.get(&format!("{prefix}.DimensionValueSource"));
+        let default = params.get(&format!("{prefix}.DefaultDimensionValue"));
+        if name.is_none() && source.is_none() && default.is_none() {
+            break;
+        }
+        configs.push(serde_json::json!({
+            "DimensionName": name.cloned().unwrap_or_default(),
+            "DimensionValueSource": source.cloned().unwrap_or_default(),
+            "DefaultDimensionValue": default.cloned().unwrap_or_default(),
+        }));
+    }
+    if configs.is_empty() {
+        None
+    } else {
+        Some(serde_json::json!({ "DimensionConfigurations": configs }))
+    }
+}
+
 pub(crate) fn send_email(
     state: &SharedSesState,
     req: &AwsRequest,
@@ -2059,7 +2103,46 @@ pub(crate) fn describe_configuration_set(
             for et in &dest.matching_event_types {
                 inner.push_str(&format!("<member>{}</member>", xml_escape(et)));
             }
-            inner.push_str("</MatchingEventTypes></member>");
+            inner.push_str("</MatchingEventTypes>");
+            // Echo the configured destination target(s). Previously the
+            // describe response dropped these entirely, so a Kinesis /
+            // CloudWatch / SNS destination created against the set was
+            // invisible on read.
+            if let Some(k) = &dest.kinesis_firehose_destination {
+                inner.push_str(&format!(
+                    "<KinesisFirehoseDestination>\
+                     <IAMRoleARN>{}</IAMRoleARN>\
+                     <DeliveryStreamARN>{}</DeliveryStreamARN>\
+                     </KinesisFirehoseDestination>",
+                    xml_escape(k["IAMRoleARN"].as_str().unwrap_or("")),
+                    xml_escape(k["DeliveryStreamARN"].as_str().unwrap_or("")),
+                ));
+            }
+            if let Some(cw) = &dest.cloud_watch_destination {
+                inner.push_str("<CloudWatchDestination><DimensionConfigurations>");
+                if let Some(arr) = cw["DimensionConfigurations"].as_array() {
+                    for dc in arr {
+                        inner.push_str(&format!(
+                            "<member>\
+                             <DimensionName>{}</DimensionName>\
+                             <DimensionValueSource>{}</DimensionValueSource>\
+                             <DefaultDimensionValue>{}</DefaultDimensionValue>\
+                             </member>",
+                            xml_escape(dc["DimensionName"].as_str().unwrap_or("")),
+                            xml_escape(dc["DimensionValueSource"].as_str().unwrap_or("")),
+                            xml_escape(dc["DefaultDimensionValue"].as_str().unwrap_or("")),
+                        ));
+                    }
+                }
+                inner.push_str("</DimensionConfigurations></CloudWatchDestination>");
+            }
+            if let Some(sns) = &dest.sns_destination {
+                inner.push_str(&format!(
+                    "<SNSDestination><TopicARN>{}</TopicARN></SNSDestination>",
+                    xml_escape(sns["TopicArn"].as_str().unwrap_or("")),
+                ));
+            }
+            inner.push_str("</member>");
         }
         inner.push_str("</EventDestinations>");
     }
@@ -2122,8 +2205,8 @@ pub(crate) fn create_configuration_set_event_destination(
         name: dest_name.to_string(),
         enabled,
         matching_event_types: event_types,
-        kinesis_firehose_destination: None,
-        cloud_watch_destination: None,
+        kinesis_firehose_destination: parse_kinesis_firehose_destination(&req.query_params),
+        cloud_watch_destination: parse_cloudwatch_destination(&req.query_params),
         sns_destination: req
             .query_params
             .get("EventDestination.SNSDestination.TopicARN")
@@ -2180,6 +2263,21 @@ pub(crate) fn update_configuration_set_event_destination(
     let event_types = parse_member_list(&req.query_params, "EventDestination.MatchingEventTypes");
     if !event_types.is_empty() {
         dest.matching_event_types = event_types;
+    }
+    // Apply destination-target changes when supplied so an update that
+    // switches or (re)configures Kinesis/CloudWatch/SNS destinations is
+    // reflected on the read side.
+    if let Some(k) = parse_kinesis_firehose_destination(&req.query_params) {
+        dest.kinesis_firehose_destination = Some(k);
+    }
+    if let Some(cw) = parse_cloudwatch_destination(&req.query_params) {
+        dest.cloud_watch_destination = Some(cw);
+    }
+    if let Some(arn) = req
+        .query_params
+        .get("EventDestination.SNSDestination.TopicARN")
+    {
+        dest.sns_destination = Some(serde_json::json!({ "TopicArn": arn }));
     }
 
     Ok(xml_metadata_only(

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -1564,6 +1564,113 @@ fn test_configuration_set_event_destination_lifecycle() {
         .is_empty());
 }
 
+#[test]
+fn test_event_destination_kinesis_and_cloudwatch_persist_and_describe() {
+    let state = make_state();
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSet",
+            vec![("ConfigurationSet.Name", "cs2")],
+        ),
+    )
+    .unwrap();
+
+    // Kinesis Firehose destination.
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSetEventDestination",
+            vec![
+                ("ConfigurationSetName", "cs2"),
+                ("EventDestination.Name", "firehose-dest"),
+                ("EventDestination.Enabled", "true"),
+                ("EventDestination.MatchingEventTypes.member.1", "send"),
+                (
+                    "EventDestination.KinesisFirehoseDestination.IAMRoleARN",
+                    "arn:aws:iam::123456789012:role/ses-firehose",
+                ),
+                (
+                    "EventDestination.KinesisFirehoseDestination.DeliveryStreamARN",
+                    "arn:aws:firehose:us-east-1:123456789012:deliverystream/ses-stream",
+                ),
+            ],
+        ),
+    )
+    .unwrap();
+
+    // CloudWatch destination with a dimension configuration.
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSetEventDestination",
+            vec![
+                ("ConfigurationSetName", "cs2"),
+                ("EventDestination.Name", "cw-dest"),
+                ("EventDestination.Enabled", "true"),
+                ("EventDestination.MatchingEventTypes.member.1", "bounce"),
+                (
+                    "EventDestination.CloudWatchDestination.DimensionConfigurations.member.1.DimensionName",
+                    "ses:configuration-set",
+                ),
+                (
+                    "EventDestination.CloudWatchDestination.DimensionConfigurations.member.1.DimensionValueSource",
+                    "messageTag",
+                ),
+                (
+                    "EventDestination.CloudWatchDestination.DimensionConfigurations.member.1.DefaultDimensionValue",
+                    "default",
+                ),
+            ],
+        ),
+    )
+    .unwrap();
+
+    // Persisted on the state.
+    {
+        let mas = state.read();
+        let st = mas.default_ref();
+        let dests = st.event_destinations.get("cs2").unwrap();
+        let fh = dests.iter().find(|d| d.name == "firehose-dest").unwrap();
+        let k = fh.kinesis_firehose_destination.as_ref().unwrap();
+        assert_eq!(
+            k["DeliveryStreamARN"],
+            "arn:aws:firehose:us-east-1:123456789012:deliverystream/ses-stream"
+        );
+        let cw = dests.iter().find(|d| d.name == "cw-dest").unwrap();
+        let cwd = cw.cloud_watch_destination.as_ref().unwrap();
+        assert_eq!(
+            cwd["DimensionConfigurations"][0]["DimensionName"],
+            "ses:configuration-set"
+        );
+    }
+
+    // DescribeConfigurationSet echoes the destination targets.
+    let resp = handle_v1_action(
+        &state,
+        &make_v1_request(
+            "DescribeConfigurationSet",
+            vec![
+                ("ConfigurationSetName", "cs2"),
+                (
+                    "ConfigurationSetAttributeNames.member.1",
+                    "eventDestinations",
+                ),
+            ],
+        ),
+    )
+    .unwrap();
+    let xml = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(
+        xml.contains("<KinesisFirehoseDestination>") && xml.contains("deliverystream/ses-stream"),
+        "describe must echo Kinesis destination, got: {xml}"
+    );
+    assert!(
+        xml.contains("<CloudWatchDestination>") && xml.contains("ses:configuration-set"),
+        "describe must echo CloudWatch destination, got: {xml}"
+    );
+}
+
 // ── Account / Quota tests ──
 
 #[test]

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -1696,6 +1696,13 @@ fn test_event_destination_rejects_multiple_and_zero_targets() {
                     "EventDestination.SNSDestination.TopicARN",
                     "arn:aws:sns:us-east-1:123456789012:t",
                 ),
+                // A fully-valid Kinesis block (both IAMRoleARN and
+                // DeliveryStreamARN) so the ONLY reason for rejection is that
+                // two targets are supplied, not an incomplete Kinesis block.
+                (
+                    "EventDestination.KinesisFirehoseDestination.IAMRoleARN",
+                    "arn:aws:iam::123456789012:role/ses-firehose",
+                ),
                 (
                     "EventDestination.KinesisFirehoseDestination.DeliveryStreamARN",
                     "arn:aws:firehose:us-east-1:123456789012:deliverystream/s",
@@ -1786,6 +1793,79 @@ fn test_event_destination_update_switches_target_type() {
     );
     assert!(dest.kinesis_firehose_destination.is_some());
     assert!(dest.cloud_watch_destination.is_none());
+}
+
+#[test]
+fn test_event_destination_update_multiple_targets_is_atomic() {
+    let state = make_state();
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSet",
+            vec![("ConfigurationSet.Name", "cs5")],
+        ),
+    )
+    .unwrap();
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSetEventDestination",
+            vec![
+                ("ConfigurationSetName", "cs5"),
+                ("EventDestination.Name", "d"),
+                ("EventDestination.Enabled", "true"),
+                ("EventDestination.MatchingEventTypes.member.1", "send"),
+                (
+                    "EventDestination.SNSDestination.TopicARN",
+                    "arn:aws:sns:us-east-1:123456789012:t",
+                ),
+            ],
+        ),
+    )
+    .unwrap();
+
+    // A rejected update (two targets + Enabled=false) must not persist ANY of
+    // its changes: Enabled and MatchingEventTypes stay as they were.
+    let err = match handle_v1_action(
+        &state,
+        &make_v1_request(
+            "UpdateConfigurationSetEventDestination",
+            vec![
+                ("ConfigurationSetName", "cs5"),
+                ("EventDestination.Name", "d"),
+                ("EventDestination.Enabled", "false"),
+                ("EventDestination.MatchingEventTypes.member.1", "bounce"),
+                (
+                    "EventDestination.SNSDestination.TopicARN",
+                    "arn:aws:sns:us-east-1:123456789012:t2",
+                ),
+                (
+                    "EventDestination.KinesisFirehoseDestination.IAMRoleARN",
+                    "arn:aws:iam::123456789012:role/r",
+                ),
+                (
+                    "EventDestination.KinesisFirehoseDestination.DeliveryStreamARN",
+                    "arn:aws:firehose:us-east-1:123456789012:deliverystream/s",
+                ),
+            ],
+        ),
+    ) {
+        Err(e) => e,
+        Ok(_) => panic!("multiple-target update must be rejected"),
+    };
+    assert_eq!(err.code(), "InvalidParameterValue");
+
+    let mas = state.read();
+    let st = mas.default_ref();
+    let dest = &st.event_destinations.get("cs5").unwrap()[0];
+    assert!(
+        dest.enabled,
+        "Enabled must be unchanged after a rejected update"
+    );
+    assert_eq!(dest.matching_event_types, vec!["send"]);
+    // The original SNS target is intact; no partial target swap happened.
+    assert!(dest.sns_destination.is_some());
+    assert!(dest.kinesis_firehose_destination.is_none());
 }
 
 // ── Account / Quota tests ──

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -1671,6 +1671,123 @@ fn test_event_destination_kinesis_and_cloudwatch_persist_and_describe() {
     );
 }
 
+#[test]
+fn test_event_destination_rejects_multiple_and_zero_targets() {
+    let state = make_state();
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSet",
+            vec![("ConfigurationSet.Name", "cs3")],
+        ),
+    )
+    .unwrap();
+
+    // Two targets on one destination -> rejected.
+    let err = match handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSetEventDestination",
+            vec![
+                ("ConfigurationSetName", "cs3"),
+                ("EventDestination.Name", "multi"),
+                ("EventDestination.MatchingEventTypes.member.1", "send"),
+                (
+                    "EventDestination.SNSDestination.TopicARN",
+                    "arn:aws:sns:us-east-1:123456789012:t",
+                ),
+                (
+                    "EventDestination.KinesisFirehoseDestination.DeliveryStreamARN",
+                    "arn:aws:firehose:us-east-1:123456789012:deliverystream/s",
+                ),
+            ],
+        ),
+    ) {
+        Err(e) => e,
+        Ok(_) => panic!("multiple targets must be rejected"),
+    };
+    assert_eq!(err.code(), "InvalidParameterValue");
+
+    // Zero targets -> rejected.
+    let err = match handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSetEventDestination",
+            vec![
+                ("ConfigurationSetName", "cs3"),
+                ("EventDestination.Name", "none"),
+                ("EventDestination.MatchingEventTypes.member.1", "send"),
+            ],
+        ),
+    ) {
+        Err(e) => e,
+        Ok(_) => panic!("zero targets must be rejected"),
+    };
+    assert_eq!(err.code(), "InvalidParameterValue");
+}
+
+#[test]
+fn test_event_destination_update_switches_target_type() {
+    let state = make_state();
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSet",
+            vec![("ConfigurationSet.Name", "cs4")],
+        ),
+    )
+    .unwrap();
+
+    // Start with an SNS target.
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "CreateConfigurationSetEventDestination",
+            vec![
+                ("ConfigurationSetName", "cs4"),
+                ("EventDestination.Name", "d"),
+                ("EventDestination.MatchingEventTypes.member.1", "send"),
+                (
+                    "EventDestination.SNSDestination.TopicARN",
+                    "arn:aws:sns:us-east-1:123456789012:t",
+                ),
+            ],
+        ),
+    )
+    .unwrap();
+
+    // Switch to a Kinesis target: the SNS target must be cleared.
+    handle_v1_action(
+        &state,
+        &make_v1_request(
+            "UpdateConfigurationSetEventDestination",
+            vec![
+                ("ConfigurationSetName", "cs4"),
+                ("EventDestination.Name", "d"),
+                (
+                    "EventDestination.KinesisFirehoseDestination.DeliveryStreamARN",
+                    "arn:aws:firehose:us-east-1:123456789012:deliverystream/s",
+                ),
+                (
+                    "EventDestination.KinesisFirehoseDestination.IAMRoleARN",
+                    "arn:aws:iam::123456789012:role/r",
+                ),
+            ],
+        ),
+    )
+    .unwrap();
+
+    let mas = state.read();
+    let st = mas.default_ref();
+    let dest = &st.event_destinations.get("cs4").unwrap()[0];
+    assert!(
+        dest.sns_destination.is_none(),
+        "old SNS target must be cleared after switching to Kinesis"
+    );
+    assert!(dest.kinesis_firehose_destination.is_some());
+    assert!(dest.cloud_watch_destination.is_none());
+}
+
 // ── Account / Quota tests ──
 
 #[test]

--- a/crates/fakecloud-ssm/src/service/associations.rs
+++ b/crates/fakecloud-ssm/src/service/associations.rs
@@ -303,6 +303,22 @@ impl SsmService {
         if let Some(cs) = body["ComplianceSeverity"].as_str() {
             assoc.compliance_severity = Some(cs.to_string());
         }
+        // SyncCompliance / ApplyOnlyAtCronInterval / ScheduleOffset /
+        // OutputLocation are all settable on CreateAssociation and echoed
+        // by DescribeAssociation, so UpdateAssociation must persist them
+        // too (previously silently dropped).
+        if let Some(sc) = body["SyncCompliance"].as_str() {
+            assoc.sync_compliance = Some(sc.to_string());
+        }
+        if let Some(ac) = body["ApplyOnlyAtCronInterval"].as_bool() {
+            assoc.apply_only_at_cron_interval = ac;
+        }
+        if let Some(so) = body["ScheduleOffset"].as_i64() {
+            assoc.schedule_offset = Some(so);
+        }
+        if let Some(ol) = body.get("OutputLocation").filter(|v| !v.is_null()) {
+            assoc.output_location = Some(ol.clone());
+        }
 
         assoc.last_update_association_date = now;
 

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -535,34 +535,14 @@ fn apply_overwrite(
 
     // Derive the effective tier: an explicit Tier in the request wins,
     // otherwise the existing parameter's tier is preserved across the
-    // overwrite (AWS never silently downgrades a tier when Tier is
-    // omitted). Validate before mutating so a rejection leaves the
-    // parameter untouched.
+    // overwrite (AWS never silently downgrades a tier when Tier is omitted).
+    // The tier/policy conflict is validated earlier in `put_parameter`,
+    // before any KMS work, so no re-check is needed here.
     let effective_tier = if input.tier_explicit {
         input.tier.clone()
     } else {
         existing.tier.clone()
     };
-    // Policies are Advanced-tier only. Compute whether policies will be
-    // attached after this overwrite: a non-empty Policies set in the
-    // request replaces the old one; omitting Policies preserves whatever
-    // is already attached. Either way, an Advanced-only policy must not
-    // end up on a non-Advanced parameter.
-    let policies_present_after = match input.policies.as_deref() {
-        Some(s) => !s.trim().is_empty(),
-        None => existing
-            .policies
-            .as_deref()
-            .is_some_and(|p| !p.trim().is_empty()),
-    };
-    if policies_present_after && effective_tier != "Advanced" {
-        return Err(AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            "Policies are only supported on Advanced-tier parameters. \
-             Set Tier=Advanced when including Policies.",
-        ));
-    }
 
     if existing.version >= PARAMETER_VERSION_LIMIT {
         let oldest_version = existing
@@ -664,21 +644,8 @@ fn create_new_parameter(
         )
     })?;
 
-    // Policies are Advanced-tier only; a brand-new parameter's effective
-    // tier is exactly the request tier.
-    let policies_present = input
-        .policies
-        .as_deref()
-        .is_some_and(|p| !p.trim().is_empty());
-    if policies_present && input.tier != "Advanced" {
-        return Err(AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            "Policies are only supported on Advanced-tier parameters. \
-             Set Tier=Advanced when including Policies.",
-        ));
-    }
-
+    // The tier/policy conflict (policies require Advanced tier) is validated
+    // earlier in `put_parameter`, before any KMS encryption work.
     let tag_map = input
         .tags
         .map(|list| list.into_iter().collect::<BTreeMap<_, _>>())
@@ -716,6 +683,38 @@ impl SsmService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+
+        // Validate the tier/policy conflict BEFORE any KMS encryption work.
+        // Policies are Advanced-tier only; rejecting a Standard-tier param
+        // that carries policies must happen ahead of encrypt_secure_value so
+        // a bad request never triggers KMS (and never surfaces InvalidKeyId
+        // ahead of the real validation error). The effective tier follows the
+        // overwrite rules: an explicit Tier wins, else the existing tier is
+        // preserved; a new parameter uses the request tier.
+        {
+            let existing = lookup_param(&state.parameters, &input.name);
+            let effective_tier = match existing {
+                Some(e) if !input.tier_explicit => e.tier.clone(),
+                _ => input.tier.clone(),
+            };
+            let policies_present = match input.policies.as_deref() {
+                Some(s) => !s.trim().is_empty(),
+                None => existing
+                    .and_then(|e| e.policies.as_deref())
+                    .is_some_and(|p| !p.trim().is_empty()),
+            };
+            if policies_present && effective_tier != "Advanced" {
+                return Err(remap_validation_to(
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationException",
+                        "Policies are only supported on Advanced-tier parameters. \
+                         Set Tier=Advanced when including Policies.",
+                    ),
+                    "InvalidAllowedPatternException",
+                ));
+            }
+        }
 
         // Determine effective param_type for KMS encryption decision.
         // For overwrite, falls back to existing.param_type; for new params,

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -684,6 +684,20 @@ impl SsmService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
+        // A non-overwrite write to a parameter that already exists fails fast
+        // with ParameterAlreadyExists, BEFORE the tier/policy validation (which
+        // only matters for a write that will actually be applied). Otherwise a
+        // duplicate PutParameter without Overwrite could surface the tier/policy
+        // error instead of the expected already-exists error.
+        if !input.overwrite && lookup_param(&state.parameters, &input.name).is_some() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ParameterAlreadyExists",
+                "The parameter already exists. To overwrite this value, set the \
+                 overwrite option in the request to true.",
+            ));
+        }
+
         // Validate the tier/policy conflict BEFORE any KMS encryption work.
         // Policies are Advanced-tier only; rejecting a Standard-tier param
         // that carries policies must happen ahead of encrypt_secure_value so

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -395,6 +395,10 @@ struct PutParameterInput {
     /// only overwrite an existing parameter's ``data_type`` when this is true.
     data_type_explicit: bool,
     tier: String,
+    /// Whether the caller explicitly included ``Tier`` in the request. On
+    /// overwrite we only change an existing parameter's tier when this is
+    /// true; otherwise the existing tier is preserved (matching AWS).
+    tier_explicit: bool,
     policies: Option<String>,
     /// Pre-parsed `policies` view, populated by ``from_body`` when the
     /// caller supplied a non-empty Policies array. Notification policies
@@ -468,28 +472,23 @@ impl PutParameterInput {
                 .collect()
         });
 
+        let tier_explicit = body["Tier"].as_str().is_some();
         let tier = body["Tier"].as_str().unwrap_or("Standard").to_string();
 
         // Parse + validate the Policies JSON up front so PutParameter
         // can return InvalidPolicyAttributeException without touching
         // state. Empty/absent Policies -> empty list -> no-op.
+        //
+        // Note: the "Policies require Advanced tier" check is NOT done
+        // here because the effective tier depends on whether this is a
+        // create (uses the request tier) or an overwrite (may preserve
+        // the existing parameter's tier). Both paths enforce it against
+        // the effective tier.
         let policies = body["Policies"].as_str().map(|s| s.to_string());
         let parsed_policies = match policies.as_deref() {
             Some(s) if !s.trim().is_empty() => parse_policies(s)?,
             _ => Vec::new(),
         };
-
-        // AWS only allows policies on Advanced-tier parameters. The
-        // real API rejects this with ValidationException; we mirror
-        // that.
-        if !parsed_policies.is_empty() && tier != "Advanced" {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationException",
-                "Policies are only supported on Advanced-tier parameters. \
-                 Set Tier=Advanced when including Policies.",
-            ));
-        }
 
         Ok(Self {
             name,
@@ -502,6 +501,7 @@ impl PutParameterInput {
             data_type,
             data_type_explicit,
             tier,
+            tier_explicit,
             policies,
             parsed_policies,
             tags,
@@ -530,6 +530,37 @@ fn apply_overwrite(
             StatusCode::BAD_REQUEST,
             "ValidationException",
             "Invalid request: tags and overwrite can't be used together.",
+        ));
+    }
+
+    // Derive the effective tier: an explicit Tier in the request wins,
+    // otherwise the existing parameter's tier is preserved across the
+    // overwrite (AWS never silently downgrades a tier when Tier is
+    // omitted). Validate before mutating so a rejection leaves the
+    // parameter untouched.
+    let effective_tier = if input.tier_explicit {
+        input.tier.clone()
+    } else {
+        existing.tier.clone()
+    };
+    // Policies are Advanced-tier only. Compute whether policies will be
+    // attached after this overwrite: a non-empty Policies set in the
+    // request replaces the old one; omitting Policies preserves whatever
+    // is already attached. Either way, an Advanced-only policy must not
+    // end up on a non-Advanced parameter.
+    let policies_present_after = match input.policies.as_deref() {
+        Some(s) => !s.trim().is_empty(),
+        None => existing
+            .policies
+            .as_deref()
+            .is_some_and(|p| !p.trim().is_empty()),
+    };
+    if policies_present_after && effective_tier != "Advanced" {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "Policies are only supported on Advanced-tier parameters. \
+             Set Tier=Advanced when including Policies.",
         ));
     }
 
@@ -605,6 +636,10 @@ fn apply_overwrite(
     if input.policies.is_some() {
         existing.policies = input.policies;
     }
+    // Apply the effective tier computed (and validated) above so the
+    // response echoes the correct tier and a Tier upgrade actually
+    // takes effect on the stored parameter.
+    existing.tier = effective_tier;
     existing.expiration_notified = false;
     existing.no_change_notified = false;
 
@@ -628,6 +663,21 @@ fn create_new_parameter(
             "A parameter type is required when you create a parameter.",
         )
     })?;
+
+    // Policies are Advanced-tier only; a brand-new parameter's effective
+    // tier is exactly the request tier.
+    let policies_present = input
+        .policies
+        .as_deref()
+        .is_some_and(|p| !p.trim().is_empty());
+    if policies_present && input.tier != "Advanced" {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "Policies are only supported on Advanced-tier parameters. \
+             Set Tier=Advanced when including Policies.",
+        ));
+    }
 
     let tag_map = input
         .tags

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -5026,3 +5026,47 @@ fn put_parameter_overwrite_rejects_downgrade_with_policies() {
     assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     assert!(err.message().contains("Advanced"));
 }
+
+/// A duplicate PutParameter WITHOUT Overwrite must return ParameterAlreadyExists,
+/// even when the request would otherwise trip the tier/policy validation
+/// (which only matters for a write that is actually applied). The
+/// already-exists check must precede the tier/policy validation.
+#[test]
+fn put_parameter_duplicate_without_overwrite_reports_already_exists_first() {
+    let svc = make_service();
+    // Existing Advanced parameter carrying a policy.
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": "9999-01-01T00:00:00.000Z" }
+    }]))
+    .unwrap();
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({
+            "Name": "/dup-param",
+            "Value": "v1",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": policies,
+        }),
+    ))
+    .unwrap();
+
+    // Re-put WITHOUT Overwrite, and with Tier=Standard (which, combined with
+    // the existing policy, would trip the tier/policy validation if it ran
+    // first). AWS returns ParameterAlreadyExists instead.
+    let err = match svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({
+            "Name": "/dup-param",
+            "Value": "v2",
+            "Type": "String",
+            "Tier": "Standard",
+        }),
+    )) {
+        Err(e) => e,
+        Ok(_) => panic!("duplicate without overwrite must fail"),
+    };
+    assert_eq!(err.code(), "ParameterAlreadyExists");
+}

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -3267,6 +3267,68 @@ fn put_parameter_secure_string_hard_fails_when_kms_rejects() {
     assert_eq!(err.code(), "InvalidKeyId");
 }
 
+/// The tier/policy conflict must be rejected BEFORE any KMS encryption work,
+/// so a SecureString + Standard-tier + Policies request surfaces the
+/// validation error rather than the KMS/InvalidKeyId error.
+#[test]
+fn put_parameter_validates_tier_policy_before_kms() {
+    use fakecloud_core::delivery::KmsHook;
+    use std::collections::HashMap;
+
+    struct AlwaysFailKms;
+    impl KmsHook for AlwaysFailKms {
+        fn encrypt(
+            &self,
+            _account_id: &str,
+            _region: &str,
+            _key_id: &str,
+            _plaintext: &[u8],
+            _service_principal: &str,
+            _ec: HashMap<String, String>,
+        ) -> Result<String, String> {
+            Err("KMS unavailable".into())
+        }
+        fn decrypt(
+            &self,
+            _account_id: &str,
+            _ciphertext_b64: &str,
+            _service_principal: &str,
+            _ec: HashMap<String, String>,
+        ) -> Result<Vec<u8>, String> {
+            Err("KMS unavailable".into())
+        }
+    }
+
+    let svc = make_service().with_kms_hook(Arc::new(AlwaysFailKms));
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": "9999-01-01T00:00:00.000Z" }
+    }]))
+    .unwrap();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/secure-standard-policy",
+            "Value": "secret",
+            "Type": "SecureString",
+            "Policies": policies
+        }),
+    );
+    let err = match svc.put_parameter(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("standard tier + policies must be rejected"),
+    };
+    // The validation error (remapped from ValidationException) must win over
+    // the KMS InvalidKeyId error, proving validation runs first.
+    assert_ne!(err.code(), "InvalidKeyId");
+    assert!(
+        err.message().contains("Advanced"),
+        "expected the Advanced-tier validation message, got: {}",
+        err.message()
+    );
+}
+
 #[test]
 fn put_parameter_string_list() {
     let svc = make_service();

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -4809,3 +4809,158 @@ async fn snapshot_hook_fires_with_store() {
     // Must not panic; exercises the closure and the snapshot save path.
     hook().await;
 }
+
+/// UpdateAssociation must persist SyncCompliance, ApplyOnlyAtCronInterval,
+/// ScheduleOffset and OutputLocation, all of which DescribeAssociation
+/// echoes back (regression: previously silently dropped).
+#[test]
+fn update_association_persists_sync_compliance_and_friends() {
+    let svc = make_service();
+    let assoc_id = create_assoc_with_instance(&svc, "AWS-RunShellScript", "i-sync");
+    let output_location = json!({
+        "S3Location": {
+            "OutputS3BucketName": "my-bucket",
+            "OutputS3KeyPrefix": "ssm/",
+        }
+    });
+    let req = make_request(
+        "UpdateAssociation",
+        json!({
+            "AssociationId": assoc_id,
+            "ScheduleExpression": "cron(0 2 ? * SUN *)",
+            "SyncCompliance": "Manual",
+            "ApplyOnlyAtCronInterval": true,
+            "ScheduleOffset": 3,
+            "OutputLocation": output_location,
+        }),
+    );
+    let resp = svc.update_association(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let ad = &body["AssociationDescription"];
+    assert_eq!(ad["SyncCompliance"].as_str().unwrap(), "Manual");
+    assert!(ad["ApplyOnlyAtCronInterval"].as_bool().unwrap());
+    assert_eq!(ad["ScheduleOffset"].as_i64().unwrap(), 3);
+    assert_eq!(ad["OutputLocation"], output_location);
+
+    // Round-trips through DescribeAssociation too.
+    let desc = svc
+        .describe_association(&make_request(
+            "DescribeAssociation",
+            json!({"AssociationId": assoc_id}),
+        ))
+        .unwrap();
+    let dbody: Value = serde_json::from_slice(desc.body.expect_bytes()).unwrap();
+    let dad = &dbody["AssociationDescription"];
+    assert_eq!(dad["SyncCompliance"].as_str().unwrap(), "Manual");
+    assert!(dad["ApplyOnlyAtCronInterval"].as_bool().unwrap());
+    assert_eq!(dad["ScheduleOffset"].as_i64().unwrap(), 3);
+    assert_eq!(dad["OutputLocation"], output_location);
+}
+
+/// PutParameter(Overwrite=true) with Tier=Advanced must actually upgrade the
+/// stored tier and echo the new tier (regression: tier was never updated so
+/// the response echoed the old Standard tier).
+#[test]
+fn put_parameter_overwrite_upgrades_tier() {
+    let svc = make_service();
+    // Create a Standard-tier parameter.
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({"Name": "/tier-upgrade", "Value": "v1", "Type": "String"}),
+    ))
+    .unwrap();
+
+    // Overwrite to Advanced with a valid Expiration policy.
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": "9999-01-01T00:00:00.000Z" }
+    }]))
+    .unwrap();
+    let resp = svc
+        .put_parameter(&make_request(
+            "PutParameter",
+            json!({
+                "Name": "/tier-upgrade",
+                "Value": "v2",
+                "Overwrite": true,
+                "Tier": "Advanced",
+                "Policies": policies,
+            }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Tier"].as_str().unwrap(), "Advanced");
+
+    // GetParameter (describe path) reports Advanced too.
+    let desc = svc
+        .describe_parameters(&make_request(
+            "DescribeParameters",
+            json!({"ParameterFilters": [{"Key": "Name", "Values": ["/tier-upgrade"]}]}),
+        ))
+        .unwrap();
+    let dbody: Value = serde_json::from_slice(desc.body.expect_bytes()).unwrap();
+    assert_eq!(dbody["Parameters"][0]["Tier"].as_str().unwrap(), "Advanced");
+}
+
+/// PutParameter overwrite must preserve the existing tier when Tier is
+/// omitted from the request (AWS never silently downgrades).
+#[test]
+fn put_parameter_overwrite_preserves_tier_when_omitted() {
+    let svc = make_service();
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({"Name": "/tier-keep", "Value": "v1", "Type": "String", "Tier": "Advanced"}),
+    ))
+    .unwrap();
+
+    let resp = svc
+        .put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/tier-keep", "Value": "v2", "Overwrite": true}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Tier"].as_str().unwrap(), "Advanced");
+}
+
+/// Overwriting an Advanced parameter (that carries policies) down to
+/// Standard while keeping the policies must be rejected: advanced-only
+/// policies cannot live on a Standard-tier parameter.
+#[test]
+fn put_parameter_overwrite_rejects_downgrade_with_policies() {
+    let svc = make_service();
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": "9999-01-01T00:00:00.000Z" }
+    }]))
+    .unwrap();
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({
+            "Name": "/tier-downgrade",
+            "Value": "v1",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": policies,
+        }),
+    ))
+    .unwrap();
+
+    // Downgrade to Standard without clearing the policies -> rejected.
+    let err = match svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({
+            "Name": "/tier-downgrade",
+            "Value": "v2",
+            "Overwrite": true,
+            "Tier": "Standard",
+        }),
+    )) {
+        Err(e) => e,
+        Ok(_) => panic!("downgrade with policies should fail"),
+    };
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    assert!(err.message().contains("Advanced"));
+}


### PR DESCRIPTION
## Summary

Batch 8d of the fakecloud bug-hunt: 12 behavioral fixes across 7 services. Every finding persists real state and reads it back, with a focused unit test per fix.

**SSM**
- `UpdateAssociation` persists `SyncCompliance`, `ApplyOnlyAtCronInterval`, `ScheduleOffset`, `OutputLocation` (all settable at create + echoed by `DescribeAssociation`, previously dropped on update).
- `PutParameter(Overwrite=true)` derives the effective tier correctly (explicit `Tier` wins, else the existing tier is preserved) and rejects advanced-only `Policies` on a non-Advanced parameter across both create and overwrite paths.

**SecretsManager**
- `RotateSecret` honors `RotateImmediately` (default true per AWS); when false it saves the rotation config and schedules the next rotation without rotating the value now (no Lambda invocation, `LastRotatedDate` untouched).
- `CreateSecret` honors `AddReplicaRegions`, persisting the replication status and echoing `ReplicationStatus` on the create response and `DescribeSecret`.

**SES**
- SESv2 `CreateEmailIdentity` honors `DkimSigningAttributes`: BYODKIM uses the caller's `DomainSigningSelector` + `DomainSigningPrivateKey` (origin `EXTERNAL`); Easy DKIM honors `NextSigningKeyLength`. Correct `DkimAttributes` / `SigningAttributesOrigin` echoed on create and `GetEmailIdentity`.
- SES v1 `CreateConfigurationSetEventDestination` persists Kinesis Firehose and CloudWatch destinations (not just SNS); `DescribeConfigurationSet` now echoes all destination targets. `UpdateConfigurationSetEventDestination` applies them too.

**EventBridge**
- `DescribeConnection` includes `InvocationHttpParameters` (`HeaderParameters` / `QueryStringParameters` / `BodyParameters`); secret values are hidden on read, keys + `IsValueSecret` round-trip.

**Firehose**
- `UpdateDestination` keeps `DestinationId` stable across updates, applies partial `*Update` blocks (`RoleARN`/`BucketARN` optional), validates `CurrentDeliveryStreamVersionId` and increments the stream version.

**apigateway (v1)**
- `UpdateStage` stores method settings under the AWS `"{resourcePath}/{httpMethod}"` key with the proper MethodSetting shape (typed fields), fixing a Terraform `aws_api_gateway_method_settings` perpetual diff.

**IAM**
- `CreatePolicyVersion` and `ListPolicyVersions` no longer return the policy `Document` (only `GetPolicyVersion` does, URL-encoded), matching AWS.
- `CreateServiceLinkedRole` derives the ARN partition from the request region; both `partition_for_region` helpers now cover GovCloud (`aws-us-gov`).

Intentionally skipped: the `FKIA` access-key-id prefix (report item 83) is left unchanged as a deliberate marker.

No new API surface -> SDKs/docs/website unaffected.

## Test plan
- New unit tests, one per finding (round-trip / validation): SSM assoc + tier upgrade/preserve/downgrade-reject; SecretsManager RotateImmediately true/false + AddReplicaRegions; SES BYODKIM + Easy-DKIM key length + v1 Kinesis/CloudWatch describe; EventBridge InvocationHttpParameters redaction; Firehose stable DestinationId + partial update + stale-version reject; apigateway MethodSetting shape + remove; IAM Document omission + gov partition.
- `cargo nextest run` green per crate: ssm 229, secretsmanager 116, ses 255, eventbridge 225, firehose 18 (+ new), apigateway 92, iam 498.
- `cargo clippy -p ... --all-targets -- -D warnings` clean across all 7 crates.
- `cargo fmt --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted dropped inputs and aligned AWS response shapes across `ssm`, `secretsmanager`, `ses`, `eventbridge`, `firehose`, `apigateway`, and `iam` to improve round-trip accuracy and validation, and to eliminate Terraform diffs.

- **Bug Fixes**
  - `ssm`: UpdateAssociation now persists SyncCompliance, ApplyOnlyAtCronInterval, ScheduleOffset, and OutputLocation. PutParameter preserves or updates Tier correctly (explicit wins; else keep existing), validates tier/policy before any KMS work, rejects Advanced-only Policies on non-Advanced (create/overwrite), and with Overwrite=false returns ParameterAlreadyExists before validation.
  - `secretsmanager`: RotateSecret honors RotateImmediately. When false and a Lambda is set, runs testSecret only, stages a temporary AWSPENDING version keyed by the token, then removes it synchronously so no AWSPENDING remains; LastRotatedDate unchanged. CreateSecret persists AddReplicaRegions and returns ReplicationStatus on create/describe.
  - `ses`: v2 CreateEmailIdentity supports BYODKIM (EXTERNAL) and Easy DKIM NextSigningKeyLength; BYODKIM private keys (base64 DER) are normalized to PEM on create and PutEmailIdentityDkimSigningAttributes; correct DkimAttributes on create/get. v1 event destinations persist/describe Kinesis Firehose and CloudWatch; exactly one target required; updates validate before mutating and clear other targets when switching.
  - `eventbridge`: DescribeConnection now returns InvocationHttpParameters; secret values redacted, keys and IsValueSecret preserved.
  - `firehose`: UpdateDestination requires CurrentDeliveryStreamVersionId and DestinationId, rejects stale versions and mismatched DestinationId, merges partial S3 updates, keeps DestinationId stable, and bumps VersionId.
  - `apigateway` (v1): UpdateStage stores methodSettings under "{resourcePath}/{httpMethod}" with typed MethodSetting and cleanly removes fields (dropping empty entries), fixing `aws_api_gateway_method_settings` diffs.
  - `iam`: CreatePolicyVersion/ListPolicyVersions omit Document (only GetPolicyVersion returns it, URL-encoded). CreateServiceLinkedRole derives the ARN partition from the request region (incl. `aws-us-gov`); helpers updated accordingly.

<sup>Written for commit 76c9f9fed0506e0aedb69f16f87bdfa54f56e54b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

