### PR TITLE
fix(bedrock): maxTokens overflow, forced-tool reply, honest embeddings (bug-hunt)

### DIFF
--- a/crates/fakecloud-bedrock/src/converse.rs
+++ b/crates/fakecloud-bedrock/src/converse.rs
@@ -52,47 +52,48 @@ pub(crate) fn converse(
         }
     };
 
-    // Respect maxTokens by truncating (rough approximation: 1 token ~= 4 chars)
-    let truncated_text = if max_tokens < u64::MAX {
-        let char_limit = (max_tokens as usize) * 4;
+    // Respect maxTokens by truncating (rough approximation: 1 token ~= 4 chars).
+    // `saturating_mul` keeps a hostile `maxTokens` (e.g. `u64::MAX - 1` sent
+    // over raw HTTP) from overflowing `usize` — a debug-build panic (dropped
+    // connection / 500) or a release-build wrap to a tiny garbage limit.
+    let (truncated_text, truncated) = if max_tokens < u64::MAX {
+        let char_limit = (max_tokens as usize).saturating_mul(4);
         if response_text.chars().count() > char_limit {
-            response_text.chars().take(char_limit).collect::<String>()
+            (
+                response_text.chars().take(char_limit).collect::<String>(),
+                true,
+            )
         } else {
-            response_text
+            (response_text, false)
         }
     } else {
-        response_text
+        (response_text, false)
     };
 
     // Build content blocks
     let mut content = vec![json!({"text": truncated_text})];
 
-    // If toolConfig is provided with tools, include a toolUse block
-    if let Some(tc) = tool_config {
-        if let Some(tools) = tc["tools"].as_array() {
-            if let Some(first_tool) = tools.first() {
-                if let Some(tool_spec) = first_tool.get("toolSpec") {
-                    let tool_name = tool_spec["name"].as_str().unwrap_or("tool");
-                    content.push(json!({
-                        "toolUse": {
-                            "toolUseId": "tooluse_fakecloud_01",
-                            "name": tool_name,
-                            "input": {}
-                        }
-                    }));
-                }
+    // Only emit a toolUse block when the caller's `toolChoice` actually
+    // requires one. A bare `toolConfig` (or `toolChoice:{auto:{}}`) leaves the
+    // decision to the model, and offline we choose a plain text reply — forcing
+    // an empty-arg tool call here derails LangChain / agent tool-loops.
+    let forced_tool = forced_tool_name(tool_config);
+    if let Some(tool_name) = &forced_tool {
+        content.push(json!({
+            "toolUse": {
+                "toolUseId": "tooluse_fakecloud_01",
+                "name": tool_name,
+                "input": {}
             }
-        }
+        }));
     }
 
-    let stop_reason = if tool_config.is_some()
-        && content.len() > 1
-        && content
-            .last()
-            .map(|c| c.get("toolUse").is_some())
-            .unwrap_or(false)
-    {
+    let stop_reason = if forced_tool.is_some() {
         "tool_use"
+    } else if truncated {
+        // Report the real reason the reply ended so tool/agent loops see the
+        // truncation, matching the upstream path's `normalize_stop`.
+        "max_tokens"
     } else {
         "end_turn"
     };
@@ -134,6 +135,43 @@ pub(crate) fn converse(
     }
 
     Ok(AwsResponse::json(StatusCode::OK, response_str))
+}
+
+/// Resolve the tool the caller *forced* the model to call via the Converse
+/// `toolConfig.toolChoice`, if any.
+///
+/// Bedrock's `toolChoice` is one of `{auto:{}}`, `{any:{}}` or
+/// `{tool:{name:...}}`. Only `any` (call some tool) and `tool` (call this
+/// specific tool) force a tool call; `auto` — and an absent `toolChoice` —
+/// let the model decide, which offline means a normal text reply. Returns the
+/// tool name to invoke, or `None` when no tool is forced or no tools are
+/// available. Shared by `Converse` and `ConverseStream` so both agree.
+pub(crate) fn forced_tool_name(tool_config: Option<&Value>) -> Option<String> {
+    let tc = tool_config?;
+    let tools = tc.get("tools").and_then(|t| t.as_array())?;
+    match tc.get("toolChoice") {
+        // Force a specific named tool.
+        Some(choice) if choice.get("tool").is_some() => {
+            if let Some(name) = choice["tool"]["name"].as_str() {
+                return Some(name.to_string());
+            }
+            // Malformed `{tool:{}}` with no name: fall back to the first tool.
+            first_tool_name(tools)
+        }
+        // Force any tool: pick the first advertised one.
+        Some(choice) if choice.get("any").is_some() => first_tool_name(tools),
+        // `auto` or absent: the model decides; offline we reply with text.
+        _ => None,
+    }
+}
+
+fn first_tool_name(tools: &[Value]) -> Option<String> {
+    tools
+        .first()?
+        .get("toolSpec")?
+        .get("name")?
+        .as_str()
+        .map(|s| s.to_string())
 }
 
 fn estimate_tokens(input: &Value) -> u64 {
@@ -253,7 +291,9 @@ mod tests {
     }
 
     #[test]
-    fn converse_tool_config_adds_tool_use_block_and_stop_reason() {
+    fn converse_tool_config_without_choice_does_not_force_tool() {
+        // A bare toolConfig (no toolChoice / implicit "auto") must NOT emit a
+        // spurious empty-arg toolUse — that used to break agent tool-loops.
         let s = shared();
         let body = br#"{
             "messages": [],
@@ -262,10 +302,110 @@ mod tests {
         let resp = converse(&s, &req(), "m", body).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["stopReason"], "end_turn");
+        let content = v["output"]["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert!(content[0].get("toolUse").is_none());
+    }
+
+    #[test]
+    fn converse_tool_choice_any_forces_first_tool() {
+        let s = shared();
+        let body = br#"{
+            "messages": [],
+            "toolConfig": {
+                "tools": [{"toolSpec": {"name": "calculator"}}],
+                "toolChoice": {"any": {}}
+            }
+        }"#;
+        let resp = converse(&s, &req(), "m", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["stopReason"], "tool_use");
         let content = v["output"]["message"]["content"].as_array().unwrap();
         assert_eq!(content.len(), 2);
         assert_eq!(content[1]["toolUse"]["name"], "calculator");
+    }
+
+    #[test]
+    fn converse_tool_choice_named_tool_is_honored() {
+        let s = shared();
+        let body = br#"{
+            "messages": [],
+            "toolConfig": {
+                "tools": [
+                    {"toolSpec": {"name": "calculator"}},
+                    {"toolSpec": {"name": "weather"}}
+                ],
+                "toolChoice": {"tool": {"name": "weather"}}
+            }
+        }"#;
+        let resp = converse(&s, &req(), "m", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        assert_eq!(v["stopReason"], "tool_use");
+        assert_eq!(
+            v["output"]["message"]["content"][1]["toolUse"]["name"],
+            "weather"
+        );
+    }
+
+    #[test]
+    fn converse_huge_max_tokens_does_not_overflow() {
+        // maxTokens just below u64::MAX would overflow `(x as usize) * 4`;
+        // saturating arithmetic must keep this a normal, un-truncated reply.
+        let s = shared();
+        let body = format!(
+            r#"{{"messages":[],"inferenceConfig":{{"maxTokens":{}}}}}"#,
+            u64::MAX - 1
+        );
+        let resp = converse(&s, &req(), "m", body.as_bytes()).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        // No truncation happened, so it's a normal end_turn reply.
+        assert_eq!(v["stopReason"], "end_turn");
+        assert!(!v["output"]["message"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn converse_reports_max_tokens_stop_reason_on_truncation() {
+        let s = shared();
+        let body = br#"{"messages":[], "inferenceConfig": {"maxTokens": 1}}"#;
+        let resp = converse(&s, &req(), "m", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        // The canned reply is longer than 1*4 chars, so it was truncated.
+        assert_eq!(v["stopReason"], "max_tokens");
+        let text = v["output"]["message"]["content"][0]["text"]
+            .as_str()
+            .unwrap();
+        assert!(text.chars().count() <= 4);
+    }
+
+    #[test]
+    fn forced_tool_name_respects_tool_choice() {
+        let cfg = json!({
+            "tools": [{"toolSpec": {"name": "a"}}, {"toolSpec": {"name": "b"}}]
+        });
+        // No toolChoice -> not forced.
+        assert_eq!(forced_tool_name(Some(&cfg)), None);
+        // auto -> not forced.
+        let mut auto = cfg.clone();
+        auto["toolChoice"] = json!({"auto": {}});
+        assert_eq!(forced_tool_name(Some(&auto)), None);
+        // any -> first tool.
+        let mut any = cfg.clone();
+        any["toolChoice"] = json!({"any": {}});
+        assert_eq!(forced_tool_name(Some(&any)), Some("a".to_string()));
+        // named tool -> that tool.
+        let mut named = cfg.clone();
+        named["toolChoice"] = json!({"tool": {"name": "b"}});
+        assert_eq!(forced_tool_name(Some(&named)), Some("b".to_string()));
+        // No config at all -> None.
+        assert_eq!(forced_tool_name(None), None);
     }
 
     #[test]

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -1767,11 +1767,44 @@ impl AwsService for BedrockService {
                 }
                 let response_text =
                     crate::streaming::get_response_text(&self.state, &req, &model_id, &req.body);
+                // Apply the same inferenceConfig / toolChoice semantics as the
+                // non-streaming Converse path so the two agree for identical
+                // input: honour maxTokens truncation, only force a tool when
+                // toolChoice requires it, and report the matching stopReason.
+                let input: serde_json::Value =
+                    serde_json::from_slice(&req.body).unwrap_or_default();
+                let max_tokens = input
+                    .get("inferenceConfig")
+                    .and_then(|c| c["maxTokens"].as_u64())
+                    .unwrap_or(u64::MAX);
+                let (response_text, truncated) = if max_tokens < u64::MAX {
+                    let char_limit = (max_tokens as usize).saturating_mul(4);
+                    if response_text.chars().count() > char_limit {
+                        (
+                            response_text.chars().take(char_limit).collect::<String>(),
+                            true,
+                        )
+                    } else {
+                        (response_text, false)
+                    }
+                } else {
+                    (response_text, false)
+                };
+                let forced_tool = crate::converse::forced_tool_name(input.get("toolConfig"));
+                let stop_reason = if forced_tool.is_some() {
+                    "tool_use"
+                } else if truncated {
+                    "max_tokens"
+                } else {
+                    "end_turn"
+                };
                 let prompt = crate::prompt::extract_prompt_text(&model_id, &req.body);
                 let input_tokens = crate::prompt::count_tokens(&prompt);
                 let output_tokens = crate::prompt::count_tokens(&response_text);
                 let body = crate::streaming::build_converse_stream_response(
                     &response_text,
+                    stop_reason,
+                    forced_tool.as_deref(),
                     input_tokens,
                     output_tokens,
                 );

--- a/crates/fakecloud-bedrock/src/service_tests.rs
+++ b/crates/fakecloud-bedrock/src/service_tests.rs
@@ -736,10 +736,12 @@ async fn converse_with_tool_config() {
     let state = make_state();
     let svc = BedrockService::new(state);
 
+    // toolChoice `any` forces the model to call a tool.
     let body = serde_json::json!({
         "messages": [{"role": "user", "content": [{"text": "Use the tool"}]}],
         "toolConfig": {
-            "tools": [{"toolSpec": {"name": "calculator", "description": "calc"}}]
+            "tools": [{"toolSpec": {"name": "calculator", "description": "calc"}}],
+            "toolChoice": {"any": {}}
         },
     });
     let req = make_request(
@@ -752,6 +754,31 @@ async fn converse_with_tool_config() {
     assert_eq!(b["stopReason"], "tool_use");
     let content = b["output"]["message"]["content"].as_array().unwrap();
     assert!(content.iter().any(|c| c.get("toolUse").is_some()));
+}
+
+#[tokio::test]
+async fn converse_with_tool_config_without_choice_does_not_force_tool() {
+    // A bare toolConfig (no toolChoice) must not push a spurious empty-arg
+    // toolUse — that used to derail agent tool-loops.
+    let state = make_state();
+    let svc = BedrockService::new(state);
+
+    let body = serde_json::json!({
+        "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+        "toolConfig": {
+            "tools": [{"toolSpec": {"name": "calculator", "description": "calc"}}]
+        },
+    });
+    let req = make_request(
+        Method::POST,
+        "/model/anthropic.claude-v2/converse",
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let b = body_json(&resp);
+    assert_eq!(b["stopReason"], "end_turn");
+    let content = b["output"]["message"]["content"].as_array().unwrap();
+    assert!(content.iter().all(|c| c.get("toolUse").is_none()));
 }
 
 // ── CountTokens ──
@@ -893,6 +920,62 @@ async fn converse_stream() {
     let resp = svc.handle(req).await.unwrap();
     assert_eq!(resp.content_type, "application/vnd.amazon.eventstream");
     assert!(!resp.body.expect_bytes().is_empty());
+}
+
+#[tokio::test]
+async fn converse_stream_matches_converse_for_forced_tool() {
+    // Converse and ConverseStream must agree for identical input: a forced
+    // toolChoice yields a tool call in both; a bare toolConfig yields neither.
+    let state = make_state();
+    let svc = BedrockService::new(state);
+
+    let forced = serde_json::json!({
+        "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+        "toolConfig": {
+            "tools": [{"toolSpec": {"name": "calculator"}}],
+            "toolChoice": {"any": {}}
+        },
+    });
+    let req = make_request(
+        Method::POST,
+        "/model/anthropic.claude-v2/converse-stream",
+        &forced.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let bytes = resp.body.expect_bytes();
+    let s = String::from_utf8_lossy(bytes);
+    assert!(
+        s.contains("tool_use"),
+        "forced stream should stop with tool_use"
+    );
+    assert!(
+        s.contains("calculator"),
+        "forced stream should name the tool"
+    );
+
+    // Bare toolConfig (no toolChoice): no tool, ends with end_turn.
+    let bare = serde_json::json!({
+        "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+        "toolConfig": {
+            "tools": [{"toolSpec": {"name": "calculator"}}]
+        },
+    });
+    let req = make_request(
+        Method::POST,
+        "/model/anthropic.claude-v2/converse-stream",
+        &bare.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let bytes = resp.body.expect_bytes();
+    let s = String::from_utf8_lossy(bytes);
+    assert!(
+        s.contains("end_turn"),
+        "bare stream should end with end_turn"
+    );
+    assert!(
+        !s.contains("toolUse"),
+        "bare stream must not emit a toolUse block"
+    );
 }
 
 // ── Unknown route ──

--- a/crates/fakecloud-bedrock/src/streaming.rs
+++ b/crates/fakecloud-bedrock/src/streaming.rs
@@ -121,8 +121,16 @@ pub(crate) fn build_invoke_stream_response(model_id: &str, response_text: &str) 
 /// `input_tokens` and `output_tokens` are surfaced verbatim in the
 /// terminating `metadata` event so callers see real, prompt-derived
 /// usage figures instead of the historical 10/20 placeholder.
+///
+/// `stop_reason` and `forced_tool` are computed by the handler from the same
+/// inference config / `toolChoice` the non-streaming `Converse` path reads, so
+/// both operations return a consistent shape for identical input. When
+/// `forced_tool` is set, a second `toolUse` content block is streamed after
+/// the text block and `stop_reason` is `tool_use`.
 pub(crate) fn build_converse_stream_response(
     response_text: &str,
+    stop_reason: &str,
+    forced_tool: Option<&str>,
     input_tokens: u64,
     output_tokens: u64,
 ) -> Vec<u8> {
@@ -134,7 +142,7 @@ pub(crate) fn build_converse_stream_response(
         .expect("serde_json::Value serialization is infallible");
     body.extend(encode_event("messageStart", "application/json", &payload));
 
-    // contentBlockStart event
+    // Text content block (index 0).
     let block_start = json!({ "contentBlockIndex": 0, "start": {} });
     let payload = serde_json::to_vec(&json!({ "contentBlockStart": block_start }))
         .expect("serde_json::Value serialization is infallible");
@@ -169,9 +177,45 @@ pub(crate) fn build_converse_stream_response(
         &payload,
     ));
 
+    // Optional forced toolUse content block (index 1), mirroring Converse.
+    if let Some(tool_name) = forced_tool {
+        let tool_start = json!({
+            "contentBlockIndex": 1,
+            "start": { "toolUse": { "toolUseId": "tooluse_fakecloud_01", "name": tool_name } }
+        });
+        let payload = serde_json::to_vec(&json!({ "contentBlockStart": tool_start }))
+            .expect("serde_json::Value serialization is infallible");
+        body.extend(encode_event(
+            "contentBlockStart",
+            "application/json",
+            &payload,
+        ));
+
+        let tool_delta = json!({
+            "contentBlockIndex": 1,
+            "delta": { "toolUse": { "input": "{}" } }
+        });
+        let payload = serde_json::to_vec(&json!({ "contentBlockDelta": tool_delta }))
+            .expect("serde_json::Value serialization is infallible");
+        body.extend(encode_event(
+            "contentBlockDelta",
+            "application/json",
+            &payload,
+        ));
+
+        let tool_stop = json!({ "contentBlockIndex": 1 });
+        let payload = serde_json::to_vec(&json!({ "contentBlockStop": tool_stop }))
+            .expect("serde_json::Value serialization is infallible");
+        body.extend(encode_event(
+            "contentBlockStop",
+            "application/json",
+            &payload,
+        ));
+    }
+
     // messageStop event
     let stop = json!({
-        "stopReason": "end_turn"
+        "stopReason": stop_reason
     });
     let payload = serde_json::to_vec(&json!({ "messageStop": stop }))
         .expect("serde_json::Value serialization is infallible");
@@ -570,7 +614,7 @@ mod tests {
 
     #[test]
     fn build_converse_stream_emits_all_events() {
-        let out = build_converse_stream_response("hello world", 5, 7);
+        let out = build_converse_stream_response("hello world", "end_turn", None, 5, 7);
         let s = String::from_utf8_lossy(&out);
         for marker in [
             "messageStart",
@@ -587,6 +631,18 @@ mod tests {
         assert!(s.contains("\"inputTokens\":5"));
         assert!(s.contains("\"outputTokens\":7"));
         assert!(s.contains("\"totalTokens\":12"));
+    }
+
+    #[test]
+    fn build_converse_stream_emits_forced_tool_block() {
+        let out = build_converse_stream_response("", "tool_use", Some("calculator"), 3, 0);
+        let s = String::from_utf8_lossy(&out);
+        // A second (index 1) toolUse content block is streamed and the message
+        // stops with tool_use — matching non-streaming Converse.
+        assert!(s.contains("\"contentBlockIndex\":1"));
+        assert!(s.contains("calculator"));
+        assert!(s.contains("tooluse_fakecloud_01"));
+        assert!(s.contains("tool_use"));
     }
 
     #[test]
@@ -702,7 +758,7 @@ mod tests {
 
     #[test]
     fn build_converse_stream_response_emits_dynamic_token_counts() {
-        let out = build_converse_stream_response("text", 42, 7);
+        let out = build_converse_stream_response("text", "end_turn", None, 42, 7);
         let s = String::from_utf8_lossy(&out);
         assert!(s.contains("\"inputTokens\":42"));
         assert!(s.contains("\"outputTokens\":7"));

--- a/crates/fakecloud-bedrock/src/upstream.rs
+++ b/crates/fakecloud-bedrock/src/upstream.rs
@@ -1115,11 +1115,11 @@ async fn call_chat_stream(
 // ---------------------------------------------------------------------------
 
 fn is_embedding_model(model_id: &str) -> bool {
-    model_id.starts_with("amazon.titan-embed") || model_id.starts_with("cohere.embed")
-}
-
-fn deterministic_embedding(dim: usize) -> Vec<f64> {
-    (0..dim).map(|i| (i as f64 * 0.001).sin()).collect()
+    // Strip any `us.` / `eu.` / cross-region inference-profile prefix first so
+    // `us.amazon.titan-embed-text-v2` still routes to the embeddings path
+    // instead of misrouting through chat.
+    let id = strip_region_prefix(model_id);
+    id.starts_with("amazon.titan-embed") || id.starts_with("cohere.embed")
 }
 
 fn build_embedding_response(
@@ -1128,7 +1128,7 @@ fn build_embedding_response(
     input_tokens: u64,
     text: &str,
 ) -> String {
-    let value = if model_id.starts_with("cohere.") {
+    let value = if strip_region_prefix(model_id).starts_with("cohere.") {
         json!({
             "embeddings": [embedding],
             "id": "fakecloud-upstream-embed",
@@ -1144,21 +1144,6 @@ fn build_embedding_response(
     serde_json::to_string(&value).expect("serde_json::Value serialization is infallible")
 }
 
-/// Deterministic offline embedding body, used both as the no-upstream
-/// default and when the configured protocol can't do embeddings.
-fn deterministic_embedding_response(model_id: &str, input_tokens: u64, text: &str) -> String {
-    let dim = if model_id.starts_with("cohere.") {
-        1024
-    } else {
-        256
-    };
-    let emb: Vec<Value> = deterministic_embedding(dim)
-        .into_iter()
-        .map(|f| json!(f))
-        .collect();
-    build_embedding_response(model_id, emb, input_tokens, text)
-}
-
 /// Returns `(response_body, input_tokens, output_tokens)`. Embeddings have
 /// no generated output tokens, so `output_tokens` is always `0`.
 async fn invoke_embedding_upstream(
@@ -1171,13 +1156,14 @@ async fn invoke_embedding_upstream(
     let embed_model = cfg.resolve_embed_model(model_id);
 
     match cfg.protocol {
-        // The Anthropic Messages protocol has no embeddings endpoint;
-        // fall back to the deterministic vector.
-        Protocol::Anthropic => Ok((
-            deterministic_embedding_response(model_id, fallback_tokens, &text),
-            fallback_tokens,
-            0,
-        )),
+        // The Anthropic Messages protocol has no embeddings endpoint. Rather
+        // than fabricate a vector (the real-inference path must never invent
+        // data), surface an honest error so callers know the configured
+        // upstream can't serve this embedding model.
+        Protocol::Anthropic => Err(model_error(format!(
+            "embedding model {model_id} is not supported by the configured \
+             anthropic upstream protocol (no embeddings endpoint)"
+        ))),
         Protocol::OpenAi => {
             let client = http_client();
             let body = json!({ "model": embed_model, "input": text });
@@ -1845,16 +1831,23 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn embedding_anthropic_protocol_falls_back_to_deterministic_vector() {
+    async fn embedding_anthropic_protocol_returns_honest_error() {
+        // The anthropic Messages protocol has no embeddings endpoint. Rather
+        // than fabricate a vector, the real-inference path must surface an
+        // honest error. No server is needed: the error is raised before any
+        // HTTP call.
         let c = cfg("http://127.0.0.1:1".to_string(), Protocol::Anthropic);
         let s = shared();
         let body = br#"{"inputText":"embed me"}"#;
-        let resp = invoke_model_upstream(&s, &req(), "amazon.titan-embed-text-v1", body, &c)
+        let err = invoke_model_upstream(&s, &req(), "amazon.titan-embed-text-v1", body, &c)
             .await
-            .unwrap();
-        let v: Value = serde_json::from_slice(&body_bytes(&resp)).unwrap();
-        assert!(v["embedding"].is_array());
-        assert_eq!(v["embedding"].as_array().unwrap().len(), 256);
+            .err()
+            .expect("anthropic embeddings should error, not fabricate a vector");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("not supported") || msg.contains("embeddings"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]
@@ -2146,5 +2139,43 @@ mod tests {
             strip_region_prefix("anthropic.claude-3"),
             "anthropic.claude-3"
         );
+    }
+
+    #[test]
+    fn is_embedding_model_strips_region_prefix() {
+        // Bare embedding ids.
+        assert!(is_embedding_model("amazon.titan-embed-text-v2:0"));
+        assert!(is_embedding_model("cohere.embed-english-v3"));
+        // Cross-region inference-profile prefixes must still route to embeddings.
+        assert!(is_embedding_model("us.amazon.titan-embed-text-v2:0"));
+        assert!(is_embedding_model("eu.cohere.embed-multilingual-v3"));
+        // Chat models are not embedding models.
+        assert!(!is_embedding_model("anthropic.claude-3"));
+        assert!(!is_embedding_model("us.amazon.titan-text-express-v1"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn region_prefixed_embedding_routes_to_embeddings_upstream() {
+        // A region-prefixed titan-embed id must hit the /v1/embeddings path,
+        // not the chat completions path.
+        let app = Router::new().route(
+            "/v1/embeddings",
+            post(|| async {
+                axum::Json(json!({
+                    "data": [{ "embedding": [0.1, 0.2, 0.3] }],
+                    "usage": { "prompt_tokens": 4 }
+                }))
+            }),
+        );
+        let url = spawn(app).await;
+        let c = cfg(url, Protocol::OpenAi);
+        let s = shared();
+        let body = br#"{"inputText":"embed me"}"#;
+        let resp = invoke_model_upstream(&s, &req(), "us.amazon.titan-embed-text-v2:0", body, &c)
+            .await
+            .expect("region-prefixed embed model should route to embeddings");
+        let v: Value = serde_json::from_slice(&body_bytes(&resp)).unwrap();
+        assert_eq!(v["embedding"], json!([0.1, 0.2, 0.3]));
+        assert_eq!(v["inputTextTokenCount"], 4);
     }
 }

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -1084,6 +1084,10 @@ async fn bedrock_converse_with_tool_config() {
     let server = TestServer::start().await;
     let http_client = reqwest::Client::new();
 
+    // A bare toolConfig (no toolChoice / implicit "auto") lets the model
+    // decide whether to call a tool. Offline we reply with plain text and
+    // must NOT fabricate an empty-arg toolUse — that used to derail agent /
+    // LangChain tool-loops.
     let body = serde_json::json!({
         "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
         "messages": [
@@ -1121,14 +1125,68 @@ async fn bedrock_converse_with_tool_config() {
 
     assert_eq!(resp.status(), 200);
     let result: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(result["stopReason"], "end_turn");
+
+    let content = result["output"]["message"]["content"].as_array().unwrap();
+    assert!(
+        content.iter().all(|c| c.get("toolUse").is_none()),
+        "bare toolConfig must not emit a toolUse block"
+    );
+}
+
+#[tokio::test]
+async fn bedrock_converse_with_forced_tool_choice() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    // toolChoice `any` forces the model to call a tool.
+    let body = serde_json::json!({
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "messages": [
+            {"role": "user", "content": [{"text": "What's the weather?"}]}
+        ],
+        "toolConfig": {
+            "tools": [
+                {
+                    "toolSpec": {
+                        "name": "get_weather",
+                        "description": "Get weather for a location",
+                        "inputSchema": {
+                            "json": {"type": "object", "properties": {}}
+                        }
+                    }
+                }
+            ],
+            "toolChoice": {"any": {}}
+        }
+    });
+
+    let resp = http_client
+        .post(format!(
+            "{}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let result: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(result["stopReason"], "tool_use");
 
     let content = result["output"]["message"]["content"].as_array().unwrap();
     assert!(content.len() >= 2, "should have text and tool_use blocks");
-    assert!(
-        content.iter().any(|c| c.get("toolUse").is_some()),
-        "should have a toolUse block"
-    );
+    let tool_use = content
+        .iter()
+        .find_map(|c| c.get("toolUse"))
+        .expect("should have a toolUse block");
+    assert_eq!(tool_use["name"], "get_weather");
 }
 
 // CountTokens (Runtime)


### PR DESCRIPTION
## Summary
Fixes real defects found auditing the new real-inference Bedrock surface.

- **maxTokens overflow (MEDIUM)**: `(max_tokens as usize) * 4` -> `saturating_mul(4)` in offline Converse + ConverseStream; a near-`u64::MAX` maxTokens over raw HTTP no longer panics (debug) / wraps to garbage (release).
- **Forced-tool reply (MEDIUM)**: offline Converse only emits a `toolUse` block when `toolChoice` is `{any}`/`{tool}`; a bare `toolConfig` or `{auto}` yields a normal text `end_turn` reply. Converse and ConverseStream now agree for identical input (previously ConverseStream never emitted a tool block). Stops spurious empty-arg tool calls that derail LangChain/agent loops.
- **stopReason (LOW)**: offline paths report `max_tokens` (not `end_turn`) when truncated, matching the upstream `normalize_stop`.
- **Honest embeddings (LOW)**: anthropic upstream protocol returns `ModelErrorException` for embedding models instead of fabricated `sin()` vectors (removed dead deterministic-embedding helpers).
- **Region-prefix routing**: `is_embedding_model` strips the region/inference-profile prefix so `us.amazon.titan-embed-*` routes to embeddings, not chat.

## Test plan
Added Converse/ConverseStream consistency, overflow-bound, stopReason, toolChoice-honoring, anthropic-embedding-error, and region-prefix routing tests. `cargo fmt` / `clippy -p fakecloud-bedrock --all-targets -D warnings` / `build` / `test` (387 passed) all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several Bedrock defects: safe `maxTokens`, correct `toolChoice` handling, accurate `stopReason`, honest embedding errors, and proper routing for region‑prefixed embeddings. Prevents overflows and spurious tool calls, and makes stream and non‑stream responses consistent.

- **Bug Fixes**
  - Guard `maxTokens` with `saturating_mul(4)` in Converse and stream to avoid overflow.
  - Honor `toolChoice`: emit `toolUse` only for `{any}` or `{tool}`; `{auto}`/absent yields text. ConverseStream mirrors Converse and streams a `toolUse` block when forced.
  - Report `stopReason: "max_tokens"` on truncation (was `end_turn`) in both paths.
  - Embeddings over Anthropic protocol now return a model error (no fabricated vectors).
  - Strip region/profile prefix before embed detection so `us.amazon.titan-embed-*` routes to embeddings, not chat.

- **Migration**
  - If using embedding models with an Anthropic upstream, handle the error response instead of expecting an embedding vector.

<sup>Written for commit 1bc79869bb9713bed15c62395f79be620ae4327e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

