### PR TITLE
chore(release): bump workspace to v0.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appconfig"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3785,7 +3785,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ce"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3845,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudtrail"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4109,7 +4109,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glacier"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4598,7 +4598,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4629,7 +4629,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4725,7 +4725,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4797,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ram"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -4985,7 +4985,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5060,7 +5060,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5135,7 +5135,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5158,7 +5158,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5268,7 +5268,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -5276,7 +5276,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transfer"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -115,275 +115,275 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-cloudtrail]
 path = "crates/fakecloud-cloudtrail"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-ce]
 path = "crates/fakecloud-ce"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-transfer]
 path = "crates/fakecloud-transfer"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-glacier]
 path = "crates/fakecloud-glacier"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-appconfig]
 path = "crates/fakecloud-appconfig"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-backup]
 path = "crates/fakecloud-backup"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-ram]
 path = "crates/fakecloud-ram"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.35.0")
+    testImplementation("dev.fakecloud:fakecloud:0.36.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.35.0</version>
+    <version>0.36.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.35.0"
+version = "0.36.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.35.0"
+version = "0.36.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Release v0.36.0. Since v0.35.0:
- **Resource Access Manager (RAM)** (#2136) — 35 ops, restJson1 (svc 61)
- **Cost Explorer** (#2138) — 47 ops, awsJson1.1 (svc 62)
- RAM `PromoteResourceShareCreatedFromPolicy` @httpQuery fix (#2137)

Parity: 60 -> 62/100 LocalStack-roster services, all at 100% conformance.

Bumps workspace + all crate version pins + SDK versions (TS/Python/Java) to 0.36.0. New crates (fakecloud-ram / -ce) already in the release.yml publish list.

## Test plan
- Version bump only; CI validates the full build + conformance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.36.0 adds RAM and Cost Explorer services and fixes a RAM @httpQuery issue, raising LocalStack parity to 62/100. Bumps the workspace and SDKs (TS/Python/Java) to 0.36.0.

- **New Features**
  - Resource Access Manager (RAM) — 35 ops, restJson1 (`fakecloud-ram`).
  - Cost Explorer — 47 ops, awsJson1.1 (`fakecloud-ce`).

- **Bug Fixes**
  - RAM PromoteResourceShareCreatedFromPolicy @httpQuery handling.

<sup>Written for commit 70df05c753741391a8064ccfc89abc387ea51763. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

