### PR TITLE
fix(ec2): bridge-family nft table for reliable same-subnet SG enforcement

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -261,6 +261,12 @@ jobs:
       - name: Enable bridge netfilter
         run: |
           sudo modprobe br_netfilter
+          # Load conntrack for the bridge family so fakecloud's bridge-family
+          # SG table (`ct state established,related accept`) applies — this is
+          # what makes same-subnet L2-switched traffic enforce reliably even
+          # when bridge-nf-call-iptables doesn't route bridged frames to the
+          # inet forward hook on this runner's kernel.
+          sudo modprobe nf_conntrack_bridge || echo "nf_conntrack_bridge unavailable; bridge-family SG enforcement will degrade"
           for knob in bridge-nf-call-iptables bridge-nf-call-ip6tables bridge-nf-call-arptables; do
             echo 1 | sudo tee "/proc/sys/net/bridge/$knob" >/dev/null
           done
@@ -304,6 +310,7 @@ jobs:
           # bug, not a leaked host-firewall state from a prior attempt.
           ensure_bridge_nf() {
             sudo modprobe br_netfilter || true
+            sudo modprobe nf_conntrack_bridge || true
             echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables >/dev/null || true
             got=$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo missing)
             echo "bridge-nf-call-iptables=${got}"

--- a/crates/fakecloud-ec2/src/runtime/firewall.rs
+++ b/crates/fakecloud-ec2/src/runtime/firewall.rs
@@ -180,6 +180,85 @@ pub fn render_ruleset(subnets: &[SubnetFirewall]) -> String {
     out
 }
 
