### PR TITLE
chore(release): bump workspace to v0.40.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acmpca"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3861,7 +3861,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appconfig"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4005,7 +4005,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4071,7 +4071,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ce"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudtrail"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeartifact"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codebuild"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codecommit"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeconnections"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codedeploy"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codepipeline"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-config"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4605,7 +4605,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-efs"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticbeanstalk"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glacier"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4994,7 +4994,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5053,7 +5053,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lakeformation"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mq"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ram"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5341,7 +5341,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53resolver"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3tables"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5623,7 +5623,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5650,7 +5650,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5807,7 +5807,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transfer"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5836,7 +5836,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -116,331 +116,331 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-cloudtrail]
 path = "crates/fakecloud-cloudtrail"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-ce]
 path = "crates/fakecloud-ce"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-codeconnections]
 path = "crates/fakecloud-codeconnections"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-transfer]
 path = "crates/fakecloud-transfer"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-elasticbeanstalk]
 path = "crates/fakecloud-elasticbeanstalk"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-glacier]
 path = "crates/fakecloud-glacier"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-appconfig]
 path = "crates/fakecloud-appconfig"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-backup]
 path = "crates/fakecloud-backup"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-ram]
 path = "crates/fakecloud-ram"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-s3tables]
 path = "crates/fakecloud-s3tables"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-lakeformation]
 path = "crates/fakecloud-lakeformation"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-codebuild]
 path = "crates/fakecloud-codebuild"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-codecommit]
 path = "crates/fakecloud-codecommit"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-codedeploy]
 path = "crates/fakecloud-codedeploy"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-codepipeline]
 path = "crates/fakecloud-codepipeline"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-codeartifact]
 path = "crates/fakecloud-codeartifact"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-efs]
 path = "crates/fakecloud-efs"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-mq]
 path = "crates/fakecloud-mq"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-route53resolver]
 path = "crates/fakecloud-route53resolver"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-acmpca]
 path = "crates/fakecloud-acmpca"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-config]
 path = "crates/fakecloud-config"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies.kube]
 version = "0.95"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.40.0")
+    testImplementation("dev.fakecloud:fakecloud:0.40.1")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.40.0</version>
+    <version>0.40.1</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -375,7 +375,7 @@ import dev.fakecloud.Types.BedrockResponseRule;
 import java.util.List;
 
 FakeCloud fc = new FakeCloud();
-String modelId = "anthropic.claude-3-haiku-20240307-v1:0";
+String modelId = "anthropic.claude-3-haiku-20.40.17-v1:0";
 
 // beforeEach
 fc.reset();

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.40.0"
+version = "0.40.1"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.40.0"
+version = "0.40.1"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Patch release v0.40.1 — new-surface hardening from the v0.40.0 bug-hunt (all merged in #2177-#2182):
- **MQ**: reboot preserves durable messages; live CFN GetAtt endpoints; honest Promote.
- **CodeBuild**: SECRETS_MANAGER ARN resolution; host-networking; spawn_blocking; orphan sweep.
- **Config**: per-account eval; real proactive eval; pagination; bucket validation.
- **Route53Resolver**: list filters; firewall-rule override persistence; real ImportFirewallDomains.
- **ACMPCA**: idempotency dedup; pagination; real S3 audit delivery; validity/status guards.
- **Bedrock**: maxTokens overflow guard; tool-choice-aware Converse; honest embedding errors.
- Release.yml crate-publish topo-order corrected for new inter-crate deps.

Version bump only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the `fakecloud` workspace and SDKs to v0.40.1 to ship the latest patch release with stability fixes. Version-only updates across Cargo.toml/Cargo.lock and SDK package versions (Java, Python, TypeScript); no behavior changes.

<sup>Written for commit 6bce5ac968c5695a503d172c57c73a376406855f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

