### PR TITLE
chore(release): bump workspace to v0.34.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,10 @@ jobs:
           publish fakecloud-identitystore    # only core/persistence/aws deps
           publish fakecloud-ssoadmin         # only core/persistence/aws deps
           publish fakecloud-verifiedpermissions # core/persistence/aws + cedar-policy
+          publish fakecloud-redshift         # only core/persistence/aws deps
+          publish fakecloud-dms              # only core/persistence/aws deps
+          publish fakecloud-opensearch       # only core/persistence/aws deps (ES + OpenSearch)
+          publish fakecloud-backup           # only core/persistence/aws deps
           publish fakecloud-kinesis
           publish fakecloud-scheduler
           publish fakecloud-bedrock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4031,7 +4031,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4384,7 +4384,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4656,7 +4656,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4691,7 +4691,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4735,7 +4735,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4756,7 +4756,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4776,7 +4776,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4796,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4876,7 +4876,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4910,7 +4910,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5026,7 +5026,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5049,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -115,115 +115,115 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
@@ -233,131 +233,131 @@ path = "crates/fakecloud-backup"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.33.0"
+version = "0.34.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.33.0")
+    testImplementation("dev.fakecloud:fakecloud:0.34.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.33.0</version>
+    <version>0.34.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.33.0"
+version = "0.34.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.33.0"
+version = "0.34.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release v0.34.0. Bumps `[workspace.package]` + all `fakecloud-*` dep pins, Cargo.lock, and the TS/Python/Java SDK versions from 0.33.0 -> 0.34.0.

Adds the four new service crates to the `release.yml` crate publish list (topo-ordered in the core/persistence/aws tier):
- `fakecloud-redshift`, `fakecloud-dms`, `fakecloud-opensearch`, `fakecloud-backup`.

### Since v0.33.0 (parity 51 -> 56 / 100)
- **Amazon Redshift** control plane (141 ops, awsQuery) — #2108
- **AWS Database Migration Service** control plane (119 ops, awsJson1.1) — #2113
- **Amazon Elasticsearch Service + Amazon OpenSearch Service** (one crate, 51 + 93 ops, restJson1, shared `es` scope) — #2117
- **AWS Backup** control plane (109 ops, restJson1) — #2123
- Bug-hunt hardening across all new services: redshift #2110/#2112, dms #2114/#2115/#2116, opensearch #2119/#2120/#2121/#2122
- RDS corrupted-state fix (#2107) — #2109
- Conformance audit fix for the dual-API opensearch crate

All new services at 100% conformance; full non-code surface (docs, website, parity, ops-index, tfacc) synced per service.

## Test plan
- CI green (workspace build/test, conformance, e2e, doc-counts, clippy, fmt).
- Tag `v0.34.0` on the merge commit triggers the publish workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.34.0. Adds Redshift, DMS, OpenSearch/Elasticsearch, and Backup services, raising parity from 51 to 56.

- **New Features**
  - Add `fakecloud-redshift`, `fakecloud-dms`, `fakecloud-opensearch` (ES + OpenSearch), and `fakecloud-backup`.
  - New services are at 100% conformance.

- **Dependencies**
  - Bump `[workspace.package]` and all `fakecloud-*` crates to `0.34.0`; update `Cargo.lock`.
  - Update SDK versions to `0.34.0` in `sdks/typescript`, `sdks/python`, and `sdks/java`.
  - Add the four new crates to the publish list in `.github/workflows/release.yml`.

<sup>Written for commit 3a745fcd1ffa559ce5a7d113fbd3737a70dde307. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

