### PR TITLE
feat(eks): terraform-provider-aws acceptance shard + cluster-shape fidelity (batch 7)

### DIFF
--- a/crates/fakecloud-eks/src/service.rs
+++ b/crates/fakecloud-eks/src/service.rs
@@ -569,6 +569,8 @@ impl EksService {
             updates: Default::default(),
             connector_config: None,
             encryption_config: None,
+            access_config: build_access_config(body.get("accessConfig")),
+            upgrade_policy: build_upgrade_policy(body.get("upgradePolicy")),
         };
 
         let out = cluster_json(&cluster, &id);
@@ -2610,6 +2612,8 @@ impl EksService {
             updates: Default::default(),
             connector_config: Some(connector_config),
             encryption_config: None,
+            access_config: build_access_config(None),
+            upgrade_policy: build_upgrade_policy(None),
         };
         let out = connected_cluster_json(&cluster, &id);
         state.clusters.insert(name, cluster);
@@ -2681,7 +2685,7 @@ impl EksService {
             .cloned()
             .unwrap_or_else(|| "eks".to_string());
 
-        let catalog: Vec<Value> = cluster_version_catalog(&cluster_type)
+        let mut catalog: Vec<Value> = cluster_version_catalog(&cluster_type)
             .into_iter()
             .filter(|v| {
                 version_filter.is_empty()
@@ -2691,6 +2695,9 @@ impl EksService {
             })
             .filter(|v| !default_only || v["defaultVersion"] == true)
             .collect();
+        // AWS reports the default version first; a stable sort keying non-default
+        // rows after default ones preserves the ascending version order otherwise.
+        catalog.sort_by_key(|v| v["defaultVersion"] != true);
 
         let (page, token) = paginate_checked(&catalog, next_token.as_deref(), max_results)
             .map_err(|_| invalid_parameter("Invalid nextToken"))?;
@@ -3591,12 +3598,43 @@ fn build_k8s_network_config(req: Option<&Value>) -> Value {
     let service_cidr = req
         .and_then(|v| v.get("serviceIpv4Cidr"))
         .and_then(|v| v.as_str())
-        .unwrap_or("10.100.0.0/16")
+        .unwrap_or("172.20.0.0/16")
         .to_string();
+    // `elasticLoadBalancing` is always present in the response; `enabled`
+    // defaults to false unless the caller opts in (auto mode / EKS Auto).
+    let elb_enabled = req
+        .and_then(|v| v.get("elasticLoadBalancing"))
+        .and_then(|v| v.get("enabled"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     json!({
         "serviceIpv4Cidr": service_cidr,
         "ipFamily": ip_family,
+        "elasticLoadBalancing": { "enabled": elb_enabled },
     })
+}
+
+/// Build an `AccessConfigResponse` object. The API only reports
+/// `authenticationMode` (bootstrap-creator permission is a create-only input),
+/// defaulting to `CONFIG_MAP` when the caller omits `accessConfig`.
+fn build_access_config(req: Option<&Value>) -> Value {
+    let mode = req
+        .and_then(|v| v.get("authenticationMode"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("CONFIG_MAP")
+        .to_string();
+    json!({ "authenticationMode": mode })
+}
+
+/// Build an `UpgradePolicyResponse` object, defaulting `supportType` to
+/// `EXTENDED` (extended support enabled) when the caller omits `upgradePolicy`.
+fn build_upgrade_policy(req: Option<&Value>) -> Value {
+    let support = req
+        .and_then(|v| v.get("supportType"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("EXTENDED")
+        .to_string();
+    json!({ "supportType": support })
 }
 
 fn build_logging(req: Option<&Value>) -> Value {
@@ -3637,6 +3675,8 @@ fn cluster_json(c: &Cluster, id: &str) -> Value {
         "platformVersion": c.platform_version,
         "tags": c.tags,
         "health": { "issues": [] },
+        "accessConfig": c.access_config,
+        "upgradePolicy": c.upgrade_policy,
     });
     if let Some(cc) = &c.connector_config {
         out["connectorConfig"] = cc.clone();
@@ -4513,6 +4553,64 @@ mod tests {
             .err()
             .unwrap();
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cluster_reports_access_config_upgrade_policy_and_elb_defaults() {
+        let svc = EksService::new(make_state());
+        // Create with no accessConfig/upgradePolicy/kubernetesNetworkConfig: the
+        // response defaults them the way the real control plane does.
+        let resp = svc
+            .handle(make_request(Method::POST, "/clusters", &create_body("c1")))
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let c = &v["cluster"];
+        assert_eq!(c["accessConfig"]["authenticationMode"], "CONFIG_MAP");
+        assert_eq!(c["upgradePolicy"]["supportType"], "EXTENDED");
+        assert_eq!(
+            c["kubernetesNetworkConfig"]["elasticLoadBalancing"]["enabled"],
+            false
+        );
+        assert_eq!(
+            c["kubernetesNetworkConfig"]["serviceIpv4Cidr"],
+            "172.20.0.0/16"
+        );
+        assert_eq!(c["kubernetesNetworkConfig"]["ipFamily"], "ipv4");
+
+        // Describe echoes the same shape (drift-free round-trip).
+        let resp = svc
+            .handle(make_request(Method::GET, "/clusters/c1", ""))
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            v["cluster"]["accessConfig"]["authenticationMode"],
+            "CONFIG_MAP"
+        );
+        assert_eq!(v["cluster"]["upgradePolicy"]["supportType"], "EXTENDED");
+        assert_eq!(
+            v["cluster"]["kubernetesNetworkConfig"]["elasticLoadBalancing"]["enabled"],
+            false
+        );
+    }
+
+    #[tokio::test]
+    async fn cluster_echoes_supplied_access_config() {
+        let svc = EksService::new(make_state());
+        let body = json!({
+            "name": "c1",
+            "roleArn": "arn:aws:iam::111122223333:role/eks-cluster",
+            "resourcesVpcConfig": { "subnetIds": ["subnet-1", "subnet-2"] },
+            "accessConfig": { "authenticationMode": "API" },
+        })
+        .to_string();
+        let resp = svc
+            .handle(make_request(Method::POST, "/clusters", &body))
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(v["cluster"]["accessConfig"]["authenticationMode"], "API");
     }
 
     #[tokio::test]
@@ -6039,6 +6137,8 @@ mod tests {
                 .count(),
             1
         );
+        // AWS reports the default version first (index 0).
+        assert_eq!(versions[0]["defaultVersion"], true);
 
         // defaultOnly filter narrows to the single default.
         let resp = svc

--- a/crates/fakecloud-eks/src/state.rs
+++ b/crates/fakecloud-eks/src/state.rs
@@ -214,6 +214,28 @@ pub struct Cluster {
     /// echoed back on describe.
     #[serde(default)]
     pub encryption_config: Option<serde_json::Value>,
+    /// The `AccessConfigResponse`-shaped object (`{authenticationMode}`) echoed
+    /// back on every describe. Defaults to `CONFIG_MAP` when the caller omits
+    /// `accessConfig` at create time, mirroring the real API default.
+    #[serde(default = "default_access_config")]
+    pub access_config: serde_json::Value,
+    /// The `UpgradePolicyResponse`-shaped object (`{supportType}`) echoed back
+    /// on every describe. Defaults to `EXTENDED` (extended support enabled) when
+    /// the caller omits `upgradePolicy` at create time.
+    #[serde(default = "default_upgrade_policy")]
+    pub upgrade_policy: serde_json::Value,
+}
+
+/// The `accessConfig` a cluster reports when none was supplied at create time:
+/// `CONFIG_MAP` authentication (the backward-compatible default).
+pub fn default_access_config() -> serde_json::Value {
+    serde_json::json!({ "authenticationMode": "CONFIG_MAP" })
+}
+
+/// The `upgradePolicy` a cluster reports when none was supplied at create time:
+/// `EXTENDED` support (extended support enabled by default).
+pub fn default_upgrade_policy() -> serde_json::Value {
+    serde_json::json!({ "supportType": "EXTENDED" })
 }
 
 /// An upgrade-readiness/misconfiguration Insight that EKS auto-generates for a

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -594,6 +594,25 @@ pub const SERVICES: &[Service] = &[
         deny: &[],
     },
     Service {
+        name: "eks",
+        // EKS is a full control plane (no real Kubernetes API server is spawned),
+        // so the Terraform provider's control-plane cluster resources and data
+        // sources are exercisable: clusters (which transition CREATING -> ACTIVE
+        // on describe so the create waiter completes), access entries and their
+        // access-policy associations, OIDC identity-provider configs, and Pod
+        // Identity associations. Managed node groups, Fargate profiles, and
+        // add-ons are deferred: they model real compute/networking a control
+        // plane alone can't stand up faithfully.
+        run_regex: concat!(
+            "^TestAccEKS(",
+            "Cluster|ClusterDataSource|ClustersDataSource|ClusterVersionsDataSource",
+            "|AccessEntry|AccessEntryDataSource|AccessPolicyAssociation",
+            "|IdentityProviderConfig|PodIdentityAssociation",
+            ")_basic$",
+        ),
+        deny: &[],
+    },
+    Service {
         name: "cloudfront",
         // Cache/origin-request/realtime-log/log-delivery data sources. The
         // CloudFront resources (distribution, function, OAC, ...) are deferred.
@@ -1159,6 +1178,18 @@ pub const SHARDS: &[Shard] = &[
         run_regex: concat!(
             "^TestAccMemoryDB(",
             "ACL|User|ParameterGroup|Snapshot|Cluster",
+            ")_basic$",
+        ),
+        extra_deny: &[],
+    },
+    Shard {
+        name: "eks",
+        service: "eks",
+        run_regex: concat!(
+            "^TestAccEKS(",
+            "Cluster|ClusterDataSource|ClustersDataSource|ClusterVersionsDataSource",
+            "|AccessEntry|AccessEntryDataSource|AccessPolicyAssociation",
+            "|IdentityProviderConfig|PodIdentityAssociation",
             ")_basic$",
         ),
         extra_deny: &[],

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -367,6 +367,7 @@ pub const ENDPOINT_ENV_VARS: &[(&str, &str)] = &[
     ("AWS_ENDPOINT_URL_RDS", "rds"),
     ("AWS_ENDPOINT_URL_ELASTICACHE", "elasticache"),
     ("AWS_ENDPOINT_URL_MEMORYDB", "memorydb"),
+    ("AWS_ENDPOINT_URL_EKS", "eks"),
     ("AWS_ENDPOINT_URL_CLOUDFORMATION", "cloudformation"),
     ("AWS_ENDPOINT_URL_SESV2", "sesv2"),
     ("AWS_ENDPOINT_URL_SES", "ses"),

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -108,6 +108,11 @@ async fn memorydb_acceptance() {
 }
 
 #[tokio::test]
+async fn eks_acceptance() {
+    run_shard("eks").await;
+}
+
+#[tokio::test]
 async fn rds_acceptance() {
     run_shard("rds").await;
 }


### PR DESCRIPTION
## Summary

Wires the EKS terraform-provider-aws acceptance-test shard into CI and fixes the cluster-response fidelity gaps it surfaced. Completes EKS to the full "matched" bar (real handlers + all 65 ops + 100% conformance + persistence + tfacc coverage + synced surface).

## tfacc shard
New `eks` shard runs 9 upstream `TestAccEKS*_basic` tests — Cluster, Cluster/Clusters/ClusterVersions data sources, AccessEntry (+ data source), AccessPolicyAssociation, IdentityProviderConfig, PodIdentityAssociation. All pass locally (`go`+`terraform` on PATH). Node groups, Fargate profiles, and add-ons are deferred to a later shard (need managed-instance / addon-catalogue surfaces), noted in the allowlist reason comment.

## Fidelity fixes (crates/fakecloud-eks)
All 6 initial failures traced to the cluster response shape:
- Cluster now always emits `accessConfig{authenticationMode}` (echoes request, default `CONFIG_MAP`) + `upgradePolicy{supportType: EXTENDED}`. Fixing this also cleared the 3 access-entry/policy "non-empty plan" drift failures (their configs create the cluster with `authentication_mode = API`).
- `kubernetesNetworkConfig` always emits `elasticLoadBalancing{enabled}`; default `serviceIpv4Cidr` is now `172.20.0.0/16`.
- `DescribeClusterVersions` sorts the default version first so `default_version = true`.
- New `access_config`/`upgrade_policy` fields on `Cluster` (serde-default, persist back-compat).

## Conformance
EKS held at 65/65 ops / 1,865 variants — only response shapes changed, not the Smithy model, so no checksum edits. `cargo test -p fakecloud-conformance --test eks` passes; `cargo test -p fakecloud-eks --lib` 53 pass; clippy `-D warnings` clean on both eks + tfacc crates.

## Test plan
- `cargo test -p fakecloud-tfacc --test acc eks_acceptance` -> 9/9 TestAccEKS* pass
- `cargo test -p fakecloud-conformance --test eks` -> 65/65
- `bash scripts/check-doc-counts.sh` green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an EKS acceptance-test shard for `terraform-provider-aws` and aligns cluster responses with AWS so all 9 `TestAccEKS*_basic` tests pass. EKS stays fully matched (65/65 ops) with persisted defaults.

- **New Features**
  - Added `eks` tfacc shard covering Cluster, Cluster/Clusters/ClusterVersions data sources, AccessEntry (+ data source), AccessPolicyAssociation, IdentityProviderConfig, and PodIdentityAssociation. Node groups, Fargate profiles, and add-ons are deferred.
  - Added `AWS_ENDPOINT_URL_EKS` support and wired the shard into the test harness.

- **Bug Fixes**
  - Cluster responses always include `accessConfig.authenticationMode` (echoes request; default `CONFIG_MAP`) and `upgradePolicy.supportType` (default `EXTENDED`).
  - `kubernetesNetworkConfig` now always includes `elasticLoadBalancing.enabled` (default false); default `serviceIpv4Cidr` set to `172.20.0.0/16`.
  - `DescribeClusterVersions` returns the default version first.
  - Persisted `access_config` and `upgrade_policy` on `Cluster` with serde defaults for backward compatibility.

<sup>Written for commit e5d70ef37a0053fd26ecb42c4fb288478094afe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

