### PR TITLE
feat(dynamodb): add explicit snapshot save endpoint

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -428,10 +428,9 @@ pub async fn save_dynamodb_snapshot(
             err.kind(),
             format!("failed to write dynamodb snapshot: {err}"),
         )),
-        Err(err) => Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("dynamodb snapshot task panicked: {err}"),
-        )),
+        Err(err) => Err(io::Error::other(format!(
+            "dynamodb snapshot task panicked: {err}"
+        ))),
     }
 }
 

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -8,6 +8,7 @@ mod streams;
 mod tables;
 
 use std::collections::HashMap;
+use std::io;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -247,21 +248,16 @@ impl DynamoDbService {
         }
     }
 
-    /// Persist the current in-memory state as a snapshot. Called after
-    /// every state-mutating action. A noop when no snapshot store is
-    /// configured (i.e. `StorageMode::Memory`).
+    /// Persist the current in-memory state to the provided snapshot store.
     ///
     /// The snapshot lock serializes the full clone + serialize + write
     /// so concurrent mutators cannot leave older bytes on disk, and
     /// serialization + the blocking file write are offloaded to the
     /// blocking pool to keep Tokio workers responsive.
-    async fn save_snapshot(&self) {
-        save_dynamodb_snapshot(
-            &self.state,
-            self.snapshot_store.clone(),
-            &self.snapshot_lock,
-        )
-        .await;
+    pub async fn save_snapshot_to_store(&self, store: Arc<dyn SnapshotStore>) -> io::Result<()> {
+        save_dynamodb_snapshot(&self.state, Some(store), &self.snapshot_lock)
+            .await
+            .map(|_| ())
     }
 
     /// Build a hook that persists the current DynamoDB state when invoked, or
@@ -278,9 +274,23 @@ impl DynamoDbService {
             let store = store.clone();
             let lock = lock.clone();
             Box::pin(async move {
-                save_dynamodb_snapshot(&state, Some(store), &lock).await;
+                if let Err(err) = save_dynamodb_snapshot(&state, Some(store), &lock).await {
+                    tracing::error!(%err, "dynamodb snapshot save failed");
+                }
             })
         }))
+    }
+
+    /// Persist the current in-memory state to the configured snapshot store.
+    /// Returns `Ok(false)` when no snapshot store is configured (i.e.
+    /// `StorageMode::Memory`).
+    pub async fn save_snapshot(&self) -> io::Result<bool> {
+        save_dynamodb_snapshot(
+            &self.state,
+            self.snapshot_store.clone(),
+            &self.snapshot_lock,
+        )
+        .await
     }
 
     fn kinesis_target(table: &DynamoTable) -> Option<KinesisDeliveryTarget> {
@@ -396,9 +406,9 @@ pub async fn save_dynamodb_snapshot(
     state: &SharedDynamoDbState,
     store: Option<Arc<dyn SnapshotStore>>,
     lock: &tokio::sync::Mutex<()>,
-) {
+) -> io::Result<bool> {
     let Some(store) = store else {
-        return;
+        return Ok(false);
     };
     let _guard = lock.lock().await;
     let snapshot = DynamoDbSnapshot {
@@ -413,9 +423,15 @@ pub async fn save_dynamodb_snapshot(
     })
     .await;
     match join {
-        Ok(Ok(())) => {}
-        Ok(Err(err)) => tracing::error!(%err, "failed to write dynamodb snapshot"),
-        Err(err) => tracing::error!(%err, "dynamodb snapshot task panicked"),
+        Ok(Ok(())) => Ok(true),
+        Ok(Err(err)) => Err(io::Error::new(
+            err.kind(),
+            format!("failed to write dynamodb snapshot: {err}"),
+        )),
+        Err(err) => Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("dynamodb snapshot task panicked: {err}"),
+        )),
     }
 }
 
