### PR TITLE
chore(release): bump workspace to v0.39.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appconfig"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ce"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4000,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudtrail"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4137,7 +4137,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeartifact"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4159,7 +4159,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codebuild"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codecommit"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeconnections"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codedeploy"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codepipeline"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-efs"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticbeanstalk"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4735,7 +4735,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glacier"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4823,7 +4823,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4866,7 +4866,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lakeformation"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4988,7 +4988,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mq"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5052,7 +5052,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ram"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3tables"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5480,7 +5480,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transfer"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5666,7 +5666,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -115,319 +115,319 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-cloudtrail]
 path = "crates/fakecloud-cloudtrail"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-ce]
 path = "crates/fakecloud-ce"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-codeconnections]
 path = "crates/fakecloud-codeconnections"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-transfer]
 path = "crates/fakecloud-transfer"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-elasticbeanstalk]
 path = "crates/fakecloud-elasticbeanstalk"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-glacier]
 path = "crates/fakecloud-glacier"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-appconfig]
 path = "crates/fakecloud-appconfig"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-backup]
 path = "crates/fakecloud-backup"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-ram]
 path = "crates/fakecloud-ram"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-s3tables]
 path = "crates/fakecloud-s3tables"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-lakeformation]
 path = "crates/fakecloud-lakeformation"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-codebuild]
 path = "crates/fakecloud-codebuild"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-codecommit]
 path = "crates/fakecloud-codecommit"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-codedeploy]
 path = "crates/fakecloud-codedeploy"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-codepipeline]
 path = "crates/fakecloud-codepipeline"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-codeartifact]
 path = "crates/fakecloud-codeartifact"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-efs]
 path = "crates/fakecloud-efs"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-mq]
 path = "crates/fakecloud-mq"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.38.0")
+    testImplementation("dev.fakecloud:fakecloud:0.39.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.38.0</version>
+    <version>0.39.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.38.0"
+version = "0.39.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.38.0"
+version = "0.39.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Release v0.39.0. Accumulated since v0.38.0 tag:
- Amazon MQ service (25 ops, restJson1) #2163
- EFS service #2160
- CloudFormation provisioners: CodeArtifact/EB/EFS #2157 #2159 #2161

Bumps `[workspace.package]` + all `fakecloud-*` dep pins + Cargo.lock + TS/Python/Java SDK manifests to 0.39.0.

## Test plan
- CI green (build/clippy/fmt/conformance/e2e)
- Tag v0.39.0 pushed post-merge triggers release.yml publish

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.39.0. Adds Amazon MQ and EFS services and bumps all crates and SDKs to `0.39.0`.

- **New Features**
  - Add Amazon MQ service (restJson1, 25 ops).
  - Add EFS service.
  - Add CloudFormation provisioners for CodeArtifact, Elastic Beanstalk, and EFS.

- **Dependencies**
  - Bump `[workspace.package]`, all `fakecloud-*` crates, and `Cargo.lock` to `0.39.0`.
  - Update SDK versions: Java, TypeScript, and Python to `0.39.0`.

<sup>Written for commit e58e299312398fe39eb49d4fd292806d9eebb44c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

