### PR TITLE
chore(release): bump workspace to v0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appconfig"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudtrail"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4253,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4429,7 +4429,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glacier"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4682,7 +4682,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4703,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4723,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4823,7 +4823,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -4977,7 +4977,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5043,7 +5043,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5070,7 +5070,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transfer"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -115,267 +115,267 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-cloudtrail]
 path = "crates/fakecloud-cloudtrail"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-transfer]
 path = "crates/fakecloud-transfer"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-glacier]
 path = "crates/fakecloud-glacier"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-appconfig]
 path = "crates/fakecloud-appconfig"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-backup]
 path = "crates/fakecloud-backup"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.34.1")
+    testImplementation("dev.fakecloud:fakecloud:0.35.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.34.1</version>
+    <version>0.35.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.34.1"
+version = "0.35.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.34.1"
+version = "0.35.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.34.1",
+  "version": "0.35.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Release v0.35.0. Since v0.34.1:
- **Transfer Family** (#2129) — 71 ops, awsJson1.1
- **AppConfig** (#2131) — 58 ops (appconfig 56 + appconfigdata 2), restJson1 dual-model
- **CloudTrail** (#2132) — 60 ops, awsJson1.1
- Post-merge bug-hunt fixes: Glacier (#2128), Transfer (#2130), AppConfig (#2133), CloudTrail (#2134)

Parity: 57 -> 60/100 LocalStack-roster services, all at 100% conformance.

Bumps workspace + all crate version pins + SDK versions (TS/Python/Java) to 0.35.0. New crates (fakecloud-transfer / -appconfig / -cloudtrail) already in the release.yml publish list.

## Test plan
- Version bump only; CI validates the full build + conformance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.35.0. Parity increases from 57 to 60 services, all at 100% conformance.

- **New Features**
  - Adds `fakecloud-transfer` (71 ops, awsJson1.1), `fakecloud-appconfig` (58 ops, restJson1 dual-model), and `fakecloud-cloudtrail` (60 ops, awsJson1.1).
  - Includes post-merge fixes for Glacier, Transfer, AppConfig, and CloudTrail.

- **Dependencies**
  - Bumps all workspace crates and SDKs to 0.35.0 (`fakecloud` for TypeScript, Python, and Java).

<sup>Written for commit 8d7fe5c14f721278a44e44d70c7c053303c5f6c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

