### PR TITLE
fix(mq): reboot preserves durable messages, live CFN endpoints, honest Promote + 4 more (bug-hunt)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1656,6 +1656,27 @@ impl ResourceProvisioner {
     /// attributes that change after creation (e.g. Lambda `FunctionUrl`)
     /// resolve correctly even when the URL was added in a separate pass.
     pub fn get_att(&self, resource: &StackResource, attribute: &str) -> Option<String> {
+        // Amazon MQ broker endpoint / IP attributes are the ONE captured set that
+        // legitimately goes stale: at create time the backing container is not up
+        // yet, so they are the cosmetic `*.amazonaws.com` synthesis, but they
+        // become the REAL bound `tcp://127.0.0.1:<port>` once the container
+        // settles. Resolve them LIVE so CFN GetAtt / outputs match what the direct
+        // DescribeBroker returns rather than serving the frozen cosmetic values.
+        const MQ_BROKER_LIVE_ATTRS: &[&str] = &[
+            "IpAddresses",
+            "OpenWireEndpoints",
+            "AmqpEndpoints",
+            "StompEndpoints",
+            "MqttEndpoints",
+            "WssEndpoints",
+        ];
+        if resource.resource_type == "AWS::AmazonMQ::Broker"
+            && MQ_BROKER_LIVE_ATTRS.contains(&attribute)
+        {
+            if let Some(v) = self.get_att_mq_broker(&resource.physical_id, attribute) {
+                return Some(v);
+            }
+        }
         // Captured attributes are the source of truth — they were computed
         // at create time and never go stale for the resources we ship today.
         if let Some(v) = resource.attributes.get(attribute) {
@@ -8080,6 +8101,68 @@ mod tests {
         assert_eq!(
             prov.get_att(&stack_resource, "TopicArn"),
             Some("captured-arn".to_string())
+        );
+    }
+
+    #[test]
+    fn getatt_mq_broker_endpoints_track_the_live_data_plane() {
+        // An MQ broker's endpoint attributes are captured cosmetic at create
+        // time (no container yet), but once a backing container binds they must
+        // resolve to the REAL `tcp://`/`amqp://<host>:<port>` the direct
+        // DescribeBroker returns -- CFN GetAtt is NOT frozen to the cosmetic set.
+        let prov = make_provisioner();
+        let created = prov
+            .create_resource(&make_resource(
+                "AWS::AmazonMQ::Broker",
+                "MyBroker",
+                serde_json::json!({
+                    "BrokerName": "cfn-live-ep",
+                    "EngineType": "ACTIVEMQ",
+                    "HostInstanceType": "mq.m5.large",
+                    "DeploymentMode": "SINGLE_INSTANCE",
+                    "PubliclyAccessible": false
+                }),
+            ))
+            .expect("create broker");
+        let broker_id = created.physical_id.clone();
+        // The captured attribute is the cosmetic amazonaws endpoint.
+        assert!(
+            created.attributes["AmqpEndpoints"].contains("amazonaws.com"),
+            "create-time capture is cosmetic: {}",
+            created.attributes["AmqpEndpoints"]
+        );
+        // Bind a live data plane, as settle_broker_up does once the container is up.
+        {
+            let mut g = prov.mq_state.write();
+            let acct = g.get_or_create("123456789012");
+            let mut ports = std::collections::BTreeMap::new();
+            ports.insert("amqp".to_string(), 15672u16);
+            ports.insert("openwire".to_string(), 15616u16);
+            acct.data_plane.insert(
+                broker_id.clone(),
+                fakecloud_mq::BrokerDataPlane {
+                    container_id: "c-live".to_string(),
+                    host: "127.0.0.1".to_string(),
+                    ports,
+                },
+            );
+        }
+        // GetAtt now returns the REAL bound endpoints, not the cosmetic capture.
+        let amqp = prov
+            .get_att(&created, "AmqpEndpoints")
+            .expect("AmqpEndpoints");
+        assert!(
+            amqp.contains("amqp://127.0.0.1:15672") && !amqp.contains("amazonaws.com"),
+            "GetAtt must project the live data plane, got: {amqp}"
+        );
+        let ips = prov.get_att(&created, "IpAddresses").expect("IpAddresses");
+        assert!(ips.contains("127.0.0.1"), "IpAddresses live: {ips}");
+        let openwire = prov
+            .get_att(&created, "OpenWireEndpoints")
+            .expect("OpenWireEndpoints");
+        assert!(
+            openwire.contains("tcp://127.0.0.1:15616"),
+            "OpenWireEndpoints live: {openwire}"
         );
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mq.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mq.rs
@@ -83,14 +83,17 @@ impl ResourceProvisioner {
                     broker_id: id.clone(),
                 });
         }
+        // A freshly-created broker has no backing container yet (it is spawned
+        // in the background after provisioning), so its endpoints are cosmetic
+        // here; `get_att` resolves them live once the container binds.
         Ok(broker_attributes(
             id,
             arn,
             &engine,
             &region,
             &deployment,
-            &config_id,
-            config_rev,
+            Some((&config_id, config_rev)),
+            None,
         ))
     }
 
@@ -196,14 +199,17 @@ impl ResourceProvisioner {
         } else {
             acct.tags.insert(arn.clone(), tags);
         }
+        // Project the REAL bound endpoints when a backing container is live, so
+        // the update's returned attributes match DescribeBroker.
+        let dp = acct.data_plane.get(&id).cloned();
         Ok(broker_attributes(
             id,
             arn,
             &old_engine,
             &region,
             &old_deployment,
-            &config_id,
-            config_rev,
+            Some((&config_id, config_rev)),
+            dp.as_ref(),
         ))
     }
 
