### PR TITLE
fix(cognito): identity claims, token validity, GetUser shape, alias usernames

### DIFF
--- a/crates/fakecloud-cognito/src/service/auth/admin.rs
+++ b/crates/fakecloud-cognito/src/service/auth/admin.rs
@@ -188,6 +188,7 @@ impl CognitoService {
                 username: input.username.clone(),
                 client_id: input.client_id.clone(),
                 issued_at: Utc::now(),
+                expires_at: Some(Utc::now() + chrono::Duration::seconds(tokens.expires_in)),
             },
         );
 
@@ -252,6 +253,11 @@ impl CognitoService {
         // Validate pool exists
         ensure_user_pool_exists(state, pool_id)?;
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         let user = state
             .users
             .get_mut(pool_id)
@@ -310,6 +316,11 @@ impl CognitoService {
         // Validate pool exists
         ensure_user_pool_exists(state, pool_id)?;
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         let user = state
             .users
             .get_mut(pool_id)
@@ -343,6 +354,11 @@ impl CognitoService {
 
         // Validate pool exists
         ensure_user_pool_exists(state, pool_id)?;
+
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
 
         // Validate user exists
         if !state

--- a/crates/fakecloud-cognito/src/service/auth/admin.rs
+++ b/crates/fakecloud-cognito/src/service/auth/admin.rs
@@ -155,6 +155,12 @@ impl CognitoService {
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
+        let claims = crate::service::token_claims_for(
+            state,
+            &input.pool_id,
+            &input.username,
+            &input.client_id,
+        );
         let tokens = generate_tokens(
             &input.pool_id,
             &input.client_id,
@@ -162,6 +168,7 @@ impl CognitoService {
             &input.username,
             region,
             signing,
+            &claims,
         );
 
         state.refresh_tokens.insert(

--- a/crates/fakecloud-cognito/src/service/auth/challenges.rs
+++ b/crates/fakecloud-cognito/src/service/auth/challenges.rs
@@ -38,7 +38,8 @@ impl CognitoService {
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
-        let tokens = generate_tokens(pool_id, client_id, &sub, username, region, signing);
+        let claims = crate::service::token_claims_for(state, pool_id, username, client_id);
+        let tokens = generate_tokens(pool_id, client_id, &sub, username, region, signing, &claims);
 
         state.refresh_tokens.insert(
             tokens.refresh_token.clone(),
@@ -75,7 +76,7 @@ impl CognitoService {
                 "IdToken": tokens.id_token,
                 "RefreshToken": tokens.refresh_token,
                 "TokenType": "Bearer",
-                "ExpiresIn": 3600
+                "ExpiresIn": tokens.expires_in
             }
         })))
     }
@@ -517,7 +518,10 @@ impl CognitoService {
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
-        let tokens = generate_tokens(&pool_id, client_id, &sub, &username, &region, signing);
+        let claims = crate::service::token_claims_for(state, &pool_id, &username, client_id);
+        let tokens = generate_tokens(
+            &pool_id, client_id, &sub, &username, &region, signing, &claims,
+        );
 
         state.refresh_tokens.insert(
             tokens.refresh_token.clone(),
@@ -545,7 +549,7 @@ impl CognitoService {
                 "IdToken": tokens.id_token,
                 "RefreshToken": tokens.refresh_token,
                 "TokenType": "Bearer",
-                "ExpiresIn": 3600
+                "ExpiresIn": tokens.expires_in
             }
         })))
     }
@@ -856,7 +860,8 @@ impl CognitoService {
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
-        let tokens = generate_tokens(pool_id, client_id, &sub, username, region, signing);
+        let claims = crate::service::token_claims_for(state, pool_id, username, client_id);
+        let tokens = generate_tokens(pool_id, client_id, &sub, username, region, signing, &claims);
 
         state.refresh_tokens.insert(
             tokens.refresh_token.clone(),
@@ -893,7 +898,7 @@ impl CognitoService {
                 "IdToken": tokens.id_token,
                 "RefreshToken": tokens.refresh_token,
                 "TokenType": "Bearer",
-                "ExpiresIn": 3600
+                "ExpiresIn": tokens.expires_in
             }
         })))
     }

--- a/crates/fakecloud-cognito/src/service/auth/challenges.rs
+++ b/crates/fakecloud-cognito/src/service/auth/challenges.rs
@@ -57,6 +57,7 @@ impl CognitoService {
                 username: username.to_string(),
                 client_id: client_id.to_string(),
                 issued_at: Utc::now(),
+                expires_at: Some(Utc::now() + chrono::Duration::seconds(tokens.expires_in)),
             },
         );
         state.auth_events.push(AuthEvent {
@@ -540,6 +541,7 @@ impl CognitoService {
                 username,
                 client_id: client_id.to_string(),
                 issued_at: Utc::now(),
+                expires_at: Some(Utc::now() + chrono::Duration::seconds(tokens.expires_in)),
             },
         );
 
@@ -879,6 +881,7 @@ impl CognitoService {
                 username: username.to_string(),
                 client_id: client_id.to_string(),
                 issued_at: Utc::now(),
+                expires_at: Some(Utc::now() + chrono::Duration::seconds(tokens.expires_in)),
             },
         );
         state.auth_events.push(AuthEvent {

--- a/crates/fakecloud-cognito/src/service/auth/initiate.rs
+++ b/crates/fakecloud-cognito/src/service/auth/initiate.rs
@@ -7,7 +7,15 @@ impl CognitoService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let input = AdminAuthInput::from_request(&req.json_body())?;
+        let mut input = AdminAuthInput::from_request(&req.json_body())?;
+        // Resolve an email/phone alias to the stored username for pools with
+        // UsernameAttributes / AliasAttributes.
+        input.username = {
+            let accounts = self.state.read();
+            let empty = CognitoState::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+            crate::service::resolve_alias_username(state, &input.pool_id, &input.username)
+        };
         let lookup = self.admin_auth_lookup(&input, req)?;
 
         if let Some(ctx) = self.delivery_ctx.as_ref() {
@@ -78,7 +86,7 @@ impl CognitoService {
                 "IdToken": tokens.id_token,
                 "RefreshToken": tokens.refresh_token,
                 "TokenType": "Bearer",
-                "ExpiresIn": 3600
+                "ExpiresIn": tokens.expires_in
             }
         })))
     }
@@ -354,6 +362,16 @@ impl CognitoService {
             ));
         }
 
+        // Resolve an email/phone alias to the stored (possibly UUID) username
+        // so SRP handshakes work for UsernameAttributes pools too.
+        let resolved_username = {
+            let accounts = self.state.read();
+            let empty = CognitoState::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+            crate::service::resolve_alias_username(state, pool_id, username)
+        };
+        let username = resolved_username.as_str();
+
         let password = {
             let accounts = self.state.read();
             let empty = CognitoState::new(&req.account_id, &req.region);
@@ -489,8 +507,21 @@ impl CognitoService {
             })?;
 
         // When the app client has a secret, the request must present a
-        // valid SECRET_HASH (matches the OAuth /token enforcement).
+        // valid SECRET_HASH (matches the OAuth /token enforcement). This is
+        // computed against the username the client actually sent, so it must
+        // run BEFORE we resolve an email/phone alias to the stored username.
         self.require_secret_hash(client_id, username, auth_params.get("SECRET_HASH"))?;
+
+        // Pools with UsernameAttributes / AliasAttributes let users sign in
+        // with their email/phone while the stored username is a UUID. Resolve
+        // the supplied identifier to the real username for all lookups below.
+        let resolved_username = {
+            let accounts = self.state.read();
+            let empty = CognitoState::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+            crate::service::resolve_alias_username(state, pool_id, username)
+        };
+        let username = resolved_username.as_str();
 
         // CompromisedCredentialsRiskConfiguration: when the pool has a
         // risk config with `EventAction = BLOCK` for sign-in events and
@@ -682,6 +713,8 @@ impl CognitoService {
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
+        let claims =
+            crate::service::collect_token_claims(&self.state, pool_id, username, client_id);
         let tokens = crate::service::generate_tokens_with_overrides(
             pool_id,
             client_id,
@@ -692,6 +725,7 @@ impl CognitoService {
             None,
             None,
             pretoken_overrides.as_ref(),
+            &claims,
         );
 
         {
@@ -754,7 +788,7 @@ impl CognitoService {
                 "IdToken": tokens.id_token,
                 "RefreshToken": tokens.refresh_token,
                 "TokenType": "Bearer",
-                "ExpiresIn": 3600
+                "ExpiresIn": tokens.expires_in
             }
         })))
     }
@@ -1054,6 +1088,8 @@ impl CognitoService {
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
+        let claims =
+            crate::service::token_claims_for(state, &token_pool_id, &token_username, client_id);
         let tokens = generate_tokens(
             &token_pool_id,
             client_id,
@@ -1061,6 +1097,7 @@ impl CognitoService {
             &token_username,
             &region,
             signing,
+            &claims,
         );
 
         state.access_tokens.insert(
@@ -1078,7 +1115,7 @@ impl CognitoService {
                 "AccessToken": tokens.access_token,
                 "IdToken": tokens.id_token,
                 "TokenType": "Bearer",
-                "ExpiresIn": 3600
+                "ExpiresIn": tokens.expires_in
             }
         })))
     }

--- a/crates/fakecloud-cognito/src/service/auth/initiate.rs
+++ b/crates/fakecloud-cognito/src/service/auth/initiate.rs
@@ -272,6 +272,18 @@ impl CognitoService {
             })?;
         self.require_secret_hash(client_id, username, auth_params.get("SECRET_HASH"))?;
 
+        // Resolve an email/phone alias to the stored username BEFORE stashing
+        // the SELECT_CHALLENGE session, so every downstream challenge
+        // (PASSWORD, PASSWORD_SRP, ...) resolves the right user. SECRET_HASH is
+        // already validated against the client-supplied identifier above.
+        let resolved_username = {
+            let accounts = self.state.read();
+            let empty = CognitoState::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+            crate::service::resolve_alias_username(state, pool_id, username)
+        };
+        let username = resolved_username.as_str();
+
         let preferred = auth_params
             .get("PREFERRED_CHALLENGE")
             .and_then(|v| v.as_str());
@@ -748,6 +760,7 @@ impl CognitoService {
                     username: username.to_string(),
                     client_id: client_id.to_string(),
                     issued_at: Utc::now(),
+                    expires_at: Some(Utc::now() + chrono::Duration::seconds(tokens.expires_in)),
                 },
             );
 
@@ -1107,6 +1120,7 @@ impl CognitoService {
                 username: token_username,
                 client_id: client_id.to_string(),
                 issued_at: Utc::now(),
+                expires_at: Some(Utc::now() + chrono::Duration::seconds(tokens.expires_in)),
             },
         );
 

