### PR TITLE
fix(rds): stop CreateDBInstance corrupting state when no container runtime (#2107)

### DIFF
--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -25,8 +25,8 @@ impl RdsService {
         let master_user_password = optional_query_param(request, "MasterUserPassword")
             .unwrap_or_else(|| "Password1!".to_string());
         let db_name = optional_query_param(request, "DBName");
-        let engine_version =
-            optional_query_param(request, "EngineVersion").unwrap_or_else(|| "16.3".to_string());
+        let engine_version = optional_query_param(request, "EngineVersion")
+            .unwrap_or_else(|| default_engine_version(&engine).to_string());
         let publicly_accessible =
             parse_optional_bool(optional_query_param(request, "PubliclyAccessible").as_deref())?
                 .unwrap_or(true);
@@ -94,6 +94,14 @@ impl RdsService {
             port,
         )?;
 
+        // Resolve the container runtime BEFORE reserving the identifier.
+        // If it is unavailable this returns early, and reserving first
+        // would leak the reservation into `in_progress_instance_ids`
+        // (nothing ever cancels it), corrupting the service: every later
+        // CreateDBInstance then fails with DBInstanceAlreadyExists while
+        // Describe/Delete see an empty instance map. See issue #2107.
+        let runtime = self.require_runtime()?.clone();
+
         {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
@@ -116,8 +124,6 @@ impl RdsService {
                 }
             }
         }
-
-        let runtime = self.require_runtime()?.clone();
 
         let logical_db_name = db_name
             .clone()

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -2012,6 +2012,23 @@ pub fn default_port_for_engine(engine: &str) -> i32 {
     }
 }
 
+/// Pick the default `EngineVersion` for `engine` when the caller omits
+/// it. Must land on a version in that engine's supported list
+/// (`validate_create_request`) -- a fixed postgres default like `16.3`
+/// would make every version-less mysql/mariadb/oracle/... create fail
+/// with "EngineVersion '16.3' is not available". See issue #2107.
+pub(crate) fn default_engine_version(engine: &str) -> &'static str {
+    match engine {
+        "postgres" => "16.3",
+        "mysql" => "8.0",
+        "mariadb" => "10.11",
+        "oracle-ee" | "oracle-se2" | "oracle-ee-cdb" | "oracle-se2-cdb" => "19.0.0",
+        "sqlserver-ee" | "sqlserver-se" | "sqlserver-ex" | "sqlserver-web" => "15.00.4322.2.v1",
+        "db2-se" | "db2-ae" => "11.5.9.0.sb00000000.r1",
+        _ => "16.3",
+    }
+}
+
 /// Pick the built-in parameter group name AWS assigns to a new
 /// instance when the caller doesn't override it. The name encodes the
 /// engine family plus its major version (e.g. `default.postgres16`,

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -2832,3 +2832,70 @@ async fn snapshot_hook_fires_with_store() {
         .expect("hook present when a store is set");
     hook().await;
 }
