### PR TITLE
fix(opensearch): persist VPC endpoint access grants + correct AuthorizedPrincipal shape

### DIFF
--- a/crates/fakecloud-opensearch/src/service.rs
+++ b/crates/fakecloud-opensearch/src/service.rs
@@ -1800,18 +1800,20 @@ impl OpenSearchService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let dom = label(l.domain.as_deref())?;
         let b = body(req);
-        let account = b.get("Account").and_then(|v| v.as_str()).unwrap_or("");
         let service = b.get("Service").and_then(|v| v.as_str());
+        let account = b.get("Account").and_then(|v| v.as_str());
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
         if !st.domains.contains_key(&dom) {
             return Err(not_found_domain(&dom));
         }
-        let principal = if let Some(s) = service {
-            json!({"AWSService": s})
-        } else {
-            json!({"AWSAccount": account})
-        };
+        // `AuthorizedPrincipal` is `{ PrincipalType, Principal }` in both
+        // models (an AWS_SERVICE SP, or an AWS_ACCOUNT id).
+        let (key, principal) = authorized_principal(service, account);
+        st.vpc_endpoint_access
+            .entry(dom)
+            .or_default()
+            .insert(key, principal.clone());
         Ok(ok(json!({ "AuthorizedPrincipal": principal })))
     }
 
@@ -1821,10 +1823,17 @@ impl OpenSearchService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let dom = label(l.domain.as_deref())?;
+        let b = body(req);
+        let service = b.get("Service").and_then(|v| v.as_str());
+        let account = b.get("Account").and_then(|v| v.as_str());
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
         if !st.domains.contains_key(&dom) {
             return Err(not_found_domain(&dom));
+        }
+        let (key, _) = authorized_principal(service, account);
+        if let Some(principals) = st.vpc_endpoint_access.get_mut(&dom) {
+            principals.remove(&key);
         }
         Ok(ok(json!({})))
     }
@@ -1836,13 +1845,17 @@ impl OpenSearchService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let dom = label(l.domain.as_deref())?;
         let accounts = self.state.read();
+        let mut list = Vec::new();
         if let Some(st) = accounts.get(&req.account_id) {
             if !st.domains.contains_key(&dom) {
                 return Err(not_found_domain(&dom));
             }
+            if let Some(principals) = st.vpc_endpoint_access.get(&dom) {
+                list.extend(principals.values().cloned());
+            }
         }
         Ok(ok(
-            json!({ "AuthorizedPrincipalList": [], "NextToken": "" }),
+            json!({ "AuthorizedPrincipalList": list, "NextToken": "" }),
         ))
     }
 
@@ -3104,6 +3117,24 @@ fn label(v: Option<&str>) -> Result<String, AwsServiceError> {
     match v {
         Some(s) if !s.is_empty() => Ok(s.to_string()),
         _ => Err(validation("A required path parameter is missing.")),
+    }
+}
+
+/// Build an `AuthorizedPrincipal` (`{ PrincipalType, Principal }`) for a
+/// VPC-endpoint-access grant, plus the map key it is stored under. A `Service`
+/// SP takes precedence over an `Account` id, matching real AWS.
+fn authorized_principal(service: Option<&str>, account: Option<&str>) -> (String, Value) {
+    if let Some(s) = service {
+        (
+            format!("service:{s}"),
+            json!({"PrincipalType": "AWS_SERVICE", "Principal": s}),
+        )
+    } else {
+        let a = account.unwrap_or("");
+        (
+            format!("account:{a}"),
+            json!({"PrincipalType": "AWS_ACCOUNT", "Principal": a}),
+        )
     }
 }
 

