### PR TITLE
chore(release): bump workspace to v0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3870,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4025,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4271,7 +4271,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4384,7 +4384,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4571,7 +4571,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -114,202 +114,202 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.29.0")
+    testImplementation("dev.fakecloud:fakecloud:0.30.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.29.0</version>
+    <version>0.30.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.29.0"
+version = "0.30.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.29.0"
+version = "0.30.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release v0.30.0. Minor bump: new **Resource Groups** service (#2069, 23 ops, restJson1, new `fakecloud-resource-groups` crate) plus a full bug-hunt correctness sweep.

Since v0.29.0:
- feat: Resource Groups service (#2069)
- fix(dynamodb): correctness cluster + canonical FilterExpression IN/contains + nested-path IN (#2059, #2070)
- fix(cognito): identity claims, token validity, GetUser shape, alias usernames (#2067)
- fix(rds-data,pipes,cloudformation): data-infra correctness cluster (#2065)
- fix(ssm,secretsmanager,ses,eventbridge,firehose,apigateway,iam): persist dropped inputs + AWS response shapes (#2066)
- fix(sqs,s3): FIFO dedup scope + sequence-number shape, stable ListQueues token, v1 NextMarker (#2060)
- fix(cloudwatch): awsJson1_0 protocol + persist alarm Metrics/Tags + anomaly Configuration (#2063)
- fix(apigatewayv2): real ImportApi/ReimportApi/ExportApi + persist dropped fields (#2064)
- fix(cloudfront): ListDistributionsBy* filters, domain move, live function code (#2061)
- fix(wafv2,glue,athena,elasticache,acm): read-back stubs, full-replace updates (#2062)

## Version bumps
- `Cargo.toml` workspace + all `fakecloud-*` dep pins 0.29.0 -> 0.30.0
- `Cargo.lock` regenerated
- TypeScript / Python / Java SDK versions
- release.yml publish list already includes `fakecloud-resource-groups`

## Test plan
- `cargo build -p fakecloud` clean at 0.30.0
- CI green + Cubic before merge, then tag v0.30.0 triggers publish

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.30.0: bumps workspace and SDK versions. Highlights: adds the new `fakecloud-resource-groups` service and ships a broad correctness sweep across services.

- **Dependencies**
  - Bump all workspace crates to 0.30.0 in `Cargo.toml`; regenerate `Cargo.lock`.
  - Update `fakecloud` SDK versions to 0.30.0 in `sdks/typescript/package.json`, `sdks/python/pyproject.toml`, `sdks/java/build.gradle.kts`, and README examples.

<sup>Written for commit 9f96961983c6039ef4542de138904db3f63a28db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

