### PR TITLE
chore(release): bump workspace to v0.32.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4000,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4079,7 +4079,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4320,7 +4320,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4402,7 +4402,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4462,7 +4462,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4617,7 +4617,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4756,7 +4756,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -114,223 +114,223 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.31.0")
+    testImplementation("dev.fakecloud:fakecloud:0.32.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.31.0</version>
+    <version>0.32.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.31.0"
+version = "0.32.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.31.0"
+version = "0.32.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release **v0.32.0**. Bumps the workspace 0.31.0 -> 0.32.0 (all crates, Cargo.lock, and the TypeScript/Python/Java SDK version files).

### Included since v0.31.0
- **Account Management** — new `fakecloud-account` crate: full 15-op AWS Account control plane (alternate contacts, contact info, account info/name, GovCloud pairing, primary-email OTP flow, Region opt-in), 100% conformance (412 variants), tfacc `account` shard (#2097).
- **EKS handler fixes** — UpdateClusterConfig field drops, sub-resource tagging, DescribeClusterVersions filters, DeleteCluster guard/cascade, ListInsights maxResults validation (#2094).
- **Cloud Map fidelity** — ListOperations UPDATE_DATE filter, malformed NextToken rejection, NextToken null-omit, DiscoverInstances health-filter (#2095).
- **CloudFormation provisioners** — write-through `AWS::EKS::*` + `AWS::ServiceDiscovery::*` resource provisioners with GetAtt + persistence (#2096).

`fakecloud-account` is in the `release.yml` publish list (after eks/servicediscovery; core/persistence/aws deps only).

## Test plan
- CI: full conformance (131,356/131,356) + e2e + tfacc + clippy/fmt/doc-counts green.
- Post-merge: tag `v0.32.0` on the merge commit to trigger the 6-registry publish.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.32.0. Bumps all workspace crates and the TypeScript, Python, and Java SDKs to 0.32.0, bundling recent Account, EKS, Cloud Map, and CloudFormation updates.

- **New Features**
  - New `fakecloud-account`: 15‑op Account control plane with OTP, GovCloud pairing, and Region opt‑in; 100% conformance.
  - EKS: config field drops, sub-resource tagging, version filters, safer delete, ListInsights maxResults validation.
  - Cloud Map: UPDATE_DATE filter, strict/malformed NextToken handling, health filter for DiscoverInstances.
  - CloudFormation: write-through provisioners for `AWS::EKS::*` and `AWS::ServiceDiscovery::*` with GetAtt + persistence.

- **Dependencies**
  - Bumped all `fakecloud-*` crates and SDKs to 0.32.0; updated `Cargo.toml`, `Cargo.lock`, and SDK version files for TypeScript, Python, and Java.

<sup>Written for commit eb00c78358711f41e0d54cfa346a962c196ca381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