+/// The bridge-family table fakecloud owns for **same-subnet L2 enforcement**.
+/// Kept separate from the `inet` table so it can be applied in its own
+/// best-effort `nft -f -` — a kernel without `nf_conntrack_bridge` rejects the
+/// `ct state` line, and isolating it means that failure never takes the `inet`
+/// table (cross-subnet routed enforcement) down with it.
+const BRIDGE_TABLE: &str = "bridge fakecloud_ec2_l2";
+
+/// Render the **bridge-family** mirror of [`render_ruleset`].
+///
+/// Traffic between two containers on the *same* fakecloud subnet bridge is
+/// L2-switched between bridge ports and only reaches the `inet` `forward` hook
+/// when `bridge-nf-call-iptables=1` — and on some kernels/runners not even
+/// then. The `bridge`-family `forward` hook sees those forwarded frames
+/// directly, so mirroring the SG/NACL drops here makes same-subnet enforcement
+/// hold regardless of the bridge-netfilter sysctl. IPv4 matches are guarded
+/// with `ether type ip` (required in the bridge family before an `ip` match);
+/// `ct state established,related` keeps replies flowing statefully via
+/// `nf_conntrack_bridge`.
+pub fn render_bridge_ruleset(subnets: &[SubnetFirewall]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("add table {BRIDGE_TABLE}\n"));
+    out.push_str(&format!("flush table {BRIDGE_TABLE}\n"));
+    out.push_str(&format!("table {BRIDGE_TABLE} {{\n"));
+    out.push_str("  chain forward {\n");
+    // Lower (earlier) priority than the default bridge filter so our decision
+    // lands before anything else in the bridge path.
+    out.push_str("    type filter hook forward priority -300; policy accept;\n");
+    out.push_str("    ct state established,related accept\n");
+
+    for subnet in subnets {
+        out.push_str(&format!("    # subnet {}\n", subnet.network_name));
+
+        let mut ordered = subnet.nacl.clone();
+        ordered.sort_by_key(|r| r.rule_number);
+        for (i, rule) in ordered.iter().enumerate() {
+            if rule.allow {
+                continue;
+            }
+            let shadowed = ordered[..i]
+                .iter()
+                .any(|earlier| earlier.allow && nacl_same_traffic(earlier, rule));
+            if shadowed {
+                continue;
+            }
+            if let Some(line) = render_nacl_drop(rule) {
+                out.push_str(&format!("    ether type ip {line}\n"));
+            }
+        }
+
+        for inst in &subnet.instances {
+            for rule in &inst.ingress {
+                out.push_str(&format!(
+                    "    ether type ip {}\n",
+                    render_rule(rule, Direction::Ingress, &inst.private_ip)
+                ));
+            }
+            out.push_str(&format!(
+                "    ether type ip ip daddr {} drop comment \"default-deny ingress\"\n",
+                inst.private_ip
+            ));
+
+            for rule in &inst.egress {
+                out.push_str(&format!(
+                    "    ether type ip {}\n",
+                    render_rule(rule, Direction::Egress, &inst.private_ip)
+                ));
+            }
+            out.push_str(&format!(
+                "    ether type ip ip saddr {} drop comment \"default-deny egress\"\n",
+                inst.private_ip
+            ));
+        }
+    }
+
+    out.push_str("  }\n");
+    out.push_str("}\n");
+    out
+}
+
 #[derive(Clone, Copy)]
 enum Direction {
     Ingress,
@@ -424,6 +503,47 @@ mod tests {
         assert!(rs.contains("ip daddr 172.30.0.2 drop comment \"default-deny ingress\""));
         // egress had no explicit allows -> still a default-deny line
         assert!(rs.contains("ip saddr 172.30.0.2 drop comment \"default-deny egress\""));
+    }
+
+    #[test]
+    fn bridge_ruleset_mirrors_inet_with_ether_type_guard() {
+        let model = vec![SubnetFirewall {
+            network_name: "fakecloud-subnet-a".into(),
+            instances: vec![InstanceFirewall {
+                private_ip: "172.30.0.2".into(),
+                ingress: vec![tcp(22, Some("10.0.0.0/8"))],
+                egress: vec![],
+            }],
+            nacl: vec![],
+        }];
+        let rs = render_bridge_ruleset(&model);
+        // Its own bridge-family table, atomically add-before-flush.
+        let add = rs
+            .find("add table bridge fakecloud_ec2_l2")
+            .expect("add table");
+        let flush = rs
+            .find("flush table bridge fakecloud_ec2_l2")
+            .expect("flush table");
+        assert!(add < flush, "add table must come before flush:\n{rs}");
+        // Bridge-family forward hook + conntrack for stateful replies.
+        assert!(rs.contains("type filter hook forward priority -300; policy accept;"));
+        assert!(rs.contains("ct state established,related accept"));
+        // Every IPv4 match is guarded with `ether type ip` (required in the
+        // bridge family before an `ip` match).
+        assert!(rs
+            .contains("ether type ip ip daddr 172.30.0.2 ip saddr 10.0.0.0/8 tcp dport 22 accept"));
+        assert!(
+            rs.contains("ether type ip ip daddr 172.30.0.2 drop comment \"default-deny ingress\"")
+        );
+        assert!(
+            rs.contains("ether type ip ip saddr 172.30.0.2 drop comment \"default-deny egress\"")
+        );
+        // No bare `ip daddr`/`ip saddr` outside an `ether type ip` guard.
+        for line in rs.lines().map(str::trim) {
+            if line.starts_with("ip daddr") || line.starts_with("ip saddr") {
+                panic!("unguarded ip match in bridge family:\n{line}");
+            }
+        }
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -28,7 +28,8 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 
 use firewall::{
-    render_ruleset, resolve_enforcement_mode, EnforcementMode, InstanceRules, SubnetFirewall,
+    render_bridge_ruleset, render_ruleset, resolve_enforcement_mode, EnforcementMode,
+    InstanceRules, SubnetFirewall,
 };
 
 /// Default base image an instance's container runs. AMIs don't map to a
@@ -244,40 +245,61 @@ impl FirewallEnforcer {
                 "could not run sysctl (is procps installed?); same-subnet security-group enforcement may filter nothing"
             ),
         }
-        let ruleset = render_ruleset(subnets);
         use tokio::io::AsyncWriteExt;
-        let mut child = match tokio::process::Command::new("nft")
-            .args(["-f", "-"])
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-        {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to spawn nft; security-group ruleset not applied");
-                return;
+        // Load a rendered ruleset via `nft -f -`. `required=false` marks the
+        // best-effort same-subnet bridge table: a kernel without
+        // `nf_conntrack_bridge` rejects its `ct state` line, and since the inet
+        // table is applied independently first, that rejection is logged at
+        // debug (degraded same-subnet enforcement) rather than warn.
+        async fn load_nft(label: &str, ruleset: &str, subnets: usize, required: bool) {
+            let mut child = match tokio::process::Command::new("nft")
+                .args(["-f", "-"])
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(error = %e, table = label, "failed to spawn nft; security-group ruleset not applied");
+                    return;
+                }
+            };
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(ruleset.as_bytes()).await;
+                let _ = stdin.shutdown().await;
             }
