### PR TITLE
fix(dms): apply Filters on remaining Describe ops + region-correct orderable AZs

### DIFF
--- a/crates/fakecloud-dms/src/service.rs
+++ b/crates/fakecloud-dms/src/service.rs
@@ -217,7 +217,9 @@ fn dispatch(s: &DmsService, req: &AwsRequest) -> Result<AwsResponse, AwsServiceE
         "DescribeReplicationInstanceTaskLogs" => {
             s.describe_replication_instance_task_logs(&acct, &b)
         }
-        "DescribeOrderableReplicationInstances" => s.describe_orderable_replication_instances(&b),
+        "DescribeOrderableReplicationInstances" => {
+            s.describe_orderable_replication_instances(&acct, &b)
+        }
         // endpoints
         "CreateEndpoint" => s.create_endpoint(&acct, &b),
         "DescribeEndpoints" => s.describe_endpoints(&acct, &b),
@@ -497,8 +499,9 @@ fn list_next_token(
     key: &str,
     mut rows: Vec<Value>,
     b: &Value,
+    filterable: &[(&str, &[&str])],
 ) -> Result<AwsResponse, AwsServiceError> {
-    apply_filters(&mut rows, b, &[]);
+    apply_filters(&mut rows, b, filterable);
     let (page, next) = paginate(rows, b);
     let mut out = Map::new();
     out.insert(key.to_string(), Value::Array(page));
@@ -870,8 +873,16 @@ impl DmsService {
 
     fn describe_orderable_replication_instances(
         &self,
+        ctx: &Ctx,
         b: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
+        // AZ names are region-scoped (`<region>a`, `<region>b`, ...); a
+        // hard-coded `us-east-1a/b` list fails AZ validation for callers in
+        // any other region.
+        let azs: Vec<Value> = ["a", "b", "c"]
+            .iter()
+            .map(|z| json!(format!("{}{z}", ctx.region)))
+            .collect();
         let rows: Vec<Value> = [
             "dms.t3.micro",
             "dms.t3.medium",
@@ -888,7 +899,7 @@ impl DmsService {
                 "MaxAllocatedStorage": 6144,
                 "DefaultAllocatedStorage": 50,
                 "IncludedAllocatedStorage": 50,
-                "AvailabilityZones": ["us-east-1a", "us-east-1b"],
+                "AvailabilityZones": azs.clone(),
                 "ReleaseStatus": "available"
             })
         })
@@ -1758,19 +1769,36 @@ impl DmsService {
         ctx: &Ctx,
         b: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let name = opt_str(b, "SubscriptionName").map(String::from);
+        let name = opt_str(b, "SubscriptionName")
+            .filter(|s| !s.is_empty())
+            .map(String::from);
         let guard = self.state.read();
-        let rows: Vec<Value> = guard
-            .get(&ctx.account)
-            .map(|d| {
-                d.event_subscriptions
-                    .iter()
+        let subs = guard.get(&ctx.account).map(|d| &d.event_subscriptions);
+        // A named lookup for a non-existent subscription raises the
+        // `ResourceNotFoundFault` the op declares, rather than a silent empty
+        // list. (An empty/omitted name lists everything.)
+        if let Some(n) = &name {
+            if !subs.map(|s| s.contains_key(n)).unwrap_or(false) {
+                return Err(not_found(&format!("Event subscription {n} not found.")));
+            }
+        }
+        let rows: Vec<Value> = subs
+            .map(|s| {
+                s.iter()
                     .filter(|(k, _)| name.as_ref().map(|n| *k == n).unwrap_or(true))
                     .map(|(_, v)| v.clone())
                     .collect()
             })
             .unwrap_or_default();
-        list_marker("EventSubscriptionsList", rows, b, &[])
+        list_marker(
+            "EventSubscriptionsList",
+            rows,
+            b,
+            &[
+                ("event-subscription-arn", &["EventSubscriptionArn"]),
+                ("event-subscription-id", &["CustSubscriptionId"]),
+            ],
+        )
     }
 
     fn modify_event_subscription(
@@ -3064,11 +3092,19 @@ impl DmsService {
             .get(&ctx.account)
             .map(|d| d.fleet_advisor_collectors.values().cloned().collect())
             .unwrap_or_default();
-        list_next_token("Collectors", rows, b)
+        list_next_token(
+            "Collectors",
+            rows,
+            b,
+            &[
+                ("collector-referenced-id", &["CollectorReferencedId"]),
+                ("collector-name", &["CollectorName"]),
+            ],
+        )
     }
 
     fn describe_fleet_advisor_databases(&self, b: &Value) -> Result<AwsResponse, AwsServiceError> {
-        list_next_token("Databases", vec![], b)
+        list_next_token("Databases", vec![], b, &[])
     }
 
     fn delete_fleet_advisor_databases(&self, b: &Value) -> Result<AwsResponse, AwsServiceError> {
@@ -3083,18 +3119,18 @@ impl DmsService {
         &self,
         b: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
-        list_next_token("Analysis", vec![], b)
+        list_next_token("Analysis", vec![], b, &[])
     }
 
     fn describe_fleet_advisor_schema_object_summary(
         &self,
         b: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
-        list_next_token("FleetAdvisorSchemaObjects", vec![], b)
+        list_next_token("FleetAdvisorSchemaObjects", vec![], b, &[])
     }
 
     fn describe_fleet_advisor_schemas(&self, b: &Value) -> Result<AwsResponse, AwsServiceError> {
-        list_next_token("FleetAdvisorSchemas", vec![], b)
+        list_next_token("FleetAdvisorSchemas", vec![], b, &[])
     }
 
     fn run_fleet_advisor_lsa_analysis(&self) -> Result<AwsResponse, AwsServiceError> {
@@ -3153,14 +3189,19 @@ impl DmsService {
             .get(&ctx.account)
             .map(|d| d.recommendations.values().cloned().collect())
             .unwrap_or_default();
-        list_next_token("Recommendations", rows, b)
+        list_next_token(
+            "Recommendations",
+            rows,
+            b,
+            &[("database-id", &["DatabaseId"]), ("status", &["Status"])],
+        )
     }
 
     fn describe_recommendation_limitations(
         &self,
         b: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
-        list_next_token("Limitations", vec![], b)
+        list_next_token("Limitations", vec![], b, &[])
     }
 }
 

--- a/crates/fakecloud-dms/src/service/tests.rs
+++ b/crates/fakecloud-dms/src/service/tests.rs
@@ -39,6 +39,13 @@ fn call(s: &DmsService, action: &str, body: Value) -> Value {
     serde_json::from_slice(resp.body.expect_bytes()).unwrap()
 }
 
+fn call_region(s: &DmsService, action: &str, region: &str, body: Value) -> Value {
+    let mut r = req(action, body);
+    r.region = region.into();
+    let resp = dispatch(s, &r).expect("op ok");
+    serde_json::from_slice(resp.body.expect_bytes()).unwrap()
+}
+
 fn err(s: &DmsService, action: &str, body: Value) -> AwsServiceError {
     dispatch(s, &req(action, body))
         .err()
@@ -650,6 +657,95 @@ fn filters_endpoints_by_engine() {
     let list = filtered["Endpoints"].as_array().unwrap();
     assert_eq!(list.len(), 1);
     assert_eq!(list[0]["EngineName"], json!("postgres"));
+}
+
+#[test]
+fn event_subscriptions_filter_and_unknown_name() {
+    let s = svc();
+    for n in ["sub-a", "sub-b"] {
+        call(
+            &s,
+            "CreateEventSubscription",
+            json!({ "SubscriptionName": n, "SnsTopicArn": "arn:aws:sns:us-east-1:000000000000:t" }),
+        );
+    }
+    // Declared `Filters` must narrow the list.
+    let filtered = call(
+        &s,
+        "DescribeEventSubscriptions",
+        json!({ "Filters": [{ "Name": "event-subscription-id", "Values": ["sub-b"] }] }),
+    );
+    let list = filtered["EventSubscriptionsList"].as_array().unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0]["CustSubscriptionId"], json!("sub-b"));
+    // A named lookup for a missing subscription raises ResourceNotFoundFault.
+    let e = err(
+        &s,
+        "DescribeEventSubscriptions",
+        json!({ "SubscriptionName": "nope" }),
+    );
+    assert_eq!(e.code(), "ResourceNotFoundFault");
+}
+
+#[test]
+fn recommendations_filter_narrows_list() {
+    let s = svc();
+    call(
+        &s,
+        "StartRecommendations",
+        json!({ "DatabaseId": "db-1", "Settings": { "InstanceSizingType": "default" } }),
+    );
+    call(
+        &s,
+        "StartRecommendations",
+        json!({ "DatabaseId": "db-2", "Settings": { "InstanceSizingType": "default" } }),
+    );
+    let filtered = call(
+        &s,
+        "DescribeRecommendations",
+        json!({ "Filters": [{ "Name": "database-id", "Values": ["db-2"] }] }),
+    );
+    let list = filtered["Recommendations"].as_array().unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0]["DatabaseId"], json!("db-2"));
+}
+
+#[test]
+fn fleet_advisor_collectors_filter_narrows_list() {
+    let s = svc();
+    for n in ["col-a", "col-b"] {
+        call(
+            &s,
+            "CreateFleetAdvisorCollector",
+            json!({ "CollectorName": n, "ServiceAccessRoleArn": "arn:aws:iam::000000000000:role/r", "S3BucketName": "b" }),
+        );
+    }
+    let filtered = call(
+        &s,
+        "DescribeFleetAdvisorCollectors",
+        json!({ "Filters": [{ "Name": "collector-name", "Values": ["col-a"] }] }),
+    );
+    let list = filtered["Collectors"].as_array().unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0]["CollectorName"], json!("col-a"));
+}
+
+#[test]
+fn orderable_instances_reflect_request_region() {
+    let s = svc();
+    let out = call_region(
+        &s,
+        "DescribeOrderableReplicationInstances",
+        "eu-west-1",
+        json!({}),
+    );
+    let azs = out["OrderableReplicationInstances"][0]["AvailabilityZones"]
+        .as_array()
+        .unwrap();
+    assert!(azs
+        .iter()
+        .all(|z| z.as_str().unwrap().starts_with("eu-west-1")));
+    assert_eq!(azs[0], json!("eu-west-1a"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #2114/#2115, closing three control-plane divergences where the DMS handlers parsed inputs but didn't act on them (parsed-then-dropped = stub), plus a region-blind static catalogue.

1. **`Filters` parsed but never applied on three Describe ops.** `DescribeEventSubscriptions`, `DescribeRecommendations`, and `DescribeFleetAdvisorCollectors` all declare a `Filters` input but previously returned every row regardless. They now filter the same way the endpoint/task/instance Describe ops already do (via the shared `apply_filters` helper):
   - `DescribeEventSubscriptions`: `event-subscription-arn`, `event-subscription-id` (-> `CustSubscriptionId`)
   - `DescribeRecommendations`: `database-id`, `status`
   - `DescribeFleetAdvisorCollectors`: `collector-referenced-id`, `collector-name`

   `list_next_token` gained a `filterable` parameter to match `list_marker`; the ops with no stored rows pass `&[]`. Unknown filter names remain ignored (the conformance probe's placeholder `Name:"string"` still yields a successful empty page).

2. **`DescribeEventSubscriptions` with an unknown `SubscriptionName` returned a silent empty list.** The op declares `ResourceNotFoundFault` in its Smithy model, so a named lookup for a non-existent subscription now raises it (an empty/omitted name still lists everything). The other two ops in item 1 do **not** declare that fault, so their behaviour for empty results is unchanged.

3. **`DescribeOrderableReplicationInstances` hard-coded `AvailabilityZones: ["us-east-1a", "us-east-1b"]` for every region.** AZ names are region-scoped, and Terraform validates them against the request region, so a non-us-east-1 caller got invalid AZs. The handler now takes `Ctx` (threaded through `dispatch`) and emits `<region>a/b/c`.

## Test plan
- New unit tests: `event_subscriptions_filter_and_unknown_name` (filter narrows + unknown name -> `ResourceNotFoundFault`), `recommendations_filter_narrows_list`, `fleet_advisor_collectors_filter_narrows_list`, `orderable_instances_reflect_request_region` (asserts `eu-west-1a`).
- `cargo test -p fakecloud-dms` (32 passed)
- `cargo clippy -p fakecloud-dms --all-targets -- -D warnings` (clean)
- `cargo fmt`
- `cargo test -p fakecloud-conformance --test dms` (green; `ResourceNotFoundFault` is a declared error on the op, so the probe classifies it as a pass — no baseline change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies missing Filters to three DMS Describe operations and fixes region-correct AvailabilityZones for orderable replication instances. Also returns ResourceNotFoundFault when a named event subscription is missing.

- **Bug Fixes**
  - Apply Filters on:
    - DescribeEventSubscriptions: event-subscription-arn, event-subscription-id.
    - DescribeRecommendations: database-id, status.
    - DescribeFleetAdvisorCollectors: collector-referenced-id, collector-name.
  - DescribeEventSubscriptions now raises ResourceNotFoundFault when SubscriptionName is provided and not found; empty or missing name still lists all.
  - DescribeOrderableReplicationInstances now returns AvailabilityZones for the request region (e.g., eu-west-1a/b/c), not a static us-east-1 list.

- **Refactors**
  - `list_next_token` accepts filter definitions to align with `list_marker`.
  - Thread `Ctx` into `describe_orderable_replication_instances` to compute region-scoped AZs.

<sup>Written for commit e24bca43ba31f1f8398eabee8c0a7f95df5a6365. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

