### PR TITLE
fix(dms): harden list pagination against overflowing Marker

### DIFF
--- a/crates/fakecloud-dms/src/service.rs
+++ b/crates/fakecloud-dms/src/service.rs
@@ -464,7 +464,10 @@ fn paginate(rows: Vec<Value>, b: &Value) -> (Vec<Value>, Option<String>) {
         .and_then(Value::as_u64)
         .map(|m| m.clamp(1, 10_000) as usize)
         .unwrap_or(100);
-    let end = (start + max).min(rows.len());
+    // `saturating_add` keeps a hostile numeric `Marker` (e.g. `usize::MAX`)
+    // from overflowing `start + max` and panicking on the request path; an
+    // out-of-range window simply yields an empty page.
+    let end = start.saturating_add(max).min(rows.len());
     let page = rows.get(start..end).unwrap_or(&[]).to_vec();
     let next = if end < rows.len() {
         Some(end.to_string())

--- a/crates/fakecloud-dms/src/service/tests.rs
+++ b/crates/fakecloud-dms/src/service/tests.rs
@@ -634,6 +634,21 @@ fn pagination_marker() {
 }
 
 #[test]
+fn pagination_hostile_marker_does_not_panic() {
+    let s = svc();
+    new_endpoint(&s, "only", "source");
+    // A `usize::MAX` marker must not overflow `start + max` on the request
+    // path; the window is out of range so the page is empty and paging ends.
+    let out = call(
+        &s,
+        "DescribeEndpoints",
+        json!({ "Marker": "18446744073709551615" }),
+    );
+    assert!(out["Endpoints"].as_array().unwrap().is_empty());
+    assert_eq!(out["Marker"], json!(""));
+}
+
+#[test]
 fn filters_endpoints_by_engine() {
     let s = svc();
     new_endpoint(&s, "m", "source");


### PR DESCRIPTION
## Summary

The DMS list pagination helper computes the page window as `start + max`, where `start` is parsed directly from the client-supplied `Marker`/`NextToken` and `max` from `MaxRecords`. A hostile numeric marker near `usize::MAX` (e.g. `Marker: "18446744073709551615"`) makes `start + max` overflow. In an overflow-checked build that panics on the request path (a dropped connection instead of a 400/empty page); in release it wraps to a bogus window.

This switches the addition to `saturating_add`, so an out-of-range marker deterministically yields an empty final page (`Marker: ""`) instead of overflowing. The existing `rows.get(start..end).unwrap_or(&[])` guard already handles `start > len` safely, so no other change is needed.

## Test plan
- New unit test `pagination_hostile_marker_does_not_panic` sends a `usize::MAX` marker to `DescribeEndpoints` and asserts an empty page with a terminal empty `Marker` (this test panics on the pre-fix code in a checked build).
- `cargo test -p fakecloud-dms` (29 passed)
- `cargo clippy -p fakecloud-dms --all-targets -- -D warnings` (clean)
- `cargo fmt`
- `cargo test -p fakecloud-conformance --test dms` (green)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened DMS pagination to prevent overflow when a hostile numeric `Marker` is supplied. Large markers now return an empty page with an empty `Marker` instead of panicking or wrapping.

- **Bug Fixes**
  - Replaced `start + max` with `start.saturating_add(max)` to avoid overflow and bogus windows in `fakecloud-dms`.
  - Added unit test `pagination_hostile_marker_does_not_panic` to assert empty page and terminal empty `Marker` for `usize::MAX`.

<sup>Written for commit f3757654efcf736cd7edb534e7ce692c691d1746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

