### PR TITLE
feat(msk): cluster attribute fidelity + full tfacc coverage — batch 3b

### DIFF
--- a/crates/fakecloud-e2e/tests/msk.rs
+++ b/crates/fakecloud-e2e/tests/msk.rs
@@ -64,16 +64,26 @@ async fn cluster_lifecycle_create_describe_list_tag_update_delete() {
     assert_eq!(info.number_of_broker_nodes(), Some(3));
     let current_version = info.current_version().expect("current version").to_string();
 
-    // GetBootstrapBrokers is synthesized from the broker nodes.
+    // GetBootstrapBrokers is synthesized from the broker nodes, gated on the
+    // cluster's in-transit encryption + client auth. This cluster took the MSK
+    // default (client_broker=TLS, no SASL), so it advertises ONLY the TLS
+    // variant (:9094) -- the plaintext / SASL / public / vpc variants are omitted
+    // exactly as real MSK omits the schemes a cluster does not enable.
     let bb = kafka
         .get_bootstrap_brokers()
         .cluster_arn(&arn)
         .send()
         .await
         .expect("bootstrap brokers");
-    let plaintext = bb.bootstrap_broker_string().expect("plaintext brokers");
-    assert_eq!(plaintext.split(',').count(), 3, "one endpoint per broker");
-    assert!(plaintext.contains(":9092"));
+    assert!(
+        bb.bootstrap_broker_string().is_none(),
+        "a TLS cluster advertises no plaintext bootstrap string"
+    );
+    let tls = bb
+        .bootstrap_broker_string_tls()
+        .expect("tls bootstrap brokers");
+    assert_eq!(tls.split(',').count(), 3, "one endpoint per broker");
+    assert!(tls.contains(":9094"));
 
     // ListNodes synthesizes one node per broker.
     let nodes = kafka

--- a/crates/fakecloud-kafka/src/builders.rs
+++ b/crates/fakecloud-kafka/src/builders.rs
@@ -22,27 +22,188 @@ pub(crate) fn gen_version(seq: u64) -> String {
     format!("K{:013X}", 0x1_0000_0000_u64 + seq)
 }
 
-/// The default `BrokerNodeGroupInfo` MSK fills in when the caller supplies none.
+/// The default `BrokerNodeGroupInfo` MSK fills in when the caller supplies none,
+/// already normalized (its `connectivityInfo` / `storageInfo` sub-objects and
+/// AWS defaults present).
 pub(crate) fn default_bngi() -> Value {
+    normalize_bngi(None)
+}
+
+/// A synthesized customer-managed KMS key ARN, in the AWS `key/{uuid}` form, for
+/// a cluster's `EncryptionAtRest.DataVolumeKMSKeyId` when the caller omits one
+/// (real MSK always echoes a resolved key ARN, so `encryption_info` round-trips
+/// and `MatchResourceAttrRegionalARN(..., "kms", "key/.+")` matches).
+fn default_kms_key_arn(region: &str, account: &str) -> String {
+    format!("arn:aws:kms:{region}:{account}:key/{}", Uuid::new_v4())
+}
+
+/// Fill an `EncryptionInfo` with the sub-objects + AWS defaults `DescribeCluster`
+/// always echoes: an `EncryptionAtRest.DataVolumeKMSKeyId` (synthesized when the
+/// caller omits it) and an `EncryptionInTransit` with `ClientBroker` defaulting
+/// to `TLS` and `InCluster` to `true`. Whatever the caller supplied wins.
+pub(crate) fn normalize_encryption_info(
+    user: Option<&Value>,
+    region: &str,
+    account: &str,
+) -> Value {
+    let kms = user
+        .and_then(|e| e.get("encryptionAtRest"))
+        .and_then(|r| r.get("dataVolumeKMSKeyId"))
+        .cloned()
+        .unwrap_or_else(|| json!(default_kms_key_arn(region, account)));
+    let transit = user.and_then(|e| e.get("encryptionInTransit"));
+    let client_broker = transit
+        .and_then(|t| t.get("clientBroker"))
+        .cloned()
+        .unwrap_or(json!("TLS"));
+    let in_cluster = transit
+        .and_then(|t| t.get("inCluster"))
+        .cloned()
+        .unwrap_or(json!(true));
     json!({
-        "brokerAZDistribution": "DEFAULT",
-        "clientSubnets": ["subnet-0123456789abcdef0", "subnet-0123456789abcdef1"],
-        "instanceType": "kafka.m5.large",
-        "securityGroups": ["sg-0123456789abcdef0"],
-        "storageInfo": { "ebsStorageInfo": { "volumeSize": 100 } },
+        "encryptionAtRest": { "dataVolumeKMSKeyId": kms },
+        "encryptionInTransit": { "clientBroker": client_broker, "inCluster": in_cluster },
     })
 }
 
-/// The default `EncryptionInfo` MSK fills in when the caller supplies none.
-pub(crate) fn default_encryption(region: &str, account: &str) -> Value {
+/// Fill a provisioned cluster's `StorageInfo` with the `EbsStorageInfo` +
+/// `VolumeSize` default (1000 GiB) MSK always echoes. `ProvisionedThroughput` is
+/// preserved verbatim when the caller set it and left OFF otherwise -- real MSK
+/// omits the block on a cluster that never enabled provisioned throughput (the
+/// provider asserts `provisioned_throughput.# == 0`), and only surfaces it once
+/// it has been configured.
+pub(crate) fn normalize_storage_info(user: Option<&Value>) -> Value {
+    let mut ebs = user
+        .and_then(|s| s.get("ebsStorageInfo"))
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    ebs.entry("volumeSize").or_insert_with(|| json!(1000));
+    json!({ "ebsStorageInfo": Value::Object(ebs) })
+}
+
+/// Fill a `ConnectivityInfo` with the `PublicAccess` (default `Type: DISABLED`)
+/// and `VpcConnectivity` (client-auth sub-object with every scheme disabled)
+/// MSK always echoes on a provisioned cluster, so `DescribeCluster` round-trips
+/// the `connectivity_info` block even for a minimal create. Whatever the caller
+/// supplied for either sub-object wins; the other is defaulted.
+pub(crate) fn normalize_connectivity_info(user: Option<&Value>) -> Value {
+    let public_access = user
+        .and_then(|c| c.get("publicAccess"))
+        .and_then(Value::as_object)
+        .map(|pa| {
+            let mut pa = pa.clone();
+            pa.entry("type").or_insert_with(|| json!("DISABLED"));
+            Value::Object(pa)
+        })
+        .unwrap_or_else(|| json!({ "type": "DISABLED" }));
+    // A create request never carries VpcConnectivity (the provider requires all
+    // schemes disabled at create and applies it via a follow-up UpdateConnectivity),
+    // but DescribeCluster always echoes the all-disabled default; a later update
+    // supplies the enabled shape, which wins here.
+    let vpc = user
+        .and_then(|c| c.get("vpcConnectivity"))
+        .cloned()
+        .unwrap_or_else(default_vpc_connectivity);
+    json!({ "publicAccess": public_access, "vpcConnectivity": vpc })
+}
+
+/// Normalize a serverless cluster's `Serverless` block into the shape
+/// `DescribeClusterV2` echoes: each `VpcConfig` gets a synthesized default
+/// `securityGroupIds` when the caller omits one (real MSK resolves a default
+/// security group, which the provider reads back as `vpc_config.0.
+/// security_group_ids.# == 1`), and `clientAuthentication.sasl.iam.enabled`
+/// defaults to `true` (IAM is the serverless auth scheme).
+pub(crate) fn normalize_serverless(user: Option<&Value>) -> Value {
+    let vpc_configs: Vec<Value> = user
+        .and_then(|s| s.get("vpcConfigs"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|cfg| {
+            let mut m = cfg.as_object().cloned().unwrap_or_default();
+            m.entry("subnetIds").or_insert_with(|| json!([]));
+            let has_sg = m
+                .get("securityGroupIds")
+                .and_then(Value::as_array)
+                .is_some_and(|a| !a.is_empty());
+            if !has_sg {
+                m.insert(
+                    "securityGroupIds".into(),
+                    json!([format!("sg-{:016x}", Uuid::new_v4().as_u128() as u64)]),
+                );
+            }
+            Value::Object(m)
+        })
+        .collect();
+    let iam_enabled = user
+        .and_then(|s| s.get("clientAuthentication"))
+        .and_then(|c| c.get("sasl"))
+        .and_then(|s| s.get("iam"))
+        .and_then(|i| i.get("enabled"))
+        .cloned()
+        .unwrap_or(json!(true));
     json!({
-        "encryptionAtRest": {
-            "dataVolumeKMSKeyId": format!(
-                "arn:aws:kms:{region}:{account}:key/msk-default-key"
-            )
-        },
-        "encryptionInTransit": { "clientBroker": "TLS", "inCluster": true },
+        "vpcConfigs": vpc_configs,
+        "clientAuthentication": { "sasl": { "iam": { "enabled": iam_enabled } } },
     })
+}
+
+/// Fill an `OpenMonitoring` block with both Prometheus exporters present
+/// (`jmxExporter` / `nodeExporter`, each defaulting `enabledInBroker` to false),
+/// so `DescribeCluster` echoes the full shape the provider flattens even when
+/// the caller set only one exporter.
+pub(crate) fn normalize_open_monitoring(user: &Value) -> Value {
+    let prom = user.get("prometheus");
+    let jmx = prom
+        .and_then(|p| p.get("jmxExporter"))
+        .and_then(|j| j.get("enabledInBroker"))
+        .cloned()
+        .unwrap_or(json!(false));
+    let node = prom
+        .and_then(|p| p.get("nodeExporter"))
+        .and_then(|n| n.get("enabledInBroker"))
+        .cloned()
+        .unwrap_or(json!(false));
+    json!({
+        "prometheus": {
+            "jmxExporter": { "enabledInBroker": jmx },
+            "nodeExporter": { "enabledInBroker": node },
+        }
+    })
+}
+
+/// The all-schemes-disabled `VpcConnectivity` default MSK echoes.
+fn default_vpc_connectivity() -> Value {
+    json!({
+        "clientAuthentication": {
+            "sasl": { "iam": { "enabled": false }, "scram": { "enabled": false } },
+            "tls": { "enabled": false },
+        }
+    })
+}
+
+/// Fill a provisioned cluster's `BrokerNodeGroupInfo` with the sub-objects +
+/// AWS defaults `DescribeCluster` always echoes (`brokerAZDistribution`,
+/// `connectivityInfo`, `storageInfo`, and placeholder subnets/security groups/
+/// instance type when omitted), so both an explicit and a minimal create
+/// round-trip faithfully. The caller's values always win.
+pub(crate) fn normalize_bngi(user: Option<&Value>) -> Value {
+    let mut bngi = user.and_then(Value::as_object).cloned().unwrap_or_default();
+    bngi.entry("brokerAZDistribution")
+        .or_insert_with(|| json!("DEFAULT"));
+    bngi.entry("clientSubnets")
+        .or_insert_with(|| json!(["subnet-0123456789abcdef0", "subnet-0123456789abcdef1"]));
+    bngi.entry("securityGroups")
+        .or_insert_with(|| json!(["sg-0123456789abcdef0"]));
+    bngi.entry("instanceType")
+        .or_insert_with(|| json!("kafka.m5.large"));
+    let storage = normalize_storage_info(bngi.get("storageInfo"));
+    bngi.insert("storageInfo".into(), storage);
+    let connectivity = normalize_connectivity_info(bngi.get("connectivityInfo"));
+    bngi.insert("connectivityInfo".into(), connectivity);
+    Value::Object(bngi)
 }
 
 /// The ZooKeeper connect strings synthesized for a provisioned cluster.
@@ -136,9 +297,7 @@ pub fn insert_cluster(
         cluster.insert("_clusterType".into(), json!("SERVERLESS"));
         cluster.insert(
             "_serverless".into(),
-            body.get("serverless")
-                .cloned()
-                .unwrap_or(json!({ "vpcConfigs": [] })),
+            normalize_serverless(body.get("serverless")),
         );
     } else {
         let kv = provisioned_src
@@ -154,15 +313,38 @@ pub fn insert_cluster(
         cluster.insert("numberOfBrokerNodes".into(), json!(num));
         cluster.insert(
             "brokerNodeGroupInfo".into(),
-            provisioned_src
-                .get("brokerNodeGroupInfo")
-                .cloned()
-                .unwrap_or_else(default_bngi),
+            normalize_bngi(provisioned_src.get("brokerNodeGroupInfo")),
         );
-        cluster.insert(
-            "currentBrokerSoftwareInfo".into(),
-            json!({ "kafkaVersion": kv }),
-        );
+        // `currentBrokerSoftwareInfo` reflects the create's Kafka version plus any
+        // associated configuration (arn + revision), which the provider surfaces
+        // as `configuration_info`.
+        let mut sw = Map::new();
+        sw.insert("kafkaVersion".into(), json!(kv));
+        if let Some(ci) = provisioned_src
+            .get("configurationInfo")
+            .and_then(Value::as_object)
+        {
+            if let Some(a) = ci.get("arn") {
+                sw.insert("configurationArn".into(), a.clone());
+            }
+            if let Some(r) = ci.get("revision") {
+                sw.insert("configurationRevision".into(), r.clone());
+            }
+        }
+        cluster.insert("currentBrokerSoftwareInfo".into(), Value::Object(sw));
+        // `clientAuthentication` / `loggingInfo` / `openMonitoring` are echoed
+        // ONLY when the caller supplied them: MSK returns no `ClientAuthentication`
+        // for an auth-less cluster (the provider asserts `client_authentication.# ==
+        // 0`) and no logging/monitoring block for a cluster that configured none.
+        if let Some(ca) = provisioned_src.get("clientAuthentication") {
+            cluster.insert("clientAuthentication".into(), ca.clone());
+        }
+        if let Some(li) = provisioned_src.get("loggingInfo") {
+            cluster.insert("loggingInfo".into(), li.clone());
+        }
+        if let Some(om) = provisioned_src.get("openMonitoring") {
+            cluster.insert("openMonitoring".into(), normalize_open_monitoring(om));
+        }
         cluster.insert(
             "enhancedMonitoring".into(),
             provisioned_src
@@ -172,10 +354,7 @@ pub fn insert_cluster(
         );
         cluster.insert(
             "encryptionInfo".into(),
-            provisioned_src
-                .get("encryptionInfo")
-                .cloned()
-                .unwrap_or_else(|| default_encryption(region, account)),
+            normalize_encryption_info(provisioned_src.get("encryptionInfo"), region, account),
         );
         cluster.insert(
             "storageMode".into(),
@@ -283,6 +462,14 @@ pub fn insert_replicator(
     let uuid = Uuid::new_v4().to_string();
     let arn = shared::replicator_arn(region, account, &name, &uuid, n);
     let created = now_iso();
+    // DescribeReplicator returns the *description* shapes, which differ from the
+    // create request: each `KafkaCluster` gains a `kafkaClusterAlias` (its MSK
+    // cluster name), and each `ReplicationInfo`'s `sourceKafkaClusterArn`/
+    // `targetKafkaClusterArn` become `sourceKafkaClusterAlias`/
+    // `targetKafkaClusterAlias`. The provider maps the aliases back to the two
+    // cluster ARNs on read, so aliasing by cluster name keeps them consistent.
+    let kafka_clusters = to_kafka_cluster_descriptions(body.get("kafkaClusters"));
+    let replication_info_list = to_replication_info_descriptions(body.get("replicationInfoList"));
     let record = json!({
         "replicatorArn": arn,
         "replicatorName": name,
@@ -292,13 +479,89 @@ pub fn insert_replicator(
         "currentVersion": gen_version(n),
         "isReplicatorReference": false,
         "serviceExecutionRoleArn": body.get("serviceExecutionRoleArn").cloned().unwrap_or(json!("")),
-        "kafkaClusters": body.get("kafkaClusters").cloned().unwrap_or(json!([])),
-        "replicationInfoList": body.get("replicationInfoList").cloned().unwrap_or(json!([])),
+        "kafkaClusters": kafka_clusters,
+        "replicationInfoList": replication_info_list,
         "replicatorDescription": body.get("description").cloned().unwrap_or(json!("")),
     });
     data.replicators.insert(arn.clone(), record);
     insert_tags(data, &arn, body);
     Ok(arn)
+}
+
+/// The MSK-cluster alias the description shapes key on: the cluster's name.
+pub(crate) fn cluster_alias(msk_cluster_arn: &str) -> String {
+    shared::cluster_name_from_arn(msk_cluster_arn)
+        .unwrap_or(msk_cluster_arn)
+        .to_string()
+}
+
+/// Transform a `CreateReplicator` `kafkaClusters` list (request shape) into the
+/// `KafkaClusterDescription` list `DescribeReplicator` returns, adding each
+/// cluster's `kafkaClusterAlias`.
+fn to_kafka_cluster_descriptions(clusters: Option<&Value>) -> Value {
+    let out: Vec<Value> = clusters
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| {
+            let mut m = c.as_object().cloned().unwrap_or_default();
+            let msk_arn = m
+                .get("amazonMskCluster")
+                .and_then(|a| a.get("mskClusterArn"))
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            m.insert("kafkaClusterAlias".into(), json!(cluster_alias(msk_arn)));
+            Value::Object(m)
+        })
+        .collect();
+    Value::Array(out)
+}
+
+/// Transform a `CreateReplicator` `replicationInfoList` (request shape) into the
+/// `ReplicationInfoDescription` list `DescribeReplicator` returns: replace the
+/// source/target cluster ARNs with their aliases (the provider resolves the
+/// ARNs back from the `kafkaClusters` alias map on read).
+pub(crate) fn to_replication_info_descriptions(list: Option<&Value>) -> Value {
+    let out: Vec<Value> = list
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|info| {
+            let mut m = info.as_object().cloned().unwrap_or_default();
+            if let Some(src) = m
+                .remove("sourceKafkaClusterArn")
+                .as_ref()
+                .and_then(Value::as_str)
+            {
+                m.insert("sourceKafkaClusterAlias".into(), json!(cluster_alias(src)));
+            }
+            if let Some(tgt) = m
+                .remove("targetKafkaClusterArn")
+                .as_ref()
+                .and_then(Value::as_str)
+            {
+                m.insert("targetKafkaClusterAlias".into(), json!(cluster_alias(tgt)));
+            }
+            // MSK fills computed defaults on the topic-replication policy: a
+            // `startingPosition` (default `LATEST`) and `topicNameConfiguration`
+            // (default `PREFIXED_WITH_SOURCE_CLUSTER_ALIAS`), which the provider
+            // reads back as Computed blocks. Preserve whatever the caller set.
+            if let Some(tr) = m
+                .entry("topicReplication".to_string())
+                .or_insert_with(|| json!({}))
+                .as_object_mut()
+            {
+                tr.entry("startingPosition")
+                    .or_insert_with(|| json!({ "type": "LATEST" }));
+                tr.entry("topicNameConfiguration")
+                    .or_insert_with(|| json!({ "type": "PREFIXED_WITH_SOURCE_CLUSTER_ALIAS" }));
+            }
+            Value::Object(m)
+        })
+        .collect();
+    Value::Array(out)
 }
 
 /// Build + insert an MSK VPC connection record from a `CreateVpcConnection` body
@@ -311,13 +574,16 @@ pub fn insert_vpc_connection(
 ) -> String {
     let n = data.next_seq();
     let uuid = Uuid::new_v4().to_string();
-    let arn = shared::vpc_connection_arn(region, account, &uuid, n);
+    let target = body.get("targetClusterArn").cloned().unwrap_or(json!(""));
+    let target_arn = target.as_str().unwrap_or_default();
+    let target_account = shared::arn_account(target_arn).unwrap_or(account);
+    let target_name = shared::cluster_name_from_arn(target_arn).unwrap_or("cluster");
+    let arn = shared::vpc_connection_arn(region, account, target_account, target_name, &uuid, n);
     let created = now_iso();
     let subnets = body.get("clientSubnets").cloned().unwrap_or(json!([]));
     let sgs = body.get("securityGroups").cloned().unwrap_or(json!([]));
     let auth = body.get("authentication").cloned().unwrap_or(json!(""));
     let vpc_id = body.get("vpcId").cloned().unwrap_or(json!(""));
-    let target = body.get("targetClusterArn").cloned().unwrap_or(json!(""));
     let record = json!({
         "vpcConnectionArn": arn,
         "targetClusterArn": target,

--- a/crates/fakecloud-kafka/src/service.rs
+++ b/crates/fakecloud-kafka/src/service.rs
@@ -591,6 +591,118 @@ fn cluster_is_serverless(cluster: &Value) -> bool {
     cluster.get("_clusterType").and_then(Value::as_str) == Some("SERVERLESS")
 }
 
+/// Merge an `UpdateReplicationInfo` sub-object (`topicReplication` /
+/// `consumerGroupReplication`) field-wise onto the stored replication-info
+/// description, so create-only members not present in the update payload (e.g.
+/// `startingPosition`, `topicNameConfiguration`) survive while the updated
+/// lists / flags are overwritten.
+fn merge_replication_sub(info: &mut Map<String, Value>, key: &str, incoming: Option<Value>) {
+    let Some(incoming) = incoming.as_ref().and_then(Value::as_object) else {
+        return;
+    };
+    let target = info
+        .entry(key.to_string())
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .expect("replication sub-object");
+    for (k, v) in incoming {
+        target.insert(k.clone(), v.clone());
+    }
+}
+
+/// Whether a nested `{ enabled: bool }` sub-object is present and enabled.
+fn sub_enabled(v: Option<&Value>) -> bool {
+    v.and_then(|x| x.get("enabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// The set of bootstrap-broker connection strings MSK advertises for a cluster,
+/// gated on its encryption-in-transit `ClientBroker` and enabled client-auth
+/// schemes (private + public + VPC-connectivity). Only the applicable variants
+/// are present; the disabled ones are omitted (the SDK reads a missing field as
+/// empty, which the provider asserts). Every present string is the same
+/// deterministic multi-broker synthesis on the per-variant port.
+fn gated_bootstrap_brokers(arn: &str, cluster: &Value) -> Map<String, Value> {
+    let num = cluster_num_brokers(cluster);
+    let client_broker = cluster
+        .get("encryptionInfo")
+        .and_then(|e| e.get("encryptionInTransit"))
+        .and_then(|t| t.get("clientBroker"))
+        .and_then(Value::as_str)
+        .unwrap_or("TLS");
+    let allows_plaintext = matches!(client_broker, "PLAINTEXT" | "TLS_PLAINTEXT");
+    let allows_tls = matches!(client_broker, "TLS" | "TLS_PLAINTEXT");
+
+    let sasl = cluster
+        .get("clientAuthentication")
+        .and_then(|c| c.get("sasl"));
+    let sasl_scram = sub_enabled(sasl.and_then(|s| s.get("scram")));
+    let sasl_iam = sub_enabled(sasl.and_then(|s| s.get("iam")));
+    let any_sasl = sasl_scram || sasl_iam;
+
+    let connectivity = cluster
+        .get("brokerNodeGroupInfo")
+        .and_then(|b| b.get("connectivityInfo"));
+    let public_enabled = connectivity
+        .and_then(|c| c.get("publicAccess"))
+        .and_then(|p| p.get("type"))
+        .and_then(Value::as_str)
+        .is_some_and(|t| t != "DISABLED");
+    let vpc_auth = connectivity
+        .and_then(|c| c.get("vpcConnectivity"))
+        .and_then(|v| v.get("clientAuthentication"));
+    let vpc_sasl = vpc_auth.and_then(|c| c.get("sasl"));
+    let vpc_sasl_iam = sub_enabled(vpc_sasl.and_then(|s| s.get("iam")));
+    let vpc_sasl_scram = sub_enabled(vpc_sasl.and_then(|s| s.get("scram")));
+    let vpc_tls = sub_enabled(vpc_auth.and_then(|c| c.get("tls")));
+
+    let mut out = Map::new();
+    let mut put = |key: &str, present: bool, port: u16| {
+        if present {
+            out.insert(
+                key.to_string(),
+                json!(shared::bootstrap_broker_string(arn, num, port)),
+            );
+        }
+    };
+    // Private (in-VPC) endpoints. The plaintext-cert TLS endpoint is offered only
+    // when NO SASL scheme is enabled (SASL clients use the SASL port instead).
+    put("bootstrapBrokerString", allows_plaintext, 9092);
+    put("bootstrapBrokerStringTls", allows_tls && !any_sasl, 9094);
+    put("bootstrapBrokerStringSaslScram", sasl_scram, 9096);
+    put("bootstrapBrokerStringSaslIam", sasl_iam, 9098);
+    // Public-access endpoints (only when public access is enabled).
+    put(
+        "bootstrapBrokerStringPublicTls",
+        public_enabled && allows_tls && !any_sasl,
+        9194,
+    );
+    put(
+        "bootstrapBrokerStringPublicSaslScram",
+        public_enabled && sasl_scram,
+        9196,
+    );
+    put(
+        "bootstrapBrokerStringPublicSaslIam",
+        public_enabled && sasl_iam,
+        9198,
+    );
+    // VPC-connectivity (PrivateLink) endpoints.
+    put("bootstrapBrokerStringVpcConnectivityTls", vpc_tls, 9094);
+    put(
+        "bootstrapBrokerStringVpcConnectivitySaslScram",
+        vpc_sasl_scram,
+        9096,
+    );
+    put(
+        "bootstrapBrokerStringVpcConnectivitySaslIam",
+        vpc_sasl_iam,
+        9098,
+    );
+    out
+}
+
 /// Project a `RunningBroker` into the persisted, describe-facing data-plane
 /// binding.
 fn running_to_dp(r: &RunningBroker) -> ClusterDataPlane {
@@ -849,27 +961,25 @@ impl KafkaService {
             .clusters
             .get(arn)
             .ok_or_else(|| bad_request(&format!("The cluster '{arn}' does not exist.")))?;
-        let num = cluster_num_brokers(cluster);
-        // When a real single-node Kafka broker backs this cluster, return its
-        // reachable `host:port` as the PLAINTEXT `bootstrapBrokerString` -- a
-        // real Kafka client produces/consumes through it. The TLS/SASL variants
-        // are not configured for the PLAINTEXT broker, so they are omitted (AWS
-        // omits the variants a cluster's client-auth config does not enable).
-        // Without a live broker (no runtime, serverless, or still creating) fall
-        // back to the cosmetic multi-broker synthesis -- same response shape.
+        // Synthesize exactly the encryption-in-transit + client-auth-gated set of
+        // bootstrap-broker strings MSK would advertise for this cluster's config
+        // (AWS omits every variant the cluster does not enable; the provider
+        // asserts the disabled ones are empty).
+        let mut out = gated_bootstrap_brokers(arn, cluster);
+        // When a real single-node Kafka broker backs this cluster (data plane on),
+        // its reachable `host:port` IS the real PLAINTEXT endpoint a Kafka client
+        // produces/consumes through, so surface it as `bootstrapBrokerString`
+        // regardless of the cosmetic gating (the single local broker is PLAINTEXT;
+        // the TLS/SASL variants stay format-synthesized). tfacc disables the
+        // backend, so there it is pure gating.
         if let Some(bootstrap) = data
             .data_plane
             .get(arn)
             .and_then(|dp| dp.bootstrap_string())
         {
-            return ok(json!({ "bootstrapBrokerString": bootstrap }));
+            out.insert("bootstrapBrokerString".into(), json!(bootstrap));
         }
-        ok(json!({
-            "bootstrapBrokerString": shared::bootstrap_broker_string(arn, num, 9092),
-            "bootstrapBrokerStringTls": shared::bootstrap_broker_string(arn, num, 9094),
-            "bootstrapBrokerStringSaslScram": shared::bootstrap_broker_string(arn, num, 9096),
-            "bootstrapBrokerStringSaslIam": shared::bootstrap_broker_string(arn, num, 9098),
-        }))
+        ok(Value::Object(out))
     }
 
     fn list_nodes(
@@ -1137,14 +1247,24 @@ fn render_cluster_v2(data: &KafkaData, arn: &str, cluster: &Value) -> Value {
             .cloned()
             .unwrap_or(json!({ "vpcConfigs": [] }));
     } else {
-        out["provisioned"] = json!({
+        let mut prov = json!({
             "brokerNodeGroupInfo": cluster.get("brokerNodeGroupInfo").cloned().unwrap_or_else(default_bngi),
             "numberOfBrokerNodes": cluster.get("numberOfBrokerNodes").cloned().unwrap_or(json!(3)),
             "currentBrokerSoftwareInfo": cluster.get("currentBrokerSoftwareInfo").cloned().unwrap_or(json!({})),
             "enhancedMonitoring": cluster.get("enhancedMonitoring").cloned().unwrap_or(json!("DEFAULT")),
+            "encryptionInfo": cluster.get("encryptionInfo").cloned().unwrap_or(json!({})),
             "storageMode": cluster.get("storageMode").cloned().unwrap_or(json!("LOCAL")),
             "zookeeperConnectString": cluster.get("zookeeperConnectString").cloned().unwrap_or(json!("")),
+            "zookeeperConnectStringTls": cluster.get("zookeeperConnectStringTls").cloned().unwrap_or(json!("")),
         });
+        // Echo the optional client-auth / logging / monitoring sub-objects only
+        // when the cluster carries them (same as the V1 view).
+        for key in ["clientAuthentication", "loggingInfo", "openMonitoring"] {
+            if let Some(v) = cluster.get(key) {
+                prov[key] = v.clone();
+            }
+        }
+        out["provisioned"] = prov;
     }
     out
 }
@@ -1240,9 +1360,44 @@ impl KafkaService {
         &self,
         ctx: &Ctx,
         arn: &str,
-        _b: &Value,
+        b: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
-        self.cluster_update(ctx, arn, "UPDATE_BROKER_STORAGE", false, |_| {})
+        // `UpdateBrokerStorage` carries the per-broker target EBS volume info
+        // (a uniform `volumeSizeGB` + optional `provisionedThroughput`); reflect
+        // it onto the cluster's `storageInfo.ebsStorageInfo` so a describe echoes
+        // the resized volume + provisioned-throughput toggle.
+        let target = b
+            .get("targetBrokerEBSVolumeInfo")
+            .and_then(Value::as_array)
+            .and_then(|a| a.first())
+            .cloned();
+        self.cluster_update(ctx, arn, "UPDATE_BROKER_STORAGE", false, |obj| {
+            let Some(target) = target else { return };
+            let Some(ebs) = obj
+                .get_mut("brokerNodeGroupInfo")
+                .and_then(Value::as_object_mut)
+                .and_then(|bngi| {
+                    bngi.entry("storageInfo")
+                        .or_insert_with(|| json!({}))
+                        .as_object_mut()
+                })
+                .and_then(|si| {
+                    si.entry("ebsStorageInfo")
+                        .or_insert_with(|| json!({}))
+                        .as_object_mut()
+                })
+            else {
+                return;
+            };
+            if let Some(vs) = target.get("volumeSizeGB") {
+                ebs.insert("volumeSize".into(), vs.clone());
+            }
+            // Echo the provisioned-throughput toggle verbatim (present once
+            // configured; enabled=false when disabled/removed).
+            if let Some(pt) = target.get("provisionedThroughput") {
+                ebs.insert("provisionedThroughput".into(), pt.clone());
+            }
+        })
     }
 
     fn update_broker_type(
@@ -1299,13 +1454,24 @@ impl KafkaService {
             .get("targetKafkaVersion")
             .and_then(Value::as_str)
             .map(str::to_string);
+        // `UpdateClusterKafkaVersion` optionally carries a new configuration to
+        // apply alongside the version bump (upgrade-with-info).
+        let info = b.get("configurationInfo").cloned();
         self.cluster_update(ctx, arn, "UPDATE_CLUSTER_KAFKA_VERSION", true, |obj| {
-            if let Some(t) = target {
-                let sw = obj
-                    .entry("currentBrokerSoftwareInfo")
-                    .or_insert_with(|| json!({}));
-                if let Some(swo) = sw.as_object_mut() {
+            let sw = obj
+                .entry("currentBrokerSoftwareInfo")
+                .or_insert_with(|| json!({}));
+            if let Some(swo) = sw.as_object_mut() {
+                if let Some(t) = target {
                     swo.insert("kafkaVersion".into(), json!(t));
+                }
+                if let Some(ci) = info {
+                    if let Some(a) = ci.get("arn") {
+                        swo.insert("configurationArn".into(), a.clone());
+                    }
+                    if let Some(r) = ci.get("revision") {
+                        swo.insert("configurationRevision".into(), r.clone());
+                    }
                 }
             }
         })
@@ -1318,9 +1484,23 @@ impl KafkaService {
         b: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
         let em = b.get("enhancedMonitoring").cloned();
+        let li = b.get("loggingInfo").cloned();
+        let om = b.get("openMonitoring").cloned();
         self.cluster_update(ctx, arn, "UPDATE_MONITORING", false, |obj| {
             if let Some(v) = em {
                 obj.insert("enhancedMonitoring".into(), v);
+            }
+            // `UpdateMonitoring` also carries the logging + open-monitoring config
+            // (the provider batches all three into one call); reflect them so a
+            // describe echoes the enabled/disabled state.
+            if let Some(v) = li {
+                obj.insert("loggingInfo".into(), v);
+            }
+            if let Some(v) = om {
+                obj.insert(
+                    "openMonitoring".into(),
+                    builders::normalize_open_monitoring(&v),
+                );
             }
         })
     }
@@ -1337,8 +1517,36 @@ impl KafkaService {
             if let Some(v) = ca {
                 obj.insert("clientAuthentication".into(), v);
             }
-            if let Some(v) = ei {
-                obj.insert("encryptionInfo".into(), v);
+            // MSK's UpdateSecurity does NOT change the at-rest key or the
+            // inter-broker (`inCluster`) encryption setting (the provider strips
+            // both from the request), so merge the incoming `encryptionInfo` onto
+            // the existing one field-wise instead of replacing it -- otherwise the
+            // preserved `inCluster` / `dataVolumeKMSKeyId` would be dropped.
+            if let Some(incoming) = ei.as_ref().and_then(Value::as_object) {
+                let existing = obj
+                    .get("encryptionInfo")
+                    .and_then(Value::as_object)
+                    .cloned()
+                    .unwrap_or_default();
+                let mut merged = existing.clone();
+                if let Some(transit) = incoming
+                    .get("encryptionInTransit")
+                    .and_then(Value::as_object)
+                {
+                    let mut t = existing
+                        .get("encryptionInTransit")
+                        .and_then(Value::as_object)
+                        .cloned()
+                        .unwrap_or_default();
+                    for (k, v) in transit {
+                        t.insert(k.clone(), v.clone());
+                    }
+                    merged.insert("encryptionInTransit".into(), Value::Object(t));
+                }
+                if let Some(at_rest) = incoming.get("encryptionAtRest") {
+                    merged.insert("encryptionAtRest".into(), at_rest.clone());
+                }
+                obj.insert("encryptionInfo".into(), Value::Object(merged));
             }
         })
     }
@@ -1351,12 +1559,28 @@ impl KafkaService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let ci = b.get("connectivityInfo").cloned();
         self.cluster_update(ctx, arn, "UPDATE_CONNECTIVITY", true, |obj| {
-            if let Some(v) = ci {
+            if let Some(incoming) = ci.as_ref().and_then(Value::as_object) {
                 if let Some(bngi) = obj
                     .get_mut("brokerNodeGroupInfo")
                     .and_then(Value::as_object_mut)
                 {
-                    bngi.insert("connectivityInfo".into(), v);
+                    // Merge the incoming `connectivityInfo` onto the existing one
+                    // (the provider sends only the sub-object it is changing --
+                    // `publicAccess` on a public-access change, `vpcConnectivity`
+                    // on the post-create vpc-connectivity apply), then re-normalize
+                    // so both sub-objects stay present with AWS defaults.
+                    let mut merged = bngi
+                        .get("connectivityInfo")
+                        .and_then(Value::as_object)
+                        .cloned()
+                        .unwrap_or_default();
+                    for (k, v) in incoming {
+                        merged.insert(k.clone(), v.clone());
+                    }
+                    bngi.insert(
+                        "connectivityInfo".into(),
+                        builders::normalize_connectivity_info(Some(&Value::Object(merged))),
+                    );
                 }
             }
         })
@@ -2601,7 +2825,7 @@ impl KafkaService {
         &self,
         ctx: &Ctx,
         arn: &str,
-        _b: &Value,
+        b: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut guard = self.state.write();
         let data = guard.get_or_create(&ctx.account);
@@ -2613,6 +2837,22 @@ impl KafkaService {
         let obj = r.as_object_mut().expect("replicator is object");
         obj.insert("replicatorState".into(), json!("UPDATING"));
         obj.insert("currentVersion".into(), json!(gen_version(n)));
+        // Reflect the topic / consumer-group replication changes onto the stored
+        // (description-shaped) replication info so a re-describe echoes them. The
+        // Update shapes carry the same member jsonNames as the description ones,
+        // so a field-wise merge preserves create-only members (e.g.
+        // `startingPosition`) the update payload does not include.
+        let topic = b.get("topicReplication").cloned();
+        let consumer = b.get("consumerGroupReplication").cloned();
+        if let Some(info) = obj
+            .get_mut("replicationInfoList")
+            .and_then(Value::as_array_mut)
+            .and_then(|l| l.first_mut())
+            .and_then(Value::as_object_mut)
+        {
+            merge_replication_sub(info, "topicReplication", topic);
+            merge_replication_sub(info, "consumerGroupReplication", consumer);
+        }
         ok(json!({ "replicatorArn": arn, "replicatorState": "UPDATING" }))
     }
 }
@@ -2854,25 +3094,91 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bootstrap_brokers_without_runtime_is_cosmetic_multi_broker() {
-        // With no data-plane binding, GetBootstrapBrokers falls back to the
-        // cosmetic multi-broker synthesis (all four listener variants present).
+    async fn bootstrap_brokers_default_tls_only() {
+        // A default cluster (client_broker=TLS, no SASL) advertises ONLY the TLS
+        // variant; the plaintext + SASL + public + vpc variants are omitted (the
+        // provider asserts those are empty).
         let s = svc();
         let c = ctx("us-east-1");
         let cluster = json_of(s.create_cluster(&c, &cluster_body("nb"), false).unwrap());
         let arn = cluster["clusterArn"].as_str().unwrap().to_string();
         let bb = json_of(s.get_bootstrap_brokers(&c, &arn).unwrap());
+        assert!(bb.get("bootstrapBrokerString").is_none());
+        assert!(bb["bootstrapBrokerStringTls"]
+            .as_str()
+            .unwrap()
+            .contains(".amazonaws.com:9094"));
+        assert!(bb.get("bootstrapBrokerStringSaslScram").is_none());
+        assert!(bb.get("bootstrapBrokerStringSaslIam").is_none());
+        assert!(bb.get("bootstrapBrokerStringPublicSaslIam").is_none());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_brokers_gated_on_client_auth_and_encryption() {
+        // client_broker=PLAINTEXT offers the plaintext string and omits TLS;
+        // enabling SASL/SCRAM offers the scram string and, being SASL, drops TLS.
+        let s = svc();
+        let c = ctx("us-east-1");
+        // PLAINTEXT-only cluster.
+        let mut body = cluster_body("pt");
+        body["encryptionInfo"] = json!({ "encryptionInTransit": { "clientBroker": "PLAINTEXT" } });
+        let arn = json_of(s.create_cluster(&c, &body, false).unwrap())["clusterArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let bb = json_of(s.get_bootstrap_brokers(&c, &arn).unwrap());
         assert!(bb["bootstrapBrokerString"]
             .as_str()
             .unwrap()
-            .contains(".amazonaws.com:9092"));
-        assert!(bb.get("bootstrapBrokerStringTls").is_some());
+            .contains(":9092"));
+        assert!(bb.get("bootstrapBrokerStringTls").is_none());
+
+        // SASL/SCRAM cluster (default TLS in transit).
+        let mut body = cluster_body("sc");
+        body["clientAuthentication"] = json!({ "sasl": { "scram": { "enabled": true } } });
+        let arn = json_of(s.create_cluster(&c, &body, false).unwrap())["clusterArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let bb = json_of(s.get_bootstrap_brokers(&c, &arn).unwrap());
+        assert!(bb["bootstrapBrokerStringSaslScram"]
+            .as_str()
+            .unwrap()
+            .contains(":9096"));
+        assert!(bb.get("bootstrapBrokerStringTls").is_none());
+        assert!(bb.get("bootstrapBrokerStringSaslIam").is_none());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_brokers_public_gated_on_public_access() {
+        // Public-access + SASL/IAM advertises both the private and the public
+        // SASL/IAM strings (on their distinct ports).
+        let s = svc();
+        let c = ctx("us-east-1");
+        let mut body = cluster_body("pub");
+        body["clientAuthentication"] = json!({ "sasl": { "iam": { "enabled": true } } });
+        body["brokerNodeGroupInfo"]["connectivityInfo"] =
+            json!({ "publicAccess": { "type": "SERVICE_PROVIDED_EIPS" } });
+        let arn = json_of(s.create_cluster(&c, &body, false).unwrap())["clusterArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let bb = json_of(s.get_bootstrap_brokers(&c, &arn).unwrap());
+        assert!(bb["bootstrapBrokerStringSaslIam"]
+            .as_str()
+            .unwrap()
+            .contains(":9098"));
+        assert!(bb["bootstrapBrokerStringPublicSaslIam"]
+            .as_str()
+            .unwrap()
+            .contains(":9198"));
     }
 
     #[tokio::test]
     async fn bootstrap_brokers_with_data_plane_returns_real_endpoint() {
         // A recorded data-plane binding makes GetBootstrapBrokers return the
-        // REAL reachable host:port as the single plaintext bootstrap string.
+        // REAL reachable host:port as the plaintext bootstrap string, on top of
+        // the cluster's gated (synthesized) TLS/SASL variants.
         let s = svc();
         let c = ctx("us-east-1");
         let cluster = json_of(s.create_cluster(&c, &cluster_body("rp"), false).unwrap());
@@ -2893,16 +3199,25 @@ mod tests {
             bb["bootstrapBrokerString"].as_str(),
             Some("127.0.0.1:51234")
         );
-        // The TLS/SASL variants are omitted for the PLAINTEXT broker.
-        assert!(bb.get("bootstrapBrokerStringTls").is_none());
+        // The cluster's TLS variant is still synthesized (default TLS in transit).
+        assert!(bb["bootstrapBrokerStringTls"]
+            .as_str()
+            .unwrap()
+            .contains(":9094"));
     }
 
     #[test]
     fn bootstrap_brokers_derived_from_broker_count() {
         let s = svc();
         let c = ctx("us-east-1");
-        let cluster = json_of(s.create_cluster(&c, &cluster_body("bb"), false).unwrap());
-        let arn = cluster["clusterArn"].as_str().unwrap().to_string();
+        // TLS_PLAINTEXT surfaces both plaintext and TLS strings, one per broker.
+        let mut body = cluster_body("bb");
+        body["encryptionInfo"] =
+            json!({ "encryptionInTransit": { "clientBroker": "TLS_PLAINTEXT" } });
+        let arn = json_of(s.create_cluster(&c, &body, false).unwrap())["clusterArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
         let bb = json_of(s.get_bootstrap_brokers(&c, &arn).unwrap());
         let s9092 = bb["bootstrapBrokerString"].as_str().unwrap();
         assert_eq!(s9092.split(',').count(), 3, "one endpoint per broker node");
@@ -2911,6 +3226,49 @@ mod tests {
             .as_str()
             .unwrap()
             .contains(":9094"));
+    }
+
+    #[test]
+    fn describe_cluster_echoes_connectivity_and_storage_defaults() {
+        // A minimal provisioned create round-trips the connectivity_info +
+        // storage_info sub-objects with AWS defaults (the deferred-tfacc gap).
+        let s = svc();
+        let c = ctx("us-east-1");
+        let arn = json_of(s.create_cluster(&c, &cluster_body("df"), false).unwrap())["clusterArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        settle(&s, &c);
+        let d = json_of(s.describe_cluster(&c, &arn, false).unwrap());
+        let bngi = &d["clusterInfo"]["brokerNodeGroupInfo"];
+        assert_eq!(bngi["brokerAZDistribution"], json!("DEFAULT"));
+        assert_eq!(
+            bngi["connectivityInfo"]["publicAccess"]["type"],
+            json!("DISABLED")
+        );
+        assert_eq!(
+            bngi["connectivityInfo"]["vpcConnectivity"]["clientAuthentication"]["sasl"]["iam"]
+                ["enabled"],
+            json!(false)
+        );
+        assert_eq!(
+            bngi["connectivityInfo"]["vpcConnectivity"]["clientAuthentication"]["tls"]["enabled"],
+            json!(false)
+        );
+        // No provisioned throughput on a cluster that never enabled it.
+        assert!(bngi["storageInfo"]["ebsStorageInfo"]
+            .get("provisionedThroughput")
+            .is_none());
+        // Encryption defaults + a synthesized KMS key ARN.
+        let ei = &d["clusterInfo"]["encryptionInfo"];
+        assert_eq!(ei["encryptionInTransit"]["clientBroker"], json!("TLS"));
+        assert_eq!(ei["encryptionInTransit"]["inCluster"], json!(true));
+        assert!(ei["encryptionAtRest"]["dataVolumeKMSKeyId"]
+            .as_str()
+            .unwrap()
+            .starts_with("arn:aws:kms:"));
+        // No client_authentication is echoed for an auth-less cluster.
+        assert!(d["clusterInfo"].get("clientAuthentication").is_none());
     }
 
     #[test]

--- a/crates/fakecloud-kafka/src/shared.rs
+++ b/crates/fakecloud-kafka/src/shared.rs
@@ -45,10 +45,28 @@ pub fn replicator_arn(region: &str, account: &str, name: &str, uuid: &str, n: u6
     format!("arn:aws:kafka:{region}:{account}:replicator/{name}/{uuid}-{n}")
 }
 
-/// MSK VPC-connection ARN:
-/// `arn:aws:kafka:{region}:{account}:vpc-connection/{uuid}-{n}`.
-pub fn vpc_connection_arn(region: &str, account: &str, uuid: &str, n: u64) -> String {
-    format!("arn:aws:kafka:{region}:{account}:vpc-connection/{uuid}-{n}")
+/// MSK VPC-connection ARN. Real MSK embeds the TARGET cluster's account, name,
+/// and a connection UUID in the resource part:
+/// `arn:aws:kafka:{region}:{account}:vpc-connection/{targetAccount}/{targetClusterName}/{uuid}-{n}`.
+/// `target_account` / `target_cluster_name` are derived from the target cluster
+/// ARN (falling back to the caller's own account / `cluster` when it can't be
+/// parsed), so the provider's ARN-shape assertion matches.
+pub fn vpc_connection_arn(
+    region: &str,
+    account: &str,
+    target_account: &str,
+    target_cluster_name: &str,
+    uuid: &str,
+    n: u64,
+) -> String {
+    format!(
+        "arn:aws:kafka:{region}:{account}:vpc-connection/{target_account}/{target_cluster_name}/{uuid}-{n}"
+    )
+}
+
+/// The account id embedded in a `kafka` ARN (the 5th colon-delimited field).
+pub fn arn_account(arn: &str) -> Option<&str> {
+    arn.split(':').nth(4)
 }
 
 /// The region embedded in a `kafka` ARN (the 4th colon-delimited field). Used
@@ -64,6 +82,12 @@ pub fn cluster_name_from_arn(arn: &str) -> Option<&str> {
 }
 
 /// The supported Kafka versions Amazon MSK offers, newest first, all `ACTIVE`.
+///
+/// This mirrors the real `ListKafkaVersions` catalog (the current Apache Kafka
+/// and KRaft/tiered-storage variants plus the still-selectable older lines) so
+/// the `aws_msk_kafka_version` data source -- which filters `ListKafkaVersions`
+/// by an exact `version` (e.g. `2.4.1.1`) and reads its `status` -- resolves,
+/// and so a cluster can be created at, and upgraded between, any of these.
 pub const KAFKA_VERSIONS: &[&str] = &[
     "3.8.x.kraft",
     "3.8.x",
@@ -72,8 +96,27 @@ pub const KAFKA_VERSIONS: &[&str] = &[
     "3.6.0",
     "3.5.1",
     "3.4.0",
+    "3.3.2",
+    "3.3.1",
+    "3.2.0",
+    "3.1.1",
     "2.8.2.tiered",
     "2.8.1",
+    "2.8.0",
+    "2.7.2",
+    "2.7.1",
+    "2.7.0",
+    "2.6.3",
+    "2.6.2",
+    "2.6.1",
+    "2.6.0",
+    "2.5.1",
+    "2.4.1.1",
+    "2.4.1",
+    "2.3.1",
+    "2.2.1",
+    "2.1.0",
+    "1.1.1",
 ];
 
 /// The `ListKafkaVersions` payload: each supported version with `ACTIVE` status.

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -1695,10 +1695,46 @@ pub const SHARDS: &[Shard] = &[
         run_regex: "^TestAccMQ(Broker|Configuration)_basic$",
         extra_deny: &[],
     },
+    // The full ^TestAccKafka suite (59 tests) exceeds a single 60-min runner's
+    // wall clock (each terraform apply/destroy cycle is slow in CI), so it is
+    // split into three resource-family shards whose union is the whole suite and
+    // whose run_regexes do not overlap. `^TestAccKafkaCluster_` captures only the
+    // cluster *resource* tests (the `_` after `Cluster` excludes ClusterPolicy /
+    // ClusterDataSource, which are claimed by the second shard).
     Shard {
-        name: "kafka",
+        name: "kafka-cluster",
         service: "kafka",
-        run_regex: "^TestAccKafka",
+        run_regex: "^TestAccKafkaCluster_",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kafka-config-serverless",
+        service: "kafka",
+        run_regex: concat!(
+            "^TestAccKafka(",
+            "Configuration",
+            "|ConfigurationDataSource",
+            "|ClusterDataSource",
+            "|ClusterPolicy",
+            "|ServerlessCluster",
+            "|BootstrapBrokersDataSource",
+            "|BrokerNodesDataSource",
+            "|KafkaVersionDataSource",
+            ")",
+        ),
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kafka-scram-repl-vpc",
+        service: "kafka",
+        run_regex: concat!(
+            "^TestAccKafka(",
+            "SCRAMSecretAssociation",
+            "|SingleSCRAMSecretAssociation",
+            "|Replicator",
+            "|VPCConnection",
+            ")",
+        ),
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -737,47 +737,31 @@ pub const SERVICES: &[Service] = &[
         // plane is disabled for tfacc via FAKECLOUD_KAFKA_DISABLE_BACKEND=1, so a
         // real broker's `127.0.0.1:<port>` bootstrap endpoints don't race the
         // provider's AWS-format `*.amazonaws.com:9092` assertions -- the data
-        // plane is proven separately by the msk-broker Docker E2E). This first
-        // wave selects the resources + data sources that round-trip cleanly
-        // against the auto-settling control plane:
-        //   - `aws_msk_configuration` (create/read/update-revision/delete, base64
-        //     ServerProperties, KafkaVersions, description; DescribeConfiguration
-        //     reports the AWS `BadRequestException` not-found shape the provider's
-        //     delete waiter keys on) + its data source,
-        //   - a provisioned cluster with an explicit instance type
-        //     (`Cluster_BrokerNodeGroupInfo_instanceType`) and the cluster
-        //     `_disappears` lifecycle,
-        //   - a serverless cluster (security-group VpcConfig + `_disappears`),
-        //   - SCRAM-secret associations (`_disappears` / `Disappears_cluster` /
-        //     single-secret `_disappears`, which stand up a real KMS key +
-        //     Secrets Manager secret and the batch-associate/list round-trip),
-        //   - the broker-nodes and bootstrap-brokers data sources.
-        //
-        // Deferred to a later widening batch (NOT env-impossible, but needing
-        // deeper cluster describe/GetBootstrapBrokers fidelity than the current
-        // control plane): the full `Cluster_basic`/tags/monitoring/storage/
-        // version-upgrade suite, the cluster + configuration-with-cluster data
-        // sources, cluster policies, replicators, and standalone VPC connections
-        // all drift on cluster attributes the control plane does not yet
-        // synthesize (encryption-in-transit-gated bootstrap-broker strings,
-        // `connectivity_info` / `client_authentication` / `logging_info` /
-        // `open_monitoring` defaults, serverless default security group). The
-        // Kafka-version data source needs a fuller ListKafkaVersions catalogue.
-        // These grow as the MSK control-plane fidelity does; they are selected
-        // out by the narrow positive regex rather than enumerated as denies.
-        run_regex: concat!(
-            "^TestAccKafka(",
-            "Configuration_(basic|description|disappears|kafkaVersions|serverProperties)",
-            "|ConfigurationDataSource_name",
-            "|Cluster_disappears",
-            "|Cluster_BrokerNodeGroupInfo_instanceType",
-            "|BrokerNodesDataSource_basic",
-            "|BootstrapBrokersDataSource_basic",
-            "|ServerlessCluster_(disappears|securityGroup)",
-            "|SCRAMSecretAssociation_(disappears|Disappears_cluster)",
-            "|SingleSCRAMSecretAssociation_disappears",
-            ")$",
-        ),
+        // plane is proven separately by the msk-broker Docker E2E). The whole
+        // upstream `internal/service/kafka` acceptance suite passes against the
+        // auto-settling control plane, so the entire `TestAccKafka*` set runs
+        // with NO denies:
+        //   - provisioned + serverless clusters (create/describe/update/delete,
+        //     tags, ImportStateVerify), with DescribeCluster round-tripping the
+        //     full `broker_node_group_info` (connectivity_info public-access +
+        //     vpc-connectivity defaults, storage_info + provisioned-throughput),
+        //     `client_authentication`, `encryption_info` (in-transit +
+        //     synthesized at-rest KMS key), `logging_info`, `open_monitoring`,
+        //     `enhanced_monitoring`, and `configuration_info`,
+        //   - GetBootstrapBrokers gated on encryption-in-transit `client_broker`
+        //     + the enabled private/public/vpc-connectivity auth schemes, so the
+        //     right `bootstrap_brokers_*` variants are present/empty,
+        //   - the cluster / cluster-policy / configuration / broker-nodes /
+        //     bootstrap-brokers / kafka-version / vpc-connection data sources,
+        //   - cluster policies, SCRAM-secret associations (single + batch),
+        //     standalone VPC connections, and replicators (the request->
+        //     description shape transform with alias mapping + computed
+        //     topic-replication defaults),
+        //   - TLS client-auth with an ACM PCA certificate-authority ARN.
+        // The Kafka-broker data plane's real in-transit produce/consume path is
+        // still proven only by the dedicated msk-broker Docker E2E (not tfacc),
+        // which is why the backend stays disabled here.
+        run_regex: "^TestAccKafka",
         deny: &[],
     },
     Service {
@@ -1714,19 +1698,7 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "kafka",
         service: "kafka",
-        run_regex: concat!(
-            "^TestAccKafka(",
-            "Configuration_(basic|description|disappears|kafkaVersions|serverProperties)",
-            "|ConfigurationDataSource_name",
-            "|Cluster_disappears",
-            "|Cluster_BrokerNodeGroupInfo_instanceType",
-            "|BrokerNodesDataSource_basic",
-            "|BootstrapBrokersDataSource_basic",
-            "|ServerlessCluster_(disappears|securityGroup)",
-            "|SCRAMSecretAssociation_(disappears|Disappears_cluster)",
-            "|SingleSCRAMSecretAssociation_disappears",
-            ")$",
-        ),
+        run_regex: "^TestAccKafka",
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -138,8 +138,18 @@ async fn mq_acceptance() {
 }
 
 #[tokio::test]
-async fn kafka_acceptance() {
-    run_shard("kafka").await;
+async fn kafka_cluster_acceptance() {
+    run_shard("kafka-cluster").await;
+}
+
+#[tokio::test]
+async fn kafka_config_serverless_acceptance() {
+    run_shard("kafka-config-serverless").await;
+}
+
+#[tokio::test]
+async fn kafka_scram_repl_vpc_acceptance() {
+    run_shard("kafka-scram-repl-vpc").await;
 }
 
 #[tokio::test]

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -138,6 +138,11 @@ async fn mq_acceptance() {
 }
 
 #[tokio::test]
+async fn kafka_acceptance() {
+    run_shard("kafka").await;
+}
+
+#[tokio::test]
 async fn glacier_acceptance() {
     run_shard("glacier").await;
 }

--- a/website/content/docs/services/kafka.md
+++ b/website/content/docs/services/kafka.md
@@ -71,11 +71,31 @@ broker.
   `CurrentVersion`, and move it to `UPDATING`/`REBOOTING_BROKER` (settling to
   `ACTIVE` on the next describe). `ListClusterOperations`/`ListClusterOperationsV2`
   and `DescribeClusterOperation`/`DescribeClusterOperationV2` return them.
+- **Cluster attributes** - `CreateCluster`/`CreateClusterV2` persist and
+  `DescribeCluster`/`DescribeClusterV2` echo the full cluster sub-objects, with
+  AWS defaults applied when omitted so both an explicit and a minimal create
+  round-trip: `BrokerNodeGroupInfo` (`ConnectivityInfo` with `PublicAccess`
+  defaulting to `DISABLED` and an all-disabled `VpcConnectivity`, `StorageInfo`/
+  `EBSStorageInfo` with `VolumeSize` and an as-configured `ProvisionedThroughput`,
+  `BrokerAZDistribution` `DEFAULT`), `EncryptionInfo` (`EncryptionInTransit`
+  `ClientBroker` `TLS` + `InCluster` `true`, and a synthesized
+  `EncryptionAtRest.DataVolumeKMSKeyId` KMS key ARN), `ClientAuthentication`,
+  `LoggingInfo`, `OpenMonitoring`, `EnhancedMonitoring` (`DEFAULT`), and
+  `CurrentBrokerSoftwareInfo` (Kafka version + any associated configuration
+  ARN/revision). Serverless clusters synthesize a default `VpcConfig` security
+  group and an IAM-enabled `ClientAuthentication`.
 - **Broker nodes** - `ListNodes` synthesizes one `BrokerNodeInfo` per
   `NumberOfBrokerNodes` (broker id `1..=N`, client VPC IP, ENI, subnet,
-  endpoints, and current software info). `GetBootstrapBrokers` returns the
-  plaintext (`:9092`), TLS (`:9094`), SASL/SCRAM (`:9096`), and SASL/IAM
-  (`:9098`) connection strings derived from those nodes.
+  endpoints, and current software info). `GetBootstrapBrokers` returns exactly
+  the connection-string variants the cluster's config enables, gated on its
+  in-transit `ClientBroker` and client-auth schemes: plaintext (`:9092`, when
+  `ClientBroker` allows `PLAINTEXT`), TLS (`:9094`, when TLS is allowed and no
+  SASL scheme is on), SASL/SCRAM (`:9096`) and SASL/IAM (`:9098`) when enabled,
+  the `Public*` variants (`:9194`/`:9196`/`:9198`) when public access is enabled,
+  and the `VpcConnectivity*` variants when vpc-connectivity auth is enabled; the
+  schemes a cluster does not enable are omitted, exactly as MSK omits them. When
+  a real broker backs the cluster, its reachable `host:port` is returned as the
+  plaintext string.
 - **Configurations** - `CreateConfiguration` stores the base64 `ServerProperties`
   with a monotonic revision list (revision `1`, `CreationTime`, `Description`);
   `UpdateConfiguration` adds a revision; `DescribeConfigurationRevision` returns
@@ -94,9 +114,12 @@ broker.
   `{TopicName, PartitionCount, ReplicationFactor, Configs}`;
   `DescribeTopic`/`ListTopics`/`DescribeTopicPartitions` reflect it;
   `UpdateTopic`/`DeleteTopic` mutate it.
-- **Versions** - `ListKafkaVersions` returns the supported MSK version catalog
-  (2.8.x through 3.8.x, including KRaft variants) with `ACTIVE` status;
-  `GetCompatibleKafkaVersions` returns compatible upgrade targets.
+- **Versions** - `ListKafkaVersions` returns the real MSK supported-version
+  catalog (the `1.1.1` / `2.x` lines through `3.8.x`, including the `2.8.2.tiered`
+  and `3.7.x`/`3.8.x` KRaft variants) with `ACTIVE` status, so the
+  `aws_msk_kafka_version` data source (which filters by an exact version + status)
+  resolves; `GetCompatibleKafkaVersions` returns the strictly-newer upgrade
+  targets for a source version.
 - **Tags** - `TagResource` (204) / `UntagResource` (204) / `ListTagsForResource`
   maintain an ARN-keyed tag map; `CreateCluster`/`CreateConfiguration`/
   `CreateVpcConnection`/`CreateReplicator` honour inline `Tags`, and tags surface
@@ -133,14 +156,19 @@ in-memory control plane, the same as the direct API.
 
 ## Terraform
 
-fakecloud is exercised by the upstream `terraform-provider-aws` MSK acceptance
-tests (`internal/service/kafka`) in the `kafka` tfacc job -- clusters,
-configurations, cluster policies, serverless clusters, SCRAM-secret
-associations, and the Kafka-version / cluster / broker-nodes / bootstrap-brokers
-data sources round-trip against the auto-settling control plane. Tests that need
-a real in-transit TLS/SASL broker handshake, real CloudWatch/S3/Firehose log
-destinations that MSK validates, or real multi-VPC/public connectivity the
-provider verifies against EC2 are out of scope for a control-plane emulator.
+fakecloud passes the **entire** upstream `terraform-provider-aws` MSK acceptance
+suite (`internal/service/kafka`) in the `kafka` tfacc job, with no denies:
+provisioned + serverless clusters (create/describe/update/delete, tags, import,
+client-auth, encryption, logging, monitoring, storage, connectivity, and
+version-upgrade paths), cluster policies, configurations, SCRAM-secret
+associations, standalone VPC connections, replicators, TLS client-auth with an
+ACM PCA certificate-authority ARN, and the cluster / cluster-policy /
+configuration / broker-nodes / bootstrap-brokers / kafka-version / vpc-connection
+data sources all round-trip against the auto-settling control plane. The suite
+runs with the Kafka broker data plane disabled (`FAKECLOUD_KAFKA_DISABLE_BACKEND=1`)
+so the AWS-format `*.amazonaws.com` bootstrap-broker assertions don't race a real
+`127.0.0.1:<port>` endpoint; the real in-transit produce/consume round trip is
+proven separately by the dedicated `msk-broker` Docker E2E.
 
 ## Persistence
 


### PR DESCRIPTION
## Summary

Closes the cluster describe-attribute fidelity gaps deferred in batch 3, so the **entire** terraform-provider-aws kafka acceptance suite passes. This is the batch that makes MSK fully match the AWS surface (real handlers, no write-read asymmetry, full tfacc, 100% conformance).

### Cluster attribute fidelity (persisted on create, echoed on describe, AWS defaults when omitted)
- **BrokerNodeGroupInfo**: `ConnectivityInfo` (`PublicAccess {Type: DISABLED}` default + `VpcConnectivity`), `StorageInfo.EbsStorageInfo` (VolumeSize 1000; `ProvisionedThroughput` echoed only when set), `BrokerAZDistribution "DEFAULT"`.
- **EncryptionInfo**: `EncryptionInTransit {ClientBroker: TLS, InCluster: true}` + synthesized `EncryptionAtRest.DataVolumeKMSKeyId` (`arn:aws:kms:.../key/{uuid}`).
- **ClientAuthentication / LoggingInfo / OpenMonitoring** echoed faithfully; **CurrentBrokerSoftwareInfo** carries kafka version + configuration ARN/revision.
- **Serverless (V2)**: default `VpcConfig` security group + IAM-enabled auth.
- Faithful `Update*` handlers (storage/monitoring/security/connectivity/version) that **merge** rather than clobber the sub-objects.
- **GetBootstrapBrokers** returns exactly the encryption/auth-gated variants the cluster enables (plaintext/TLS/SASL-SCRAM/SASL-IAM + public + vpc-connectivity); the real-broker data-plane path still overrides the plaintext string with the reachable `host:port`.

### Version catalog
`ListKafkaVersions` returns the real MSK catalog (1.1.1..3.8.x incl. KRaft/tiered), all `ACTIVE`; `GetCompatibleKafkaVersions` returns newer targets.

### tfacc — full coverage, zero denies
Widened the `kafka` Service + Shard `run_regex` to `^TestAccKafka` (the whole suite) with **ZERO denies** — all **59 `TestAccKafka*` tests pass live** (Go 1.26 + provider v5.97.0), including Replicator, ClusterPolicy, VPC connections, and TLS client-auth with a real ACM-PCA CA. Nothing was environment-impossible.

**Also fixed**: the batch-3 tfacc shard existed but was never bound to a test fn in `tests/acc.rs`, so it ran **zero** tests in CI (vacuous pass). Added `kafka_acceptance()` so the shard actually runs the suite.

## Test plan
- [x] `cargo build --workspace`, `clippy --all-targets -D warnings`, `fmt --check` clean
- [x] `cargo test -p fakecloud-kafka` (37, incl. new bootstrap-gating + attribute-default tests)
- [x] Conformance unchanged: `run --services kafka` -> 59/59, 1555/1555; `nextest --test kafka` green
- [x] `cargo nextest run -p fakecloud-e2e --test msk --test cloudformation_msk` -> 4 passed (updated for TLS-default bootstrap)
- [x] `scripts/check-doc-counts.sh` exits 0
- [x] All 59 `TestAccKafka*` acc tests pass live; CI `tfacc kafka` shard now actually runs them

SDKs: no change. With this, MSK is control plane (59 ops) + real Kafka data plane + CFN + full tfacc + 100% conformance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings MSK cluster describe parity with AWS and gates bootstrap brokers correctly, enabling the full `terraform-provider-aws` Kafka acceptance suite to run and pass. Splits the tfacc run into three shards to stay within CI time limits.

- **New Features**
  - Cluster attribute fidelity with AWS defaults on create/describe: `BrokerNodeGroupInfo` (`ConnectivityInfo` public access default `DISABLED` + VPC connectivity, `StorageInfo` EBS volume size 1000 with provisioned throughput only when set, `BrokerAZDistribution` `DEFAULT`), `EncryptionInfo` (in-transit `ClientBroker` `TLS` + `InCluster` `true`, synthesized at-rest KMS key ARN), optional `ClientAuthentication`/`LoggingInfo`/`OpenMonitoring`, and `CurrentBrokerSoftwareInfo` (Kafka version + configuration ARN/revision). Serverless defaults a `VpcConfig` security group and IAM auth.
  - `GetBootstrapBrokers` returns only the variants enabled by encryption/client auth (private/public/VPC connectivity; plaintext/TLS/SASL-SCRAM/SASL-IAM). When the data plane is active, the plaintext string is the real `host:port`.
  - Update handlers merge sub-objects (storage, monitoring/logging/open-monitoring, security, connectivity, version incl. upgrade-with-info) instead of replacing them.
  - Replicator describes with cluster aliases and computed topic defaults; updates merge topic/consumer-group replication fields.
  - `ListKafkaVersions` mirrors the real MSK catalog (`1.1.1`…`3.8.x`, incl. KRaft/tiered). `GetCompatibleKafkaVersions` returns newer targets.
  - VPC connection ARN now includes target account and cluster name to match AWS.

- **Bug Fixes**
  - tfacc: run the entire `^TestAccKafka` suite with no denies; all 59 tests pass. Split into three shards — `kafka-cluster`, `kafka-config-serverless`, `kafka-scram-repl-vpc` — and added matching test runners to avoid 60‑min CI timeouts.

<sup>Written for commit 25a7a30ed9d2e3efad53bd7d89aa8bc7e757c972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

