### PR TITLE
ci(release): fix publish-go perms + resource-groups-tagging & dsql version pins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,6 +438,10 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # Creating the sdks/go/vX.Y.Z ref via the API needs write access to repo
+    # contents; the default job token is read-only, which 403s the tag create.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ version = "0.30.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.29.0"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,7 @@ version = "0.30.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
+version = "0.30.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"


### PR DESCRIPTION
## Summary

Three release-infrastructure fixes surfaced while publishing v0.30.0:

1. **`publish-go` 403** — the job creates the `sdks/go/vX.Y.Z` tag via the GitHub refs API, but the default job token is read-only for `contents`, so it returned `403 Resource not accessible by integration`. Grant `permissions: contents: write`. (On v0.30.0 the tag was created manually to unblock.)

2. **`fakecloud-resource-groups-tagging` version skew** — PR #2071 added the crate with a stale `"0.29.0"` workspace-dependency pin and merged after the 0.30.0 bump, so the member resolved to 0.30.0 while the pin + `Cargo.lock` required 0.29.0 -> `failed to select a version for the requirement fakecloud-resource-groups-tagging = ^0.29.0`, breaking every build on `main`. Bump to 0.30.0.

3. **`fakecloud-dsql` missing version** — the `[workspace.dependencies.fakecloud-dsql]` entry had a `path` but no `version`. `cargo publish` requires every dependency of a published crate to carry a version, so the `fakecloud` (server) **bin** crate failed manifest verification (`dependency fakecloud-dsql does not specify a version`) and has silently failed to publish to crates.io since dsql was added — the bin is stuck at 0.28.2 while the libs advanced. Pin it like every other fakecloud dep.

Fixes 2 + 3 also mean the next release's `fakecloud` bin will publish to crates.io again (planned as v0.30.1).

## Test plan

- `cargo build` clean at 0.30.0 with the version-pin fixes.
- `cargo publish -p fakecloud --dry-run` now passes manifest verification for `fakecloud-dsql` (the remaining dry-run "not found" is only because `fakecloud-resource-groups-tagging` is a brand-new crate not yet on the index; it publishes before the bin in a full release run).
- publish-go perms change is YAML-only, effective on the next tag push.