### PR TITLE
fix(ssoadmin): honor PrincipalType in ListAccountAssignmentsForPrincipal

### DIFF
--- a/crates/fakecloud-ssoadmin/src/service.rs
+++ b/crates/fakecloud-ssoadmin/src/service.rs
@@ -1260,14 +1260,20 @@ impl SsoAdminService {
         validate_common(&b)?;
         req_str(&b, "InstanceArn")?;
         let principal_id = req_str(&b, "PrincipalId")?.to_string();
-        req_str(&b, "PrincipalType")?;
+        let principal_type = req_str(&b, "PrincipalType")?.to_string();
         let guard = self.state.read();
         let rows: Vec<Value> = guard
             .get(&req.account_id)
             .map(|a| {
                 a.assignments
                     .iter()
-                    .filter(|x| x.principal_id == principal_id)
+                    // `PrincipalType` is a required input and AWS filters on it
+                    // together with `PrincipalId`; ignoring it would surface a
+                    // USER assignment when the caller queried a GROUP (and vice
+                    // versa) whose id happened to collide.
+                    .filter(|x| {
+                        x.principal_id == principal_id && x.principal_type == principal_type
+                    })
                     .map(|x| {
                         json!({
                             "AccountId": x.account_id,

--- a/crates/fakecloud-ssoadmin/src/service/tests.rs
+++ b/crates/fakecloud-ssoadmin/src/service/tests.rs
@@ -575,3 +575,39 @@ fn not_found_and_validation() {
     let e = err(&s, "ListInstances", json!({ "MaxResults": 500 }));
     assert_eq!(e.code(), "ValidationException");
 }
+
+#[test]
+fn list_account_assignments_for_principal_filters_by_principal_type() {
+    let s = svc();
+    let inst = new_instance(&s);
+    let ps_arn = call(
+        &s,
+        "CreatePermissionSet",
+        json!({ "InstanceArn": inst, "Name": "PS" }),
+    )["PermissionSet"]["PermissionSetArn"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    // Two assignments that share a principal id but differ in principal type.
+    let shared_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    for (ptype, target) in [("USER", "111122223333"), ("GROUP", "444455556666")] {
+        call(
+            &s,
+            "CreateAccountAssignment",
+            json!({
+                "InstanceArn": inst, "TargetId": target, "TargetType": "AWS_ACCOUNT",
+                "PermissionSetArn": ps_arn, "PrincipalType": ptype, "PrincipalId": shared_id
+            }),
+        );
+    }
+    let listed = call(
+        &s,
+        "ListAccountAssignmentsForPrincipal",
+        json!({ "InstanceArn": inst, "PrincipalId": shared_id, "PrincipalType": "USER" }),
+    );
+    let rows = listed["AccountAssignments"].as_array().unwrap();
+    // Only the USER assignment must come back, not the GROUP one.
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["PrincipalType"], json!("USER"));
+    assert_eq!(rows[0]["AccountId"], json!("111122223333"));
+}


### PR DESCRIPTION
## Summary
`ListAccountAssignmentsForPrincipal` requires `PrincipalType` as input and AWS filters assignments on **both** `PrincipalId` and `PrincipalType`. The handler validated `PrincipalType` but then filtered only by `PrincipalId`:

```rust
.filter(|x| x.principal_id == principal_id)
```

So a query for a `GROUP` principal would return a `USER` assignment (and vice versa) whenever the two principal ids collided — the returned rows would carry the wrong `PrincipalType`, breaking a caller that lists a principal's assignments to reconcile them.

The fix filters on both fields. The sibling `ListApplicationAssignmentsForPrincipal` already filtered on both, so this makes the two consistent.

## Test plan
- `cargo test -p fakecloud-ssoadmin` (new test creates a USER and a GROUP assignment sharing one principal id and asserts the USER query returns only the USER row)
- `cargo clippy -p fakecloud-ssoadmin --all-targets` clean
- `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `ListAccountAssignmentsForPrincipal` to filter by both `PrincipalId` and `PrincipalType`, matching AWS and preventing cross-type results when IDs collide.

- **Bug Fixes**
  - Filter on both fields (was only `PrincipalId`), consistent with `ListApplicationAssignmentsForPrincipal`.
  - Add a test that creates `USER` and `GROUP` with the same id and verifies only the requested `PrincipalType` is returned.

<sup>Written for commit b872d759ab0facd7950e782a1d4f39f4efccabe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

