### PR TITLE
fix(identitystore): return 409 for ConflictException

### DIFF
--- a/crates/fakecloud-identitystore/src/service.rs
+++ b/crates/fakecloud-identitystore/src/service.rs
@@ -164,7 +164,11 @@ fn not_found(msg: &str) -> AwsServiceError {
 }
 
 fn conflict(msg: &str) -> AwsServiceError {
-    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ConflictException", msg)
+    // `ConflictException` is modeled with `@httpError(409)`; the SDKs and
+    // Terraform's retry/error handling key on the 409 status, so returning 400
+    // here would misclassify a duplicate-resource conflict as a plain
+    // client-validation error.
+    AwsServiceError::aws_error(StatusCode::CONFLICT, "ConflictException", msg)
 }
 
 fn req_str<'a>(b: &'a Value, f: &str) -> Result<&'a str, AwsServiceError> {
@@ -1026,6 +1030,48 @@ mod tests {
         dispatch(&s, &req("CreateUser", body.clone())).unwrap();
         let err = dispatch(&s, &req("CreateUser", body)).err().unwrap();
         assert_eq!(err.code(), "ConflictException");
+        // ConflictException is modeled with @httpError(409), not a generic 400.
+        assert_eq!(err.status(), http::StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn duplicate_group_and_membership_conflicts_are_409() {
+        let s = svc();
+        let sid = "d-c";
+        let g = call(
+            &s,
+            "CreateGroup",
+            json!({ "IdentityStoreId": sid, "DisplayName": "grp" }),
+        );
+        let gid = g["GroupId"].as_str().unwrap().to_string();
+        // Duplicate group display name.
+        let err = dispatch(
+            &s,
+            &req(
+                "CreateGroup",
+                json!({ "IdentityStoreId": sid, "DisplayName": "grp" }),
+            ),
+        )
+        .err()
+        .unwrap();
+        assert_eq!(err.code(), "ConflictException");
+        assert_eq!(err.status(), http::StatusCode::CONFLICT);
+        // Duplicate membership.
+        let uid = call(
+            &s,
+            "CreateUser",
+            json!({ "IdentityStoreId": sid, "UserName": "mm" }),
+        )["UserId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let body = json!({ "IdentityStoreId": sid, "GroupId": gid, "MemberId": { "UserId": uid } });
+        dispatch(&s, &req("CreateGroupMembership", body.clone())).unwrap();
+        let err = dispatch(&s, &req("CreateGroupMembership", body))
+            .err()
+            .unwrap();
+        assert_eq!(err.code(), "ConflictException");
+        assert_eq!(err.status(), http::StatusCode::CONFLICT);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The Identity Store `conflict()` error helper returned HTTP **400**, but the Smithy model marks `ConflictException` with `@httpError(409)` (the sibling verifiedpermissions crate already uses 409). Every duplicate-resource path — `CreateUser` (duplicate `UserName`), `CreateGroup` (duplicate `DisplayName`), and `CreateGroupMembership` (duplicate membership) — surfaced the conflict as a plain 400.

AWS SDKs and the Terraform provider key retry/error classification on the 409 status for conflicts, so a real client would misclassify a genuine conflict as a client-validation error. This changes only the HTTP status; the error `__type`/code (`ConflictException`) and message are unchanged, so the awsJson wire shape conformance is unaffected.

## Test plan
- `cargo test -p fakecloud-identitystore` (new assertions on `err.status() == 409` for duplicate user, group, and membership; existing tests still green)
- `cargo clippy -p fakecloud-identitystore --all-targets` clean
- `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return HTTP 409 for Identity Store `ConflictException` to match the Smithy model and real IAM Identity Center behavior. This ensures duplicate user/group/membership creates are treated as conflicts by SDKs and Terraform.

- **Bug Fixes**
  - Updated `conflict()` to return 409; error code `ConflictException` and message unchanged.
  - Duplicate `CreateUser`, `CreateGroup`, and `CreateGroupMembership` now return 409.
  - Added tests in `fakecloud-identitystore` asserting 409 for these cases.

<sup>Written for commit 4dbeb3cf8f0abc5d242e787bb66fc9d080a2acf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