+
+#[tokio::test]
+async fn create_without_runtime_does_not_corrupt_state() {
+    // Regression for issue #2107. With no container runtime, a failed
+    // CreateDBInstance must not leak the in-progress reservation, or the
+    // service jams: re-create -> DBInstanceAlreadyExists while
+    // Describe/Delete see nothing.
+    let svc = make_service();
+    let create = request(
+        "CreateDBInstance",
+        &[
+            ("DBInstanceIdentifier", "corrupt-db"),
+            ("Engine", "mysql"),
+            ("EngineVersion", "8.0"),
+            ("DBInstanceClass", "db.t3.micro"),
+            ("MasterUsername", "admin"),
+            ("MasterUserPassword", "secretpass"),
+        ],
+    );
+
+    for _ in 0..2 {
+        let err = match svc.create_db_instance(&create).await {
+            Ok(_) => panic!("expected failure with no runtime"),
+            Err(e) => e,
+        };
+        // Never DBInstanceAlreadyExists -- always the honest
+        // runtime-unavailable error, every attempt.
+        assert_eq!(err.code(), "InsufficientDBInstanceCapacity");
+    }
+
+    let accounts = svc.state.read();
+    let state = accounts.default_ref();
+    assert!(
+        state.in_progress_instance_ids.is_empty(),
+        "failed create leaked an in-progress reservation"
+    );
+    assert!(state.instances.is_empty());
+}
+
+#[tokio::test]
+async fn create_defaults_engine_version_per_engine() {
+    // Issue #2107: a version-less MySQL create must not inherit the
+    // postgres default "16.3" and fail validation. Stub runtime lets the
+    // handler reach the stored placeholder without a container daemon.
+    let svc = make_service().with_runtime(Arc::new(crate::runtime::RdsRuntime::new_stub()));
+    let create = request(
+        "CreateDBInstance",
+        &[
+            ("DBInstanceIdentifier", "mysql-default-ver"),
+            ("Engine", "mysql"),
+            ("DBInstanceClass", "db.t3.micro"),
+            ("MasterUsername", "admin"),
+            ("MasterUserPassword", "secretpass"),
+        ],
+    );
+    svc.create_db_instance(&create)
+        .await
+        .expect("version-less mysql create should succeed");
+
+    let accounts = svc.state.read();
+    let inst = accounts
+        .default_ref()
+        .instances
+        .get("mysql-default-ver")
+        .expect("placeholder stored");
+    assert_eq!(inst.engine_version, "8.0");
+}


### PR DESCRIPTION
Fixes #2107.

## Problem

Two bugs in `CreateDBInstance`, both reported in #2107 by a user running fakecloud without Docker/Podman.

**1. Corrupted state (the headline symptom).** The handler reserved the instance identifier (`begin_instance_creation`) and only *afterwards* called `require_runtime()`, whose `?` returned early when no container runtime was available -- without cancelling the reservation. The identifier stayed forever in `in_progress_instance_ids` while the `instances` map stayed empty. Every later call then observed the split:

- `CreateDBInstance` -> `DBInstanceAlreadyExists` (reservation still held)
- `DescribeDBInstances` -> empty list (instances map empty)
- `DeleteDBInstance` -> `DBInstanceNotFound` (not in instances map)
- survived `terraform destroy` (delete is a no-op; the leak is in-memory)

Every symptom in the issue, exactly.

**2. Wrong default EngineVersion.** `EngineVersion` defaulted to the postgres value `"16.3"` regardless of engine, so a version-less mysql/mariadb/oracle/... create failed with `EngineVersion '16.3' is not available` -- the issue's second reported error.

## Fix

- Resolve the container runtime **before** reserving the identifier, so a missing runtime leaks nothing. Create now fails cleanly and repeatably with `InsufficientDBInstanceCapacity`, and Describe/Delete stay consistent.
- Add `default_engine_version(engine)` -- a per-engine default that always lands in that engine's supported-version list.

## Tests

- `create_without_runtime_does_not_corrupt_state` -- two consecutive runtime-less creates both return `InsufficientDBInstanceCapacity` (never `DBInstanceAlreadyExists`), no leaked reservation, instances map empty. Fails before the reorder.
- `create_defaults_engine_version_per_engine` -- version-less mysql create succeeds and stores `8.0`.

227 RDS tests pass; fmt + clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops RDS CreateDBInstance from corrupting state when no container runtime is available and sets engine-specific default EngineVersion. Creates now fail cleanly without a runtime, and version-less creates pick valid defaults. Fixes #2107.

- **Bug Fixes**
  - Resolve the container runtime before reserving the instance ID to avoid leaked reservations and inconsistent Describe/Delete. Repeated creates now return InsufficientDBInstanceCapacity instead of DBInstanceAlreadyExists.
  - Add per-engine default_engine_version so omitted EngineVersion uses a valid value (e.g., MySQL 8.0) instead of the fixed Postgres default.

<sup>Written for commit 50d4b7ff7d64eed024bab07b4ce8296f9ab599d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

