### PR TITLE
test(memorydb): tfacc harness coverage (5 resources) + seed default parameter groups

### DIFF
--- a/crates/fakecloud-memorydb/src/service.rs
+++ b/crates/fakecloud-memorydb/src/service.rs
@@ -2190,4 +2190,34 @@ mod tests {
         let sys = call(&s, "DescribeSnapshots", json!({"Source": "system"})).unwrap();
         assert!(sys["Snapshots"].as_array().unwrap().is_empty());
     }
+
+    #[test]
+    fn default_parameter_groups_are_seeded() {
+        let s = service();
+        let groups = call(&s, "DescribeParameterGroups", json!({})).unwrap();
+        let names: Vec<&str> = groups["ParameterGroups"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|g| g["Name"].as_str())
+            .collect();
+        for expected in [
+            "default.memorydb-redis7",
+            "default.memorydb-redis6",
+            "default.memorydb-valkey7",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "missing {expected}; got {names:?}"
+            );
+        }
+        // The default group is readable by name (the TF provider reads it).
+        let one = call(
+            &s,
+            "DescribeParameterGroups",
+            json!({"ParameterGroupName": "default.memorydb-redis7"}),
+        )
+        .unwrap();
+        assert_eq!(one["ParameterGroups"][0]["Family"], "memorydb_redis7");
+    }
 }

--- a/crates/fakecloud-memorydb/src/state.rs
+++ b/crates/fakecloud-memorydb/src/state.rs
@@ -215,6 +215,25 @@ impl AccountState for MemoryDbState {
                 arn: format!("arn:aws:memorydb:{region}:{account_id}:acl/open-access"),
             },
         );
+        // AWS provides a default parameter group per supported engine family.
+        // The Terraform provider reads e.g. `default.memorydb-redis7` when
+        // managing a parameter group, so these must exist out of the box.
+        for (pg_name, family) in [
+            ("default.memorydb-redis7", "memorydb_redis7"),
+            ("default.memorydb-redis6", "memorydb_redis6"),
+            ("default.memorydb-valkey7", "memorydb_valkey7"),
+        ] {
+            s.parameter_groups.insert(
+                pg_name.to_string(),
+                ParameterGroup {
+                    name: pg_name.to_string(),
+                    family: family.to_string(),
+                    description: format!("Default parameter group for {family}"),
+                    arn: format!("arn:aws:memorydb:{region}:{account_id}:parametergroup/{pg_name}"),
+                    parameters: BTreeMap::new(),
+                },
+            );
+        }
         s
     }
 }

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -574,6 +574,26 @@ pub const SERVICES: &[Service] = &[
         deny: &[],
     },
     Service {
+        name: "memorydb",
+        // MemoryDB is a full control plane (no Redis/Valkey data-plane container),
+        // so the Terraform provider's control-plane resources are exercisable:
+        // ACLs, users, parameter groups (a default group per family is seeded so
+        // the provider's default-group read succeeds), snapshots, and clusters
+        // (which transition creating -> available on describe, so the create
+        // waiter completes; shard slots are partitioned to match).
+        //
+        // SubnetGroup_basic is excluded: its check asserts `vpc_id` equals the
+        // real EC2 VPC the test created, which needs cross-service subnet ->
+        // VPC resolution the memorydb crate does not have (the sibling
+        // ElastiCache subnet group has the same limitation). Tracked follow-up.
+        run_regex: concat!(
+            "^TestAccMemoryDB(",
+            "ACL|User|ParameterGroup|Snapshot|Cluster",
+            ")_basic$",
+        ),
+        deny: &[],
+    },
+    Service {
         name: "cloudfront",
         // Cache/origin-request/realtime-log/log-delivery data sources. The
         // CloudFront resources (distribution, function, OAC, ...) are deferred.
@@ -1129,6 +1149,16 @@ pub const SHARDS: &[Shard] = &[
             "User|UserDataSource",
             "|UserGroup|UserGroupAssociation",
             "|SubnetGroup|SubnetGroupDataSource",
+            ")_basic$",
+        ),
+        extra_deny: &[],
+    },
+    Shard {
+        name: "memorydb",
+        service: "memorydb",
+        run_regex: concat!(
+            "^TestAccMemoryDB(",
+            "ACL|User|ParameterGroup|Snapshot|Cluster",
             ")_basic$",
         ),
         extra_deny: &[],

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -366,6 +366,7 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_KINESIS", "kinesis"),
     ("AWS_ENDPOINT_URL_RDS", "rds"),
     ("AWS_ENDPOINT_URL_ELASTICACHE", "elasticache"),
+    ("AWS_ENDPOINT_URL_MEMORYDB", "memorydb"),
     ("AWS_ENDPOINT_URL_CLOUDFORMATION", "cloudformation"),
     ("AWS_ENDPOINT_URL_SESV2", "sesv2"),
     ("AWS_ENDPOINT_URL_SES", "ses"),

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -103,6 +103,11 @@ async fn elasticache_acceptance() {
 }
 
 #[tokio::test]
+async fn memorydb_acceptance() {
+    run_shard("memorydb").await;
+}
+
+#[tokio::test]
 async fn rds_acceptance() {
     run_shard("rds").await;
 }


### PR DESCRIPTION
## Summary
Bug-hunt batch D on MemoryDB (report 2026-07-02, finding G1). Adds acceptance coverage and the one behavior change it required.

- **Wire memorydb into the terraform-provider-aws acceptance harness**: new Service + Shard in the tfacc allowlist, `AWS_ENDPOINT_URL_MEMORYDB` env, and a `memorydb_acceptance` shard test. Covers `TestAccMemoryDB{ACL,User,ParameterGroup,Snapshot,Cluster}_basic` — all pass locally against the real Terraform provider.
- **Seed AWS's default parameter groups** (`default.memorydb-redis7`/`redis6`/`valkey7`) per account, so the provider's default-group read during `aws_memorydb_parameter_group` management succeeds (was `ParameterGroupNotFoundFault`).

`TestAccMemoryDBCluster_basic` passes on top of the shard-slot partitioning merged in the batch-C PR (#2080).

## Excluded (documented, tracked)
`TestAccMemoryDBSubnetGroup_basic` — its check asserts `vpc_id` equals the real EC2 VPC the test created, which needs cross-service subnet -> VPC resolution the memorydb crate lacks (the sibling ElastiCache subnet group has the same limitation).

## Test plan
- memorydb tfacc shard: 5/5 pass locally (Go + Terraform 1.14.5 against the vendored provider).
- memorydb conformance **1,201/1,201**; +1 unit test (default param groups seeded); crate suite 25/25.
- clippy `-D warnings` + fmt clean.

## Surface
Test-harness + seeded-defaults; no new API op/count/protocol (checked).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MemoryDB to the Terraform acceptance harness and seeds default parameter groups so `terraform-provider-aws` tests for ACL, User, ParameterGroup, Snapshot, and Cluster pass without manual setup.

- **New Features**
  - Added `memorydb` to `fakecloud-tfacc`: Service + Shard allowlist, `AWS_ENDPOINT_URL_MEMORYDB`, and a `memorydb_acceptance` shard test.
  - Seeded per-account default parameter groups: `default.memorydb-redis7`, `default.memorydb-redis6`, `default.memorydb-valkey7`, enabling default-group reads during `aws_memorydb_parameter_group` management.
  - Excluded `TestAccMemoryDBSubnetGroup_basic` pending cross-service subnet→VPC resolution.

<sup>Written for commit ff66dfe018ef1a59daf26ab5a3001541f19fc38d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

