### PR TITLE
fix(test): restore #2057-backgrounding e2e/conformance tests

### DIFF
--- a/crates/fakecloud-conformance/tests/ec2.rs
+++ b/crates/fakecloud-conformance/tests/ec2.rs
@@ -5901,9 +5901,27 @@ async fn ec2_describe_transit_gateway_vpc_attachments() {
 async fn ec2_modify_transit_gateway_vpc_attachment() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    // ModifyTransitGatewayVpcAttachment now validates the attachment exists
+    // (returns InvalidTransitGatewayAttachmentID.NotFound otherwise), so create
+    // one first and modify that id rather than a hardcoded (non-existent) id.
+    let t = make_tgw(&c).await;
+    let created = c
+        .create_transit_gateway_vpc_attachment()
+        .transit_gateway_id(&t)
+        .vpc_id("vpc-1")
+        .subnet_ids("subnet-1")
+        .send()
+        .await
+        .unwrap();
+    let id = created
+        .transit_gateway_vpc_attachment()
+        .unwrap()
+        .transit_gateway_attachment_id()
+        .unwrap()
+        .to_string();
     let r = c
         .modify_transit_gateway_vpc_attachment()
-        .transit_gateway_attachment_id("tgw-attach-1")
+        .transit_gateway_attachment_id(id)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -618,6 +618,14 @@ async fn rds_restore_from_snapshot() {
     assert_eq!(restored_instance.master_username(), Some("admin"));
     assert_eq!(restored_instance.db_name(), Some("appdb"));
 
+    // RestoreDBInstanceFromDBSnapshot is backgrounded (same client-timeout fix
+    // as CreateDBInstance): it returns `creating` with no endpoint yet, then the
+    // backing container is provisioned and the instance flips to `available`
+    // with its endpoint populated. A real client waits for `available` before
+    // connecting, so poll for it rather than reading the endpoint synchronously.
+    assert_eq!(restored_instance.db_instance_status(), Some("creating"));
+    helpers::wait_for_db_available(&client, "orders-restored-db", 180).await;
+
     let describe_response = client
         .describe_db_instances()
         .db_instance_identifier("orders-restored-db")

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -720,6 +720,11 @@ async fn rds_create_and_query_read_replica() {
         Some("orders-source-db")
     );
 
+    // CreateDBInstanceReadReplica is backgrounded (client-timeout fix): the
+    // replica returns `creating` with no endpoint, then flips to `available`
+    // with its endpoint once its backing container replays the source data.
+    helpers::wait_for_db_available(&client, "orders-replica-db", 180).await;
+
     let source_describe_after = client
         .describe_db_instances()
         .db_instance_identifier("orders-source-db")
@@ -976,8 +981,12 @@ async fn final_snapshot_on_delete() {
         .await
         .unwrap();
 
+    // Restore is backgrounded: it returns `creating` with no endpoint, then
+    // flips to `available` once the backing container is provisioned.
     let restored = response.db_instance().expect("db instance");
-    let restored_port = restored.endpoint().unwrap().port().unwrap();
+    assert_eq!(restored.db_instance_status(), Some("creating"));
+    let ready = helpers::wait_for_db_available(&client, "e2e-rds-restored", 180).await;
+    let restored_port = ready.endpoint().unwrap().port().unwrap();
 
     let (postgres, connection) =
         connect_with_retry("127.0.0.1", restored_port, "admin", "secret123", "testdb")


### PR DESCRIPTION
## Summary
#2057 (batch-1 Tier-0 propagation) backgrounded RestoreDBInstanceFromDBSnapshot / CreateDBInstanceReadReplica and hardened ModifyTransitGatewayVpcAttachment to validate existence. Those changes were merged while E2E/conformance were still running, so main went red on tests that encoded the old synchronous / stub behavior. This unblocks every open PR based on current main.

Fixes (test-only; no handler/behavior change):
- **rds_restore_from_snapshot** (e2e): restore now returns `creating` with no endpoint; poll `wait_for_db_available` before reading it.
- **rds_create_and_query_read_replica** (e2e): replica creation backgrounded; wait for `available` before reading the replica endpoint.
- **final_snapshot_on_delete** (e2e): restore-from-final-snapshot backgrounded; wait for `available` before connecting.
- **ec2_modify_transit_gateway_vpc_attachment** (conformance): the op now returns `InvalidTransitGatewayAttachmentID.NotFound` for an unknown id (matches AWS), so the test creates a real attachment first instead of modifying a hardcoded non-existent id.

Not addressed here: `security_group_actually_drops_and_allows_packets` is the known recurring privileged-SG flake (clears on rerun), not a #2057 regression.

## Test plan
- All four tests now exercise the real backgrounded/validated contract.
- No SDK/docs/metadata impact.