### PR TITLE
fix(tfacc): serialize provider clone to end setup race

### DIFF
--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -14,6 +14,7 @@
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use std::sync::Mutex;
 
 pub mod allowlist;
 
@@ -61,9 +62,22 @@ pub fn require_toolchain() {
 /// On Go ≥ 1.24 the upstream `go.mod` needs its `godebug tlskyber=0`
 /// directive stripped (the pragma was removed in 1.24). We apply the strip
 /// unconditionally — it's harmless on 1.23.
+/// Serializes the check-clone-strip below across the concurrent
+/// `#[tokio::test]` functions that share one test-binary process. Without it
+/// two tests in the same shard (e.g. `autoscaling` + `appautoscaling`) race:
+/// the first creates `target` and starts the clone, the second sees the dir
+/// already exists, skips the clone, and then reads a not-yet-cloned `go.mod`
+/// -> `NotFound` panic. A completion sentinel (`go.mod` present) plus a
+/// clone-to-temp + atomic rename make it robust even across processes that
+/// share the same `target/` dir on one runner.
+static SETUP_LOCK: Mutex<()> = Mutex::new(());
+
 pub fn setup_provider_source() -> std::io::Result<PathBuf> {
     let target = provider_dir();
-    if !target.exists() {
+    let _guard = SETUP_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // `go.mod` only exists once a clone finished, so it is the completion
+    // sentinel — a bare `target.exists()` can be true mid-clone.
+    if !target.join("go.mod").exists() {
         let parent = target.parent().ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -71,6 +85,17 @@ pub fn setup_provider_source() -> std::io::Result<PathBuf> {
             )
         })?;
         std::fs::create_dir_all(parent)?;
+        // Drop any partial clone from a previously-crashed run.
+        if target.exists() {
+            std::fs::remove_dir_all(&target)?;
+        }
+        // Clone into a temp sibling then atomically rename, so `target` never
+        // exists in a half-populated state that a concurrent process could
+        // mistake for a finished clone.
+        let tmp = target.with_extension(format!("tmp.{}", std::process::id()));
+        if tmp.exists() {
+            std::fs::remove_dir_all(&tmp)?;
+        }
         let status = Command::new("git")
             .args([
                 "clone",
@@ -79,13 +104,22 @@ pub fn setup_provider_source() -> std::io::Result<PathBuf> {
                 "--branch",
                 PROVIDER_TAG,
                 PROVIDER_REPO,
-                &target.display().to_string(),
+                &tmp.display().to_string(),
             ])
             .status()?;
         if !status.success() {
+            let _ = std::fs::remove_dir_all(&tmp);
             return Err(std::io::Error::other(format!(
                 "failed to clone {PROVIDER_REPO}@{PROVIDER_TAG}"
             )));
+        }
+        // Another process may have won the race while we cloned; only rename
+        // if the destination is still absent, otherwise discard our copy.
+        if target.join("go.mod").exists() {
+            let _ = std::fs::remove_dir_all(&tmp);
+        } else {
+            let _ = std::fs::remove_dir_all(&target);
+            std::fs::rename(&tmp, &target)?;
         }
     }
     strip_godebug(&target.join("go.mod"))?;


### PR DESCRIPTION
## Summary

Fixes a pre-existing flake in the tfacc harness that surfaced as a recurring `setup terraform-provider-aws: No such file or directory` panic at `acc.rs:21` on shards with two acceptance tests (e.g. `autoscaling` + `appautoscaling`).

Root cause: `setup_provider_source()` did check-then-act — `if !target.exists() { clone }`. The two `#[tokio::test]` functions in one shard binary run concurrently in the same process. Test A creates `target` and starts the git clone; test B sees the dir already exists, skips the clone, then reads a not-yet-cloned `go.mod` and panics with `NotFound`. Whichever test lost the race failed — which is why two reruns failed on different tests (`autoscaling` then `appautoscaling`).

Fix:
- Process-global `Mutex` serializes the check-clone-strip section.
- Completion sentinel is `go.mod` presence, not bare directory existence (a dir can exist mid-clone).
- Clone into a temp sibling then atomically `rename` into place, so `target/` is never observed half-populated; clean up any partial dir from a previously-crashed run.

## Test plan
- `cargo clippy -p fakecloud-tfacc --all-targets -- -D warnings` clean.
- The autoscaling tfacc shard (the one that was flaking) exercises this exact two-concurrent-test path; CI's tfacc autoscaling job is the regression gate.

No non-code surface affected (internal test harness only).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `fakecloud-tfacc` provider setup that caused flaky "setup terraform-provider-aws: No such file or directory" panics when two tests ran concurrently. Internal harness only.

- **Bug Fixes**
  - Serialized check/clone/strip with a process‑global `Mutex`.
  - Use `go.mod` presence as the completion sentinel instead of directory existence.
  - Clone to a temp sibling and atomically rename; remove any partial dirs from crashed runs.

<sup>Written for commit 7c6b94bc7652a24f3b63c0de2ce4be596c3b0d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

