### PR TITLE
feat(runtime): loud, actionable UX when no container runtime is present

### DIFF
--- a/crates/fakecloud-core/src/container_net.rs
+++ b/crates/fakecloud-core/src/container_net.rs
@@ -19,6 +19,12 @@
 //!   fakecloud's container as `host.docker.internal:<port>`, not
 //!   `127.0.0.1:<port>`.
 
+/// Actionable remediation appended to every error raised when a container
+/// runtime (Docker/Podman) is required for an operation but none is
+/// available. Kept in one place so RDS, Lambda, ECS, and the server startup
+/// banner all surface the same fix steps and can't drift apart.
+pub const CONTAINER_RUNTIME_HINT: &str = "Install and start Docker or Podman, or set FAKECLOUD_CONTAINER_CLI to your container CLI path.";
+
 /// Auto-detect an available container CLI. Honors `FAKECLOUD_CONTAINER_CLI`
 /// as an explicit override (returns `None` if the override doesn't work),
 /// otherwise prefers `docker` then `podman`. Returns `None` when neither

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -358,9 +358,10 @@ impl EcsService {
                         t.last_status = "STOPPED".into();
                         t.desired_status = "STOPPED".into();
                         t.stop_code = Some("TaskFailedToStart".into());
-                        t.stopped_reason = Some(
-                            "No container runtime available (docker/podman not installed)".into(),
-                        );
+                        t.stopped_reason = Some(format!(
+                            "No container runtime available (docker/podman not installed). {}",
+                            fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                        ));
                         t.stopped_at = Some(chrono::Utc::now());
                         for c in t.containers.iter_mut() {
                             c.last_status = "STOPPED".into();

--- a/crates/fakecloud-ecs/src/service_daemons.rs
+++ b/crates/fakecloud-ecs/src/service_daemons.rs
@@ -336,9 +336,10 @@ impl EcsService {
                         t.last_status = "STOPPED".into();
                         t.desired_status = "STOPPED".into();
                         t.stop_code = Some("TaskFailedToStart".into());
-                        t.stopped_reason = Some(
-                            "No container runtime available (docker/podman not installed)".into(),
-                        );
+                        t.stopped_reason = Some(format!(
+                            "No container runtime available (docker/podman not installed). {}",
+                            fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                        ));
                         t.stopped_at = Some(Utc::now());
                         for c in t.containers.iter_mut() {
                             c.last_status = "STOPPED".into();
@@ -544,9 +545,10 @@ impl EcsService {
                         t.last_status = "STOPPED".into();
                         t.desired_status = "STOPPED".into();
                         t.stop_code = Some("TaskFailedToStart".into());
-                        t.stopped_reason = Some(
-                            "No container runtime available (docker/podman not installed)".into(),
-                        );
+                        t.stopped_reason = Some(format!(
+                            "No container runtime available (docker/podman not installed). {}",
+                            fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                        ));
                         t.stopped_at = Some(Utc::now());
                         for c in t.containers.iter_mut() {
                             c.last_status = "STOPPED".into();

--- a/crates/fakecloud-ecs/src/service_services_resource.rs
+++ b/crates/fakecloud-ecs/src/service_services_resource.rs
@@ -303,9 +303,10 @@ impl EcsService {
                     if let Some(t) = state.tasks.get_mut(id) {
                         t.last_status = "STOPPED".into();
                         t.stop_code = Some("TaskFailedToStart".into());
-                        t.stopped_reason = Some(
-                            "No container runtime available (docker/podman not installed)".into(),
-                        );
+                        t.stopped_reason = Some(format!(
+                            "No container runtime available (docker/podman not installed). {}",
+                            fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                        ));
                         t.stopped_at = Some(Utc::now());
                         for c in t.containers.iter_mut() {
                             c.last_status = "STOPPED".into();
@@ -833,9 +834,10 @@ impl EcsService {
                     if let Some(t) = state.tasks.get_mut(id) {
                         t.last_status = "STOPPED".into();
                         t.stop_code = Some("TaskFailedToStart".into());
-                        t.stopped_reason = Some(
-                            "No container runtime available (docker/podman not installed)".into(),
-                        );
+                        t.stopped_reason = Some(format!(
+                            "No container runtime available (docker/podman not installed). {}",
+                            fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                        ));
                         t.stopped_at = Some(Utc::now());
                         for c in t.containers.iter_mut() {
                             c.last_status = "STOPPED".into();

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -358,9 +358,10 @@ impl EcsService {
                         // caller explicitly stops it. This also ensures
                         // list_tasks (default filter=RUNNING) finds it.
                         t.stop_code = Some("TaskFailedToStart".into());
-                        t.stopped_reason = Some(
-                            "No container runtime available (docker/podman not installed)".into(),
-                        );
+                        t.stopped_reason = Some(format!(
+                            "No container runtime available (docker/podman not installed). {}",
+                            fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                        ));
                         t.stopped_at = Some(Utc::now());
                         for c in t.containers.iter_mut() {
                             c.last_status = "STOPPED".into();

--- a/crates/fakecloud-ecs/src/service_tests.rs
+++ b/crates/fakecloud-ecs/src/service_tests.rs
@@ -368,6 +368,25 @@ mod scheduler_reconcile {
             "scheduler must spawn desiredCount tasks for a service at 0 running"
         );
 
+        // The stop reason must stay actionable: it names the missing runtime
+        // and tells the operator how to enable real task execution.
+        {
+            let accounts = state.read();
+            let reason = accounts
+                .get(ACCOUNT)
+                .unwrap()
+                .tasks
+                .values()
+                .find_map(|t| t.stopped_reason.clone())
+                .expect("a STOPPED task must carry a stopped_reason");
+            assert!(
+                reason.contains("No container runtime available")
+                    && reason.contains("Install and start Docker or Podman")
+                    && reason.contains("FAKECLOUD_CONTAINER_CLI"),
+                "runtime-missing stop reason must explain how to fix it: {reason}"
+            );
+        }
+
         // Simulate those tasks actually running (as the runtime would), then
         // tick again: the service is now at desiredCount so NO new tasks spawn.
         {

--- a/crates/fakecloud-lambda/src/extras/stream.rs
+++ b/crates/fakecloud-lambda/src/extras/stream.rs
@@ -90,7 +90,10 @@ impl LambdaService {
             AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "ServiceException",
-                "Docker/Podman is required for Lambda execution but is not available",
+                format!(
+                    "Docker/Podman is required for Lambda execution but is not available. {}",
+                    fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                ),
             )
         })?;
 

--- a/crates/fakecloud-lambda/src/service/invoke.rs
+++ b/crates/fakecloud-lambda/src/service/invoke.rs
@@ -334,7 +334,10 @@ impl LambdaService {
             Err(AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "ServiceException",
-                "Docker/Podman is required for Lambda execution but is not available",
+                format!(
+                    "Docker/Podman is required for Lambda execution but is not available. {}",
+                    fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                ),
             ))
         };
 

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -292,12 +292,14 @@ async fn test_invoke_without_runtime_returns_error() {
     let state = make_state();
     let svc = LambdaService::new(state);
 
+    // A real deployment package is required to get past the "no deployment
+    // package" guard and actually reach the runtime-missing branch.
     let create_body = json!({
         "FunctionName": "invoke-me",
         "Runtime": "python3.12",
         "Role": "arn:aws:iam::123456789012:role/test",
         "Handler": "index.handler",
-        "Code": {}
+        "Code": { "ZipFile": "UEsFBgAAAAAAAAAAAAAAAAAAAAA=" }
     });
 
     let req = make_request(
@@ -312,8 +314,18 @@ async fn test_invoke_without_runtime_returns_error() {
         "/2015-03-31/functions/invoke-me/invocations",
         r#"{"key": "value"}"#,
     );
-    let resp = svc.handle(req).await;
-    assert!(resp.is_err());
+    let err = match svc.handle(req).await {
+        Ok(_) => panic!("invoke with no runtime must error"),
+        Err(e) => e,
+    };
+    // The message must stay actionable: name the runtime and how to enable it.
+    let message = err.message();
+    assert!(
+        message.contains("Docker/Podman is required for Lambda execution")
+            && message.contains("Install and start Docker or Podman")
+            && message.contains("FAKECLOUD_CONTAINER_CLI"),
+        "runtime-missing Lambda error must explain how to fix it: {message}"
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -763,7 +763,10 @@ impl RdsService {
             AwsServiceError::aws_error(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "InsufficientDBInstanceCapacity",
-                "Docker/Podman is required for RDS DB instances but is not available",
+                format!(
+                    "Docker/Podman is required for RDS DB instances but is not available. {}",
+                    fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                ),
             )
         })
     }

--- a/crates/fakecloud-rds/src/service/replicas.rs
+++ b/crates/fakecloud-rds/src/service/replicas.rs
@@ -56,7 +56,10 @@ impl RdsService {
             AwsServiceError::aws_error(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "InsufficientDBInstanceCapacity",
-                "Docker/Podman is required for RDS read replicas but is not available",
+                format!(
+                    "Docker/Podman is required for RDS read replicas but is not available. {}",
+                    fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                ),
             )
         })?;
 

--- a/crates/fakecloud-rds/src/service/snapshots.rs
+++ b/crates/fakecloud-rds/src/service/snapshots.rs
@@ -19,7 +19,10 @@ impl RdsService {
             AwsServiceError::aws_error(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "InvalidDBSnapshotState",
-                "Docker/Podman is required for RDS snapshots but is not available",
+                format!(
+                    "Docker/Podman is required for RDS snapshots but is not available. {}",
+                    fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                ),
             )
         })?;
 
@@ -159,7 +162,10 @@ impl RdsService {
             AwsServiceError::aws_error(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "InvalidDBInstanceState",
-                "Docker/Podman is required for RDS snapshots but is not available",
+                format!(
+                    "Docker/Podman is required for RDS snapshots but is not available. {}",
+                    fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+                ),
             )
         })?;
 

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -2089,7 +2089,10 @@ pub(crate) fn runtime_error_to_service_error(error: RuntimeError) -> AwsServiceE
         RuntimeError::Unavailable => AwsServiceError::aws_error(
             StatusCode::SERVICE_UNAVAILABLE,
             "InsufficientDBInstanceCapacity",
-            "Docker/Podman is required for RDS DB instances but is not available",
+            format!(
+                "Docker/Podman is required for RDS DB instances but is not available. {}",
+                fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
+            ),
         ),
         RuntimeError::ContainerStartFailed(message) => AwsServiceError::aws_error(
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -2856,6 +2856,14 @@ async fn repro_issue_2107_corrupt_state_when_runtime_absent() {
         Err(e) => e,
     };
     assert_eq!(e1.code(), "InsufficientDBInstanceCapacity");
+    // The human-readable message must stay actionable: tell the operator how
+    // to enable the runtime rather than just that it is missing.
+    assert!(
+        e1.message().contains("Install and start Docker or Podman")
+            && e1.message().contains("FAKECLOUD_CONTAINER_CLI"),
+        "runtime-missing error must explain how to fix it: {}",
+        e1.message()
+    );
 
     // Second create must ALSO be InsufficientDBInstanceCapacity, NOT
     // DBInstanceAlreadyExists. A leaked reservation shows up here.

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -243,10 +243,15 @@ async fn main() {
     } else {
         fakecloud_lambda::runtime::ContainerRuntime::new(bound_addr.port()).map(Arc::new)
     };
+    // Services backed by a container runtime degrade honestly when no
+    // Docker/Podman CLI is present. Collect which ones so a single
+    // consolidated banner can warn the operator once (below, after the EC2
+    // runtime is resolved) instead of scattering five separate log lines.
+    let mut degraded_runtimes: Vec<&str> = Vec::new();
     if let Some(ref rt) = container_runtime {
         tracing::info!(backend = rt.cli_name(), "Lambda execution enabled");
     } else {
-        tracing::info!("Docker/Podman not available — Lambda Invoke will return errors for functions with code");
+        degraded_runtimes.push("Lambda (Invoke returns errors for functions with code)");
     }
     let lambda_backend_is_k8s = lambda_backend == fakecloud_k8s::Backend::K8s;
     let secretsmanager_state = Arc::new(parking_lot::RwLock::new(
@@ -558,7 +563,7 @@ async fn main() {
             "RDS execution enabled via container runtime"
         );
     } else {
-        tracing::info!("Docker/Podman not available — RDS CreateDBInstance will return errors");
+        degraded_runtimes.push("RDS (CreateDBInstance and snapshot/replica ops return errors)");
     }
     let elasticache_runtime = if fakecloud_k8s::backend_choice("FAKECLOUD_ELASTICACHE_BACKEND")
         == fakecloud_k8s::Backend::K8s
@@ -589,9 +594,7 @@ async fn main() {
             "ElastiCache execution enabled via container runtime"
         );
     } else {
-        tracing::info!(
-            "Docker/Podman not available — ElastiCache CreateReplicationGroup will return errors"
-        );
+        degraded_runtimes.push("ElastiCache (metadata-only clusters, no cache data plane)");
     }
     // ECS runtime is constructed below, after the EventBridge + CloudWatch
     // Logs wiring is in place. Placeholder kept here so downstream blocks
@@ -800,7 +803,7 @@ async fn main() {
             "ECS task execution enabled via container runtime"
         );
     } else {
-        tracing::info!("Docker/Podman not available — ECS RunTask will return TaskFailedToStart");
+        degraded_runtimes.push("ECS (RunTask fails with TaskFailedToStart)");
     }
     // EC2 instance backing runtime. FAKECLOUD_EC2_BACKEND=k8s (or the global
     // FAKECLOUD_CONTAINER_BACKEND=k8s) runs instances as native Kubernetes
@@ -830,8 +833,16 @@ async fn main() {
             "EC2 instance execution enabled via container runtime"
         );
     } else {
-        tracing::info!(
-            "Docker/Podman not available — EC2 RunInstances will serve metadata-only instances"
+        degraded_runtimes.push("EC2 (RunInstances serves metadata-only instances)");
+    }
+    // One consolidated banner instead of five scattered lines: if any
+    // container-backed service is degraded, warn once and tell the operator
+    // exactly how to enable them.
+    if !degraded_runtimes.is_empty() {
+        tracing::warn!(
+            "No container runtime (Docker/Podman) detected. The following services run in degraded or metadata-only mode and will fail or serve metadata only for operations that need a real container: {}. {}",
+            degraded_runtimes.join("; "),
+            fakecloud_core::container_net::CONTAINER_RUNTIME_HINT
         );
     }
     // Clone state refs for internal endpoints

--- a/website/content/docs/reference/limitations.md
+++ b/website/content/docs/reference/limitations.md
@@ -42,7 +42,9 @@ Lambda function execution, RDS DB instances, and ElastiCache clusters all use re
 
 **Security note:** granting access to the Docker socket gives the fakecloud process the ability to manage containers on the host. Only use this in development or CI environments you trust. Don't run fakecloud with Docker socket access on shared infrastructure.
 
-If you don't need Lambda/RDS/ElastiCache, fakecloud runs fine without Docker at all — just don't mount the socket and those services will return errors only when you try to use them.
+If you don't need the container-backed services (Lambda, RDS, ECS, ElastiCache, EC2), fakecloud runs fine without Docker at all. Just don't mount the socket. The control plane keeps working; only the operations that need a real container are affected, and only when you actually call them: Lambda `Invoke`, RDS `CreateDBInstance` (and snapshot/replica ops), and ECS `RunTask` return errors, while ElastiCache and EC2 degrade to metadata-only resources with no data plane.
+
+When no container runtime is detected, fakecloud logs a single consolidated startup warning listing which services are degraded, and the per-operation errors tell you exactly how to fix it: install and start Docker or Podman, or set `FAKECLOUD_CONTAINER_CLI` to your container CLI path.
 
 ## SigV4 signatures and IAM policies are off by default
 


### PR DESCRIPTION
## Summary

Follow-up to #2109 (the RDS #2107 fix), same "fail honestly and loudly" theme. Container-backed services already fail correctly when Docker/Podman is absent, but too quietly. This makes the **existing honest failures** louder and more actionable. No mocked/stub mode is added (real containers are the core value prop).

Two changes:

1. **Consolidated startup banner.** The five scattered `tracing::info!("Docker/Podman not available ...")` lines are replaced by a single `warn!` banner emitted once at startup, listing every service in degraded/metadata-only mode and how to enable them.

2. **Actionable per-call errors.** The runtime-required error messages now tell the user how to fix it: install/start Docker or Podman, or set `FAKECLOUD_CONTAINER_CLI`. Enriched sites:
   - RDS (5): `require_runtime`, the `RuntimeError::Unavailable` mapping, snapshots (2), read replicas.
   - Lambda (2): `Invoke` and the streaming path.
   - ECS (6): the `stopped_reason` set on tasks that stop with `TaskFailedToStart`.

   The fix hint lives in one shared const, `fakecloud_core::container_net::CONTAINER_RUNTIME_HINT`, so the remediation text stays consistent across services.

### Notes / decisions
- **Error codes unchanged** (`InsufficientDBInstanceCapacity`, `ServiceException`, `TaskFailedToStart`, `InvalidDBSnapshotState`, etc.) — only the human-readable message is enriched, so conformance is unaffected.
- **ElastiCache and EC2** degrade to metadata-only resources and have no "is required"/"not available" error path (checked, not assumed), so only their banner descriptors change.
- The existing Lambda `test_invoke_without_runtime_returns_error` actually errored on a missing deployment package, never reaching the runtime branch. It now supplies a real ZipFile so it exercises the intended path and asserts the enriched message.
- **No SDK changes**: no new/changed API surface, endpoint, or field — this is log/error message text only.
- No em-dashes / unicode arrows in any user-facing string (the change also removes the em-dashes from the old banner lines).

## Test plan
- `cargo build` + `cargo clippy --all-targets` clean on core/rds/lambda/ecs/server.
- Targeted unit tests updated to assert the message stays actionable and pass:
  - `fakecloud-rds`: `repro_issue_2107_corrupt_state_when_runtime_absent`
  - `fakecloud-lambda`: `test_invoke_without_runtime_returns_error`
  - `fakecloud-ecs`: `service_converges_to_desired_count_and_is_idempotent`
- Full `--lib` suites green: core 230, ecs 227, lambda 207, rds 108.
- Docs: `website/content/docs/reference/limitations.md` no-Docker section updated to describe the banner and fix steps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make missing-container-runtime behavior loud and actionable. Adds a single startup warning and per-operation error messages that tell users how to fix missing Docker/Podman, without changing error codes or APIs.

- New Features
  - One startup warn banner lists all degraded services and how to enable them when no Docker/Podman is found.
  - Enriched errors for Lambda Invoke/streaming, RDS instances/replicas/snapshots, and ECS task `stopped_reason` include fix steps, shared via `fakecloud_core::container_net::CONTAINER_RUNTIME_HINT`.
  - Error codes stay the same; ElastiCache and EC2 still run in metadata-only mode, with updated banner text.
  - Tests updated to assert actionable messages; docs updated to describe the banner and remediation.

<sup>Written for commit da24aa89950a1813b72a93cb9cd47f87d58f1670. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