@@ -513,7 +529,9 @@ impl AwsService for DynamoDbService {
             )),
         };
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
-            self.save_snapshot().await;
+            if let Err(err) = self.save_snapshot().await {
+                tracing::error!(%err, "dynamodb snapshot save failed");
+            }
         }
         result
     }

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -252,14 +252,30 @@ async fn assert_snapshot_round_trip_fixture(service: &DynamoDbService) {
     assert_eq!(item["flag"], json!({"BOOL": true}));
     assert_eq!(item["none"], json!({"NULL": true}));
     assert_eq!(item["b"], json!({"B": "aGVsbG8="}));
-    assert_eq!(item["list"]["L"][0], json!({"S": "nested"}));
-    assert_eq!(item["map"]["M"]["inner"], json!({"S": "value"}));
-    assert!(item["ss"]["SS"].as_array().unwrap().contains(&json!("red")));
-    assert!(item["ns"]["NS"].as_array().unwrap().contains(&json!("2")));
-    assert!(item["bs"]["BS"]
-        .as_array()
-        .unwrap()
-        .contains(&json!("Yg==")));
+    // Lists and maps are ordered/deterministic, so assert full equality: a
+    // regression that drops later list elements or extra map fields fails here.
+    assert_eq!(
+        item["list"],
+        json!({"L": [{"S": "nested"}, {"N": "7"}, {"BOOL": false}]})
+    );
+    assert_eq!(
+        item["map"],
+        json!({"M": {"inner": {"S": "value"}, "count": {"N": "3"}}})
+    );
+    // Sets are unordered: check the exact length plus every expected member so
+    // a dropped or duplicated element is caught regardless of ordering.
+    let ss = item["ss"]["SS"].as_array().unwrap();
+    assert_eq!(ss.len(), 2);
+    assert!(ss.contains(&json!("red")));
+    assert!(ss.contains(&json!("blue")));
+    let ns = item["ns"]["NS"].as_array().unwrap();
+    assert_eq!(ns.len(), 2);
+    assert!(ns.contains(&json!("1")));
+    assert!(ns.contains(&json!("2")));
+    let bs = item["bs"]["BS"].as_array().unwrap();
+    assert_eq!(bs.len(), 2);
+    assert!(bs.contains(&json!("YQ==")));
+    assert!(bs.contains(&json!("Yg==")));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -1,5 +1,316 @@
 use super::*;
+use fakecloud_persistence::SnapshotStore;
 use serde_json::json;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+#[derive(Default)]
+struct RecordingSnapshotStore {
+    bytes: parking_lot::Mutex<Option<Vec<u8>>>,
+}
+
+impl SnapshotStore for RecordingSnapshotStore {
+    fn load(&self) -> io::Result<Option<Vec<u8>>> {
+        Ok(self.bytes.lock().clone())
+    }
+
+    fn save(&self, bytes: &[u8]) -> io::Result<()> {
+        *self.bytes.lock() = Some(bytes.to_vec());
+        Ok(())
+    }
+}
+
+struct TempSnapshotDir {
+    path: PathBuf,
+}
+
+impl TempSnapshotDir {
+    fn new() -> Self {
+        let path =
+            std::env::temp_dir().join(format!("fakecloud-dynamodb-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempSnapshotDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+async fn call_dynamodb(service: &DynamoDbService, action: &str, body: Value) -> Value {
+    let resp = service.handle(make_request(action, body)).await.unwrap();
+    let status = resp.status;
+    let body = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(status, StatusCode::OK, "{action} failed: {body}");
+    body
+}
+
+fn load_recorded_snapshot(store: &RecordingSnapshotStore) -> Vec<u8> {
+    SnapshotStore::load(store).unwrap().unwrap()
+}
+
+fn service_from_snapshot_bytes(bytes: &[u8]) -> DynamoDbService {
+    let snapshot: DynamoDbSnapshot = serde_json::from_slice(bytes).unwrap();
+    assert_eq!(snapshot.schema_version, DYNAMODB_SNAPSHOT_SCHEMA_VERSION);
+
+    let state: SharedDynamoDbState = Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ));
+    if let Some(accounts) = snapshot.accounts {
+        *state.write() = accounts;
+    } else if let Some(single_state) = snapshot.state {
+        let account_id = single_state.account_id.clone();
+        *state.write().get_or_create(&account_id) = single_state;
+    } else {
+        panic!("snapshot must contain either multi-account or legacy state");
+    }
+
+    DynamoDbService::new(state)
+}
+
+async fn populate_snapshot_round_trip_fixture(service: &DynamoDbService) {
+    call_dynamodb(
+        service,
+        "CreateTable",
+        json!({
+            "TableName": "orders",
+            "KeySchema": [
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"}
+            ],
+            "AttributeDefinitions": [
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+                {"AttributeName": "gsi_pk", "AttributeType": "S"},
+                {"AttributeName": "gsi_sk", "AttributeType": "N"},
+                {"AttributeName": "lsi_sk", "AttributeType": "S"}
+            ],
+            "BillingMode": "PAY_PER_REQUEST",
+            "GlobalSecondaryIndexes": [{
+                "IndexName": "by-status",
+                "KeySchema": [
+                    {"AttributeName": "gsi_pk", "KeyType": "HASH"},
+                    {"AttributeName": "gsi_sk", "KeyType": "RANGE"}
+                ],
+                "Projection": {"ProjectionType": "ALL"}
+            }],
+            "LocalSecondaryIndexes": [{
+                "IndexName": "by-due",
+                "KeySchema": [
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "lsi_sk", "KeyType": "RANGE"}
+                ],
+                "Projection": {"ProjectionType": "ALL"}
+            }]
+        }),
+    )
+    .await;
+
+    call_dynamodb(
+        service,
+        "CreateTable",
+        json!({
+            "TableName": "typed",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+            "BillingMode": "PAY_PER_REQUEST"
+        }),
+    )
+    .await;
+
+    call_dynamodb(
+        service,
+        "PutItem",
+        json!({
+            "TableName": "orders",
+            "Item": {
+                "pk": {"S": "acct#1"},
+                "sk": {"S": "order#1"},
+                "gsi_pk": {"S": "open"},
+                "gsi_sk": {"N": "10"},
+                "lsi_sk": {"S": "due#2026-07-01"},
+                "payload": {"S": "first order"}
+            }
+        }),
+    )
+    .await;
+    call_dynamodb(
+        service,
+        "PutItem",
+        json!({
+            "TableName": "orders",
+            "Item": {
+                "pk": {"S": "acct#1"},
+                "sk": {"S": "order#2"},
+                "gsi_pk": {"S": "open"},
+                "gsi_sk": {"N": "20"},
+                "lsi_sk": {"S": "due#2026-07-02"},
+                "payload": {"S": "second order"}
+            }
+        }),
+    )
+    .await;
+    call_dynamodb(
+        service,
+        "PutItem",
+        json!({
+            "TableName": "typed",
+            "Item": {
+                "pk": {"S": "types#1"},
+                "s": {"S": "hello"},
+                "n": {"N": "42.5"},
+                "flag": {"BOOL": true},
+                "none": {"NULL": true},
+                "ss": {"SS": ["red", "blue"]},
+                "ns": {"NS": ["1", "2"]},
+                "b": {"B": "aGVsbG8="},
+                "bs": {"BS": ["YQ==", "Yg=="]},
+                "list": {"L": [{"S": "nested"}, {"N": "7"}, {"BOOL": false}]},
+                "map": {"M": {"inner": {"S": "value"}, "count": {"N": "3"}}}
+            }
+        }),
+    )
+    .await;
+}
+
+async fn assert_snapshot_round_trip_fixture(service: &DynamoDbService) {
+    let tables = call_dynamodb(service, "ListTables", json!({})).await;
+    let table_names = tables["TableNames"].as_array().unwrap();
+    assert!(table_names.iter().any(|name| name == "orders"));
+    assert!(table_names.iter().any(|name| name == "typed"));
+
+    let orders = call_dynamodb(service, "DescribeTable", json!({"TableName": "orders"})).await;
+    let order_table = &orders["Table"];
+    assert_eq!(
+        order_table["GlobalSecondaryIndexes"][0]["IndexName"],
+        "by-status"
+    );
+    assert_eq!(
+        order_table["LocalSecondaryIndexes"][0]["IndexName"],
+        "by-due"
+    );
+
+    let item = call_dynamodb(
+        service,
+        "GetItem",
+        json!({
+            "TableName": "orders",
+            "Key": {"pk": {"S": "acct#1"}, "sk": {"S": "order#1"}}
+        }),
+    )
+    .await;
+    assert_eq!(item["Item"]["payload"], json!({"S": "first order"}));
+
+    let gsi = call_dynamodb(
+        service,
+        "Query",
+        json!({
+            "TableName": "orders",
+            "IndexName": "by-status",
+            "KeyConditionExpression": "gsi_pk = :status",
+            "ExpressionAttributeValues": {":status": {"S": "open"}}
+        }),
+    )
+    .await;
+    assert_eq!(gsi["Count"], 2);
+
+    let lsi = call_dynamodb(
+        service,
+        "Query",
+        json!({
+            "TableName": "orders",
+            "IndexName": "by-due",
+            "KeyConditionExpression": "pk = :pk AND begins_with(lsi_sk, :prefix)",
+            "ExpressionAttributeValues": {
+                ":pk": {"S": "acct#1"},
+                ":prefix": {"S": "due#"}
+            }
+        }),
+    )
+    .await;
+    assert_eq!(lsi["Count"], 2);
+
+    let typed = call_dynamodb(
+        service,
+        "GetItem",
+        json!({
+            "TableName": "typed",
+            "Key": {"pk": {"S": "types#1"}}
+        }),
+    )
+    .await;
+    let item = &typed["Item"];
+    assert_eq!(item["s"], json!({"S": "hello"}));
+    assert_eq!(item["n"], json!({"N": "42.5"}));
+    assert_eq!(item["flag"], json!({"BOOL": true}));
+    assert_eq!(item["none"], json!({"NULL": true}));
+    assert_eq!(item["b"], json!({"B": "aGVsbG8="}));
+    assert_eq!(item["list"]["L"][0], json!({"S": "nested"}));
+    assert_eq!(item["map"]["M"]["inner"], json!({"S": "value"}));
+    assert!(item["ss"]["SS"].as_array().unwrap().contains(&json!("red")));
+    assert!(item["ns"]["NS"].as_array().unwrap().contains(&json!("2")));
+    assert!(item["bs"]["BS"]
+        .as_array()
+        .unwrap()
+        .contains(&json!("Yg==")));
+}
+
+#[tokio::test]
+async fn save_snapshot_round_trips_empty_state() {
+    let store = Arc::new(RecordingSnapshotStore::default());
+    let service = make_service().with_snapshot_store(store.clone());
+
+    assert!(service.save_snapshot().await.unwrap());
+
+    let bytes = load_recorded_snapshot(store.as_ref());
+    let restored = service_from_snapshot_bytes(&bytes);
+    let tables = call_dynamodb(&restored, "ListTables", json!({})).await;
+    assert_eq!(tables["TableNames"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn save_snapshot_round_trips_tables_items_and_indexes() {
+    let store = Arc::new(RecordingSnapshotStore::default());
+    let service = make_service().with_snapshot_store(store.clone());
+    populate_snapshot_round_trip_fixture(&service).await;
+
+    assert!(service.save_snapshot().await.unwrap());
+
+    let bytes = load_recorded_snapshot(store.as_ref());
+    let restored = service_from_snapshot_bytes(&bytes);
+    assert_snapshot_round_trip_fixture(&restored).await;
+}
+
+#[tokio::test]
+async fn save_snapshot_to_store_round_trips_tables_items_and_indexes() {
+    let tmp = TempSnapshotDir::new();
+    let snapshot_path = tmp.path().join("dynamodb").join("snapshot.json");
+    let store = Arc::new(fakecloud_persistence::DiskSnapshotStore::new(
+        snapshot_path.clone(),
+    ));
+    let service = make_service();
+    populate_snapshot_round_trip_fixture(&service).await;
+
+    service.save_snapshot_to_store(store).await.unwrap();
+
+    let bytes = std::fs::read(snapshot_path).unwrap();
+    let restored = service_from_snapshot_bytes(&bytes);
+    assert_snapshot_round_trip_fixture(&restored).await;
+}
+
+#[tokio::test]
+async fn save_snapshot_reports_missing_store() {
+    let service = make_service();
+
+    assert!(!service.save_snapshot().await.unwrap());
+}
 
 #[test]
 fn test_parse_update_clauses_set() {
@@ -241,7 +552,6 @@ fn test_project_item_alias_with_dot_is_top_level_attr() {
 
 use crate::state::SharedDynamoDbState;
 use parking_lot::RwLock;
-use std::sync::Arc;
 
 fn make_service() -> DynamoDbService {
     let state: SharedDynamoDbState = Arc::new(RwLock::new(

--- a/crates/fakecloud-e2e/tests/dynamodb_persistence.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb_persistence.rs
@@ -1,6 +1,8 @@
 mod helpers;
 
 use std::collections::HashMap;
+use std::io;
+use std::path::Path;
 
 use aws_sdk_dynamodb::primitives::Blob;
 use aws_sdk_dynamodb::types::{
@@ -9,6 +11,273 @@ use aws_sdk_dynamodb::types::{
     ScalarAttributeType, TimeToLiveSpecification,
 };
 use helpers::TestServer;
+
+async fn create_snapshot_test_table(client: &aws_sdk_dynamodb::Client, table_name: &str) {
+    client
+        .create_table()
+        .table_name(table_name)
+        .billing_mode(BillingMode::PayPerRequest)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+async fn put_snapshot_test_item(
+    client: &aws_sdk_dynamodb::Client,
+    table_name: &str,
+    pk: &str,
+    payload: &str,
+) {
+    client
+        .put_item()
+        .table_name(table_name)
+        .item("pk", AttributeValue::S(pk.to_string()))
+        .item("payload", AttributeValue::S(payload.to_string()))
+        .send()
+        .await
+        .unwrap();
+}
+
+async fn assert_snapshot_test_item(
+    client: &aws_sdk_dynamodb::Client,
+    table_name: &str,
+    pk: &str,
+    payload: &str,
+) {
+    let resp = client
+        .get_item()
+        .table_name(table_name)
+        .key("pk", AttributeValue::S(pk.to_string()))
+        .send()
+        .await
+        .unwrap();
+    let item = resp.item().expect("snapshot test item should exist");
+    assert_eq!(
+        item.get("payload"),
+        Some(&AttributeValue::S(payload.to_string())),
+    );
+}
+
+async fn post_snapshot_save(endpoint: &str, body: Option<serde_json::Value>) -> reqwest::Response {
+    let request =
+        reqwest::Client::new().post(format!("{endpoint}/_fakecloud/dynamodb/snapshot/save",));
+    let request = if let Some(body) = body {
+        request.json(&body)
+    } else {
+        request
+    };
+    request.send().await.unwrap()
+}
+
+fn assert_snapshot_file_contains_item(
+    snapshot_path: &Path,
+    table_name: &str,
+    pk: &str,
+    payload: &str,
+) {
+    let snapshot: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(snapshot_path).unwrap()).unwrap();
+    assert_eq!(
+        snapshot.get("schema_version").and_then(|v| v.as_u64()),
+        Some(2),
+    );
+
+    let table = snapshot
+        .pointer("/accounts/accounts")
+        .and_then(|v| v.as_object())
+        .and_then(|accounts| {
+            accounts.values().find_map(|account| {
+                account
+                    .get("tables")
+                    .and_then(|tables| tables.get(table_name))
+            })
+        })
+        .unwrap_or_else(|| panic!("snapshot should contain table {table_name}: {snapshot}"));
+
+    let items = table
+        .get("items")
+        .and_then(|v| v.as_array())
+        .expect("snapshot table should contain items");
+    assert!(
+        items.iter().any(|item| {
+            item.get("pk")
+                .and_then(|v| v.get("S"))
+                .and_then(|v| v.as_str())
+                == Some(pk)
+                && item
+                    .get("payload")
+                    .and_then(|v| v.get("S"))
+                    .and_then(|v| v.as_str())
+                    == Some(payload)
+        }),
+        "snapshot should contain item {pk}: {items:?}",
+    );
+}
+
+fn remove_file_if_exists(path: &Path) {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(err) => panic!("failed to remove {}: {err}", path.display()),
+    }
+}
+
+fn write_fakecloud_version_file(data_path: &Path) {
+    std::fs::write(
+        data_path.join("fakecloud.version.toml"),
+        format!(
+            "format_version = 1\nfakecloud_version = {:?}\ncreated_at = \"test\"\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn snapshot_save_endpoint_writes_requested_data_path_and_reloads() {
+    let source = tempfile::tempdir().unwrap();
+    let target = tempfile::tempdir().unwrap();
+    let server = TestServer::start_persistent(source.path()).await;
+    let client = server.dynamodb_client().await;
+
+    create_snapshot_test_table(&client, "ManualSnapshot").await;
+    put_snapshot_test_item(&client, "ManualSnapshot", "manual#1", "explicit-path").await;
+
+    let resp = post_snapshot_save(
+        server.endpoint(),
+        Some(serde_json::json!({
+            "dataPath": target.path().display().to_string(),
+        })),
+    )
+    .await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        resp.json::<serde_json::Value>().await.unwrap()["saved"].as_bool(),
+        Some(true),
+    );
+
+    let snapshot_path = target.path().join("dynamodb").join("snapshot.json");
+    assert!(!target.path().join("fakecloud.version.toml").exists());
+    assert_snapshot_file_contains_item(
+        &snapshot_path,
+        "ManualSnapshot",
+        "manual#1",
+        "explicit-path",
+    );
+
+    write_fakecloud_version_file(target.path());
+    drop(server);
+    let restored = TestServer::start_persistent(target.path()).await;
+    let client = restored.dynamodb_client().await;
+    assert_snapshot_test_item(&client, "ManualSnapshot", "manual#1", "explicit-path").await;
+}
+
+#[tokio::test]
+async fn snapshot_save_endpoint_writes_requested_data_path_without_configured_store() {
+    let target = tempfile::tempdir().unwrap();
+    let server = TestServer::start_with_env(&[("FAKECLOUD_CONTAINER_CLI", "false")]).await;
+    let client = server.dynamodb_client().await;
+
+    create_snapshot_test_table(&client, "MemorySnapshot").await;
+    put_snapshot_test_item(&client, "MemorySnapshot", "memory#1", "explicit-path").await;
+
+    let resp = post_snapshot_save(
+        server.endpoint(),
+        Some(serde_json::json!({
+            "dataPath": target.path().display().to_string(),
+        })),
+    )
+    .await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        resp.json::<serde_json::Value>().await.unwrap()["saved"].as_bool(),
+        Some(true),
+    );
+
+    let snapshot_path = target.path().join("dynamodb").join("snapshot.json");
+    assert!(!target.path().join("fakecloud.version.toml").exists());
+    assert_snapshot_file_contains_item(
+        &snapshot_path,
+        "MemorySnapshot",
+        "memory#1",
+        "explicit-path",
+    );
+
+    write_fakecloud_version_file(target.path());
+    drop(server);
+    let restored = TestServer::start_persistent(target.path()).await;
+    let client = restored.dynamodb_client().await;
+    assert_snapshot_test_item(&client, "MemorySnapshot", "memory#1", "explicit-path").await;
+}
+
+#[tokio::test]
+async fn snapshot_save_endpoint_rejects_missing_store_without_data_path() {
+    let server = TestServer::start_with_env(&[("FAKECLOUD_CONTAINER_CLI", "false")]).await;
+
+    let resp = post_snapshot_save(server.endpoint(), None).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body = resp.json::<serde_json::Value>().await.unwrap();
+    assert_eq!(
+        body.get("error").and_then(|v| v.as_str()),
+        Some("dynamodb snapshot store is not configured and request body did not include dataPath"),
+    );
+}
+
+#[tokio::test]
+async fn snapshot_save_endpoint_uses_configured_store_without_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut server = TestServer::start_persistent(tmp.path()).await;
+    let client = server.dynamodb_client().await;
+
+    create_snapshot_test_table(&client, "ConfiguredSnapshot").await;
+    put_snapshot_test_item(
+        &client,
+        "ConfiguredSnapshot",
+        "configured#1",
+        "configured-store",
+    )
+    .await;
+
+    let snapshot_path = tmp.path().join("dynamodb").join("snapshot.json");
+    remove_file_if_exists(&snapshot_path);
+
+    let resp = post_snapshot_save(server.endpoint(), None).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        resp.json::<serde_json::Value>().await.unwrap()["saved"].as_bool(),
+        Some(true),
+    );
+    assert_snapshot_file_contains_item(
+        &snapshot_path,
+        "ConfiguredSnapshot",
+        "configured#1",
+        "configured-store",
+    );
+
+    server.restart().await;
+    let client = server.dynamodb_client().await;
+    assert_snapshot_test_item(
+        &client,
+        "ConfiguredSnapshot",
+        "configured#1",
+        "configured-store",
+    )
+    .await;
+}
 
 /// Full round-trip: create tables, populate items across every attribute
 /// type, configure TTL + tags + GSIs + LSIs, restart, and assert everything

--- a/crates/fakecloud-persistence/src/atomic.rs
+++ b/crates/fakecloud-persistence/src/atomic.rs
@@ -149,17 +149,18 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = Arc::new(dir.path().join("snap.bin"));
         let payloads: Vec<Vec<u8>> = (0..16).map(|i| vec![b'A' + i as u8; 8192]).collect();
-        let handles: Vec<_> = payloads
-            .iter()
-            .cloned()
-            .map(|p| {
-                let path = Arc::clone(&path);
-                std::thread::spawn(move || write_atomic_bytes(&path, &p).unwrap())
-            })
-            .collect();
-        for h in handles {
-            h.join().unwrap();
-        }
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = payloads
+                .iter()
+                .map(|p| {
+                    let path = Arc::clone(&path);
+                    scope.spawn(move || write_atomic_bytes(&path, p).unwrap())
+                })
+                .collect();
+            for h in handles {
+                h.join().unwrap();
+            }
+        });
         let got = std::fs::read(&*path).unwrap();
         assert!(
             payloads.contains(&got),

--- a/crates/fakecloud-sdk/README.md
+++ b/crates/fakecloud-sdk/README.md
@@ -127,6 +127,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Method             | Description                     |
 | ------------------ | ------------------------------- |
 | `tick_ttl().await` | Tick the DynamoDB TTL processor |
+| `save_snapshot(data_path).await` | Save a DynamoDB snapshot on demand (`None` -> configured store) |
 
 ### `fc.ecr()`
 

--- a/crates/fakecloud-sdk/src/client.rs
+++ b/crates/fakecloud-sdk/src/client.rs
@@ -955,6 +955,30 @@ impl DynamoDbClient<'_> {
             .await?;
         FakeCloud::parse(resp).await
     }
+
+    /// Write the current DynamoDB state as a canonical snapshot on demand.
+    ///
+    /// With `data_path` set, the snapshot is written to
+    /// `<data_path>/dynamodb/snapshot.json`; with `None`, it is written to the
+    /// server's configured persistent store (an error if none is configured).
+    pub async fn save_snapshot(
+        &self,
+        data_path: Option<&str>,
+    ) -> Result<DynamoDbSnapshotSaveResponse, Error> {
+        let resp = self
+            .fc
+            .client
+            .post(format!(
+                "{}/_fakecloud/dynamodb/snapshot/save",
+                self.fc.base_url
+            ))
+            .json(&DynamoDbSnapshotSaveRequest {
+                data_path: data_path.map(str::to_string),
+            })
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
 }
 
 // ── SecretsManager ──────────────────────────────────────────────────

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -792,6 +792,12 @@ pub struct DynamoDbSnapshotSaveRequest {
     pub data_path: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamoDbSnapshotSaveResponse {
+    pub saved: bool,
+}
+
 // ── SecretsManager ──────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -786,6 +786,12 @@ pub struct TtlTickResponse {
     pub expired_items: u64,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamoDbSnapshotSaveRequest {
+    pub data_path: Option<String>,
+}
+
 // ── SecretsManager ──────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2002,7 +2002,8 @@ async fn main() {
     if let Some(h) = dynamodb_service.snapshot_hook() {
         cfn_snapshot_hooks.insert("dynamodb", h);
     }
-    registry.register(Arc::new(dynamodb_service));
+    let dynamodb_service = Arc::new(dynamodb_service);
+    registry.register(dynamodb_service.clone());
     // Companion data plane: DynamoDB Streams (`streams.dynamodb.<region>.amazonaws.com`)
     // shares the same per-table state populated by mutations on the main
     // service. Lambda event source mappings against
@@ -5962,11 +5963,64 @@ async fn main() {
                     // handler, so without this the expired items reappear on the
                     // next restart (the normal mutating API path saves here).
                     if count > 0 {
-                        fakecloud_dynamodb::save_dynamodb_snapshot(&ds, store.clone(), &lock).await;
+                        if let Err(err) =
+                            fakecloud_dynamodb::save_dynamodb_snapshot(&ds, store.clone(), &lock)
+                                .await
+                        {
+                            tracing::error!(%err, "dynamodb snapshot save failed");
+                        }
                     }
                     axum::Json(types::TtlTickResponse {
                         expired_items: count as u64,
                     })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/dynamodb/snapshot/save",
+            axum::routing::post({
+                let service = dynamodb_service.clone();
+                move |body: Option<axum::Json<types::DynamoDbSnapshotSaveRequest>>| {
+                    let service = service.clone();
+                    async move {
+                        let result = if let Some(data_path) =
+                            body.and_then(|axum::Json(body)| body.data_path)
+                        {
+                            let data_path = std::path::PathBuf::from(data_path);
+                            let store = fakecloud_persistence::DiskSnapshotStore::new(
+                                data_path.join("dynamodb").join("snapshot.json"),
+                            );
+                            service
+                                .save_snapshot_to_store(Arc::new(store))
+                                .await
+                                .map(|_| true)
+                        } else {
+                            service.save_snapshot().await
+                        };
+
+                        match result {
+                            Ok(true) => {
+                                axum::Json(serde_json::json!({ "saved": true })).into_response()
+                            }
+                            Ok(false) => (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                axum::Json(serde_json::json!({
+                                    "error": "dynamodb snapshot store is not configured and request body did not include dataPath"
+                                })),
+                            )
+                                .into_response(),
+                            Err(err) => {
+                                tracing::error!(%err, "manual dynamodb snapshot save failed");
+                                (
+                                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                                    axum::Json(serde_json::json!({
+                                        "error": "failed to save dynamodb snapshot"
+                                    })),
+                                )
+                                    .into_response()
+                            }
+                        }
+                    }
                 }
             }),
         )

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -192,6 +192,7 @@ func main() {
 | Method | Description |
 |--------|-------------|
 | `TickTTL(ctx)` | Tick the TTL processor |
+| `SaveSnapshot(ctx, dataPath)` | Save a DynamoDB snapshot on demand (empty dataPath -> configured store) |
 
 ### SecretsManager - `fc.SecretsManager()`
 

--- a/sdks/go/dynamodb.go
+++ b/sdks/go/dynamodb.go
@@ -15,3 +15,19 @@ func (c *DynamoDBClient) TickTTL(ctx context.Context) (*TTLTickResponse, error) 
 	}
 	return &out, nil
 }
+
+// SaveSnapshot writes the current DynamoDB state as a canonical snapshot on
+// demand. When dataPath is non-empty the snapshot is written to
+// <dataPath>/dynamodb/snapshot.json; when empty it is written to the server's
+// configured persistent store (an error if none is configured).
+func (c *DynamoDBClient) SaveSnapshot(ctx context.Context, dataPath string) (*DynamoDBSnapshotSaveResponse, error) {
+	var body *DynamoDBSnapshotSaveRequest
+	if dataPath != "" {
+		body = &DynamoDBSnapshotSaveRequest{DataPath: dataPath}
+	}
+	var out DynamoDBSnapshotSaveResponse
+	if err := c.fc.doPost(ctx, "/_fakecloud/dynamodb/snapshot/save", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -602,6 +602,17 @@ type TTLTickResponse struct {
 	ExpiredItems uint64 `json:"expiredItems"`
 }
 
+// DynamoDBSnapshotSaveRequest is the optional body for SaveSnapshot. An empty
+// DataPath saves to the server's configured persistent store.
+type DynamoDBSnapshotSaveRequest struct {
+	DataPath string `json:"dataPath,omitempty"`
+}
+
+// DynamoDBSnapshotSaveResponse is returned after saving a DynamoDB snapshot.
+type DynamoDBSnapshotSaveResponse struct {
+	Saved bool `json:"saved"`
+}
+
 // ── SecretsManager ─────────────────────────────────────────────────
 
 // RotationTickResponse is returned after ticking the rotation scheduler.

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -168,6 +168,7 @@ FakeCloud fc = new FakeCloud("http://localhost:4566"); // explicit base URL
 | Method       | Description            |
 | ------------ | ---------------------- |
 | `tickTtl()`  | Tick the TTL processor |
+| `saveSnapshot(dataPath)` | Save a DynamoDB snapshot on demand (`null` dataPath -> configured store) |
 
 ### `fc.secretsmanager()`
 

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -100,6 +100,8 @@ import dev.fakecloud.Types.StepFunctionsSyncExecutionsResponse;
 import dev.fakecloud.Types.StepFunctionsExecutionTreeResponse;
 import dev.fakecloud.Types.TokensResponse;
 import dev.fakecloud.Types.TtlTickResponse;
+import dev.fakecloud.Types.DynamoDbSnapshotSaveRequest;
+import dev.fakecloud.Types.DynamoDbSnapshotSaveResponse;
 import dev.fakecloud.Types.UserConfirmationCodes;
 import dev.fakecloud.Types.WarmContainersResponse;
 
@@ -716,6 +718,21 @@ public final class FakeCloud {
 
         public TtlTickResponse tickTtl() {
             return http.postEmpty("/_fakecloud/dynamodb/ttl-processor/tick", TtlTickResponse.class);
+        }
+
+        /**
+         * Write the current DynamoDB state as a canonical snapshot on demand.
+         *
+         * <p>When {@code dataPath} is non-null the snapshot is written to
+         * {@code <dataPath>/dynamodb/snapshot.json}; when null it is written to
+         * the server's configured persistent store (an error if none is
+         * configured).
+         */
+        public DynamoDbSnapshotSaveResponse saveSnapshot(String dataPath) {
+            return http.postJson(
+                    "/_fakecloud/dynamodb/snapshot/save",
+                    new DynamoDbSnapshotSaveRequest(dataPath),
+                    DynamoDbSnapshotSaveResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -576,6 +576,12 @@ public final class Types {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record TtlTickResponse(int expiredItems) {}
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record DynamoDbSnapshotSaveRequest(String dataPath) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record DynamoDbSnapshotSaveResponse(boolean saved) {}
+
     // ── SecretsManager ─────────────────────────────────────────────
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record RotationTickResponse(List<String> rotatedSecrets) {}

--- a/sdks/php/README.md
+++ b/sdks/php/README.md
@@ -206,6 +206,7 @@ $fc = new FakeCloud('http://localhost:4566'); // explicit base URL
 | Method       | Description            |
 | ------------ | ---------------------- |
 | `tickTtl()`  | Tick the TTL processor |
+| `saveSnapshot(?dataPath)` | Save a DynamoDB snapshot on demand (`null` -> configured store) |
 
 ### `$fc->secretsmanager()`
 

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -721,6 +721,21 @@ final class DynamoDbClient
             $this->http->postEmpty('/_fakecloud/dynamodb/ttl-processor/tick')
         );
     }
+
+    /**
+     * Write the current DynamoDB state as a canonical snapshot on demand.
+     *
+     * When $dataPath is provided the snapshot is written to
+     * "<dataPath>/dynamodb/snapshot.json"; when null it is written to the
+     * server's configured persistent store (an error if none is configured).
+     */
+    public function saveSnapshot(?string $dataPath = null): DynamoDbSnapshotSaveResponse
+    {
+        $body = $dataPath !== null ? ['dataPath' => $dataPath] : [];
+        return DynamoDbSnapshotSaveResponse::fromArray(
+            $this->http->postJson('/_fakecloud/dynamodb/snapshot/save', $body)
+        );
+    }
 }
 
 final class SecretsManagerClient

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -1759,6 +1759,18 @@ final class TtlTickResponse
     }
 }
 
+final class DynamoDbSnapshotSaveResponse
+{
+    public function __construct(
+        public readonly bool $saved,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['saved']);
+    }
+}
+
 // ── SecretsManager ─────────────────────────────────────────────
 
 final class RotationTickResponse

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -300,6 +300,7 @@ Called as a method on the main client: `fc.organizations()`.
 | Method | Description |
 |---|---|
 | `tick_ttl()` | Tick the TTL processor |
+| `save_snapshot(data_path=None)` | Save a DynamoDB snapshot on demand (`None` -> configured store) |
 
 ### `fc.secretsmanager`
 

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -34,6 +34,7 @@ from fakecloud.types import (
     ConfirmUserRequest,
     ConfirmUserResponse,
     CreateAdminResponse,
+    DynamoDbSnapshotSaveResponse,
     Ec2InstanceNetworksResponse,
     Ec2InstancesResponse,
     EcrImagesResponse,
@@ -1440,6 +1441,23 @@ class DynamoDbClient:
         _check(resp)
         return TtlTickResponse.from_dict(resp.json())
 
+    async def save_snapshot(
+        self, data_path: Optional[str] = None
+    ) -> DynamoDbSnapshotSaveResponse:
+        """Write the current DynamoDB state as a canonical snapshot on demand.
+
+        With ``data_path`` set, the snapshot is written to
+        ``<data_path>/dynamodb/snapshot.json``; with ``None`` it is written to
+        the server's configured persistent store (an error if none is
+        configured).
+        """
+        body = {"dataPath": data_path} if data_path is not None else None
+        resp = await self._client.post(
+            f"{self._base}/_fakecloud/dynamodb/snapshot/save", json=body
+        )
+        _check(resp)
+        return DynamoDbSnapshotSaveResponse.from_dict(resp.json())
+
 
 class SecretsManagerClient:
     """Async SecretsManager introspection client."""
@@ -2197,6 +2215,23 @@ class _SyncDynamoDbClient:
         resp = self._client.post(f"{self._base}/_fakecloud/dynamodb/ttl-processor/tick")
         _check(resp)
         return TtlTickResponse.from_dict(resp.json())
+
+    def save_snapshot(
+        self, data_path: Optional[str] = None
+    ) -> DynamoDbSnapshotSaveResponse:
+        """Write the current DynamoDB state as a canonical snapshot on demand.
+
+        With ``data_path`` set, the snapshot is written to
+        ``<data_path>/dynamodb/snapshot.json``; with ``None`` it is written to
+        the server's configured persistent store (an error if none is
+        configured).
+        """
+        body = {"dataPath": data_path} if data_path is not None else None
+        resp = self._client.post(
+            f"{self._base}/_fakecloud/dynamodb/snapshot/save", json=body
+        )
+        _check(resp)
+        return DynamoDbSnapshotSaveResponse.from_dict(resp.json())
 
 
 class _SyncSecretsManagerClient:

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -1515,6 +1515,16 @@ class TtlTickResponse:
         return cls(**d)
 
 
+@dataclass
+class DynamoDbSnapshotSaveResponse:
+    saved: bool
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> DynamoDbSnapshotSaveResponse:
+        d = _convert_keys(data)
+        return cls(**d)
+
+
 # ── SecretsManager ──────────────────────────────────────────────────
 
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -135,9 +135,10 @@ Top-level client. Defaults to `http://localhost:4566`.
 
 ### `fc.dynamodb`
 
-| Method      | Description            |
-| ----------- | ---------------------- |
-| `tickTtl()` | Tick the TTL processor |
+| Method                    | Description                                                            |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `tickTtl()`               | Tick the TTL processor                                                 |
+| `saveSnapshot(dataPath?)` | Save a DynamoDB snapshot on demand (omit dataPath -> configured store) |
 
 ### `fc.ec2`
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakecloud",
-  "version": "0.17.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.17.0",
+      "version": "0.29.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -1,6 +1,8 @@
 import type {
   AthenaNamedQueriesResponse,
   CreateAdminResponse,
+  DynamoDbSnapshotSaveRequest,
+  DynamoDbSnapshotSaveResponse,
   ApiGatewayV2RequestsResponse,
   ApiGatewayV2ConnectionsResponse,
   RdsLambdaInvokeRequest,
@@ -673,6 +675,28 @@ export class DynamoDbClient {
     const resp = await fetch(
       `${this.baseUrl}/_fakecloud/dynamodb/ttl-processor/tick`,
       { method: "POST" },
+    );
+    return parse(resp);
+  }
+
+  /**
+   * Write the current DynamoDB state as a canonical snapshot on demand.
+   *
+   * With `dataPath` set, the snapshot is written to
+   * `<dataPath>/dynamodb/snapshot.json`; with it omitted, the snapshot is
+   * written to the server's configured persistent store (an error if none is
+   * configured).
+   */
+  async saveSnapshot(dataPath?: string): Promise<DynamoDbSnapshotSaveResponse> {
+    const req: DynamoDbSnapshotSaveRequest =
+      dataPath !== undefined ? { dataPath } : {};
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/dynamodb/snapshot/save`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(req),
+      },
     );
     return parse(resp);
   }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -514,6 +514,14 @@ export interface TtlTickResponse {
   expiredItems: number;
 }
 
+export interface DynamoDbSnapshotSaveRequest {
+  dataPath?: string;
+}
+
+export interface DynamoDbSnapshotSaveResponse {
+  saved: boolean;
+}
+
 // ── SecretsManager ─────────────────────────────────────────────────
 
 export interface RotationTickResponse {

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -176,6 +176,7 @@ curl http://localhost:4566/_fakecloud/health
 | Endpoint | Method | Description |
 | -------- | ------ | ----------- |
 | `/_fakecloud/dynamodb/ttl-processor/tick` | POST | Expire TTL items that are due. |
+| `/_fakecloud/dynamodb/snapshot/save` | POST | Write the current DynamoDB state as a canonical snapshot on demand. Optional JSON body `{"dataPath": "<dir>"}` saves to `<dir>/dynamodb/snapshot.json`; with no body it saves to the configured persistent store. Returns `{"saved": true}`, `400` if neither a store nor `dataPath` is available, `500` on write failure. |
 
 ## EC2
 

--- a/website/content/docs/sdks/go.md
+++ b/website/content/docs/sdks/go.md
@@ -149,6 +149,7 @@ Sub-clients are accessed via methods: `fc.SES()`, `fc.SNS()`, `fc.Lambda()`, etc
 | Method | Description |
 |--------|-------------|
 | `TickTTL(ctx)` | Tick the TTL processor |
+| `SaveSnapshot(ctx, dataPath)` | Save a DynamoDB snapshot on demand (empty -> configured store) |
 
 ## `fc.SecretsManager()`
 

--- a/website/content/docs/sdks/java.md
+++ b/website/content/docs/sdks/java.md
@@ -166,6 +166,7 @@ FakeCloud fc2 = new FakeCloud("http://localhost:5000"); // explicit base URL
 | Method       | Description            |
 | ------------ | ---------------------- |
 | `tickTtl()`  | Tick the TTL processor |
+| `saveSnapshot(dataPath)` | Save a DynamoDB snapshot on demand (`null` -> configured store) |
 
 ## `fc.secretsmanager()`
 

--- a/website/content/docs/sdks/php.md
+++ b/website/content/docs/sdks/php.md
@@ -163,6 +163,7 @@ $fc = new FakeCloud('http://localhost:5000');   // explicit base URL
 | Method      | Description            |
 | ----------- | ---------------------- |
 | `tickTtl()` | Tick the TTL processor |
+| `saveSnapshot(?dataPath)` | Save a DynamoDB snapshot on demand (`null` -> configured store) |
 
 ## `$fc->secretsmanager()`
 

--- a/website/content/docs/sdks/python.md
+++ b/website/content/docs/sdks/python.md
@@ -267,6 +267,7 @@ Called as a method on the main client: `fc.organizations()`.
 | Method        | Description            |
 | ------------- | ---------------------- |
 | `tick_ttl()`  | Tick the TTL processor |
+| `save_snapshot(data_path=None)` | Save a DynamoDB snapshot on demand (`None` -> configured store) |
 
 ## `fc.secretsmanager`
 

--- a/website/content/docs/sdks/rust.md
+++ b/website/content/docs/sdks/rust.md
@@ -112,6 +112,7 @@ Every sub-client is constructed lazily via an accessor (`fc.lambda()`, `fc.sqs()
 | Method             | Description                                |
 | ------------------ | ------------------------------------------ |
 | `tick_ttl().await` | Tick the DynamoDB TTL processor            |
+| `save_snapshot(data_path).await` | Save a DynamoDB snapshot on demand (`None` -> store) |
 
 ## `fc.ec2()`
 

--- a/website/content/docs/sdks/typescript.md
+++ b/website/content/docs/sdks/typescript.md
@@ -111,6 +111,7 @@ const fc = new FakeCloud("http://localhost:5000");
 | Method      | Description            |
 | ----------- | ---------------------- |
 | `tickTtl()` | Tick the TTL processor |
+| `saveSnapshot(dataPath?)` | Save a DynamoDB snapshot on demand (omit -> configured store) |
 
 ## `fc.ec2`
 

--- a/website/content/docs/services/dynamodb.md
+++ b/website/content/docs/services/dynamodb.md
@@ -30,6 +30,7 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 ## Introspection
 
 - `POST /_fakecloud/dynamodb/ttl-processor/tick` — expire items whose TTL attribute is in the past
+- `POST /_fakecloud/dynamodb/snapshot/save` — write the current DynamoDB state as a canonical snapshot on demand. An optional JSON body `{"dataPath": "<dir>"}` writes to `<dir>/dynamodb/snapshot.json`; with no body it writes to the configured persistent store. Returns `{"saved": true}`, `400` when neither a store nor `dataPath` is available, and `500` on write failure. Lets import/export tooling populate DynamoDB through the normal API and then have fakecloud emit the canonical snapshot format instead of reproducing snapshot internals out of tree.
 
 ## Cross-service delivery
 


### PR DESCRIPTION
Add a private DynamoDB snapshot save endpoint so callers can generate a shareable dump on demand. This lets import/export tooling populate FakeCloud through normal DynamoDB APIs, then ask FakeCloud to write the canonical snapshot format instead of mirroring snapshot internals out of tree.

The endpoint supports saving to the configured persistent store, or to a caller-provided dataPath.

If neither a configured store nor dataPath is available, it returns a 400.

Tests cover:
- E2E HTTP requests for all four configured-store/dataPath combinations
- E2E DynamoDB setup and reload verification using the real AWS SDK
- save_snapshot() with no configured store
- save_snapshot() round-tripping empty state
- save_snapshot() and save_snapshot_to_store() round-tripping multiple tables, indexes, and varied DynamoDB attribute types

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a private POST endpoint to save a DynamoDB snapshot on demand and wires it into all SDKs and docs. Supports saving to the configured store or a provided `dataPath`, with clear errors and stronger round‑trip tests.

- **New Features**
  - POST `/_fakecloud/dynamodb/snapshot/save` with optional `{ "dataPath": "<dir>" }`. Writes to the configured store or `<dir>/dynamodb/snapshot.json`. Returns `{ "saved": true }`; 400 if neither a store nor `dataPath` is provided; 500 on write failure.
  - Service API: `DynamoDbService::save_snapshot() -> io::Result<bool>` (false when no store); `save_snapshot_to_store(Arc<dyn SnapshotStore>) -> io::Result<()>`; `save_dynamodb_snapshot(...) -> io::Result<bool>`. Errors are logged on mutation and TTL tick paths.
  - SDKs: add `saveSnapshot`/`save_snapshot` across Rust (`fakecloud-sdk`), Go, Python, TypeScript, PHP, and Java, plus request/response types. Updated SDK READMEs and website docs.
  - Tests: E2E coverage for configured‑store/`dataPath` permutations and reloads using the AWS SDK; unit tests for no‑store and explicit store paths; round‑trip for empty state; stricter typed‑attribute checks (full list/map equality; set size and all members).

<sup>Written for commit 6a19278cae1df26b8a85a41a5c6bc0fba9d9d505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

