### PR TITLE
fix(cloudtrail): 4 behavioral fixes from post-merge bug-hunt

### DIFF
--- a/crates/fakecloud-cloudtrail/src/service.rs
+++ b/crates/fakecloud-cloudtrail/src/service.rs
@@ -322,6 +322,12 @@ fn now_ts() -> f64 {
     chrono::Utc::now().timestamp() as f64
 }
 
+/// Current time as an ISO-8601 / RFC-3339 UTC string (e.g. `2023-01-01T00:00:00Z`),
+/// matching the model's string type for the `TimeLogging{Started,Stopped}` members.
+fn now_iso() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
 fn new_uuid() -> String {
     Uuid::new_v4().to_string()
 }
@@ -357,8 +363,12 @@ fn paginate(rows: Vec<Value>, b: &Value, default_max: usize) -> (Vec<Value>, Opt
         .unwrap_or(default_max);
     let end = start.saturating_add(max).min(rows.len());
     let page = rows.get(start..end).unwrap_or(&[]).to_vec();
+    // Zero-pad to >=4 chars so the token satisfies the model's
+    // `PaginationToken @length(min:4)` validation on the follow-up request.
+    // The read side parses with `parse::<usize>()`, which recovers the value
+    // from a padded token (e.g. "0100" -> 100).
     let next = if end < rows.len() {
-        Some(end.to_string())
+        Some(format!("{end:04}"))
     } else {
         None
     };
@@ -536,6 +546,12 @@ impl CloudTrailService {
         data.trail_status.remove(&name);
         data.event_selectors.remove(&name);
         data.insight_selectors.remove(&name);
+        // Trail ARN is name-derived, so a destroy+recreate reuses it. Purge
+        // tags and event configuration keyed by the ARN to avoid leaking stale
+        // state onto the recreated trail.
+        let arn = trail_arn(ctx, &name);
+        data.tags.remove(&arn);
+        data.event_configurations.remove(&arn);
         empty_ok()
     }
 
@@ -625,10 +641,10 @@ impl CloudTrailService {
         if let Some(obj) = status.as_object_mut() {
             if logging {
                 obj.insert("StartLoggingTime".into(), json!(now_ts()));
-                obj.insert("TimeLoggingStarted".into(), json!(now_ts().to_string()));
+                obj.insert("TimeLoggingStarted".into(), json!(now_iso()));
             } else {
                 obj.insert("StopLoggingTime".into(), json!(now_ts()));
-                obj.insert("TimeLoggingStopped".into(), json!(now_ts().to_string()));
+                obj.insert("TimeLoggingStopped".into(), json!(now_iso()));
             }
         }
         empty_ok()
@@ -1117,20 +1133,31 @@ impl CloudTrailService {
             ctx.account,
             new_uuid()
         );
+        // The channel's source configuration. CreateChannel exposes no input
+        // members for `ApplyToAllRegions`/`AdvancedEventSelectors`, so persist a
+        // per-channel config (honouring `SourceConfig` if a client supplies it)
+        // that GetChannel later echoes back verbatim, rather than a shared literal.
+        let source_config = b
+            .get("SourceConfig")
+            .cloned()
+            .unwrap_or_else(|| json!({ "ApplyToAllRegions": false, "AdvancedEventSelectors": [] }));
         let mut chan = Map::new();
         chan.insert("ChannelArn".into(), json!(arn));
         chan.insert("Name".into(), json!(name));
         chan.insert("Source".into(), json!(source));
         chan.insert("Destinations".into(), destinations);
+        chan.insert("SourceConfig".into(), source_config);
+        chan.insert("IngestionStatus".into(), json!({}));
         if let Some(tags) = b.get("Tags") {
             chan.insert("Tags".into(), tags.clone());
         }
         store_tags(data, &arn, b);
         let chan = Value::Object(chan);
         data.channels.insert(arn, chan.clone());
-        // CreateChannel output echoes name/source/destinations/tags.
+        // CreateChannel output echoes name/source/destinations/tags only.
         let mut out = chan.as_object().cloned().unwrap_or_default();
         out.remove("SourceConfig");
+        out.remove("IngestionStatus");
         ok(Value::Object(out))
     }
 
@@ -1144,11 +1171,11 @@ impl CloudTrailService {
             .ok_or_else(|| channel_not_found(&arn))?;
         let mut out = chan.as_object().cloned().unwrap_or_default();
         out.remove("Tags");
-        out.insert(
-            "SourceConfig".into(),
-            json!({ "ApplyToAllRegions": true, "AdvancedEventSelectors": [] }),
-        );
-        out.insert("IngestionStatus".into(), json!({}));
+        // Echo the channel's own persisted config, defaulting for channels
+        // stored before these fields were persisted.
+        out.entry("SourceConfig")
+            .or_insert_with(|| json!({ "ApplyToAllRegions": false, "AdvancedEventSelectors": [] }));
+        out.entry("IngestionStatus").or_insert_with(|| json!({}));
         ok(Value::Object(out))
     }
 
@@ -1171,6 +1198,8 @@ impl CloudTrailService {
         let chan = chan.clone();
         let mut out = chan.as_object().cloned().unwrap_or_default();
         out.remove("Tags");
+        out.remove("SourceConfig");
+        out.remove("IngestionStatus");
         ok(Value::Object(out))
     }
 
@@ -1591,6 +1620,9 @@ impl CloudTrailService {
         if data.dashboards.remove(&id).is_none() {
             return Err(dashboard_not_found(&id));
         }
+        // Dashboard ARN is name-derived, so destroy+recreate reuses it. Purge
+        // tags keyed by the ARN so they don't leak onto the recreated dashboard.
+        data.tags.remove(&id);
         empty_ok()
     }
 

--- a/crates/fakecloud-cloudtrail/src/service/tests.rs
+++ b/crates/fakecloud-cloudtrail/src/service/tests.rs
@@ -534,3 +534,155 @@ fn validation_rejects_bad_enum() {
         "InvalidParameterException"
     );
 }
