### PR TITLE
chore(release): bump workspace to v0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3870,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4031,7 +4031,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4293,7 +4293,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4391,7 +4391,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4579,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4590,7 +4590,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4656,7 +4656,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4755,7 +4755,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -114,219 +114,219 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.30.2"
+version = "0.31.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.30.2")
+    testImplementation("dev.fakecloud:fakecloud:0.31.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.30.2</version>
+    <version>0.31.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.30.2"
+version = "0.31.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.30.2"
+version = "0.31.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.30.2",
+  "version": "0.31.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release **v0.31.0** (minor). Two new complete AWS services since v0.30.2, both at 100% conformance with terraform-provider-aws acceptance coverage:

- **EKS** — new `fakecloud-eks` crate, complete 65-op control plane (clusters, node groups, Fargate profiles, add-ons, access entries, OIDC identity-provider configs, pod-identity associations, insights, capabilities, encryption config, EKS Anywhere). 1,865 conformance variants; tfacc `eks` shard green.
- **Cloud Map** — new `fakecloud-servicediscovery` crate, complete 30-op control plane + discovery (namespaces, services, instances, `DiscoverInstances`, tagging; async operation model). 1,062 conformance variants; tfacc `servicediscovery` shard green.

fakecloud now covers **50 services / 3,932 operations / 130,944 conformance variants**.

Both new crates are in the `release.yml` publish list (after `fakecloud-memorydb`, core/persistence/aws deps only).

## Changes
Version bump only: `Cargo.toml` (workspace + all fakecloud dep pins), `Cargo.lock`, and the TypeScript/Python/Java SDK manifests.

## Test plan
Standard release bump; CI validates the workspace builds + all SDK/doc-count checks. Publish is tag-driven post-merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v0.31.0 release by bumping versions across the Rust workspace and SDKs. This release includes two new fully conformant services: `fakecloud-eks` and `fakecloud-servicediscovery`.

- **Dependencies**
  - Bumped all `fakecloud-*` crates to `0.31.0` in `Cargo.toml` and `Cargo.lock`.
  - Updated SDK manifests to `0.31.0`: Java (`build.gradle.kts`, README), Python (`pyproject.toml`), TypeScript (`package.json`).

<sup>Written for commit 918e6621a1ef032a2b2d98adaedc87e531a92450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

