### PR TITLE
fix(redshift): persist endpoint authorizations (real Authorize/Revoke/Describe round-trip)

### DIFF
--- a/crates/fakecloud-redshift/src/service/access.rs
+++ b/crates/fakecloud-redshift/src/service/access.rs
@@ -11,8 +11,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use super::helpers::*;
 use super::RedshiftService;
 use crate::state::{
-    AuthenticationProfile, CustomDomainAssociation, DataShare, EndpointAccess, Integration,
-    Partner, RedshiftIdcApplication, ReservedNode,
+    AuthenticationProfile, CustomDomainAssociation, DataShare, EndpointAccess,
+    EndpointAuthorization, Integration, Partner, RedshiftIdcApplication, ReservedNode,
 };
 
 fn render_endpoint(e: &EndpointAccess) -> String {
@@ -55,6 +55,31 @@ fn render_endpoint(e: &EndpointAccess) -> String {
         owner = xml_escape(&e.resource_owner),
         port = e.port,
         addr = xml_escape(&e.address),
+    )
+}
+
+fn render_endpoint_authorization(a: &EndpointAuthorization) -> String {
+    // `AllowedVPCs` (`VpcIdentifierList`) serializes its members under the
+    // `VpcIdentifier` xmlName wrapper.
+    let vpcs: String = a
+        .allowed_vpcs
+        .iter()
+        .map(|v| tag_elem("VpcIdentifier", v))
+        .collect();
+    format!(
+        "<Grantor>{grantor}</Grantor><Grantee>{grantee}</Grantee>\
+         <ClusterIdentifier>{cluster}</ClusterIdentifier><AuthorizeTime>{time}</AuthorizeTime>\
+         <ClusterStatus>{cstatus}</ClusterStatus><Status>{status}</Status>\
+         <AllowedAllVPCs>{allowed_all}</AllowedAllVPCs><AllowedVPCs>{vpcs}</AllowedVPCs>\
+         <EndpointCount>{count}</EndpointCount>",
+        grantor = xml_escape(&a.grantor),
+        grantee = xml_escape(&a.grantee),
+        cluster = xml_escape(&a.cluster_identifier),
+        time = a.authorize_time.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
+        cstatus = xml_escape(&a.cluster_status),
+        status = xml_escape(&a.status),
+        allowed_all = a.allowed_all_vpcs,
+        count = a.endpoint_count,
     )
 }
 
@@ -288,40 +313,68 @@ impl RedshiftService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        self.endpoint_authorization(req, "AuthorizeEndpointAccess", "Authorized")
+        let grantee = param(req, "Account").unwrap_or_default();
+        let cluster = param(req, "ClusterIdentifier").unwrap_or_default();
+        let vpcs = member_list(req, "VpcIds", "VpcIdentifier");
+        let key = Self::endpoint_auth_key(&cluster, &grantee);
+        let mut guard = self.state.write();
+        let acct = guard.account(&req.account_id);
+        // The grantor must own the cluster it is sharing access to.
+        if !cluster.is_empty() && !acct.clusters.contains_key(&cluster) {
+            return Err(cluster_not_found(&cluster));
+        }
+        if acct.endpoint_authorizations.contains_key(&key) {
+            return Err(endpoint_authorization_already_exists(&grantee));
+        }
+        let auth = EndpointAuthorization {
+            grantor: req.account_id.clone(),
+            grantee: grantee.clone(),
+            cluster_identifier: cluster,
+            authorize_time: Utc::now(),
+            cluster_status: "available".to_string(),
+            status: "Authorized".to_string(),
+            allowed_all_vpcs: vpcs.is_empty(),
+            allowed_vpcs: vpcs,
+            endpoint_count: 0,
+        };
+        acct.endpoint_authorizations.insert(key, auth.clone());
+        Ok(xml_resp(
+            "AuthorizeEndpointAccess",
+            render_endpoint_authorization(&auth),
+            &req.request_id,
+        ))
     }
 
     pub(super) fn revoke_endpoint_access(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        self.endpoint_authorization(req, "RevokeEndpointAccess", "Revoking")
-    }
-
-    fn endpoint_authorization(
-        &self,
-        req: &AwsRequest,
-        action: &str,
-        status: &str,
-    ) -> Result<AwsResponse, AwsServiceError> {
         let grantee = param(req, "Account").unwrap_or_default();
         let cluster = param(req, "ClusterIdentifier").unwrap_or_default();
-        let now = Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
-        let vpcs = member_list(req, "VpcIds", "VpcIdentifier");
-        let allowed_all = vpcs.is_empty();
-        let vpc_xml: String = vpcs.iter().map(|v| tag_elem("VpcIdentifier", v)).collect();
+        let force = bool_param(req, "Force").unwrap_or(false);
+        let key = Self::endpoint_auth_key(&cluster, &grantee);
+        let mut guard = self.state.write();
+        let acct = guard.account(&req.account_id);
+        if !cluster.is_empty() && !acct.clusters.contains_key(&cluster) {
+            return Err(cluster_not_found(&cluster));
+        }
+        let mut auth = acct
+            .endpoint_authorizations
+            .get(&key)
+            .cloned()
+            .ok_or_else(|| endpoint_authorization_not_found(&grantee))?;
+        // Revoking while endpoints still reference the authorization requires
+        // `Force`; without live endpoints (endpoint_count == 0) it is a no-op.
+        if auth.endpoint_count > 0 && !force {
+            return Err(invalid_authorization_state(
+                "This endpoint authorization has active endpoints; retry with Force=true.",
+            ));
+        }
+        acct.endpoint_authorizations.remove(&key);
+        auth.status = "Revoking".to_string();
         Ok(xml_resp(
-            action,
-            format!(
-                "<Grantor>{grantor}</Grantor><Grantee>{grantee}</Grantee>\
-                 <ClusterIdentifier>{cluster}</ClusterIdentifier><AuthorizeTime>{now}</AuthorizeTime>\
-                 <ClusterStatus>available</ClusterStatus><Status>{status}</Status>\
-                 <AllowedAllVPCs>{allowed_all}</AllowedAllVPCs><AllowedVPCs>{vpc_xml}</AllowedVPCs>\
-                 <EndpointCount>0</EndpointCount>",
-                grantor = xml_escape(&req.account_id),
-                grantee = xml_escape(&grantee),
-                cluster = xml_escape(&cluster),
-            ),
+            "RevokeEndpointAccess",
+            render_endpoint_authorization(&auth),
             &req.request_id,
         ))
     }
