### PR TITLE
fix(release): publish fakecloud-codebuild after its secretsmanager/ssm deps (topo order)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,6 @@ jobs:
           publish fakecloud-s3tables          # only core/persistence/aws deps
           publish fakecloud-lakeformation     # only core/persistence/aws deps
           publish fakecloud-codeconnections   # only core/persistence/aws deps
-          publish fakecloud-codebuild         # only core/persistence/aws deps
           publish fakecloud-codecommit        # only core/persistence/aws deps
           publish fakecloud-codedeploy        # only core/persistence/aws deps
           publish fakecloud-codepipeline      # only core/persistence/aws deps
@@ -254,6 +253,7 @@ jobs:
           publish fakecloud-s3             # depends on kms
           publish fakecloud-ecr            # depends on iam, kms
           publish fakecloud-ssm            # depends on secretsmanager
+          publish fakecloud-codebuild      # depends on secretsmanager, ssm, logs (real buildspec exec)
           publish fakecloud-apigateway     # depends on elbv2, wafv2
 
           # Layer 5: depend on layer 4


### PR DESCRIPTION
## Summary
The v0.40.0 publish run's `Publish Crates` job would fail at `fakecloud-codebuild` with `failed to select a version for the requirement fakecloud-secretsmanager = "^0.40.0"` — the CodeBuild real-buildspec-execution data plane (#2168) added crate deps on `fakecloud-secretsmanager`, `fakecloud-ssm`, and `fakecloud-logs`, but release.yml still listed `codebuild` in the early 'core/persistence/aws only' group, before those deps are published to crates.io.

Moves `publish fakecloud-codebuild` to after `fakecloud-ssm` (which itself follows `fakecloud-secretsmanager`), and corrects the stale dependency comment.

(v0.40.0 itself was backfilled to crates.io by publishing the remaining crates in dependency order from the tag; this fixes the ordering so the next tagged release publishes cleanly in one pass.)

## Test plan
- release.yml is only exercised on tag push; the fix is a pure reordering of the hand-maintained publish list to respect the actual crate dependency graph. Verified codebuild's fakecloud deps are core/persistence/logs/secretsmanager/ssm and all now precede it in the list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes release workflow ordering so `fakecloud-codebuild` is published after its deps `fakecloud-secretsmanager`, `fakecloud-ssm`, and `fakecloud-logs`, preventing `cargo publish` failures and letting tagged releases complete in one pass. Also updates the stale dependency comment.

<sup>Written for commit 197a0b60d5768be2099a7218e1e1c9f9a91bf55c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

