### PR TITLE
fix(codebuild): SECRETS_MANAGER ARN resolution, host networking, spawn_blocking, orphan sweep (bug-hunt)

### DIFF
--- a/crates/fakecloud-codebuild/src/runtime.rs
+++ b/crates/fakecloud-codebuild/src/runtime.rs
@@ -81,6 +81,11 @@ fn env_truthy(name: &str) -> bool {
 /// the deterministic settle path.
 pub struct CodeBuildBackend {
     cli: String,
+    /// Container-to-host networking (add-host injection + the alias a build
+    /// uses to reach the fakecloud endpoint), resolved once per the shared
+    /// helper so a buildspec that calls back to fakecloud works and so
+    /// `FAKECLOUD_IN_CONTAINER` sibling-host resolution matches Lambda/ECS.
+    host_net: fakecloud_core::container_net::HostNetworking,
 }
 
 impl CodeBuildBackend {
@@ -94,13 +99,37 @@ impl CodeBuildBackend {
             return None;
         }
         let cli = fakecloud_core::container_net::detect_container_cli()?;
+        let host_net = fakecloud_core::container_net::HostNetworking::detect(&cli);
         tracing::info!(%cli, "CodeBuild real build backend enabled");
-        Some(Arc::new(Self { cli }))
+        Some(Arc::new(Self { cli, host_net }))
     }
 
     /// The resolved container CLI (`docker`/`podman`).
     pub fn cli(&self) -> &str {
         &self.cli
+    }
+
+    /// Resolved container-to-host networking for this backend.
+    pub fn host_net(&self) -> &fakecloud_core::container_net::HostNetworking {
+        &self.host_net
+    }
+}
+
+/// Rewrite `localhost`/`127.0.0.1` in the host portion of `http(s)://` URLs in
+/// build env values to `target_host`, so a buildspec that calls back to the
+/// fakecloud endpoint reaches the host from inside the build container. Mirrors
+/// Lambda's `rewrite_localhost_envs`; other occurrences of "localhost" pass
+/// through unchanged.
+fn rewrite_localhost_env(env: &mut [(String, String)], target_host: &str) {
+    if target_host == "127.0.0.1" || target_host == "localhost" {
+        return;
+    }
+    for (_k, v) in env.iter_mut() {
+        *v = v
+            .replace("http://127.0.0.1:", &format!("http://{target_host}:"))
+            .replace("https://127.0.0.1:", &format!("https://{target_host}:"))
+            .replace("http://localhost:", &format!("http://{target_host}:"))
+            .replace("https://localhost:", &format!("https://{target_host}:"));
     }
 }
 
@@ -183,6 +212,58 @@ pub async fn kill_container(cli: &str, container_id: &str) {
         .args(["rm", "-f", container_id])
         .output()
         .await;
+}
+
+/// The `fakecloud-instance` label value for the current process. Build
+/// containers are tagged with it so the restart sweep can tell its own live
+/// containers apart from a previous (crashed) process's leaked ones.
+fn current_instance_label() -> String {
+    format!("fakecloud-{}", std::process::id())
+}
+
+/// Remove build containers leaked by a previous fakecloud process. On a hard
+/// restart (SIGKILL, OOM, `docker kill` of the server) the detached `sleep`
+/// build containers survive: `reconcile_builds` flips the persisted
+/// `IN_PROGRESS` builds to `FAILED`, but nothing reaps the containers, so the
+/// daemon slowly leaks them. Sweep every container tagged `fakecloud-codebuild`
+/// whose `fakecloud-instance` label is not the current process. Best-effort:
+/// any daemon error is ignored (the backend stays usable). Containers owned by
+/// the live process are left untouched so a concurrent build is never killed.
+pub async fn sweep_orphan_containers(cli: &str) {
+    let current = current_instance_label();
+    let out = Command::new(cli)
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            "label=fakecloud-codebuild",
+            "--format",
+            "{{.ID}} {{.Label \"fakecloud-instance\"}}",
+        ])
+        .output()
+        .await;
+    let out = match out {
+        Ok(o) if o.status.success() => o,
+        _ => return,
+    };
+    let listing = String::from_utf8_lossy(&out.stdout);
+    let mut orphans: Vec<String> = Vec::new();
+    for line in listing.lines() {
+        let mut parts = line.split_whitespace();
+        let Some(id) = parts.next() else {
+            continue;
+        };
+        let instance = parts.next().unwrap_or("");
+        if instance != current {
+            orphans.push(id.to_string());
+        }
+    }
+    for id in &orphans {
+        kill_container(cli, id).await;
+    }
+    if !orphans.is_empty() {
+        tracing::info!(count = orphans.len(), "swept orphaned codebuild containers");
+    }
 }
 
 /// Blocking container removal for the Drop-guard cleanup path (no async runtime
