### PR TITLE
feat(kinesisanalyticsv2): real Docker-backed Flink-job data plane (batch 2)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -510,3 +510,62 @@ jobs:
       - name: Prune container state after tests
         if: always()
         run: docker system prune -af --volumes || true
+
+  flink-runtime:
+    name: Managed Flink data plane
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    # A Flink session cluster boot is slow (JVM JobManager + TaskManager start +
+    # first cold image pull + job submission); allow ample headroom over the
+    # test's own 360s app-readiness window plus retries.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/free-disk
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Prune container state before tests
+        run: docker system prune -af --volumes || true
+
+      # Pre-pull the Flink image (with retry) so the first StartApplication
+      # doesn't pay a cold pull inside the readiness window. The image ref
+      # matches the runtime default; keep it in sync with FlinkRuntime::image
+      # (FAKECLOUD_KINESISANALYTICSV2_IMAGE).
+      - name: Pre-pull Flink image
+        run: |
+          for i in 1 2 3; do
+            if docker pull flink:1.19; then break; fi
+            echo "docker pull flink:1.19 attempt $i failed; retrying"; sleep $((i * 5))
+            [ "$i" = 3 ] && { echo "::error::could not pull flink:1.19"; exit 1; }
+          done
+
+      # The testkit boots this binary via its workspace-relative path, so a plain
+      # debug build in place is all the test needs.
+      - name: Build fakecloud
+        run: cargo build --bin fakecloud
+
+      # Run ONLY the Flink data-plane round-trip test. FAKECLOUD_E2E_FLINK=1 flips
+      # it from skip to run; CI=1 makes a missing docker a hard failure rather
+      # than a silent skip. --retries 2 reruns only a failed test to ride out
+      # cold-pull / first-connection flake; a test that fails every attempt still
+      # fails the job red.
+      - name: Run Flink runtime E2E
+        env:
+          FAKECLOUD_E2E_FLINK: "1"
+          CI: "1"
+        run: |
+          cargo nextest run -P ci -p fakecloud-e2e --retries 2 \
+            -E 'test(flink_application_runs_a_real_job_in_a_container)'
+
+      - name: Flink container diagnostics
+        if: always()
+        run: |
+          echo "=== docker ps -a ==="
+          docker ps -a || true
+
+      - name: Prune container state after tests
+        if: always()
+        run: docker system prune -af --volumes || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5138,6 +5138,7 @@ dependencies = [
  "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -7573,6 +7574,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8789,6 +8800,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -10359,6 +10371,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/fakecloud-e2e/tests/kinesisanalyticsv2.rs
+++ b/crates/fakecloud-e2e/tests/kinesisanalyticsv2.rs
@@ -7,9 +7,16 @@
 //!   create -> describe -> start (settles RUNNING) -> snapshot -> stop
 //!          -> update (version bump) -> delete
 //!
-//! This is a pure control-plane test — no real Flink container is spawned; the
-//! lifecycle auto-settles in memory on describe. The Docker-backed Flink job
-//! data plane is a separate later batch.
+//! This runs in the shared partition with
+//! `FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND=1`, so it is a pure
+//! CONTROL-PLANE test: no real Flink container is spawned and the lifecycle
+//! auto-settles in memory (STARTING -> RUNNING on the first describe). The real
+//! Docker-backed Flink job + REST round trip lives in
+//! `kinesisanalyticsv2_dataplane.rs`, which runs ONLY in the dedicated
+//! `flink-runtime` CI job. Without the flag, a docker-capable shared runner
+//! would attach the live runtime and spawn a heavy Flink cluster here (and the
+//! app would not instantly settle to RUNNING) — exactly what the dedicated job
+//! exists to isolate.
 
 mod helpers;
 
@@ -22,7 +29,8 @@ async fn ka2_client(server: &TestServer) -> aws_sdk_kinesisanalyticsv2::Client {
 
 #[tokio::test]
 async fn application_lifecycle_create_start_snapshot_stop_update_delete() {
-    let server = TestServer::start().await;
+    let server =
+        TestServer::start_with_env(&[("FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND", "1")]).await;
     let ka2 = ka2_client(&server).await;
 
     let role = "arn:aws:iam::000000000000:role/service-role/kinesis-analytics";

--- a/crates/fakecloud-e2e/tests/kinesisanalyticsv2_dataplane.rs
+++ b/crates/fakecloud-e2e/tests/kinesisanalyticsv2_dataplane.rs
@@ -1,0 +1,285 @@
+//! Amazon Managed Service for Apache Flink (kinesisanalyticsv2) DATA-PLANE E2E:
+//! proves that starting a Flink-flavor application spawns a REAL Apache Flink
+//! job in a Docker container, not a formatted-but-dead dashboard URL.
+//!
+//! The test obtains a genuine Flink job JAR by copying one of the `flink:1.19`
+//! image's bundled examples (`StateMachineExample.jar`, which runs
+//! continuously) out of the image, uploads it into a fakecloud S3 bucket, then:
+//!
+//!   1. CreateApplication (FLINK-1_19, code = that S3 object) + StartApplication
+//!   2. poll DescribeApplication until RUNNING — which only happens once the
+//!      REAL Flink job reaches RUNNING on the spawned session cluster
+//!   3. CreateApplicationPresignedUrl returns the reachable dashboard; querying
+//!      the live Flink REST `/jobs` through it shows exactly one RUNNING job
+//!      (the round trip that proves the data plane actually works)
+//!   4. StopApplication -> poll until READY; the backing container is torn down
+//!      (which only happens after the real job is canceled) — asserted by the
+//!      absence of any leftover container.
+//!
+//! Gated on Docker + `FAKECLOUD_E2E_FLINK=1` (the heavy Flink container). It
+//! runs ONLY in the dedicated, resourced `flink-runtime` CI job; in the shared
+//! partition the flag is unset and it skips loudly. In that CI job a missing
+//! Docker hard-fails rather than silently skipping.
+
+mod helpers;
+
+use std::time::Duration;
+
+use aws_sdk_kinesisanalyticsv2::types::{
+    ApplicationCodeConfiguration, ApplicationConfiguration, CodeContent, CodeContentType,
+    RuntimeEnvironment, S3ContentLocation, UrlType,
+};
+use aws_sdk_s3::primitives::ByteStream;
+use helpers::TestServer;
+
+const FLINK_IMAGE: &str = "flink:1.19";
+const EXAMPLE_JAR: &str = "/opt/flink/examples/streaming/StateMachineExample.jar";
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    // The real Flink session cluster (a JVM JobManager + TaskManager) is heavy
+    // and strains the shared E2E partition's runner, so this suite runs ONLY in
+    // the dedicated, resourced `flink-runtime` CI job, which sets
+    // FAKECLOUD_E2E_FLINK=1. In the shared partition the flag is unset and we
+    // skip loudly (by design). In the dedicated CI job a missing Docker
+    // hard-fails rather than silently skipping.
+    if std::env::var("FAKECLOUD_E2E_FLINK").as_deref() != Ok("1") {
+        eprintln!(
+            "Skipping {test}: FAKECLOUD_E2E_FLINK!=1 (runs in the dedicated flink-runtime CI job)"
+        );
+        return false;
+    }
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in the flink-runtime CI job");
+    }
+    eprintln!("Skipping {test}: docker not available");
+    false
+}
+
+/// Copy the bundled StateMachineExample JAR out of the Flink image so we can
+/// upload it into S3 as a genuine, runnable Flink job.
+fn extract_example_jar() -> Vec<u8> {
+    let out = std::process::Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--entrypoint",
+            "cat",
+            FLINK_IMAGE,
+            EXAMPLE_JAR,
+        ])
+        .output()
+        .expect("run docker to extract the example jar");
+    assert!(
+        out.status.success(),
+        "failed to extract {EXAMPLE_JAR} from {FLINK_IMAGE}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.stdout.len() > 1_000_000,
+        "example jar looks too small ({} bytes)",
+        out.stdout.len()
+    );
+    out.stdout
+}
+
+/// Whether any backing Flink container for `app_arn` is still present.
+fn leftover_container(app_arn: &str) -> bool {
+    let out = std::process::Command::new("docker")
+        .args([
+            "ps",
+            "-aq",
+            "--filter",
+            &format!("label=fakecloud-flink={app_arn}"),
+        ])
+        .output()
+        .expect("docker ps");
+    !String::from_utf8_lossy(&out.stdout).trim().is_empty()
+}
+
+async fn ka2_client(server: &TestServer) -> aws_sdk_kinesisanalyticsv2::Client {
+    aws_sdk_kinesisanalyticsv2::Client::new(&server.aws_config().await)
+}
+
+#[tokio::test]
+async fn flink_application_runs_a_real_job_in_a_container() {
+    if !require_docker_or_skip("flink_application_runs_a_real_job_in_a_container") {
+        return;
+    }
+
+    let server = TestServer::start().await;
+    let ka2 = ka2_client(&server).await;
+    let s3 = server.s3_client().await;
+    let http = reqwest::Client::new();
+
+    // 1. Publish a genuine Flink job JAR into a fakecloud S3 bucket.
+    let bucket = "fc-flink-code";
+    let key = "jobs/StateMachineExample.jar";
+    s3.create_bucket()
+        .bucket(bucket)
+        .send()
+        .await
+        .expect("create S3 bucket");
+    let jar = extract_example_jar();
+    s3.put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(ByteStream::from(jar))
+        .send()
+        .await
+        .expect("put jar object");
+
+    // 2. CreateApplication pointing at that S3 object, then StartApplication.
+    let role = "arn:aws:iam::000000000000:role/service-role/kinesis-analytics";
+    let code_cfg = ApplicationConfiguration::builder()
+        .application_code_configuration(
+            ApplicationCodeConfiguration::builder()
+                .code_content(
+                    CodeContent::builder()
+                        .s3_content_location(
+                            S3ContentLocation::builder()
+                                .bucket_arn(format!("arn:aws:s3:::{bucket}"))
+                                .file_key(key)
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .code_content_type(CodeContentType::Zipfile)
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    let app_name = "fc-flink-dataplane";
+    let created = ka2
+        .create_application()
+        .application_name(app_name)
+        .runtime_environment(RuntimeEnvironment::from("FLINK_1_19"))
+        .service_execution_role(role)
+        .application_configuration(code_cfg)
+        .send()
+        .await
+        .expect("create application");
+    let app_arn = created
+        .application_detail()
+        .map(|d| d.application_arn().to_string())
+        .expect("application arn");
+
+    ka2.start_application()
+        .application_name(app_name)
+        .send()
+        .await
+        .expect("start application");
+
+    // 3. Poll DescribeApplication until RUNNING. This only flips once the REAL
+    //    Flink job reaches RUNNING on the spawned cluster (container pull + boot
+    //    + TaskManager registration + job submission), so allow a wide window.
+    let deadline = std::time::Instant::now() + Duration::from_secs(360);
+    loop {
+        let d = ka2
+            .describe_application()
+            .application_name(app_name)
+            .send()
+            .await
+            .expect("describe application");
+        let status = d
+            .application_detail()
+            .map(|a| a.application_status().as_str().to_string())
+            .unwrap_or_default();
+        if status == "RUNNING" {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "application did not reach RUNNING within the deadline (last status: {status})"
+        );
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+
+    // 4. The presigned URL is the REAL reachable Flink dashboard/REST base.
+    //    Querying its /jobs endpoint must show exactly one RUNNING job — the
+    //    round trip that proves the data plane genuinely works.
+    let presigned = ka2
+        .create_application_presigned_url()
+        .application_name(app_name)
+        .url_type(UrlType::FlinkDashboardUrl)
+        .send()
+        .await
+        .expect("create presigned url");
+    let dashboard = presigned
+        .authorized_url()
+        .expect("authorized url")
+        .to_string();
+    assert!(
+        !dashboard.contains("amazonaws.com"),
+        "a running Flink app must return a reachable dashboard, got {dashboard}"
+    );
+
+    let jobs: serde_json::Value = http
+        .get(format!("{dashboard}/jobs"))
+        .send()
+        .await
+        .expect("GET /jobs on the live Flink cluster")
+        .json()
+        .await
+        .expect("parse /jobs");
+    let running: Vec<&serde_json::Value> = jobs["jobs"]
+        .as_array()
+        .expect("jobs array")
+        .iter()
+        .filter(|j| j["status"] == "RUNNING")
+        .collect();
+    assert_eq!(
+        running.len(),
+        1,
+        "exactly one RUNNING Flink job expected on the live cluster, got {jobs}"
+    );
+
+    // 5. StopApplication -> poll until READY; the container is torn down only
+    //    after the real job is canceled, so no container may be left behind.
+    ka2.stop_application()
+        .application_name(app_name)
+        .send()
+        .await
+        .expect("stop application");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        let d = ka2
+            .describe_application()
+            .application_name(app_name)
+            .send()
+            .await
+            .expect("describe application");
+        let status = d
+            .application_detail()
+            .map(|a| a.application_status().as_str().to_string())
+            .unwrap_or_default();
+        if status == "READY" {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "application did not return to READY after stop (last status: {status})"
+        );
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+
+    assert!(
+        !leftover_container(&app_arn),
+        "the backing Flink container must be torn down on stop (no leftover)"
+    );
+}

--- a/crates/fakecloud-kinesisanalyticsv2/Cargo.toml
+++ b/crates/fakecloud-kinesisanalyticsv2/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
+reqwest = { workspace = true, features = ["multipart"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/fakecloud-kinesisanalyticsv2/src/lib.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/lib.rs
@@ -2,8 +2,10 @@
 //! Kinesis Data Analytics v2) implementation for FakeCloud.
 
 pub mod persistence;
+pub mod runtime;
 pub mod service;
 pub mod state;
 
+pub use runtime::FlinkRuntime;
 pub use service::{Ka2Service, KA2_ACTIONS};
 pub use state::{Ka2Snapshot, Ka2State, SharedKa2State, KA2_SNAPSHOT_SCHEMA_VERSION};

--- a/crates/fakecloud-kinesisanalyticsv2/src/runtime/mod.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/runtime/mod.rs
@@ -1,0 +1,697 @@
+//! Backing-container runtime for Amazon Managed Service for Apache Flink
+//! (`kinesisanalyticsv2`).
+//!
+//! A **Flink-flavor** application (`RuntimeEnvironment` `FLINK-1_x`, with a JAR
+//! in S3) is backed by a REAL Apache Flink session cluster running in a Docker
+//! container: the application's code JAR is submitted to the cluster's
+//! JobManager over its REST API and the application only becomes `RUNNING` once
+//! Flink reports the job `RUNNING`. `StopApplication` cancels the real Flink
+//! job. This is the same data-plane bar Amazon MQ / MSK / RDS / ElastiCache /
+//! Lambda meet -- not a formatted-but-dead dashboard URL.
+//!
+//! Image: `flink:1.19` (the official Apache Flink image; ships the REST API and
+//! bundled example JARs under `/opt/flink/examples/`), overridable via
+//! `FAKECLOUD_KINESISANALYTICSV2_IMAGE`.
+//!
+//! Session mode, a SINGLE container running both the JobManager and a
+//! TaskManager via `start-cluster.sh`. The Flink REST port `8081` is published
+//! to a pre-allocated fixed free host port so external clients (the E2E suite,
+//! the presigned dashboard URL) can reach it. `flink:1.19`'s default
+//! `config.yaml` already binds the REST endpoint to `0.0.0.0`, so no config
+//! rewrite is needed. `host` is the shared [`fakecloud_core::container_net`]
+//! sibling host (`127.0.0.1` normally, `host.docker.internal` /
+//! `host.containers.internal` when fakecloud is itself containerized), so the
+//! reach address can't drift from the issue #1539 portability fixes.
+//!
+//! **SQL-flavor** applications (`RuntimeEnvironment` `SQL-1_0`) do NOT get a real
+//! runtime: running arbitrary SQL as a live Flink job needs the SQL gateway,
+//! which is out of scope. SQL apps keep the control-plane state machine and this
+//! split is documented honestly in the service module + the website doc.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::RwLock;
+
+/// A running application's backing Flink session cluster.
+#[derive(Debug, Clone)]
+pub struct RunningFlink {
+    pub container_id: String,
+    /// Address clients reach the published Flink REST port at (`127.0.0.1` or
+    /// the sibling host alias when fakecloud is containerized).
+    pub host: String,
+    /// Published host port mapped to the container's Flink REST port (8081).
+    pub rest_port: u16,
+}
+
+impl RunningFlink {
+    /// The reachable Flink Web Dashboard / REST base URL.
+    pub fn dashboard_url(&self) -> String {
+        format!("http://{}:{}", self.host, self.rest_port)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("container runtime is unavailable")]
+    Unavailable,
+    #[error("Flink cluster container failed to start: {0}")]
+    ContainerStartFailed(String),
+}
+
+/// A job-submission / job-control failure against the live Flink cluster.
+#[derive(Debug, thiserror::Error)]
+pub enum JobError {
+    #[error("failed to reach the Flink REST API: {0}")]
+    Http(String),
+    #[error("Flink rejected the job: {0}")]
+    Rejected(String),
+    #[error("job {0} was not found on the cluster")]
+    NotFound(String),
+}
+
+/// The Flink REST port inside the container.
+const FLINK_REST_PORT: u16 = 8081;
+
+/// Docker/Podman-backed single-container Flink session-cluster runtime.
+#[derive(Debug, Clone)]
+pub struct FlinkRuntime {
+    cli: String,
+    net: fakecloud_core::container_net::HostNetworking,
+    instance_id: String,
+    http: reqwest::Client,
+    /// Application ARN -> running Flink cluster, for describe/stop/reattach.
+    containers: Arc<RwLock<HashMap<String, RunningFlink>>>,
+}
+
+impl FlinkRuntime {
+    /// Construct the Docker/Podman runtime. Returns `None` when no container CLI
+    /// is available (fakecloud then degrades to the control-plane-only state
+    /// machine), or when the real backend is explicitly disabled via
+    /// `FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND` (the shared-partition
+    /// control-plane E2E and the tfacc harness set this: they assert the AWS
+    /// response *format* and must not spawn a heavy Flink container).
+    pub fn new() -> Option<Self> {
+        if std::env::var("FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND")
+            .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        {
+            return None;
+        }
+        let cli = fakecloud_core::container_net::detect_container_cli()?;
+        let net = fakecloud_core::container_net::HostNetworking::detect(&cli);
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+            .ok()?;
+        Some(Self {
+            cli,
+            net,
+            instance_id: format!("fakecloud-{}", std::process::id()),
+            http,
+            containers: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+
+    /// Name of the active container CLI, for logging.
+    pub fn cli_name(&self) -> &str {
+        &self.cli
+    }
+
+    /// The Flink image, overridable via `FAKECLOUD_KINESISANALYTICSV2_IMAGE`.
+    fn image(&self) -> String {
+        std::env::var("FAKECLOUD_KINESISANALYTICSV2_IMAGE")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "flink:1.19".to_string())
+    }
+
+    /// Spawn (or return the already-tracked) backing Flink session cluster for
+    /// an application and block until its REST API reports a free task slot.
+    pub async fn ensure_cluster(&self, app_arn: &str) -> Result<RunningFlink, RuntimeError> {
+        if let Some(existing) = self.containers.read().get(app_arn).cloned() {
+            return Ok(existing);
+        }
+        let running = self.spawn_container(app_arn).await?;
+        self.containers
+            .write()
+            .insert(app_arn.to_string(), running.clone());
+        Ok(running)
+    }
+
+    /// Re-attach to an application's PERSISTED Flink cluster container after a
+    /// fakecloud restart rather than spawning a fresh empty one. `Ok(None)` when
+    /// the container is truly gone (the caller then marks the app `READY`),
+    /// `Err` on a transient daemon failure, `Ok(Some(..))` once it is ready.
+    pub async fn reattach_cluster(
+        &self,
+        app_arn: &str,
+        container_id: &str,
+    ) -> Result<Option<RunningFlink>, RuntimeError> {
+        let inspect = tokio::process::Command::new(&self.cli)
+            .args(["inspect", "--format", "{{.State.Status}}", container_id])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !inspect.status.success() {
+            return Ok(None);
+        }
+        let start = tokio::process::Command::new(&self.cli)
+            .args(["start", container_id])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !start.status.success() {
+            let stderr = String::from_utf8_lossy(&start.stderr);
+            if stderr.contains("No such container") || stderr.contains("no such container") {
+                return Ok(None);
+            }
+            return Err(RuntimeError::ContainerStartFailed(format!(
+                "reattach start failed: {}",
+                stderr.trim()
+            )));
+        }
+        let rest_port = self.lookup_port(container_id, FLINK_REST_PORT).await?;
+        let running = RunningFlink {
+            container_id: container_id.to_string(),
+            host: self.net.sibling_host.clone(),
+            rest_port,
+        };
+        self.wait_for_ready(&running, container_id).await?;
+        self.containers
+            .write()
+            .insert(app_arn.to_string(), running.clone());
+        tracing::info!(
+            app_arn = %app_arn,
+            container_id = %container_id,
+            "re-attached persisted Flink session-cluster container",
+        );
+        Ok(Some(running))
+    }
+
+    /// Stop + remove an application's backing container and drop its tracking
+    /// entry. Called on the application's last stop and on delete.
+    pub async fn stop_cluster(&self, app_arn: &str) {
+        let running = self.containers.write().remove(app_arn);
+        if let Some(running) = running {
+            self.remove_container(&running.container_id).await;
+        }
+    }
+
+    /// Remove a container by id without a tracking entry (delete-while-tracked).
+    pub async fn remove_by_id(&self, container_id: &str) {
+        self.remove_container(container_id).await;
+    }
+
+    /// Stop every tracked cluster container (graceful shutdown / reset).
+    pub async fn stop_all(&self) {
+        let containers: Vec<RunningFlink> = {
+            let mut map = self.containers.write();
+            map.drain().map(|(_, c)| c).collect()
+        };
+        for c in containers {
+            self.remove_container(&c.container_id).await;
+        }
+    }
+
+    async fn spawn_container(&self, app_arn: &str) -> Result<RunningFlink, RuntimeError> {
+        // Reap a leaked container left by a PRIOR failed bring-up of THIS app,
+        // scoped to this app AND this fakecloud instance.
+        self.reap_stale_containers(app_arn).await;
+
+        // Allocate a fixed free host port FIRST so the published REST port is
+        // stable across a restart (re-read on reattach for good measure).
+        let rest_port = alloc_free_port()?;
+
+        let mut args: Vec<String> = vec!["create".to_string()];
+        args.push("-p".to_string());
+        args.push(format!("{rest_port}:{FLINK_REST_PORT}"));
+        args.push("--label".to_string());
+        args.push(format!("fakecloud-flink={app_arn}"));
+        args.push("--label".to_string());
+        args.push(format!("fakecloud-instance={}", self.instance_id));
+        self.net.push_add_host_args(&mut args);
+        // Single container: start the JobManager + a local TaskManager, then
+        // hold the container open by tailing the cluster logs.
+        args.push("--entrypoint".to_string());
+        args.push("bash".to_string());
+        args.push(self.image());
+        args.push("-c".to_string());
+        args.push("/opt/flink/bin/start-cluster.sh && tail -f /opt/flink/log/*.log".to_string());
+
+        let output = tokio::process::Command::new(&self.cli)
+            .args(&args)
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !output.status.success() {
+            return Err(RuntimeError::ContainerStartFailed(
+                String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            ));
+        }
+        let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+        let start = tokio::process::Command::new(&self.cli)
+            .args(["start", &container_id])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !start.status.success() {
+            let diag = self.capture_container_diagnostics(&container_id).await;
+            return Err(RuntimeError::ContainerStartFailed(format!(
+                "container start failed: {}; {diag}",
+                String::from_utf8_lossy(&start.stderr).trim()
+            )));
+        }
+
+        let running = RunningFlink {
+            container_id: container_id.clone(),
+            host: self.net.sibling_host.clone(),
+            rest_port,
+        };
+        self.wait_for_ready(&running, &container_id).await?;
+
+        tracing::info!(
+            app_arn = %app_arn,
+            container_id = %container_id,
+            host = %running.host,
+            rest_port = rest_port,
+            "Flink session-cluster container started",
+        );
+        Ok(running)
+    }
+
+    /// Read the host port the container's REST port (8081) is published on.
+    async fn lookup_port(
+        &self,
+        container_id: &str,
+        container_port: u16,
+    ) -> Result<u16, RuntimeError> {
+        let out = tokio::process::Command::new(&self.cli)
+            .args(["port", container_id, &container_port.to_string()])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !out.status.success() {
+            return Err(RuntimeError::ContainerStartFailed(format!(
+                "port lookup for {container_port} failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        let s = String::from_utf8_lossy(&out.stdout);
+        s.lines()
+            .next()
+            .and_then(|l| l.trim().rsplit(':').next())
+            .and_then(|p| p.parse::<u16>().ok())
+            .ok_or_else(|| {
+                RuntimeError::ContainerStartFailed(format!(
+                    "could not determine host port for {container_port} from '{}'",
+                    s.trim()
+                ))
+            })
+    }
+
+    /// Block until the Flink cluster answers its REST API AND a task slot is
+    /// available (the JobManager REST endpoint binds before the TaskManager
+    /// registers, so `/overview` answering is not enough to submit a job). On
+    /// timeout the container's recent logs + terminal state are surfaced so a CI
+    /// failure is diagnosable.
+    async fn wait_for_ready(
+        &self,
+        running: &RunningFlink,
+        container_id: &str,
+    ) -> Result<(), RuntimeError> {
+        // 240 * 500ms = ~120s (plus per-probe time): generous for a cold Flink
+        // cluster boot + TaskManager registration on a constrained CI runner.
+        const ATTEMPTS: u32 = 240;
+        let start = std::time::Instant::now();
+        let url = format!("{}/overview", running.dashboard_url());
+        for _ in 0..ATTEMPTS {
+            if let Ok(resp) = self.http.get(&url).send().await {
+                if let Ok(v) = resp.json::<serde_json::Value>().await {
+                    let slots = v
+                        .get("slots-available")
+                        .and_then(serde_json::Value::as_i64)
+                        .unwrap_or(0);
+                    if slots >= 1 {
+                        return Ok(());
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        Err(RuntimeError::ContainerStartFailed(
+            self.readiness_timeout_reason(container_id, start).await,
+        ))
+    }
+
+    // ===================== job operations =====================
+
+    /// Upload a job JAR to the cluster via `POST /jars/upload` (multipart) and
+    /// return the Flink jar id (the basename of the stored filename).
+    pub async fn upload_jar(
+        &self,
+        running: &RunningFlink,
+        jar_bytes: Vec<u8>,
+        file_name: &str,
+    ) -> Result<String, JobError> {
+        let part = reqwest::multipart::Part::bytes(jar_bytes)
+            .file_name(file_name.to_string())
+            .mime_str("application/x-java-archive")
+            .map_err(|e| JobError::Http(e.to_string()))?;
+        let form = reqwest::multipart::Form::new().part("jarfile", part);
+        let url = format!("{}/jars/upload", running.dashboard_url());
+        let resp = self
+            .http
+            .post(&url)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| JobError::Http(e.to_string()))?;
+        let status = resp.status();
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| JobError::Http(e.to_string()))?;
+        if !status.is_success() || body.get("status").and_then(|s| s.as_str()) != Some("success") {
+            return Err(JobError::Rejected(sanitize(&body.to_string())));
+        }
+        let filename = body
+            .get("filename")
+            .and_then(|s| s.as_str())
+            .ok_or_else(|| JobError::Rejected("upload response missing filename".to_string()))?;
+        Ok(filename.rsplit('/').next().unwrap_or(filename).to_string())
+    }
+
+    /// Run an uploaded jar via `POST /jars/{jar_id}/run` and return the Flink
+    /// job id. `parallelism`, `program_args`, and `entry_class` are forwarded
+    /// when present (from the application's Flink/Environment configuration).
+    pub async fn run_job(
+        &self,
+        running: &RunningFlink,
+        jar_id: &str,
+        parallelism: Option<i64>,
+        program_args: Option<&str>,
+        entry_class: Option<&str>,
+    ) -> Result<String, JobError> {
+        let mut payload = serde_json::Map::new();
+        if let Some(p) = parallelism {
+            payload.insert("parallelism".into(), serde_json::json!(p.max(1)));
+        }
+        if let Some(a) = program_args.filter(|s| !s.trim().is_empty()) {
+            payload.insert("programArgs".into(), serde_json::json!(a));
+        }
+        if let Some(c) = entry_class.filter(|s| !s.trim().is_empty()) {
+            payload.insert("entryClass".into(), serde_json::json!(c));
+        }
+        let url = format!("{}/jars/{}/run", running.dashboard_url(), jar_id);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&serde_json::Value::Object(payload))
+            .send()
+            .await
+            .map_err(|e| JobError::Http(e.to_string()))?;
+        let status = resp.status();
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| JobError::Http(e.to_string()))?;
+        if !status.is_success() {
+            return Err(JobError::Rejected(sanitize(&body.to_string())));
+        }
+        body.get("jobid")
+            .and_then(|s| s.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| JobError::Rejected(sanitize(&body.to_string())))
+    }
+
+    /// Query a Flink job's lifecycle state via `GET /jobs/{job_id}` -> the raw
+    /// Flink `state` string (`RUNNING`, `FINISHED`, `FAILED`, `CANCELED`, ...).
+    pub async fn job_state(
+        &self,
+        running: &RunningFlink,
+        job_id: &str,
+    ) -> Result<String, JobError> {
+        let url = format!("{}/jobs/{}", running.dashboard_url(), job_id);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| JobError::Http(e.to_string()))?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(JobError::NotFound(job_id.to_string()));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| JobError::Http(e.to_string()))?;
+        body.get("state")
+            .and_then(|s| s.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| JobError::NotFound(job_id.to_string()))
+    }
+
+    /// Cancel a running Flink job via `PATCH /jobs/{job_id}?mode=cancel`.
+    pub async fn cancel_job(&self, running: &RunningFlink, job_id: &str) -> Result<(), JobError> {
+        let url = format!("{}/jobs/{}?mode=cancel", running.dashboard_url(), job_id);
+        let resp = self
+            .http
+            .patch(&url)
+            .send()
+            .await
+            .map_err(|e| JobError::Http(e.to_string()))?;
+        // 202 Accepted is the normal cancel response; a 404 means the job is
+        // already gone, which is fine for a cancel.
+        if resp.status().is_success() || resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        Err(JobError::Rejected(format!(
+            "cancel returned {status}: {}",
+            sanitize(&text)
+        )))
+    }
+
+    // ===================== exec / cleanup plumbing =====================
+
+    async fn remove_container(&self, container_id: &str) {
+        let _ = tokio::process::Command::new(&self.cli)
+            .args(["rm", "-f", container_id])
+            .output()
+            .await;
+    }
+
+    /// Remove any container labeled for THIS app AND this fakecloud instance.
+    async fn reap_stale_containers(&self, app_arn: &str) {
+        let Ok(out) = tokio::process::Command::new(&self.cli)
+            .args([
+                "ps",
+                "-aq",
+                "--filter",
+                &format!("label=fakecloud-flink={app_arn}"),
+                "--filter",
+                &format!("label=fakecloud-instance={}", self.instance_id),
+            ])
+            .output()
+            .await
+        else {
+            return;
+        };
+        if !out.status.success() {
+            return;
+        }
+        for id in String::from_utf8_lossy(&out.stdout).split_whitespace() {
+            self.remove_container(id).await;
+        }
+    }
+
+    async fn readiness_timeout_reason(
+        &self,
+        container_id: &str,
+        started: std::time::Instant,
+    ) -> String {
+        let state = tokio::process::Command::new(&self.cli)
+            .args([
+                "inspect",
+                "--format",
+                "status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}",
+                container_id,
+            ])
+            .output()
+            .await
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default();
+        let exited = state.contains("status=exited");
+        let logs = self.container_logs(container_id, 60).await;
+        let headline = if exited {
+            "Flink cluster exited during boot before a task slot became available".to_string()
+        } else {
+            "Flink cluster did not report an available task slot within 120 seconds; the container is still running".to_string()
+        };
+        let reason =
+            format!("{headline}; container state [{state}]; recent container logs:\n{logs}");
+        tracing::error!(
+            container_id = %container_id,
+            elapsed_secs = started.elapsed().as_secs(),
+            container_state = %state,
+            reason = %headline,
+            "Flink cluster readiness timed out",
+        );
+        reason
+    }
+
+    async fn capture_container_diagnostics(&self, container_id: &str) -> String {
+        let state = tokio::process::Command::new(&self.cli)
+            .args([
+                "inspect",
+                "--format",
+                "status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}",
+                container_id,
+            ])
+            .output()
+            .await
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default();
+        let logs = self.container_logs(container_id, 80).await;
+        format!("container state [{state}]; recent container logs:\n{logs}")
+    }
+
+    async fn container_logs(&self, container_id: &str, tail: u32) -> String {
+        tokio::process::Command::new(&self.cli)
+            .args(["logs", "--tail", &tail.to_string(), container_id])
+            .output()
+            .await
+            .map(|o| {
+                let mut s = String::from_utf8_lossy(&o.stdout).into_owned();
+                s.push_str(&String::from_utf8_lossy(&o.stderr));
+                s.trim().to_string()
+            })
+            .unwrap_or_else(|e| format!("<container logs failed: {e}>"))
+    }
+}
+
+/// Map a raw Flink job `state` to the corresponding KDA/MSF application status.
+/// A live `RUNNING` (or transiently `RESTARTING`/`CREATED`) job keeps the
+/// application `RUNNING`; any terminal state (canceled, finished, failed) means
+/// the job is no longer running, so the application is back to `READY` -- the
+/// application-status enum has no `FAILED` member, so `READY` is the faithful
+/// steady state a stopped/finished job settles to.
+pub fn flink_state_to_app_status(state: &str) -> &'static str {
+    match state {
+        "RUNNING" | "RESTARTING" | "CREATED" | "RECONCILING" => "RUNNING",
+        _ => "READY",
+    }
+}
+
+/// Whether a raw Flink job `state` is terminal (no further transitions).
+pub fn is_terminal_flink_state(state: &str) -> bool {
+    matches!(state, "FINISHED" | "CANCELED" | "FAILED" | "SUSPENDED")
+}
+
+/// Bind a `127.0.0.1:0` listener, read the assigned port, and drop it -- the
+/// standard free-port trick. The port is then published with `-p {P}:8081`.
+fn alloc_free_port() -> Result<u16, RuntimeError> {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).map_err(|e| {
+        RuntimeError::ContainerStartFailed(format!("could not allocate a host port: {e}"))
+    })?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?
+        .port();
+    drop(listener);
+    Ok(port)
+}
+
+/// Sanitize multi-line REST/daemon output for embedding in an error string or
+/// header: take the most informative line, strip control chars, bound length.
+/// NEVER put raw multi-line output into a response header (issue #1539 Bug 2).
+fn sanitize(s: &str) -> String {
+    let line = s
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("")
+        .replace(|c: char| c.is_control(), " ");
+    let line = line.trim();
+    if line.len() > 300 {
+        format!("{}...", &line[..300])
+    } else {
+        line.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alloc_free_port_returns_a_usable_port() {
+        let p = alloc_free_port().expect("port");
+        assert!(p >= 1024, "expected an ephemeral port, got {p}");
+        let _ = alloc_free_port().expect("second port");
+    }
+
+    #[test]
+    fn dashboard_url_projects_host_and_port() {
+        let r = RunningFlink {
+            container_id: "abc".into(),
+            host: "127.0.0.1".into(),
+            rest_port: 58192,
+        };
+        assert_eq!(r.dashboard_url(), "http://127.0.0.1:58192");
+    }
+
+    #[test]
+    fn dashboard_url_uses_sibling_host_when_containerized() {
+        let r = RunningFlink {
+            container_id: "abc".into(),
+            host: "host.docker.internal".into(),
+            rest_port: 5000,
+        };
+        assert_eq!(r.dashboard_url(), "http://host.docker.internal:5000");
+    }
+
+    #[test]
+    fn running_flink_state_maps_to_running() {
+        assert_eq!(flink_state_to_app_status("RUNNING"), "RUNNING");
+        assert_eq!(flink_state_to_app_status("RESTARTING"), "RUNNING");
+    }
+
+    #[test]
+    fn terminal_flink_states_map_to_ready() {
+        for s in ["FINISHED", "CANCELED", "FAILED", "SUSPENDED"] {
+            assert_eq!(flink_state_to_app_status(s), "READY", "{s}");
+            assert!(is_terminal_flink_state(s), "{s} is terminal");
+        }
+        assert!(!is_terminal_flink_state("RUNNING"));
+    }
+
+    #[test]
+    fn disable_backend_env_returns_no_runtime() {
+        // Explicit disable -> None regardless of a container CLI being present.
+        temp_env_set("FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND", "1");
+        assert!(FlinkRuntime::new().is_none());
+        temp_env_unset("FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND");
+    }
+
+    #[test]
+    fn sanitize_strips_control_chars_and_bounds() {
+        let raw = "line one\n\tERROR something bad\nmore";
+        let s = sanitize(raw);
+        assert!(!s.contains('\n'));
+        assert!(!s.contains('\t'));
+        assert_eq!(s, "line one");
+    }
+
+    fn temp_env_set(k: &str, v: &str) {
+        // SAFETY: single-threaded unit test mutating a process env var.
+        unsafe { std::env::set_var(k, v) };
+    }
+    fn temp_env_unset(k: &str) {
+        // SAFETY: single-threaded unit test mutating a process env var.
+        unsafe { std::env::remove_var(k) };
+    }
+}

--- a/crates/fakecloud-kinesisanalyticsv2/src/service.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/service.rs
@@ -11,6 +11,7 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -19,11 +20,15 @@ use serde_json::{json, Value};
 use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
+use fakecloud_core::delivery::S3Delivery;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_persistence::SnapshotStore;
 
 use crate::persistence::save_snapshot;
-use crate::state::{Application, OperationRecord, SharedKa2State, Snapshot, TagMap, VersionRecord};
+use crate::runtime::{flink_state_to_app_status, is_terminal_flink_state, FlinkRuntime};
+use crate::state::{
+    Application, FlinkBinding, OperationRecord, SharedKa2State, Snapshot, TagMap, VersionRecord,
+};
 
 /// Every operation name in the kinesisanalyticsv2 Smithy model.
 pub const KA2_ACTIONS: &[&str] = &[
@@ -88,6 +93,15 @@ pub struct Ka2Service {
     state: SharedKa2State,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
+    /// The backing-container runtime that spawns REAL Apache Flink session
+    /// clusters and submits jobs. `None` in the degraded / control-plane-only
+    /// path (no container CLI, or the backend explicitly disabled): Flink apps
+    /// then behave as the pure state machine (`STARTING` settles to `RUNNING`
+    /// on the next describe).
+    runtime: Option<Arc<FlinkRuntime>>,
+    /// In-process S3 reader used to fetch an application's code JAR from a
+    /// fakecloud S3 bucket for submission to the Flink cluster.
+    s3: Option<Arc<dyn S3Delivery>>,
 }
 
 impl Ka2Service {
@@ -96,11 +110,27 @@ impl Ka2Service {
             state,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
+            runtime: None,
+            s3: None,
         }
     }
 
     pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
         self.snapshot_store = Some(store);
+        self
+    }
+
+    /// Attach the backing-container runtime that spawns real Flink session
+    /// clusters. With it present, a **Flink-flavor** application with a JAR in
+    /// S3 runs as a genuine Flink job in Docker.
+    pub fn with_runtime(mut self, runtime: Arc<FlinkRuntime>) -> Self {
+        self.runtime = Some(runtime);
+        self
+    }
+
+    /// Attach the in-process S3 reader used to fetch application code JARs.
+    pub fn with_s3(mut self, s3: Arc<dyn S3Delivery>) -> Self {
+        self.s3 = Some(s3);
         self
     }
 
@@ -955,6 +985,7 @@ impl Ka2Service {
             version_updated_from: None,
             version_rolled_back_from: None,
             version_rolled_back_to: None,
+            flink_binding: None,
         };
         record_version(&mut app);
         let detail = build_application_detail(&app);
@@ -978,11 +1009,34 @@ impl Ka2Service {
             .applications
             .get_mut(&name)
             .ok_or_else(|| not_found(&name))?;
-        let settled = settle_status(&app.status);
-        if settled != app.status {
-            app.status = settled.to_string();
+        // A Flink-flavor app backed by the REAL runtime has ALL its lifecycle
+        // transitions driven by the background container/job tasks -- never
+        // auto-settle those in place (that would report RUNNING before the real
+        // Flink job is actually up). The pure control-plane path (SQL apps, no
+        // runtime, or a Flink app with no JAR) keeps the in-memory settle.
+        let real = self.runtime.is_some() && is_real_flink(app);
+        if !real {
+            let settled = settle_status(&app.status);
+            if settled != app.status {
+                app.status = settled.to_string();
+            }
         }
         let detail = build_application_detail(app);
+        // If a real job is RUNNING, reconcile it against the live cluster in the
+        // background so a later describe reflects a job that finished/failed on
+        // its own (the "a read fires a transition" pattern).
+        let reconcile = if real && app.status == "RUNNING" {
+            app.flink_binding
+                .as_ref()
+                .and_then(|b| b.job_id.as_ref().map(|j| (b.clone(), j.clone())))
+        } else {
+            None
+        };
+        let account = req.account_id.clone();
+        drop(accounts);
+        if let Some((binding, job_id)) = reconcile {
+            self.spawn_flink_reconcile(account, name, binding, job_id);
+        }
         ok(json!({ "ApplicationDetail": detail }))
     }
 
@@ -1074,6 +1128,15 @@ impl Ka2Service {
             .remove(&name)
             .ok_or_else(|| not_found(&name))?;
         st.tags.remove(&app.arn);
+        let binding = app.flink_binding.clone();
+        drop(accounts);
+        // Tear down the backing Flink cluster container on delete so it is not
+        // leaked (fire-and-forget; the request must not block on the daemon).
+        if let (Some(runtime), Some(bind)) = (self.runtime.clone(), binding) {
+            tokio::spawn(async move {
+                runtime.remove_by_id(&bind.container_id).await;
+            });
+        }
         ok_empty()
     }
 
@@ -1127,6 +1190,28 @@ impl Ka2Service {
         }
         app.status = "STARTING".to_string();
         let op_id = record_operation(app, "StartApplication", None, None);
+        // Real path: a Flink-flavor app with a JAR in S3 and a runtime attached
+        // spawns a genuine Flink session cluster and submits the job in the
+        // background (never block the handler on a container pull/start/submit,
+        // issues #1539/#1730). The app settles to RUNNING only once Flink reports
+        // the job RUNNING. Otherwise the pure state machine settles on describe.
+        let real = self.runtime.is_some() && is_real_flink(app);
+        let code = if real { flink_code_location(app) } else { None };
+        let parallelism = if real { flink_parallelism(app) } else { None };
+        let program_args = if real { flink_program_args(app) } else { None };
+        let arn = app.arn.clone();
+        drop(accounts);
+        if let Some((bucket, key)) = code {
+            self.spawn_flink_start(
+                req.account_id.clone(),
+                name,
+                arn,
+                bucket,
+                key,
+                parallelism,
+                program_args,
+            );
+        }
         ok(json!({ "OperationId": op_id }))
     }
 
@@ -1141,12 +1226,30 @@ impl Ka2Service {
             .applications
             .get_mut(&name)
             .ok_or_else(|| not_found(&name))?;
-        app.status = if force {
-            "FORCE_STOPPING".to_string()
+        let real = self.runtime.is_some() && is_real_flink(app);
+        let binding = app.flink_binding.clone();
+        let running_job = binding
+            .as_ref()
+            .and_then(|b| b.job_id.clone())
+            .filter(|_| real);
+        if real && running_job.is_none() {
+            // A real-flink app with no live job must settle straight to READY:
+            // describe skips the in-memory settle for real apps, so a STOPPING
+            // with no background canceller would strand forever.
+            app.status = "READY".to_string();
         } else {
-            "STOPPING".to_string()
-        };
+            app.status = if force {
+                "FORCE_STOPPING".to_string()
+            } else {
+                "STOPPING".to_string()
+            };
+        }
         let op_id = record_operation(app, "StopApplication", None, None);
+        let arn = app.arn.clone();
+        drop(accounts);
+        if let (Some(bind), Some(_job)) = (binding, running_job) {
+            self.spawn_flink_stop(req.account_id.clone(), name, arn, bind);
+        }
         ok(json!({ "OperationId": op_id }))
     }
 
@@ -1836,15 +1939,23 @@ impl Ka2Service {
             ec,
         )?;
         let accounts = self.state.read();
-        let _app = accounts
+        let app = accounts
             .get(&req.account_id)
             .and_then(|st| st.applications.get(&name))
             .ok_or_else(|| not_found(&name))?;
-        let token = new_token();
-        let url = format!(
-            "https://{}.kinesisanalytics.{}.amazonaws.com/dashboard?authToken={token}",
-            name, req.region
-        );
+        // When a REAL Flink cluster is running for this app, return its actually
+        // reachable dashboard/REST base URL so a client (or the E2E) can hit the
+        // live JobManager. Otherwise fall back to the synthesized AWS-shaped URL.
+        let url = match &app.flink_binding {
+            Some(bind) if app.status == "RUNNING" => bind.dashboard_url(),
+            _ => {
+                let token = new_token();
+                format!(
+                    "https://{}.kinesisanalytics.{}.amazonaws.com/dashboard?authToken={token}",
+                    name, req.region
+                )
+            }
+        };
         ok(json!({ "AuthorizedUrl": url }))
     }
 
@@ -1960,6 +2071,437 @@ impl Ka2Service {
         let tags = st.tags.get(&resource_arn).cloned().unwrap_or_default();
         ok(json!({ "Tags": tags_json(&tags) }))
     }
+}
+
+// ===== real Flink data-plane background tasks =====
+
+/// Bounded poll for a job to reach RUNNING (or a terminal state) after
+/// submission: 120 * 500ms = ~60s.
+const JOB_POLL_ATTEMPTS: u32 = 120;
+/// Bounded poll for a canceled job to reach a terminal state: ~30s.
+const CANCEL_POLL_ATTEMPTS: u32 = 60;
+
+impl Ka2Service {
+    /// Whether a real container runtime is attached.
+    pub fn runtime_present(&self) -> bool {
+        self.runtime.is_some()
+    }
+
+    /// Bring up the backing Flink cluster, fetch the app's code JAR from S3,
+    /// submit it, and settle the application to RUNNING once Flink reports the
+    /// job RUNNING. Any failure settles the app back to READY (and tears the
+    /// container down) with a logged reason. Fire-and-forget: never blocks the
+    /// StartApplication handler.
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_flink_start(
+        &self,
+        account: String,
+        name: String,
+        arn: String,
+        bucket: String,
+        key: String,
+        parallelism: Option<i64>,
+        program_args: Option<String>,
+    ) {
+        let Some(runtime) = self.runtime.clone() else {
+            return;
+        };
+        let s3 = self.s3.clone();
+        let state = self.state.clone();
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
+        tokio::spawn(async move {
+            // 1. Spawn (or reuse) the backing Flink session cluster.
+            let running = match runtime.ensure_cluster(&arn).await {
+                Ok(r) => r,
+                Err(error) => {
+                    tracing::error!(%error, app_arn = %arn, "failed to bring up Flink cluster; app back to READY");
+                    set_app_status(&state, &account, &name, "READY", None);
+                    save_snapshot(&state, store.clone(), &lock).await;
+                    return;
+                }
+            };
+            // Persist the container binding immediately so a restart can
+            // re-attach it (no RUNNING-with-dead-container, #1338).
+            set_app_binding(
+                &state,
+                &account,
+                &name,
+                Some(FlinkBinding {
+                    container_id: running.container_id.clone(),
+                    host: running.host.clone(),
+                    rest_port: running.rest_port,
+                    jar_id: None,
+                    job_id: None,
+                }),
+            );
+            save_snapshot(&state, store.clone(), &lock).await;
+
+            // 2. Fetch the code JAR from fakecloud S3.
+            let Some(s3) = s3 else {
+                tracing::error!(app_arn = %arn, "no S3 reader attached; cannot submit Flink job");
+                runtime.stop_cluster(&arn).await;
+                set_app_status(&state, &account, &name, "READY", Some(None));
+                save_snapshot(&state, store.clone(), &lock).await;
+                return;
+            };
+            let jar_bytes = match s3.get_object(&account, &bucket, &key) {
+                Ok(b) => b,
+                Err(error) => {
+                    tracing::error!(%error, app_arn = %arn, bucket = %bucket, key = %key, "failed to read Flink code JAR from S3; app back to READY");
+                    runtime.stop_cluster(&arn).await;
+                    set_app_status(&state, &account, &name, "READY", Some(None));
+                    save_snapshot(&state, store.clone(), &lock).await;
+                    return;
+                }
+            };
+            let file_name = key.rsplit('/').next().unwrap_or("application.jar");
+
+            // 3. Upload + run the job.
+            let jar_id = match runtime.upload_jar(&running, jar_bytes, file_name).await {
+                Ok(id) => id,
+                Err(error) => {
+                    tracing::error!(%error, app_arn = %arn, "Flink jar upload failed; app back to READY");
+                    runtime.stop_cluster(&arn).await;
+                    set_app_status(&state, &account, &name, "READY", Some(None));
+                    save_snapshot(&state, store.clone(), &lock).await;
+                    return;
+                }
+            };
+            let job_id = match runtime
+                .run_job(
+                    &running,
+                    &jar_id,
+                    parallelism,
+                    program_args.as_deref(),
+                    None,
+                )
+                .await
+            {
+                Ok(id) => id,
+                Err(error) => {
+                    tracing::error!(%error, app_arn = %arn, "Flink job submission failed; app back to READY");
+                    runtime.stop_cluster(&arn).await;
+                    set_app_status(&state, &account, &name, "READY", Some(None));
+                    save_snapshot(&state, store.clone(), &lock).await;
+                    return;
+                }
+            };
+            set_app_binding(
+                &state,
+                &account,
+                &name,
+                Some(FlinkBinding {
+                    container_id: running.container_id.clone(),
+                    host: running.host.clone(),
+                    rest_port: running.rest_port,
+                    jar_id: Some(jar_id),
+                    job_id: Some(job_id.clone()),
+                }),
+            );
+            save_snapshot(&state, store.clone(), &lock).await;
+
+            // 4. Poll until the real Flink job is RUNNING (or terminal).
+            for _ in 0..JOB_POLL_ATTEMPTS {
+                match runtime.job_state(&running, &job_id).await {
+                    Ok(state_str) if flink_state_to_app_status(&state_str) == "RUNNING" => {
+                        set_app_status(&state, &account, &name, "RUNNING", None);
+                        save_snapshot(&state, store.clone(), &lock).await;
+                        tracing::info!(app_arn = %arn, job_id = %job_id, "Flink job is RUNNING");
+                        return;
+                    }
+                    Ok(state_str) if is_terminal_flink_state(&state_str) => {
+                        tracing::error!(app_arn = %arn, job_id = %job_id, flink_state = %state_str, "Flink job reached a terminal state before RUNNING; app back to READY");
+                        runtime.stop_cluster(&arn).await;
+                        set_app_status(&state, &account, &name, "READY", Some(None));
+                        save_snapshot(&state, store.clone(), &lock).await;
+                        return;
+                    }
+                    _ => tokio::time::sleep(Duration::from_millis(500)).await,
+                }
+            }
+            tracing::error!(app_arn = %arn, job_id = %job_id, "Flink job did not reach RUNNING within the deadline; app back to READY");
+            runtime.stop_cluster(&arn).await;
+            set_app_status(&state, &account, &name, "READY", Some(None));
+            save_snapshot(&state, store, &lock).await;
+        });
+    }
+
+    /// Cancel the real Flink job, wait for it to reach a terminal state, tear
+    /// the cluster down, and settle the application to READY. Fire-and-forget.
+    fn spawn_flink_stop(&self, account: String, name: String, arn: String, binding: FlinkBinding) {
+        let Some(runtime) = self.runtime.clone() else {
+            return;
+        };
+        let state = self.state.clone();
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
+        tokio::spawn(async move {
+            let running = crate::runtime::RunningFlink {
+                container_id: binding.container_id.clone(),
+                host: binding.host.clone(),
+                rest_port: binding.rest_port,
+            };
+            if let Some(job_id) = &binding.job_id {
+                if let Err(error) = runtime.cancel_job(&running, job_id).await {
+                    tracing::warn!(%error, app_arn = %arn, "cancel_job failed; tearing the cluster down anyway");
+                }
+                // Wait for the cancel to settle (best-effort).
+                for _ in 0..CANCEL_POLL_ATTEMPTS {
+                    match runtime.job_state(&running, job_id).await {
+                        Ok(s) if is_terminal_flink_state(&s) => break,
+                        Err(_) => break,
+                        _ => tokio::time::sleep(Duration::from_millis(500)).await,
+                    }
+                }
+            }
+            runtime.stop_cluster(&arn).await;
+            set_app_status(&state, &account, &name, "READY", Some(None));
+            save_snapshot(&state, store, &lock).await;
+            tracing::info!(app_arn = %arn, "Flink app stopped and cluster torn down");
+        });
+    }
+
+    /// Poll a RUNNING app's real job once; if it is no longer running, settle
+    /// the app to READY. Guards against clobbering a concurrent start/stop by
+    /// only acting when the app is still RUNNING with the same job id.
+    fn spawn_flink_reconcile(
+        &self,
+        account: String,
+        name: String,
+        binding: FlinkBinding,
+        job_id: String,
+    ) {
+        let Some(runtime) = self.runtime.clone() else {
+            return;
+        };
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        let state = self.state.clone();
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
+        tokio::spawn(async move {
+            let running = crate::runtime::RunningFlink {
+                container_id: binding.container_id.clone(),
+                host: binding.host.clone(),
+                rest_port: binding.rest_port,
+            };
+            let terminal = match runtime.job_state(&running, &job_id).await {
+                Ok(s) => flink_state_to_app_status(&s) != "RUNNING",
+                // Job vanished from the cluster -> no longer running.
+                Err(crate::runtime::JobError::NotFound(_)) => true,
+                // Transient REST hiccup: leave the app as-is.
+                Err(_) => return,
+            };
+            if !terminal {
+                return;
+            }
+            let changed = mutate_app(&state, &account, &name, |app| {
+                let same_job = app.flink_binding.as_ref().and_then(|b| b.job_id.as_deref())
+                    == Some(job_id.as_str());
+                if app.status == "RUNNING" && same_job {
+                    app.status = "READY".to_string();
+                    true
+                } else {
+                    false
+                }
+            });
+            if changed {
+                save_snapshot(&state, store, &lock).await;
+                tracing::info!(app = %name, "real Flink job is no longer RUNNING; app settled to READY");
+            }
+        });
+    }
+
+    /// Re-attach backing Flink containers for apps a restored snapshot claims
+    /// are RUNNING/STARTING, mirroring the restart-recovery contract of MSK / MQ
+    /// / RDS (no RUNNING-with-dead-container, #1338/#914). When the persisted
+    /// container is gone or its job is no longer running, the app is settled to
+    /// READY. Fire-and-forget per app so a slow re-attach doesn't block startup.
+    pub async fn recover_persisted_containers(&self) {
+        let Some(runtime) = self.runtime.clone() else {
+            return;
+        };
+        // Collect (account, name, binding) for apps that should have a live job.
+        let targets: Vec<(String, String, FlinkBinding)> = {
+            let accounts = self.state.read();
+            let mut out = Vec::new();
+            for (account, st) in accounts.iter() {
+                for (name, app) in &st.applications {
+                    if matches!(app.status.as_str(), "RUNNING" | "STARTING") {
+                        if let Some(b) = &app.flink_binding {
+                            out.push((account.to_string(), name.clone(), b.clone()));
+                        }
+                    }
+                }
+            }
+            out
+        };
+        for (account, name, binding) in targets {
+            let runtime = runtime.clone();
+            let state = self.state.clone();
+            let store = self.snapshot_store.clone();
+            let lock = self.snapshot_lock.clone();
+            let arn = binding_arn(&state, &account, &name);
+            tokio::spawn(async move {
+                let recovered = match runtime.reattach_cluster(&arn, &binding.container_id).await {
+                    Ok(Some(running)) => match &binding.job_id {
+                        Some(job_id) => match runtime.job_state(&running, job_id).await {
+                            Ok(s) if flink_state_to_app_status(&s) == "RUNNING" => Some(running),
+                            _ => None,
+                        },
+                        None => None,
+                    },
+                    _ => None,
+                };
+                match recovered {
+                    Some(running) => {
+                        // Refresh host/port in case the published port moved.
+                        set_app_binding(
+                            &state,
+                            &account,
+                            &name,
+                            Some(FlinkBinding {
+                                container_id: running.container_id,
+                                host: running.host,
+                                rest_port: running.rest_port,
+                                jar_id: binding.jar_id.clone(),
+                                job_id: binding.job_id.clone(),
+                            }),
+                        );
+                        set_app_status(&state, &account, &name, "RUNNING", None);
+                        tracing::info!(app = %name, "recovered RUNNING Flink app after restart");
+                    }
+                    None => {
+                        runtime.stop_cluster(&arn).await;
+                        set_app_status(&state, &account, &name, "READY", Some(None));
+                        tracing::warn!(app = %name, "could not recover Flink job after restart; app settled to READY");
+                    }
+                }
+                save_snapshot(&state, store, &lock).await;
+            });
+        }
+    }
+}
+
+/// Whether an application is a REAL-runtime-managed Flink app: a Flink-flavor
+/// runtime environment (`FLINK_1_x`, excluding SQL and Zeppelin) AND a code JAR
+/// in S3 to submit. Only these get the Docker-backed Flink job; everything else
+/// stays on the control-plane state machine.
+fn is_real_flink(app: &Application) -> bool {
+    app.runtime_environment.starts_with("FLINK_") && flink_code_location(app).is_some()
+}
+
+/// Extract the `(bucket, key)` of an application's code JAR from its
+/// `ApplicationCodeConfigurationDescription`, or `None` when it has no S3 code
+/// location. The `BucketARN` (`arn:aws:s3:::bucket`) is reduced to the name.
+fn flink_code_location(app: &Application) -> Option<(String, String)> {
+    let s3 = app
+        .config_description
+        .get("ApplicationCodeConfigurationDescription")?
+        .get("CodeContentDescription")?
+        .get("S3ApplicationCodeLocationDescription")?;
+    let bucket_arn = s3.get("BucketARN").and_then(Value::as_str)?;
+    let key = s3.get("FileKey").and_then(Value::as_str)?;
+    let bucket = bucket_arn.rsplit(":::").next().unwrap_or(bucket_arn);
+    if bucket.is_empty() || key.is_empty() {
+        return None;
+    }
+    Some((bucket.to_string(), key.to_string()))
+}
+
+/// Read the configured job parallelism from a Flink app's config description.
+fn flink_parallelism(app: &Application) -> Option<i64> {
+    app.config_description
+        .get("FlinkApplicationConfigurationDescription")?
+        .get("ParallelismConfigurationDescription")?
+        .get("Parallelism")
+        .and_then(Value::as_i64)
+}
+
+/// Derive program arguments from the app's environment property groups. KDA has
+/// no first-class "program args" field; a `PropertyGroupId` of
+/// `kinesis.analytics.flink.run.options` with a `ProgramArgs` key is the
+/// convention we honor, joining nothing else.
+fn flink_program_args(app: &Application) -> Option<String> {
+    let groups = app
+        .config_description
+        .get("EnvironmentPropertyDescriptions")?
+        .get("PropertyGroupDescriptions")?
+        .as_array()?;
+    for g in groups {
+        if g.get("PropertyGroupId").and_then(Value::as_str)
+            == Some("kinesis.analytics.flink.run.options")
+        {
+            if let Some(args) = g
+                .get("PropertyMap")
+                .and_then(|m| m.get("ProgramArgs"))
+                .and_then(Value::as_str)
+            {
+                return Some(args.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Look up an application's ARN from state (used by the recovery task, which
+/// only carries the account+name).
+fn binding_arn(state: &SharedKa2State, account: &str, name: &str) -> String {
+    state
+        .read()
+        .get(account)
+        .and_then(|st| st.applications.get(name))
+        .map(|a| a.arn.clone())
+        .unwrap_or_default()
+}
+
+/// Apply a mutation to an application in state, returning whether it was found.
+fn mutate_app<F: FnOnce(&mut Application) -> bool>(
+    state: &SharedKa2State,
+    account: &str,
+    name: &str,
+    f: F,
+) -> bool {
+    let mut accounts = state.write();
+    let st = accounts.get_or_create(account);
+    match st.applications.get_mut(name) {
+        Some(app) => f(app),
+        None => false,
+    }
+}
+
+/// Set an application's status. `binding` is `Some(new_binding)` to also replace
+/// the Flink binding (e.g. `Some(None)` to clear it on stop), or `None` to leave
+/// the binding untouched.
+fn set_app_status(
+    state: &SharedKa2State,
+    account: &str,
+    name: &str,
+    status: &str,
+    binding: Option<Option<FlinkBinding>>,
+) {
+    mutate_app(state, account, name, |app| {
+        app.status = status.to_string();
+        if let Some(b) = binding {
+            app.flink_binding = b;
+        }
+        true
+    });
+}
+
+/// Replace an application's Flink binding.
+fn set_app_binding(
+    state: &SharedKa2State,
+    account: &str,
+    name: &str,
+    binding: Option<FlinkBinding>,
+) {
+    mutate_app(state, account, name, |app| {
+        app.flink_binding = binding;
+        true
+    });
 }
 
 // ===== config-description manipulation helpers =====
@@ -2251,6 +2793,141 @@ mod tests {
             .unwrap(),
         );
         assert_eq!(v["SnapshotDetails"]["SnapshotStatus"], "READY");
+    }
+
+    fn flink_app_with_jar() -> Application {
+        let cfg = config_to_description(
+            &json!({
+                "FlinkApplicationConfiguration": {
+                    "ParallelismConfiguration": { "Parallelism": 3 }
+                },
+                "ApplicationCodeConfiguration": {
+                    "CodeContentType": "ZIPFILE",
+                    "CodeContent": {
+                        "S3ContentLocation": {
+                            "BucketARN": "arn:aws:s3:::my-code-bucket",
+                            "FileKey": "jobs/app.jar"
+                        }
+                    }
+                },
+                "EnvironmentProperties": {
+                    "PropertyGroups": [
+                        { "PropertyGroupId": "kinesis.analytics.flink.run.options",
+                          "PropertyMap": { "ProgramArgs": "--error-rate 0.1" } }
+                    ]
+                }
+            }),
+            Some("arn:aws:iam::000000000000:role/r"),
+            &mut 0,
+        );
+        Application {
+            name: "flinkapp".into(),
+            arn: arn("us-east-1", "000000000000", "flinkapp"),
+            description: None,
+            runtime_environment: "FLINK_1_19".into(),
+            service_execution_role: Some("arn:aws:iam::000000000000:role/r".into()),
+            application_mode: Some("STREAMING".into()),
+            status: "READY".into(),
+            version_id: 1,
+            create_timestamp: Utc::now(),
+            last_update_timestamp: Utc::now(),
+            conditional_token: "t".into(),
+            config_description: cfg,
+            cloudwatch_logging_options: Vec::new(),
+            maintenance_start: DEFAULT_MAINTENANCE_START.into(),
+            maintenance_end: DEFAULT_MAINTENANCE_END.into(),
+            snapshots: BTreeMap::new(),
+            operations: Vec::new(),
+            versions: BTreeMap::new(),
+            id_counter: 0,
+            version_updated_from: None,
+            version_rolled_back_from: None,
+            version_rolled_back_to: None,
+            flink_binding: None,
+        }
+    }
+
+    #[test]
+    fn flink_app_with_jar_is_real() {
+        let app = flink_app_with_jar();
+        assert!(is_real_flink(&app));
+        assert_eq!(
+            flink_code_location(&app),
+            Some(("my-code-bucket".into(), "jobs/app.jar".into()))
+        );
+        assert_eq!(flink_parallelism(&app), Some(3));
+        assert_eq!(
+            flink_program_args(&app).as_deref(),
+            Some("--error-rate 0.1")
+        );
+    }
+
+    #[test]
+    fn sql_app_is_not_real_flink() {
+        let mut app = flink_app_with_jar();
+        app.runtime_environment = "SQL_1_0".into();
+        // SQL flavor -> control-plane only, never the real Docker Flink job.
+        assert!(!is_real_flink(&app));
+    }
+
+    #[test]
+    fn flink_app_without_jar_is_not_real() {
+        // A Flink runtime with no S3 code location stays on the control plane.
+        let mut app = flink_app_with_jar();
+        app.config_description = json!({});
+        assert!(!is_real_flink(&app));
+        assert_eq!(flink_code_location(&app), None);
+    }
+
+    #[test]
+    fn degraded_fallback_no_runtime_settles_and_synthesizes_url() {
+        // With no runtime attached (the degraded / control-plane path), a Flink
+        // app with a JAR still starts as the pure state machine and the
+        // presigned URL is the synthesized AWS-shaped URL, not a live endpoint.
+        let s = svc();
+        assert!(!s.runtime_present());
+        s.create_application(&req(
+            "CreateApplication",
+            json!({
+                "ApplicationName": "app1",
+                "RuntimeEnvironment": "FLINK_1_19",
+                "ServiceExecutionRole": "arn:aws:iam::000000000000:role/r",
+                "ApplicationConfiguration": {
+                    "ApplicationCodeConfiguration": {
+                        "CodeContentType": "ZIPFILE",
+                        "CodeContent": { "S3ContentLocation": {
+                            "BucketARN": "arn:aws:s3:::b", "FileKey": "app.jar" } }
+                    }
+                }
+            }),
+        ))
+        .unwrap();
+        s.start_application(&req("StartApplication", json!({"ApplicationName":"app1"})))
+            .unwrap();
+        let v = body_of(
+            s.describe_application(&req(
+                "DescribeApplication",
+                json!({"ApplicationName":"app1"}),
+            ))
+            .unwrap(),
+        );
+        // No runtime -> the state machine settles STARTING -> RUNNING in place.
+        assert_eq!(v["ApplicationDetail"]["ApplicationStatus"], "RUNNING");
+        let u = body_of(
+            s.create_application_presigned_url(&req(
+                "CreateApplicationPresignedUrl",
+                json!({"ApplicationName":"app1","UrlType":"FLINK_DASHBOARD_URL"}),
+            ))
+            .unwrap(),
+        );
+        assert!(
+            u["AuthorizedUrl"]
+                .as_str()
+                .unwrap()
+                .contains("kinesisanalytics.us-east-1.amazonaws.com"),
+            "degraded path returns the synthesized dashboard URL: {}",
+            u["AuthorizedUrl"]
+        );
     }
 
     #[test]

--- a/crates/fakecloud-kinesisanalyticsv2/src/state.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/state.rs
@@ -56,6 +56,32 @@ pub struct VersionRecord {
     pub detail: Value,
 }
 
+/// The persisted, describe-facing binding to an application's REAL backing
+/// Flink session-cluster container + submitted job. Present only for
+/// Flink-flavor applications that have been started with a container runtime
+/// attached; `None` for SQL-flavor apps and the control-plane-only path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlinkBinding {
+    /// Backing Flink cluster container id.
+    pub container_id: String,
+    /// Reach address for the published REST port (`127.0.0.1` or the sibling
+    /// host alias when fakecloud is containerized).
+    pub host: String,
+    /// Host port the container's Flink REST port (8081) is published on.
+    pub rest_port: u16,
+    /// Flink jar id returned by `POST /jars/upload` (once the job is submitted).
+    pub jar_id: Option<String>,
+    /// Flink job id returned by `POST /jars/{jar_id}/run` (once submitted).
+    pub job_id: Option<String>,
+}
+
+impl FlinkBinding {
+    /// The reachable Flink Web Dashboard / REST base URL.
+    pub fn dashboard_url(&self) -> String {
+        format!("http://{}:{}", self.host, self.rest_port)
+    }
+}
+
 /// A managed Flink / SQL application.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Application {
@@ -85,6 +111,11 @@ pub struct Application {
     pub version_updated_from: Option<i64>,
     pub version_rolled_back_from: Option<i64>,
     pub version_rolled_back_to: Option<i64>,
+    /// Binding to the REAL backing Flink cluster + job, when one is running.
+    /// `#[serde(default)]` so snapshots written before the data-plane batch
+    /// (which had no such field) still load.
+    #[serde(default)]
+    pub flink_binding: Option<FlinkBinding>,
 }
 
 impl Application {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -4687,6 +4687,22 @@ async fn main() {
     if let Some(store) = kinesisanalyticsv2_snapshot_store {
         kinesisanalyticsv2_service = kinesisanalyticsv2_service.with_snapshot_store(store);
     }
+    // Amazon Managed Service for Apache Flink: a Flink-flavor application with a
+    // JAR in S3 runs as a REAL Apache Flink job in a Docker container (the
+    // MQ/MSK data-plane bar). Attach the backing-container runtime + the
+    // in-process S3 reader used to fetch the application's code JAR. `None` when
+    // no container CLI is available or the backend is disabled -> the app stays
+    // on the control-plane state machine.
+    if let Some(flink_runtime) = fakecloud_kinesisanalyticsv2::FlinkRuntime::new().map(Arc::new) {
+        kinesisanalyticsv2_service = kinesisanalyticsv2_service
+            .with_runtime(flink_runtime)
+            .with_s3(s3_delivery_for_logs.clone());
+    }
+    // Re-attach backing Flink containers for persisted RUNNING apps (same
+    // restart-recovery contract as MSK / MQ / RDS). Fire-and-forget per app.
+    kinesisanalyticsv2_service
+        .recover_persisted_containers()
+        .await;
     registry.register(Arc::new(kinesisanalyticsv2_service));
 
     // Cloud Map (servicediscovery) namespace control plane.

--- a/website/content/docs/services/kinesisanalyticsv2.md
+++ b/website/content/docs/services/kinesisanalyticsv2.md
@@ -23,9 +23,14 @@ persistent mode. The wire protocol is awsJson1.1 (x-amz-target
   created or updated is persisted and echoed back on describe. Applications
   carry `arn:aws:kinesisanalytics:<region>:<account>:application/<name>` ARNs.
 - **Lifecycle** (`StartApplication`, `StopApplication`, `RollbackApplication`).
+  For a **Flink-flavor** application with a JAR in S3, `StartApplication` spawns
+  a REAL Apache Flink job in a Docker container (see [Data plane](#data-plane)
+  below) and only reaches `RUNNING` once Flink reports the job `RUNNING`;
+  `StopApplication` cancels the real job and tears the container down. In the
+  degraded / control-plane-only path (no container runtime, or a SQL app),
   `StartApplication` moves `READY` -> `STARTING` -> `RUNNING` (settling on the
-  next describe); `StopApplication` moves `RUNNING` -> `STOPPING` -> `READY`
-  (with `Force` support); `RollbackApplication` restores the previous version's
+  next describe) and `StopApplication` moves `RUNNING` -> `STOPPING` -> `READY`.
+  `Force` is supported; `RollbackApplication` restores the previous version's
   configuration into a new version.
 - **Versioning** (`DescribeApplicationVersion`, `ListApplicationVersions`).
   Every configuration-changing operation increments `ApplicationVersionId` and
@@ -49,22 +54,50 @@ persistent mode. The wire protocol is awsJson1.1 (x-amz-target
   `DeleteApplicationReferenceDataSource`) assign ids and update the version.
 - **Schema discovery** (`DiscoverInputSchema`) infers a record format and
   columns from the provided input.
-- **Presigned dashboard URL** (`CreateApplicationPresignedUrl`) returns a
-  well-formed authorized URL.
+- **Presigned dashboard URL** (`CreateApplicationPresignedUrl`) returns the
+  REAL reachable Flink Web Dashboard / REST base URL when a Flink app is running
+  against the live container runtime, and a well-formed synthesized authorized
+  URL otherwise.
 - **Maintenance windows** (`UpdateApplicationMaintenanceConfiguration`).
 - **Tagging** (`TagResource`, `UntagResource`, `ListTagsForResource`),
   ARN-keyed; `CreateApplication` honors inline `Tags`.
 
 100% conformance: all 1,232 generated Smithy probe variants pass.
 
-## Control plane vs data plane
+## Data plane
 
-Amazon Managed Service for Apache Flink ships as a full control plane today:
-every application, version, snapshot, and operation is real, validated,
-account-partitioned, and persisted. The real Flink-job **data plane**
-(`StartApplication` actually running a Flink job inside a Docker container) is a
-roadmap item, mirroring how other fakecloud services shipped their control plane
-first.
+Starting a **Flink-flavor** application (`RuntimeEnvironment` `FLINK-1_x`) whose
+`ApplicationCodeConfiguration` points at a JAR in a fakecloud S3 bucket runs a
+GENUINE Apache Flink job, the same Docker-backed data-plane bar Amazon MQ, MSK,
+RDS, ElastiCache, and Lambda meet:
+
+- `StartApplication` spawns a real **`flink:1.19`** session cluster (a JobManager
+  + TaskManager) in a container, publishing the Flink REST port `8081` on a free
+  host port.
+- fakecloud fetches the application's code JAR from its own S3 service, uploads
+  it to the cluster via the Flink REST API (`POST /jars/upload`), and submits it
+  (`POST /jars/{id}/run`) with the configured parallelism.
+- The application settles to `RUNNING` **only once the real Flink job reaches
+  `RUNNING`** (polled via `GET /jobs/{id}`); `DescribeApplication` reflects the
+  live job status.
+- `CreateApplicationPresignedUrl` returns the cluster's reachable dashboard/REST
+  URL, so you can drive the live JobManager directly.
+- `StopApplication` cancels the real job (`PATCH /jobs/{id}?mode=cancel`) and
+  tears the container down; `DeleteApplication` reaps it. Persisted RUNNING apps
+  re-attach their container on restart (no `RUNNING`-with-dead-container).
+
+The backing runtime is used automatically when a container CLI (Docker/Podman)
+is available. It is skipped (and the pure control-plane state machine used
+instead) when none is present or when `FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND=1`
+is set; the image is overridable via `FAKECLOUD_KINESISANALYTICSV2_IMAGE`. The
+end-to-end Docker-backed job is proven by the `flink-runtime` CI job, gated on
+`FAKECLOUD_E2E_FLINK=1`.
+
+**Honest scope: SQL applications do not run for real.** A **SQL-flavor**
+application (`RuntimeEnvironment` `SQL-1_0`) keeps the control-plane state
+machine (`STARTING` -> `RUNNING` in memory) — running arbitrary SQL as a live
+Flink job needs the Flink SQL gateway, which is out of scope for now. Only
+Flink-flavor apps with a JAR get the real runtime.
 
 ## Example
 


### PR DESCRIPTION
## Summary

Batch 2 of Amazon Managed Service for Apache Flink (`kinesisanalyticsv2`): the real, Docker-backed **Flink-job data plane**. A Flink-flavor application (`RuntimeEnvironment` `FLINK-1_x` with a code JAR in S3) is now backed by a REAL Apache Flink session cluster running in a container — not a formatted-but-dead dashboard URL.

- **Real job submission**: `StartApplication` pulls the app's JAR from fakecloud S3 and submits it to the JobManager over the Flink REST API (`POST /jars/upload` + `POST /jars/{id}/run`). The app only becomes `RUNNING` once Flink reports the job `RUNNING`. `StopApplication` cancels the real Flink job (`PATCH /jobs/{id}?mode=cancel`).
- **`FlinkRuntime`** (`src/runtime/mod.rs`): single container running JobManager + TaskManager via `start-cluster.sh` (`flink:1.19`); REST port `8081` published to a preallocated fixed host port; portable reach address via `fakecloud_core::container_net` (sibling-host / `--add-host`, #1539); readiness gated on an available task slot; multi-line daemon/REST output sanitized before surfacing (#1539 Bug 2).
- **No client-timeout**: `StartApplication` backgrounds the cluster bring-up + job submit in a spawned task (`STARTING` -> settles to `RUNNING` on describe); the cold image pull / cluster boot never blocks the handler.
- **Restart recovery**: `FlinkBinding {container_id, job_id, ...}` is persisted; `recover_persisted` reattaches the container and resumes `RUNNING`/`STARTING` apps, else settles to `READY` when the container is gone. Mirrors the MSK / MQ contract.
- **Honest scope split**: SQL-flavor apps (`SQL-1_0`) keep the control-plane state machine — running arbitrary SQL as a live job needs the SQL gateway, out of scope — documented in the module + the website doc.

## Test plan

- Conformance: **33/33 ops, 1232/1232 variants** (unchanged).
- Control-plane E2E (`--test kinesisanalyticsv2`, `FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND=1`): **PASS**. The shared-partition test disables the backend so it can't spawn a heavy Flink container on docker-capable general runners.
- Data-plane E2E (`kinesisanalyticsv2_dataplane.rs`, `FAKECLOUD_E2E_FLINK=1`): submits a REAL Flink job end to end (create -> start -> job `RUNNING` via REST -> stop -> `READY` -> 0 leftover containers). Verified locally against `flink:1.19` (~46s). Runs in the new dedicated **`flink-runtime`** CI job.
- `cargo fmt --check`, `cargo clippy -p fakecloud-kinesisanalyticsv2 -p fakecloud-e2e --all-targets -D warnings`, unit tests, doc-counts: all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Flink-flavor apps as real Apache Flink jobs in Docker for `kinesisanalyticsv2`. Start/Stop now talk to the Flink REST API; restart recovery re-attaches containers so RUNNING apps stay honest.

- **New Features**
  - Real job submission: `StartApplication` uploads the app JAR from fakecloud S3 to Flink (`/jars/upload` + `/jars/{id}/run`) and only reports `RUNNING` once the job is `RUNNING`. `StopApplication` cancels the job.
  - `FlinkRuntime`: single-container session cluster (`flink:1.19`) with REST `8081` published to a fixed host port; portable host via `container_net`; readiness waits for a free task slot; logs/REST errors are sanitized.
  - Non-blocking start: cluster boot and submit run in the background; status settles on `DescribeApplication`.
  - Restart recovery: persisted `FlinkBinding` lets us reattach the container/job after a restart; if missing, the app settles to `READY`.
  - Presigned URL returns the live dashboard/REST URL when a real cluster is running. SQL apps remain control‑plane only.
  - New E2E test runs a full Docker-backed round trip in a dedicated `flink-runtime` CI job; shared runners keep the backend off.

- **Migration**
  - Requires Docker/Podman to use the real data plane. Set `FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND=1` to force control‑plane mode (used in shared CI). Override the image with `FAKECLOUD_KINESISANALYTICSV2_IMAGE`.

<sup>Written for commit 5a91f0d39d8abe6be5fb01a5619b906530e1b1d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

