### PR TITLE
fix(verifiedpermissions): validate pagination inputs on remaining list ops

### DIFF
--- a/crates/fakecloud-verifiedpermissions/src/service.rs
+++ b/crates/fakecloud-verifiedpermissions/src/service.rs
@@ -818,6 +818,7 @@ impl VerifiedPermissionsService {
     fn list_policies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let b = parse(req)?;
         let store_id = policy_store_id(&b)?;
+        check_pagination(&b)?;
         let filter = b.get("filter");
         let rows = self.with_store_read(&req.account_id, &store_id, |store| {
             store
@@ -1003,6 +1004,7 @@ impl VerifiedPermissionsService {
     fn list_policy_templates(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let b = parse(req)?;
         let store_id = policy_store_id(&b)?;
+        check_pagination(&b)?;
         let rows = self.with_store_read(&req.account_id, &store_id, |store| {
             store
                 .templates
@@ -1153,6 +1155,7 @@ impl VerifiedPermissionsService {
     fn list_identity_sources(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let b = parse(req)?;
         let store_id = policy_store_id(&b)?;
+        check_pagination(&b)?;
         let rows = self.with_store_read(&req.account_id, &store_id, |store| {
             store
                 .identity_sources

--- a/crates/fakecloud-verifiedpermissions/src/service/tests.rs
+++ b/crates/fakecloud-verifiedpermissions/src/service/tests.rs
@@ -468,6 +468,22 @@ fn is_authorized_with_token_resolves_principal_from_sub() {
 }
 
 #[test]
+fn list_policies_rejects_invalid_max_results() {
+    // maxResults has @range(min: 1); the list ops must reject maxResults < 1
+    // with a ValidationException instead of silently returning a page.
+    let s = svc();
+    let id = new_store(&s);
+    for op in ["ListPolicies", "ListPolicyTemplates", "ListIdentitySources"] {
+        let err = call_err(&s, op, json!({ "policyStoreId": id, "maxResults": 0 }));
+        assert_eq!(
+            err.code(),
+            "ValidationException",
+            "{op} should reject maxResults=0"
+        );
+    }
+}
+
+#[test]
 fn batch_get_policy_mixes_found_and_errors() {
     let s = svc();
     let id = new_store(&s);


### PR DESCRIPTION
## Summary
`ListPolicies`, `ListPolicyTemplates`, and `ListIdentitySources` never called the shared `check_pagination` guard that `ListPolicyStores` / `ListPolicyStoreAliases` already run. `maxResults` is modeled with `@range(min: 1)`, but a value < 1 was silently clamped to 1 by `paginate()` and returned a page instead of the modeled `ValidationException` (an over-long `nextToken` was likewise unvalidated). This runs the same guard on every list op so the whole surface validates pagination consistently.

Only an error path is added; success response shapes are unchanged.

## Test plan
- `cargo test -p fakecloud-verifiedpermissions` (new test asserts `maxResults: 0` yields ValidationException on all three ops)
- `cargo test -p fakecloud-conformance --test verifiedpermissions` still passes (probe green)
- `cargo clippy -p fakecloud-verifiedpermissions --all-targets` clean
- `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate pagination for `ListPolicies`, `ListPolicyTemplates`, and `ListIdentitySources` in `fakecloud-verifiedpermissions` for consistent behavior across list ops. Invalid `maxResults` (< 1) or overlong `nextToken` now return `ValidationException` instead of a clamped page.

- **Bug Fixes**
  - Run shared `check_pagination` in the three handlers (aligns with `ListPolicyStores` and `ListPolicyStoreAliases`).
  - Enforce `@range(min: 1)` for `maxResults` and validate `nextToken` length.
  - Add a test that asserts `maxResults: 0` is rejected for all three ops.

<sup>Written for commit 36d6a6d88bc87988747f45851cdd8ed522c01764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