@@ -797,6 +878,9 @@ pub async fn run_build(job: BuildJob) {
     // Build-level env = base env + buildspec env.variables (buildspec wins).
     let mut env = job.base_env.clone();
     env.extend(spec.env_vars.iter().cloned());
+    // Rewrite localhost/127.0.0.1 endpoints so a buildspec that calls back to
+    // fakecloud reaches the host from inside the build container.
+    rewrite_localhost_env(&mut env, &job.backend.host_net.host_alias);
 
     // Run ALL phases in ONE continuous shell so cd/export persist across phases.
     let script = build_script(&spec);
@@ -978,10 +1062,15 @@ async fn start_container(
         .arg("--label")
         .arg(format!("fakecloud-codebuild={}", job.project_name))
         .arg("--label")
-        .arg(format!(
-            "fakecloud-instance=fakecloud-{}",
-            std::process::id()
-        ));
+        .arg(format!("fakecloud-instance={}", current_instance_label()));
+    // Wire container-to-host networking so a buildspec can reach the fakecloud
+    // endpoint at `host.docker.internal`/`host.containers.internal` (no-op for
+    // podman, which provides the alias natively).
+    let mut add_host_args: Vec<String> = Vec::new();
+    job.backend.host_net.push_add_host_args(&mut add_host_args);
+    for arg in &add_host_args {
+        cmd.arg(arg);
+    }
     // Override the entrypoint so an image with its own ENTRYPOINT still just
     // sleeps; size the sleep to the build timeout (plus a teardown buffer) so a
     // long build's container never exits mid-run (AWS allows up to 8h).
@@ -1193,27 +1282,41 @@ async fn upload_artifacts(
         ));
     }
 