@@ -235,6 +241,10 @@ impl ResourceProvisioner {
             .and_then(|c| c.get("revision"))
             .and_then(Value::as_i64)
             .unwrap_or(0);
+        // Project the REAL bound host/ports when a backing container is live
+        // (the same `data_plane` source DescribeBroker reads), so CFN GetAtt /
+        // outputs match the direct API instead of the cosmetic create-time set.
+        let dp = acct.data_plane.get(physical_id);
         let res = broker_attributes(
             physical_id.to_string(),
             b.get("brokerArn")
@@ -244,8 +254,8 @@ impl ResourceProvisioner {
             engine,
             &self.region,
             deployment,
-            &cid,
-            crev,
+            Some((&cid, crev)),
+            dp,
         );
         res.attributes.get(attribute).cloned()
     }
@@ -474,10 +484,10 @@ fn broker_attributes(
     engine: &str,
     region: &str,
     deployment_mode: &str,
-    config_id: &str,
-    config_revision: i64,
+    config: Option<(&str, i64)>,
+    data_plane: Option<&fakecloud_mq::BrokerDataPlane>,
 ) -> ProvisionResult {
-    let e = mq_shared::broker_endpoints(&id, engine, region, deployment_mode, None);
+    let e = mq_shared::broker_endpoints(&id, engine, region, deployment_mode, data_plane);
     let mut res = ProvisionResult::new(id)
         .with("Arn", arn)
         .with("IpAddresses", json_list(&e.ips))
@@ -486,7 +496,7 @@ fn broker_attributes(
         .with("StompEndpoints", json_list(&e.stomp))
         .with("MqttEndpoints", json_list(&e.mqtt))
         .with("WssEndpoints", json_list(&e.wss));
-    if !config_id.is_empty() {
+    if let Some((config_id, config_revision)) = config.filter(|(id, _)| !id.is_empty()) {
         res = res
             .with("ConfigurationId", config_id.to_string())
             .with("ConfigurationRevision", config_revision.to_string());

--- a/crates/fakecloud-e2e/tests/mq_dataplane.rs
+++ b/crates/fakecloud-e2e/tests/mq_dataplane.rs
@@ -200,6 +200,152 @@ async fn activemq_broker_delivers_a_message_over_stomp() {
         .expect("delete broker");
 }
 
+/// The backing container id for a broker (via its `fakecloud-mq` label), or
+/// empty when none is running.
+fn broker_container_id(broker_id: &str) -> String {
+    let out = std::process::Command::new("docker")
+        .args([
+            "ps",
+            "-aq",
+            "--filter",
+            &format!("label=fakecloud-mq={broker_id}"),
+        ])
+        .output()
+        .expect("docker ps");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[tokio::test]
+async fn rebooting_an_activemq_broker_preserves_durable_messages() {
+    if !require_docker_or_skip("rebooting_an_activemq_broker_preserves_durable_messages") {
+        return;
+    }
+
+    let server = TestServer::start().await;
+    let client = mq_client(&server).await;
+
+    let username = "fcadmin";
+    let password = "FakecloudMQ1234";
+    let created = client
+        .create_broker()
+        .broker_name("fc-activemq-reboot")
+        .engine_type(EngineType::Activemq)
+        .host_instance_type("mq.t3.micro")
+        .deployment_mode(DeploymentMode::SingleInstance)
+        .publicly_accessible(false)
+        .auto_minor_version_upgrade(false)
+        .users(
+            User::builder()
+                .username(username)
+                .password(password)
+                .console_access(true)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create broker");
+    let broker_id = created.broker_id().expect("broker id").to_string();
+
+    let endpoints = wait_for_running(&server, &client, &broker_id, 300).await;
+    let stomp = endpoints
+        .iter()
+        .find(|e| e.starts_with("stomp://"))
+        .expect("a STOMP endpoint");
+    let addr = host_port(stomp);
+
+    // The backing container id BEFORE the reboot; a durable-message-preserving
+    // reboot must restart THIS SAME container (not remove + recreate it, which
+    // would wipe KahaDB).
+    let container_before = broker_container_id(&broker_id);
+    assert!(
+        !container_before.is_empty(),
+        "a RUNNING broker must have a backing container"
+    );
+
+    // Produce a PERSISTENT message to a queue, with NO consumer attached, and
+    // confirm the broker acknowledged persisting it (STOMP `receipt`).
+    let dest = "/queue/fakecloud.reboot.durable";
+    let body = "SURVIVE_THE_REBOOT";
+    {
+        let mut stream = stomp_authenticate(&addr, username, password).await;
+        let send = format!(
+            "SEND\ndestination:{dest}\npersistent:true\nreceipt:r-send\ncontent-type:text/plain\n\n{body}\0"
+        );
+        stream.write_all(send.as_bytes()).await.expect("SEND");
+        // Read frames until the RECEIPT confirms the persistent write landed.
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(5), read_frame(&mut stream))
+                .await
+                .expect("timed out awaiting RECEIPT frame");
+            if frame.contains("RECEIPT") {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "broker never acknowledged the persistent SEND"
+            );
+        }
+    }
+
+    // Reboot the broker. AWS preserves durable messages across a reboot.
+    client
+        .reboot_broker()
+        .broker_id(&broker_id)
+        .send()
+        .await
+        .expect("reboot broker");
+
+    // The reboot transitions REBOOT_IN_PROGRESS -> RUNNING; wait it out. Give the
+    // state machine a beat to leave RUNNING first so we don't observe the
+    // pre-reboot RUNNING.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let endpoints = wait_for_running(&server, &client, &broker_id, 300).await;
+    let stomp = endpoints
+        .iter()
+        .find(|e| e.starts_with("stomp://"))
+        .expect("a STOMP endpoint after reboot");
+    let addr = host_port(stomp);
+
+    // The SAME container was restarted in place -- proof the data directory
+    // (KahaDB) was never destroyed.
+    let container_after = broker_container_id(&broker_id);
+    assert_eq!(
+        container_before, container_after,
+        "reboot must restart the same container, not remove + recreate it"
+    );
+
+    // The persistent message queued before the reboot is redelivered after it.
+    let mut stream = stomp_authenticate(&addr, username, password).await;
+    let subscribe = format!("SUBSCRIBE\nid:sub-0\ndestination:{dest}\nack:auto\n\n\0");
+    stream
+        .write_all(subscribe.as_bytes())
+        .await
+        .expect("SUBSCRIBE");
+    let mut acc = String::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(5), read_frame(&mut stream))
+            .await
+            .expect("timed out awaiting redelivered MESSAGE frame");
+        acc.push_str(&frame);
+        if acc.contains("MESSAGE") && acc.contains(body) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "durable message did not survive the reboot; got: {acc}"
+        );
+    }
+
+    client
+        .delete_broker()
+        .broker_id(&broker_id)
+        .send()
+        .await
+        .expect("delete broker");
+}
+
 #[tokio::test]
 async fn rabbitmq_broker_speaks_amqp() {
     if !require_docker_or_skip("rabbitmq_broker_speaks_amqp") {

--- a/crates/fakecloud-mq/src/runtime/mod.rs
+++ b/crates/fakecloud-mq/src/runtime/mod.rs
@@ -194,9 +194,14 @@ impl MqRuntime {
         Ok(running)
     }
 
-    /// Reboot a broker: tear the container down and bring a fresh one up with
-    /// the (post-pending) users + configuration, mirroring AWS applying
-    /// staged changes on `RebootBroker`.
+    /// Reboot a broker, mirroring AWS: a reboot RESTARTS the broker in place and
+    /// preserves durable messages. The SAME backing container is stopped, the
+    /// (post-pending) engine configuration is re-staged so a config change
+    /// staged for the reboot takes effect, and the container is started again --
+    /// its data directory (KahaDB / Mnesia) is never touched, so persisted
+    /// messages survive. Only if the tracked container is truly gone does this
+    /// fall back to spawning a fresh one (an empty broker being strictly better
+    /// than a wedged one).
     pub async fn reboot_broker(
         &self,
         broker_id: &str,
@@ -204,7 +209,25 @@ impl MqRuntime {
         users: &[BrokerUser],
         user_config: Option<&str>,
     ) -> Result<RunningBroker, RuntimeError> {
-        self.stop_broker(broker_id).await;
+        let existing = self.containers.read().get(broker_id).cloned();
+        if let Some(existing) = existing {
+            match self
+                .restart_container(engine, users, user_config, &existing.container_id)
+                .await?
+            {
+                Some(running) => {
+                    self.containers
+                        .write()
+                        .insert(broker_id.to_string(), running.clone());
+                    return Ok(running);
+                }
+                None => {
+                    // The tracked container vanished between reboots -> drop the
+                    // stale tracking entry and spawn a fresh one below.
+                    self.containers.write().remove(broker_id);
+                }
+            }
+        }
         let running = self
             .spawn_container(broker_id, engine, users, user_config)
             .await?;
@@ -212,6 +235,76 @@ impl MqRuntime {
             .write()
             .insert(broker_id.to_string(), running.clone());
         Ok(running)
+    }
+
+    /// Restart an EXISTING backing container in place for a reboot, re-staging
+    /// the (post-pending) engine configuration first so a staged config change
+    /// takes effect while the data directory (KahaDB / Mnesia) survives intact.
+    /// Returns `Ok(None)` when the container is gone (the caller spawns fresh),
+    /// `Err` on a real daemon/readiness failure, and `Ok(Some(..))` once it is
+    /// running again and its (possibly re-assigned) host ports have been re-read.
+    async fn restart_container(
+        &self,
+        engine: MqEngine,
+        users: &[BrokerUser],
+        user_config: Option<&str>,
+        container_id: &str,
+    ) -> Result<Option<RunningBroker>, RuntimeError> {
+        // Does the container still exist? A non-zero `inspect` means it is gone.
+        let inspect = tokio::process::Command::new(&self.cli)
+            .args(["inspect", "--format", "{{.State.Status}}", container_id])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !inspect.status.success() {
+            return Ok(None);
+        }
+        // Stop it so the config re-stage lands before the broker boots again.
+        let _ = tokio::process::Command::new(&self.cli)
+            .args(["stop", container_id])
+            .output()
+            .await;
+        // Re-stage the (possibly changed) engine configuration. The data
+        // directory is a separate volume path the broker owns and `docker cp` of
+        // the config file never touches it, so durable messages survive.
+        self.stage_config(container_id, engine, users, user_config)
+            .await?;
+        let start = tokio::process::Command::new(&self.cli)
+            .args(["start", container_id])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !start.status.success() {
+            let stderr = String::from_utf8_lossy(&start.stderr);
+            if stderr.contains("No such container") || stderr.contains("no such container") {
+                return Ok(None);
+            }
+            return Err(RuntimeError::ContainerStartFailed(format!(
+                "reboot restart failed: {}",
+                stderr.trim()
+            )));
+        }
+        // Re-read the host->container port mapping (a restarted container with
+        // ephemeral publishing may be assigned different host ports).
+        let mut ports = BTreeMap::new();
+        for (label, cport) in engine.published_ports() {
+            let hp = self.lookup_port(container_id, *cport).await?;
+            ports.insert((*label).to_string(), hp);
+        }
+        self.wait_for_broker_ready(engine, container_id, &ports)
+            .await?;
+        // RabbitMQ users are applied live (they persist in Mnesia across the
+        // restart, so re-applying is idempotent and covers any staged additions).
+        if engine == MqEngine::RabbitMq {
+            for u in users.iter().skip(1) {
+                let _ = self.rabbit_apply_user_to_container(container_id, u).await;
+            }
+        }
+        Ok(Some(RunningBroker {
+            container_id: container_id.to_string(),
+            host: self.net.sibling_host.clone(),
+            ports,
+        }))
     }
 
     /// Re-attach to a broker's PERSISTED backing container after a fakecloud

--- a/crates/fakecloud-mq/src/service.rs
+++ b/crates/fakecloud-mq/src/service.rs
@@ -299,7 +299,7 @@ impl MqService {
             "DeleteTags" => self.delete_tags(&ctx, a0, &q),
             "ListTags" => self.list_tags(&ctx, a0),
             "DescribeBrokerEngineTypes" => self.describe_broker_engine_types(&q),
-            "DescribeBrokerInstanceOptions" => self.describe_broker_instance_options(&q),
+            "DescribeBrokerInstanceOptions" => self.describe_broker_instance_options(&ctx, &q),
             _ => Err(AwsServiceError::action_not_implemented("mq", action)),
         };
         (result, settled)
@@ -536,6 +536,10 @@ pub(crate) async fn settle_broker_up(
                 let data = guard.get_or_create(account);
                 if let Some(obj) = data.brokers.get_mut(id).and_then(Value::as_object_mut) {
                     obj.insert("brokerState".into(), json!("RUNNING"));
+                    // A prior failed bring-up may have left a statusReason; a
+                    // successful settle to RUNNING clears it so DescribeBroker
+                    // doesn't report a stale failure reason on a healthy broker.
+                    obj.remove("statusReason");
                     data.data_plane.insert(id.to_string(), running_to_dp(&r));
                     true
                 } else {
@@ -877,7 +881,15 @@ impl MqService {
                 le.insert("pending".into(), pending);
             }
         }
-        if let Some(cfg) = b.get("configuration") {
+        // Only ActiveMQ brokers carry a configuration; RabbitMQ brokers have no
+        // `configurations` in AWS, so a configuration on an UpdateBroker to a
+        // RabbitMQ broker is ignored rather than staged into a phantom pending.
+        let is_rabbit = obj
+            .get("engineType")
+            .and_then(Value::as_str)
+            .map(shared::is_rabbit)
+            .unwrap_or(false);
+        if let Some(cfg) = b.get("configuration").filter(|_| !is_rabbit) {
             let configs = obj
                 .entry("configurations")
                 .or_insert_with(|| json!({ "history": [] }));
@@ -890,7 +902,7 @@ impl MqService {
             "brokerId": id,
             "authenticationStrategy": obj.get("authenticationStrategy").cloned().unwrap_or(json!("SIMPLE")),
             "autoMinorVersionUpgrade": obj.get("autoMinorVersionUpgrade").cloned().unwrap_or(json!(false)),
-            "configuration": b.get("configuration").cloned().unwrap_or(json!(null)),
+            "configuration": if is_rabbit { json!(null) } else { b.get("configuration").cloned().unwrap_or(json!(null)) },
             "engineVersion": b.get("engineVersion").cloned().or_else(|| obj.get("engineVersion").cloned()).unwrap_or(json!(null)),
             "hostInstanceType": b.get("hostInstanceType").cloned().or_else(|| obj.get("hostInstanceType").cloned()).unwrap_or(json!(null)),
             "logs": b.get("logs").cloned().unwrap_or(json!(null)),
@@ -1152,7 +1164,15 @@ impl MqService {
         if !data.brokers.contains_key(id) {
             return Err(not_found(&format!("Can't find requested broker [{id}].")));
         }
-        ok(json!({ "brokerId": id }))
+        // Promote drives a Cross-Region Data Replication (CRDR) failover /
+        // switchover between a primary and a replica broker. fakecloud models a
+        // single standalone broker and has no CRDR replica to promote, so rather
+        // than return a fake success that did nothing (a broker with no
+        // `dataReplicationMode: CRDR` cannot be promoted), reject it exactly as
+        // AWS rejects promoting a broker that is not part of a CRDR deployment.
+        Err(bad_request(&format!(
+            "Broker [{id}] is not configured for CRDR (Cross-Region Data Replication) and cannot be promoted."
+        )))
     }
 
     fn list_brokers(
@@ -1257,7 +1277,13 @@ impl MqService {
         let id = format!("c-{}", Uuid::new_v4());
         let arn = config_arn(ctx, &id);
         let created = now_iso();
-        let rev = json!({ "revision": 1, "created": created, "description": "Auto-generated default for Configuration" });
+        // The auto-generated revision names the actual engine (ActiveMQ /
+        // RabbitMQ), matching the broker-auto-config path in `shared.rs`.
+        let auto_desc = format!(
+            "Auto-generated default for {}",
+            shared::engine_display(&engine)
+        );
+        let rev = json!({ "revision": 1, "created": created, "description": auto_desc });
 
         let mut guard = self.state.write();
         let data = guard.get_or_create(&ctx.account);
@@ -1280,7 +1306,7 @@ impl MqService {
             vec![json!({
                 "revision": 1,
                 "created": created,
-                "description": "Auto-generated default for Configuration",
+                "description": auto_desc,
                 "data": shared::default_config_data(&engine),
             })],
         );
@@ -1883,14 +1909,18 @@ impl MqService {
 
     fn describe_broker_instance_options(
         &self,
+        ctx: &Ctx,
         q: &[(String, String)],
     ) -> Result<AwsResponse, AwsServiceError> {
         let engine_filter = query_one(q, "engineType");
         let host_filter = query_one(q, "hostInstanceType");
         let storage_filter = query_one(q, "storageType");
-        let azs: Vec<Value> = ["us-east-1a", "us-east-1b", "us-east-1c"]
+        // Availability zones are named for the REQUEST's region (`<region>a/b/c`),
+        // not a hardcoded us-east-1, so a broker created in eu-west-1 reports
+        // eu-west-1a/b/c as AWS does.
+        let azs: Vec<Value> = ['a', 'b', 'c']
             .iter()
-            .map(|n| json!({ "name": n }))
+            .map(|suffix| json!({ "name": format!("{}{suffix}", ctx.region) }))
             .collect();
         let mut options = Vec::new();
         for engine in ["ACTIVEMQ", "RABBITMQ"] {
@@ -2167,5 +2197,156 @@ mod tests {
         let mut settled2 = true;
         let _ = s.describe_broker(&c, &id, &mut settled2).unwrap();
         assert!(!settled2, "stable read must not report a settle");
+    }
+
+    fn rabbit_body(name: &str) -> Value {
+        json!({
+            "brokerName": name,
+            "engineType": "RABBITMQ",
+            "deploymentMode": "SINGLE_INSTANCE",
+            "hostInstanceType": "mq.m5.large",
+            "publiclyAccessible": false
+        })
+    }
+
+    #[test]
+    fn promote_rejects_a_non_crdr_broker_rather_than_faking_success() {
+        // Promote is a CRDR failover/switchover; fakecloud has no CRDR replica,
+        // so it returns an honest BadRequestException instead of a fake success
+        // that did nothing (finding 3 / no-stub-responses).
+        let s = svc();
+        let c = ctx("us-east-1");
+        let created = json_of(s.create_broker(&c, &active_body("prom")).unwrap());
+        let id = created["brokerId"].as_str().unwrap().to_string();
+        let Err(err) = s.promote(&c, &id, &json!({ "mode": "SWITCHOVER" })) else {
+            panic!("promote of a non-CRDR broker must be rejected");
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.code(), "BadRequestException");
+        // A missing broker still surfaces the not-found error, not the CRDR one.
+        let Err(missing) = s.promote(&c, "b-does-not-exist", &json!({ "mode": "FAILOVER" })) else {
+            panic!("promote of a missing broker must be not-found");
+        };
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn create_configuration_revision_description_names_the_engine() {
+        let s = svc();
+        let c = ctx("us-east-1");
+        for (engine, expected) in [("ACTIVEMQ", "ActiveMQ"), ("RABBITMQ", "RabbitMQ")] {
+            let body = json!({ "name": "cfg", "engineType": engine });
+            let created = json_of(s.create_configuration(&c, &body).unwrap());
+            let cid = created["id"].as_str().unwrap().to_string();
+            assert_eq!(
+                created["latestRevision"]["description"].as_str(),
+                Some(format!("Auto-generated default for {expected}").as_str())
+            );
+            let rev = json_of(s.describe_configuration_revision(&c, &cid, "1").unwrap());
+            assert_eq!(
+                rev["description"].as_str(),
+                Some(format!("Auto-generated default for {expected}").as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn broker_instance_options_availability_zones_follow_the_region() {
+        // AZ names are derived from the request region, not a hardcoded
+        // us-east-1 (finding 5).
+        let s = svc();
+        let c = ctx("eu-west-1");
+        let out = json_of(s.describe_broker_instance_options(&c, &[]).unwrap());
+        let azs = out["brokerInstanceOptions"][0]["availabilityZones"]
+            .as_array()
+            .expect("availability zones");
+        let names: Vec<&str> = azs.iter().filter_map(|z| z["name"].as_str()).collect();
+        assert_eq!(names, vec!["eu-west-1a", "eu-west-1b", "eu-west-1c"]);
+    }
+
+    #[test]
+    fn update_broker_does_not_stage_configuration_on_rabbitmq() {
+        // RabbitMQ brokers have no `configurations` in AWS, so a configuration
+        // on an UpdateBroker must not create a phantom pending (finding 6).
+        let s = svc();
+        let c = ctx("us-east-1");
+        let created = json_of(s.create_broker(&c, &rabbit_body("rabbit-upd")).unwrap());
+        let id = created["brokerId"].as_str().unwrap().to_string();
+        let resp = json_of(
+            s.update_broker(
+                &c,
+                &id,
+                &json!({ "configuration": { "id": "c-abc", "revision": 3 } }),
+            )
+            .unwrap(),
+        );
+        assert!(
+            resp["configuration"].is_null(),
+            "RabbitMQ UpdateBroker must not echo a configuration"
+        );
+        let mut settled = false;
+        let described = json_of(s.describe_broker(&c, &id, &mut settled).unwrap());
+        assert!(
+            described.get("configurations").is_none(),
+            "RabbitMQ broker must never grow a configurations block, got: {described}"
+        );
+    }
+
+    #[test]
+    fn update_broker_still_stages_configuration_on_activemq() {
+        // The RabbitMQ guard must not regress ActiveMQ, which does carry a config.
+        let s = svc();
+        let c = ctx("us-east-1");
+        let created = json_of(s.create_broker(&c, &active_body("active-upd")).unwrap());
+        let id = created["brokerId"].as_str().unwrap().to_string();
+        s.update_broker(
+            &c,
+            &id,
+            &json!({ "configuration": { "id": "c-xyz", "revision": 2 } }),
+        )
+        .unwrap();
+        let mut settled = false;
+        let described = json_of(s.describe_broker(&c, &id, &mut settled).unwrap());
+        assert_eq!(
+            described["configurations"]["pending"]["id"].as_str(),
+            Some("c-xyz")
+        );
+    }
+
+    #[test]
+    fn malformed_next_token_is_rejected() {
+        // A non-numeric pagination token is malformed and must be rejected with
+        // BadRequestException, not silently served as page 1 (finding 7).
+        let bad = crate::validate::validate_query(&[("nextToken".to_string(), "abc".to_string())])
+            .expect_err("malformed nextToken must be rejected");
+        assert_eq!(bad.status(), StatusCode::BAD_REQUEST);
+        // A well-formed numeric token is accepted.
+        assert!(
+            crate::validate::validate_query(&[("nextToken".to_string(), "5".to_string())]).is_ok()
+        );
+    }
+
+    #[test]
+    fn successful_transition_to_running_clears_stale_status_reason() {
+        // A prior failed attempt may leave a statusReason; a settle to RUNNING
+        // must clear it so DescribeBroker doesn't report a stale failure on a
+        // healthy broker (finding 7-tail).
+        let s = svc();
+        let c = ctx("us-east-1");
+        let created = json_of(s.create_broker(&c, &active_body("reason")).unwrap());
+        let id = created["brokerId"].as_str().unwrap().to_string();
+        {
+            let mut guard = s.state.write();
+            let data = guard.get_or_create(&c.account);
+            let obj = data.brokers.get_mut(&id).unwrap().as_object_mut().unwrap();
+            obj.insert("statusReason".into(), json!("a previous boot failure"));
+        }
+        let mut settled = false;
+        let described = json_of(s.describe_broker(&c, &id, &mut settled).unwrap());
+        assert_eq!(described["brokerState"].as_str(), Some("RUNNING"));
+        assert!(
+            described.get("statusReason").is_none(),
+            "statusReason must be cleared on a successful transition to RUNNING"
+        );
     }
 }

--- a/crates/fakecloud-mq/src/state.rs
+++ b/crates/fakecloud-mq/src/state.rs
@@ -111,6 +111,9 @@ impl MqData {
                 "CREATION_IN_PROGRESS" => {
                     if let Some(obj) = self.brokers.get_mut(&id).and_then(Value::as_object_mut) {
                         obj.insert("brokerState".into(), Value::String("RUNNING".into()));
+                        // A successful transition to RUNNING clears any stale
+                        // failure reason from a prior attempt.
+                        obj.remove("statusReason");
                     }
                     changed = true;
                 }
@@ -184,6 +187,8 @@ impl MqData {
                 }
             }
             obj.insert("brokerState".into(), Value::String("RUNNING".into()));
+            // A successful reboot back to RUNNING clears any stale failure reason.
+            obj.remove("statusReason");
         }
         // Apply each user's pending change.
         if let Some(users) = self.users.get_mut(broker_id) {

--- a/crates/fakecloud-mq/src/validate.rs
+++ b/crates/fakecloud-mq/src/validate.rs
@@ -110,6 +110,14 @@ pub fn validate_query(q: &[(String, String)]) -> Result<(), AwsServiceError> {
                 "Value '{v}' at 'maxResults' failed to satisfy constraint: Member must be between 1 and 100"
             )));
         }
+        // NextToken is an opaque offset the service itself minted (a decimal
+        // string); a client that echoes a malformed token gets a
+        // BadRequestException rather than silently being served page 1.
+        if k == "nextToken" && v.parse::<usize>().is_err() {
+            return Err(bad_request(&format!(
+                "Value '{v}' at 'nextToken' is not a valid pagination token."
+            )));
+        }
     }
     Ok(())
 }

--- a/website/content/docs/services/mq.md
+++ b/website/content/docs/services/mq.md
@@ -47,16 +47,20 @@ lifecycle, but no real broker container is spawned.
   to the well-formed cosmetic `*.amazonaws.com` forms - identical response shape,
   synthetic values.)
 - **Broker lifecycle** - `RebootBroker` moves the broker to
-  `REBOOT_IN_PROGRESS`, restarts the real container applying every staged
-  pending change (engine version, host instance type, security groups,
-  authentication strategy, logs, and the pending configuration - the old current
-  configuration is pushed to `history`, and the injected users / uploaded config
-  are re-applied to the fresh container), then returns to `RUNNING`.
-  `UpdateBroker` stages those pending changes. `DeleteBroker` moves the broker to
-  `DELETION_IN_PROGRESS` and stops + removes its backing container. `Promote` is
-  accepted for a broker (the cross-region-data-replication promotion). A broker
-  persisted as `RUNNING` reconciles its backing container on restart (respawning
-  it if it is gone), so its endpoint is never advertised dead.
+  `REBOOT_IN_PROGRESS` and restarts the **same** backing container in place -
+  preserving durable messages (ActiveMQ KahaDB / RabbitMQ Mnesia survive the
+  reboot exactly as they do on AWS) - re-staging every pending change (engine
+  version, host instance type, security groups, authentication strategy, logs,
+  and the pending configuration; the old current configuration is pushed to
+  `history`), then returns to `RUNNING`. Only if the container is truly gone is a
+  fresh one spawned. `UpdateBroker` stages those pending changes (for ActiveMQ; a
+  RabbitMQ broker has no configuration to stage). `DeleteBroker` moves the broker
+  to `DELETION_IN_PROGRESS` and stops + removes its backing container. `Promote`
+  is a Cross-Region Data Replication (CRDR) failover / switchover; fakecloud
+  models a single standalone broker with no CRDR replica, so it returns a
+  `BadRequestException` rather than a fake success. A broker persisted as
+  `RUNNING` reconciles its backing container on restart (respawning it if it is
+  gone), so its endpoint is never advertised dead.
 - **Configurations** - `CreateConfiguration` returns a `c-`-prefixed id and its
   ARN with revision 1; `UpdateConfiguration` appends a new revision carrying the
   base64 `Data` and description. `DescribeConfiguration`,
@@ -117,10 +121,12 @@ accepts connections (a stack delete stops + removes the container). `Ref`
 resolves to the broker / configuration id, and `Fn::GetAtt` exposes the broker's
 `Arn`, `IpAddresses`, `OpenWireEndpoints`, `AmqpEndpoints`, `StompEndpoints`,
 `MqttEndpoints`, `WssEndpoints`, `ConfigurationId`, and `ConfigurationRevision`,
-and the configuration's `Arn`, `Id`, and `Revision`. (The `Fn::GetAtt` endpoint
-lists are resolved synchronously at provision time and so carry the cosmetic
-forms; `DescribeBroker` returns the real connectable endpoints once the broker is
-`RUNNING`.)
+and the configuration's `Arn`, `Id`, and `Revision`. The `Fn::GetAtt` endpoint /
+IP lists resolve **live** from the same backing-container binding
+`DescribeBroker` reads, so once the broker is `RUNNING` they return the real
+connectable `tcp://`/`amqp://<host>:<port>` endpoints (they carry the cosmetic
+forms only before the container has bound, matching `DescribeBroker` at that same
+moment).
 
 ## Known limitations
 


### PR DESCRIPTION
## Summary
Fixes real defects found auditing the new Amazon MQ real-broker data plane.

- **RebootBroker destroyed durable messages (MEDIUM)**: reboot did `rm -f` + fresh spawn, wiping KahaDB/Mnesia. Now restarts the SAME container in place (inspect -> stop -> re-stage config -> start -> re-read ports -> wait ready -> re-apply RabbitMQ users), so durable messages survive; falls back to a fresh spawn only if the container is truly gone.
- **CFN GetAtt endpoints always cosmetic (MEDIUM)**: broker endpoint/IP attributes are now resolved LIVE from the data plane (bypassing the frozen create-time capture), so `Fn::GetAtt`/outputs match `DescribeBroker` once the container binds.
- **Promote validate-then-drop (LOW)**: returns `BadRequestException` (broker not in a CRDR deployment) instead of a fake success.
- **CreateConfiguration revision description (LOW)**: "Auto-generated default for <ActiveMQ|RabbitMQ>".
- **DescribeBrokerInstanceOptions (LOW)**: AZ names derived from request region.
- **UpdateBroker (LOW)**: configuration only staged for ActiveMQ; RabbitMQ never grows a phantom `configurations` block.
- **tail**: clears stale `statusReason` on transition to RUNNING; malformed `nextToken` -> `BadRequestException`.

Docs synced (`website/content/docs/services/mq.md`).

## Test plan
Reboot-durability E2E (same container id survives + durable STOMP message redelivered after reboot; runs in the dedicated mq-broker CI job), CFN getatt-live unit test, + unit tests for Promote error, engine-named config revision, region AZs, RabbitMQ no-config, statusReason clearing, bad nextToken. `cargo fmt`/`clippy -p fakecloud-mq -p fakecloud-cloudformation --all-targets -D warnings`/`build`/`test` (32 passed) all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebooting an Amazon MQ broker now preserves durable messages by restarting the same container. CloudFormation GetAtt now returns live broker endpoints that match DescribeBroker once the container binds.

- **Bug Fixes**
  - RebootBroker restarts the same container in place, preserves KahaDB/Mnesia, re-stages config, reapplies RabbitMQ users; spawns fresh only if the container is gone.
  - CFN GetAtt for IpAddresses and endpoint lists resolves from the live data plane, matching DescribeBroker after bind.
  - Promote returns BadRequestException when the broker is not in a CRDR deployment.
  - CreateConfiguration revision description names the engine (ActiveMQ/RabbitMQ).
  - DescribeBrokerInstanceOptions derives AZ names from the request region (<region>a/b/c).
  - UpdateBroker stages configuration only for ActiveMQ; RabbitMQ never gains a phantom configurations block.
  - Transition to RUNNING clears stale statusReason; malformed non-numeric nextToken is rejected with BadRequestException.

<sup>Written for commit 5777929c41117851286f8484f255f406eaab48fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

