### PR TITLE
fix(dms): ModifyReplicationInstance persists VpcSecurityGroupIds

### DIFF
--- a/crates/fakecloud-dms/src/service.rs
+++ b/crates/fakecloud-dms/src/service.rs
@@ -441,6 +441,20 @@ fn arn(ctx: &Ctx, kind: &str, id: &str) -> String {
     format!("arn:aws:dms:{}:{}:{}:{}", ctx.region, ctx.account, kind, id)
 }
 
+/// Build the `VpcSecurityGroups` describe list from a `VpcSecurityGroupIds`
+/// input array (`["sg-x", ...]` -> `[{VpcSecurityGroupId, Status}, ...]`).
+fn vpc_security_groups(b: &Value) -> Vec<Value> {
+    b.get("VpcSecurityGroupIds")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| json!({ "VpcSecurityGroupId": s, "Status": "active" }))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Copy a set of fields verbatim from `src` into `dst` when present.
 fn copy_fields(src: &Value, dst: &mut Map<String, Value>, fields: &[&str]) {
     for f in fields {
@@ -633,16 +647,7 @@ impl DmsService {
             )));
         }
         let instance_arn = arn(ctx, "rep", &res_id());
-        let vpc_sgs: Vec<Value> = b
-            .get("VpcSecurityGroupIds")
-            .and_then(Value::as_array)
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str())
-                    .map(|s| json!({ "VpcSecurityGroupId": s, "Status": "active" }))
-                    .collect()
-            })
-            .unwrap_or_default();
+        let vpc_sgs = vpc_security_groups(b);
         let mut inst = Map::new();
         inst.insert("ReplicationInstanceArn".into(), json!(instance_arn));
         inst.insert("ReplicationInstanceIdentifier".into(), json!(id));
@@ -771,6 +776,12 @@ impl DmsService {
             if let Some(v) = b.get(in_field) {
                 obj.insert(out_field.to_string(), v.clone());
             }
+        }
+        // `VpcSecurityGroupIds` is an input-only array that DMS reflects back
+        // as the derived `VpcSecurityGroups` describe list; rebuild it so a
+        // modified security-group set round-trips through Describe.
+        if b.get("VpcSecurityGroupIds").is_some() {
+            obj.insert("VpcSecurityGroups".into(), json!(vpc_security_groups(b)));
         }
         obj.insert("ReplicationInstanceStatus".into(), json!("available"));
         let inst = inst.clone();

--- a/crates/fakecloud-dms/src/service/tests.rs
+++ b/crates/fakecloud-dms/src/service/tests.rs
@@ -97,6 +97,28 @@ fn replication_instance_crud() {
 }
 
 #[test]
+fn modify_instance_updates_vpc_security_groups() {
+    let s = svc();
+    let arn = new_instance(&s);
+    let modified = call(
+        &s,
+        "ModifyReplicationInstance",
+        json!({ "ReplicationInstanceArn": arn, "VpcSecurityGroupIds": ["sg-aaa", "sg-bbb"] }),
+    );
+    let sgs = modified["ReplicationInstance"]["VpcSecurityGroups"]
+        .as_array()
+        .unwrap();
+    assert_eq!(sgs.len(), 2);
+    assert_eq!(sgs[0]["VpcSecurityGroupId"], json!("sg-aaa"));
+    assert_eq!(sgs[0]["Status"], json!("active"));
+    // The change must round-trip through Describe, not just the modify echo.
+    let desc = call(&s, "DescribeReplicationInstances", json!({}));
+    let listed = &desc["ReplicationInstances"][0]["VpcSecurityGroups"];
+    assert_eq!(listed.as_array().unwrap().len(), 2);
+    assert_eq!(listed[1]["VpcSecurityGroupId"], json!("sg-bbb"));
+}
+
+#[test]
 fn replication_instance_dup_rejected() {
     let s = svc();
     call(


### PR DESCRIPTION
## Summary

`ModifyReplicationInstance` accepts a `VpcSecurityGroupIds` input array (per the DMS Smithy model), and `CreateReplicationInstance` already reflects it back as the derived `VpcSecurityGroups` describe list. The modify handler, however, only copied a fixed set of scalar fields and silently dropped `VpcSecurityGroupIds` — so changing an instance's security groups never round-tripped: `DescribeReplicationInstances` kept showing the create-time groups.

This rebuilds the `VpcSecurityGroups` list from `VpcSecurityGroupIds` on modify (only when the field is present, so unrelated modifies are unaffected), matching the create path. The `[{VpcSecurityGroupId, Status}]` construction is factored into a shared `vpc_security_groups` helper used by both handlers.

## Test plan
- New unit test `modify_instance_updates_vpc_security_groups` asserts the modified groups appear in both the `ModifyReplicationInstance` echo and a subsequent `DescribeReplicationInstances`.
- `cargo test -p fakecloud-dms` (29 passed)
- `cargo clippy -p fakecloud-dms --all-targets -- -D warnings` (clean)
- `cargo fmt`
- `cargo test -p fakecloud-conformance --test dms` (green)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DMS ModifyReplicationInstance so changes to VpcSecurityGroupIds persist and show up in DescribeReplicationInstances. Matches the create path and adds a unit test to prevent regressions.

- **Bug Fixes**
  - Rebuilds VpcSecurityGroups from VpcSecurityGroupIds when provided.
  - Adds a unit test to verify the updated groups echo on modify and round-trip through describe.

- **Refactors**
  - Extracts a shared vpc_security_groups helper used by create and modify paths.

<sup>Written for commit 886616bb6f114d674257b5080dc5f076ee62f6fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