-        };
-        if let Some(mut stdin) = child.stdin.take() {
-            let _ = stdin.write_all(ruleset.as_bytes()).await;
-            let _ = stdin.shutdown().await;
+            match child.wait_with_output().await {
+                Ok(out) if out.status.success() => {
+                    tracing::debug!(
+                        subnets,
+                        table = label,
+                        "applied EC2 security-group nft ruleset"
+                    );
+                }
+                Ok(out) => {
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    let stderr = stderr.trim();
+                    if required {
+                        tracing::warn!(table = label, stderr = %stderr, "nft rejected the security-group ruleset; leaving the previous ruleset in place");
+                    } else {
+                        tracing::debug!(table = label, stderr = %stderr, "bridge-family SG ruleset not applied (kernel may lack nf_conntrack_bridge); same-subnet enforcement degraded to inet table only");
+                    }
+                }
+                Err(e) => tracing::warn!(error = %e, table = label, "nft apply failed"),
+            }
         }
-        match child.wait_with_output().await {
-            Ok(out) if out.status.success() => {
-                tracing::debug!(
-                    subnets = subnets.len(),
-                    "applied EC2 security-group nft ruleset"
-                );
-            }
-            Ok(out) => {
-                tracing::warn!(
-                    stderr = %String::from_utf8_lossy(&out.stderr).trim(),
-                    "nft rejected the security-group ruleset; leaving the previous ruleset in place"
-                );
-            }
-            Err(e) => tracing::warn!(error = %e, "nft apply failed"),
-        }
+        let n = subnets.len();
+        // inet: cross-subnet routed enforcement (required). bridge: same-subnet
+        // L2 enforcement that the inet forward hook misses for bridged frames.
+        load_nft("inet fakecloud_ec2", &render_ruleset(subnets), n, true).await;
+        load_nft(
+            "bridge fakecloud_ec2_l2",
+            &render_bridge_ruleset(subnets),
+            n,
+            false,
+        )
+        .await;
     }
 }
 


### PR DESCRIPTION
## Summary

The `EC2 SG enforcement (privileged)` e2e is environmentally flaky (~50% fail on ubuntu-24.04 runners; alternates pass/fail across unrelated commits, pre-dating #2099). Root cause: traffic between two containers on the **same subnet bridge** is L2-switched between bridge ports and only reaches the `inet` `forward` hook when `bridge-nf-call-iptables` routes bridged frames there — which some runner kernels don't do reliably even with the sysctl reading `1`. The deny rule is installed but the packet bypasses the chain → the "must DROP" assertion fails.

## Fix

Mirror the SG/NACL ruleset into a dedicated **`bridge`-family** nft table (`render_bridge_ruleset`) whose `forward` hook sees L2-forwarded frames directly, independent of `bridge-nf-call-iptables`:
- IPv4 matches guarded with `ether type ip` (required before an `ip` match in the bridge family).
- `ct state established,related accept` keeps replies stateful via `nf_conntrack_bridge`.
- Applied as a **separate best-effort** `nft -f -` load: a kernel lacking `nf_conntrack_bridge` rejects only the bridge table (logged at debug — same-subnet enforcement degrades to inet-only), never taking the required `inet` table (cross-subnet routed enforcement) down with it.
- The `inet` table and its exhaustive unit tests are **unchanged**.
- e2e workflow: `modprobe nf_conntrack_bridge` in setup + per-attempt.

## Test plan

- New unit test `bridge_ruleset_mirrors_inet_with_ether_type_guard`: asserts the add-before-flush, the `hook forward priority -300`, the `ct state` line, the `ether type ip` guard on every IPv4 match, and no unguarded `ip` match.
- `cargo test -p fakecloud-ec2 --lib firewall` green (15 tests); clippy + fmt clean.
- **The real validation is this PR's `EC2 SG enforcement (privileged)` job** — it exercises actual nftables packet filtering on the privileged runner (can't run on darwin locally). Watching it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mirrors EC2 SG/NACL rules into a bridge-family nftables table to reliably enforce same-subnet traffic and stop the flaky SG e2e failures on some Ubuntu runners. The `inet` table remains unchanged; the bridge table loads best-effort and degrades cleanly if `nf_conntrack_bridge` is missing.

- **Bug Fixes**
  - Added `render_bridge_ruleset` to install `bridge fakecloud_ec2_l2` with `hook forward priority -300`, `ct state established,related accept`, and `ether type ip` guards for all IPv4 matches.
  - Applied rules in two steps: required `inet fakecloud_ec2`, then optional bridge table; bridge rejection logs at debug and never affects the inet table.
  - Updated e2e workflow to `modprobe br_netfilter` and `nf_conntrack_bridge` in setup and per-attempt; same-subnet enforcement no longer depends on `bridge-nf-call-iptables`.
  - Added unit test `bridge_ruleset_mirrors_inet_with_ether_type_guard`; no changes to existing inet table tests.

<sup>Written for commit 6e03552bc779cf64f1b549ac0d9ae31c8e58b664. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

