### PR TITLE
fix(glacier): 6 behavioral bugs from post-merge bug-hunt

### DIFF
--- a/crates/fakecloud-glacier/src/service.rs
+++ b/crates/fakecloud-glacier/src/service.rs
@@ -437,9 +437,21 @@ impl GlacierService {
     fn delete_vault(&self, req: &AwsRequest, name: &str) -> Result<AwsResponse, GlacierError> {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        if state.vaults.remove(name).is_none() {
-            return Err(not_found_vault(name));
+        let vault = state
+            .vaults
+            .get(name)
+            .ok_or_else(|| not_found_vault(name))?;
+        // AWS deletes a vault only if it holds no archives as of the last
+        // inventory and there have been no writes since; a non-empty vault
+        // fails with InvalidParameterValueException rather than silently
+        // dropping its archives.
+        if !vault.archives.is_empty() {
+            return Err(invalid_param(format!(
+                "Vault not empty or recently written to: {}",
+                vault_arn(&req.region, &req.account_id, name)
+            )));
         }
+        state.vaults.remove(name);
         Ok(empty(StatusCode::NO_CONTENT))
     }
 
@@ -603,6 +615,26 @@ impl GlacierService {
             .multipart_uploads
             .get_mut(upload_id)
             .ok_or_else(|| not_found_upload(upload_id))?;
+        // The Content-Range must describe exactly the bytes in the body, the
+        // start must be aligned to the upload's part size, and no part may
+        // exceed the part size. AWS rejects misaligned/oversized parts with
+        // InvalidParameterValueException; silently accepting them yields an
+        // archive whose combined tree hash never matches a from-scratch hash.
+        if end < start || end - start + 1 != data.len() as u64 {
+            return Err(invalid_param(
+                "The Content-Range does not match the length of the request body",
+            ));
+        }
+        if !start.is_multiple_of(upload.part_size) {
+            return Err(invalid_param(
+                "The byte range in Content-Range must be aligned to the part size",
+            ));
+        }
+        if data.len() as u64 > upload.part_size {
+            return Err(invalid_param(
+                "The part is larger than the multipart upload's part size",
+            ));
+        }
         upload.parts.insert(
             start,
             Part {
@@ -639,6 +671,13 @@ impl GlacierService {
             .multipart_uploads
             .get(upload_id)
             .ok_or_else(|| not_found_upload(upload_id))?;
+        // Completing an upload with no parts would mint a zero-byte archive;
+        // AWS rejects it.
+        if upload.parts.is_empty() {
+            return Err(invalid_param(
+                "Cannot complete a multipart upload with no uploaded parts",
+            ));
+        }
 
         // Assemble parts in ascending range order.
         let mut data: Vec<u8> = Vec::new();
@@ -867,6 +906,9 @@ impl GlacierService {
                 job.inventory_size = Some(bytes.len() as u64);
                 job.output = bytes;
                 job.output_content_type = "application/json".to_string();
+                // An inventory ran, so DescribeVault's LastInventoryDate must
+                // advance; without this it stays null forever.
+                v.last_inventory_date = Some(Utc::now());
             }
             "select" => {
                 // SELECT jobs run a query over an archive; we model the control
@@ -980,11 +1022,28 @@ impl GlacierService {
         // Honour a Range header for partial retrieval.
         let (slice, content_range, status) = match header(req, "range") {
             Some(r) => match parse_bytes_range(&r, full.len()) {
-                Some((s, e)) => (
-                    full[s..=e.min(full.len().saturating_sub(1))].to_vec(),
-                    Some(format!("bytes {}-{}/{}", s, e, full.len())),
-                    StatusCode::PARTIAL_CONTENT,
-                ),
+                Some((s, e)) => {
+                    // A start past the end of the payload is unsatisfiable;
+                    // AWS returns 416 rather than crashing on an inverted slice.
+                    if full.is_empty() || s >= full.len() {
+                        let mut resp =
+                            AwsResponse::json(StatusCode::RANGE_NOT_SATISFIABLE, Vec::new());
+                        set_header(
+                            &mut resp,
+                            "Content-Range",
+                            &format!("bytes */{}", full.len()),
+                        );
+                        return Ok(resp);
+                    }
+                    // Clamp the end to the last byte and report the *clamped*
+                    // end in Content-Range, matching AWS.
+                    let end = e.min(full.len() - 1);
+                    (
+                        full[s..=end].to_vec(),
+                        Some(format!("bytes {}-{}/{}", s, end, full.len())),
+                        StatusCode::PARTIAL_CONTENT,
+                    )
+                }
                 None => (full.clone(), None, StatusCode::OK),
             },
             None => (full.clone(), None, StatusCode::OK),

--- a/crates/fakecloud-glacier/tests/service_tests.rs
+++ b/crates/fakecloud-glacier/tests/service_tests.rs
@@ -918,3 +918,189 @@ async fn unroutable_path_returns_aws_error() {
     assert_eq!(status, 400);
     assert_eq!(code, "InvalidParameterValueException");
 }
+
+// Initiate an archive-retrieval job and return its job id.
+async fn retrieve_job(svc: &GlacierService, vault: &str, archive_id: &str) -> String {
+    let resp = call(
+        svc,
+        req(
+            Method::POST,
+            &format!("/-/vaults/{vault}/jobs"),
+            json!({ "Type": "archive-retrieval", "ArchiveId": archive_id }),
+        ),
+    )
+    .await;
+    header_of(&resp, "x-amz-job-id").unwrap()
+}
+
+#[tokio::test]
+async fn delete_non_empty_vault_is_rejected() {
+    let svc = service();
+    make_vault(&svc, "v").await;
+    upload(&svc, "v", b"payload").await;
+
+    // A vault holding archives must not be deletable.
+    let (status, code) = err_of(&call(&svc, req(Method::DELETE, "/-/vaults/v", Value::Null)).await);
+    assert_eq!(status, 400);
+    assert_eq!(code, "InvalidParameterValueException");
+
+    // Still present.
+    let d = body_of(&call(&svc, req(Method::GET, "/-/vaults/v", Value::Null)).await);
+    assert_eq!(d["NumberOfArchives"], 1);
+}
+
+#[tokio::test]
+async fn get_job_output_range_past_end_is_416_not_panic() {
+    let svc = service();
+    make_vault(&svc, "v").await;
+    let archive_id = upload(&svc, "v", b"0123456789").await;
+    let job_id = retrieve_job(&svc, "v", &archive_id).await;
+
+    // start beyond the payload length: must not panic, must be unsatisfiable.
+    let out = call(
+        &svc,
+        req_raw(
+            Method::GET,
+            &format!("/-/vaults/v/jobs/{job_id}/output"),
+            Bytes::new(),
+            &[("Range", "bytes=100-200")],
+        ),
+    )
+    .await;
+    assert_eq!(out.status.as_u16(), 416);
+    assert_eq!(header_of(&out, "Content-Range").unwrap(), "bytes */10");
+}
+
+#[tokio::test]
+async fn get_job_output_range_end_clamped_to_payload() {
+    let svc = service();
+    make_vault(&svc, "v").await;
+    let archive_id = upload(&svc, "v", b"0123456789").await;
+    let job_id = retrieve_job(&svc, "v", &archive_id).await;
+
+    // end past the last byte is clamped, and Content-Range reports the clamp.
+    let out = call(
+        &svc,
+        req_raw(
+            Method::GET,
+            &format!("/-/vaults/v/jobs/{job_id}/output"),
+            Bytes::new(),
+            &[("Range", "bytes=8-99")],
+        ),
+    )
+    .await;
+    assert_eq!(out.status.as_u16(), 206);
+    assert_eq!(raw_body(&out).as_ref(), b"89");
+    assert_eq!(header_of(&out, "Content-Range").unwrap(), "bytes 8-9/10");
+}
+
+#[tokio::test]
+async fn inventory_job_sets_last_inventory_date() {
+    let svc = service();
+    make_vault(&svc, "v").await;
+    upload(&svc, "v", b"payload").await;
+
+    // Before any inventory job, LastInventoryDate is null.
+    let d = body_of(&call(&svc, req(Method::GET, "/-/vaults/v", Value::Null)).await);
+    assert!(d["LastInventoryDate"].is_null());
+
+    call(
+        &svc,
+        req(
+            Method::POST,
+            "/-/vaults/v/jobs",
+            json!({ "Type": "inventory-retrieval" }),
+        ),
+    )
+    .await;
+
+    // Running an inventory job advances LastInventoryDate.
+    let d = body_of(&call(&svc, req(Method::GET, "/-/vaults/v", Value::Null)).await);
+    assert!(
+        d["LastInventoryDate"].as_str().is_some(),
+        "LastInventoryDate should be populated after an inventory job, got {:?}",
+        d["LastInventoryDate"]
+    );
+}
+
+#[tokio::test]
+async fn upload_part_misaligned_or_oversized_rejected() {
+    let svc = service();
+    make_vault(&svc, "v").await;
+    let one_mib = 1024usize * 1024;
+    let init = call(
+        &svc,
+        req_raw(
+            Method::POST,
+            "/-/vaults/v/multipart-uploads",
+            Bytes::new(),
+            &[("x-amz-part-size", &one_mib.to_string())],
+        ),
+    )
+    .await;
+    let upload_id = header_of(&init, "x-amz-multipart-upload-id").unwrap();
+
+    // Start not aligned to the part size.
+    let (status, code) = err_of(
+        &call(
+            &svc,
+            req_raw(
+                Method::PUT,
+                &format!("/-/vaults/v/multipart-uploads/{upload_id}"),
+                Bytes::from(vec![0u8; 100]),
+                &[("Content-Range", "bytes 100-199/*")],
+            ),
+        )
+        .await,
+    );
+    assert_eq!(status, 400);
+    assert_eq!(code, "InvalidParameterValueException");
+
+    // Content-Range length not matching the body.
+    let (status, _) = err_of(
+        &call(
+            &svc,
+            req_raw(
+                Method::PUT,
+                &format!("/-/vaults/v/multipart-uploads/{upload_id}"),
+                Bytes::from(vec![0u8; 10]),
+                &[("Content-Range", "bytes 0-99/*")],
+            ),
+        )
+        .await,
+    );
+    assert_eq!(status, 400);
+}
+
+#[tokio::test]
+async fn complete_multipart_with_no_parts_rejected() {
+    let svc = service();
+    make_vault(&svc, "v").await;
+    let one_mib = 1024usize * 1024;
+    let init = call(
+        &svc,
+        req_raw(
+            Method::POST,
+            "/-/vaults/v/multipart-uploads",
+            Bytes::new(),
+            &[("x-amz-part-size", &one_mib.to_string())],
+        ),
+    )
+    .await;
+    let upload_id = header_of(&init, "x-amz-multipart-upload-id").unwrap();
+
+    let (status, code) = err_of(
+        &call(
+            &svc,
+            req_raw(
+                Method::POST,
+                &format!("/-/vaults/v/multipart-uploads/{upload_id}"),
+                Bytes::new(),
+                &[("x-amz-archive-size", "0")],
+            ),
+        )
+        .await,
+    );
+    assert_eq!(status, 400);
+    assert_eq!(code, "InvalidParameterValueException");
+}


### PR DESCRIPTION
## Summary
Post-merge behavioral bug-hunt on the new Glacier crate (#2125) surfaced 6 real findings across three parallel audits. Persistence/concurrency audit came back clean (archive bytes persist through the snapshot, no background tasks, sound lock discipline).

- **HIGH — panic:** `GetJobOutput` with a `Range` whose start is past the payload end (or any range on empty output) built an inverted/out-of-bounds slice and panicked, dropping the client connection (no `catch_unwind` in the request path). Now returns `416 RequestedRangeNotSatisfiable` with `Content-Range: bytes */<len>`.
- **HIGH — stub:** `DeleteVault` unconditionally removed the vault and its archives and returned 204. Per the Smithy model doc, AWS deletes a vault only if it holds no archives and returns `InvalidParameterValueException` otherwise. Now enforced.
- **MED:** `LastInventoryDate` was never populated — `DescribeVault` returned `null` forever even after a completed `inventory-retrieval` job. Now advanced when an inventory job runs.
- **LOW:** `GetJobOutput` `Content-Range` reported the raw client end instead of the clamped end (`bytes 0-5/3`); now reports the clamped end.
- **LOW:** `UploadMultipartPart` accepted misaligned/oversized parts and `Content-Range` values not matching the body length, yielding a silently wrong combined tree hash. Now validated (start aligned to part size, part <= part size, range length == body length).
- **LOW:** `CompleteMultipartUpload` with no uploaded parts minted a zero-byte archive; AWS rejects it. Now rejected.

## Test plan
- 6 new regression tests (one per fix); full glacier unit suite 31 passed.
- `cargo nextest run -p fakecloud-conformance -E 'test(glacier)'` -> glacier_probe PASS (no response-shape regression).
- `cargo clippy -p fakecloud-glacier --all-targets -- -D warnings` clean.

No non-code surface change (behavioral fixes to existing ops; op set and counts unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes six Glacier API behavior mismatches in `fakecloud-glacier`, including a panic fix in ranged job output. Aligns delete-vault, range handling, multipart uploads, and inventory date semantics with AWS.

- **Bug Fixes**
  - GetJobOutput: start past end or empty output now returns 416 with Content-Range bytes */len (no panic).
  - GetJobOutput: Content-Range now reports the clamped end.
  - DeleteVault: reject non-empty vaults with InvalidParameterValueException.
  - DescribeVault: LastInventoryDate updates after an inventory job.
  - UploadMultipartPart: validate Content-Range vs body, start aligned to part size, and size <= part size.
  - CompleteMultipartUpload: reject completion with no uploaded parts.

<sup>Written for commit 94f47d61243ce65115d63c5645edbc3ddf136f0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

