### PR TITLE
chore(release): bump workspace to v0.30.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4120,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4268,7 +4268,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.30.0"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4308,7 +4308,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4446,7 +4446,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4588,7 +4588,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4687,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -114,211 +114,211 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.30.0"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.30.1"
+version = "0.30.2"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.30.1")
+    testImplementation("dev.fakecloud:fakecloud:0.30.2")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.30.1</version>
+    <version>0.30.2</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.30.1"
+version = "0.30.2"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.30.1"
+version = "0.30.2"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release completing the v0.30.x publish. v0.30.1 published the libs + SDKs but its GitHub Release + binaries were **skipped**: `fakecloud-memorydb` (added around the 0.30.1 bump) kept a stale `"0.30.0"` workspace-dependency pin, so `Cargo.lock` was inconsistent with `Cargo.toml` and `cargo build --locked` (the release binary-build step) failed with `cannot update the lock file because --locked was passed`. That also left `main` red for `--locked` builds.

This bump fixes the memorydb pin to the workspace version and regenerates `Cargo.lock`, so:
- the 4 release binaries build again -> GitHub Release is created
- the `fakecloud` bin crate publishes to crates.io (also carried the dsql/tagging pin + publish-go perms fixes from #2074)

## Version bumps
- `Cargo.toml` workspace + all `fakecloud-*` dep pins -> 0.30.2 (incl. the previously-stale `fakecloud-memorydb`)
- `Cargo.lock` regenerated; `cargo build --locked --bin fakecloud` verified locally
- TypeScript / Python / Java SDK versions (vanniktech gradle plugin left at its own 0.30.0)

## Test plan
- `cargo build --locked --bin fakecloud` passes (no lock drift).
- CI green + Cubic before merge; tag v0.30.2 triggers publish; verify `fakecloud` bin indexed at 0.30.2 + GitHub Release has 8 assets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump workspace and SDKs to v0.30.2 and fix a stale `fakecloud-memorydb` pin that broke `cargo build --locked`, restoring release binaries and completing the 0.30.x publish.

- **Bug Fixes**
  - Set `fakecloud-memorydb` to `0.30.2` and regenerated `Cargo.lock` to fix `--locked` build failures and unblock the GitHub Release and `fakecloud` bin publish.

- **Dependencies**
  - Updated all `fakecloud-*` crates to `0.30.2`.
  - Bumped SDK versions to `0.30.2` in `sdks/typescript/package.json`, `sdks/python/pyproject.toml`, and `sdks/java` (build + README).

<sup>Written for commit daa4d272dfc36a804d1815ae046d908683e6b510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