+
+// Regression (#1): the NextToken minted for page 2 must satisfy the model's
+// `PaginationToken @length(min:4)` validation, or feeding it back into a second
+// list call is rejected with InvalidParameterException.
+#[test]
+fn pagination_token_survives_second_page_call() {
+    let s = svc();
+    for i in 0..5 {
+        new_eds(&s, &format!("eds-{i}"));
+    }
+    let page1 = call(&s, "ListEventDataStores", json!({ "MaxResults": 2 }));
+    let token = page1["NextToken"].as_str().expect("page 1 has NextToken");
+    // Token must be >= 4 chars so it passes input validation.
+    assert!(token.len() >= 4, "token {token:?} too short for min:4 rule");
+
+    // The follow-up call must not be rejected and must return the next page.
+    let page2 = call(
+        &s,
+        "ListEventDataStores",
+        json!({ "MaxResults": 2, "NextToken": token }),
+    );
+    assert_eq!(
+        page2["EventDataStores"].as_array().unwrap().len(),
+        2,
+        "second page should return the next 2 rows"
+    );
+    // And it must not surface as a validation error.
+    assert!(dispatch(
+        &s,
+        &req(
+            "ListEventDataStores",
+            json!({ "MaxResults": 2, "NextToken": token }),
+        )
+    )
+    .is_ok());
+}
+
+// Regression (#2): DeleteTrail must purge tags and event config keyed by the
+// name-derived ARN, so a recreated same-name trail does not inherit stale tags.
+#[test]
+fn delete_trail_purges_tags_on_recreate() {
+    let s = svc();
+    let created = new_trail(&s, "t");
+    let arn = created["TrailARN"].as_str().unwrap().to_string();
+    call(
+        &s,
+        "AddTags",
+        json!({ "ResourceId": arn, "TagsList": [{ "Key": "old", "Value": "1" }] }),
+    );
+
+    call(&s, "DeleteTrail", json!({ "Name": "t" }));
+
+    // Recreate the same name (reuses the deterministic ARN) with a new tag.
+    new_trail(&s, "t");
+    call(
+        &s,
+        "AddTags",
+        json!({ "ResourceId": arn, "TagsList": [{ "Key": "new", "Value": "2" }] }),
+    );
+    let listed = call(&s, "ListTags", json!({ "ResourceIdList": [arn] }));
+    let tags = listed["ResourceTagList"][0]["TagsList"].as_array().unwrap();
+    assert_eq!(
+        tags.len(),
+        1,
+        "stale tag leaked onto recreated trail: {tags:?}"
+    );
+    assert_eq!(tags[0]["Key"], json!("new"));
+}
+
+// Regression (#2): DeleteDashboard must purge tags keyed by the name-derived ARN.
+#[test]
+fn delete_dashboard_purges_tags_on_recreate() {
+    let s = svc();
+    let created = call(
+        &s,
+        "CreateDashboard",
+        json!({ "Name": "dash", "TagsList": [{ "Key": "old", "Value": "1" }] }),
+    );
+    let arn = created["DashboardArn"].as_str().unwrap().to_string();
+
+    call(&s, "DeleteDashboard", json!({ "DashboardId": arn }));
+
+    call(
+        &s,
+        "CreateDashboard",
+        json!({ "Name": "dash", "TagsList": [{ "Key": "new", "Value": "2" }] }),
+    );
+    let listed = call(&s, "ListTags", json!({ "ResourceIdList": [arn] }));
+    let tags = listed["ResourceTagList"][0]["TagsList"].as_array().unwrap();
+    assert_eq!(
+        tags.len(),
+        1,
+        "stale tag leaked onto recreated dashboard: {tags:?}"
+    );
+    assert_eq!(tags[0]["Key"], json!("new"));
+}
+
+// Regression (#3): TimeLoggingStarted/Stopped must be ISO-8601 strings, not
+// stringified epoch numbers.
+#[test]
+fn get_trail_status_time_logging_is_iso8601() {
+    let s = svc();
+    new_trail(&s, "t");
+    call(&s, "StartLogging", json!({ "Name": "t" }));
+    let status = call(&s, "GetTrailStatus", json!({ "Name": "t" }));
+    let started = status["TimeLoggingStarted"].as_str().unwrap();
+    assert!(
+        started.contains('T') && started.ends_with('Z'),
+        "TimeLoggingStarted not ISO-8601: {started:?}"
+    );
+
+    call(&s, "StopLogging", json!({ "Name": "t" }));
+    let status = call(&s, "GetTrailStatus", json!({ "Name": "t" }));
+    let stopped = status["TimeLoggingStopped"].as_str().unwrap();
+    assert!(
+        stopped.contains('T') && stopped.ends_with('Z'),
+        "TimeLoggingStopped not ISO-8601: {stopped:?}"
+    );
+}
+
+// Regression (#4): GetChannel must echo the channel's own persisted config, not
+// a hardcoded literal identical for every channel.
+#[test]
+fn get_channel_echoes_persisted_source_config() {
+    let s = svc();
+    let created = call(
+        &s,
+        "CreateChannel",
+        json!({
+            "Name": "chanX",
+            "Source": "custom",
+            "Destinations": [{ "Type": "EVENT_DATA_STORE", "Location": "arn" }],
+            "SourceConfig": {
+                "ApplyToAllRegions": true,
+                "AdvancedEventSelectors": [{ "Name": "sel" }]
+            }
+        }),
+    );
+    let arn = created["ChannelArn"].as_str().unwrap().to_string();
+    // CreateChannel output must not carry the internal config fields.
+    assert!(created.get("SourceConfig").is_none());
+    assert!(created.get("IngestionStatus").is_none());
+
+    let got = call(&s, "GetChannel", json!({ "Channel": arn }));
+    assert_eq!(got["SourceConfig"]["ApplyToAllRegions"], json!(true));
+    assert_eq!(
+        got["SourceConfig"]["AdvancedEventSelectors"][0]["Name"],
+        json!("sel")
+    );
+    assert!(got.get("IngestionStatus").is_some());
+    assert!(got.get("Tags").is_none());
+}


