### PR TITLE
fix(appconfig): 7 behavioral fixes from post-merge bug-hunt

### DIFF
--- a/crates/fakecloud-appconfig/src/handlers.rs
+++ b/crates/fakecloud-appconfig/src/handlers.rs
@@ -153,6 +153,18 @@ fn gen_token() -> String {
     uuid::Uuid::new_v4().simple().to_string()
 }
 
+/// The hosted configuration version number the environment's most recent
+/// deployment pinned, if any (data plane serves the DEPLOYED version, not the
+/// latest hosted one).
+fn deployed_version(env: &EnvironmentRecord) -> Option<i64> {
+    env.deployments
+        .values()
+        .next_back()
+        .and_then(|d| d.deployment.get("ConfigurationVersion"))
+        .and_then(Value::as_str)
+        .and_then(|s| s.parse::<i64>().ok())
+}
+
 // ---------------------------------------------------------------------------
 // Record -> JSON
 // ---------------------------------------------------------------------------
@@ -218,13 +230,20 @@ fn profile_summary_json(p: &ProfileRecord) -> Value {
 }
 
 /// Serve the hosted-version raw bytes plus AppConfig's metadata headers.
-fn hosted_version_response(status: u16, v: &HostedVersionRecord) -> AwsResponse {
+fn hosted_version_response(
+    status: u16,
+    app_id: &str,
+    profile_id: &str,
+    v: &HostedVersionRecord,
+) -> AwsResponse {
     let mut resp = AwsResponse::json(
         StatusCode::from_u16(status).unwrap_or(StatusCode::OK),
         v.content.clone(),
     );
     resp.content_type = v.content_type.clone();
     set_header(&mut resp, "Content-Type", &v.content_type);
+    set_header(&mut resp, "Application-Id", app_id);
+    set_header(&mut resp, "Configuration-Profile-Id", profile_id);
     set_header(&mut resp, "Version-Number", &v.version_number.to_string());
     if let Some(d) = &v.description {
         set_header(&mut resp, "Description", d);
@@ -362,8 +381,13 @@ impl AppConfigService {
         if st.applications.remove(id).is_none() {
             return Err(not_found(format!("Application not found: {id}")));
         }
+        // Cascade also drops the tags of the removed children: every taggable
+        // child (environment, configuration profile) has an ARN nested under
+        // the application's ARN, so a prefix sweep removes them all.
         let arn = application_arn(&req.region, &req.account_id, id);
-        st.tags.remove(&arn);
+        let child_prefix = format!("{arn}/");
+        st.tags
+            .retain(|k, _| k != &arn && !k.starts_with(&child_prefix));
         Ok(empty(204))
     }
 
@@ -503,8 +527,11 @@ impl AppConfigService {
         if app.profiles.remove(id).is_none() {
             return Err(not_found(format!("ConfigurationProfile not found: {id}")));
         }
+        // Drop the profile's tags and any nested child ARN tags with it.
         let arn = profile_arn(&req.region, &req.account_id, app_id, id);
-        st.tags.remove(&arn);
+        let child_prefix = format!("{arn}/");
+        st.tags
+            .retain(|k, _| k != &arn && !k.starts_with(&child_prefix));
         Ok(empty(204))
     }
 
@@ -578,7 +605,7 @@ impl AppConfigService {
             content_type,
             version_label,
         };
-        let out = hosted_version_response(201, &record);
+        let out = hosted_version_response(201, app_id, profile_id, &record);
         p.hosted_versions.insert(version_number, record);
         Ok(out)
     }
@@ -600,7 +627,7 @@ impl AppConfigService {
             .and_then(|app| app.profiles.get(profile_id))
             .and_then(|p| p.hosted_versions.get(&version_number))
             .ok_or_else(|| not_found(format!("HostedConfigurationVersion not found: {version}")))?;
-        Ok(hosted_version_response(200, v))
+        Ok(hosted_version_response(200, app_id, profile_id, v))
     }
 
     fn delete_hosted_version(
@@ -995,28 +1022,33 @@ impl AppConfigService {
             .get(&req.account_id)
             .and_then(|st| st.applications.get(app_id))
             .ok_or_else(|| not_found(format!("Application not found: {app_id}")))?;
-        if !app.environments.contains_key(env_id) {
-            return Err(not_found(format!("Environment not found: {env_id}")));
-        }
+        let env = app
+            .environments
+            .get(env_id)
+            .ok_or_else(|| not_found(format!("Environment not found: {env_id}")))?;
         let profile = app
             .profiles
             .get(config_id)
             .or_else(|| app.profiles.values().find(|p| p.name == config_id))
             .ok_or_else(|| not_found(format!("Configuration not found: {config_id}")))?;
-        let latest = profile
-            .hosted_versions
-            .values()
-            .next_back()
-            .ok_or_else(|| not_found("No configuration content deployed"))?;
-        let mut resp =
-            AwsResponse::json(StatusCode::OK, latest.content.clone());
-        resp.content_type = latest.content_type.clone();
-        set_header(&mut resp, "Content-Type", &latest.content_type);
-        set_header(
-            &mut resp,
-            "Configuration-Version",
-            &latest.version_number.to_string(),
-        );
+        // Serve the version the environment's latest deployment pinned, not
+        // merely the newest hosted version. No deployment => empty config.
+        let served = deployed_version(env)
+            .and_then(|n| profile.hosted_versions.get(&n));
+        let (content, content_type, version) = match served {
+            Some(v) => (
+                v.content.clone(),
+                v.content_type.clone(),
+                Some(v.version_number.to_string()),
+            ),
+            None => (Vec::new(), "application/json".to_string(), None),
+        };
+        let mut resp = AwsResponse::json(StatusCode::OK, content);
+        resp.content_type = content_type.clone();
+        set_header(&mut resp, "Content-Type", &content_type);
+        if let Some(v) = &version {
+            set_header(&mut resp, "Configuration-Version", v);
+        }
         Ok(resp)
     }
 
@@ -1214,6 +1246,13 @@ impl AppConfigService {
                     obj.insert(key.to_string(), v.clone());
                 }
             }
+            // AWS increments the extension's VersionNumber on every update.
+            let next = obj
+                .get("VersionNumber")
+                .and_then(Value::as_i64)
+                .unwrap_or(1)
+                + 1;
+            obj.insert("VersionNumber".to_string(), json!(next));
         }
         Ok(ok(e.clone()))
     }
