### PR TITLE
chore(release): bump workspace to v0.38.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appconfig"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3860,7 +3860,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ce"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudtrail"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeartifact"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codebuild"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codecommit"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4096,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeconnections"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codedeploy"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codepipeline"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4536,7 +4536,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4609,7 +4609,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glacier"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4734,7 +4734,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4756,7 +4756,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lakeformation"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4862,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4903,7 +4903,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4942,7 +4942,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ram"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5043,7 +5043,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3tables"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5238,7 +5238,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transfer"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -115,307 +115,307 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-cloudtrail]
 path = "crates/fakecloud-cloudtrail"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-ce]
 path = "crates/fakecloud-ce"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-codeconnections]
 path = "crates/fakecloud-codeconnections"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-transfer]
 path = "crates/fakecloud-transfer"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-glacier]
 path = "crates/fakecloud-glacier"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-appconfig]
 path = "crates/fakecloud-appconfig"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-backup]
 path = "crates/fakecloud-backup"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-ram]
 path = "crates/fakecloud-ram"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-s3tables]
 path = "crates/fakecloud-s3tables"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-lakeformation]
 path = "crates/fakecloud-lakeformation"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-codebuild]
 path = "crates/fakecloud-codebuild"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-codecommit]
 path = "crates/fakecloud-codecommit"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-codedeploy]
 path = "crates/fakecloud-codedeploy"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-codepipeline]
 path = "crates/fakecloud-codepipeline"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-codeartifact]
 path = "crates/fakecloud-codeartifact"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.37.0")
+    testImplementation("dev.fakecloud:fakecloud:0.38.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.37.0</version>
+    <version>0.38.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.37.0"
+version = "0.38.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.37.0"
+version = "0.38.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Release v0.38.0 — the AWS developer-tools (Code*) family: CodeDeploy, CodePipeline, CodeArtifact, CodeCommit (+ their review/bug-hunt fixes) since v0.37.0.

- New services: **CodeDeploy** (47 ops), **CodePipeline** (44 ops), **CodeArtifact** (48 ops, + CFN Domain/Repository provisioner), **CodeCommit** (79 ops, real git object store + merge/PR engine).
- 4 new published crates (fakecloud-codedeploy/codepipeline/codeartifact/codecommit) added to release.yml in topo order.
- Version bump only: Cargo.toml (workspace + all fakecloud pins), Cargo.lock, TS/Python/Java SDK manifests.

## Test plan
- CI green (fmt/clippy/conformance/e2e/examples).
- Tag `v0.38.0` on the merge commit triggers the publish workflow (crates + 4-platform binaries + 5 SDK registries).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v0.38.0 release, introducing the AWS developer-tools family: CodeDeploy, CodePipeline, CodeArtifact, and CodeCommit. This bumps workspace and SDK versions to 0.38.0; tagging `v0.38.0` will trigger publishing.

- **Dependencies**
  - Bumped all `fakecloud-*` crates to `0.38.0` in `Cargo.toml` and `Cargo.lock`.
  - Updated SDK package versions to `0.38.0`: `sdks/typescript` (`package.json`), `sdks/python` (`pyproject.toml`), `sdks/java` (`build.gradle.kts`, README).

<sup>Written for commit 0555219d6073f5b46dd84937466c86d28f9b29d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

