### PR TITLE
fix(mq): ActiveMQ web console starts so brokers reach RUNNING + honest spawn failures + dedicated mq-broker CI job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -373,3 +373,73 @@ jobs:
       - name: nft ruleset diagnostics
         if: always()
         run: sudo nft list ruleset || true
+
+  # Dedicated, resourced job for the Amazon MQ broker data-plane E2E. These
+  # tests spawn REAL broker containers (a JVM ActiveMQ and an Erlang RabbitMQ),
+  # which are far heavier than the images in the shared partition matrix, so they
+  # are gated behind FAKECLOUD_E2E_MQ_BROKER=1 (skipped loudly everywhere else)
+  # and run here with docker, a generous timeout for the slow broker boot, and a
+  # test-step retry that absorbs genuine cold-pull/first-connection flake WITHOUT
+  # masking a real regression (a persistently failing test still fails the job).
+  mq-broker:
+    name: MQ broker data plane
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    # Broker boot is slow (JVM/Erlang start + first cold image pull); allow ample
+    # headroom over the tests' own 300s per-broker readiness windows plus retries.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/free-disk
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Prune container state before tests
+        run: docker system prune -af --volumes || true
+
+      # Pre-pull the broker images (with retry) so the first CreateBroker doesn't
+      # pay a cold pull inside the readiness window. Retries absorb a flaky
+      # registry; a persistent pull failure is surfaced (the tests would fail
+      # anyway). The image refs match the runtime defaults; keep them in sync with
+      # MqEngine::image (FAKECLOUD_MQ_ACTIVEMQ_IMAGE / _RABBITMQ_IMAGE).
+      - name: Pre-pull broker images
+        run: |
+          for img in apache/activemq-classic rabbitmq:3.13-alpine; do
+            for i in 1 2 3; do
+              if docker pull "$img"; then break; fi
+              echo "docker pull $img attempt $i failed; retrying"; sleep $((i * 5))
+              [ "$i" = 3 ] && { echo "::error::could not pull $img"; exit 1; }
+            done
+          done
+
+      # The testkit boots this binary via its workspace-relative path, so a plain
+      # debug build in place is all the tests need.
+      - name: Build fakecloud
+        run: cargo build --bin fakecloud
+
+      # Run ONLY the two broker E2E tests: the data-plane round-trips
+      # (mq_dataplane: ActiveMQ STOMP + RabbitMQ AMQP) and the CFN provisioner
+      # (cloudformation_mq: cfn_provisions_mq_broker_and_configuration). FAKECLOUD_
+      # E2E_MQ_BROKER=1 flips them from skip to run; CI=1 makes a missing docker a
+      # hard failure rather than a silent skip. --retries 2 reruns only a failed
+      # test (up to 2 extra times) to ride out cold-pull / first-connection flake;
+      # a test that fails every attempt still fails the job red.
+      - name: Run MQ broker E2E
+        env:
+          FAKECLOUD_E2E_MQ_BROKER: "1"
+          CI: "1"
+        run: |
+          cargo nextest run -P ci -p fakecloud-e2e --retries 2 \
+            -E 'test(activemq_broker_delivers_a_message_over_stomp) + test(rabbitmq_broker_speaks_amqp) + test(cfn_provisions_mq_broker_and_configuration)'
+
+      - name: Broker container diagnostics
+        if: always()
+        run: |
+          echo "=== docker ps -a ==="
+          docker ps -a || true
+
+      - name: Prune container state after tests
+        if: always()
+        run: docker system prune -af --volumes || true