-    let matched = match_artifact_files(tmp.path(), &spec.artifacts_files)
-        .map_err(|e| format!("failed to enumerate artifacts: {e}"))?;
-    if matched.is_empty() {
-        return Err(format!(
-            "no matching artifact files for patterns {:?}",
-            spec.artifacts_files
-        ));
-    }
-
-    // Read each matched file's bytes.
-    let mut collected: Vec<(String, Vec<u8>)> = Vec::new();
-    for rel in &matched {
-        let bytes = std::fs::read(tmp.path().join(rel))
-            .map_err(|e| format!("failed to read artifact {rel}: {e}"))?;
-        let stored = if spec.artifacts_discard_paths {
-            rel.rsplit('/').next().unwrap_or(rel).to_string()
+    // Enumerate, read, and (for ZIP packaging) compress artifacts off the async
+    // runtime: `match_artifact_files`, `std::fs::read`, and `zip_files` are all
+    // blocking std::fs / CPU work that must not stall the Tokio worker thread.
+    let patterns = spec.artifacts_files.clone();
+    let discard_paths = spec.artifacts_discard_paths;
+    let want_zip = packaging.eq_ignore_ascii_case("ZIP");
+    let payload = tokio::task::spawn_blocking(move || -> Result<ArtifactPayload, String> {
+        let matched = match_artifact_files(tmp.path(), &patterns)
+            .map_err(|e| format!("failed to enumerate artifacts: {e}"))?;
+        if matched.is_empty() {
+            return Err(format!(
+                "no matching artifact files for patterns {patterns:?}"
+            ));
+        }
+        let mut collected: Vec<(String, Vec<u8>)> = Vec::new();
+        for rel in &matched {
+            let bytes = std::fs::read(tmp.path().join(rel))
+                .map_err(|e| format!("failed to read artifact {rel}: {e}"))?;
+            let stored = if discard_paths {
+                rel.rsplit('/').next().unwrap_or(rel).to_string()
+            } else {
+                rel.clone()
+            };
+            collected.push((stored, bytes));
+        }
+        if want_zip {
+            let zip_bytes =
+                zip_files(&collected).map_err(|e| format!("failed to zip artifacts: {e}"))?;
+            Ok(ArtifactPayload::Zip(zip_bytes))
         } else {
-            rel.clone()
-        };
-        collected.push((stored, bytes));
-    }
+            Ok(ArtifactPayload::Files(collected))
+        }
+    })
+    .await
+    .map_err(|e| format!("artifact staging task failed: {e}"))??;
 
     let prefix = match (art_path.is_empty(), art_name.is_empty()) {
         (true, true) => String::new(),
@@ -1223,38 +1326,47 @@ async fn upload_artifacts(
     };
 
     let mut written = 0usize;
-    if packaging.eq_ignore_ascii_case("ZIP") {
-        let zip_bytes =
-            zip_files(&collected).map_err(|e| format!("failed to zip artifacts: {e}"))?;
-        let key = if prefix.is_empty() {
-            format!("{art_name}.zip")
-        } else {
-            prefix.clone()
-        };
-        delivery
-            .put_object(
-                &job.account,
-                &bucket,
-                &key,
-                zip_bytes,
-                Some("application/zip"),
-            )
-            .map_err(|e| format!("failed to upload artifact zip: {e}"))?;
-        written += 1;
-    } else {
-        for (rel, bytes) in collected {
+    match payload {
+        ArtifactPayload::Zip(zip_bytes) => {
             let key = if prefix.is_empty() {
-                rel.clone()
+                format!("{art_name}.zip")
             } else {
-                format!("{prefix}/{rel}")
+                prefix.clone()
             };
             delivery
-                .put_object(&job.account, &bucket, &key, bytes, None)
-                .map_err(|e| format!("failed to upload artifact {rel}: {e}"))?;
+                .put_object(
+                    &job.account,
+                    &bucket,
+                    &key,
+                    zip_bytes,
+                    Some("application/zip"),
+                )
+                .map_err(|e| format!("failed to upload artifact zip: {e}"))?;
             written += 1;
+        }
+        ArtifactPayload::Files(collected) => {
+            for (rel, bytes) in collected {
+                let key = if prefix.is_empty() {
+                    rel.clone()
+                } else {
+                    format!("{prefix}/{rel}")
+                };
+                delivery
+                    .put_object(&job.account, &bucket, &key, bytes, None)
+                    .map_err(|e| format!("failed to upload artifact {rel}: {e}"))?;
+                written += 1;
+            }
         }
     }
     Ok(written)
+}
+
+/// Collected artifact bytes ready for S3 upload, produced on the blocking pool.
+enum ArtifactPayload {
+    /// A single zip archive (`packaging: ZIP`).
+    Zip(Vec<u8>),
+    /// Individual `(key-relative-path, bytes)` files (`packaging: NONE`).
+    Files(Vec<(String, Vec<u8>)>),
 }
 
 /// Recursively list files under `root` (relative, `/`-separated) and return
@@ -1496,5 +1608,43 @@ mod tests {
     #[test]
     fn disabled_env_recognized() {
         assert!(!env_truthy("FAKECLOUD_CODEBUILD_DISABLE_BACKEND_UNSET_XYZ"));
+    }
+
+    #[test]
+    fn rewrite_localhost_env_targets_only_urls() {
+        let mut env = vec![
+            (
+                "FAKECLOUD_ENDPOINT".to_string(),
+                "http://localhost:4566".to_string(),
+            ),
+            (
+                "AWS_URL".to_string(),
+                "https://127.0.0.1:4566/x".to_string(),
+            ),
+            ("MSG".to_string(), "connect to localhost later".to_string()),
+            ("EMPTY".to_string(), String::new()),
+        ];
+        rewrite_localhost_env(&mut env, "host.docker.internal");
+        assert_eq!(env[0].1, "http://host.docker.internal:4566");
+        assert_eq!(env[1].1, "https://host.docker.internal:4566/x");
+        // A bare "localhost" word outside an http(s):// URL is untouched.
+        assert_eq!(env[2].1, "connect to localhost later");
+        assert_eq!(env[3].1, "");
+    }
+
+    #[test]
+    fn rewrite_localhost_env_noop_on_host() {
+        // When fakecloud runs on the host the alias is 127.0.0.1: no rewrite.
+        let mut env = vec![("U".to_string(), "http://localhost:4566".to_string())];
+        rewrite_localhost_env(&mut env, "127.0.0.1");
+        assert_eq!(env[0].1, "http://localhost:4566");
+    }
+
+    #[test]
+    fn instance_label_is_process_scoped() {
+        assert_eq!(
+            current_instance_label(),
+            format!("fakecloud-{}", std::process::id())
+        );
     }
 }

--- a/crates/fakecloud-codebuild/src/service.rs
+++ b/crates/fakecloud-codebuild/src/service.rs
@@ -143,6 +143,18 @@ impl CodeBuildService {
     /// deterministic settle-on-read behavior unless they ask for the real one.
     pub fn with_backend_autodetect(mut self) -> Self {
         self.backend = CodeBuildBackend::detect();
+        // Reap build containers leaked by a previous (crashed) process. Runs in
+        // the background so startup is never blocked on a daemon call; guarded
+        // by a runtime check so embedders that call this off a Tokio runtime
+        // don't panic.
+        if let Some(backend) = &self.backend {
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                let cli = backend.cli().to_string();
+                handle.spawn(async move {
+                    crate::runtime::sweep_orphan_containers(&cli).await;
+                });
+            }
+        }
         self
     }
 
@@ -1061,19 +1073,16 @@ fn resolve_env_value(
             let Some(secrets) = secrets else {
                 return String::new();
             };
-            // CodeBuild's value is `secret-id` or `secret-id:json-key`.
-            let (secret_id, json_key) = match value.split_once(':') {
-                Some((id, key)) if !key.is_empty() => (id, Some(key)),
-                _ => (value, None),
-            };
+            // CodeBuild's `value` can be a bare secret name, `name:json-key`, a
+            // full secret ARN, or `arn:...:secret:name-suffix:json-key`. A secret
+            // name may itself contain `-` and `/` but never `:`, so the ARN's
+            // colons must be handled explicitly before splitting off the json key.
+            let (secret_ref, json_key) = split_secret_ref(value);
             let accounts = secrets.read();
             let Some(st) = accounts.get(account) else {
                 return String::new();
             };
-            // Accept a bare name or an ARN tail; strip the AWS 6-char suffix.
-            let name = secret_id.rsplit(":secret:").next().unwrap_or(secret_id);
-            let name = name.rsplit_once('-').map(|(n, _)| n).unwrap_or(name);
-            let Some(secret) = st.secrets.get(name).or_else(|| st.secrets.get(secret_id)) else {
+            let Some(secret) = find_secret(st, &secret_ref) else {
                 return String::new();
             };
             let Some(vid) = secret.current_version_id.as_ref() else {
@@ -1089,7 +1098,7 @@ fn resolve_env_value(
             match json_key {
                 Some(key) => serde_json::from_str::<Value>(&raw)
                     .ok()
-                    .and_then(|v| v.get(key).and_then(Value::as_str).map(str::to_string))
+                    .and_then(|v| v.get(&key).and_then(Value::as_str).map(str::to_string))
                     .unwrap_or_default(),
                 None => raw,
             }
@@ -1097,6 +1106,81 @@ fn resolve_env_value(
         // PLAINTEXT (and any unknown type) -> verbatim.
         _ => value.to_string(),
     }
+}
+
+/// Split a CodeBuild `SECRETS_MANAGER` env `value` into a secret reference (bare
+/// name or full ARN) and an optional json key. Because a full secret ARN
+/// (`arn:aws:secretsmanager:region:account:secret:name-suffix`) contains colons,
+/// a naive `split_once(':')` would truncate the ARN at `arn`. Secret names never
+/// contain `:`, so for a non-ARN input the first colon (if any) separates the
+/// json key; for an ARN input the json key is only the 8th colon-delimited
+/// segment (everything up to and including `secret:name-suffix` is the ARN).
+fn split_secret_ref(value: &str) -> (String, Option<String>) {
+    if value.starts_with("arn:aws:secretsmanager:") {
+        // arn(0) aws(1) secretsmanager(2) region(3) account(4) secret(5)
+        // name-suffix(6) [json-key(7)]
+        let parts: Vec<&str> = value.splitn(8, ':').collect();
+        if parts.len() >= 7 {
+            let arn = parts[..7].join(":");
+            let json_key = parts
+                .get(7)
+                .filter(|k| !k.is_empty())
+                .map(|k| k.to_string());
+            return (arn, json_key);
+        }
+        return (value.to_string(), None);
+    }
+    match value.split_once(':') {
+        Some((id, key)) if !key.is_empty() => (id.to_string(), Some(key.to_string())),
+        _ => (value.to_string(), None),
+    }
+}
+
+/// Strip the trailing `-<6 alphanumeric>` suffix AWS appends to a secret ARN's
+/// name segment (`prod-config-AbCdEf` -> `prod-config`). Only a segment that is
+/// exactly six alphanumeric characters is treated as the suffix, so a hyphenated
+/// user-supplied name is never mangled.
+fn strip_arn_secret_suffix(name_with_suffix: &str) -> &str {
+    match name_with_suffix.rsplit_once('-') {
+        Some((base, suffix))
+            if suffix.len() == 6 && suffix.chars().all(|c| c.is_ascii_alphanumeric()) =>
+        {
+            base
+        }
+        _ => name_with_suffix,
+    }
+}
+
+/// Resolve a secret by name or ARN against a Secrets Manager account state,
+/// mirroring Secrets Manager's own lookup: exact name key, then full/partial ARN
+/// match, then the ARN's name segment (with the 6-char suffix stripped). A bare
+/// plaintext name is looked up verbatim and is never suffix-stripped, so a
+/// hyphenated name like `prod-config` cannot collide with a secret named `prod`.
+fn find_secret<'a>(
+    st: &'a fakecloud_secretsmanager::SecretsManagerState,
+    secret_ref: &str,
+) -> Option<&'a fakecloud_secretsmanager::Secret> {
+    if let Some(secret) = st.secrets.get(secret_ref) {
+        return Some(secret);
+    }
+    if secret_ref.starts_with("arn:aws:secretsmanager:") {
+        for secret in st.secrets.values() {
+            if secret.arn == secret_ref || secret.arn.starts_with(secret_ref) {
+                return Some(secret);
+            }
+        }
+        // Fall back to the name embedded in the ARN tail.
+        if let Some(tail) = secret_ref.rsplit(":secret:").next() {
+            let name = strip_arn_secret_suffix(tail);
+            if let Some(secret) = st.secrets.get(name) {
+                return Some(secret);
+            }
+            if let Some(secret) = st.secrets.get(tail) {
+                return Some(secret);
+            }
+        }
+    }
+    None
 }
 
 /// Next per-project `buildBatchNumber`, with the same monotonic semantics.
@@ -3642,5 +3726,175 @@ mod tests {
         )));
         // ResourceNotFound wins over the malformed exportConfig.
         assert!(err.to_string().contains("does not exist"), "{err}");
+    }
+
+    // ---------------------------------------------------------------------
+    // SECRETS_MANAGER env var resolution.
+    // ---------------------------------------------------------------------
+
+    /// Build a shared Secrets Manager state seeded with `(name, arn, secret_string)`
+    /// entries in the default account.
+    fn secrets_state(entries: &[(&str, &str, &str)]) -> SharedSecretsManagerState {
+        use fakecloud_secretsmanager::{Secret, SecretVersion};
+        use std::collections::BTreeMap;
+        let mut accounts: MultiAccountState<fakecloud_secretsmanager::SecretsManagerState> =
+            MultiAccountState::new("000000000000", "us-east-1", "");
+        let st = accounts.get_or_create("000000000000");
+        for (name, arn, secret_string) in entries {
+            let mut versions = BTreeMap::new();
+            versions.insert(
+                "v1".to_string(),
+                SecretVersion {
+                    version_id: "v1".to_string(),
+                    secret_string: Some(secret_string.to_string()),
+                    secret_binary: None,
+                    stages: vec!["AWSCURRENT".to_string()],
+                    created_at: Utc::now(),
+                },
+            );
+            st.secrets.insert(
+                name.to_string(),
+                Secret {
+                    name: name.to_string(),
+                    arn: arn.to_string(),
+                    description: None,
+                    kms_key_id: None,
+                    versions,
+                    current_version_id: Some("v1".to_string()),
+                    tags: vec![],
+                    tags_ever_set: false,
+                    deleted: false,
+                    deletion_date: None,
+                    created_at: Utc::now(),
+                    last_changed_at: Utc::now(),
+                    last_accessed_at: None,
+                    rotation_enabled: None,
+                    rotation_lambda_arn: None,
+                    rotation_rules: None,
+                    last_rotated_at: None,
+                    resource_policy: None,
+                    replica_regions: Vec::new(),
+                },
+            );
+        }
+        Arc::new(RwLock::new(accounts))
+    }
+
+    fn resolve_secret(state: &SharedSecretsManagerState, value: &str) -> String {
+        resolve_env_value(None, Some(state), "000000000000", "SECRETS_MANAGER", value)
+    }
+
+    #[test]
+    fn split_secret_ref_bare_name() {
+        assert_eq!(split_secret_ref("mysecret"), ("mysecret".to_string(), None));
+    }
+
+    #[test]
+    fn split_secret_ref_name_and_key() {
+        assert_eq!(
+            split_secret_ref("mysecret:username"),
+            ("mysecret".to_string(), Some("username".to_string()))
+        );
+    }
+
+    #[test]
+    fn split_secret_ref_full_arn() {
+        let arn = "arn:aws:secretsmanager:us-east-1:000000000000:secret:prod-config-AbCdEf";
+        assert_eq!(split_secret_ref(arn), (arn.to_string(), None));
+    }
+
+    #[test]
+    fn split_secret_ref_arn_and_key() {
+        let arn = "arn:aws:secretsmanager:us-east-1:000000000000:secret:prod-config-AbCdEf";
+        assert_eq!(
+            split_secret_ref(&format!("{arn}:username")),
+            (arn.to_string(), Some("username".to_string()))
+        );
+    }
+
+    #[test]
+    fn strip_arn_secret_suffix_only_strips_six_char_suffix() {
+        // ARN tails always carry the `-<6 alnum>` suffix AWS appends; it is
+        // stripped even when the real name itself contains hyphens.
+        assert_eq!(strip_arn_secret_suffix("prod-config-AbCdEf"), "prod-config");
+        assert_eq!(strip_arn_secret_suffix("mysecret-A1b2C3"), "mysecret");
+        // A trailing segment that is not exactly six alphanumeric chars is not a
+        // suffix and is left intact (e.g. a name with no random tail).
+        assert_eq!(strip_arn_secret_suffix("prod-settings"), "prod-settings");
+        assert_eq!(strip_arn_secret_suffix("prod"), "prod");
+    }
+
+    #[test]
+    fn resolve_secret_bare_name() {
+        let st = secrets_state(&[(
+            "mysecret",
+            "arn:aws:secretsmanager:us-east-1:000000000000:secret:mysecret-A1b2C3",
+            "topsecret",
+        )]);
+        assert_eq!(resolve_secret(&st, "mysecret"), "topsecret");
+    }
+
+    #[test]
+    fn resolve_secret_name_with_json_key() {
+        let st = secrets_state(&[(
+            "creds",
+            "arn:aws:secretsmanager:us-east-1:000000000000:secret:creds-A1b2C3",
+            r#"{"username":"alice","password":"pw"}"#,
+        )]);
+        assert_eq!(resolve_secret(&st, "creds:username"), "alice");
+        assert_eq!(resolve_secret(&st, "creds:password"), "pw");
+    }
+
+    #[test]
+    fn resolve_secret_full_arn() {
+        // The common `value = aws_secretsmanager_secret.x.arn` Terraform pattern.
+        let arn = "arn:aws:secretsmanager:us-east-1:000000000000:secret:mysecret-A1b2C3";
+        let st = secrets_state(&[("mysecret", arn, "topsecret")]);
+        assert_eq!(resolve_secret(&st, arn), "topsecret");
+    }
+
+    #[test]
+    fn resolve_secret_arn_with_json_key() {
+        let arn = "arn:aws:secretsmanager:us-east-1:000000000000:secret:creds-A1b2C3";
+        let st = secrets_state(&[("creds", arn, r#"{"username":"alice"}"#)]);
+        assert_eq!(resolve_secret(&st, &format!("{arn}:username")), "alice");
+    }
+
+    #[test]
+    fn resolve_secret_hyphenated_plaintext_name_not_mangled() {
+        // A plaintext name that itself contains a hyphen must resolve verbatim,
+        // never suffix-stripped to `prod`.
+        let st = secrets_state(&[(
+            "prod-config",
+            "arn:aws:secretsmanager:us-east-1:000000000000:secret:prod-config-A1b2C3",
+            "the-real-config",
+        )]);
+        assert_eq!(resolve_secret(&st, "prod-config"), "the-real-config");
+    }
+
+    #[test]
+    fn resolve_secret_hyphenated_name_does_not_collide() {
+        // Both `prod-config` and `prod` exist; a bare `prod-config` reference
+        // must NOT fetch `prod` (the old rsplit('-') truncation bug).
+        let st = secrets_state(&[
+            (
+                "prod-config",
+                "arn:aws:secretsmanager:us-east-1:000000000000:secret:prod-config-A1b2C3",
+                "RIGHT",
+            ),
+            (
+                "prod",
+                "arn:aws:secretsmanager:us-east-1:000000000000:secret:prod-Z9y8X7",
+                "WRONG",
+            ),
+        ]);
+        assert_eq!(resolve_secret(&st, "prod-config"), "RIGHT");
+        assert_eq!(resolve_secret(&st, "prod"), "WRONG");
+    }
+
+    #[test]
+    fn resolve_secret_missing_yields_empty() {
+        let st = secrets_state(&[]);
+        assert_eq!(resolve_secret(&st, "nope"), "");
     }
 }


### PR DESCRIPTION
## Summary
Fixes real defects found auditing the new real-buildspec-execution CodeBuild surface.

- **SECRETS_MANAGER env with an ARN resolved to empty (MEDIUM)**: `resolve_env_value` did `value.split_once(':')`, truncating a full secret ARN at `arn` -> empty env var, breaking the ubiquitous `value = aws_secretsmanager_secret.x.arn` Terraform pattern. Rewrote into `split_secret_ref` (bare name / `name:json-key` / full ARN / `arn:...:secret:name-suffix:json-key`) + `find_secret`; the `-<6char>` suffix is only stripped for genuine ARNs, so a plaintext `prod-config` no longer collides with a secret named `prod`.
- **Build container host-networking (LOW)**: added `HostNetworking` (shared `container_net`) — injects `--add-host` and rewrites `localhost`/`127.0.0.1` in the build env, so buildspec callbacks to the fakecloud endpoint + `FAKECLOUD_IN_CONTAINER` resolution work (mirrors Lambda).
- **spawn_blocking for artifacts (LOW)**: artifact enumeration/read/zip moved off the async worker into `spawn_blocking`.
- **SIGKILL orphan sweep (LOW)**: label-based (`fakecloud-codebuild`) removal of containers from prior instances on restart, leaving live builds untouched.

## Test plan
Added secret-ARN parsing tests (bare/name+key/ARN/ARN+key/hyphenated/collision/missing) + the other behaviors. `cargo fmt`/`clippy -p fakecloud-codebuild --all-targets -D warnings`/`build`/`test` (67 passed) + `cargo build -p fakecloud` all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CodeBuild env secret ARN parsing and improves container networking and stability. Also moves artifact work off the async worker for better responsiveness.

- **Bug Fixes**
  - `SECRETS_MANAGER` env: correctly parse bare names, `name:json-key`, full ARNs, and `ARN:json-key`. Only strip the 6-char ARN suffix for genuine ARNs to avoid `prod-config` vs `prod` collisions and fix empty values for ARN inputs.
  - Build container networking: inject `--add-host` and rewrite `localhost`/`127.0.0.1` URLs in env to the host alias so buildspec callbacks reach the fakecloud endpoint (mirrors Lambda/ECS).
  - Restart orphan sweep: on startup, remove leaked `fakecloud-codebuild` containers from prior processes using the `fakecloud-instance` label; live builds are untouched.

- **Refactors**
  - Artifact staging uses a blocking task for file enumeration, reads, and zipping to avoid blocking the async runtime.

<sup>Written for commit 874648c405e4f39b8800e1576a19cd99c9397fcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

