### PR TITLE
chore(release): bump workspace to v0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3452,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3595,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3948,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4117,7 +4117,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4187,7 +4187,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4242,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4462,7 +4462,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4703,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -114,207 +114,207 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.30.0"
+version = "0.30.1"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.30.0")
+    testImplementation("dev.fakecloud:fakecloud:0.30.1")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.30.0</version>
+    <version>0.30.1</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -4,7 +4,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
     `java-library`
-    id("com.vanniktech.maven.publish") version "0.30.1"
+    id("com.vanniktech.maven.publish") version "0.30.0"
 }
 
 group = "dev.fakecloud"

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -4,11 +4,11 @@ import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
     `java-library`
-    id("com.vanniktech.maven.publish") version "0.30.0"
+    id("com.vanniktech.maven.publish") version "0.30.1"
 }
 
 group = "dev.fakecloud"
-version = "0.30.0"
+version = "0.30.1"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.30.0"
+version = "0.30.1"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release. Purpose: publish the `fakecloud` bin crate to crates.io, which has been stuck at 0.28.2 since `fakecloud-dsql` was added with a version-less workspace dependency (fixed in #2074), and ship the release-workflow fixes from #2074:

- `publish-go` now has `contents: write` (was 403 on the API tag-create)
- `fakecloud-resource-groups-tagging` + `fakecloud-dsql` deps carry versions so the bin crate passes `cargo publish` manifest verification

All v0.30.0 library crates + SDKs + GitHub Release binaries already published; this patch republishes them at 0.30.1 and finally lands the bin crate again.

## Version bumps
- `Cargo.toml` workspace + all `fakecloud-*` dep pins 0.30.0 -> 0.30.1
- `Cargo.lock` regenerated
- TypeScript / Python / Java SDK versions

## Test plan
- CI green + Cubic before merge; tag v0.30.1 triggers publish; verify `fakecloud` bin indexed at 0.30.1 on crates.io.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch release to v0.30.1 to publish the `fakecloud` bin crate to crates.io and align workspace and SDK versions. Also fixes release workflow and Gradle plugin versioning for a clean publish.

- **Bug Fixes**
  - Add explicit versions to `fakecloud-dsql` and `fakecloud-resource-groups-tagging` to pass `cargo publish` checks.
  - Grant `publish-go` workflow `contents: write` to avoid 403 on tag creation.
  - Keep `com.vanniktech.maven.publish` Gradle plugin pinned at `0.30.0` to prevent plugin-not-found errors.

- **Dependencies**
  - Bump all workspace crates and pins from 0.30.0 to 0.30.1.
  - Update SDKs to 0.30.1: TypeScript, Python, and Java.

<sup>Written for commit a68a0d7f6464f0ab86c4dd5706f0da3e7bd800c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