@@ -330,11 +383,58 @@ impl RedshiftService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        let cluster_filter = param(req, "ClusterIdentifier");
+        let account_filter = param(req, "Account");
+        // `Grantee=true` lists authorizations where the caller is the grantee
+        // (access received); otherwise where the caller is the grantor (default).
+        let as_grantee = bool_param(req, "Grantee").unwrap_or(false);
+        let guard = self.state.read();
+        let all: Vec<EndpointAuthorization> = guard
+            .accounts
+            .get(&req.account_id)
+            .map(|a| {
+                a.endpoint_authorizations
+                    .values()
+                    .filter(|auth| {
+                        if as_grantee {
+                            auth.grantee == req.account_id
+                        } else {
+                            auth.grantor == req.account_id
+                        }
+                    })
+                    .filter(|auth| {
+                        cluster_filter
+                            .as_ref()
+                            .map(|c| &auth.cluster_identifier == c)
+                            .unwrap_or(true)
+                    })
+                    .filter(|auth| {
+                        account_filter
+                            .as_ref()
+                            .map(|acc| &auth.grantee == acc)
+                            .unwrap_or(true)
+                    })
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        let (page, next) = paginate(&all, req);
+        let inner: String = page
+            .iter()
+            .map(|auth| format!("<member>{}</member>", render_endpoint_authorization(auth)))
+            .collect();
         Ok(xml_resp(
             "DescribeEndpointAuthorization",
-            "<EndpointAuthorizationList/>".to_string(),
+            format!(
+                "{}<EndpointAuthorizationList>{inner}</EndpointAuthorizationList>",
+                render_marker(next)
+            ),
             &req.request_id,
         ))
+    }
+
+    fn endpoint_auth_key(cluster: &str, grantee: &str) -> String {
+        format!("{cluster}\u{1}{grantee}")
     }
 
     // ── Datashares ────────────────────────────────────────────────

--- a/crates/fakecloud-redshift/src/service/helpers.rs
+++ b/crates/fakecloud-redshift/src/service/helpers.rs
@@ -382,6 +382,26 @@ pub(crate) fn endpoint_already_exists(id: &str) -> AwsServiceError {
     )
 }
 
