### PR TITLE
fix(ram): read PromoteResourceShareCreatedFromPolicy arn from @httpQuery

### DIFF
--- a/crates/fakecloud-ram/src/service.rs
+++ b/crates/fakecloud-ram/src/service.rs
@@ -1332,7 +1332,12 @@ impl RamService {
         req: &AwsRequest,
         body: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let arn = req_str(body, "resourceShareArn")?;
+        // `resourceShareArn` is bound to `@httpQuery`, so real SDK / Terraform
+        // clients send it in the query string (empty body). Accept the body form
+        // too for permissive round-tripping.
+        let arn = query_str(req, "resourceShareArn")
+            .or_else(|| str_field(body, "resourceShareArn"))
+            .ok_or_else(|| invalid_param("resourceShareArn is required."))?;
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
         let share = st

--- a/crates/fakecloud-ram/src/validate.rs
+++ b/crates/fakecloud-ram/src/validate.rs
@@ -135,14 +135,18 @@ fn input_rules(action: &str) -> Vec<Rule> {
         }
         "AssociateResourceShare"
         | "DisassociateResourceShare"
-        | "PromoteResourceShareCreatedFromPolicy"
         | "UpdateResourceShare"
         | "ListResourceSharePermissions" => {
             vec![Rule::Required("resourceShareArn")]
         }
-        // The `Delete*` operations bind their identifiers to `@httpQuery`, not
-        // the JSON body; the handlers validate those from the query string.
-        "DeletePermission" | "DeletePermissionVersion" | "DeleteResourceShare" => Vec::new(),
+        // These operations bind their identifiers to `@httpQuery`, not the JSON
+        // body; the handlers validate those from the query string. The `Delete*`
+        // ops and `PromoteResourceShareCreatedFromPolicy` (single `@httpQuery`
+        // `resourceShareArn`, no body members) all fall here.
+        "DeletePermission"
+        | "DeletePermissionVersion"
+        | "DeleteResourceShare"
+        | "PromoteResourceShareCreatedFromPolicy" => Vec::new(),
         "AssociateResourceSharePermission" | "DisassociateResourceSharePermission" => vec![
             Rule::Required("resourceShareArn"),
             Rule::Required("permissionArn"),


### PR DESCRIPTION
## Summary
`PromoteResourceShareCreatedFromPolicy` binds its only input `resourceShareArn` to `@httpQuery` (no body members) per the RAM Smithy model. The handler read it from the JSON body and `validate.rs` required it there, so real aws-sdk / terraform-provider-aws clients (which send it in the query string with an empty body) always got `400 InvalidParameterException`. The conformance probe missed it because it serialized the arg where the handler looked.

Found by a post-merge bug-hunt on the new RAM surface — the same `@httpQuery` class the initial review fixed for the `Delete*` ops, missed for this one non-DELETE query-bound op.

## Fix
- Handler reads `resourceShareArn` from the query string (falls back to the body form for robustness), mirroring `DeleteResourceShare`.
- `validate.rs`: move `PromoteResourceShareCreatedFromPolicy` into the query-bound group (no body-required rule); the handler validates presence.

## Test plan
- `cargo run -p fakecloud-conformance -- run --services ram` -> 35/35, 1073/1073 (100%, unchanged).
- clippy + fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RAM `PromoteResourceShareCreatedFromPolicy` to read `resourceShareArn` from the HTTP query (`@httpQuery`), as defined in the Smithy model. This prevents 400 InvalidParameterException errors for SDK/Terraform clients that send an empty body.

- **Bug Fixes**
  - Handler reads `resourceShareArn` from the query string, with body fallback for robustness (matches `DeleteResourceShare`).
  - Validation now treats this op as query-bound (no body-required rule).

<sup>Written for commit 8c8aa7ca44752df6f71a8821410a5a27fef42e84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