--- a/crates/fakecloud-cognito/src/service/groups.rs
+++ b/crates/fakecloud-cognito/src/service/groups.rs
@@ -231,6 +231,11 @@ impl CognitoService {
 
         ensure_user_pool_exists(state, pool_id)?;
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         // Validate user exists
         if !state
             .users
@@ -286,6 +291,11 @@ impl CognitoService {
 
         ensure_user_pool_exists(state, pool_id)?;
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         // Validate user exists
         if !state
             .users
@@ -339,6 +349,11 @@ impl CognitoService {
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
         ensure_user_pool_exists(state, pool_id)?;
+
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
 
         // Validate user exists
         if !state

--- a/crates/fakecloud-cognito/src/service/legacy.rs
+++ b/crates/fakecloud-cognito/src/service/legacy.rs
@@ -41,6 +41,10 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let username = crate::service::resolve_alias_username(state, &pool_id, &username);
+
         // Validate pool and user exist
         let users = state.users.get_mut(&pool_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -180,6 +184,14 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
+        // For a Cognito destination the ProviderAttributeValue IS the username,
+        // which may be an email/phone alias in a UsernameAttributes pool.
+        let dest_username = if dest_provider == "Cognito" {
+            crate::service::resolve_alias_username(state, pool_id, dest_attr_value)
+        } else {
+            dest_attr_value.to_string()
+        };
+
         let users = state.users.get_mut(pool_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -190,7 +202,7 @@ impl CognitoService {
 
         // Find the destination user (by Cognito username or provider attribute)
         let user = if dest_provider == "Cognito" {
-            users.get_mut(dest_attr_value)
+            users.get_mut(&dest_username)
         } else {
             users.values_mut().find(|u| {
                 u.linked_providers.iter().any(|lp| {
@@ -232,6 +244,11 @@ impl CognitoService {
         let accounts = self.state.read();
         let empty = CognitoState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
 
         // Validate pool and user
         let users = state.users.get(pool_id).ok_or_else(|| {
@@ -312,6 +329,11 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         // Validate pool and user
         if !state
             .users
@@ -355,6 +377,11 @@ impl CognitoService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
 
         // Validate pool and user
         if !state

--- a/crates/fakecloud-cognito/src/service/mfa.rs
+++ b/crates/fakecloud-cognito/src/service/mfa.rs
@@ -165,6 +165,11 @@ impl CognitoService {
         // Verify pool exists
         ensure_user_pool_exists(state, pool_id)?;
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         let user = state
             .users
             .get_mut(pool_id)

--- a/crates/fakecloud-cognito/src/service/misc.rs
+++ b/crates/fakecloud-cognito/src/service/misc.rs
@@ -167,6 +167,11 @@ impl CognitoService {
         let empty = CognitoState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         let users = state.users.get(pool_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -209,6 +214,11 @@ impl CognitoService {
         let accounts = self.state.read();
         let empty = CognitoState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
 
         let users = state.users.get(pool_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -268,6 +278,11 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         let users = state.users.get_mut(pool_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -309,6 +324,11 @@ impl CognitoService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
 
         let users = state.users.get_mut(pool_id).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -739,6 +759,7 @@ impl CognitoService {
                 username,
                 client_id: client_id.to_string(),
                 issued_at: now,
+                expires_at: Some(now + chrono::Duration::seconds(tokens.expires_in)),
             },
         );
 

--- a/crates/fakecloud-cognito/src/service/misc.rs
+++ b/crates/fakecloud-cognito/src/service/misc.rs
@@ -702,7 +702,10 @@ impl CognitoService {
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
-        let tokens = super::generate_tokens(&pool_id, client_id, &sub, &username, &region, signing);
+        let claims = super::token_claims_for(state, &pool_id, &username, client_id);
+        let tokens = super::generate_tokens(
+            &pool_id, client_id, &sub, &username, &region, signing, &claims,
+        );
 
         let rotation_enabled = state
             .user_pool_clients
@@ -743,7 +746,7 @@ impl CognitoService {
             "AccessToken": tokens.access_token,
             "IdToken": tokens.id_token,
             "TokenType": "Bearer",
-            "ExpiresIn": 3600
+            "ExpiresIn": tokens.expires_in
         });
         if let Some(ref rt) = rotated_refresh {
             auth["RefreshToken"] = json!(rt);

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1306,33 +1306,44 @@ enum FilterOp {
     StartsWith,
 }
 
-/// Parse a Cognito ListUsers filter expression like `email = "foo@bar.com"` or `email ^= "foo"`.
+/// Parse a Cognito ListUsers filter expression like `email = "foo@bar.com"` or
+/// `email ^= "foo"`. Returns `None` for any malformed input (missing operator,
+/// empty attribute, or a value that is not a non-empty double-quoted string);
+/// callers surface `None` as `InvalidParameterException`.
 fn parse_filter_expression(filter: &str) -> Option<FilterExpression> {
     let filter = filter.trim();
 
-    // Try ^= first (starts with)
-    if let Some((attr, val)) = filter.split_once("^=") {
-        let attribute = attr.trim().trim_matches('"').to_string();
-        let value = val.trim().trim_matches('"').to_string();
-        return Some(FilterExpression {
-            attribute,
-            operator: FilterOp::StartsWith,
-            value,
-        });
+    // `^=` (starts-with) must be tried before `=`.
+    let (attr_raw, value_raw, operator) = if let Some((attr, val)) = filter.split_once("^=") {
+        (attr, val, FilterOp::StartsWith)
+    } else if let Some((attr, val)) = filter.split_once('=') {
+        (attr, val, FilterOp::Equals)
+    } else {
+        return None;
+    };
+
+    // Attribute: non-empty (optional surrounding quotes tolerated).
+    let attribute = attr_raw.trim().trim_matches('"').trim().to_string();
+    if attribute.is_empty() {
+        return None;
     }
 
-    // Try = (equals)
-    if let Some((attr, val)) = filter.split_once('=') {
-        let attribute = attr.trim().trim_matches('"').to_string();
-        let value = val.trim().trim_matches('"').to_string();
-        return Some(FilterExpression {
-            attribute,
-            operator: FilterOp::Equals,
-            value,
-        });
+    // Value MUST be a non-empty, properly double-quoted string. Reject
+    // `email = ` (empty), `email = x` (unquoted), and `email = "` (unterminated).
+    let value_raw = value_raw.trim();
+    if value_raw.len() < 2 || !value_raw.starts_with('"') || !value_raw.ends_with('"') {
+        return None;
+    }
+    let value = value_raw[1..value_raw.len() - 1].to_string();
+    if value.is_empty() {
+        return None;
     }
 
-    None
+    Some(FilterExpression {
+        attribute,
+        operator,
+        value,
+    })
 }
 
 /// Check if a user matches a filter expression.
@@ -2103,9 +2114,19 @@ fn generate_tokens_with_overrides(
         };
         apply_claim_overrides(id_payload.as_object_mut().unwrap(), id_block);
         apply_claim_overrides(access_payload.as_object_mut().unwrap(), access_block);
+        // An explicit `groupsToOverride` (even an empty array) REPLACES the
+        // real-membership groups: a present-but-empty list clears
+        // `cognito:groups`, matching real Cognito. Only a fully absent
+        // `groupOverrideDetails` leaves the real membership untouched.
         if let Some(arr) = group_block["groupsToOverride"].as_array() {
             let groups: Vec<Value> = arr.iter().filter(|v| v.is_string()).cloned().collect();
-            if !groups.is_empty() {
+            if groups.is_empty() {
+                id_payload.as_object_mut().unwrap().remove("cognito:groups");
+                access_payload
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("cognito:groups");
+            } else {
                 id_payload["cognito:groups"] = Value::Array(groups.clone());
                 access_payload["cognito:groups"] = Value::Array(groups);
             }
@@ -2641,6 +2662,7 @@ async fn handle_authorization_code_grant(
                     username: consumed.username.clone(),
                     client_id: client_id.to_string(),
                     issued_at: Utc::now(),
+                    expires_at: Some(Utc::now() + chrono::Duration::seconds(tokens.expires_in)),
                 },
             );
             break;
@@ -2736,6 +2758,7 @@ async fn handle_refresh_token_grant(
                     username: username.clone(),
                     client_id: client_id.to_string(),
                     issued_at: Utc::now(),
+                    expires_at: Some(Utc::now() + chrono::Duration::seconds(tokens.expires_in)),
                 },
             );
             break;
@@ -2830,6 +2853,7 @@ async fn handle_client_credentials_grant(
                     username: client_id.to_string(),
                     client_id: client_id.to_string(),
                     issued_at: Utc::now(),
+                    expires_at: Some(Utc::now() + chrono::Duration::seconds(access_ttl)),
                 },
             );
             break;
@@ -3405,6 +3429,9 @@ pub async fn handle_oauth2_authorize(
                             username: username.to_string(),
                             client_id: req.client_id.clone(),
                             issued_at: Utc::now(),
+                            expires_at: Some(
+                                Utc::now() + chrono::Duration::seconds(tokens.expires_in),
+                            ),
                         },
                     );
                     break;

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1340,7 +1340,11 @@ fn matches_filter(user: &User, filter: &FilterExpression) -> bool {
     let user_value = match filter.attribute.as_str() {
         "username" => Some(user.username.as_str()),
         "sub" => Some(user.sub.as_str()),
-        "cognito:user_status" | "status" => Some(user.user_status.as_str()),
+        // `cognito:user_status` is the account confirmation status
+        // (CONFIRMED / UNCONFIRMED / ...); `status` is the Enabled/Disabled
+        // flag. They are distinct filter attributes in real Cognito.
+        "cognito:user_status" => Some(user.user_status.as_str()),
+        "status" => Some(if user.enabled { "Enabled" } else { "Disabled" }),
         attr => user
             .attributes
             .iter()
@@ -1696,6 +1700,245 @@ struct TokenSet {
     id_token: String,
     access_token: String,
     refresh_token: String,
+    /// Access-token lifetime in seconds, honoring the app client's
+    /// `AccessTokenValidity` + `TokenValidityUnits`. Callers surface this as
+    /// `AuthenticationResult.ExpiresIn` and the OAuth `expires_in` field.
+    expires_in: i64,
+}
+
+/// OIDC standard claims that Cognito copies from a user's attributes into
+/// the **id** token (never the access token). `custom:*` attributes are
+/// handled separately and always pass through.
+const STANDARD_ID_TOKEN_CLAIMS: &[&str] = &[
+    "email",
+    "email_verified",
+    "phone_number",
+    "phone_number_verified",
+    "name",
+    "given_name",
+    "family_name",
+    "nickname",
+    "preferred_username",
+    "picture",
+    "locale",
+    "zoneinfo",
+    "birthdate",
+    "gender",
+    "middle_name",
+    "profile",
+    "website",
+    "updated_at",
+    "address",
+];
+
+/// Per-user, per-client context threaded into the token generator so issued
+/// id/access tokens carry real identity claims + group memberships and honor
+/// the app client's configured token validity. Built by [`token_claims_for`]
+/// (holding an account) or [`collect_token_claims`] (holding the shared lock).
+#[derive(Default, Clone)]
+pub(crate) struct TokenClaims {
+    /// The signed-in user's stored attributes (standard OIDC + `custom:*`),
+    /// injected into the id token.
+    pub attributes: Vec<UserAttribute>,
+    /// Group names the user belongs to, ordered by Precedence then creation.
+    /// Emitted as `cognito:groups` on both tokens.
+    pub groups: Vec<String>,
+    /// Access-token lifetime in seconds, already resolved from the client's
+    /// `AccessTokenValidity` + unit. `None` -> AWS default of 3600s.
+    pub access_validity_secs: Option<i64>,
+    /// Id-token lifetime in seconds. `None` -> AWS default of 3600s.
+    pub id_validity_secs: Option<i64>,
+}
+
+impl TokenClaims {
+    fn access_ttl(&self) -> i64 {
+        self.access_validity_secs.filter(|s| *s > 0).unwrap_or(3600)
+    }
+
+    fn id_ttl(&self) -> i64 {
+        self.id_validity_secs.filter(|s| *s > 0).unwrap_or(3600)
+    }
+}
+
+/// Multiplier (in seconds) for a `TokenValidityUnits` value. Cognito
+/// defaults access/id units to `hours`, refresh to `days`.
+fn token_validity_unit_secs(unit: Option<&str>, default: &str) -> i64 {
+    match unit.unwrap_or(default).to_ascii_lowercase().as_str() {
+        "seconds" => 1,
+        "minutes" => 60,
+        "hours" => 3600,
+        "days" => 86400,
+        _ => 3600,
+    }
+}
+
+/// Resolve an app client's (access, id) token lifetimes to seconds, applying
+/// `TokenValidityUnits` (default `hours`) to the raw validity integers.
+fn client_token_validity(client: &UserPoolClient) -> (Option<i64>, Option<i64>) {
+    let units = client.token_validity_units.as_ref();
+    let access = client.access_token_validity.map(|v| {
+        v * token_validity_unit_secs(units.and_then(|u| u.access_token.as_deref()), "hours")
+    });
+    let id = client
+        .id_token_validity
+        .map(|v| v * token_validity_unit_secs(units.and_then(|u| u.id_token.as_deref()), "hours"));
+    (access, id)
+}
+
+/// Group names a user belongs to, ordered by Precedence (ascending; groups
+/// without a precedence sort last) then creation date — matching how Cognito
+/// orders `cognito:groups`.
+fn ordered_user_groups(
+    account: &crate::state::CognitoState,
+    pool_id: &str,
+    username: &str,
+) -> Vec<String> {
+    let Some(names) = account
+        .user_groups
+        .get(pool_id)
+        .and_then(|m| m.get(username))
+    else {
+        return Vec::new();
+    };
+    let pool_groups = account.groups.get(pool_id);
+    let mut with_meta: Vec<(&String, Option<i64>, chrono::DateTime<Utc>)> = names
+        .iter()
+        .map(|n| {
+            let g = pool_groups.and_then(|pg| pg.get(n));
+            (
+                n,
+                g.and_then(|g| g.precedence),
+                g.map(|g| g.creation_date).unwrap_or_else(Utc::now),
+            )
+        })
+        .collect();
+    with_meta.sort_by(|a, b| {
+        match (a.1, b.1) {
+            (Some(x), Some(y)) => x.cmp(&y),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        }
+        .then(a.2.cmp(&b.2))
+    });
+    with_meta.into_iter().map(|(n, _, _)| n.clone()).collect()
+}
+
+/// Assemble the identity claims + validity for `(pool_id, username,
+/// client_id)` from a single account's state. Missing user/client fall back
+/// to empty defaults so token minting never fails.
+pub(crate) fn token_claims_for(
+    account: &crate::state::CognitoState,
+    pool_id: &str,
+    username: &str,
+    client_id: &str,
+) -> TokenClaims {
+    let attributes = account
+        .users
+        .get(pool_id)
+        .and_then(|u| u.get(username))
+        .map(|u| u.attributes.clone())
+        .unwrap_or_default();
+    let groups = ordered_user_groups(account, pool_id, username);
+    let (access_validity_secs, id_validity_secs) = account
+        .user_pool_clients
+        .get(client_id)
+        .map(client_token_validity)
+        .unwrap_or((None, None));
+    TokenClaims {
+        attributes,
+        groups,
+        access_validity_secs,
+        id_validity_secs,
+    }
+}
+
+/// Resolve a client-supplied sign-in identifier to the stored username key.
+/// With `UsernameAttributes` / `AliasAttributes`, the stored username may be a
+/// UUID while callers sign in with their email / phone / preferred_username.
+/// Returns the matching user's real username, or the input unchanged when it
+/// already is a username or no alias matches.
+pub(crate) fn resolve_alias_username(
+    account: &crate::state::CognitoState,
+    pool_id: &str,
+    supplied: &str,
+) -> String {
+    let Some(pool_users) = account.users.get(pool_id) else {
+        return supplied.to_string();
+    };
+    // A literal username always wins over alias resolution.
+    if pool_users.contains_key(supplied) {
+        return supplied.to_string();
+    }
+    // Attributes that act as sign-in aliases for this pool.
+    let mut alias_attrs: Vec<&str> = Vec::new();
+    if let Some(pool) = account.user_pools.get(pool_id) {
+        if let Some(ua) = &pool.username_attributes {
+            alias_attrs.extend(ua.iter().map(String::as_str));
+        }
+        if let Some(aa) = &pool.alias_attributes {
+            alias_attrs.extend(aa.iter().map(String::as_str));
+        }
+    }
+    if alias_attrs.is_empty() {
+        return supplied.to_string();
+    }
+    for (uname, user) in pool_users {
+        if user
+            .attributes
+            .iter()
+            .any(|attr| alias_attrs.contains(&attr.name.as_str()) && attr.value == supplied)
+        {
+            return uname.clone();
+        }
+    }
+    supplied.to_string()
+}
+
+/// Read-lock variant of [`token_claims_for`] used by the OAuth2 grant
+/// handlers, which search every account for the pool.
+fn collect_token_claims(
+    state: &SharedCognitoState,
+    pool_id: &str,
+    username: &str,
+    client_id: &str,
+) -> TokenClaims {
+    let mas = state.read();
+    for (_, account) in mas.iter() {
+        if account.user_pools.contains_key(pool_id) {
+            return token_claims_for(account, pool_id, username, client_id);
+        }
+    }
+    TokenClaims::default()
+}
+
+/// Inject a user's identity attributes into an **id** token payload. Standard
+/// OIDC claims are type-coerced (booleans for the `*_verified` claims, a
+/// number for `updated_at`); `custom:*` attributes pass through as strings.
+/// `sub` is never overwritten (already set from the user record).
+fn inject_identity_claims(map: &mut serde_json::Map<String, Value>, attributes: &[UserAttribute]) {
+    for attr in attributes {
+        let name = attr.name.as_str();
+        if name == "sub" {
+            continue;
+        }
+        if name.starts_with("custom:") {
+            map.insert(name.to_string(), Value::String(attr.value.clone()));
+        } else if STANDARD_ID_TOKEN_CLAIMS.contains(&name) {
+            let value = match name {
+                "email_verified" | "phone_number_verified" => {
+                    Value::Bool(attr.value.eq_ignore_ascii_case("true"))
+                }
+                "updated_at" => attr
+                    .value
+                    .parse::<i64>()
+                    .map(Value::from)
+                    .unwrap_or_else(|_| Value::String(attr.value.clone())),
+                _ => Value::String(attr.value.clone()),
+            };
+            map.insert(name.to_string(), value);
+        }
+    }
 }
 
 /// Generate Cognito ID/Access/Refresh tokens. `signing` is the pool's
@@ -1705,6 +1948,9 @@ struct TokenSet {
 /// (only reachable from in-process unit tests that intentionally skip
 /// keygen for speed), we synthesize a one-shot keypair so the resulting
 /// JWT still has a real RS256 signature — never a placeholder.
+///
+/// `claims` carries the signed-in user's attributes + group memberships and
+/// the client's token-validity config; see [`TokenClaims`].
 fn generate_tokens(
     pool_id: &str,
     client_id: &str,
@@ -1712,9 +1958,10 @@ fn generate_tokens(
     username: &str,
     region: &str,
     signing: Option<(&str, &str)>,
+    claims: &TokenClaims,
 ) -> TokenSet {
     generate_tokens_with_scope(
-        pool_id, client_id, sub, username, region, signing, None, None,
+        pool_id, client_id, sub, username, region, signing, None, None, claims,
     )
 }
 
@@ -1732,9 +1979,10 @@ fn generate_tokens_with_scope(
     signing: Option<(&str, &str)>,
     scope: Option<&str>,
     nonce: Option<&str>,
+    claims: &TokenClaims,
 ) -> TokenSet {
     generate_tokens_with_overrides(
-        pool_id, client_id, sub, username, region, signing, scope, nonce, None,
+        pool_id, client_id, sub, username, region, signing, scope, nonce, None, claims,
     )
 }
 
@@ -1757,11 +2005,14 @@ fn generate_tokens_with_overrides(
     scope: Option<&str>,
     nonce: Option<&str>,
     overrides: Option<&Value>,
+    claims: &TokenClaims,
 ) -> TokenSet {
     let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let now = Utc::now().timestamp();
     let jti = Uuid::new_v4().to_string();
     let iss = format!("https://cognito-idp.{region}.amazonaws.com/{pool_id}");
+    let access_ttl = claims.access_ttl();
+    let id_ttl = claims.id_ttl();
 
     let owned_signing = signing
         .map(|(p, k)| (p.to_string(), k.to_string()))
@@ -1780,15 +2031,19 @@ fn generate_tokens_with_overrides(
         "cognito:username": username,
         "token_use": "id",
         "auth_time": now,
-        "exp": now + 3600,
+        "exp": now + id_ttl,
         "iat": now,
         "jti": jti,
     });
-    if let Some(n) = nonce {
-        id_payload
+    {
+        let map = id_payload
             .as_object_mut()
-            .expect("id_payload is always a JSON object")
-            .insert("nonce".to_string(), Value::String(n.to_string()));
+            .expect("id_payload is always a JSON object");
+        // Standard OIDC + custom:* identity claims live on the id token only.
+        inject_identity_claims(map, &claims.attributes);
+        if let Some(n) = nonce {
+            map.insert("nonce".to_string(), Value::String(n.to_string()));
+        }
     }
 
     let access_jti = Uuid::new_v4().to_string();
@@ -1800,12 +2055,26 @@ fn generate_tokens_with_overrides(
         "sub": sub,
         "iss": iss,
         "client_id": client_id,
+        "username": username,
         "token_use": "access",
         "scope": access_scope,
         "jti": access_jti,
-        "exp": now + 3600,
+        "exp": now + access_ttl,
         "iat": now,
     });
+
+    // Real group membership (AdminAddUserToGroup) surfaces as `cognito:groups`
+    // on BOTH tokens. A PreTokenGeneration `groupsToOverride` replaces this
+    // below.
+    if !claims.groups.is_empty() {
+        let groups: Vec<Value> = claims
+            .groups
+            .iter()
+            .map(|g| Value::String(g.clone()))
+            .collect();
+        id_payload["cognito:groups"] = Value::Array(groups.clone());
+        access_payload["cognito:groups"] = Value::Array(groups);
+    }
 
     // PreTokenGeneration trigger merge. Schema (v2):
     //   claimsAndScopeOverrideDetails: {
@@ -1866,6 +2135,7 @@ fn generate_tokens_with_overrides(
         id_token,
         access_token,
         refresh_token,
+        expires_in: access_ttl,
     }
 }
 
@@ -2336,6 +2606,7 @@ async fn handle_authorization_code_grant(
     } else {
         Some(consumed.scopes.join(" "))
     };
+    let claims = collect_token_claims(state, pool_id, &consumed.username, client_id);
     let tokens = generate_tokens_with_scope(
         pool_id,
         client_id,
@@ -2345,6 +2616,7 @@ async fn handle_authorization_code_grant(
         signing_ref,
         scope_str.as_deref(),
         consumed.nonce.as_deref(),
+        &claims,
     );
 
     {
@@ -2379,7 +2651,7 @@ async fn handle_authorization_code_grant(
         access_token: tokens.access_token,
         id_token: Some(tokens.id_token),
         refresh_token: Some(tokens.refresh_token),
-        expires_in: 3600,
+        expires_in: tokens.expires_in,
         token_type: "Bearer".to_string(),
     })
 }
@@ -2418,7 +2690,16 @@ async fn handle_refresh_token_grant(
     };
     let signing = ensure_pool_signing_key(state, pool_id).await;
     let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
-    let tokens = generate_tokens(pool_id, client_id, &sub, &username, region, signing_ref);
+    let claims = collect_token_claims(state, pool_id, &username, client_id);
+    let tokens = generate_tokens(
+        pool_id,
+        client_id,
+        &sub,
+        &username,
+        region,
+        signing_ref,
+        &claims,
+    );
     let rotated_refresh = {
         let mut mas = state.write();
         let mut new_rt = None;
@@ -2465,7 +2746,7 @@ async fn handle_refresh_token_grant(
         access_token: tokens.access_token,
         id_token: Some(tokens.id_token),
         refresh_token: rotated_refresh,
-        expires_in: 3600,
+        expires_in: tokens.expires_in,
         token_type: "Bearer".to_string(),
     })
 }
@@ -2521,12 +2802,16 @@ async fn handle_client_credentials_grant(
 
     let signing = ensure_pool_signing_key(state, pool_id).await;
     let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
+    // client_credentials has no user, but still honors the client's
+    // AccessTokenValidity.
+    let access_ttl = collect_token_claims(state, pool_id, client_id, client_id).access_ttl();
     let access_token = build_client_credentials_access_token(
         pool_id,
         client_id,
         Some(&granted),
         region,
         signing_ref,
+        access_ttl,
     );
 
     {
@@ -2555,7 +2840,7 @@ async fn handle_client_credentials_grant(
         access_token,
         id_token: None,
         refresh_token: None,
-        expires_in: 3600,
+        expires_in: access_ttl,
         token_type: "Bearer".to_string(),
     })
 }
@@ -2586,6 +2871,7 @@ fn build_client_credentials_access_token(
     scope: Option<&str>,
     region: &str,
     signing: Option<(&str, &str)>,
+    ttl_secs: i64,
 ) -> String {
     let now = Utc::now().timestamp();
     let jti = Uuid::new_v4().to_string();
@@ -2612,7 +2898,7 @@ fn build_client_credentials_access_token(
         "token_use": "access",
         "scope": scope.unwrap_or(""),
         "jti": jti,
-        "exp": now + 3600,
+        "exp": now + ttl_secs,
         "iat": now,
     });
     sign_jwt(&header, &payload, pem)
@@ -3092,6 +3378,7 @@ pub async fn handle_oauth2_authorize(
             };
             let signing = ensure_pool_signing_key(state, &pool_id).await;
             let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
+            let claims = collect_token_claims(state, &pool_id, username, &req.client_id);
             let tokens = generate_tokens_with_scope(
                 &pool_id,
                 &req.client_id,
@@ -3101,6 +3388,7 @@ pub async fn handle_oauth2_authorize(
                 signing_ref,
                 scope_str.as_deref(),
                 req.nonce.as_deref(),
+                &claims,
             );
             // Persist the access_token so /oauth2/userInfo and
             // /oauth2/revoke can resolve it back to the user.
@@ -3123,9 +3411,10 @@ pub async fn handle_oauth2_authorize(
                 }
             }
             let mut fragment = format!(
-                "access_token={}&id_token={}&token_type=Bearer&expires_in=3600",
+                "access_token={}&id_token={}&token_type=Bearer&expires_in={}",
                 urlencoding_encode(&tokens.access_token),
                 urlencoding_encode(&tokens.id_token),
+                tokens.expires_in,
             );
             if let Some(s) = req.state.as_deref() {
                 fragment.push_str("&state=");

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -525,12 +525,19 @@ fn filter_matches_user_status() {
         mfa_options: Vec::new(),
     };
 
+    // `cognito:user_status` filters the confirmation status.
     let filter =
         parse_filter_expression(r#"cognito:user_status = "FORCE_CHANGE_PASSWORD""#).unwrap();
     assert!(matches_filter(&user, &filter));
 
-    let filter = parse_filter_expression(r#"status = "FORCE_CHANGE_PASSWORD""#).unwrap();
+    // `status` filters Enabled/Disabled, NOT the confirmation status
+    // (bug-hunt batch 4, finding 5): an enabled user matches "Enabled" and
+    // must NOT match a confirmation-status value.
+    let filter = parse_filter_expression(r#"status = "Enabled""#).unwrap();
     assert!(matches_filter(&user, &filter));
+
+    let filter = parse_filter_expression(r#"status = "FORCE_CHANGE_PASSWORD""#).unwrap();
+    assert!(!matches_filter(&user, &filter));
 }
 
 #[test]
@@ -619,6 +626,7 @@ fn jwt_format_three_base64url_segments() {
         "user1",
         "us-east-1",
         None,
+        &TokenClaims::default(),
     );
     // Each token should have 3 dot-separated segments
     for (name, token) in [("id", &tokens.id_token), ("access", &tokens.access_token)] {
@@ -671,6 +679,7 @@ fn jwt_id_token_payload_contains_required_fields() {
         "user1",
         "us-east-1",
         None,
+        &TokenClaims::default(),
     );
     let parts: Vec<&str> = tokens.id_token.split('.').collect();
     let header: Value = serde_json::from_slice(&b64url.decode(parts[0]).unwrap()).unwrap();
@@ -709,6 +718,7 @@ fn jwt_access_token_payload_contains_required_fields() {
         "user1",
         "us-east-1",
         None,
+        &TokenClaims::default(),
     );
     let parts: Vec<&str> = tokens.access_token.split('.').collect();
     let payload: Value = serde_json::from_slice(&b64url.decode(parts[1]).unwrap()).unwrap();
@@ -7821,6 +7831,7 @@ fn pretoken_overrides_merge_into_id_and_access_tokens() {
         None,
         None,
         Some(&overrides),
+        &crate::service::TokenClaims::default(),
     );
 
     let parts: Vec<&str> = tokens.id_token.split('.').collect();
@@ -7871,6 +7882,7 @@ fn pretoken_v1_claims_override_details_shape() {
         None,
         None,
         Some(&overrides),
+        &crate::service::TokenClaims::default(),
     );
 
     let parts: Vec<&str> = tokens.id_token.split('.').collect();
@@ -8219,4 +8231,394 @@ fn admin_create_user_validates_temporary_password_against_policy() {
         &format!(r#"{{"UserPoolId":"{pool_id}","Username":"u2","TemporaryPassword":"Strong123"}}"#),
     );
     block_on(svc.admin_create_user(&strong)).unwrap();
+}
+
+// ── bug-hunt batch 4 (Cognito correctness) ──────────────────────────────
+
+/// Decode a JWT's payload (2nd segment) into a JSON value.
+fn decode_jwt_payload(token: &str) -> Value {
+    use base64::Engine;
+    let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let part = token.split('.').nth(1).expect("jwt has a payload segment");
+    serde_json::from_slice(&b64url.decode(part).unwrap()).unwrap()
+}
+
+/// Create a pool + ADMIN_USER_PASSWORD_AUTH client + user (with the given
+/// UserAttributes) and set a permanent password. Returns (svc, pool_id,
+/// client_id). Extra client body fields can be supplied via `client_extra`.
+fn setup_signin(user_attrs: Value, client_extra: Value) -> (CognitoService, String, String) {
+    let (svc, pool_id) = setup_svc_with_pool();
+    let mut client_body = json!({
+        "UserPoolId": pool_id,
+        "ClientName": "c",
+        "ExplicitAuthFlows": ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+    });
+    for (k, v) in client_extra.as_object().cloned().unwrap_or_default() {
+        client_body[k] = v;
+    }
+    let resp = svc
+        .create_user_pool_client(&make_req("CreateUserPoolClient", &client_body.to_string()))
+        .unwrap();
+    let cb: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let client_id = cb["UserPoolClient"]["ClientId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let create = json!({
+        "UserPoolId": pool_id,
+        "Username": "signinuser",
+        "TemporaryPassword": "TempP@ss1!",
+        "UserAttributes": user_attrs,
+    });
+    block_on(svc.admin_create_user(&make_req("AdminCreateUser", &create.to_string()))).unwrap();
+    svc.admin_set_user_password(&make_req(
+        "AdminSetUserPassword",
+        &json!({
+            "UserPoolId": pool_id,
+            "Username": "signinuser",
+            "Password": "P@ssw0rd!",
+            "Permanent": true,
+        })
+        .to_string(),
+    ))
+    .unwrap();
+    (svc, pool_id, client_id)
+}
+
+fn admin_signin(svc: &CognitoService, pool_id: &str, client_id: &str, username: &str) -> Value {
+    let body = json!({
+        "UserPoolId": pool_id,
+        "ClientId": client_id,
+        "AuthFlow": "ADMIN_USER_PASSWORD_AUTH",
+        "AuthParameters": {"USERNAME": username, "PASSWORD": "P@ssw0rd!"},
+    });
+    let resp = block_on(svc.admin_initiate_auth(&make_req("AdminInitiateAuth", &body.to_string())))
+        .unwrap();
+    serde_json::from_slice(resp.body.expect_bytes()).unwrap()
+}
+
+#[test]
+fn id_token_carries_identity_claims_but_access_token_does_not() {
+    // Finding 1: standard OIDC + custom:* claims must be injected into the id
+    // token (never the access token) from the user's attributes.
+    let (svc, pool_id, client_id) = setup_signin(
+        json!([
+            {"Name": "email", "Value": "alice@example.com"},
+            {"Name": "email_verified", "Value": "true"},
+            {"Name": "name", "Value": "Alice"},
+            {"Name": "custom:tier", "Value": "gold"},
+        ]),
+        json!({}),
+    );
+    let result = admin_signin(&svc, &pool_id, &client_id, "signinuser");
+    let id = decode_jwt_payload(result["AuthenticationResult"]["IdToken"].as_str().unwrap());
+    assert_eq!(id["email"], "alice@example.com");
+    assert_eq!(id["email_verified"], Value::Bool(true), "must be a bool");
+    assert_eq!(id["name"], "Alice");
+    assert_eq!(id["custom:tier"], "gold");
+    assert_eq!(id["token_use"], "id");
+
+    let access = decode_jwt_payload(
+        result["AuthenticationResult"]["AccessToken"]
+            .as_str()
+            .unwrap(),
+    );
+    assert!(
+        access.get("email").is_none(),
+        "access token must not carry email"
+    );
+    assert!(access.get("name").is_none());
+    assert_eq!(access["token_use"], "access");
+}
+
+#[test]
+fn tokens_reflect_real_group_membership_ordered_by_precedence() {
+    // Finding 3: cognito:groups must come from real AdminAddUserToGroup
+    // membership on BOTH tokens, ordered by precedence then creation.
+    let (svc, pool_id, client_id) = setup_signin(json!([]), json!({}));
+    // Two groups: "low" precedence 1 (higher priority), "high" precedence 10.
+    for (name, prec) in [("high", 10), ("low", 1)] {
+        svc.create_group(&make_req(
+            "CreateGroup",
+            &json!({"UserPoolId": pool_id, "GroupName": name, "Precedence": prec}).to_string(),
+        ))
+        .unwrap();
+        svc.admin_add_user_to_group(&make_req(
+            "AdminAddUserToGroup",
+            &json!({"UserPoolId": pool_id, "Username": "signinuser", "GroupName": name})
+                .to_string(),
+        ))
+        .unwrap();
+    }
+    let result = admin_signin(&svc, &pool_id, &client_id, "signinuser");
+    let id = decode_jwt_payload(result["AuthenticationResult"]["IdToken"].as_str().unwrap());
+    assert_eq!(
+        id["cognito:groups"],
+        json!(["low", "high"]),
+        "groups ordered by precedence asc"
+    );
+    let access = decode_jwt_payload(
+        result["AuthenticationResult"]["AccessToken"]
+            .as_str()
+            .unwrap(),
+    );
+    assert_eq!(access["cognito:groups"], json!(["low", "high"]));
+}
+
+#[test]
+fn token_validity_honored_from_client_config() {
+    // Finding 7: client AccessTokenValidity + TokenValidityUnits drive exp and
+    // ExpiresIn; defaults stay 3600s.
+    let (svc, pool_id, client_id) = setup_signin(
+        json!([]),
+        json!({
+            "AccessTokenValidity": 2,
+            "IdTokenValidity": 30,
+            "TokenValidityUnits": {"AccessToken": "hours", "IdToken": "minutes"},
+        }),
+    );
+    let result = admin_signin(&svc, &pool_id, &client_id, "signinuser");
+    assert_eq!(result["AuthenticationResult"]["ExpiresIn"], 7200);
+    let access = decode_jwt_payload(
+        result["AuthenticationResult"]["AccessToken"]
+            .as_str()
+            .unwrap(),
+    );
+    let ttl = access["exp"].as_i64().unwrap() - access["iat"].as_i64().unwrap();
+    assert_eq!(ttl, 7200, "AccessTokenValidity=2 hours");
+    let id = decode_jwt_payload(result["AuthenticationResult"]["IdToken"].as_str().unwrap());
+    let id_ttl = id["exp"].as_i64().unwrap() - id["iat"].as_i64().unwrap();
+    assert_eq!(id_ttl, 1800, "IdTokenValidity=30 minutes");
+}
+
+#[test]
+fn token_validity_defaults_to_one_hour() {
+    let (svc, pool_id, client_id) = setup_signin(json!([]), json!({}));
+    let result = admin_signin(&svc, &pool_id, &client_id, "signinuser");
+    assert_eq!(result["AuthenticationResult"]["ExpiresIn"], 3600);
+    let access = decode_jwt_payload(
+        result["AuthenticationResult"]["AccessToken"]
+            .as_str()
+            .unwrap(),
+    );
+    let ttl = access["exp"].as_i64().unwrap() - access["iat"].as_i64().unwrap();
+    assert_eq!(ttl, 3600);
+}
+
+#[test]
+fn get_user_response_matches_aws_shape() {
+    // Finding 2: GetUser (access token) must not leak UserStatus /
+    // UserCreateDate / UserLastModifiedDate, and must report MFA settings.
+    let (svc, pool_id, username) = setup_svc_with_pool_and_user();
+    // Give the user an MFA preference + a fresh access token.
+    let token = "acc-token-getuser".to_string();
+    {
+        let mut mas = svc.state.write();
+        let st = mas.default_mut();
+        let user = st
+            .users
+            .get_mut(&pool_id)
+            .unwrap()
+            .get_mut(&username)
+            .unwrap();
+        user.mfa_preferences = Some(crate::state::MfaPreferences {
+            sms_enabled: false,
+            sms_preferred: false,
+            software_token_enabled: true,
+            software_token_preferred: true,
+        });
+        st.access_tokens.insert(
+            token.clone(),
+            AccessTokenData {
+                user_pool_id: pool_id.clone(),
+                username: username.clone(),
+                client_id: "c".to_string(),
+                issued_at: Utc::now(),
+            },
+        );
+    }
+    let resp = svc
+        .get_user(&make_req(
+            "GetUser",
+            &json!({"AccessToken": token}).to_string(),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Username"], username);
+    assert!(body["UserAttributes"].is_array());
+    assert!(body.get("UserStatus").is_none(), "must not leak UserStatus");
+    assert!(body.get("UserCreateDate").is_none());
+    assert!(body.get("UserLastModifiedDate").is_none());
+    assert_eq!(body["PreferredMfaSetting"], "SOFTWARE_TOKEN_MFA");
+    assert_eq!(body["UserMFASettingList"], json!(["SOFTWARE_TOKEN_MFA"]));
+}
+
+#[test]
+fn list_users_malformed_filter_errors_not_whole_pool() {
+    // Finding 4: a non-empty malformed filter is InvalidParameterException,
+    // not a silent "return everything". An empty/absent filter returns all.
+    let (svc, pool_id) = setup_svc_with_pool();
+    for u in ["u1", "u2"] {
+        block_on(
+            svc.admin_create_user(&make_req(
+                "AdminCreateUser",
+                &json!({"UserPoolId": pool_id, "Username": u, "TemporaryPassword": "TempP@ss1!"})
+                    .to_string(),
+            )),
+        )
+        .unwrap();
+    }
+    // Malformed (no operator) -> error.
+    match svc.list_users(&make_req(
+        "ListUsers",
+        &json!({"UserPoolId": pool_id, "Filter": "email"}).to_string(),
+    )) {
+        Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+        Ok(_) => panic!("malformed filter must error"),
+    }
+    // Empty filter -> all users.
+    let resp = svc
+        .list_users(&make_req(
+            "ListUsers",
+            &json!({"UserPoolId": pool_id, "Filter": ""}).to_string(),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Users"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn list_users_status_and_user_status_are_distinct_filters() {
+    // Finding 5: `status` filters Enabled/Disabled; `cognito:user_status`
+    // filters the confirmation status.
+    let (svc, pool_id) = setup_svc_with_pool();
+    for u in ["enabled_user", "disabled_user"] {
+        block_on(
+            svc.admin_create_user(&make_req(
+                "AdminCreateUser",
+                &json!({"UserPoolId": pool_id, "Username": u, "TemporaryPassword": "TempP@ss1!"})
+                    .to_string(),
+            )),
+        )
+        .unwrap();
+    }
+    svc.admin_disable_user(&make_req(
+        "AdminDisableUser",
+        &json!({"UserPoolId": pool_id, "Username": "disabled_user"}).to_string(),
+    ))
+    .unwrap();
+
+    // status = "Disabled" -> only the disabled user.
+    let resp = svc
+        .list_users(&make_req(
+            "ListUsers",
+            &json!({"UserPoolId": pool_id, "Filter": "status = \"Disabled\""}).to_string(),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let users = body["Users"].as_array().unwrap();
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0]["Username"], "disabled_user");
+
+    // cognito:user_status = "FORCE_CHANGE_PASSWORD" -> both (admin-created).
+    let resp = svc
+        .list_users(&make_req(
+            "ListUsers",
+            &json!({"UserPoolId": pool_id, "Filter": "cognito:user_status = \"FORCE_CHANGE_PASSWORD\""})
+                .to_string(),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Users"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn admin_create_user_virtualizes_username_for_username_attributes_pool() {
+    // Finding 6: a UsernameAttributes=["email"] pool mints a UUID username and
+    // stores the email as an alias; AdminGetUser by the email resolves.
+    let state = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4569",
+        ),
+    ));
+    let svc = CognitoService::new(state);
+    let resp = block_on(svc.create_user_pool(&make_req(
+        "CreateUserPool",
+        &json!({"PoolName": "emailpool", "UsernameAttributes": ["email"]}).to_string(),
+    )))
+    .unwrap();
+    let pb: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let pool_id = pb["UserPool"]["Id"].as_str().unwrap().to_string();
+
+    let resp = block_on(svc.admin_create_user(&make_req(
+        "AdminCreateUser",
+        &json!({"UserPoolId": pool_id, "Username": "bob@example.com"}).to_string(),
+    )))
+    .unwrap();
+    let cb: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let minted = cb["User"]["Username"].as_str().unwrap();
+    assert_ne!(minted, "bob@example.com", "Username must be a minted UUID");
+    assert!(
+        minted.contains('-'),
+        "minted username looks like a UUID: {minted}"
+    );
+    let attrs = cb["User"]["Attributes"].as_array().unwrap();
+    assert!(
+        attrs
+            .iter()
+            .any(|a| a["Name"] == "email" && a["Value"] == "bob@example.com"),
+        "email alias attribute stored"
+    );
+
+    // AdminGetUser by the email alias resolves to the minted user.
+    let resp = svc
+        .admin_get_user(&make_req(
+            "AdminGetUser",
+            &json!({"UserPoolId": pool_id, "Username": "bob@example.com"}).to_string(),
+        ))
+        .unwrap();
+    let gb: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(gb["Username"], minted);
+
+    // A second user with the same email alias -> AliasExistsException.
+    match block_on(svc.admin_create_user(&make_req(
+        "AdminCreateUser",
+        &json!({"UserPoolId": pool_id, "Username": "bob@example.com"}).to_string(),
+    ))) {
+        Err(e) => assert_eq!(e.code(), "AliasExistsException"),
+        Ok(_) => panic!("duplicate alias must be AliasExists"),
+    }
+}
+
+#[test]
+fn admin_create_user_keeps_username_verbatim_without_username_attributes() {
+    let (svc, pool_id) = setup_svc_with_pool();
+    let resp = block_on(svc.admin_create_user(&make_req(
+        "AdminCreateUser",
+        &json!({"UserPoolId": pool_id, "Username": "plainuser"}).to_string(),
+    )))
+    .unwrap();
+    let cb: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(cb["User"]["Username"], "plainuser");
+}
+
+#[test]
+fn sub_is_immutable_via_update_attributes() {
+    // Verify: sub must not be writable via AdminUpdateUserAttributes.
+    let (svc, pool_id, username) = setup_svc_with_pool_and_user();
+    match svc.admin_update_user_attributes(&make_req(
+        "AdminUpdateUserAttributes",
+        &json!({
+            "UserPoolId": pool_id,
+            "Username": username,
+            "UserAttributes": [{"Name": "sub", "Value": "hacked"}],
+        })
+        .to_string(),
+    )) {
+        Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+        Ok(_) => panic!("sub must be read-only"),
+    }
 }

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -844,6 +844,7 @@ fn access_token_lookup() {
                 username: "testuser".to_string(),
                 client_id: "testclient123".to_string(),
                 issued_at: Utc::now(),
+                expires_at: None,
             },
         );
     }
@@ -1182,6 +1183,7 @@ fn self_service_get_user_via_access_token() {
                 username: "selfuser".to_string(),
                 client_id: "test-client".to_string(),
                 issued_at: Utc::now(),
+                expires_at: None,
             },
         );
     }
@@ -1312,6 +1314,7 @@ fn self_service_delete_user_cleans_up_tokens() {
                 username: "deluser".to_string(),
                 client_id: "test-client".to_string(),
                 issued_at: Utc::now(),
+                expires_at: None,
             },
         );
         s.refresh_tokens.insert(
@@ -1434,6 +1437,7 @@ fn verify_user_attribute_with_correct_code() {
                 username: "verifyuser".to_string(),
                 client_id: "test-client".to_string(),
                 issued_at: Utc::now(),
+                expires_at: None,
             },
         );
     }
@@ -6157,6 +6161,7 @@ fn issue_access_token(
             username: username.to_string(),
             client_id: client_id.to_string(),
             issued_at: chrono::Utc::now(),
+            expires_at: None,
         },
     );
     token
@@ -6395,6 +6400,7 @@ fn issue_access_token_for(
             username: username.to_string(),
             client_id: client_id.to_string(),
             issued_at: chrono::Utc::now(),
+            expires_at: None,
         },
     );
     token
@@ -6851,6 +6857,7 @@ fn issue_at_for_users(
             username: username.to_string(),
             client_id: client_id.to_string(),
             issued_at: chrono::Utc::now(),
+            expires_at: None,
         },
     );
     token
@@ -7237,6 +7244,7 @@ fn issue_at(
             username: username.to_string(),
             client_id: client_id.to_string(),
             issued_at: chrono::Utc::now(),
+            expires_at: None,
         },
     );
     token
@@ -8147,6 +8155,7 @@ fn oauth_token_maps_survive_snapshot_roundtrip() {
                 username: "alice".to_string(),
                 client_id: "client-1".to_string(),
                 issued_at: Utc::now(),
+                expires_at: None,
             },
         );
         acct.authorization_codes.insert(
@@ -8435,6 +8444,7 @@ fn get_user_response_matches_aws_shape() {
                 username: username.clone(),
                 client_id: "c".to_string(),
                 issued_at: Utc::now(),
+                expires_at: None,
             },
         );
     }
@@ -8621,4 +8631,315 @@ fn sub_is_immutable_via_update_attributes() {
         Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
         Ok(_) => panic!("sub must be read-only"),
     }
+}
+
+// ── bug-hunt batch 4 — Cubic review follow-ups ──────────────────────────
+
+#[test]
+fn empty_group_override_clears_real_membership() {
+    // Cubic 2: an explicit empty `groupsToOverride` must CLEAR cognito:groups,
+    // not leave the real-membership groups in place.
+    use crate::service::{generate_tokens_with_overrides, TokenClaims};
+    let overrides = json!({
+        "claimsAndScopeOverrideDetails": {
+            "groupOverrideDetails": { "groupsToOverride": [] }
+        }
+    });
+    let claims = TokenClaims {
+        groups: vec!["admins".to_string(), "beta".to_string()],
+        ..Default::default()
+    };
+    let tokens = generate_tokens_with_overrides(
+        "us-east-1_abc",
+        "client1",
+        "sub-1",
+        "alice",
+        "us-east-1",
+        None,
+        None,
+        None,
+        Some(&overrides),
+        &claims,
+    );
+    let id = decode_jwt_payload(&tokens.id_token);
+    assert!(
+        id.get("cognito:groups").is_none(),
+        "empty override must clear cognito:groups: {id}"
+    );
+    let access = decode_jwt_payload(&tokens.access_token);
+    assert!(access.get("cognito:groups").is_none());
+}
+
+#[test]
+fn absent_group_override_keeps_real_membership() {
+    // Complementary to the above: NO groupOverrideDetails leaves real
+    // membership intact.
+    use crate::service::{generate_tokens_with_overrides, TokenClaims};
+    let overrides = json!({
+        "claimsAndScopeOverrideDetails": {
+            "idTokenGeneration": { "claimsToAddOrOverride": {"x": "y"} }
+        }
+    });
+    let claims = TokenClaims {
+        groups: vec!["admins".to_string()],
+        ..Default::default()
+    };
+    let tokens = generate_tokens_with_overrides(
+        "us-east-1_abc",
+        "client1",
+        "sub-1",
+        "alice",
+        "us-east-1",
+        None,
+        None,
+        None,
+        Some(&overrides),
+        &claims,
+    );
+    let id = decode_jwt_payload(&tokens.id_token);
+    assert_eq!(id["cognito:groups"], json!(["admins"]));
+}
+
+#[test]
+fn parse_filter_rejects_malformed_with_operator() {
+    // Cubic 4: filters that HAVE an operator but a bad value must be rejected.
+    for bad in [
+        r#"email = "#,   // empty value
+        r#"email = x"#,  // unquoted value
+        r#"email = """#, // empty quoted value
+        r#"email = "x"#, // unterminated quote
+        r#" = "x""#,     // empty attribute
+        r#"email"#,      // no operator
+    ] {
+        assert!(
+            parse_filter_expression(bad).is_none(),
+            "malformed filter must not parse: {bad:?}"
+        );
+    }
+    // Well-formed still parses.
+    assert!(parse_filter_expression(r#"email = "a@b.com""#).is_some());
+    assert!(parse_filter_expression(r#"email ^= "a""#).is_some());
+}
+
+#[test]
+fn list_users_malformed_filter_with_operator_errors() {
+    let (svc, pool_id) = setup_svc_with_pool();
+    block_on(
+        svc.admin_create_user(&make_req(
+            "AdminCreateUser",
+            &json!({"UserPoolId": pool_id, "Username": "u1", "TemporaryPassword": "TempP@ss1!"})
+                .to_string(),
+        )),
+    )
+    .unwrap();
+    for bad in [r#"email = "#, r#"email = x"#] {
+        match svc.list_users(&make_req(
+            "ListUsers",
+            &json!({"UserPoolId": pool_id, "Filter": bad}).to_string(),
+        )) {
+            Err(e) => assert_eq!(e.code(), "InvalidParameterException", "filter {bad:?}"),
+            Ok(_) => panic!("malformed filter {bad:?} must error"),
+        }
+    }
+}
+
+#[test]
+fn sub_cannot_be_deleted_via_attribute_delete() {
+    // Cubic 5: both attribute-delete paths must reject removing `sub`.
+    let (svc, pool_id, username) = setup_svc_with_pool_and_user();
+    match svc.admin_delete_user_attributes(&make_req(
+        "AdminDeleteUserAttributes",
+        &json!({
+            "UserPoolId": pool_id,
+            "Username": username,
+            "UserAttributeNames": ["sub"],
+        })
+        .to_string(),
+    )) {
+        Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+        Ok(_) => panic!("AdminDeleteUserAttributes must reject deleting sub"),
+    }
+
+    // Self-service path (access token).
+    let token = "acc-token-delsub".to_string();
+    {
+        let mut mas = svc.state.write();
+        let st = mas.default_mut();
+        st.access_tokens.insert(
+            token.clone(),
+            AccessTokenData {
+                user_pool_id: pool_id.clone(),
+                username: username.clone(),
+                client_id: "c".to_string(),
+                issued_at: Utc::now(),
+                expires_at: None,
+            },
+        );
+    }
+    match svc.delete_user_attributes(&make_req(
+        "DeleteUserAttributes",
+        &json!({"AccessToken": token, "UserAttributeNames": ["sub"]}).to_string(),
+    )) {
+        Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+        Ok(_) => panic!("DeleteUserAttributes must reject deleting sub"),
+    }
+}
+
+/// Create a UsernameAttributes=["email"] pool with a USER_AUTH-capable client
+/// and one user created by email. Returns (svc, pool_id, client_id, minted, email).
+fn setup_email_alias_pool() -> (CognitoService, String, String, String, String) {
+    let state = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4569",
+        ),
+    ));
+    let svc = CognitoService::new(state);
+    let resp = block_on(svc.create_user_pool(&make_req(
+        "CreateUserPool",
+        &json!({"PoolName": "emailpool", "UsernameAttributes": ["email"]}).to_string(),
+    )))
+    .unwrap();
+    let pb: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let pool_id = pb["UserPool"]["Id"].as_str().unwrap().to_string();
+
+    let resp = svc
+        .create_user_pool_client(&make_req(
+            "CreateUserPoolClient",
+            &json!({
+                "UserPoolId": pool_id,
+                "ClientName": "c",
+                "ExplicitAuthFlows": [
+                    "ALLOW_USER_AUTH",
+                    "ALLOW_USER_PASSWORD_AUTH",
+                    "ALLOW_ADMIN_USER_PASSWORD_AUTH"
+                ],
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let cb: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let client_id = cb["UserPoolClient"]["ClientId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let email = "carol@example.com".to_string();
+    let resp = block_on(svc.admin_create_user(&make_req(
+        "AdminCreateUser",
+        &json!({"UserPoolId": pool_id, "Username": email}).to_string(),
+    )))
+    .unwrap();
+    let ub: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let minted = ub["User"]["Username"].as_str().unwrap().to_string();
+    (svc, pool_id, client_id, minted, email)
+}
+
+#[test]
+fn user_auth_select_challenge_session_resolves_alias() {
+    // Cubic 3: USER_AUTH must resolve email/phone aliases before storing the
+    // SELECT_CHALLENGE session, so subsequent challenges find the user.
+    let (svc, pool_id, client_id, minted, email) = setup_email_alias_pool();
+    let resp = block_on(
+        svc.initiate_auth(&make_req(
+            "InitiateAuth",
+            &json!({
+                "ClientId": client_id,
+                "AuthFlow": "USER_AUTH",
+                "AuthParameters": {"USERNAME": email},
+            })
+            .to_string(),
+        )),
+    )
+    .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["ChallengeName"], "SELECT_CHALLENGE");
+    let session = body["Session"].as_str().unwrap();
+    // The stashed session must key the minted (UUID) username, not the email.
+    let mas = svc.state.read();
+    let st = mas.default_ref();
+    let sd = st.sessions.get(session).expect("session stored");
+    assert_eq!(sd.username, minted);
+    assert_eq!(sd.user_pool_id, pool_id);
+}
+
+#[test]
+fn admin_mutations_accept_email_alias() {
+    // Cubic 6: follow-up admin mutations addressed by the original email must
+    // resolve to the virtualized (UUID) user.
+    let (svc, pool_id, _client_id, minted, email) = setup_email_alias_pool();
+
+    // Create a group and add the user by email.
+    svc.create_group(&make_req(
+        "CreateGroup",
+        &json!({"UserPoolId": pool_id, "GroupName": "g1"}).to_string(),
+    ))
+    .unwrap();
+    svc.admin_add_user_to_group(&make_req(
+        "AdminAddUserToGroup",
+        &json!({"UserPoolId": pool_id, "Username": email, "GroupName": "g1"}).to_string(),
+    ))
+    .unwrap();
+
+    // Update attributes by email.
+    svc.admin_update_user_attributes(&make_req(
+        "AdminUpdateUserAttributes",
+        &json!({
+            "UserPoolId": pool_id,
+            "Username": email,
+            "UserAttributes": [{"Name": "name", "Value": "Carol"}],
+        })
+        .to_string(),
+    ))
+    .unwrap();
+
+    // Set a password by email.
+    svc.admin_set_user_password(&make_req(
+        "AdminSetUserPassword",
+        &json!({
+            "UserPoolId": pool_id,
+            "Username": email,
+            "Password": "P@ssw0rd!",
+            "Permanent": true,
+        })
+        .to_string(),
+    ))
+    .unwrap();
+
+    // Disable by email.
+    svc.admin_disable_user(&make_req(
+        "AdminDisableUser",
+        &json!({"UserPoolId": pool_id, "Username": email}).to_string(),
+    ))
+    .unwrap();
+
+    // Verify all mutations landed on the minted user.
+    {
+        let mas = svc.state.read();
+        let st = mas.default_ref();
+        let user = st.users.get(&pool_id).unwrap().get(&minted).unwrap();
+        assert!(!user.enabled, "disable resolved via alias");
+        assert!(user
+            .attributes
+            .iter()
+            .any(|a| a.name == "name" && a.value == "Carol"));
+        assert_eq!(user.password.as_deref(), Some("P@ssw0rd!"));
+        let groups = st.user_groups.get(&pool_id).unwrap().get(&minted).unwrap();
+        assert_eq!(
+            groups,
+            &vec!["g1".to_string()],
+            "group add resolved via alias"
+        );
+    }
+
+    // Finally delete by email.
+    svc.admin_delete_user(&make_req(
+        "AdminDeleteUser",
+        &json!({"UserPoolId": pool_id, "Username": email}).to_string(),
+    ))
+    .unwrap();
+    let mas = svc.state.read();
+    let st = mas.default_ref();
+    assert!(st.users.get(&pool_id).map(|u| u.is_empty()).unwrap_or(true));
 }

--- a/crates/fakecloud-cognito/src/service/users.rs
+++ b/crates/fakecloud-cognito/src/service/users.rs
@@ -317,6 +317,11 @@ impl CognitoService {
         // Validate pool exists
         ensure_user_pool_exists(state, pool_id)?;
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         let pool_users = state.users.get_mut(pool_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -372,6 +377,11 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         let user = state
             .users
             .get_mut(pool_id)
@@ -420,6 +430,11 @@ impl CognitoService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
 
         let user = state
             .users
@@ -482,6 +497,11 @@ impl CognitoService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
+
         let user = state
             .users
             .get_mut(pool_id)
@@ -538,13 +558,27 @@ impl CognitoService {
 
         let attr_names = parse_string_array(&body["UserAttributeNames"]);
 
+        // `sub` is a Cognito-reserved read-only attribute; it cannot be
+        // deleted any more than it can be modified.
+        if attr_names.iter().any(|n| n == "sub") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "Cannot modify the value of a read-only attribute: sub",
+            ));
+        }
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+
+        // Resolve email/phone alias -> stored username for UsernameAttributes
+        // pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
 
         let user = state
             .users
             .get_mut(pool_id)
-            .and_then(|users| users.get_mut(username))
+            .and_then(|users| users.get_mut(&resolved))
             .ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -738,6 +772,11 @@ impl CognitoService {
         })?;
 
         validate_password(password, &pool.policies.password_policy)?;
+
+        // Resolve an email/phone alias -> stored username for
+        // UsernameAttributes pools.
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+        let username = resolved.as_str();
 
         let user = state
             .users
@@ -940,6 +979,15 @@ impl CognitoService {
         let body = req.json_body();
         let access_token = require_str(&body, "AccessToken")?;
         let attr_names = parse_string_array(&body["UserAttributeNames"]);
+
+        // `sub` is a Cognito-reserved read-only attribute; it cannot be deleted.
+        if attr_names.iter().any(|n| n == "sub") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "Cannot modify the value of a read-only attribute: sub",
+            ));
+        }
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);

--- a/crates/fakecloud-cognito/src/service/users.rs
+++ b/crates/fakecloud-cognito/src/service/users.rs
@@ -69,14 +69,53 @@ impl CognitoService {
                 }
             }
 
-            // Check username doesn't already exist
+            // Pools configured with UsernameAttributes (email / phone_number)
+            // mint a UUID as the real Username and store the supplied value as
+            // an alias attribute; sign-in / AdminGetUser then resolve the alias
+            // back to the UUID. Without UsernameAttributes the Username is used
+            // verbatim.
+            let username_attributes: Vec<String> = state
+                .user_pools
+                .get(pool_id)
+                .and_then(|p| p.username_attributes.clone())
+                .unwrap_or_default();
+            let virtualize = !username_attributes.is_empty();
+            let alias_attr = if virtualize {
+                Some(pick_alias_attribute(&username_attributes, username))
+            } else {
+                None
+            };
+            let stored_username = if virtualize {
+                Uuid::new_v4().to_string()
+            } else {
+                username.to_string()
+            };
+
             let pool_users = state.users.entry(pool_id.to_string()).or_default();
-            if pool_users.contains_key(username) {
+
+            // A literal-username collision is UsernameExists; an alias-value
+            // collision (another user already owns this email/phone) is
+            // AliasExists.
+            if !virtualize && pool_users.contains_key(username) {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "UsernameExistsException",
                     "User account already exists.",
                 ));
+            }
+            if let Some(ref attr) = alias_attr {
+                let taken = pool_users.values().any(|u| {
+                    u.attributes
+                        .iter()
+                        .any(|a| &a.name == attr && a.value == username)
+                });
+                if taken {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "AliasExistsException",
+                        "An account with the given email already exists.",
+                    ));
+                }
             }
 
             let now = Utc::now();
@@ -84,6 +123,19 @@ impl CognitoService {
 
             // Parse user attributes
             let mut attributes = parse_user_attributes(&body["UserAttributes"]);
+
+            // Store the supplied identifier as its alias attribute so sign-in
+            // by email/phone resolves.
+            if let Some(ref attr) = alias_attr {
+                if let Some(existing) = attributes.iter_mut().find(|a| &a.name == attr) {
+                    existing.value = username.to_string();
+                } else {
+                    attributes.push(UserAttribute {
+                        name: attr.clone(),
+                        value: username.to_string(),
+                    });
+                }
+            }
 
             // Ensure sub attribute is present
             if !attributes.iter().any(|a| a.name == "sub") {
@@ -96,7 +148,7 @@ impl CognitoService {
             let temporary_password = body["TemporaryPassword"].as_str().map(|s| s.to_string());
 
             let user = crate::state::User {
-                username: username.to_string(),
+                username: stored_username.clone(),
                 sub: sub_val,
                 attributes,
                 enabled: true,
@@ -117,7 +169,7 @@ impl CognitoService {
 
             let resp = user_to_json(&user);
             let uc = user.clone();
-            pool_users.insert(username.to_string(), user);
+            pool_users.insert(stored_username.clone(), user);
 
             let region = state.region.clone();
             let account_id = state.account_id.clone();
@@ -128,7 +180,7 @@ impl CognitoService {
                 region,
                 account_id,
                 pool_id.to_string(),
-                username.to_string(),
+                stored_username,
             )
         };
 
@@ -200,10 +252,14 @@ impl CognitoService {
         // Validate pool exists
         ensure_user_pool_exists(state, pool_id)?;
 
+        // Allow AdminGetUser by an email/phone alias for UsernameAttributes
+        // pools (the stored username may be a UUID).
+        let resolved = crate::service::resolve_alias_username(state, pool_id, username);
+
         let user = state
             .users
             .get(pool_id)
-            .and_then(|users| users.get(username))
+            .and_then(|users| users.get(&resolved))
             .ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
@@ -413,6 +469,16 @@ impl CognitoService {
 
         let new_attrs = parse_user_attributes(&body["UserAttributes"]);
 
+        // `sub` is a Cognito-reserved read-only attribute; it must not be
+        // mutable via AdminUpdateUserAttributes.
+        if new_attrs.iter().any(|a| a.name == "sub") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "Cannot modify the value of a read-only attribute: sub",
+            ));
+        }
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
@@ -569,9 +635,19 @@ impl CognitoService {
         let mut users: Vec<&crate::state::User> = pool_users.values().collect();
         users.sort_by_key(|u| u.user_create_date);
 
-        // Apply filter if present
+        // Apply filter if present. An empty/whitespace Filter means "no
+        // filter" (return all); a non-empty but malformed filter (e.g.
+        // `email` with no operator) is an InvalidParameterException in real
+        // Cognito, NOT a silent "return the whole pool".
         if let Some(filter) = filter_str {
-            if let Some(parsed) = parse_filter_expression(filter) {
+            if !filter.trim().is_empty() {
+                let parsed = parse_filter_expression(filter).ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterException",
+                        "Invalid filter expression",
+                    )
+                })?;
                 users.retain(|u| matches_filter(u, &parsed));
             }
         }
@@ -719,19 +795,27 @@ impl CognitoService {
                 )
             })?;
 
-        let response = json!({
+        // Real GetUser (access-token, self-service) returns ONLY Username,
+        // UserAttributes, MFAOptions (deprecated), PreferredMfaSetting and
+        // UserMFASettingList. It does NOT leak UserStatus / UserCreateDate /
+        // UserLastModifiedDate — those belong to AdminGetUser.
+        let mut response = json!({
             "Username": user.username,
             "UserAttributes": user.attributes.iter().map(|a| {
                 json!({ "Name": a.name, "Value": a.value })
             }).collect::<Vec<Value>>(),
-            "UserCreateDate": user.user_create_date.timestamp() as f64,
-            "UserLastModifiedDate": user.user_last_modified_date.timestamp() as f64,
-            "UserStatus": user.user_status,
             "MFAOptions": user.mfa_options.iter().map(|o| json!({
                 "DeliveryMedium": o.delivery_medium,
                 "AttributeName": o.attribute_name,
             })).collect::<Vec<Value>>(),
         });
+        let (mfa_settings, preferred) = user_mfa_settings(user);
+        if !mfa_settings.is_empty() {
+            response["UserMFASettingList"] = json!(mfa_settings);
+        }
+        if let Some(pref) = preferred {
+            response["PreferredMfaSetting"] = json!(pref);
+        }
 
         Ok(AwsResponse::ok_json(response))
     }
@@ -800,6 +884,16 @@ impl CognitoService {
         let body = req.json_body();
         let access_token = require_str(&body, "AccessToken")?;
         let new_attrs = parse_user_attributes(&body["UserAttributes"]);
+
+        // `sub` is a Cognito-reserved read-only attribute and cannot be
+        // changed by the user either.
+        if new_attrs.iter().any(|a| a.name == "sub") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "Cannot modify the value of a read-only attribute: sub",
+            ));
+        }
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -1168,4 +1262,45 @@ impl CognitoService {
             }
         })))
     }
+}
+
+/// Choose which alias attribute a supplied `UsernameAttributes` value maps
+/// to. Emails (containing `@`) map to `email`, `+`-prefixed values to
+/// `phone_number`, when those are configured; otherwise the first configured
+/// attribute wins.
+fn pick_alias_attribute(username_attributes: &[String], value: &str) -> String {
+    let has = |name: &str| username_attributes.iter().any(|a| a == name);
+    if value.contains('@') && has("email") {
+        "email".to_string()
+    } else if value.starts_with('+') && has("phone_number") {
+        "phone_number".to_string()
+    } else {
+        username_attributes
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "email".to_string())
+    }
+}
+
+/// Derive a user's `(UserMFASettingList, PreferredMfaSetting)` from stored
+/// MFA preferences. Shared by GetUser / AdminGetUser so both report MFA the
+/// same way real Cognito does.
+fn user_mfa_settings(user: &crate::state::User) -> (Vec<&'static str>, Option<&'static str>) {
+    let mut settings = Vec::new();
+    let mut preferred = None;
+    if let Some(prefs) = &user.mfa_preferences {
+        if prefs.sms_enabled {
+            settings.push("SMS_MFA");
+            if prefs.sms_preferred {
+                preferred = Some("SMS_MFA");
+            }
+        }
+        if prefs.software_token_enabled {
+            settings.push("SOFTWARE_TOKEN_MFA");
+            if prefs.software_token_preferred {
+                preferred = Some("SOFTWARE_TOKEN_MFA");
+            }
+        }
+    }
+    (settings, preferred)
 }

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -235,10 +235,14 @@ impl CognitoState {
         let now = Utc::now();
         // The JWT's real `exp` is persisted on the token (honoring the app
         // client's AccessTokenValidity). Older snapshots that predate the
-        // field fall back to the fixed 1h TTL from `issued_at`.
+        // field fall back to the fixed 1h TTL from `issued_at`. Per JWT
+        // semantics a token is invalid AT OR AFTER `exp`, so equality counts
+        // as expired (`>=`), not still-valid.
         let expired = match data.expires_at {
-            Some(exp) => now > exp,
-            None => now.signed_duration_since(data.issued_at).num_seconds() > ACCESS_TOKEN_TTL_SECS,
+            Some(exp) => now >= exp,
+            None => {
+                now.signed_duration_since(data.issued_at).num_seconds() >= ACCESS_TOKEN_TTL_SECS
+            }
         };
         if expired {
             None
@@ -972,6 +976,33 @@ mod tests {
         };
         state.access_tokens.insert("short".to_string(), short);
         assert!(state.valid_access_token("short").is_none());
+
+        // A token is invalid AT its exp instant, not just after (Cubic P3):
+        // `exp` set to "now" is already expired by the time the `>=` check
+        // runs. A far-future exp of the same token would be valid, proving it
+        // is the boundary — not a stale field — that rejects it.
+        let at_expiry = AccessTokenData {
+            user_pool_id: "pool".to_string(),
+            username: "u".to_string(),
+            client_id: "c".to_string(),
+            issued_at: Utc::now(),
+            expires_at: Some(Utc::now()),
+        };
+        state
+            .access_tokens
+            .insert("at_expiry".to_string(), at_expiry);
+        assert!(
+            state.valid_access_token("at_expiry").is_none(),
+            "token must be invalid at (not only after) its exp instant"
+        );
+
+        // Fallback path: a token whose age exactly equals the 1h TTL is
+        // likewise expired at the boundary (`>=`).
+        state.access_tokens.insert(
+            "at_ttl".to_string(),
+            mk(Utc::now() - chrono::Duration::seconds(ACCESS_TOKEN_TTL_SECS)),
+        );
+        assert!(state.valid_access_token("at_ttl").is_none());
     }
 
     #[test]

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -232,10 +232,15 @@ impl CognitoState {
     /// 2026-06-24, 5.3).
     pub fn valid_access_token(&self, token: &str) -> Option<&AccessTokenData> {
         let data = self.access_tokens.get(token)?;
-        let age = Utc::now()
-            .signed_duration_since(data.issued_at)
-            .num_seconds();
-        if age > ACCESS_TOKEN_TTL_SECS {
+        let now = Utc::now();
+        // The JWT's real `exp` is persisted on the token (honoring the app
+        // client's AccessTokenValidity). Older snapshots that predate the
+        // field fall back to the fixed 1h TTL from `issued_at`.
+        let expired = match data.expires_at {
+            Some(exp) => now > exp,
+            None => now.signed_duration_since(data.issued_at).num_seconds() > ACCESS_TOKEN_TTL_SECS,
+        };
+        if expired {
             None
         } else {
             Some(data)
@@ -348,6 +353,11 @@ pub struct AccessTokenData {
     pub username: String,
     pub client_id: String,
     pub issued_at: DateTime<Utc>,
+    /// Absolute expiry, matching the issued JWT's `exp` (issued_at +
+    /// AccessTokenValidity). `None` on legacy snapshots -> callers fall back
+    /// to the fixed 1h TTL from `issued_at`.
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -923,6 +933,7 @@ mod tests {
             username: "u".to_string(),
             client_id: "c".to_string(),
             issued_at,
+            expires_at: None,
         };
         // Fresh token: accepted.
         state
@@ -937,6 +948,30 @@ mod tests {
         assert!(state.valid_access_token("stale").is_none());
         // Unknown token: rejected.
         assert!(state.valid_access_token("nope").is_none());
+
+        // Persisted expires_at overrides the 1h fallback in BOTH directions
+        // (bug-hunt batch 4 / Cubic 1): a token issued >1h ago but whose
+        // configured TTL is 2h is still valid...
+        let long = AccessTokenData {
+            user_pool_id: "pool".to_string(),
+            username: "u".to_string(),
+            client_id: "c".to_string(),
+            issued_at: Utc::now() - chrono::Duration::hours(2),
+            expires_at: Some(Utc::now() + chrono::Duration::hours(2)),
+        };
+        state.access_tokens.insert("long".to_string(), long);
+        assert!(state.valid_access_token("long").is_some());
+        // ...and a freshly-issued token whose short TTL already elapsed is
+        // rejected even though issued_at is recent.
+        let short = AccessTokenData {
+            user_pool_id: "pool".to_string(),
+            username: "u".to_string(),
+            client_id: "c".to_string(),
+            issued_at: Utc::now(),
+            expires_at: Some(Utc::now() - chrono::Duration::seconds(1)),
+        };
+        state.access_tokens.insert("short".to_string(), short);
+        assert!(state.valid_access_token("short").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bug-hunt batch 4 (Cognito correctness). All changes are confined to `crates/fakecloud-cognito`.

- **Finding 1 (HIGH) - ID token missing identity claims.** The token generator never injected user attributes. It now injects standard OIDC claims (email, email_verified as a bool, phone_number, phone_number_verified as a bool, name, given_name, family_name, nickname, preferred_username, picture, locale, zoneinfo, birthdate, gender, middle_name, profile, website, updated_at as a number, address) plus `custom:*` pass-through into the id token, and deliberately keeps them out of the access token. A new `TokenClaims` context is threaded through `generate_tokens*` and every sign-in caller (InitiateAuth password/SRP/refresh, AdminInitiateAuth, custom-auth challenges, NEW_PASSWORD_REQUIRED, OAuth2 code/implicit/refresh grants).
- **Finding 2 (HIGH) - GetUser wrong shape.** GetUser (access-token) no longer leaks `UserStatus` / `UserCreateDate` / `UserLastModifiedDate` and now returns `PreferredMfaSetting` + `UserMFASettingList` alongside `Username`, `UserAttributes`, `MFAOptions`. MFA-setting derivation is shared via a `user_mfa_settings` helper.
- **Finding 3 (MED) - cognito:groups not from real membership.** `cognito:groups` is now populated from real `AdminAddUserToGroup` membership on both the id and access tokens, ordered by Precedence (ascending, unset last) then creation date. A PreTokenGeneration `groupsToOverride` still replaces the list.
- **Finding 4 (MED) - malformed ListUsers filter returned whole pool.** A non-empty but malformed filter (e.g. `Filter=email` with no operator) now returns `InvalidParameterException`. An empty/whitespace or absent filter still returns all users.
- **Finding 5 (MED) - status vs cognito:user_status conflation.** `status` now filters Enabled/Disabled; `cognito:user_status` filters the confirmation status (CONFIRMED/UNCONFIRMED/...). They were both mapped to the confirmation status before.
- **Finding 6 (MED) - AdminCreateUser username virtualization.** For pools with `UsernameAttributes` (email/phone_number), AdminCreateUser now mints a UUID as the stored Username, saves the supplied email/phone as the alias attribute, and enforces `AliasExistsException` on duplicates. Sign-in (InitiateAuth USER_PASSWORD_AUTH + SRP, AdminInitiateAuth) and AdminGetUser resolve the alias back to the stored username via a shared `resolve_alias_username` helper. SECRET_HASH is validated against the client-supplied identifier before alias resolution. Pools without UsernameAttributes keep the Username verbatim.
- **Finding 7 (MED) - token validity ignored.** id/access JWT `exp` and `AuthenticationResult.ExpiresIn` / OAuth `expires_in` are now computed from the app client's `AccessTokenValidity` / `IdTokenValidity` + `TokenValidityUnits` (units default to hours; overall default stays 3600s). The client_credentials access token honors AccessTokenValidity too.

### Also verified

- **sub mutable via AdminUpdateUserAttributes - CONFIRMED, fixed.** `sub` was writable via both AdminUpdateUserAttributes and (self-service) UpdateUserAttributes. Both now reject a `sub` write with `InvalidParameterException` (read-only attribute).
- **AdminCreateUser email_verified default - FALSE POSITIVE.** fakecloud never injects `email_verified=true` on create; the attribute is simply absent unless supplied, which already matches AWS (absent == not verified). No change made.

### SDK/docs surface

No SDK or docs change. All findings are behavioral corrections to existing operations (token claim contents, GetUser response fields, ListUsers filter semantics, AdminCreateUser username handling); no new operations, request fields, or introspection endpoints were added.

## Test plan

- Added unit/E2E tests in `service/tests.rs` (in-memory `CognitoService`, no Docker):
  - id token carries identity + custom claims; access token does not
  - cognito:groups from real membership, ordered by precedence, on both tokens
  - token validity honored (2h access / 30m id -> exp + ExpiresIn) and default 3600s
  - GetUser response shape (no UserStatus/dates, has Preferred/UserMFASettingList)
  - ListUsers malformed filter -> InvalidParameterException; empty -> all
  - status vs cognito:user_status distinct filters
  - AdminCreateUser virtualization (UUID username + email alias), AdminGetUser by alias, AliasExists, verbatim username without UsernameAttributes
  - sub immutable via AdminUpdateUserAttributes
  - updated the pre-existing `filter_matches_user_status` test to the corrected status semantics
- `cargo nextest run -p fakecloud-cognito` -> 354 passed, 0 failed.
- `cargo clippy -p fakecloud-cognito --all-targets -- -D warnings` -> clean.
- `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Cognito behavior with AWS by correcting token claims, token lifetimes and enforcement, user filtering, GetUser shape, and alias-username handling. All changes are scoped to `crates/fakecloud-cognito`.

- **Bug Fixes**
  - ID token now includes standard OIDC identity claims and `custom:*` from user attributes; access token omits identity claims.
  - `cognito:groups` is populated from real group membership on both tokens, ordered by Precedence then creation; PreTokenGeneration overrides still apply, and an explicit empty `groupsToOverride` clears the list.
  - Token validity is fully honored: JWT `exp` and `ExpiresIn`/`expires_in` reflect client `AccessTokenValidity`/`IdTokenValidity` + `TokenValidityUnits` (default 3600s); tokens expire exactly at the `exp` instant; access-token expiry is persisted and enforced across internal/OAuth checks; `client_credentials` respects access validity.
  - `GetUser` (access token) matches AWS: removes status/dates and includes `PreferredMfaSetting` and `UserMFASettingList`.
  - `ListUsers` parity: empty/whitespace `Filter` returns all; malformed filters (missing operator, empty attribute, unquoted/empty/unterminated value) return `InvalidParameterException`; `status` filters Enabled/Disabled while `cognito:user_status` filters confirmation status.
  - Username aliases: for pools with `UsernameAttributes`/`AliasAttributes`, `AdminCreateUser` mints a UUID username and stores the alias; sign-in (password/SRP/`USER_AUTH`, admin), `AdminGetUser`, and admin ops (enable/disable, set/reset password, update/delete attributes, delete user, link provider, groups/devices/MFA, global sign-out, confirm sign-up, event feedback) all resolve aliases; duplicates raise `AliasExistsException`; `SECRET_HASH` is validated before alias resolution.
  - `sub` is enforced read-only across admin and self-service updates and deletes.

<sup>Written for commit e89aa98ba85e23a6796c130fdd639e67fac7fafe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