@@ -1350,9 +1389,27 @@ impl AppConfigService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
-        if st.extension_associations.remove(id).is_none() {
-            return Err(not_found(format!("ExtensionAssociation not found: {id}")));
+        let removed = st
+            .extension_associations
+            .remove(id)
+            .ok_or_else(|| not_found(format!("ExtensionAssociation not found: {id}")))?;
+        // Drop the referenced-extension shim this association created, unless
+        // another association still points at the same extension ARN.
+        if let Some(ext_arn) = removed
+            .get("ExtensionArn")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        {
+            let still_used = st.extension_associations.values().any(|a| {
+                a.get("ExtensionArn").and_then(Value::as_str) == Some(ext_arn.as_str())
+            });
+            if !still_used {
+                st.referenced_extensions
+                    .retain(|_, e| e.get("Arn").and_then(Value::as_str) != Some(ext_arn.as_str()));
+            }
         }
+        let arn = extension_association_arn(&req.region, &req.account_id, id);
+        st.tags.remove(&arn);
         Ok(empty(204))
     }
 
@@ -1846,14 +1903,17 @@ impl AppConfigService {
             .get("configuration_token")
             .cloned()
             .ok_or_else(|| bad_request("ConfigurationToken is required"))?;
-        let accounts = self.state.read();
+        let mut accounts = self.state.write();
         let st = accounts
-            .get(&req.account_id)
+            .get_mut(&req.account_id)
             .ok_or_else(|| bad_request("Invalid ConfigurationToken"))?;
+        // Clone the binding so we can drop the read borrow before rotating the
+        // poll token below (which mutates `st.sessions`).
         let session = st
             .sessions
             .get(&token)
-            .ok_or_else(|| bad_request("Invalid ConfigurationToken"))?;
+            .ok_or_else(|| bad_request("Invalid ConfigurationToken"))?
+            .clone();
         let app = st
             .applications
             .get(&session.application_id)
@@ -1862,24 +1922,43 @@ impl AppConfigService {
             .profiles
             .get(&session.configuration_profile_id)
             .ok_or_else(|| not_found("ConfigurationProfile not found"))?;
-        // Resolve the latest deployed hosted-config version's bytes (highest
-        // version number wins) for this app/env/profile.
-        let latest = profile.hosted_versions.values().next_back();
-        let (content, content_type, version) = match latest {
+        // Serve the version the environment's latest deployment pinned, not the
+        // newest hosted version. No deployment => empty configuration.
+        let served = app
+            .environments
+            .get(&session.environment_id)
+            .and_then(deployed_version)
+            .and_then(|n| profile.hosted_versions.get(&n));
+        let (content, content_type, version_label) = match served {
             Some(v) => (
                 v.content.clone(),
                 v.content_type.clone(),
-                v.version_number.to_string(),
+                v.version_label.clone(),
             ),
-            None => (Vec::new(), "application/json".to_string(), "null".to_string()),
+            None => (Vec::new(), "application/json".to_string(), None),
         };
+        // Rotate the poll token: AWS mints a fresh single-use token each poll.
+        // Register it against the same binding so the client's next poll with
+        // the rotated token resolves (the old token stays valid too, which is
+        // harmless for a mock). Without this the AWS poll loop dies on poll 2.
         let next_token = gen_token();
+        st.sessions.insert(
+            next_token.clone(),
+            SessionRecord {
+                token: next_token.clone(),
+                application_id: session.application_id.clone(),
+                environment_id: session.environment_id.clone(),
+                configuration_profile_id: session.configuration_profile_id.clone(),
+            },
+        );
         let mut resp = AwsResponse::json(StatusCode::OK, content);
         resp.content_type = content_type.clone();
         set_header(&mut resp, "Content-Type", &content_type);
         set_header(&mut resp, "Next-Poll-Configuration-Token", &next_token);
         set_header(&mut resp, "Next-Poll-Interval-In-Seconds", "60");
-        set_header(&mut resp, "Version-Label", &version);
+        if let Some(l) = &version_label {
+            set_header(&mut resp, "Version-Label", l);
+        }
         Ok(resp)
     }
 }

--- a/crates/fakecloud-appconfig/src/validation.rs
+++ b/crates/fakecloud-appconfig/src/validation.rs
@@ -140,7 +140,7 @@ fn label_fields(action: &str) -> &'static [&'static str] {
         "DeleteApplication" => &["ApplicationId"],
         "DeleteConfigurationProfile" => &["ApplicationId", "ConfigurationProfileId"],
         "DeleteDeploymentStrategy" => &["DeploymentStrategyId"],
-        "DeleteEnvironment" => &["EnvironmentId", "ApplicationId"],
+        "DeleteEnvironment" => &["ApplicationId", "EnvironmentId"],
         "DeleteExperimentDefinition" => {
             &["ApplicationIdentifier", "ExperimentDefinitionIdentifier"]
         }

--- a/crates/fakecloud-appconfig/tests/service_tests.rs
+++ b/crates/fakecloud-appconfig/tests/service_tests.rs
@@ -285,7 +285,11 @@ async fn hosted_version_bytes_roundtrip_and_autoincrement() {
     .await;
     assert_eq!(raw_bytes(&got), content2);
     assert_eq!(header(&got, "Content-Type"), "application/octet-stream");
-    assert_eq!(header(&got, "Application-Id"), "");
+    // The id headers the model binds are populated on both create and get.
+    assert_eq!(header(&got, "Application-Id"), app);
+    assert_eq!(header(&got, "Configuration-Profile-Id"), profile);
+    assert_eq!(header(&v1, "Application-Id"), app);
+    assert_eq!(header(&v1, "Configuration-Profile-Id"), profile);
 
     // List returns both summaries.
     let list = body_of(
@@ -506,6 +510,21 @@ async fn extension_and_association_crud() {
     );
     assert_eq!(got["Name"], "ext");
 
+    // UpdateExtension bumps VersionNumber (AWS increments on every update).
+    let updated = body_of(
+        &call(
+            &svc,
+            req(
+                Method::PATCH,
+                &format!("/extensions/{ext_id}"),
+                json!({ "Description": "v2" }),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(updated["VersionNumber"], 2);
+    assert_eq!(updated["Description"], "v2");
+
     let assoc = body_of(
         &call(
             &svc,
@@ -544,6 +563,108 @@ async fn extension_and_association_crud() {
     )
     .await;
     assert_eq!(del.status.as_u16(), 204);
+}
+
+#[tokio::test]
+async fn delete_application_cascades_child_tags() {
+    // Regression: deleting an application must drop the tags of its child
+    // environments and profiles, not just the application's own tags.
+    let svc = service();
+    let app = make_app(&svc, "app").await;
+    let profile = make_profile(&svc, &app, "prof").await;
+    let env = make_env(&svc, &app, "env").await;
+
+    let app_arn = format!("arn:aws:appconfig:us-east-1:000000000000:application/{app}");
+    let env_arn = format!("{app_arn}/environment/{env}");
+    let profile_arn = format!("{app_arn}/configurationprofile/{profile}");
+    for arn in [&app_arn, &env_arn, &profile_arn] {
+        let enc = arn.replace('/', "%2F");
+        call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("/tags/{enc}"),
+                json!({ "Tags": { "team": "infra" } }),
+            ),
+        )
+        .await;
+    }
+
+    // Delete the application; its cascade must sweep child tags too.
+    let del = call(
+        &svc,
+        req(Method::DELETE, &format!("/applications/{app}"), Value::Null),
+    )
+    .await;
+    assert_eq!(del.status.as_u16(), 204);
+
+    for arn in [&app_arn, &env_arn, &profile_arn] {
+        let enc = arn.replace('/', "%2F");
+        let tags =
+            body_of(&call(&svc, req(Method::GET, &format!("/tags/{enc}"), Value::Null)).await);
+        assert!(
+            tags["Tags"].as_object().unwrap().is_empty(),
+            "tags for {arn} should have been cascaded away"
+        );
+    }
+}
+
+#[tokio::test]
+async fn delete_extension_association_removes_referenced_extension() {
+    // Regression: deleting the sole association referencing an AWS-authored
+    // extension must drop the referenced-extension shim it created.
+    let svc = service();
+    let assoc = body_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                "/extensionassociations",
+                json!({
+                    "ExtensionIdentifier": "AWS.AppConfig.JiraServiceManagement",
+                    "ResourceIdentifier": "arn:aws:appconfig:us-east-1:000000000000:application/abc1234",
+                }),
+            ),
+        )
+        .await,
+    );
+    let assoc_id = id_of(&assoc);
+
+    // GetExtension resolves via the referenced-extension shim.
+    let got = body_of(
+        &call(
+            &svc,
+            req(
+                Method::GET,
+                "/extensions/AWS.AppConfig.JiraServiceManagement",
+                Value::Null,
+            ),
+        )
+        .await,
+    );
+    assert_eq!(got["Name"], "AWS.AppConfig.JiraServiceManagement");
+
+    call(
+        &svc,
+        req(
+            Method::DELETE,
+            &format!("/extensionassociations/{assoc_id}"),
+            Value::Null,
+        ),
+    )
+    .await;
+
+    // The shim is gone now that no association references it.
+    let (code, _) = call_err(
+        &svc,
+        req(
+            Method::GET,
+            "/extensions/AWS.AppConfig.JiraServiceManagement",
+            Value::Null,
+        ),
+    )
+    .await;
+    assert_eq!(code, 404);
 }
 
 #[tokio::test]
@@ -658,19 +779,29 @@ async fn tags_roundtrip() {
     assert!(after["Tags"].as_object().unwrap().is_empty());
 }
 
-#[tokio::test]
-async fn appconfigdata_session_returns_deployed_bytes() {
-    let svc = service();
-    let app = make_app(&svc, "app").await;
-    let profile = make_profile(&svc, &app, "prof").await;
-    let env = make_env(&svc, &app, "env").await;
-    let content = b"{\"feature\": \"on\"}";
-    make_hosted_version(&svc, &app, &profile, content, "application/json").await;
+/// Deploy `version` of `profile` to `env` via AllAtOnce (settles COMPLETE).
+async fn deploy(svc: &AppConfigService, app: &str, env: &str, profile: &str, version: &str) {
+    let resp = call(
+        svc,
+        req(
+            Method::POST,
+            &format!("/applications/{app}/environments/{env}/deployments"),
+            json!({
+                "DeploymentStrategyId": "AppConfig.AllAtOnce",
+                "ConfigurationProfileId": profile,
+                "ConfigurationVersion": version,
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status.as_u16(), 201);
+}
 
-    // Start a session bound to the app/env/profile.
+/// Start a data-plane session, returning its InitialConfigurationToken.
+async fn start_session(svc: &AppConfigService, app: &str, env: &str, profile: &str) -> String {
     let session = body_of(
         &call(
-            &svc,
+            svc,
             req(
                 Method::POST,
                 "/configurationsessions",
@@ -683,10 +814,23 @@ async fn appconfigdata_session_returns_deployed_bytes() {
         )
         .await,
     );
-    let token = session["InitialConfigurationToken"]
+    session["InitialConfigurationToken"]
         .as_str()
         .unwrap()
-        .to_string();
+        .to_string()
+}
+
+#[tokio::test]
+async fn appconfigdata_session_returns_deployed_bytes() {
+    let svc = service();
+    let app = make_app(&svc, "app").await;
+    let profile = make_profile(&svc, &app, "prof").await;
+    let env = make_env(&svc, &app, "env").await;
+    let content = b"{\"feature\": \"on\"}";
+    make_hosted_version(&svc, &app, &profile, content, "application/json").await;
+    deploy(&svc, &app, &env, &profile, "1").await;
+
+    let token = start_session(&svc, &app, &env, &profile).await;
 
     // GetLatestConfiguration returns the deployed hosted-config bytes.
     let cfg = call(
@@ -714,6 +858,152 @@ async fn appconfigdata_session_returns_deployed_bytes() {
     .await;
     assert_eq!(code, 400);
     assert_eq!(name, "BadRequestException");
+}
+
+#[tokio::test]
+async fn appconfigdata_next_poll_token_resolves_on_second_poll() {
+    // Regression: the rotated Next-Poll-Configuration-Token must be a live
+    // token, or the AWS poll loop dies with "Invalid ConfigurationToken".
+    let svc = service();
+    let app = make_app(&svc, "app").await;
+    let profile = make_profile(&svc, &app, "prof").await;
+    let env = make_env(&svc, &app, "env").await;
+    let content = b"{\"k\": 1}";
+    make_hosted_version(&svc, &app, &profile, content, "application/json").await;
+    deploy(&svc, &app, &env, &profile, "1").await;
+
+    let token = start_session(&svc, &app, &env, &profile).await;
+    let first = call(
+        &svc,
+        req(
+            Method::GET,
+            &format!("/configuration?configuration_token={token}"),
+            Value::Null,
+        ),
+    )
+    .await;
+    assert_eq!(first.status.as_u16(), 200);
+    let next = header(&first, "Next-Poll-Configuration-Token");
+    assert!(!next.is_empty());
+
+    // Poll again with the rotated token: still 200, still the bytes.
+    let second = call(
+        &svc,
+        req(
+            Method::GET,
+            &format!("/configuration?configuration_token={next}"),
+            Value::Null,
+        ),
+    )
+    .await;
+    assert_eq!(second.status.as_u16(), 200);
+    assert_eq!(raw_bytes(&second), content);
+    assert!(!header(&second, "Next-Poll-Configuration-Token").is_empty());
+}
+
+#[tokio::test]
+async fn appconfigdata_serves_deployed_version_not_latest() {
+    // Regression: the data plane must serve the DEPLOYED version, not merely
+    // the newest hosted version.
+    let svc = service();
+    let app = make_app(&svc, "app").await;
+    let profile = make_profile(&svc, &app, "prof").await;
+    let env = make_env(&svc, &app, "env").await;
+
+    let v1_bytes = b"{\"v\": 1}";
+    make_hosted_version(&svc, &app, &profile, v1_bytes, "application/json").await;
+    deploy(&svc, &app, &env, &profile, "1").await;
+
+    // Create v2 but DO NOT deploy it.
+    make_hosted_version(&svc, &app, &profile, b"{\"v\": 2}", "application/json").await;
+
+    let token = start_session(&svc, &app, &env, &profile).await;
+    let cfg = call(
+        &svc,
+        req(
+            Method::GET,
+            &format!("/configuration?configuration_token={token}"),
+            Value::Null,
+        ),
+    )
+    .await;
+    // Deployed v1 wins over the newer, undeployed v2.
+    assert_eq!(raw_bytes(&cfg), v1_bytes);
+
+    // Legacy GetConfiguration agrees.
+    let legacy = call(
+        &svc,
+        req(
+            Method::GET,
+            &format!(
+                "/applications/{app}/environments/{env}/configurations/{profile}?client_id=c1"
+            ),
+            Value::Null,
+        ),
+    )
+    .await;
+    assert_eq!(raw_bytes(&legacy), v1_bytes);
+    assert_eq!(header(&legacy, "Configuration-Version"), "1");
+}
+
+#[tokio::test]
+async fn appconfigdata_no_deployment_returns_empty() {
+    // An environment with no deployment serves an empty configuration.
+    let svc = service();
+    let app = make_app(&svc, "app").await;
+    let profile = make_profile(&svc, &app, "prof").await;
+    let env = make_env(&svc, &app, "env").await;
+    make_hosted_version(&svc, &app, &profile, b"{\"x\": 1}", "application/json").await;
+
+    let token = start_session(&svc, &app, &env, &profile).await;
+    let cfg = call(
+        &svc,
+        req(
+            Method::GET,
+            &format!("/configuration?configuration_token={token}"),
+            Value::Null,
+        ),
+    )
+    .await;
+    assert_eq!(cfg.status.as_u16(), 200);
+    assert!(raw_bytes(&cfg).is_empty());
+    // No served version => no Version-Label header (never the literal "null").
+    assert_eq!(header(&cfg, "Version-Label"), "");
+}
+
+#[tokio::test]
+async fn appconfigdata_version_label_is_the_label_not_number() {
+    // Regression: Version-Label must carry the served version's label string,
+    // not its number, and be omitted when unlabeled.
+    let svc = service();
+    let app = make_app(&svc, "app").await;
+    let profile = make_profile(&svc, &app, "prof").await;
+    let env = make_env(&svc, &app, "env").await;
+
+    // Hosted version 1 carries a VersionLabel header.
+    let mut headers = HeaderMap::new();
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+    headers.insert("VersionLabel", "release-2024".parse().unwrap());
+    let r = build(
+        Method::POST,
+        &format!("/applications/{app}/configurationprofiles/{profile}/hostedconfigurationversions"),
+        Bytes::from_static(b"{\"labeled\": true}"),
+        headers,
+    );
+    call(&svc, r).await;
+    deploy(&svc, &app, &env, &profile, "1").await;
+
+    let token = start_session(&svc, &app, &env, &profile).await;
+    let cfg = call(
+        &svc,
+        req(
+            Method::GET,
+            &format!("/configuration?configuration_token={token}"),
+            Value::Null,
+        ),
+    )
+    .await;
+    assert_eq!(header(&cfg, "Version-Label"), "release-2024");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Post-merge bug-hunt on the AppConfig crate (#2131) found 7 behavioral divergences (1 HIGH, 3 MED, 3 LOW). CRUD round-trip, persistence, and concurrency were clean; these are data-plane and response-fidelity fixes.

- **HIGH — GetLatestConfiguration dead poll token:** the minted `Next-Poll-Configuration-Token` was never registered, so the canonical AppConfig poll loop failed on the 2nd poll with `BadRequestException`. Now the rotated token is inserted into the session store (write lock) so subsequent polls resolve.
- **MED — Hosted-version responses omit `Application-Id`/`Configuration-Profile-Id` headers:** the model binds both as response headers; now threaded through `hosted_version_response` from create + get.
- **MED — Data plane served the latest hosted version, not the deployed one:** `GetLatestConfiguration`/`GetConfiguration` now resolve the session environment's most-recent deployment's `ConfigurationVersion` and serve that version's bytes; empty config when the environment has no deployment.
- **MED — `Version-Label` carried the version number (or "null"):** now emits the served version's label string, header omitted when unset.
- **LOW — DeleteEnvironment validation label order** `[EnvironmentId,ApplicationId]` -> `[ApplicationId,EnvironmentId]`.
- **LOW — Cascade deletes leaked child tags + referenced_extensions:** delete_application/delete_profile now sweep descendant-ARN tags; delete_extension_association drops its referenced-extension shim (only when unreferenced by other associations).
- **LOW — UpdateExtension now bumps VersionNumber.**

## Test plan
- 6 new regression tests (incl. double-poll token, id headers, deployed-version resolution) + strengthened 2 existing: 17/17 pass.
- Conformance unchanged: appconfig 56/56 (2257 variants), appconfigdata 2/2 (67 variants), both 100%. Audit PASS.
- `cargo clippy --all-targets -- -D warnings` clean.

No non-code surface change (behavioral fixes; op set/counts unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes seven data-plane and response behavior issues in `fakecloud-appconfig` to match AWS AppConfig semantics and keep the AppConfigData poll loop stable. No API shape changes; only behavior and headers corrected.

- **Bug Fixes**
  - Register rotated Next-Poll-Configuration-Token so the second poll succeeds.
  - Serve the DEPLOYED hosted version, not the latest; empty body when no deployment (applies to GetLatestConfiguration and legacy GetConfiguration).
  - Add Application-Id and Configuration-Profile-Id headers to hosted version create/get responses.
  - Version-Label now uses the served version’s label string; header omitted when unset.
  - Fix DeleteEnvironment validation label order to [ApplicationId, EnvironmentId].
  - Cascade deletes remove child tags under application/profile ARNs; deleting an extension association removes its referenced-extension shim when no longer used and drops its own tags.
  - UpdateExtension now increments VersionNumber.

<sup>Written for commit 84fba26d54c7e94bc263b703ebcf385d71c691de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