+pub(crate) fn endpoint_authorization_already_exists(account: &str) -> AwsServiceError {
+    err(
+        400,
+        "EndpointAuthorizationAlreadyExists",
+        format!("Endpoint authorization for account {account} already exists."),
+    )
+}
+
+pub(crate) fn endpoint_authorization_not_found(account: &str) -> AwsServiceError {
+    err(
+        404,
+        "EndpointAuthorizationNotFound",
+        format!("Endpoint authorization for account {account} not found."),
+    )
+}
+
+pub(crate) fn invalid_authorization_state(msg: impl Into<String>) -> AwsServiceError {
+    err(400, "InvalidAuthorizationState", msg.into())
+}
+
 pub(crate) fn authentication_profile_not_found(id: &str) -> AwsServiceError {
     err(
         404,

--- a/crates/fakecloud-redshift/src/service/tests.rs
+++ b/crates/fakecloud-redshift/src/service/tests.rs
@@ -472,6 +472,129 @@ fn unknown_cluster_operations_error_cleanly() {
 }
 
 #[test]
+fn endpoint_authorization_round_trip() {
+    let svc = service();
+    ok(
+        &svc,
+        "CreateCluster",
+        &[
+            ("ClusterIdentifier", "eac"),
+            ("NodeType", "ra3.xlplus"),
+            ("MasterUsername", "admin"),
+            ("MasterUserPassword", "Passw0rd123"),
+        ],
+    );
+    // Authorize returns a persisted authorization.
+    let authed = ok(
+        &svc,
+        "AuthorizeEndpointAccess",
+        &[("ClusterIdentifier", "eac"), ("Account", "210987654321")],
+    );
+    assert!(authed.contains("<Grantee>210987654321</Grantee>"));
+    assert!(authed.contains("<Status>Authorized</Status>"));
+    assert!(authed.contains("<AllowedAllVPCs>true</AllowedAllVPCs>"));
+
+    // Describe sees it, wrapped in the `member` list wrapper.
+    let listed = ok(&svc, "DescribeEndpointAuthorization", &[]);
+    assert!(
+        listed.contains("<EndpointAuthorizationList><member><Grantor>"),
+        "expected member wrapper, got: {listed}"
+    );
+    assert!(listed.contains("<Grantee>210987654321</Grantee>"));
+    assert!(listed.contains("<ClusterIdentifier>eac</ClusterIdentifier>"));
+
+    // A duplicate authorization for the same (cluster, account) conflicts.
+    assert_eq!(
+        err_code(
+            &svc,
+            "AuthorizeEndpointAccess",
+            &[("ClusterIdentifier", "eac"), ("Account", "210987654321")],
+        ),
+        "EndpointAuthorizationAlreadyExists"
+    );
+
+    // Revoke removes it (status flips to Revoking on the echoed copy).
+    let revoked = ok(
+        &svc,
+        "RevokeEndpointAccess",
+        &[("ClusterIdentifier", "eac"), ("Account", "210987654321")],
+    );
+    assert!(revoked.contains("<Status>Revoking</Status>"));
+
+    // Describe is now empty, and a second revoke is a not-found fault.
+    let empty = ok(&svc, "DescribeEndpointAuthorization", &[]);
+    assert!(!empty.contains("<Grantee>210987654321</Grantee>"));
+    assert_eq!(
+        err_code(
+            &svc,
+            "RevokeEndpointAccess",
+            &[("ClusterIdentifier", "eac"), ("Account", "210987654321")],
+        ),
+        "EndpointAuthorizationNotFound"
+    );
+}
+
+#[test]
+fn endpoint_authorization_unknown_cluster_and_filters() {
+    let svc = service();
+    for id in ["ea1", "ea2"] {
+        ok(
+            &svc,
+            "CreateCluster",
+            &[
+                ("ClusterIdentifier", id),
+                ("NodeType", "ra3.xlplus"),
+                ("MasterUsername", "admin"),
+                ("MasterUserPassword", "Passw0rd123"),
+            ],
+        );
+    }
+    // Authorizing against a cluster that does not exist is ClusterNotFound.
+    assert_eq!(
+        err_code(
+            &svc,
+            "AuthorizeEndpointAccess",
+            &[("ClusterIdentifier", "ghost"), ("Account", "210987654321")],
+        ),
+        "ClusterNotFound"
+    );
+    ok(
+        &svc,
+        "AuthorizeEndpointAccess",
+        &[("ClusterIdentifier", "ea1"), ("Account", "210987654321")],
+    );
+    ok(
+        &svc,
+        "AuthorizeEndpointAccess",
+        &[("ClusterIdentifier", "ea2"), ("Account", "310987654321")],
+    );
+    // Filter by ClusterIdentifier.
+    let by_cluster = ok(
+        &svc,
+        "DescribeEndpointAuthorization",
+        &[("ClusterIdentifier", "ea1")],
+    );
+    assert!(by_cluster.contains("<Grantee>210987654321</Grantee>"));
+    assert!(!by_cluster.contains("<Grantee>310987654321</Grantee>"));
+    // Filter by grantee Account.
+    let by_account = ok(
+        &svc,
+        "DescribeEndpointAuthorization",
+        &[("Account", "310987654321")],
+    );
+    assert!(by_account.contains("<ClusterIdentifier>ea2</ClusterIdentifier>"));
+    assert!(!by_account.contains("<Grantee>210987654321</Grantee>"));
+    // Grantee=true asks for authorizations received by the caller; the caller is
+    // the grantor of both, so the list is empty.
+    let as_grantee = ok(
+        &svc,
+        "DescribeEndpointAuthorization",
+        &[("Grantee", "true")],
+    );
+    assert!(!as_grantee.contains("<Grantee>"));
+}
+
+#[test]
 fn tag_operations_round_trip() {
     let svc = service();
     ok(


### PR DESCRIPTION
## Summary

The endpoint-authorization ops were stubs with a write-read asymmetry:
`AuthorizeEndpointAccess` and `RevokeEndpointAccess` echoed a synthesized
response without persisting anything, and `DescribeEndpointAuthorization`
always returned an empty list. A client that authorized cross-account endpoint
access could never read it back.

This wires the (already-declared, already-persisted, `#[serde(default)]`)
`endpoint_authorizations` state map into the three handlers so they form a real
round-trip:

- **AuthorizeEndpointAccess** — persists an authorization keyed by
  (grantor cluster, grantee account) with the model's `EndpointAuthorization`
  output fields (`Grantor`/`Grantee`/`ClusterIdentifier`/`AuthorizeTime`/
  `ClusterStatus`/`Status=Authorized`/`AllowedAllVPCs`/`AllowedVPCs`/
  `EndpointCount`). Unknown cluster -> `ClusterNotFoundFault`; duplicate ->
  `EndpointAuthorizationAlreadyExistsFault` (the model's declared fault).
- **RevokeEndpointAccess** — removes the matching authorization and echoes it
  with `Status=Revoking`; missing -> `EndpointAuthorizationNotFoundFault`;
  unknown cluster -> `ClusterNotFoundFault`. Honors the `Force` param.
- **DescribeEndpointAuthorization** — returns the persisted authorizations
  under the correct `member` list wrapper (the `EndpointAuthorizations` list
  has no `xmlName`), filtered by `ClusterIdentifier` / `Account` (grantee) /
  the `Grantee` boolean (grantor-vs-grantee perspective), with `Marker`
  pagination.

Mutations flush through the existing snapshot hook (both ops are non-Describe/
Get/List, so `handle` persists after success), so authorizations survive
restart like the rest of the redshift state.

## Test plan

- New unit tests:
  - `endpoint_authorization_round_trip` — authorize -> describe sees it ->
    duplicate conflicts -> revoke -> describe empty -> second revoke is
    not-found.
  - `endpoint_authorization_unknown_cluster_and_filters` — unknown cluster
    rejected; `ClusterIdentifier` / `Account` / `Grantee` filters.
- `cargo test -p fakecloud-redshift` — 23 passed.
- `cargo clippy -p fakecloud-redshift --all-targets -- -D warnings` — clean.
- `cargo fmt`.
- `fakecloud-conformance run --services redshift` — 141/141 ops, 4240/4240
  variants (AuthorizeEndpointAccess 27/27, RevokeEndpointAccess 28/28,
  DescribeEndpointAuthorization 30/30). No baseline change required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted Redshift endpoint authorizations and wired a real Authorize/Revoke/Describe round-trip so clients can read back grants. Fixes empty Describe results, returns correct faults, and adds filtering and pagination.

- **Bug Fixes**
  - AuthorizeEndpointAccess: persist by cluster + grantee; return full `EndpointAuthorization` (Status=Authorized, AllowedAllVPCs/AllowedVPCs, EndpointCount=0). Reject unknown clusters (ClusterNotFound) and duplicates (EndpointAuthorizationAlreadyExists).
  - RevokeEndpointAccess: delete and echo with Status=Revoking; require Force=true if active endpoints exist (InvalidAuthorizationState). Return EndpointAuthorizationNotFound when missing; validate cluster.
  - DescribeEndpointAuthorization: return persisted items with the correct member wrapper; support ClusterIdentifier, Account, and Grantee=true filters; support Marker pagination.
  - State survives restarts via snapshotting. Added unit tests; Redshift conformance remains fully passing.

<sup>Written for commit 474398c63f0aac299ebdb7e074e6471f21df235b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

