### PR TITLE
chore(release): bump workspace to v0.37.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3522,7 +3522,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appconfig"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ce"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudtrail"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3982,7 +3982,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codebuild"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeconnections"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4072,7 +4072,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4242,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4373,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glacier"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4541,7 +4541,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4605,7 +4605,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lakeformation"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4727,7 +4727,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ram"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4910,7 +4910,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5017,7 +5017,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -5051,7 +5051,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3tables"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5094,7 +5094,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5126,7 +5126,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5171,7 +5171,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transfer"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -115,291 +115,291 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-cloudtrail]
 path = "crates/fakecloud-cloudtrail"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-ce]
 path = "crates/fakecloud-ce"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-codeconnections]
 path = "crates/fakecloud-codeconnections"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-transfer]
 path = "crates/fakecloud-transfer"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-glacier]
 path = "crates/fakecloud-glacier"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-appconfig]
 path = "crates/fakecloud-appconfig"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-backup]
 path = "crates/fakecloud-backup"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-ram]
 path = "crates/fakecloud-ram"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-s3tables]
 path = "crates/fakecloud-s3tables"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-lakeformation]
 path = "crates/fakecloud-lakeformation"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-codebuild]
 path = "crates/fakecloud-codebuild"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.36.0"
+version = "0.37.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.36.0")
+    testImplementation("dev.fakecloud:fakecloud:0.37.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.36.0"
+version = "0.37.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.36.0"
+version = "0.37.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version bump 0.36.0 -> 0.37.0 (minor).

## What's in this release
- **Lake Formation** service (new)
- **CodeConnections** service (new)
- **CodeBuild** service (new)
- Repeated query-key collapse fix (multi-value list params in core dispatch)
- Per-service bug-hunt follow-ups since v0.36.0

## Version bump
Canonical release-bump file set:
- `Cargo.toml` — workspace.package + all fakecloud-* dependency pins
- `Cargo.lock` — `cargo update --workspace`
- `sdks/typescript/package.json`
- `sdks/python/pyproject.toml`
- `sdks/java/build.gradle.kts` + `sdks/java/README.md`

`release.yml` publish list verified: all publishable crates present (including the three new services in dependency order), no stale entries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the workspace and SDKs to v0.37.0. Fixes a multi-value query param collapse bug in `fakecloud-core` dispatch.

- **New Features**
  - Adds `fakecloud-lakeformation`, `fakecloud-codeconnections`, and `fakecloud-codebuild` services.

- **Bug Fixes**
  - Follow-up fixes across services since v0.36.0.

<sup>Written for commit 9b9fe182e7264e56cad4080dd56c6ffcb1c54cae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