--- a/crates/fakecloud-opensearch/src/state.rs
+++ b/crates/fakecloud-opensearch/src/state.rs
@@ -165,6 +165,10 @@ pub struct OpenSearchState {
     /// Purchased reserved instances keyed by reservation id.
     #[serde(default)]
     pub reserved_instances: BTreeMap<String, Value>,
+    /// VPC-endpoint-access principals authorized per domain: domain name ->
+    /// principal key (account id or service SP) -> `AuthorizedPrincipal` JSON.
+    #[serde(default)]
+    pub vpc_endpoint_access: BTreeMap<String, BTreeMap<String, Value>>,
 }
 
 impl AccountState for OpenSearchState {

--- a/crates/fakecloud-opensearch/tests/service_tests.rs
+++ b/crates/fakecloud-opensearch/tests/service_tests.rs
@@ -667,6 +667,84 @@ async fn vpc_endpoint_create_and_list() {
 }
 
 #[tokio::test]
+async fn vpc_endpoint_access_authorize_list_revoke_roundtrip() {
+    // Regression: AuthorizeVpcEndpointAccess must persist the principal (in the
+    // model's { PrincipalType, Principal } shape), ListVpcEndpointAccess must
+    // return it, and RevokeVpcEndpointAccess must remove it -- across the
+    // shared store, so a grant made via the 2021 API is visible via 2015.
+    let svc = service();
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/domain"),
+            json!({"DomainName": "vpcacc"}),
+        ),
+    )
+    .await;
+
+    let authed = json_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("{OS}/opensearch/domain/vpcacc/authorizeVpcEndpointAccess"),
+                json!({"Account": "111122223333"}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(
+        authed["AuthorizedPrincipal"]["PrincipalType"], "AWS_ACCOUNT",
+        "AuthorizedPrincipal must use the model shape"
+    );
+    assert_eq!(authed["AuthorizedPrincipal"]["Principal"], "111122223333");
+
+    // Listed via the legacy 2015 API (shared store).
+    let listed = json_of(
+        &call(
+            &svc,
+            req(
+                Method::GET,
+                &format!("{ES}/es/domain/vpcacc/listVpcEndpointAccess"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    let principals = listed["AuthorizedPrincipalList"].as_array().unwrap();
+    assert_eq!(principals.len(), 1, "authorized principal must persist");
+    assert_eq!(principals[0]["Principal"], "111122223333");
+    assert!(listed.get("NextToken").is_some());
+
+    // Revoke, then the list is empty again.
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/domain/vpcacc/revokeVpcEndpointAccess"),
+            json!({"Account": "111122223333"}),
+        ),
+    )
+    .await;
+    let after = json_of(
+        &call(
+            &svc,
+            req(
+                Method::GET,
+                &format!("{OS}/opensearch/domain/vpcacc/listVpcEndpointAccess"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert!(after["AuthorizedPrincipalList"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
 async fn outbound_connection_create_and_delete() {
     let svc = service();
     let created = json_of(


### PR DESCRIPTION
## Summary

`AuthorizeVpcEndpointAccess` accepted the `Account`/`Service` principal, then dropped it and returned a non-model `AuthorizedPrincipal` (`{"AWSAccount": ...}` / `{"AWSService": ...}`). Both Smithy models declare `AuthorizedPrincipal` as `{ PrincipalType, Principal }` (`PrincipalType` ∈ `AWS_ACCOUNT`/`AWS_SERVICE`).

Worse, the grant was never observable:
- `ListVpcEndpointAccess` always returned an empty `AuthorizedPrincipalList`.
- `RevokeVpcEndpointAccess` was a no-op.

So authorize -> list returned nothing, a write-read asymmetry / stub. This fixes all three:
- New per-domain `vpc_endpoint_access` store in the shared state (`#[serde(default)]`, schema unchanged, backward compatible).
- `Authorize` persists the principal and returns the model-correct shape.
- `List` returns the persisted principals (still with the required `NextToken`).
- `Revoke` removes the matching principal.

Grants round-trip across both APIs since the store is shared (grant via 2021 -> visible via 2015).

## Test plan
- New `vpc_endpoint_access_authorize_list_revoke_roundtrip` test: authorize (2021) asserts `PrincipalType`/`Principal`, list (2015) returns it, revoke (2021) empties the list.
- `cargo test -p fakecloud-opensearch` (28 passed)
- `cargo test -p fakecloud-conformance --test es --test opensearch` (es_probe + opensearch_probe green)
- `cargo clippy -p fakecloud-opensearch --all-targets -- -D warnings` clean
- `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix VPC endpoint access grants in OpenSearch. List and revoke now work, and grants use the correct `{ PrincipalType, Principal }` shape.

- **Bug Fixes**
  - Persist grants per domain in shared state (`vpc_endpoint_access`), keeping the state schema backward compatible.
  - Ensure listed principals come from the saved store and still include `NextToken`.
  - Share the store between the 2021 and 2015 APIs so grants round‑trip across both.

<sup>Written for commit bdf90f1e91f410113d509e1fdbae13f18930ca04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

