### PR TITLE
fix(opensearch): persist UpgradeDomain version + consistent cross-cluster connection status

### DIFF
--- a/crates/fakecloud-opensearch/src/service.rs
+++ b/crates/fakecloud-opensearch/src/service.rs
@@ -396,6 +396,8 @@ fn is_mutating(action: &str) -> bool {
             | "PurchaseReservedElasticsearchInstanceOffering"
             | "StartDomainMaintenance"
             | "PutDefaultApplicationSetting"
+            | "UpgradeDomain"
+            | "UpgradeElasticsearchDomain"
     )
 }
 
@@ -1076,7 +1078,7 @@ impl OpenSearchService {
                 Ok(ok(compatible_versions(api)))
             }
             // ---- Upgrade ----
-            "UpgradeDomain" | "UpgradeElasticsearchDomain" => self.upgrade_domain(l, req),
+            "UpgradeDomain" | "UpgradeElasticsearchDomain" => self.upgrade_domain(api, req),
             "GetUpgradeHistory" => Ok(ok(json!({"UpgradeHistories": []}))),
             "GetUpgradeStatus" => Ok(ok(json!({
                 "UpgradeStep": "PRE_UPGRADE_CHECK",
@@ -1164,11 +1166,7 @@ impl OpenSearchService {
             .or_else(|| b.get("ElasticsearchVersion"))
             .and_then(|v| v.as_str())
         {
-            Some(v) if v.contains('_') => v.to_string(),
-            Some(v) => match api {
-                Api::Es => format!("Elasticsearch_{v}"),
-                Api::OpenSearch => format!("OpenSearch_{v}"),
-            },
+            Some(v) => canonical_engine_version(api, v),
             None => match api {
                 Api::Es => "Elasticsearch_7.10".to_string(),
                 Api::OpenSearch => "OpenSearch_2.11".to_string(),
@@ -1885,13 +1883,12 @@ impl OpenSearchService {
                 .unwrap_or("DIRECT")
                 .to_string(),
             properties: b.get("ConnectionProperties").cloned().unwrap_or(json!({})),
-            inbound: false,
         };
-        // The same connection is also visible inbound to the remote domain.
-        let mut inbound = conn.clone();
-        inbound.inbound = true;
+        // A cross-cluster connection is ONE entity with one status, viewed as
+        // "outbound" by the requester and "inbound" by the accepter. Store it
+        // once (keyed by id) so every transition is single-sourced and the two
+        // describe views always agree.
         st.connections.insert(id.clone(), conn.clone());
-        st.connections.insert(format!("{id}-in"), inbound);
         Ok(ok(connection_create_json(api, &conn)))
     }
 
@@ -1905,15 +1902,9 @@ impl OpenSearchService {
         let id = label(l.connection_id.as_deref())?;
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
-        let key = format!("{id}-in");
-        let real_key = if st.connections.contains_key(&key) {
-            key
-        } else {
-            id.clone()
-        };
         let conn = st
             .connections
-            .get_mut(&real_key)
+            .get_mut(&id)
             .ok_or_else(|| not_found_generic(&format!("Connection {id} not found.")))?;
         conn.status_code = new_status.to_string();
         Ok(ok(
@@ -1931,20 +1922,11 @@ impl OpenSearchService {
         let id = label(l.connection_id.as_deref())?;
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
-        let key = if inbound {
-            format!("{id}-in")
-        } else {
-            id.clone()
-        };
-        let mut conn = match st.connections.remove(&key) {
-            Some(c) => c,
-            None => st
-                .connections
-                .remove(&id)
-                .ok_or_else(|| not_found_generic(&format!("Connection {id} not found.")))?,
-        };
+        let mut conn = st
+            .connections
+            .remove(&id)
+            .ok_or_else(|| not_found_generic(&format!("Connection {id} not found.")))?;
         conn.status_code = "DELETING".to_string();
-        conn.inbound = inbound;
         if inbound {
             Ok(ok(
                 json!({ "CrossClusterSearchConnection": inbound_connection_json(api, &conn) }),
@@ -1965,8 +1947,10 @@ impl OpenSearchService {
         let accounts = self.state.read();
         let mut list = Vec::new();
         if let Some(st) = accounts.get(&req.account_id) {
+            // The single stored record is both an inbound and an outbound
+            // connection; render it into whichever view the caller asked for.
             for conn in st.connections.values() {
-                if conn.inbound == inbound && connection_well_formed(conn) {
+                if connection_well_formed(conn) {
                     list.push(if inbound {
                         inbound_connection_json(api, conn)
                     } else {
@@ -2629,16 +2613,43 @@ impl OpenSearchService {
     // Upgrade / software update / maintenance
     // ===================================================================
 
-    fn upgrade_domain(&self, l: &Labels, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let _ = l;
+    fn upgrade_domain(&self, api: Api, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let b = body(req);
         let dom = req_str(&b, "DomainName")?;
-        self.require_domain(&dom, &req.account_id)?;
+        let target = b
+            .get("TargetVersion")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        // A check-only upgrade is a dry run: report what would happen but do
+        // not change the domain's engine version.
+        let check_only = b
+            .get("PerformCheckOnly")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let d = st
+            .domains
+            .get_mut(&dom)
+            .ok_or_else(|| not_found_domain(&dom))?;
+        // Upgrade is the only path that changes a domain's engine version
+        // (UpdateDomainConfig has no version member), so persist the requested
+        // target in canonical prefixed form. Both APIs then reflect it: the
+        // 2021 view via `EngineVersion`, the 2015 view via `ElasticsearchVersion`
+        // (prefix stripped).
+        if !check_only {
+            if let Some(t) = target.as_deref() {
+                d.engine_version = canonical_engine_version(api, t);
+            }
+        }
+        let response_target = target
+            .map(Value::from)
+            .unwrap_or_else(|| json!("OpenSearch_2.11"));
         Ok(ok(json!({
             "UpgradeId": short_id(),
             "DomainName": dom,
-            "TargetVersion": b.get("TargetVersion").cloned().unwrap_or(json!("OpenSearch_2.11")),
-            "PerformCheckOnly": b.get("PerformCheckOnly").cloned().unwrap_or(json!(false)),
+            "TargetVersion": response_target,
+            "PerformCheckOnly": check_only,
             "AdvancedOptions": b.get("AdvancedOptions").cloned().unwrap_or(json!({})),
         })))
     }
@@ -2847,6 +2858,21 @@ fn default_cluster_config() -> Value {
         "ZoneAwarenessEnabled": false,
         "WarmEnabled": false,
     })
+}
+
+/// Canonicalize an engine version to the prefixed form (`OpenSearch_x.y` /
+/// `Elasticsearch_x.y`) the shared store keeps. An already-prefixed value
+/// (any string carrying `_`, e.g. `OpenSearch_2.11`) is kept verbatim; a bare
+/// number (the 2015 API's `7.10`) is prefixed per the requesting API.
+fn canonical_engine_version(api: Api, v: &str) -> String {
+    if v.contains('_') {
+        v.to_string()
+    } else {
+        match api {
+            Api::Es => format!("Elasticsearch_{v}"),
+            Api::OpenSearch => format!("OpenSearch_{v}"),
+        }
+    }
 }
 
 /// Strip the engine prefix (`OpenSearch_2.11` / `Elasticsearch_7.10`) to the

--- a/crates/fakecloud-opensearch/src/state.rs
+++ b/crates/fakecloud-opensearch/src/state.rs
@@ -111,8 +111,6 @@ pub struct Connection {
     pub alias: String,
     pub mode: String,
     pub properties: Value,
-    #[serde(default)]
-    pub inbound: bool,
 }
 
 /// An OpenSearch application (2021 API only).

--- a/crates/fakecloud-opensearch/tests/service_tests.rs
+++ b/crates/fakecloud-opensearch/tests/service_tests.rs
@@ -706,6 +706,158 @@ async fn outbound_connection_create_and_delete() {
     );
 }
 
+#[tokio::test]
+async fn accept_connection_makes_both_views_active() {
+    // Regression: a cross-cluster connection is single-sourced, so accepting it
+    // moves BOTH the inbound (accepter) and outbound (requester) describe views
+    // to ACTIVE -- they must never disagree.
+    let svc = service();
+    let created = json_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("{OS}/opensearch/cc/outboundConnection"),
+                json!({
+                    "LocalDomainInfo": {"AWSDomainInformation": {"DomainName": "local"}},
+                    "RemoteDomainInfo": {"AWSDomainInformation": {"DomainName": "remote"}},
+                    "ConnectionAlias": "link"
+                }),
+            ),
+        )
+        .await,
+    );
+    let cid = created["ConnectionId"].as_str().unwrap().to_string();
+
+    call(
+        &svc,
+        req(
+            Method::PUT,
+            &format!("{OS}/opensearch/cc/inboundConnection/{cid}/accept"),
+            json!({}),
+        ),
+    )
+    .await;
+
+    let inbound = json_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("{OS}/opensearch/cc/inboundConnection/search"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    let in_list = inbound["Connections"].as_array().unwrap();
+    assert_eq!(in_list.len(), 1);
+    assert_eq!(in_list[0]["ConnectionStatus"]["StatusCode"], "ACTIVE");
+
+    let outbound = json_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("{OS}/opensearch/cc/outboundConnection/search"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    let out_list = outbound["Connections"].as_array().unwrap();
+    assert_eq!(out_list.len(), 1);
+    assert_eq!(
+        out_list[0]["ConnectionStatus"]["StatusCode"], "ACTIVE",
+        "outbound view must agree with inbound after accept"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Upgrade (engine version persistence)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn upgrade_domain_persists_target_version_across_both_apis() {
+    // Regression: UpgradeDomain is the only path that changes a domain's engine
+    // version, so the target must persist and be visible via both API shapes.
+    let svc = service();
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/domain"),
+            json!({"DomainName": "upgd", "EngineVersion": "OpenSearch_2.9"}),
+        ),
+    )
+    .await;
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/upgradeDomain"),
+            json!({"DomainName": "upgd", "TargetVersion": "OpenSearch_2.11"}),
+        ),
+    )
+    .await;
+    let os = json_of(
+        &call(
+            &svc,
+            req(
+                Method::GET,
+                &format!("{OS}/opensearch/domain/upgd"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(os["DomainStatus"]["EngineVersion"], "OpenSearch_2.11");
+    // Same entity via the legacy 2015 API: prefix stripped.
+    let es = json_of(
+        &call(
+            &svc,
+            req(Method::GET, &format!("{ES}/es/domain/upgd"), json!({})),
+        )
+        .await,
+    );
+    assert_eq!(es["DomainStatus"]["ElasticsearchVersion"], "2.11");
+}
+
+#[tokio::test]
+async fn upgrade_domain_check_only_does_not_persist() {
+    let svc = service();
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/domain"),
+            json!({"DomainName": "upgdry", "EngineVersion": "OpenSearch_2.9"}),
+        ),
+    )
+    .await;
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/upgradeDomain"),
+            json!({"DomainName": "upgdry", "TargetVersion": "OpenSearch_2.11", "PerformCheckOnly": true}),
+        ),
+    )
+    .await;
+    let described = json_of(
+        &call(
+            &svc,
+            req(
+                Method::GET,
+                &format!("{OS}/opensearch/domain/upgdry"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(described["DomainStatus"]["EngineVersion"], "OpenSearch_2.9");
+}
+
 // ---------------------------------------------------------------------------
 // Applications + reserved instances + versions
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two write-read stubs in the shared OpenSearch/Elasticsearch control plane.

### 1. UpgradeDomain / UpgradeElasticsearchDomain didn't persist the target version
The handler echoed the requested `TargetVersion` but never wrote it to the domain. Because `UpdateDomainConfig`/`UpdateElasticsearchDomainConfig` have **no** version member (confirmed against both models), upgrade is the *only* path that changes a domain's engine version — so `DescribeDomain` always returned the original version, which would show up as a perpetual diff on terraform's `aws_opensearch_domain.engine_version`.

Now the requested target is persisted onto the shared domain in canonical prefixed form (`OpenSearch_x.y` / `Elasticsearch_x.y`), so both API views reflect it: the 2021 `DescribeDomain` via `EngineVersion`, the 2015 `DescribeElasticsearchDomain` via `ElasticsearchVersion` (prefix stripped). `PerformCheckOnly=true` is honored as a dry run and leaves the version unchanged. The create-time canonicalization is factored into a shared `canonical_engine_version` helper. `UpgradeDomain`/`UpgradeElasticsearchDomain` are added to `is_mutating` so the change is snapshotted.

### 2. Accepting a cross-cluster connection didn't flip the outbound view
A connection was stored as two independent copies (`id` and `id-in`). `AcceptInboundConnection`/`Reject` mutated only the inbound copy, so `DescribeOutboundConnections` still reported `PENDING_ACCEPTANCE` after the requester's view should have been `ACTIVE`. The connection is now a single-sourced record (one entity, one status) rendered into whichever view — inbound or outbound — the caller requests, so both describes always agree after accept/reject/delete. The now-obsolete `Connection.inbound` field is removed (unknown fields are ignored on load, so old snapshots still deserialize).

## Test plan
- `accept_connection_makes_both_views_active`: request -> accept -> both inbound and outbound describe show `ACTIVE`.
- `upgrade_domain_persists_target_version_across_both_apis`: upgrade (2021) -> `DescribeDomain` shows `OpenSearch_2.11` and `DescribeElasticsearchDomain` shows `2.11`.
- `upgrade_domain_check_only_does_not_persist`: `PerformCheckOnly=true` leaves the version unchanged.
- `cargo test -p fakecloud-opensearch` (30 passed)
- `cargo test -p fakecloud-conformance --test es --test opensearch` (es_probe + opensearch_probe green)
- `cargo clippy -p fakecloud-opensearch --all-targets -- -D warnings` clean
- `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted engine version updates on domain upgrades and made cross-cluster connection status consistent across inbound/outbound views. Fixes Terraform diffs on `engine_version` and removes mismatched connection states.

- **Bug Fixes**
  - `UpgradeDomain`/`UpgradeElasticsearchDomain` now persist `TargetVersion` in canonical form (`OpenSearch_x.y`/`Elasticsearch_x.y`), honor `PerformCheckOnly`, and update both API shapes (`EngineVersion` and `ElasticsearchVersion`). Added a shared canonicalization helper and marked both actions as mutating.
  - Cross-cluster connections are now single-sourced (one record per connection). Accept/reject/delete updates both inbound and outbound views consistently. Removed the obsolete `Connection.inbound` field (old snapshots still load).

<sup>Written for commit 46c521780ac1d60086ea1a1db77bb5cd3758e6ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