### PR DESCRIPTION
## Summary
Post-merge bug-hunt on the CloudTrail crate (#2132). Panics/persistence/concurrency were clean; these are pagination, tag-lifecycle, and response-fidelity fixes.

- **HIGH — Pagination NextToken violated the crate's own `min:4` validation:** `paginate` minted the raw offset as the token (e.g. `"100"`, 3 chars), but `validate_input` enforces the model's `PaginationToken @length(min:4)` on every request, so page 2 of any listing >100 items failed with `InvalidParameterException`. Now zero-padded (`{end:04}`); the read side still recovers the offset via `parse::<usize>()`. Restores ListEventDataStores/ListChannels/ListImports/ListQueries/ListDashboards multi-page.
- **MED — Tag/event-config leak on name-derived ARNs:** trail/dashboard ARNs are deterministic from the name, so destroy+recreate reused the ARN and merged new tags onto stale ones. DeleteTrail now removes `tags` + `event_configurations`; DeleteDashboard removes `tags`.
- **LOW — GetTrailStatus `TimeLoggingStarted`/`TimeLoggingStopped`** now ISO-8601 (model type) instead of epoch-number strings.
- **LOW — GetChannel** now echoes per-channel `SourceConfig`/`IngestionStatus` (persisted on create, honoring a client-supplied config) instead of a shared hardcoded constant; Create/Update responses strip these fields (model shapes exclude them).

## Test plan
- 4 new regression tests (double-page pagination, tag-purge-on-recreate for trail + dashboard, ISO-8601 time-logging, per-channel SourceConfig) + existing: 28/28 lib tests pass.
- Conformance unchanged: 60/60 ops, 1910/1910 variants. Audit PASS.
- `cargo clippy --all-targets -- -D warnings` clean.

No non-code surface change (behavioral fixes; op set/counts unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four behavioral issues in the `fakecloud-cloudtrail` crate: pagination tokens, tag cleanup on recreate, time formatting, and channel response fidelity. Restores multi-page listings and prevents stale tag/config leaks while aligning outputs with the model.

- Bug Fixes
  - Pagination: zero-pad `NextToken` to satisfy `min:4`, so page 2+ of all List* ops work.
  - DeleteTrail/DeleteDashboard: purge tags (and trail event config) tied to name-derived ARNs to avoid leaking onto recreated resources.
  - GetTrailStatus: return ISO-8601 strings for `TimeLoggingStarted`/`TimeLoggingStopped`.
  - Channels: persist per-channel `SourceConfig`/`IngestionStatus`; `GetChannel` echoes them, while `Create/Update` omit them as per shapes.

<sup>Written for commit a2feac34afeff2edb174cd74a058d724a3323a05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

