### PR TITLE
fix(opensearch): stop double-storing create-time domain tags

### DIFF
--- a/crates/fakecloud-opensearch/src/service.rs
+++ b/crates/fakecloud-opensearch/src/service.rs
@@ -1186,16 +1186,18 @@ impl OpenSearchService {
             created: false,
             deleted: false,
             config: cfg,
-            tags: tags.clone(),
+            tags,
             created_at: Utc::now(),
             data_sources: Default::default(),
             indices: Default::default(),
             scheduled_actions: Default::default(),
             maintenances: Default::default(),
         };
-        if !tags.is_empty() {
-            st.tags.insert(arn, tags);
-        }
+        // A domain's tags live on the domain itself (`d.tags`); `AddTags` /
+        // `RemoveTags` / `ListTags` all operate there via `apply_tag_target`.
+        // Do NOT also copy them into the side `st.tags` map: that map takes
+        // precedence in `ListTags`, so a duplicate there would shadow later
+        // `AddTags` updates and resurrect `RemoveTags`-deleted tags.
         let out = domain_status(&d, api, /*created=*/ false, /*processing=*/ true);
         st.domains.insert(name, d);
         Ok(ok(json!({ status_key(api): out })))

--- a/crates/fakecloud-opensearch/tests/service_tests.rs
+++ b/crates/fakecloud-opensearch/tests/service_tests.rs
@@ -548,6 +548,81 @@ async fn add_and_remove_tags_roundtrip() {
     assert!(after["TagList"].as_array().unwrap().is_empty());
 }
 
+#[tokio::test]
+async fn create_time_tag_can_be_removed_and_overridden() {
+    // Regression: tags supplied at CreateDomain must not be double-stored in
+    // the side tag map, or a later RemoveTags would leave a stale copy that
+    // ListTags resurrects, and an AddTags value update would be shadowed.
+    let svc = service();
+    let created = json_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("{OS}/opensearch/domain"),
+                json!({"DomainName": "tagfix", "TagList": [{"Key": "env", "Value": "prod"}]}),
+            ),
+        )
+        .await,
+    );
+    let arn = created["DomainStatus"]["ARN"].as_str().unwrap().to_string();
+
+    // Overriding the create-time value via the 2015 ES AddTags must win.
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{ES}/tags"),
+            json!({"ARN": arn, "TagList": [{"Key": "env", "Value": "dev"}]}),
+        ),
+    )
+    .await;
+    let listed = json_of(
+        &call(
+            &svc,
+            with_query(
+                req(Method::GET, &format!("{OS}/tags"), json!({})),
+                "arn",
+                &arn,
+            ),
+        )
+        .await,
+    );
+    let tags = listed["TagList"].as_array().unwrap();
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0]["Key"], "env");
+    assert_eq!(
+        tags[0]["Value"], "dev",
+        "AddTags update must not be shadowed"
+    );
+
+    // Removing the create-time tag must actually delete it (not resurrect).
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/tags-removal"),
+            json!({"ARN": arn, "TagKeys": ["env"]}),
+        ),
+    )
+    .await;
+    let after = json_of(
+        &call(
+            &svc,
+            with_query(
+                req(Method::GET, &format!("{ES}/tags"), json!({})),
+                "arn",
+                &arn,
+            ),
+        )
+        .await,
+    );
+    assert!(
+        after["TagList"].as_array().unwrap().is_empty(),
+        "removed create-time tag must not reappear"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Packages
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A domain's tags are stored on the domain itself (`Domain.tags`) and, redundantly, in the account-level side tag map (`OpenSearchState.tags`) at create time. `ListTags` merges the side map **after** the domain's own tags, so the side-map copy wins on any key collision.

That double-storage causes two write-read asymmetries once a domain is created **with** a `TagList`:

- **AddTags update shadowed**: updating a create-time tag's value writes to `d.tags` (via `apply_tag_target`), but `ListTags` re-overlays the stale create-time value from the side map, so the old value is returned.
- **RemoveTags resurrected**: removing a create-time tag deletes it from `d.tags` only; the side-map copy survives and `ListTags` brings it back.

Both APIs share the same ARN/tag space, so this hits ES (2015) and OpenSearch (2021) callers identically. Fix: keep create-time tags only on the domain and drop the duplicate side-map insert. `apply_tag_target`/`ListTags` already treat domain ARNs by reading/writing `d.tags`, so no functionality is lost.

## Test plan
- New `create_time_tag_can_be_removed_and_overridden` regression test: creates a domain with a tag, overrides its value via the 2015 `AddTags`, asserts `ListTags` (2021) returns the new value, then `RemoveTags` and asserts the tag does not reappear.
- `cargo test -p fakecloud-opensearch` (28 passed)
- `cargo clippy -p fakecloud-opensearch --all-targets -- -D warnings` clean
- `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop double-storing create-time domain tags in `fakecloud-opensearch` to prevent stale values and tag “resurrection.” This ensures AddTags updates win and RemoveTags deletions stay deleted across ES (2015) and OpenSearch (2021) APIs.

- **Bug Fixes**
  - Store create-time tags only on the domain (`d.tags`); stop writing to `OpenSearchState.tags`.
  - `ListTags` no longer returns stale side-map values, so updates and deletions behave correctly.
  - Added a regression test to verify override and removal across `AddTags`, `RemoveTags`, and `ListTags`.

<sup>Written for commit cbc3c05c271f937253156c1b17485d47cb3abae7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

