### PR TITLE
chore(release): bump workspace to v0.40.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acmpca"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appconfig"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ce"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4109,7 +4109,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudtrail"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4249,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeartifact"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4271,7 +4271,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codebuild"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codecommit"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeconnections"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codedeploy"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codepipeline"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-config"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4429,7 +4429,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4514,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4579,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4686,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4738,7 +4738,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-efs"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4789,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticbeanstalk"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4902,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glacier"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5027,7 +5027,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5049,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lakeformation"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5100,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mq"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5238,7 +5238,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5257,7 +5257,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ram"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5358,7 +5358,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53resolver"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -5498,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3tables"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5737,7 +5737,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transfer"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -116,331 +116,331 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-cloudtrail]
 path = "crates/fakecloud-cloudtrail"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-ce]
 path = "crates/fakecloud-ce"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-codeconnections]
 path = "crates/fakecloud-codeconnections"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-transfer]
 path = "crates/fakecloud-transfer"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-elasticbeanstalk]
 path = "crates/fakecloud-elasticbeanstalk"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-glacier]
 path = "crates/fakecloud-glacier"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-appconfig]
 path = "crates/fakecloud-appconfig"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-backup]
 path = "crates/fakecloud-backup"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-ram]
 path = "crates/fakecloud-ram"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-s3tables]
 path = "crates/fakecloud-s3tables"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-lakeformation]
 path = "crates/fakecloud-lakeformation"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-codebuild]
 path = "crates/fakecloud-codebuild"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-codecommit]
 path = "crates/fakecloud-codecommit"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-codedeploy]
 path = "crates/fakecloud-codedeploy"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-codepipeline]
 path = "crates/fakecloud-codepipeline"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-codeartifact]
 path = "crates/fakecloud-codeartifact"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-efs]
 path = "crates/fakecloud-efs"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-mq]
 path = "crates/fakecloud-mq"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-route53resolver]
 path = "crates/fakecloud-route53resolver"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-acmpca]
 path = "crates/fakecloud-acmpca"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-config]
 path = "crates/fakecloud-config"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.39.0")
+    testImplementation("dev.fakecloud:fakecloud:0.40.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.39.0</version>
+    <version>0.40.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.39.0"
+version = "0.40.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.39.0"
+version = "0.40.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Release v0.40.0. New since v0.39.0:
- **Amazon MQ** — real Docker-backed ActiveMQ + RabbitMQ broker data plane (dedicated `mq-broker` CI job green).
- **AWS Config** (97 ops), **ACM Private CA** (23 ops), **Route 53 Resolver** (72 ops) — new services.
- **CodeBuild** real buildspec execution in Docker; **Bedrock** real configurable upstream inference (InvokeModel/Converse + streaming).
- 3 new published crates: fakecloud-acmpca, fakecloud-config, fakecloud-route53resolver.

Version bump only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.40.0 and bump all workspace and SDK versions. This release adds Amazon MQ (Docker‑backed ActiveMQ/RabbitMQ), new services (AWS Config, ACM Private CA, Route 53 Resolver), CodeBuild buildspec execution in Docker, and configurable Bedrock upstream inference with streaming.

<sup>Written for commit 3814fdfbe40268f7867d2012753d3b02fa5488c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

