### PR TITLE
fix(redshift): use Association wrapper for DescribeCustomDomainAssociations list

### DIFF
--- a/crates/fakecloud-redshift/src/service/access.rs
+++ b/crates/fakecloud-redshift/src/service/access.rs
@@ -1058,8 +1058,12 @@ impl RedshiftService {
         let inner: String = all
             .iter()
             .map(|c| {
+                // The `Associations` (`AssociationList`) member serializes each
+                // element under its `xmlName` wrapper `Association` — not
+                // `CustomDomainAssociation`. Using the wrong wrapper makes the
+                // AWS SDK / Terraform provider parse an empty association list.
                 format!(
-                    "<CustomDomainAssociation><CustomDomainCertificateArn>{cert}</CustomDomainCertificateArn><CustomDomainCertificateExpiryDate>{expiry}</CustomDomainCertificateExpiryDate><CertificateAssociations><CertificateAssociation><CustomDomainName>{name}</CustomDomainName><ClusterIdentifier>{cluster}</ClusterIdentifier></CertificateAssociation></CertificateAssociations></CustomDomainAssociation>",
+                    "<Association><CustomDomainCertificateArn>{cert}</CustomDomainCertificateArn><CustomDomainCertificateExpiryDate>{expiry}</CustomDomainCertificateExpiryDate><CertificateAssociations><CertificateAssociation><CustomDomainName>{name}</CustomDomainName><ClusterIdentifier>{cluster}</ClusterIdentifier></CertificateAssociation></CertificateAssociations></Association>",
                     cert = xml_escape(&c.custom_domain_certificate_arn),
                     expiry = c.custom_domain_certificate_expiry_date.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
                     name = xml_escape(&c.custom_domain_name),

--- a/crates/fakecloud-redshift/src/service/tests.rs
+++ b/crates/fakecloud-redshift/src/service/tests.rs
@@ -472,6 +472,43 @@ fn unknown_cluster_operations_error_cleanly() {
 }
 
 #[test]
+fn custom_domain_associations_use_association_wrapper() {
+    let svc = service();
+    ok(
+        &svc,
+        "CreateCluster",
+        &[
+            ("ClusterIdentifier", "cdc"),
+            ("NodeType", "ra3.xlplus"),
+            ("MasterUsername", "admin"),
+            ("MasterUserPassword", "Passw0rd123"),
+        ],
+    );
+    ok(
+        &svc,
+        "CreateCustomDomainAssociation",
+        &[
+            ("ClusterIdentifier", "cdc"),
+            ("CustomDomainName", "redshift.example.com"),
+            (
+                "CustomDomainCertificateArn",
+                "arn:aws:acm:us-east-1:123456789012:certificate/abc123def456",
+            ),
+        ],
+    );
+    let listed = ok(&svc, "DescribeCustomDomainAssociations", &[]);
+    // The `AssociationList` member's xmlName is `Association`; the AWS SDK /
+    // Terraform provider parses an empty list if the wrapper is anything else.
+    assert!(
+        listed.contains("<Associations><Association>"),
+        "expected <Association> list wrapper, got: {listed}"
+    );
+    assert!(!listed.contains("<CustomDomainAssociation>"));
+    assert!(listed.contains("<CustomDomainName>redshift.example.com</CustomDomainName>"));
+    assert!(listed.contains("<ClusterIdentifier>cdc</ClusterIdentifier>"));
+}
+
+#[test]
 fn tag_operations_round_trip() {
     let svc = service();
     ok(


### PR DESCRIPTION
## Summary

`DescribeCustomDomainAssociations` rendered each list element under the wrong
XML wrapper. The output's `Associations` member is an `AssociationList` whose
member carries `xmlName: Association` in the model, but the handler emitted
`<CustomDomainAssociation>`. With the awsQuery protocol the element name is how
the SDK locates list members, so an AWS SDK / `terraform-provider-aws` client
parses the associations list as **empty** even right after creating one — the
`aws_redshift_custom_domain_association` resource would perpetually see itself
as missing.

The fix renders each element as `<Association>` to match the model. Every other
list-returning op in the crate was audited against the model's list `xmlName`
traits and found correct; this was the only mismatch.

## Test plan

- New unit test `custom_domain_associations_use_association_wrapper` creates a
  cluster + custom domain association and asserts the describe response uses the
  `<Associations><Association>` wrapper (and no longer contains the old
  `<CustomDomainAssociation>` element).
- `cargo test -p fakecloud-redshift` (22 passed)
- `cargo clippy -p fakecloud-redshift --all-targets -- -D warnings` (clean)
- `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the wrong XML wrapper in Redshift `DescribeCustomDomainAssociations`. Items now serialize under `<Association>`, so SDK and `terraform-provider-aws` clients correctly see existing associations.

- **Bug Fixes**
  - Serialize each list item under `<Association>` (per model xmlName) instead of `<CustomDomainAssociation>`, fixing empty list parsing in awsQuery clients.
  - Add regression test `custom_domain_associations_use_association_wrapper` in `fakecloud-redshift`.

<sup>Written for commit 7f2f4cf64162375ee76af96a3a295b47e104d43a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