--- a/crates/fakecloud-e2e/tests/cloudformation_mq.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_mq.rs
@@ -136,11 +136,11 @@ async fn cfn_provisions_mq_broker_and_configuration() {
             break broker;
         }
         if state == "CREATION_FAILED" {
-            helpers::dump_mq_broker_diagnostics(broker_ref);
+            helpers::dump_mq_broker_diagnostics(&s, broker_ref).await;
             panic!("broker container failed to start");
         }
         if std::time::Instant::now() >= deadline {
-            helpers::dump_mq_broker_diagnostics(broker_ref);
+            helpers::dump_mq_broker_diagnostics(&s, broker_ref).await;
             panic!("CFN broker did not reach RUNNING (last state: {state})");
         }
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -194,7 +194,31 @@ pub async fn wait_for_serverless_cache_available(
 /// This exists so a broker that fails to become ready in CI is DIAGNOSABLE: the
 /// container's recent logs reveal the real reason (OOM kill, Erlang node/cookie
 /// error, slow boot, crash loop) instead of a bare "CREATION_FAILED".
-pub fn dump_mq_broker_diagnostics(broker_id: &str) {
+pub async fn dump_mq_broker_diagnostics(server: &TestServer, broker_id: &str) {
+    // The broker's persisted `statusReason` carries the REAL cause a bring-up
+    // failed (docker stderr + the failed container's logs), captured by the mq
+    // runtime and stored on the CREATION_FAILED record. The typed AWS SDK drops
+    // this non-modeled field, so read it straight off the raw restJson1
+    // DescribeBroker body (`GET /v1/brokers/{id}`). Best-effort: a fetch failure
+    // just prints a note rather than masking the docker diagnostics below.
+    println!("\n===== MQ broker statusReason for {broker_id} =====");
+    match reqwest::Client::new()
+        .get(format!("{}/v1/brokers/{broker_id}", server.endpoint()))
+        .send()
+        .await
+    {
+        Ok(resp) => match resp.json::<serde_json::Value>().await {
+            Ok(body) => println!(
+                "statusReason: {}",
+                body.get("statusReason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<none set>")
+            ),
+            Err(e) => println!("<could not parse DescribeBroker body: {e}>"),
+        },
+        Err(e) => println!("<could not fetch DescribeBroker: {e}>"),
+    }
+
     fn docker(args: &[&str]) -> String {
         match std::process::Command::new("docker").args(args).output() {
             Ok(o) => {

--- a/crates/fakecloud-e2e/tests/mq_dataplane.rs
+++ b/crates/fakecloud-e2e/tests/mq_dataplane.rs
@@ -62,6 +62,7 @@ async fn mq_client(server: &TestServer) -> aws_sdk_mq::Client {
 /// Poll DescribeBroker until the broker reaches `RUNNING`, returning the
 /// broker's `brokerInstances` endpoints. Fails loudly on `CREATION_FAILED`.
 async fn wait_for_running(
+    server: &TestServer,
     client: &aws_sdk_mq::Client,
     broker_id: &str,
     timeout_secs: u64,
@@ -89,11 +90,11 @@ async fn wait_for_running(
             return endpoints;
         }
         if state == "CREATION_FAILED" {
-            helpers::dump_mq_broker_diagnostics(broker_id);
+            helpers::dump_mq_broker_diagnostics(server, broker_id).await;
             panic!("broker container failed to start (data plane could not come up)");
         }
         if std::time::Instant::now() >= deadline {
-            helpers::dump_mq_broker_diagnostics(broker_id);
+            helpers::dump_mq_broker_diagnostics(server, broker_id).await;
             panic!("broker {broker_id} did not reach RUNNING within {timeout_secs}s (last state: {state})");
         }
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -142,7 +143,7 @@ async fn activemq_broker_delivers_a_message_over_stomp() {
 
     // The container starts in the background (image pull + JVM boot), so allow
     // a generous window before the broker accepts connections.
-    let endpoints = wait_for_running(&client, &broker_id, 300).await;
+    let endpoints = wait_for_running(&server, &client, &broker_id, 300).await;
 
     // The STOMP endpoint must be a REAL reachable address, not *.amazonaws.com.
     let stomp = endpoints
@@ -228,7 +229,7 @@ async fn rabbitmq_broker_speaks_amqp() {
         .expect("create broker");
     let broker_id = created.broker_id().expect("broker id").to_string();
 
-    let endpoints = wait_for_running(&client, &broker_id, 300).await;
+    let endpoints = wait_for_running(&server, &client, &broker_id, 300).await;
     let amqp = endpoints
         .iter()
         .find(|e| e.starts_with("amqp://"))

--- a/crates/fakecloud-mq/src/cfn_provision.rs
+++ b/crates/fakecloud-mq/src/cfn_provision.rs
@@ -44,10 +44,10 @@ pub async fn cfn_ensure_broker_container(
             spec.user_config.as_deref(),
         )
         .await
-        .map_err(
-            |error| tracing::error!(%error, broker_id = %broker_id, "CFN MQ broker container failed to start"),
-        )
-        .ok();
+        .map_err(|error| {
+            tracing::error!(%error, broker_id = %broker_id, "CFN MQ broker container failed to start");
+            error.to_string()
+        });
     settle_broker_up(&state, &account_id, &broker_id, running, &runtime).await;
 }
 

--- a/crates/fakecloud-mq/src/runtime/mod.rs
+++ b/crates/fakecloud-mq/src/runtime/mod.rs
@@ -306,6 +306,14 @@ impl MqRuntime {
         users: &[BrokerUser],
         user_config: Option<&str>,
     ) -> Result<RunningBroker, RuntimeError> {
+        // Reap a leaked container left by a PRIOR failed bring-up of THIS broker.
+        // A failed attempt is intentionally left un-reaped for post-mortem (see
+        // the failure paths below), so bound accumulation across the recover /
+        // reboot retry loop to a single most-recent failed container. Scoped to
+        // this broker AND this fakecloud instance, so it never disturbs another
+        // broker or another process's containers.
+        self.reap_stale_broker_containers(broker_id).await;
+
         let mut args: Vec<String> = vec!["create".to_string()];
         for (_, cport) in engine.published_ports() {
             args.push("-p".to_string());
@@ -377,9 +385,12 @@ impl MqRuntime {
             .await
             .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
         if !start.status.success() {
-            self.remove_container(&container_id).await;
+            // Leave the container un-reaped for post-mortem (the E2E diagnostics
+            // dump finds it by label and prints its logs); the next bring-up
+            // attempt's stale-reap and the server-shutdown sweep clean it up.
+            let diag = self.capture_container_diagnostics(&container_id).await;
             return Err(RuntimeError::ContainerStartFailed(format!(
-                "container start failed: {}",
+                "container start failed: {}; {diag}",
                 String::from_utf8_lossy(&start.stderr).trim()
             )));
         }
@@ -391,8 +402,8 @@ impl MqRuntime {
                     ports.insert((*label).to_string(), hp);
                 }
                 Err(e) => {
-                    self.remove_container(&container_id).await;
-                    return Err(e);
+                    let diag = self.capture_container_diagnostics(&container_id).await;
+                    return Err(RuntimeError::ContainerStartFailed(format!("{e}; {diag}")));
                 }
             }
         }
@@ -401,8 +412,8 @@ impl MqRuntime {
             .wait_for_broker_ready(engine, &container_id, &ports)
             .await
         {
-            self.remove_container(&container_id).await;
-            return Err(e);
+            let diag = self.capture_container_diagnostics(&container_id).await;
+            return Err(RuntimeError::ContainerStartFailed(format!("{e}; {diag}")));
         }
 
         // RabbitMQ users beyond the create-time env user are applied live,
@@ -809,6 +820,62 @@ impl MqRuntime {
             .output()
             .await;
     }
+
+    /// Remove any container labeled for THIS broker AND this fakecloud instance.
+    /// Used to sweep a leaked container left un-reaped by a prior failed bring-up
+    /// before a fresh attempt, without disturbing other brokers or another
+    /// fakecloud process's containers.
+    async fn reap_stale_broker_containers(&self, broker_id: &str) {
+        let Ok(out) = tokio::process::Command::new(&self.cli)
+            .args([
+                "ps",
+                "-aq",
+                "--filter",
+                &format!("label=fakecloud-mq={broker_id}"),
+                "--filter",
+                &format!("label=fakecloud-instance={}", self.instance_id),
+            ])
+            .output()
+            .await
+        else {
+            return;
+        };
+        if !out.status.success() {
+            return;
+        }
+        for id in String::from_utf8_lossy(&out.stdout).split_whitespace() {
+            self.remove_container(id).await;
+        }
+    }
+
+    /// Capture a failed container's terminal state + recent logs for a
+    /// CREATION_FAILED reason, so the failure surfaces WHY the broker didn't come
+    /// up (in the broker's `statusReason` and the E2E diagnostics dump) instead
+    /// of a bare "did not become ready" timeout.
+    async fn capture_container_diagnostics(&self, container_id: &str) -> String {
+        let state = tokio::process::Command::new(&self.cli)
+            .args([
+                "inspect",
+                "--format",
+                "status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}",
+                container_id,
+            ])
+            .output()
+            .await
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default();
+        let logs = tokio::process::Command::new(&self.cli)
+            .args(["logs", "--tail", "80", container_id])
+            .output()
+            .await
+            .map(|o| {
+                let mut s = String::from_utf8_lossy(&o.stdout).into_owned();
+                s.push_str(&String::from_utf8_lossy(&o.stderr));
+                s.trim().to_string()
+            })
+            .unwrap_or_else(|e| format!("<docker logs failed: {e}>"));
+        format!("container state [{state}]; recent container logs:\n{logs}")
+    }
 }
 
 /// A STABLE, valid DNS-label container hostname for a RabbitMQ broker.
@@ -944,6 +1011,19 @@ pub fn activemq_config(users: &[BrokerUser], user_config: Option<&str>) -> Strin
         </shutdownHooks>
 
     </broker>
+
+    <!--
+      Start the Jetty web console (the `apache/activemq-classic` image's stock
+      activemq.xml ends with exactly this import). Broker readiness is gated on
+      the console answering HTTP on 8161, which starts LAST in the boot sequence
+      -- once it responds every transport connector is bound and accepting. When
+      this generated config REPLACES the image's default activemq.xml the import
+      must be carried over, or the console never binds, readiness times out after
+      180s, and the (otherwise fully-working) broker is reaped and marked
+      CREATION_FAILED. The Jetty connectors themselves live in the image's
+      conf/jetty.xml, which we don't touch.
+    -->
+    <import resource="jetty.xml"/>
 </beans>
 "#
     )
@@ -983,6 +1063,38 @@ mod tests {
         assert!(xml.contains("tcp://0.0.0.0:61616"));
         assert!(xml.contains("stomp://0.0.0.0:61613"));
         assert!(xml.contains("amqp://0.0.0.0:5672"));
+    }
+
+    #[test]
+    fn activemq_config_imports_jetty_so_the_console_starts() {
+        // Readiness is gated on the ActiveMQ web console (Jetty on 8161). The
+        // generated config REPLACES the image's stock activemq.xml, so it must
+        // carry over the `<import resource="jetty.xml"/>` that starts the console
+        // -- otherwise the console never binds, readiness times out after 180s,
+        // and the otherwise-healthy broker is reaped as CREATION_FAILED.
+        let xml = activemq_config(&[user("app", "s3cr3t", true)], None);
+        assert!(
+            xml.contains(r#"<import resource="jetty.xml"/>"#),
+            "generated activemq.xml must import jetty.xml to start the web console"
+        );
+        // The import is a sibling of </broker>, inside <beans> -- i.e. after the
+        // broker element closes, before the document ends.
+        let import_at = xml.find("import resource").expect("import present");
+        let broker_close = xml.find("</broker>").expect("broker closes");
+        assert!(
+            import_at > broker_close,
+            "jetty import must come after the broker element closes"
+        );
+    }
+
+    #[test]
+    fn activemq_config_verbatim_user_config_is_untouched() {
+        // A complete standalone config is applied byte-for-byte; we must NOT
+        // inject the jetty import into a user's verbatim broker config.
+        let user_cfg = "<broker><transportConnectors><transportConnector uri=\"tcp://0.0.0.0:61616\"/></transportConnectors></broker>";
+        let xml = activemq_config(&[user("app", "pw", true)], Some(user_cfg));
+        assert_eq!(xml, user_cfg);
+        assert!(!xml.contains("jetty.xml"));
     }
 
     #[test]

--- a/crates/fakecloud-mq/src/service.rs
+++ b/crates/fakecloud-mq/src/service.rs
@@ -526,11 +526,11 @@ pub(crate) async fn settle_broker_up(
     state: &SharedMqState,
     account: &str,
     id: &str,
-    running: Option<crate::runtime::RunningBroker>,
+    running: Result<crate::runtime::RunningBroker, String>,
     runtime: &Arc<MqRuntime>,
 ) {
     match running {
-        Some(r) => {
+        Ok(r) => {
             let present = {
                 let mut guard = state.write();
                 let data = guard.get_or_create(account);
@@ -547,11 +547,16 @@ pub(crate) async fn settle_broker_up(
                 runtime.stop_broker(id).await;
             }
         }
-        None => {
+        Err(reason) => {
             let mut guard = state.write();
             let data = guard.get_or_create(account);
             if let Some(obj) = data.brokers.get_mut(id).and_then(Value::as_object_mut) {
                 obj.insert("brokerState".into(), json!("CREATION_FAILED"));
+                // Persist the real reason (docker stderr + the failed container's
+                // logs) so a CREATION_FAILED broker says WHY it failed rather than
+                // being a black box. Surfaces in the raw DescribeBroker body and
+                // the persisted snapshot; the E2E diagnostics dump prints it too.
+                obj.insert("statusReason".into(), json!(reason));
             }
         }
     }
@@ -721,10 +726,10 @@ impl MqService {
             let running = runtime
                 .ensure_broker(&id, spec.engine, &spec.users, spec.user_config.as_deref())
                 .await
-                .map_err(
-                    |error| tracing::error!(%error, broker_id = %id, "MQ broker container failed to start"),
-                )
-                .ok();
+                .map_err(|error| {
+                    tracing::error!(%error, broker_id = %id, "MQ broker container failed to start");
+                    error.to_string()
+                });
             settle_broker_up(&state, &account, &id, running, &runtime).await;
             save_snapshot(&state, store, &lock).await;
         });
@@ -752,8 +757,8 @@ impl MqService {
         tokio::spawn(async move {
             let running =
                 recover_bring_up(&runtime, &id, &spec, persisted_container_id.as_deref()).await;
-            if running.is_some() {
-                settle_broker_up(&state, &account, &id, running, &runtime).await;
+            if let Some(r) = running {
+                settle_broker_up(&state, &account, &id, Ok(r), &runtime).await;
             } else {
                 // Recovery exhausted its retries. Leave the broker
                 // CREATION_IN_PROGRESS (set during recovery setup) rather than a


### PR DESCRIPTION
## Summary
Fixes the real reason Amazon MQ ActiveMQ brokers never reached `RUNNING` in CI, adds honest failure surfacing, and adds a dedicated resourced `mq-broker` CI job that runs the broker data-plane E2E (gated behind `FAKECLOUD_E2E_MQ_BROKER=1` from #2171).

### Root cause
The generated `activemq.xml` that the MQ runtime `docker cp`s over the `apache/activemq-classic` image dropped the stock config's trailing `<import resource="jetty.xml"/>`. That import starts the web console (Jetty, 8161). MQ's ActiveMQ readiness gate polls **only** the web console, so with no jetty import the console never binds, readiness times out after 180s, and the container is reaped — which is why CI diagnostics saw an **empty `docker ps -a`** (misread as "docker run errored"; the container actually spawned fine, all messaging connectors up, then got reaped). RabbitMQ was never affected.

Reproduced deterministically under podman: stock generated config → console never answers → CREATION_FAILED; with the jetty import → console answers in ~4s → authenticated STOMP round-trip succeeds.

### Fix
- `crates/fakecloud-mq/src/runtime/mod.rs`: carry `<import resource="jetty.xml"/>` into the generated `activemq.xml` (sibling of `</broker>`, matching the image default). Verbatim user configs still applied byte-for-byte. +2 unit tests.
- **Honest failures**: on start/port/readiness failure the runtime captures the container's terminal state + `docker logs` into the error and leaves the container un-reaped for post-mortem (bounded by a stale-reap on next attempt + testkit shutdown sweep). `statusReason` on `CREATION_FAILED` now carries the real reason (surfaces in raw DescribeBroker + persisted snapshot). Both callers (`service.rs`, `cfn_provision.rs`) updated.
- `crates/fakecloud-e2e/tests/helpers/mod.rs`: `dump_mq_broker_diagnostics` also prints persisted `statusReason` (raw GET, since the typed SDK drops the non-modeled field) alongside container logs.

### Dedicated CI job
New `mq-broker` job in `.github/workflows/e2e.yml`: `needs: changes`, gated on `code=='true'`, 45-min timeout, free-disk + docker prune + pre-pull both broker images with retry + build, then runs ONLY the 3 broker tests with `FAKECLOUD_E2E_MQ_BROKER=1 CI=1 --retries 2` (absorbs cold-pull flake without masking a persistent failure).

## Test plan
- `cargo fmt`, `cargo clippy -p fakecloud-mq --all-targets -- -D warnings`, `cargo build -p fakecloud-mq -p fakecloud-e2e` clean.
- 6 mq unit tests pass; both E2E targets compile.
- Data-plane path validated end-to-end under podman: console-ready + authenticated STOMP round-trip against the fixed config.
- The `mq-broker` job exercises the real broker spawn in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ActiveMQ brokers failing to reach RUNNING by starting the web console in generated configs, surfaces real spawn failures, and adds a dedicated `mq-broker` CI job for broker E2Es. Impact: ActiveMQ now settles to RUNNING reliably and CI captures actionable failure reasons.

- **Bug Fixes**
  - Start the Jetty web console by carrying `<import resource="jetty.xml"/>` into generated `activemq.xml` for `apache/activemq-classic`. Readiness now passes; verbatim user configs stay untouched. (+2 unit tests)
  - Honest failures: on start/port/readiness errors, capture container state and `docker logs`, persist as `statusReason`, and leave the failed container for inspection (stale containers are reaped on next attempt). E2E diagnostics now also print `statusReason` via raw `GET /v1/brokers/{id}`.
  - Service/CFN paths propagate the real error so `CREATION_FAILED` records include the reason instead of a silent timeout.

- **New Features**
  - Dedicated `mq-broker` CI job in `.github/workflows/e2e.yml`: gated by `FAKECLOUD_E2E_MQ_BROKER=1`, 45‑min timeout, docker prune, pre-pulls `apache/activemq-classic` and `rabbitmq:3.13-alpine` with retry, builds, and runs only the broker tests with `--retries 2`.
  - Adds post-run docker diagnostics to aid triage.

<sup>Written for commit dbb264f3b78781c55f5bd99125d0c2973ae0d138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

