### PR TITLE
feat(kinesisanalyticsv2): CloudFormation provisioning + tfacc coverage (batch 3)

### DIFF
--- a/.github/workflows/tfacc.yml
+++ b/.github/workflows/tfacc.yml
@@ -74,13 +74,7 @@ jobs:
     needs: [changes, tfacc-matrix]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    # 90, not 60: the heaviest shards (the kinesisanalyticsv2 flink/sql suites,
-    # whose acc tests upload the 66MB app JAR and drive a full app lifecycle) run
-    # ~5-6min per test on the 2-core runner and need ~60-70min even split in half.
-    # A 60min cap cancelled them mid-run, which ALSO skips the cache-save step, so
-    # reruns never warmed. 90min lets them finish and persist the build cache.
-    # Light shards finish in minutes and exit well under the cap regardless.
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tfacc.yml
+++ b/.github/workflows/tfacc.yml
@@ -74,7 +74,13 @@ jobs:
     needs: [changes, tfacc-matrix]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 90, not 60: the heaviest shards (the kinesisanalyticsv2 flink/sql suites,
+    # whose acc tests upload the 66MB app JAR and drive a full app lifecycle) run
+    # ~5-6min per test on the 2-core runner and need ~60-70min even split in half.
+    # A 60min cap cancelled them mid-run, which ALSO skips the cache-save step, so
+    # reruns never warmed. 90min lets them finish and persist the build cache.
+    # Light shards finish in minutes and exit well under the cap regardless.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4198,6 +4198,7 @@ dependencies = [
  "fakecloud-iam",
  "fakecloud-kafka",
  "fakecloud-kinesis",
+ "fakecloud-kinesisanalyticsv2",
  "fakecloud-kms",
  "fakecloud-lambda",
  "fakecloud-logs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5136,6 +5136,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-ec2",
  "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -59,6 +59,7 @@ fakecloud-efs = { workspace = true }
 fakecloud-elasticbeanstalk = { workspace = true }
 fakecloud-mq = { workspace = true }
 fakecloud-kafka = { workspace = true }
+fakecloud-kinesisanalyticsv2 = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -2744,6 +2744,7 @@ mod tests {
             )),
             mq: shared::<fakecloud_mq::MqData>(),
             kafka: shared::<fakecloud_kafka::KafkaData>(),
+            kinesisanalyticsv2: shared::<fakecloud_kinesisanalyticsv2::Ka2State>(),
             delivery: Arc::new(DeliveryBus::new()),
             lambda_runtime: None,
             rds_runtime: None,

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudformation.rs
@@ -118,6 +118,7 @@ impl ResourceProvisioner {
             elasticbeanstalk_state: self.elasticbeanstalk_state.clone(),
             mq_state: self.mq_state.clone(),
             kafka_state: self.kafka_state.clone(),
+            ka2_state: self.ka2_state.clone(),
             cloudformation_state: self.cloudformation_state.clone(),
             delivery: self.delivery.clone(),
             lambda_runtime: self.lambda_runtime.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/kinesisanalyticsv2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/kinesisanalyticsv2.rs
@@ -1,0 +1,264 @@
+//! `AWS::KinesisAnalyticsV2::*` CloudFormation provisioning (Amazon Managed
+//! Service for Apache Flink / Kinesis Data Analytics v2, `kinesisanalyticsv2`).
+//!
+//! Each resource is written through to the `kinesisanalyticsv2` service state as
+//! the same wire JSON the direct `CreateApplication` / `AddApplication*` handlers
+//! store -- via the shared `fakecloud_kinesisanalyticsv2::builders` module -- so
+//! a CFN-created application (and its outputs / reference data sources /
+//! CloudWatch logging options) reads back identically on `DescribeApplication`
+//! and persists through the `kinesisanalyticsv2` snapshot hook (survives a
+//! restart -- the #1766 phantom-resource lesson). The application is inserted
+//! synchronously and settles to `READY` exactly as the direct `CreateApplication`
+//! does (which never starts a Flink job -- `StartApplication` is a separate
+//! action), so `Ref` resolves during provisioning and CFN never spawns a Flink
+//! container.
+//!
+//! Physical id + `Ref` / `Fn::GetAtt` (verified against the AWS CloudFormation
+//! resource specification):
+//!   Application                      -> physical id / Ref = ApplicationName;
+//!                                        no returnable Fn::GetAtt attributes
+//!   ApplicationOutput                -> physical id / Ref = the output Id
+//!   ApplicationReferenceDataSource   -> physical id / Ref = the reference Id
+//!   ApplicationCloudWatchLoggingOption -> physical id / Ref = the logging-option Id
+//!
+//! The sub-resources carry their owning `ApplicationName` in the stack
+//! resource's `attributes` (`ApplicationName`) so delete -- which only receives
+//! the physical id (the numeric sub-resource id) -- can still locate the app to
+//! detach the sub-resource from.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use fakecloud_kinesisanalyticsv2::builders;
+
+use super::{ProvisionResult, ResourceDefinition, StackResource};
+
+impl super::ResourceProvisioner {
+    // ------------------------------------------------------------- Application
+
+    pub(super) fn create_ka2_application(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = ka2_str(props, "ApplicationName").ok_or_else(|| {
+            "AWS::KinesisAnalyticsV2::Application requires ApplicationName".to_string()
+        })?;
+        let runtime = ka2_str(props, "RuntimeEnvironment").ok_or_else(|| {
+            "AWS::KinesisAnalyticsV2::Application requires RuntimeEnvironment".to_string()
+        })?;
+        let role = ka2_str(props, "ServiceExecutionRole").ok_or_else(|| {
+            "AWS::KinesisAnalyticsV2::Application requires ServiceExecutionRole".to_string()
+        })?;
+        let description = ka2_str(props, "ApplicationDescription");
+        let mode = ka2_str(props, "ApplicationMode");
+
+        let mut guard = self.ka2_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        builders::insert_application(
+            st,
+            &self.region,
+            &self.account_id,
+            &name,
+            description,
+            &runtime,
+            &role,
+            mode,
+            props.get("ApplicationConfiguration"),
+            props.get("CloudWatchLoggingOptions"),
+            cfn_tags(props),
+        )?;
+        // Ref / physical id = ApplicationName (Application exposes no GetAtt).
+        Ok(ProvisionResult::new(name))
+    }
+
+    pub(super) fn update_ka2_application(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        // Every persisted difference is captured by rebuilding the record from
+        // the new desired state under the (possibly new) ApplicationName. When
+        // the name is unchanged the ARN / physical id is stable (an in-place
+        // update); when it changes, dropping the old record + inserting the new
+        // one yields a new physical id, which CloudFormation treats as a
+        // replacement. ApplicationName is create-only on the real resource, so
+        // this matches its replacement semantics.
+        self.delete_ka2_application(&existing.physical_id);
+        self.create_ka2_application(resource)
+    }
+
+    pub(super) fn delete_ka2_application(&self, physical_id: &str) {
+        let mut guard = self.ka2_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        if let Some(app) = st.applications.remove(physical_id) {
+            st.tags.remove(&app.arn);
+        }
+    }
+
+    // ------------------------------------------------------- ApplicationOutput
+
+    pub(super) fn create_ka2_application_output(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let app_name = ka2_str(props, "ApplicationName").ok_or_else(|| {
+            "AWS::KinesisAnalyticsV2::ApplicationOutput requires ApplicationName".to_string()
+        })?;
+        let output = props.get("Output").cloned().ok_or_else(|| {
+            "AWS::KinesisAnalyticsV2::ApplicationOutput requires Output".to_string()
+        })?;
+        let mut guard = self.ka2_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        let id = builders::insert_output(st, &app_name, &output)?;
+        // Ref / physical id = the output Id; stash the app name for teardown.
+        Ok(ProvisionResult::new(id).with("ApplicationName", app_name))
+    }
+
+    pub(super) fn update_ka2_application_output(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        if let Some(app_name) = existing.attributes.get("ApplicationName") {
+            let mut guard = self.ka2_state.write();
+            let st = guard.get_or_create(&self.account_id);
+            builders::remove_output(st, app_name, &existing.physical_id);
+        }
+        self.create_ka2_application_output(resource)
+    }
+
+    pub(super) fn delete_ka2_application_output(&self, resource: &StackResource) {
+        if let Some(app_name) = resource.attributes.get("ApplicationName") {
+            let mut guard = self.ka2_state.write();
+            let st = guard.get_or_create(&self.account_id);
+            builders::remove_output(st, app_name, &resource.physical_id);
+        }
+    }
+
+    // -------------------------------------------- ApplicationReferenceDataSource
+
+    pub(super) fn create_ka2_reference_data_source(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let app_name = ka2_str(props, "ApplicationName").ok_or_else(|| {
+            "AWS::KinesisAnalyticsV2::ApplicationReferenceDataSource requires ApplicationName"
+                .to_string()
+        })?;
+        let rds = props.get("ReferenceDataSource").cloned().ok_or_else(|| {
+            "AWS::KinesisAnalyticsV2::ApplicationReferenceDataSource requires ReferenceDataSource"
+                .to_string()
+        })?;
+        let mut guard = self.ka2_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        let id = builders::insert_reference_data_source(st, &app_name, &rds)?;
+        Ok(ProvisionResult::new(id).with("ApplicationName", app_name))
+    }
+
+    pub(super) fn update_ka2_reference_data_source(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        if let Some(app_name) = existing.attributes.get("ApplicationName") {
+            let mut guard = self.ka2_state.write();
+            let st = guard.get_or_create(&self.account_id);
+            builders::remove_reference_data_source(st, app_name, &existing.physical_id);
+        }
+        self.create_ka2_reference_data_source(resource)
+    }
+
+    pub(super) fn delete_ka2_reference_data_source(&self, resource: &StackResource) {
+        if let Some(app_name) = resource.attributes.get("ApplicationName") {
+            let mut guard = self.ka2_state.write();
+            let st = guard.get_or_create(&self.account_id);
+            builders::remove_reference_data_source(st, app_name, &resource.physical_id);
+        }
+    }
+
+    // -------------------------------------- ApplicationCloudWatchLoggingOption
+
+    pub(super) fn create_ka2_cloudwatch_logging_option(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let app_name = ka2_str(props, "ApplicationName").ok_or_else(|| {
+            "AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption requires ApplicationName"
+                .to_string()
+        })?;
+        let opt = props
+            .get("CloudWatchLoggingOption")
+            .cloned()
+            .ok_or_else(|| {
+                "AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption requires \
+             CloudWatchLoggingOption"
+                    .to_string()
+            })?;
+        let mut guard = self.ka2_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        let id = builders::insert_cloudwatch_logging_option(st, &app_name, &opt)?;
+        Ok(ProvisionResult::new(id).with("ApplicationName", app_name))
+    }
+
+    pub(super) fn update_ka2_cloudwatch_logging_option(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        if let Some(app_name) = existing.attributes.get("ApplicationName") {
+            let mut guard = self.ka2_state.write();
+            let st = guard.get_or_create(&self.account_id);
+            builders::remove_cloudwatch_logging_option(st, app_name, &existing.physical_id);
+        }
+        self.create_ka2_cloudwatch_logging_option(resource)
+    }
+
+    pub(super) fn delete_ka2_cloudwatch_logging_option(&self, resource: &StackResource) {
+        if let Some(app_name) = resource.attributes.get("ApplicationName") {
+            let mut guard = self.ka2_state.write();
+            let st = guard.get_or_create(&self.account_id);
+            builders::remove_cloudwatch_logging_option(st, app_name, &resource.physical_id);
+        }
+    }
+}
+
+// ---------------------------------------------------------------- helpers
+
+fn ka2_str(props: &Value, key: &str) -> Option<String> {
+    props
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// CloudFormation `Tags` (`[{Key, Value}]`) -> the `{k: v}` map the shared
+/// builder stores. The KinesisAnalyticsV2 CFN `Tags` property is always the
+/// list-of-pairs form; an object form is accepted too for robustness.
+fn cfn_tags(props: &Value) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    match props.get("Tags") {
+        Some(Value::Array(a)) => {
+            for t in a {
+                if let Some(k) = t.get("Key").and_then(Value::as_str) {
+                    let v = t.get("Value").and_then(Value::as_str).unwrap_or("");
+                    out.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+        Some(Value::Object(m)) => {
+            for (k, v) in m {
+                if let Some(s) = v.as_str() {
+                    out.insert(k.clone(), s.to_string());
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -913,6 +913,7 @@ pub struct ResourceProvisioner {
     pub elasticbeanstalk_state: fakecloud_elasticbeanstalk::SharedEbState,
     pub mq_state: fakecloud_mq::SharedMqState,
     pub kafka_state: fakecloud_kafka::SharedKafkaState,
+    pub ka2_state: fakecloud_kinesisanalyticsv2::SharedKa2State,
     pub cloudformation_state: SharedCloudFormationState,
     pub delivery: Arc<DeliveryBus>,
     /// Lambda container runtime for pre-pulling CFN-provisioned function
@@ -1093,6 +1094,7 @@ mod glue;
 mod iam;
 mod kafka;
 mod kinesis;
+mod kinesisanalyticsv2;
 mod kms;
 mod lambda;
 mod logs;
@@ -1239,6 +1241,16 @@ impl ResourceProvisioner {
             "AWS::MSK::BatchScramSecret" => self.create_msk_batch_scram_secret(resource),
             "AWS::MSK::VpcConnection" => self.create_msk_vpc_connection(resource),
             "AWS::MSK::Replicator" => self.create_msk_replicator(resource),
+            "AWS::KinesisAnalyticsV2::Application" => self.create_ka2_application(resource),
+            "AWS::KinesisAnalyticsV2::ApplicationOutput" => {
+                self.create_ka2_application_output(resource)
+            }
+            "AWS::KinesisAnalyticsV2::ApplicationReferenceDataSource" => {
+                self.create_ka2_reference_data_source(resource)
+            }
+            "AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption" => {
+                self.create_ka2_cloudwatch_logging_option(resource)
+            }
             "AWS::CodeCommit::Repository" => self.create_codecommit_repository(resource),
             "AWS::EFS::FileSystem" => self.create_efs_file_system(resource),
             "AWS::EFS::MountTarget" => self.create_efs_mount_target(resource),
@@ -1639,6 +1651,18 @@ impl ResourceProvisioner {
             }
             "AWS::MSK::VpcConnection" => Some(self.update_msk_vpc_connection(existing, new_def)?),
             "AWS::MSK::Replicator" => Some(self.update_msk_replicator(existing, new_def)?),
+            "AWS::KinesisAnalyticsV2::Application" => {
+                Some(self.update_ka2_application(existing, new_def)?)
+            }
+            "AWS::KinesisAnalyticsV2::ApplicationOutput" => {
+                Some(self.update_ka2_application_output(existing, new_def)?)
+            }
+            "AWS::KinesisAnalyticsV2::ApplicationReferenceDataSource" => {
+                Some(self.update_ka2_reference_data_source(existing, new_def)?)
+            }
+            "AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption" => {
+                Some(self.update_ka2_cloudwatch_logging_option(existing, new_def)?)
+            }
             "AWS::CodeCommit::Repository" => {
                 Some(self.update_codecommit_repository(existing, new_def)?)
             }
@@ -2091,6 +2115,22 @@ impl ResourceProvisioner {
             }
             "AWS::MSK::Replicator" => {
                 self.delete_msk_replicator(&resource.physical_id);
+                Ok(())
+            }
+            "AWS::KinesisAnalyticsV2::Application" => {
+                self.delete_ka2_application(&resource.physical_id);
+                Ok(())
+            }
+            "AWS::KinesisAnalyticsV2::ApplicationOutput" => {
+                self.delete_ka2_application_output(resource);
+                Ok(())
+            }
+            "AWS::KinesisAnalyticsV2::ApplicationReferenceDataSource" => {
+                self.delete_ka2_reference_data_source(resource);
+                Ok(())
+            }
+            "AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption" => {
+                self.delete_ka2_cloudwatch_logging_option(resource);
                 Ok(())
             }
             "AWS::CodeCommit::Repository" => {
@@ -6756,6 +6796,9 @@ mod tests {
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             kafka_state: Arc::new(parking_lot::RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
+            ka2_state: Arc::new(parking_lot::RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             delivery: Arc::new(DeliveryBus::new()),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -185,6 +185,11 @@ fn service_key_for_type(resource_type: &str) -> Option<&'static str> {
         // VpcConnection, Replicator) since the mapping keys on the service
         // segment. The server registers a `kafka` snapshot hook.
         "MSK" => "kafka",
+        // A single entry covers every AWS::KinesisAnalyticsV2::* type
+        // (Application / ApplicationOutput / ApplicationReferenceDataSource /
+        // ApplicationCloudWatchLoggingOption) since the mapping keys on the
+        // service segment. The server registers a `kinesisanalyticsv2` hook.
+        "KinesisAnalyticsV2" => "kinesisanalyticsv2",
         "EKS" => "eks",
         "ServiceDiscovery" => "servicediscovery",
         _ => return None,
@@ -425,6 +430,7 @@ pub struct CloudFormationDeps {
     pub elasticbeanstalk: fakecloud_elasticbeanstalk::SharedEbState,
     pub mq: fakecloud_mq::SharedMqState,
     pub kafka: fakecloud_kafka::SharedKafkaState,
+    pub kinesisanalyticsv2: fakecloud_kinesisanalyticsv2::SharedKa2State,
     pub delivery: Arc<DeliveryBus>,
     /// Lambda container runtime, when Docker/Podman is available. Used to
     /// pre-pull the runtime image of a CFN-provisioned `AWS::Lambda::Function`
@@ -940,6 +946,7 @@ impl CloudFormationService {
             elasticbeanstalk_state: self.deps.elasticbeanstalk.clone(),
             mq_state: self.deps.mq.clone(),
             kafka_state: self.deps.kafka.clone(),
+            ka2_state: self.deps.kinesisanalyticsv2.clone(),
             cloudformation_state: self.state.clone(),
             delivery: self.deps.delivery.clone(),
             lambda_runtime: self.deps.lambda_runtime.clone(),
@@ -3226,6 +3233,13 @@ mod tests {
                 ),
             )),
             kafka: Arc::new(parking_lot::RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            kinesisanalyticsv2: Arc::new(parking_lot::RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",

--- a/crates/fakecloud-e2e/tests/cloudformation_kinesisanalyticsv2.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_kinesisanalyticsv2.rs
@@ -1,0 +1,187 @@
+//! CloudFormation provisions `AWS::KinesisAnalyticsV2::*` resources as real
+//! records in the `kinesisanalyticsv2` (Amazon Managed Service for Apache Flink)
+//! control plane: a SQL application (settling to READY), plus an
+//! `ApplicationCloudWatchLoggingOption` and an `ApplicationOutput` sub-resource
+//! that reference the application via `Ref`. Each reads back through the
+//! kinesisanalyticsv2 API (`DescribeApplication`), proving write-through: the
+//! CFN-provisioned application stores the same wire state the direct
+//! `CreateApplication` handler does (RuntimeEnvironment + ServiceExecutionRole +
+//! the added logging option + output), and the stack `Outputs` surface each
+//! resource's `Ref`.
+//!
+//! Runs with the Flink container backend DISABLED
+//! (`FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND=1`) so no real Flink cluster is
+//! spawned -- `CreateApplication` never starts a job anyway, so this is a pure
+//! control-plane / Ref / write-through test in the shared E2E partition.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const ROLE: &str = "arn:aws:iam::123456789012:role/service-role/kinesis-analytics";
+
+// A SQL application plus a CloudWatch logging option and an output, both
+// referencing the application by Ref (which resolves to the application name =
+// the application's physical id). The multi-pass provisioner must therefore
+// order the application first.
+const TEMPLATE: &str = r#"{
+  "Resources": {
+    "App": {
+      "Type": "AWS::KinesisAnalyticsV2::Application",
+      "Properties": {
+        "ApplicationName": "cfn-ka2-app",
+        "RuntimeEnvironment": "SQL_1_0",
+        "ServiceExecutionRole": "arn:aws:iam::123456789012:role/service-role/kinesis-analytics",
+        "ApplicationDescription": "provisioned by cloudformation",
+        "Tags": [{ "Key": "env", "Value": "test" }]
+      }
+    },
+    "Logging": {
+      "Type": "AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption",
+      "Properties": {
+        "ApplicationName": { "Ref": "App" },
+        "CloudWatchLoggingOption": {
+          "LogStreamARN": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/ka2:log-stream:app"
+        }
+      }
+    },
+    "Output": {
+      "Type": "AWS::KinesisAnalyticsV2::ApplicationOutput",
+      "Properties": {
+        "ApplicationName": { "Ref": "App" },
+        "Output": {
+          "Name": "DESTINATION_STREAM",
+          "KinesisStreamsOutput": {
+            "ResourceARN": "arn:aws:kinesis:us-east-1:123456789012:stream/out-stream"
+          },
+          "DestinationSchema": { "RecordFormatType": "JSON" }
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "AppRef":     { "Value": { "Ref": "App" } },
+    "LoggingRef": { "Value": { "Ref": "Logging" } },
+    "OutputRef":  { "Value": { "Ref": "Output" } }
+  }
+}"#;
+
+fn output<'a>(stack: &'a aws_sdk_cloudformation::types::Stack, key: &str) -> &'a str {
+    stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some(key))
+        .and_then(|o| o.output_value())
+        .unwrap_or_else(|| panic!("missing output {key}"))
+}
+
+#[tokio::test]
+async fn cfn_provisions_kinesisanalyticsv2_resources_control_plane() {
+    let s =
+        TestServer::start_with_env(&[("FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND", "1")]).await;
+    let cfg = s.aws_config().await;
+    let cfn = s.cloudformation_client().await;
+    let ka2 = aws_sdk_kinesisanalyticsv2::Client::new(&cfg);
+
+    cfn.create_stack()
+        .stack_name("ka2-stack")
+        .template_body(TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("ka2-stack")
+        .send()
+        .await
+        .unwrap();
+    let stack = &described.stacks()[0];
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    // --- Ref resolution: the application's Ref is its name (its physical id);
+    //     the sub-resources' Refs are their minted numeric ids. ---
+    assert_eq!(output(stack, "AppRef"), "cfn-ka2-app");
+    assert!(
+        !output(stack, "LoggingRef").is_empty(),
+        "logging Ref should be the minted logging-option id"
+    );
+    assert!(
+        !output(stack, "OutputRef").is_empty(),
+        "output Ref should be the minted output id"
+    );
+
+    // --- Write-through: DescribeApplication reads back the exact wire state the
+    //     direct CreateApplication + AddApplication* handlers store. ---
+    let desc = ka2
+        .describe_application()
+        .application_name("cfn-ka2-app")
+        .send()
+        .await
+        .expect("describe application");
+    let detail = desc.application_detail().expect("application detail");
+    assert_eq!(detail.runtime_environment().as_str(), "SQL_1_0");
+    assert_eq!(detail.service_execution_role(), Some(ROLE));
+    assert_eq!(
+        detail.application_description(),
+        Some("provisioned by cloudformation")
+    );
+
+    // The CloudWatch logging option was written through and reads back.
+    let logs = detail.cloud_watch_logging_option_descriptions();
+    assert_eq!(logs.len(), 1, "one cloudwatch logging option");
+    assert_eq!(
+        logs[0].log_stream_arn(),
+        "arn:aws:logs:us-east-1:123456789012:log-group:/aws/ka2:log-stream:app"
+    );
+    assert_eq!(
+        logs[0].cloud_watch_logging_option_id(),
+        Some(output(stack, "LoggingRef")),
+        "logging option id matches its Ref"
+    );
+
+    // The output was written through under the SQL application configuration.
+    let outputs = detail
+        .application_configuration_description()
+        .and_then(|c| c.sql_application_configuration_description())
+        .map(|s| s.output_descriptions())
+        .unwrap_or_default();
+    assert_eq!(outputs.len(), 1, "one output description");
+    assert_eq!(outputs[0].name(), Some("DESTINATION_STREAM"));
+    assert_eq!(
+        outputs[0].output_id(),
+        Some(output(stack, "OutputRef")),
+        "output id matches its Ref"
+    );
+
+    // --- The tag applied on the Application resource persisted. ---
+    let tags = ka2
+        .list_tags_for_resource()
+        .resource_arn(detail.application_arn())
+        .send()
+        .await
+        .expect("list tags");
+    assert!(
+        tags.tags()
+            .iter()
+            .any(|t| t.key() == "env" && t.value() == Some("test")),
+        "env=test tag present"
+    );
+
+    // --- Deleting the stack removes the application from the ka2 control plane. ---
+    cfn.delete_stack()
+        .stack_name("ka2-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let gone = ka2
+        .describe_application()
+        .application_name("cfn-ka2-app")
+        .send()
+        .await;
+    assert!(
+        gone.is_err(),
+        "application should be gone after stack delete"
+    );
+}

--- a/crates/fakecloud-e2e/tests/cloudformation_kinesisanalyticsv2.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_kinesisanalyticsv2.rs
@@ -30,7 +30,7 @@ const TEMPLATE: &str = r#"{
       "Type": "AWS::KinesisAnalyticsV2::Application",
       "Properties": {
         "ApplicationName": "cfn-ka2-app",
-        "RuntimeEnvironment": "SQL_1_0",
+        "RuntimeEnvironment": "SQL-1_0",
         "ServiceExecutionRole": "arn:aws:iam::123456789012:role/service-role/kinesis-analytics",
         "ApplicationDescription": "provisioned by cloudformation",
         "Tags": [{ "Key": "env", "Value": "test" }]
@@ -120,7 +120,7 @@ async fn cfn_provisions_kinesisanalyticsv2_resources_control_plane() {
         .await
         .expect("describe application");
     let detail = desc.application_detail().expect("application detail");
-    assert_eq!(detail.runtime_environment().as_str(), "SQL_1_0");
+    assert_eq!(detail.runtime_environment().as_str(), "SQL-1_0");
     assert_eq!(detail.service_execution_role(), Some(ROLE));
     assert_eq!(
         detail.application_description(),

--- a/crates/fakecloud-e2e/tests/kinesisanalyticsv2.rs
+++ b/crates/fakecloud-e2e/tests/kinesisanalyticsv2.rs
@@ -39,7 +39,7 @@ async fn application_lifecycle_create_start_snapshot_stop_update_delete() {
     let created = ka2
         .create_application()
         .application_name("e2e-flink-app")
-        .runtime_environment(RuntimeEnvironment::from("FLINK_1_20"))
+        .runtime_environment(RuntimeEnvironment::from("FLINK-1_20"))
         .service_execution_role(role)
         .application_description("e2e managed flink app")
         .send()

--- a/crates/fakecloud-e2e/tests/kinesisanalyticsv2_dataplane.rs
+++ b/crates/fakecloud-e2e/tests/kinesisanalyticsv2_dataplane.rs
@@ -167,7 +167,7 @@ async fn flink_application_runs_a_real_job_in_a_container() {
     let created = ka2
         .create_application()
         .application_name(app_name)
-        .runtime_environment(RuntimeEnvironment::from("FLINK_1_19"))
+        .runtime_environment(RuntimeEnvironment::from("FLINK-1_19"))
         .service_execution_role(role)
         .application_configuration(code_cfg)
         .send()

--- a/crates/fakecloud-kinesisanalyticsv2/Cargo.toml
+++ b/crates/fakecloud-kinesisanalyticsv2/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-ec2 = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-kinesisanalyticsv2/src/builders.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/builders.rs
@@ -49,10 +49,15 @@ pub fn insert_application(
     let now = Utc::now();
     let application_arn = arn(region, account, name);
     let mut id_counter = 0u64;
-    let config_description = match application_configuration {
-        Some(cfg) if cfg.is_object() => config_to_description(cfg, Some(role), &mut id_counter),
-        _ => Value::Object(serde_json::Map::new()),
+    // Always run the transform (even with no `ApplicationConfiguration`): a Flink
+    // app materializes its AWS-populated Flink/snapshot defaults from an empty
+    // input, while a SQL/Zeppelin app with no config yields an empty description.
+    let empty = Value::Object(serde_json::Map::new());
+    let cfg_input = match application_configuration {
+        Some(cfg) if cfg.is_object() => cfg,
+        _ => &empty,
     };
+    let config_description = config_to_description(cfg_input, Some(role), runtime, &mut id_counter);
     let cloudwatch: Vec<Value> = cloudwatch_logging_options
         .and_then(Value::as_array)
         .map(|arr| {

--- a/crates/fakecloud-kinesisanalyticsv2/src/builders.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/builders.rs
@@ -1,0 +1,201 @@
+//! Shared record builders used by BOTH the direct API handlers (`service.rs`)
+//! and the CloudFormation `AWS::KinesisAnalyticsV2::*` provisioner, so a
+//! CFN-created application / output / reference-data-source / CloudWatch-logging
+//! option is byte-for-byte identical to its direct-API equivalent and the two
+//! paths cannot diverge (#1766). Each builder mutates the shared [`Ka2State`] in
+//! place exactly as the direct `CreateApplication` / `AddApplication*` handler
+//! does (inserting the same `ApplicationConfigurationDescription` /
+//! `CloudWatchLoggingOptionDescription` wire objects), so a CFN-provisioned
+//! resource reads back identically on `DescribeApplication` AND survives a
+//! restart through the `kinesisanalyticsv2` snapshot hook.
+
+use std::collections::BTreeMap;
+
+use chrono::Utc;
+use serde_json::Value;
+
+use crate::service::{
+    arn, bump_version, cloudwatch_desc, config_to_description, new_token, output_desc,
+    record_version, reference_desc, sql_array_push, sql_array_retain, DEFAULT_MAINTENANCE_END,
+    DEFAULT_MAINTENANCE_START,
+};
+use crate::state::{Application, Ka2State};
+
+/// Build + insert an `Application` into `st` exactly as the direct
+/// `CreateApplication` handler does, returning the application ARN. Shared with
+/// the `AWS::KinesisAnalyticsV2::Application` provisioner. Returns `Err` when an
+/// application of that name already exists (mapped to `ResourceInUseException`
+/// on the direct path). `application_configuration` / `cloudwatch_logging_options`
+/// are the raw AWS input-shaped `ApplicationConfiguration` object and
+/// `CloudWatchLoggingOptions` array (PascalCase, identical between the direct API
+/// and CloudFormation), or `None`.
+#[allow(clippy::too_many_arguments)]
+pub fn insert_application(
+    st: &mut Ka2State,
+    region: &str,
+    account: &str,
+    name: &str,
+    description: Option<String>,
+    runtime: &str,
+    role: &str,
+    mode: Option<String>,
+    application_configuration: Option<&Value>,
+    cloudwatch_logging_options: Option<&Value>,
+    tags: BTreeMap<String, String>,
+) -> Result<String, String> {
+    if st.applications.contains_key(name) {
+        return Err(format!("Application {name} already exists."));
+    }
+    let now = Utc::now();
+    let application_arn = arn(region, account, name);
+    let mut id_counter = 0u64;
+    let config_description = match application_configuration {
+        Some(cfg) if cfg.is_object() => config_to_description(cfg, Some(role), &mut id_counter),
+        _ => Value::Object(serde_json::Map::new()),
+    };
+    let cloudwatch: Vec<Value> = cloudwatch_logging_options
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .map(|o| {
+                    id_counter += 1;
+                    cloudwatch_desc(o, &id_counter.to_string(), Some(role))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut app = Application {
+        name: name.to_string(),
+        arn: application_arn.clone(),
+        description,
+        runtime_environment: runtime.to_string(),
+        service_execution_role: Some(role.to_string()),
+        application_mode: mode,
+        status: "READY".to_string(),
+        version_id: 1,
+        create_timestamp: now,
+        last_update_timestamp: now,
+        conditional_token: new_token(),
+        config_description,
+        cloudwatch_logging_options: cloudwatch,
+        maintenance_start: DEFAULT_MAINTENANCE_START.to_string(),
+        maintenance_end: DEFAULT_MAINTENANCE_END.to_string(),
+        snapshots: BTreeMap::new(),
+        operations: Vec::new(),
+        versions: BTreeMap::new(),
+        id_counter,
+        version_updated_from: None,
+        version_rolled_back_from: None,
+        version_rolled_back_to: None,
+        flink_binding: None,
+    };
+    record_version(&mut app);
+    if !tags.is_empty() {
+        st.tags.insert(application_arn.clone(), tags);
+    }
+    st.applications.insert(name.to_string(), app);
+    Ok(application_arn)
+}
+
+/// Append an `Output` to a SQL application exactly as `AddApplicationOutput`
+/// does, returning the minted `OutputId`. Shared with the
+/// `AWS::KinesisAnalyticsV2::ApplicationOutput` provisioner (whose `Ref` is the
+/// output id).
+pub fn insert_output(st: &mut Ka2State, name: &str, output: &Value) -> Result<String, String> {
+    let app = st
+        .applications
+        .get_mut(name)
+        .ok_or_else(|| format!("Application {name} not found."))?;
+    let id = app.next_id();
+    let role = app.service_execution_role.clone();
+    let desc = output_desc(output, &mut || id.clone(), role.as_deref());
+    sql_array_push(&mut app.config_description, "OutputDescriptions", desc);
+    bump_version(app);
+    Ok(id)
+}
+
+/// Append a `ReferenceDataSource` exactly as `AddApplicationReferenceDataSource`
+/// does, returning the minted `ReferenceId`. Shared with the
+/// `AWS::KinesisAnalyticsV2::ApplicationReferenceDataSource` provisioner (whose
+/// `Ref` is the reference id).
+pub fn insert_reference_data_source(
+    st: &mut Ka2State,
+    name: &str,
+    rds: &Value,
+) -> Result<String, String> {
+    let app = st
+        .applications
+        .get_mut(name)
+        .ok_or_else(|| format!("Application {name} not found."))?;
+    let id = app.next_id();
+    let role = app.service_execution_role.clone();
+    let desc = reference_desc(rds, &mut || id.clone(), role.as_deref());
+    sql_array_push(
+        &mut app.config_description,
+        "ReferenceDataSourceDescriptions",
+        desc,
+    );
+    bump_version(app);
+    Ok(id)
+}
+
+/// Append a `CloudWatchLoggingOption` exactly as
+/// `AddApplicationCloudWatchLoggingOption` does, returning the minted
+/// `CloudWatchLoggingOptionId`. Shared with the
+/// `AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption` provisioner
+/// (whose `Ref` is the logging-option id).
+pub fn insert_cloudwatch_logging_option(
+    st: &mut Ka2State,
+    name: &str,
+    opt: &Value,
+) -> Result<String, String> {
+    let app = st
+        .applications
+        .get_mut(name)
+        .ok_or_else(|| format!("Application {name} not found."))?;
+    let id = app.next_id();
+    let role = app.service_execution_role.clone();
+    app.cloudwatch_logging_options
+        .push(cloudwatch_desc(opt, &id, role.as_deref()));
+    bump_version(app);
+    Ok(id)
+}
+
+/// Remove an application output by id, mirroring `DeleteApplicationOutput`. A
+/// no-op when the application or output is absent (idempotent teardown).
+pub fn remove_output(st: &mut Ka2State, name: &str, id: &str) {
+    if let Some(app) = st.applications.get_mut(name) {
+        sql_array_retain(
+            &mut app.config_description,
+            "OutputDescriptions",
+            "OutputId",
+            id,
+        );
+        bump_version(app);
+    }
+}
+
+/// Remove a reference data source by id, mirroring
+/// `DeleteApplicationReferenceDataSource`. Idempotent.
+pub fn remove_reference_data_source(st: &mut Ka2State, name: &str, id: &str) {
+    if let Some(app) = st.applications.get_mut(name) {
+        sql_array_retain(
+            &mut app.config_description,
+            "ReferenceDataSourceDescriptions",
+            "ReferenceId",
+            id,
+        );
+        bump_version(app);
+    }
+}
+
+/// Remove a CloudWatch logging option by id, mirroring
+/// `DeleteApplicationCloudWatchLoggingOption`. Idempotent.
+pub fn remove_cloudwatch_logging_option(st: &mut Ka2State, name: &str, id: &str) {
+    if let Some(app) = st.applications.get_mut(name) {
+        app.cloudwatch_logging_options
+            .retain(|o| o.get("CloudWatchLoggingOptionId").and_then(Value::as_str) != Some(id));
+        bump_version(app);
+    }
+}

--- a/crates/fakecloud-kinesisanalyticsv2/src/lib.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/lib.rs
@@ -1,6 +1,7 @@
 //! Amazon Managed Service for Apache Flink (`kinesisanalyticsv2`, formerly
 //! Kinesis Data Analytics v2) implementation for FakeCloud.
 
+pub mod builders;
 pub mod persistence;
 pub mod runtime;
 pub mod service;

--- a/crates/fakecloud-kinesisanalyticsv2/src/service.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/service.rs
@@ -67,20 +67,24 @@ pub const KA2_ACTIONS: &[&str] = &[
     "UpdateApplicationMaintenanceConfiguration",
 ];
 
+// The AWS wire values for RuntimeEnvironment are hyphenated (`FLINK-1_20`,
+// `SQL-1_0`, `ZEPPELIN-FLINK-1_0`) — the Smithy enum NAME is `FLINK-1_20` but
+// its serialized `value` is `FLINK-1_20`, which is what the AWS SDKs and the
+// terraform provider send. Validate against the wire values, not the names.
 const RUNTIME_ENVIRONMENTS: &[&str] = &[
-    "SQL_1_0",
-    "FLINK_1_6",
-    "FLINK_1_8",
-    "ZEPPELIN_FLINK_1_0",
-    "FLINK_1_11",
-    "FLINK_1_13",
-    "ZEPPELIN_FLINK_2_0",
-    "FLINK_1_15",
-    "ZEPPELIN_FLINK_3_0",
-    "FLINK_1_18",
-    "FLINK_1_19",
-    "FLINK_1_20",
-    "FLINK_2_2",
+    "SQL-1_0",
+    "FLINK-1_6",
+    "FLINK-1_8",
+    "ZEPPELIN-FLINK-1_0",
+    "FLINK-1_11",
+    "FLINK-1_13",
+    "ZEPPELIN-FLINK-2_0",
+    "FLINK-1_15",
+    "ZEPPELIN-FLINK-3_0",
+    "FLINK-1_18",
+    "FLINK-1_19",
+    "FLINK-1_20",
+    "FLINK-2_2",
 ];
 const APPLICATION_MODES: &[&str] = &["STREAMING", "INTERACTIVE"];
 const URL_TYPES: &[&str] = &["FLINK_DASHBOARD_URL", "ZEPPELIN_UI_URL"];
@@ -2350,11 +2354,11 @@ impl Ka2Service {
 }
 
 /// Whether an application is a REAL-runtime-managed Flink app: a Flink-flavor
-/// runtime environment (`FLINK_1_x`, excluding SQL and Zeppelin) AND a code JAR
+/// runtime environment (`FLINK-1_x`, excluding SQL and Zeppelin) AND a code JAR
 /// in S3 to submit. Only these get the Docker-backed Flink job; everything else
 /// stays on the control-plane state machine.
 fn is_real_flink(app: &Application) -> bool {
-    app.runtime_environment.starts_with("FLINK_") && flink_code_location(app).is_some()
+    app.runtime_environment.starts_with("FLINK-") && flink_code_location(app).is_some()
 }
 
 /// Extract the `(bucket, key)` of an application's code JAR from its
@@ -2638,7 +2642,7 @@ mod tests {
                 "CreateApplication",
                 json!({
                     "ApplicationName": "app1",
-                    "RuntimeEnvironment": "FLINK_1_20",
+                    "RuntimeEnvironment": "FLINK-1_20",
                     "ServiceExecutionRole": "arn:aws:iam::000000000000:role/r",
                     "ApplicationDescription": "hello"
                 }),
@@ -2655,7 +2659,7 @@ mod tests {
             "CreateApplication",
             json!({
                 "ApplicationName": "app1",
-                "RuntimeEnvironment": "FLINK_1_20",
+                "RuntimeEnvironment": "FLINK-1_20",
                 "ServiceExecutionRole": "arn:aws:iam::000000000000:role/r"
             }),
         )));
@@ -2669,7 +2673,7 @@ mod tests {
             "CreateApplication",
             json!({
                 "ApplicationName": "app1",
-                "RuntimeEnvironment": "FLINK_1_20",
+                "RuntimeEnvironment": "FLINK-1_20",
                 "ServiceExecutionRole": "arn:aws:iam::000000000000:role/r"
             }),
         ))
@@ -2703,7 +2707,7 @@ mod tests {
             "CreateApplication",
             json!({
                 "ApplicationName": "app1",
-                "RuntimeEnvironment": "FLINK_1_20",
+                "RuntimeEnvironment": "FLINK-1_20",
                 "ServiceExecutionRole": "arn:aws:iam::000000000000:role/r"
             }),
         ))
@@ -2739,7 +2743,7 @@ mod tests {
             "CreateApplication",
             json!({
                 "ApplicationName": "app1",
-                "RuntimeEnvironment": "FLINK_1_20",
+                "RuntimeEnvironment": "FLINK-1_20",
                 "ServiceExecutionRole": "arn:aws:iam::000000000000:role/r"
             }),
         ))
@@ -2788,7 +2792,7 @@ mod tests {
             name: "flinkapp".into(),
             arn: arn("us-east-1", "000000000000", "flinkapp"),
             description: None,
-            runtime_environment: "FLINK_1_19".into(),
+            runtime_environment: "FLINK-1_19".into(),
             service_execution_role: Some("arn:aws:iam::000000000000:role/r".into()),
             application_mode: Some("STREAMING".into()),
             status: "READY".into(),
@@ -2829,7 +2833,7 @@ mod tests {
     #[test]
     fn sql_app_is_not_real_flink() {
         let mut app = flink_app_with_jar();
-        app.runtime_environment = "SQL_1_0".into();
+        app.runtime_environment = "SQL-1_0".into();
         // SQL flavor -> control-plane only, never the real Docker Flink job.
         assert!(!is_real_flink(&app));
     }
@@ -2854,7 +2858,7 @@ mod tests {
             "CreateApplication",
             json!({
                 "ApplicationName": "app1",
-                "RuntimeEnvironment": "FLINK_1_19",
+                "RuntimeEnvironment": "FLINK-1_19",
                 "ServiceExecutionRole": "arn:aws:iam::000000000000:role/r",
                 "ApplicationConfiguration": {
                     "ApplicationCodeConfiguration": {
@@ -2902,7 +2906,7 @@ mod tests {
                 "CreateApplication",
                 json!({
                     "ApplicationName": format!("app{i}"),
-                    "RuntimeEnvironment": "FLINK_1_20",
+                    "RuntimeEnvironment": "FLINK-1_20",
                     "ServiceExecutionRole": "arn:aws:iam::000000000000:role/r"
                 }),
             ))

--- a/crates/fakecloud-kinesisanalyticsv2/src/service.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/service.rs
@@ -210,8 +210,19 @@ fn is_mutating(action: &str) -> bool {
         || action.starts_with("Rollback")
         || action.starts_with("Tag")
         || action.starts_with("Untag")
-        // DescribeApplication settles transient lifecycle state in place.
-        || action == "DescribeApplication"
+    // NOTE: DescribeApplication is deliberately NOT listed here. It settles
+    // transient lifecycle state (STARTING -> RUNNING, UPDATING -> RUNNING, ...)
+    // in memory, but that settle is deterministic and idempotent -- the next
+    // describe re-derives it from `settle_status`, so it never needs to be
+    // persisted. Terraform's status waiters poll DescribeApplication rapidly
+    // while an application settles; if every poll triggered `save()` (clone the
+    // whole account state, JSON-serialize a Flink app's multi-MB code payload
+    // under `spawn_blocking`, write the snapshot to disk, and AWAIT it, all
+    // serialized behind the snapshot mutex), the awaited saves back up faster
+    // than they drain on a 2-core CI runner. Describe then stops responding and
+    // the provider's waiter wedges to the job timeout -- a stall that never
+    // reproduces on a many-core dev box where the saves drain between polls.
+    // A real mutation (Start/Stop/Update/...) still persists the settled state.
 }
 
 fn dispatch(s: &Ka2Service, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1113,25 +1124,49 @@ impl Ka2Service {
     /// state (AWS derives `VpcId` from the configuration's subnets). A no-op
     /// when EC2 state is not wired or a subnet is unknown -- the synthesized
     /// placeholder id set by `vpc_desc` is then left in place.
-    fn resolve_vpc_ids(&self, account: &str, cfg: &mut Value) {
+    /// Snapshot the EC2 `subnet_id -> owning vpc_id` map for an account, taken
+    /// WITHOUT holding the ka2 state lock. Callers gather this *before*
+    /// acquiring `self.state.write()` so the EC2 read lock is never nested
+    /// inside the ka2 write lock. That nesting (ka2.write -> ec2.read) is a
+    /// cross-service lock ordering: under `parking_lot`'s writer-priority, a
+    /// concurrent EC2 writer (terraform provisions the VPC/subnets/security
+    /// groups in parallel with the application) makes the nested `ec2.read()`
+    /// block while the ka2 write lock is held, stalling every other ka2 request
+    /// -- on a 2-core CI runner this wedged the provider's status waiters to the
+    /// job timeout even though it never reproduced on a many-core dev box.
+    /// Returns an empty map when EC2 is not wired.
+    fn ec2_subnet_vpc_map(&self, account: &str) -> BTreeMap<String, String> {
         let Some(ec2) = self.ec2_state.as_ref() else {
-            return;
+            return BTreeMap::new();
         };
+        let guard = ec2.read();
+        guard
+            .get(account)
+            .map(|st| {
+                st.subnets
+                    .iter()
+                    .map(|(sid, sub)| (sid.clone(), sub.vpc_id.clone()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Overwrite each VPC configuration description's `VpcId` from a
+    /// pre-snapshotted `subnet_id -> vpc_id` map (see `ec2_subnet_vpc_map`).
+    /// Pure: takes no lock, so it is safe to call while holding `self.state`.
+    fn resolve_vpc_ids(cfg: &mut Value, subnet_vpc: &BTreeMap<String, String>) {
         let Some(arr) = cfg
             .get_mut("VpcConfigurationDescriptions")
             .and_then(Value::as_array_mut)
         else {
             return;
         };
-        let guard = ec2.read();
-        let acc = guard.get(account);
         for d in arr.iter_mut() {
             let vpc = d
                 .get("SubnetIds")
                 .and_then(Value::as_array)
                 .and_then(|s| s.iter().filter_map(Value::as_str).next())
-                .and_then(|sid| acc.and_then(|st| st.subnets.get(sid)))
-                .map(|sub| sub.vpc_id.clone());
+                .and_then(|sid| subnet_vpc.get(sid).cloned());
             if let (Some(v), Some(o)) = (vpc, d.as_object_mut()) {
                 o.insert("VpcId".into(), json!(v));
             }
@@ -1148,6 +1183,9 @@ impl Ka2Service {
         let role = req_str_len(&b, "ServiceExecutionRole", 1, 2048, ec)?;
         let mode = enum_field(&b, "ApplicationMode", APPLICATION_MODES, false, ec)?;
 
+        // Snapshot the EC2 subnet->vpc map BEFORE taking the ka2 write lock so
+        // the EC2 read lock is never nested inside it (see `ec2_subnet_vpc_map`).
+        let vpc_map = self.ec2_subnet_vpc_map(&req.account_id);
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
         // Build + insert through the shared builder so a CFN-provisioned
@@ -1170,7 +1208,7 @@ impl Ka2Service {
         let app = st.applications.get_mut(&name).expect("just inserted");
         // Resolve each VPC configuration's owning VpcId from EC2 state, then
         // refresh the version-1 detail so the persisted version reflects it.
-        self.resolve_vpc_ids(&req.account_id, &mut app.config_description);
+        Self::resolve_vpc_ids(&mut app.config_description, &vpc_map);
         record_version(app);
         let detail = build_application_detail(app);
         ok(json!({ "ApplicationDetail": detail }))
@@ -1232,6 +1270,8 @@ impl Ka2Service {
         )?;
         let role_update = opt_str_len(&b, "ServiceExecutionRoleUpdate", 1, 2048, ec)?;
 
+        // Snapshot EC2 subnet->vpc BEFORE the ka2 write lock (no nested locks).
+        let vpc_map = self.ec2_subnet_vpc_map(&req.account_id);
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
         let app = st
@@ -1251,7 +1291,7 @@ impl Ka2Service {
                 apply_config_update(app, cfg);
                 // A VpcConfigurationUpdate may change the subnets; re-resolve the
                 // owning VpcId from EC2 state.
-                self.resolve_vpc_ids(&req.account_id, &mut app.config_description);
+                Self::resolve_vpc_ids(&mut app.config_description, &vpc_map);
             }
         }
         // A `RunConfigurationUpdate` (top-level on UpdateApplication) revises the
@@ -1807,6 +1847,8 @@ impl Ka2Service {
             .get("VpcConfiguration")
             .cloned()
             .ok_or_else(|| fault(ec, "VpcConfiguration is required."))?;
+        // Snapshot EC2 subnet->vpc BEFORE the ka2 write lock (no nested locks).
+        let vpc_map = self.ec2_subnet_vpc_map(&req.account_id);
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
         let app = st
@@ -1823,7 +1865,7 @@ impl Ka2Service {
         );
         // Resolve the owning VpcId from EC2 state, then read the stored
         // description back so the response carries the resolved id.
-        self.resolve_vpc_ids(&req.account_id, &mut app.config_description);
+        Self::resolve_vpc_ids(&mut app.config_description, &vpc_map);
         let stored = app
             .config_description
             .get("VpcConfigurationDescriptions")

--- a/crates/fakecloud-kinesisanalyticsv2/src/service.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/service.rs
@@ -86,8 +86,8 @@ const APPLICATION_MODES: &[&str] = &["STREAMING", "INTERACTIVE"];
 const URL_TYPES: &[&str] = &["FLINK_DASHBOARD_URL", "ZEPPELIN_UI_URL"];
 const OPERATION_STATUSES: &[&str] = &["IN_PROGRESS", "CANCELLED", "SUCCESSFUL", "FAILED"];
 
-const DEFAULT_MAINTENANCE_START: &str = "06:00";
-const DEFAULT_MAINTENANCE_END: &str = "14:00";
+pub(crate) const DEFAULT_MAINTENANCE_START: &str = "06:00";
+pub(crate) const DEFAULT_MAINTENANCE_END: &str = "14:00";
 
 pub struct Ka2Service {
     state: SharedKa2State,
@@ -141,6 +141,26 @@ impl Ka2Service {
             &self.snapshot_lock,
         )
         .await;
+    }
+
+    /// Persist hook for the CloudFormation provisioner (registered by name in
+    /// the server). The CFN `AWS::KinesisAnalyticsV2::*` provisioner mutates the
+    /// shared `Ka2State` directly and never triggers this service's own save
+    /// path, so CloudFormation invokes this hook after a stack op to write the
+    /// state through to disk -- the same persistence a direct mutating API call
+    /// gets. `None` in memory mode (no snapshot store configured).
+    pub fn snapshot_hook(&self) -> Option<fakecloud_persistence::SnapshotHook> {
+        let store = self.snapshot_store.clone()?;
+        let state = self.state.clone();
+        let lock = self.snapshot_lock.clone();
+        Some(Arc::new(move || {
+            let state = state.clone();
+            let store = store.clone();
+            let lock = lock.clone();
+            Box::pin(async move {
+                crate::persistence::save_snapshot(&state, Some(store), &lock).await;
+            })
+        }))
     }
 }
 
@@ -365,11 +385,11 @@ fn int_range(
     }
 }
 
-fn arn(region: &str, account: &str, name: &str) -> String {
+pub(crate) fn arn(region: &str, account: &str, name: &str) -> String {
     format!("arn:aws:kinesisanalytics:{region}:{account}:application/{name}")
 }
 
-fn new_token() -> String {
+pub(crate) fn new_token() -> String {
     Uuid::new_v4().simple().to_string()
 }
 
@@ -544,7 +564,7 @@ fn str_of(v: &Value, k: &str) -> Option<String> {
 /// `ApplicationConfiguration`, assigning ids to inputs/outputs/reference data
 /// sources/VPC configurations. Only members present in the input are emitted;
 /// every emitted member matches the output shape exactly.
-fn config_to_description(cfg: &Value, role: Option<&str>, id: &mut u64) -> Value {
+pub(crate) fn config_to_description(cfg: &Value, role: Option<&str>, id: &mut u64) -> Value {
     let mut out = serde_json::Map::new();
     let mut next = || {
         *id += 1;
@@ -747,7 +767,11 @@ fn input_desc(input: &Value, next: &mut impl FnMut() -> String, role: Option<&st
     Value::Object(d)
 }
 
-fn output_desc(output: &Value, next: &mut impl FnMut() -> String, role: Option<&str>) -> Value {
+pub(crate) fn output_desc(
+    output: &Value,
+    next: &mut impl FnMut() -> String,
+    role: Option<&str>,
+) -> Value {
     let mut d = serde_json::Map::new();
     d.insert("OutputId".into(), json!(next()));
     if let Some(n) = str_of(output, "Name") {
@@ -777,7 +801,11 @@ fn output_desc(output: &Value, next: &mut impl FnMut() -> String, role: Option<&
     Value::Object(d)
 }
 
-fn reference_desc(r: &Value, next: &mut impl FnMut() -> String, role: Option<&str>) -> Value {
+pub(crate) fn reference_desc(
+    r: &Value,
+    next: &mut impl FnMut() -> String,
+    role: Option<&str>,
+) -> Value {
     let mut d = serde_json::Map::new();
     d.insert("ReferenceId".into(), json!(next()));
     d.insert(
@@ -833,7 +861,7 @@ fn vpc_desc(v: &Value, next: &mut impl FnMut() -> String) -> Value {
     })
 }
 
-fn cloudwatch_desc(opt: &Value, id: &str, role: Option<&str>) -> Value {
+pub(crate) fn cloudwatch_desc(opt: &Value, id: &str, role: Option<&str>) -> Value {
     let mut m = serde_json::Map::new();
     m.insert("CloudWatchLoggingOptionId".into(), json!(id));
     m.insert(
@@ -848,7 +876,7 @@ fn cloudwatch_desc(opt: &Value, id: &str, role: Option<&str>) -> Value {
 
 // ===== version + operation recording =====
 
-fn record_version(app: &mut Application) {
+pub(crate) fn record_version(app: &mut Application) {
     let detail = build_application_detail(app);
     app.versions.insert(
         app.version_id,
@@ -883,7 +911,7 @@ fn record_operation(
 
 /// Bump the application version for a config-changing operation, refresh the
 /// conditional token, and record the new version snapshot.
-fn bump_version(app: &mut Application) {
+pub(crate) fn bump_version(app: &mut Application) {
     let from = app.version_id;
     app.version_id += 1;
     app.version_updated_from = Some(from);
@@ -934,68 +962,24 @@ impl Ka2Service {
 
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
-        if st.applications.contains_key(&name) {
-            return Err(fault(
-                "ResourceInUseException",
-                &format!("Application {name} already exists."),
-            ));
-        }
-        let now = Utc::now();
-        let application_arn = arn(&req.region, &req.account_id, &name);
-        let mut id_counter = 0u64;
-        let config_description = match b.get("ApplicationConfiguration") {
-            Some(cfg) if cfg.is_object() => {
-                config_to_description(cfg, Some(&role), &mut id_counter)
-            }
-            _ => Value::Object(serde_json::Map::new()),
-        };
-        let cloudwatch: Vec<Value> = b
-            .get("CloudWatchLoggingOptions")
-            .and_then(Value::as_array)
-            .map(|arr| {
-                arr.iter()
-                    .map(|o| {
-                        id_counter += 1;
-                        cloudwatch_desc(o, &id_counter.to_string(), Some(&role))
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let mut app = Application {
-            name: name.clone(),
-            arn: application_arn.clone(),
+        // Build + insert through the shared builder so a CFN-provisioned
+        // `AWS::KinesisAnalyticsV2::Application` stores byte-identical wire state
+        // and cannot diverge from this path (#1766).
+        crate::builders::insert_application(
+            st,
+            &req.region,
+            &req.account_id,
+            &name,
             description,
-            runtime_environment: runtime,
-            service_execution_role: Some(role),
-            application_mode: mode,
-            status: "READY".to_string(),
-            version_id: 1,
-            create_timestamp: now,
-            last_update_timestamp: now,
-            conditional_token: new_token(),
-            config_description,
-            cloudwatch_logging_options: cloudwatch,
-            maintenance_start: DEFAULT_MAINTENANCE_START.to_string(),
-            maintenance_end: DEFAULT_MAINTENANCE_END.to_string(),
-            snapshots: BTreeMap::new(),
-            operations: Vec::new(),
-            versions: BTreeMap::new(),
-            id_counter,
-            version_updated_from: None,
-            version_rolled_back_from: None,
-            version_rolled_back_to: None,
-            flink_binding: None,
-        };
-        record_version(&mut app);
-        let detail = build_application_detail(&app);
-
-        let tags = parse_tags(&b);
-        if !tags.is_empty() {
-            st.tags.insert(application_arn.clone(), tags);
-        }
-        st.applications.insert(name, app);
-
+            &runtime,
+            &role,
+            mode,
+            b.get("ApplicationConfiguration"),
+            b.get("CloudWatchLoggingOptions"),
+            parse_tags(&b),
+        )
+        .map_err(|m| fault("ResourceInUseException", &m))?;
+        let detail = build_application_detail(st.applications.get(&name).expect("just inserted"));
         ok(json!({ "ApplicationDetail": detail }))
     }
 
@@ -1540,16 +1524,13 @@ impl Ka2Service {
             .ok_or_else(|| fault(ec, "CloudWatchLoggingOption is required."))?;
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
-        let app = st
-            .applications
-            .get_mut(&name)
-            .ok_or_else(|| not_found(&name))?;
-        check_concurrency(app, &b)?;
-        let id = app.next_id();
-        let role = app.service_execution_role.clone();
-        app.cloudwatch_logging_options
-            .push(cloudwatch_desc(&opt, &id, role.as_deref()));
-        bump_version(app);
+        {
+            let app = st.applications.get(&name).ok_or_else(|| not_found(&name))?;
+            check_concurrency(app, &b)?;
+        }
+        crate::builders::insert_cloudwatch_logging_option(st, &name, &opt)
+            .map_err(|_| not_found(&name))?;
+        let app = st.applications.get_mut(&name).expect("just updated");
         let op_id = record_operation(
             app,
             "UpdateApplication",
@@ -1793,15 +1774,8 @@ impl Ka2Service {
             .ok_or_else(|| fault(ec, "Output is required."))?;
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
-        let app = st
-            .applications
-            .get_mut(&name)
-            .ok_or_else(|| not_found(&name))?;
-        let id = app.next_id();
-        let role = app.service_execution_role.clone();
-        let desc = output_desc(&output, &mut || id.clone(), role.as_deref());
-        sql_array_push(&mut app.config_description, "OutputDescriptions", desc);
-        bump_version(app);
+        crate::builders::insert_output(st, &name, &output).map_err(|_| not_found(&name))?;
+        let app = st.applications.get(&name).expect("just updated");
         let descs = sql_array_get(&app.config_description, "OutputDescriptions");
         ok(json!({
             "ApplicationARN": app.arn,
@@ -1846,19 +1820,9 @@ impl Ka2Service {
             .ok_or_else(|| fault(ec, "ReferenceDataSource is required."))?;
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
-        let app = st
-            .applications
-            .get_mut(&name)
-            .ok_or_else(|| not_found(&name))?;
-        let id = app.next_id();
-        let role = app.service_execution_role.clone();
-        let desc = reference_desc(&rds, &mut || id.clone(), role.as_deref());
-        sql_array_push(
-            &mut app.config_description,
-            "ReferenceDataSourceDescriptions",
-            desc,
-        );
-        bump_version(app);
+        crate::builders::insert_reference_data_source(st, &name, &rds)
+            .map_err(|_| not_found(&name))?;
+        let app = st.applications.get(&name).expect("just updated");
         let descs = sql_array_get(&app.config_description, "ReferenceDataSourceDescriptions");
         ok(json!({
             "ApplicationARN": app.arn,
@@ -2530,7 +2494,7 @@ fn config_array_retain(cfg: &mut Value, key: &str, id_field: &str, id: &str) {
 
 /// Push into `SqlApplicationConfigurationDescription.<key>`, creating the
 /// nested structure as needed.
-fn sql_array_push(cfg: &mut Value, key: &str, item: Value) {
+pub(crate) fn sql_array_push(cfg: &mut Value, key: &str, item: Value) {
     let obj = ensure_object(cfg);
     let sql = obj
         .entry("SqlApplicationConfigurationDescription")
@@ -2542,7 +2506,7 @@ fn sql_array_push(cfg: &mut Value, key: &str, item: Value) {
     }
 }
 
-fn sql_array_retain(cfg: &mut Value, key: &str, id_field: &str, id: &str) {
+pub(crate) fn sql_array_retain(cfg: &mut Value, key: &str, id_field: &str, id: &str) {
     if let Some(arr) = cfg
         .get_mut("SqlApplicationConfigurationDescription")
         .and_then(|s| s.get_mut(key))

--- a/crates/fakecloud-kinesisanalyticsv2/src/service.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/service.rs
@@ -106,6 +106,10 @@ pub struct Ka2Service {
     /// In-process S3 reader used to fetch an application's code JAR from a
     /// fakecloud S3 bucket for submission to the Flink cluster.
     s3: Option<Arc<dyn S3Delivery>>,
+    /// Shared EC2 state, used to resolve the owning VPC of an application's VPC
+    /// configuration subnets (AWS derives `VpcId` from the subnets). `None` when
+    /// EC2 is not wired -> a synthesized placeholder VPC id is used.
+    ec2_state: Option<fakecloud_ec2::SharedEc2State>,
 }
 
 impl Ka2Service {
@@ -116,7 +120,15 @@ impl Ka2Service {
             snapshot_lock: Arc::new(AsyncMutex::new(())),
             runtime: None,
             s3: None,
+            ec2_state: None,
         }
+    }
+
+    /// Attach shared EC2 state so a VPC configuration's `VpcId` is resolved from
+    /// the owning VPC of its subnets, exactly as AWS derives it.
+    pub fn with_ec2_state(mut self, ec2_state: fakecloud_ec2::SharedEc2State) -> Self {
+        self.ec2_state = Some(ec2_state);
+        self
     }
 
     pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
@@ -566,9 +578,21 @@ fn str_of(v: &Value, k: &str) -> Option<String> {
 
 /// Build the `ApplicationConfigurationDescription` object from an input
 /// `ApplicationConfiguration`, assigning ids to inputs/outputs/reference data
-/// sources/VPC configurations. Only members present in the input are emitted;
-/// every emitted member matches the output shape exactly.
-pub(crate) fn config_to_description(cfg: &Value, role: Option<&str>, id: &mut u64) -> Value {
+/// sources/VPC configurations.
+///
+/// For a **Flink** runtime (`FLINK-1_x`) AWS always materializes a full
+/// `FlinkApplicationConfigurationDescription` (checkpoint / monitoring /
+/// parallelism) and an `ApplicationSnapshotConfigurationDescription`, filling
+/// the documented DEFAULT values for anything the caller omitted -- so a bare
+/// Flink app still reads back a populated configuration. SQL / Zeppelin apps
+/// only echo the members that were supplied.
+pub(crate) fn config_to_description(
+    cfg: &Value,
+    role: Option<&str>,
+    runtime: &str,
+    id: &mut u64,
+) -> Value {
+    let is_flink = runtime.starts_with("FLINK-");
     let mut out = serde_json::Map::new();
     let mut next = || {
         *id += 1;
@@ -604,20 +628,13 @@ pub(crate) fn config_to_description(cfg: &Value, role: Option<&str>, id: &mut u6
         );
     }
 
-    if let Some(flink) = cfg.get("FlinkApplicationConfiguration") {
-        let mut fd = serde_json::Map::new();
-        if let Some(c) = flink.get("CheckpointConfiguration") {
-            fd.insert("CheckpointConfigurationDescription".into(), c.clone());
-        }
-        if let Some(c) = flink.get("MonitoringConfiguration") {
-            fd.insert("MonitoringConfigurationDescription".into(), c.clone());
-        }
-        if let Some(c) = flink.get("ParallelismConfiguration") {
-            fd.insert("ParallelismConfigurationDescription".into(), c.clone());
-        }
+    if is_flink {
+        // AWS always returns a fully-populated FlinkApplicationConfiguration
+        // description for a Flink app, defaulting any sub-config the caller
+        // omitted to its documented DEFAULT values.
         out.insert(
             "FlinkApplicationConfigurationDescription".into(),
-            Value::Object(fd),
+            flink_config_description(cfg.get("FlinkApplicationConfiguration")),
         );
     }
 
@@ -656,7 +673,19 @@ pub(crate) fn config_to_description(cfg: &Value, role: Option<&str>, id: &mut u6
         );
     }
 
-    if let Some(snap) = cfg.get("ApplicationSnapshotConfiguration") {
+    if is_flink {
+        // A Flink app always reports a snapshot configuration; when the caller
+        // did not supply one AWS defaults SnapshotsEnabled to `true`.
+        let enabled = cfg
+            .get("ApplicationSnapshotConfiguration")
+            .and_then(|s| s.get("SnapshotsEnabled"))
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        out.insert(
+            "ApplicationSnapshotConfigurationDescription".into(),
+            json!({ "SnapshotsEnabled": enabled }),
+        );
+    } else if let Some(snap) = cfg.get("ApplicationSnapshotConfiguration") {
         let enabled = snap
             .get("SnapshotsEnabled")
             .and_then(Value::as_bool)
@@ -717,6 +746,110 @@ pub(crate) fn config_to_description(cfg: &Value, role: Option<&str>, id: &mut u6
     Value::Object(out)
 }
 
+// ===== Flink application-configuration defaults =====
+//
+// AWS auto-populates a Flink app's FlinkApplicationConfiguration description on
+// create, and returns it (plus its DEFAULT-vs-CUSTOM per-sub-config values) on
+// every describe. When a sub-config's ConfigurationType is DEFAULT (or the
+// sub-config was omitted entirely) AWS reports the documented default values;
+// when CUSTOM it echoes the caller's values (defaulting any individual field
+// the caller left unset).
+
+const DEFAULT_CHECKPOINT_INTERVAL: i64 = 60_000;
+const DEFAULT_MIN_PAUSE_BETWEEN_CHECKPOINTS: i64 = 5_000;
+const DEFAULT_METRICS_LEVEL: &str = "APPLICATION";
+const DEFAULT_LOG_LEVEL: &str = "INFO";
+
+/// Build the full `FlinkApplicationConfigurationDescription` (all three
+/// sub-descriptions) from an optional input `FlinkApplicationConfiguration`.
+fn flink_config_description(flink: Option<&Value>) -> Value {
+    json!({
+        "CheckpointConfigurationDescription":
+            checkpoint_description(flink.and_then(|f| f.get("CheckpointConfiguration"))),
+        "MonitoringConfigurationDescription":
+            monitoring_description(flink.and_then(|f| f.get("MonitoringConfiguration"))),
+        "ParallelismConfigurationDescription":
+            parallelism_description(flink.and_then(|f| f.get("ParallelismConfiguration"))),
+    })
+}
+
+/// The `ConfigurationType` of an input sub-config, defaulting to `DEFAULT` when
+/// the sub-config is absent or did not specify one.
+fn configuration_type(input: Option<&Value>) -> String {
+    input
+        .and_then(|v| str_of(v, "ConfigurationType"))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "DEFAULT".to_string())
+}
+
+fn checkpoint_description(input: Option<&Value>) -> Value {
+    let ctype = configuration_type(input);
+    let custom = ctype == "CUSTOM";
+    let get_bool = |k: &str, d: bool| {
+        input
+            .filter(|_| custom)
+            .and_then(|v| v.get(k))
+            .and_then(Value::as_bool)
+            .unwrap_or(d)
+    };
+    let get_int = |k: &str, d: i64| {
+        input
+            .filter(|_| custom)
+            .and_then(|v| v.get(k))
+            .and_then(Value::as_i64)
+            .unwrap_or(d)
+    };
+    json!({
+        "ConfigurationType": ctype,
+        "CheckpointingEnabled": get_bool("CheckpointingEnabled", true),
+        "CheckpointInterval": get_int("CheckpointInterval", DEFAULT_CHECKPOINT_INTERVAL),
+        "MinPauseBetweenCheckpoints":
+            get_int("MinPauseBetweenCheckpoints", DEFAULT_MIN_PAUSE_BETWEEN_CHECKPOINTS),
+    })
+}
+
+fn monitoring_description(input: Option<&Value>) -> Value {
+    let ctype = configuration_type(input);
+    let custom = ctype == "CUSTOM";
+    let get_str = |k: &str, d: &str| {
+        input
+            .filter(|_| custom)
+            .and_then(|v| str_of(v, k))
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| d.to_string())
+    };
+    json!({
+        "ConfigurationType": ctype,
+        "LogLevel": get_str("LogLevel", DEFAULT_LOG_LEVEL),
+        "MetricsLevel": get_str("MetricsLevel", DEFAULT_METRICS_LEVEL),
+    })
+}
+
+fn parallelism_description(input: Option<&Value>) -> Value {
+    let ctype = configuration_type(input);
+    let custom = ctype == "CUSTOM";
+    let get_int = |k: &str, d: i64| {
+        input
+            .filter(|_| custom)
+            .and_then(|v| v.get(k))
+            .and_then(Value::as_i64)
+            .unwrap_or(d)
+    };
+    let parallelism = get_int("Parallelism", 1);
+    let auto_scaling = input
+        .filter(|_| custom)
+        .and_then(|v| v.get("AutoScalingEnabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    json!({
+        "ConfigurationType": ctype,
+        "Parallelism": parallelism,
+        "ParallelismPerKPU": get_int("ParallelismPerKPU", 1),
+        "AutoScalingEnabled": auto_scaling,
+        "CurrentParallelism": parallelism,
+    })
+}
+
 fn s3_code_location(s3: &Value) -> Value {
     let mut m = serde_json::Map::new();
     m.insert(
@@ -733,11 +866,30 @@ fn s3_code_location(s3: &Value) -> Value {
     Value::Object(m)
 }
 
+/// Build the ordered list of in-app stream names AWS mints for a SQL input:
+/// one `<NamePrefix>_NNN` (1-based, zero-padded to 3 digits) per unit of the
+/// input's parallelism `Count`. So a `Count=1` input reports a single stream
+/// and a `Count=42` input reports 42.
+fn in_app_stream_names(name_prefix: &str, count: i64) -> Vec<String> {
+    (1..=count.max(1))
+        .map(|i| format!("{name_prefix}_{i:03}"))
+        .collect()
+}
+
 fn input_desc(input: &Value, next: &mut impl FnMut() -> String, role: Option<&str>) -> Value {
     let mut d = serde_json::Map::new();
     d.insert("InputId".into(), json!(next()));
+    // AWS auto-populates InputParallelism.Count to 1 when the caller omits it.
+    let count = input
+        .get("InputParallelism")
+        .and_then(|p| p.get("Count"))
+        .and_then(Value::as_i64)
+        .unwrap_or(1);
     if let Some(np) = str_of(input, "NamePrefix") {
-        d.insert("InAppStreamNames".into(), json!([format!("{np}_001")]));
+        d.insert(
+            "InAppStreamNames".into(),
+            json!(in_app_stream_names(&np, count)),
+        );
         d.insert("NamePrefix".into(), json!(np));
     }
     if let Some(ipc) = input.get("InputProcessingConfiguration") {
@@ -762,12 +914,14 @@ fn input_desc(input: &Value, next: &mut impl FnMut() -> String, role: Option<&st
             resource_role_desc(k, role),
         );
     }
-    if let Some(p) = input.get("InputParallelism") {
-        d.insert("InputParallelism".into(), p.clone());
-    }
+    d.insert("InputParallelism".into(), json!({ "Count": count }));
     if let Some(s) = input.get("InputSchema") {
         d.insert("InputSchema".into(), s.clone());
     }
+    // AWS always reports an InputStartingPositionConfiguration on the input; its
+    // InputStartingPosition stays unset (reads back empty) until the application
+    // is started with a run configuration that pins one.
+    d.insert("InputStartingPositionConfiguration".into(), json!({}));
     Value::Object(d)
 }
 
@@ -954,6 +1108,36 @@ fn check_concurrency(app: &Application, b: &Value) -> Result<(), AwsServiceError
 // ===== handlers =====
 
 impl Ka2Service {
+    /// Overwrite each `VpcConfigurationDescription.VpcId` in a config
+    /// description with the real owning VPC of its subnets, resolved from EC2
+    /// state (AWS derives `VpcId` from the configuration's subnets). A no-op
+    /// when EC2 state is not wired or a subnet is unknown -- the synthesized
+    /// placeholder id set by `vpc_desc` is then left in place.
+    fn resolve_vpc_ids(&self, account: &str, cfg: &mut Value) {
+        let Some(ec2) = self.ec2_state.as_ref() else {
+            return;
+        };
+        let Some(arr) = cfg
+            .get_mut("VpcConfigurationDescriptions")
+            .and_then(Value::as_array_mut)
+        else {
+            return;
+        };
+        let guard = ec2.read();
+        let acc = guard.get(account);
+        for d in arr.iter_mut() {
+            let vpc = d
+                .get("SubnetIds")
+                .and_then(Value::as_array)
+                .and_then(|s| s.iter().filter_map(Value::as_str).next())
+                .and_then(|sid| acc.and_then(|st| st.subnets.get(sid)))
+                .map(|sub| sub.vpc_id.clone());
+            if let (Some(v), Some(o)) = (vpc, d.as_object_mut()) {
+                o.insert("VpcId".into(), json!(v));
+            }
+        }
+    }
+
     fn create_application(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let b = parse(req)?;
         let ec = "InvalidArgumentException";
@@ -983,7 +1167,12 @@ impl Ka2Service {
             parse_tags(&b),
         )
         .map_err(|m| fault("ResourceInUseException", &m))?;
-        let detail = build_application_detail(st.applications.get(&name).expect("just inserted"));
+        let app = st.applications.get_mut(&name).expect("just inserted");
+        // Resolve each VPC configuration's owning VpcId from EC2 state, then
+        // refresh the version-1 detail so the persisted version reflects it.
+        self.resolve_vpc_ids(&req.account_id, &mut app.config_description);
+        record_version(app);
+        let detail = build_application_detail(app);
         ok(json!({ "ApplicationDetail": detail }))
     }
 
@@ -1059,11 +1248,19 @@ impl Ka2Service {
         }
         if let Some(cfg) = b.get("ApplicationConfigurationUpdate") {
             if cfg.is_object() {
-                let role = app.service_execution_role.clone();
-                let mut id = app.id_counter;
-                let new_desc = config_to_description(cfg, role.as_deref(), &mut id);
-                app.id_counter = id;
-                merge_config_description(&mut app.config_description, new_desc);
+                apply_config_update(app, cfg);
+                // A VpcConfigurationUpdate may change the subnets; re-resolve the
+                // owning VpcId from EC2 state.
+                self.resolve_vpc_ids(&req.account_id, &mut app.config_description);
+            }
+        }
+        // A `RunConfigurationUpdate` (top-level on UpdateApplication) revises the
+        // run configuration a started Flink app reports.
+        if app.runtime_environment.starts_with("FLINK-") {
+            if let Some(rc) = b.get("RunConfigurationUpdate") {
+                let desc = run_config_description(Some(rc));
+                ensure_object(&mut app.config_description)
+                    .insert("RunConfigurationDescription".into(), desc);
             }
         }
         if let Some(updates) = b
@@ -1173,8 +1370,19 @@ impl Ka2Service {
             .applications
             .get_mut(&name)
             .ok_or_else(|| not_found(&name))?;
-        if let Some(rc) = b.get("RunConfiguration") {
-            apply_run_configuration(app, rc);
+        if app.runtime_environment.starts_with("FLINK-") {
+            // Once a Flink app is started, AWS records a RunConfiguration
+            // description on it -- defaulting to RESTORE_FROM_LATEST_SNAPSHOT /
+            // AllowNonRestoredState=false when the caller supplied nothing, and
+            // echoing any provided RunConfiguration otherwise.
+            let desc = run_config_description(b.get("RunConfiguration"));
+            ensure_object(&mut app.config_description)
+                .insert("RunConfigurationDescription".into(), desc);
+        } else if let Some(rc) = b.get("RunConfiguration") {
+            // A SQL app's RunConfiguration pins each input's starting position
+            // via SqlRunConfigurations; unlike Flink it records no
+            // RunConfigurationDescription.
+            apply_sql_run_configuration(app, rc);
         }
         app.status = "STARTING".to_string();
         let op_id = record_operation(app, "StartApplication", None, None);
@@ -1214,6 +1422,11 @@ impl Ka2Service {
             .applications
             .get_mut(&name)
             .ok_or_else(|| not_found(&name))?;
+        // AWS drops the RunConfiguration description once an application is
+        // stopped; it is re-established on the next StartApplication.
+        if let Some(obj) = app.config_description.as_object_mut() {
+            obj.remove("RunConfigurationDescription");
+        }
         let real = self.runtime.is_some() && is_real_flink(app);
         let binding = app.flink_binding.clone();
         let running_job = binding
@@ -1606,8 +1819,23 @@ impl Ka2Service {
         config_array_push(
             &mut app.config_description,
             "VpcConfigurationDescriptions",
-            desc.clone(),
+            desc,
         );
+        // Resolve the owning VpcId from EC2 state, then read the stored
+        // description back so the response carries the resolved id.
+        self.resolve_vpc_ids(&req.account_id, &mut app.config_description);
+        let stored = app
+            .config_description
+            .get("VpcConfigurationDescriptions")
+            .and_then(Value::as_array)
+            .and_then(|arr| {
+                arr.iter()
+                    .find(|d| {
+                        d.get("VpcConfigurationId").and_then(Value::as_str) == Some(id.as_str())
+                    })
+                    .cloned()
+            })
+            .unwrap_or(Value::Null);
         bump_version(app);
         let op_id = record_operation(
             app,
@@ -1618,7 +1846,7 @@ impl Ka2Service {
         ok(json!({
             "ApplicationARN": app.arn,
             "ApplicationVersionId": app.version_id,
-            "VpcConfigurationDescription": desc,
+            "VpcConfigurationDescription": stored,
             "OperationId": op_id,
         }))
     }
@@ -2518,6 +2746,37 @@ pub(crate) fn sql_array_retain(cfg: &mut Value, key: &str, id_field: &str, id: &
     {
         arr.retain(|e| e.get(id_field).and_then(Value::as_str) != Some(id));
     }
+    collapse_empty_sql_config(cfg);
+}
+
+/// Drop the whole `SqlApplicationConfigurationDescription` once its inputs,
+/// outputs and reference data sources are all gone. AWS reports no
+/// `SqlApplicationConfiguration` (rather than an empty one) after the last SQL
+/// resource is removed, so terraform reads `sql_application_configuration.# = 0`.
+fn collapse_empty_sql_config(cfg: &mut Value) {
+    let Some(obj) = cfg.as_object_mut() else {
+        return;
+    };
+    let empty = obj
+        .get("SqlApplicationConfigurationDescription")
+        .map(|sql| {
+            [
+                "InputDescriptions",
+                "OutputDescriptions",
+                "ReferenceDataSourceDescriptions",
+            ]
+            .iter()
+            .all(|k| {
+                sql.get(k)
+                    .and_then(Value::as_array)
+                    .map(|a| a.is_empty())
+                    .unwrap_or(true)
+            })
+        })
+        .unwrap_or(false);
+    if empty {
+        obj.remove("SqlApplicationConfigurationDescription");
+    }
 }
 
 fn sql_array_mut<'a>(cfg: &'a mut Value, key: &str) -> Option<&'a mut Vec<Value>> {
@@ -2533,34 +2792,439 @@ fn sql_array_get(cfg: &Value, key: &str) -> Value {
         .unwrap_or_else(|| json!([]))
 }
 
-/// Merge a freshly-transformed config description over the existing one,
-/// replacing top-level members that the update supplied.
-fn merge_config_description(existing: &mut Value, update: Value) {
-    let dst = ensure_object(existing);
-    if let Value::Object(src) = update {
-        for (k, v) in src {
-            dst.insert(k, v);
+/// Apply an `ApplicationConfigurationUpdate` to an application's stored
+/// `ApplicationConfigurationDescription` in place. Each member present in the
+/// update (which carries `*Update`-suffixed shapes) rebuilds the corresponding
+/// description member; members the update omits are preserved. This mirrors how
+/// AWS re-derives the description after `UpdateApplication`, including
+/// re-defaulting a Flink sub-config whose `ConfigurationType` reverted to
+/// `DEFAULT`.
+fn apply_config_update(app: &mut Application, update: &Value) {
+    let is_flink = app.runtime_environment.starts_with("FLINK-");
+
+    if let Some(code) = update.get("ApplicationCodeConfigurationUpdate") {
+        let existing = app
+            .config_description
+            .get("ApplicationCodeConfigurationDescription")
+            .cloned();
+        let desc = code_config_update_description(code, existing.as_ref());
+        ensure_object(&mut app.config_description)
+            .insert("ApplicationCodeConfigurationDescription".into(), desc);
+    }
+
+    if is_flink {
+        if let Some(flink) = update.get("FlinkApplicationConfigurationUpdate") {
+            let existing = app
+                .config_description
+                .get("FlinkApplicationConfigurationDescription")
+                .cloned();
+            let desc = flink_config_update_description(flink, existing.as_ref());
+            ensure_object(&mut app.config_description)
+                .insert("FlinkApplicationConfigurationDescription".into(), desc);
+        }
+    } else if let Some(sql) = update.get("SqlApplicationConfigurationUpdate") {
+        let role = app.service_execution_role.clone();
+        apply_sql_config_update(&mut app.config_description, role.as_deref(), sql);
+    }
+
+    if let Some(snap) = update.get("ApplicationSnapshotConfigurationUpdate") {
+        if let Some(enabled) = snap.get("SnapshotsEnabledUpdate").and_then(Value::as_bool) {
+            ensure_object(&mut app.config_description).insert(
+                "ApplicationSnapshotConfigurationDescription".into(),
+                json!({ "SnapshotsEnabled": enabled }),
+            );
+        }
+    }
+
+    if let Some(env) = update.get("EnvironmentPropertyUpdates") {
+        // An empty PropertyGroups list removes all groups.
+        let groups = env.get("PropertyGroups").and_then(Value::as_array);
+        match groups {
+            Some(pg) if !pg.is_empty() => {
+                ensure_object(&mut app.config_description).insert(
+                    "EnvironmentPropertyDescriptions".into(),
+                    json!({ "PropertyGroupDescriptions": pg.clone() }),
+                );
+            }
+            Some(_) => {
+                ensure_object(&mut app.config_description)
+                    .remove("EnvironmentPropertyDescriptions");
+            }
+            None => {}
+        }
+    }
+
+    if let Some(vpcs) = update
+        .get("VpcConfigurationUpdates")
+        .and_then(Value::as_array)
+    {
+        for vu in vpcs {
+            let id = str_of(vu, "VpcConfigurationIdUpdate");
+            if let Some(arr) = app
+                .config_description
+                .get_mut("VpcConfigurationDescriptions")
+                .and_then(Value::as_array_mut)
+            {
+                for d in arr.iter_mut() {
+                    let matches = id.is_none()
+                        || d.get("VpcConfigurationId").and_then(Value::as_str) == id.as_deref();
+                    if !matches {
+                        continue;
+                    }
+                    if let Some(s) = vu.get("SubnetIdUpdates") {
+                        d.as_object_mut()
+                            .unwrap()
+                            .insert("SubnetIds".into(), s.clone());
+                    }
+                    if let Some(s) = vu.get("SecurityGroupIdUpdates") {
+                        d.as_object_mut()
+                            .unwrap()
+                            .insert("SecurityGroupIds".into(), s.clone());
+                    }
+                }
+            }
         }
     }
 }
 
-fn apply_run_configuration(app: &mut Application, rc: &Value) {
-    let mut run_desc = serde_json::Map::new();
-    if let Some(restore) = rc.get("ApplicationRestoreConfiguration") {
-        run_desc.insert(
-            "ApplicationRestoreConfigurationDescription".into(),
-            restore.clone(),
+/// Map a `*Update`-suffixed input object to its base description-shaped object
+/// (e.g. `ConfigurationTypeUpdate` -> `ConfigurationType`). Values are cloned.
+fn strip_update_suffix(update: &Value) -> Value {
+    let mut m = serde_json::Map::new();
+    if let Some(obj) = update.as_object() {
+        for (k, v) in obj {
+            let base = k.strip_suffix("Update").unwrap_or(k);
+            m.insert(base.to_string(), v.clone());
+        }
+    }
+    Value::Object(m)
+}
+
+/// Rebuild a `FlinkApplicationConfigurationDescription` from a
+/// `FlinkApplicationConfigurationUpdate`, preserving any sub-description the
+/// update does not touch.
+fn flink_config_update_description(flink_update: &Value, existing: Option<&Value>) -> Value {
+    let mut out = existing
+        .and_then(|e| e.as_object())
+        .cloned()
+        .unwrap_or_default();
+    if let Some(c) = flink_update.get("CheckpointConfigurationUpdate") {
+        out.insert(
+            "CheckpointConfigurationDescription".into(),
+            checkpoint_description(Some(&strip_update_suffix(c))),
         );
     }
-    if let Some(flink) = rc.get("FlinkRunConfiguration") {
-        run_desc.insert("FlinkRunConfigurationDescription".into(), flink.clone());
-    }
-    if !run_desc.is_empty() {
-        let obj = ensure_object(&mut app.config_description);
-        obj.insert(
-            "RunConfigurationDescription".into(),
-            Value::Object(run_desc),
+    if let Some(m) = flink_update.get("MonitoringConfigurationUpdate") {
+        out.insert(
+            "MonitoringConfigurationDescription".into(),
+            monitoring_description(Some(&strip_update_suffix(m))),
         );
+    }
+    if let Some(p) = flink_update.get("ParallelismConfigurationUpdate") {
+        out.insert(
+            "ParallelismConfigurationDescription".into(),
+            parallelism_description(Some(&strip_update_suffix(p))),
+        );
+    }
+    Value::Object(out)
+}
+
+/// Rebuild an `ApplicationCodeConfigurationDescription` from an
+/// `ApplicationCodeConfigurationUpdate`, preserving fields the update omits.
+fn code_config_update_description(code_update: &Value, existing: Option<&Value>) -> Value {
+    let mut out = existing
+        .and_then(|e| e.as_object())
+        .cloned()
+        .unwrap_or_default();
+    if let Some(t) = str_of(code_update, "CodeContentTypeUpdate") {
+        out.insert("CodeContentType".into(), json!(t));
+    }
+    out.entry("CodeContentType")
+        .or_insert_with(|| json!("ZIPFILE"));
+    if let Some(cc) = code_update.get("CodeContentUpdate") {
+        let mut ccd = out
+            .get("CodeContentDescription")
+            .and_then(|v| v.as_object())
+            .cloned()
+            .unwrap_or_default();
+        if let Some(t) = str_of(cc, "TextContentUpdate") {
+            ccd.insert("TextContent".into(), json!(t));
+        }
+        if let Some(s3u) = cc.get("S3ContentLocationUpdate") {
+            ccd.insert(
+                "S3ApplicationCodeLocationDescription".into(),
+                s3_code_location(&strip_update_suffix(s3u)),
+            );
+        }
+        out.insert("CodeContentDescription".into(), Value::Object(ccd));
+    }
+    Value::Object(out)
+}
+
+/// Build the `RunConfigurationDescription` AWS records on a started Flink app,
+/// from an optional input `RunConfiguration` / `RunConfigurationUpdate` (both
+/// carry an `ApplicationRestoreConfiguration` + `FlinkRunConfiguration`). Unset
+/// fields default to AWS's documented values: `RESTORE_FROM_LATEST_SNAPSHOT`
+/// and `AllowNonRestoredState=false`.
+fn run_config_description(rc: Option<&Value>) -> Value {
+    let restore = rc.and_then(|r| r.get("ApplicationRestoreConfiguration"));
+    let restore_type = restore
+        .and_then(|v| str_of(v, "ApplicationRestoreType"))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "RESTORE_FROM_LATEST_SNAPSHOT".to_string());
+    let mut restore_desc = serde_json::Map::new();
+    restore_desc.insert("ApplicationRestoreType".into(), json!(restore_type));
+    if let Some(sn) = restore.and_then(|v| str_of(v, "SnapshotName")) {
+        restore_desc.insert("SnapshotName".into(), json!(sn));
+    }
+    let allow = rc
+        .and_then(|r| r.get("FlinkRunConfiguration"))
+        .and_then(|v| v.get("AllowNonRestoredState"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    json!({
+        "ApplicationRestoreConfigurationDescription": Value::Object(restore_desc),
+        "FlinkRunConfigurationDescription": { "AllowNonRestoredState": allow },
+    })
+}
+
+/// Build a `{ ResourceARN, RoleARN }` description from a bare resource ARN and
+/// the application's service-execution role, used when an `*Update` shape
+/// carries only a `ResourceARNUpdate`.
+fn arn_role_desc(arn: &str, role: Option<&str>) -> Value {
+    let mut m = serde_json::Map::new();
+    m.insert("ResourceARN".into(), json!(arn));
+    if let Some(r) = role {
+        m.insert("RoleARN".into(), json!(r));
+    }
+    Value::Object(m)
+}
+
+/// Apply a `SqlApplicationConfigurationUpdate` (sent by `UpdateApplication` for
+/// a SQL app) in place: input / output / reference-data-source updates each
+/// match an existing description by its minted id and revise it, mirroring how
+/// AWS re-derives the `SqlApplicationConfigurationDescription`.
+fn apply_sql_config_update(cfg: &mut Value, role: Option<&str>, sql_update: &Value) {
+    if let Some(updates) = sql_update.get("InputUpdates").and_then(Value::as_array) {
+        for iu in updates {
+            apply_input_update(cfg, role, iu);
+        }
+    }
+    if let Some(updates) = sql_update.get("OutputUpdates").and_then(Value::as_array) {
+        for ou in updates {
+            apply_output_update(cfg, role, ou);
+        }
+    }
+    if let Some(updates) = sql_update
+        .get("ReferenceDataSourceUpdates")
+        .and_then(Value::as_array)
+    {
+        for ru in updates {
+            apply_reference_update(cfg, ru);
+        }
+    }
+}
+
+/// Revise an existing `InputDescription` from an `InputUpdate` matched by
+/// `InputId`. Regenerates `InAppStreamNames` whenever the name prefix or
+/// parallelism count changes, and switches the input source type (a Kinesis
+/// streams / Firehose source is mutually exclusive).
+fn apply_input_update(cfg: &mut Value, role: Option<&str>, iu: &Value) {
+    let input_id = str_of(iu, "InputId");
+    let Some(list) = sql_array_mut(cfg, "InputDescriptions") else {
+        return;
+    };
+    for i in list.iter_mut() {
+        let matches =
+            input_id.is_none() || i.get("InputId").and_then(Value::as_str) == input_id.as_deref();
+        if !matches {
+            continue;
+        }
+        let Some(o) = i.as_object_mut() else { continue };
+        if let Some(np) = str_of(iu, "NamePrefixUpdate") {
+            o.insert("NamePrefix".into(), json!(np));
+        }
+        if let Some(c) = iu
+            .get("InputParallelismUpdate")
+            .and_then(|p| p.get("CountUpdate"))
+            .and_then(Value::as_i64)
+        {
+            o.insert("InputParallelism".into(), json!({ "Count": c }));
+        }
+        // Re-mint the in-app stream names from the (possibly updated) prefix and
+        // count so their number tracks the parallelism.
+        let count = o
+            .get("InputParallelism")
+            .and_then(|p| p.get("Count"))
+            .and_then(Value::as_i64)
+            .unwrap_or(1);
+        if let Some(np) = o
+            .get("NamePrefix")
+            .and_then(Value::as_str)
+            .map(String::from)
+        {
+            o.insert(
+                "InAppStreamNames".into(),
+                json!(in_app_stream_names(&np, count)),
+            );
+        }
+        if let Some(su) = iu.get("InputSchemaUpdate") {
+            let mut schema = o
+                .get("InputSchema")
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            if let Some(rf) = su.get("RecordFormatUpdate") {
+                schema.insert("RecordFormat".into(), rf.clone());
+            }
+            if let Some(re) = su.get("RecordEncodingUpdate") {
+                schema.insert("RecordEncoding".into(), re.clone());
+            }
+            if let Some(rc) = su.get("RecordColumnUpdates") {
+                schema.insert("RecordColumns".into(), rc.clone());
+            }
+            o.insert("InputSchema".into(), Value::Object(schema));
+        }
+        if let Some(k) = iu.get("KinesisStreamsInputUpdate") {
+            let arn = str_of(k, "ResourceARNUpdate").unwrap_or_default();
+            o.insert(
+                "KinesisStreamsInputDescription".into(),
+                arn_role_desc(&arn, role),
+            );
+            o.remove("KinesisFirehoseInputDescription");
+        }
+        if let Some(k) = iu.get("KinesisFirehoseInputUpdate") {
+            let arn = str_of(k, "ResourceARNUpdate").unwrap_or_default();
+            o.insert(
+                "KinesisFirehoseInputDescription".into(),
+                arn_role_desc(&arn, role),
+            );
+            o.remove("KinesisStreamsInputDescription");
+        }
+        if let Some(ipc) = iu.get("InputProcessingConfigurationUpdate") {
+            if let Some(lp) = ipc.get("InputLambdaProcessorUpdate") {
+                let arn = str_of(lp, "ResourceARNUpdate").unwrap_or_default();
+                o.insert(
+                    "InputProcessingConfigurationDescription".into(),
+                    json!({ "InputLambdaProcessorDescription": arn_role_desc(&arn, role) }),
+                );
+            }
+        }
+    }
+}
+
+/// Revise an existing `OutputDescription` from an `OutputUpdate` matched by
+/// `OutputId`, switching the (mutually exclusive) destination type as needed.
+fn apply_output_update(cfg: &mut Value, role: Option<&str>, ou: &Value) {
+    let output_id = str_of(ou, "OutputId");
+    let Some(list) = sql_array_mut(cfg, "OutputDescriptions") else {
+        return;
+    };
+    for out in list.iter_mut() {
+        let matches = output_id.is_none()
+            || out.get("OutputId").and_then(Value::as_str) == output_id.as_deref();
+        if !matches {
+            continue;
+        }
+        let Some(o) = out.as_object_mut() else {
+            continue;
+        };
+        if let Some(n) = str_of(ou, "NameUpdate") {
+            o.insert("Name".into(), json!(n));
+        }
+        if let Some(ds) = ou.get("DestinationSchemaUpdate") {
+            o.insert("DestinationSchema".into(), ds.clone());
+        }
+        let sink_keys = [
+            (
+                "KinesisStreamsOutputUpdate",
+                "KinesisStreamsOutputDescription",
+            ),
+            (
+                "KinesisFirehoseOutputUpdate",
+                "KinesisFirehoseOutputDescription",
+            ),
+            ("LambdaOutputUpdate", "LambdaOutputDescription"),
+        ];
+        for (update_key, desc_key) in sink_keys {
+            if let Some(k) = ou.get(update_key) {
+                let arn = str_of(k, "ResourceARNUpdate").unwrap_or_default();
+                for (_, dk) in sink_keys {
+                    o.remove(dk);
+                }
+                o.insert(desc_key.into(), arn_role_desc(&arn, role));
+                break;
+            }
+        }
+    }
+}
+
+/// Revise an existing `ReferenceDataSourceDescription` from a
+/// `ReferenceDataSourceUpdate` matched by `ReferenceId`.
+fn apply_reference_update(cfg: &mut Value, ru: &Value) {
+    let ref_id = str_of(ru, "ReferenceId");
+    let Some(list) = sql_array_mut(cfg, "ReferenceDataSourceDescriptions") else {
+        return;
+    };
+    for r in list.iter_mut() {
+        let matches =
+            ref_id.is_none() || r.get("ReferenceId").and_then(Value::as_str) == ref_id.as_deref();
+        if !matches {
+            continue;
+        }
+        let Some(o) = r.as_object_mut() else { continue };
+        if let Some(tn) = str_of(ru, "TableNameUpdate") {
+            o.insert("TableName".into(), json!(tn));
+        }
+        if let Some(s3u) = ru.get("S3ReferenceDataSourceUpdate") {
+            let mut s3 = o
+                .get("S3ReferenceDataSourceDescription")
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            if let Some(b) = str_of(s3u, "BucketARNUpdate") {
+                s3.insert("BucketARN".into(), json!(b));
+            }
+            if let Some(f) = str_of(s3u, "FileKeyUpdate") {
+                s3.insert("FileKey".into(), json!(f));
+            }
+            o.insert("S3ReferenceDataSourceDescription".into(), Value::Object(s3));
+        }
+        if let Some(rs) = ru.get("ReferenceSchemaUpdate") {
+            o.insert("ReferenceSchema".into(), rs.clone());
+        }
+    }
+}
+
+/// Apply a SQL app's `RunConfiguration.SqlRunConfigurations` (supplied to
+/// `StartApplication`) by pinning each targeted input's
+/// `InputStartingPositionConfiguration.InputStartingPosition`.
+fn apply_sql_run_configuration(app: &mut Application, rc: &Value) {
+    let Some(runs) = rc.get("SqlRunConfigurations").and_then(Value::as_array) else {
+        return;
+    };
+    for run in runs {
+        let input_id = str_of(run, "InputId");
+        let Some(pos) = run
+            .get("InputStartingPositionConfiguration")
+            .and_then(|c| str_of(c, "InputStartingPosition"))
+        else {
+            continue;
+        };
+        if let Some(list) = sql_array_mut(&mut app.config_description, "InputDescriptions") {
+            for i in list.iter_mut() {
+                let matches = input_id.is_none()
+                    || i.get("InputId").and_then(Value::as_str) == input_id.as_deref();
+                if matches {
+                    if let Some(o) = i.as_object_mut() {
+                        o.insert(
+                            "InputStartingPositionConfiguration".into(),
+                            json!({ "InputStartingPosition": pos }),
+                        );
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -2767,7 +3431,10 @@ mod tests {
         let cfg = config_to_description(
             &json!({
                 "FlinkApplicationConfiguration": {
-                    "ParallelismConfiguration": { "Parallelism": 3 }
+                    "ParallelismConfiguration": {
+                        "ConfigurationType": "CUSTOM",
+                        "Parallelism": 3
+                    }
                 },
                 "ApplicationCodeConfiguration": {
                     "CodeContentType": "ZIPFILE",
@@ -2786,6 +3453,7 @@ mod tests {
                 }
             }),
             Some("arn:aws:iam::000000000000:role/r"),
+            "FLINK-1_19",
             &mut 0,
         );
         Application {

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2580,6 +2580,24 @@ pub(crate) fn extract_xml_value(xml: &str, tag: &str) -> Option<String> {
 }
 
 /// Parse the CompleteMultipartUpload XML body into (part_number, etag) pairs.
+/// Strip the surrounding quotes AWS clients wrap a part ETag in, so the value
+/// matches the bare hex ETag fakecloud stores. The quote character arrives in
+/// several encodings depending on the client's XML serializer: a literal `"`
+/// (aws-cli/boto), the named entity `&quot;`, or the numeric character
+/// references `&#34;` / `&#x22;` (aws-sdk-go-v2 — the terraform provider). All
+/// must be removed, else a valid part is rejected with `InvalidPart` on
+/// CompleteMultipartUpload. (2026-07-07: go-SDK multipart uploads of large
+/// objects, e.g. the KinesisAnalyticsV2 tfacc app JAR, failed on this.)
+pub(crate) fn strip_etag_quotes(s: &str) -> String {
+    s.replace("&quot;", "")
+        .replace("&#34;", "")
+        .replace("&#x22;", "")
+        .replace("&#X22;", "")
+        .replace('"', "")
+        .trim()
+        .to_string()
+}
+
 pub(crate) fn parse_complete_multipart_xml(xml: &str) -> Vec<(u32, String)> {
     let mut parts = Vec::new();
     let mut remaining = xml;
@@ -2589,8 +2607,7 @@ pub(crate) fn parse_complete_multipart_xml(xml: &str) -> Vec<(u32, String)> {
             let part_body = &after[..part_end];
             let part_num =
                 extract_xml_value(part_body, "PartNumber").and_then(|s| s.parse::<u32>().ok());
-            let etag = extract_xml_value(part_body, "ETag")
-                .map(|s| s.replace("&quot;", "").replace('"', ""));
+            let etag = extract_xml_value(part_body, "ETag").map(|s| strip_etag_quotes(&s));
             if let (Some(num), Some(e)) = (part_num, etag) {
                 parts.push((num, e));
             }
@@ -3103,4 +3120,45 @@ mod compute_checksum_tests {
     }
 
     use base64::Engine as _;
+}
+
+#[cfg(test)]
+mod complete_multipart_parse_tests {
+    use super::parse_complete_multipart_xml;
+
+    // 2026-07-07: aws-sdk-go-v2 (the terraform AWS provider) serializes the
+    // part ETag with the quote char as the numeric reference `&#34;`, e.g.
+    // <ETag>&#34;<hex>&#34;</ETag>. The parser must decode that to the bare hex
+    // so it matches the stored part ETag; otherwise every large go-SDK
+    // multipart upload fails CompleteMultipartUpload with InvalidPart.
+    #[test]
+    fn parses_go_sdk_numeric_quote_entity_etag() {
+        let xml = "<CompleteMultipartUpload>\
+            <Part><PartNumber>1</PartNumber><ETag>&#34;100bffa249c1cbde1a66242835cdab03&#34;</ETag></Part>\
+            <Part><PartNumber>2</PartNumber><ETag>&#x22;5df1aff8ceab081b20d677b2d4f7eab1&#x22;</ETag></Part>\
+            </CompleteMultipartUpload>";
+        let parts = parse_complete_multipart_xml(xml);
+        assert_eq!(
+            parts,
+            vec![
+                (1, "100bffa249c1cbde1a66242835cdab03".to_string()),
+                (2, "5df1aff8ceab081b20d677b2d4f7eab1".to_string()),
+            ]
+        );
+    }
+
+    // aws-cli / boto send the quote as a literal `"` or the named entity
+    // `&quot;` — both must still parse to the same bare hex.
+    #[test]
+    fn parses_cli_literal_and_named_quote_etag() {
+        let xml = "<CompleteMultipartUpload>\
+            <Part><PartNumber>1</PartNumber><ETag>\"abc123\"</ETag></Part>\
+            <Part><PartNumber>2</PartNumber><ETag>&quot;def456&quot;</ETag></Part>\
+            </CompleteMultipartUpload>";
+        let parts = parse_complete_multipart_xml(xml);
+        assert_eq!(
+            parts,
+            vec![(1, "abc123".to_string()), (2, "def456".to_string())]
+        );
+    }
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -4684,7 +4684,8 @@ async fn main() {
             None
         };
     let mut kinesisanalyticsv2_service =
-        fakecloud_kinesisanalyticsv2::Ka2Service::new(kinesisanalyticsv2_state.clone());
+        fakecloud_kinesisanalyticsv2::Ka2Service::new(kinesisanalyticsv2_state.clone())
+            .with_ec2_state(ec2_state.clone());
     if let Some(store) = kinesisanalyticsv2_snapshot_store {
         kinesisanalyticsv2_service = kinesisanalyticsv2_service.with_snapshot_store(store);
     }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1247,6 +1247,7 @@ async fn main() {
             elasticbeanstalk: beanstalk_state.clone(),
             mq: mq_state.clone(),
             kafka: kafka_state.clone(),
+            kinesisanalyticsv2: kinesisanalyticsv2_state.clone(),
             delivery: delivery_for_cf,
             lambda_runtime: container_runtime.clone(),
             rds_runtime: rds_runtime.clone(),
@@ -4703,6 +4704,12 @@ async fn main() {
     kinesisanalyticsv2_service
         .recover_persisted_containers()
         .await;
+    // CloudFormation `AWS::KinesisAnalyticsV2::*` resources mutate the ka2 state
+    // directly; register its snapshot hook so a CFN-provisioned application is
+    // written through to disk after a stack op, matching the direct API.
+    if let Some(h) = kinesisanalyticsv2_service.snapshot_hook() {
+        cfn_snapshot_hooks.insert("kinesisanalyticsv2", h);
+    }
     registry.register(Arc::new(kinesisanalyticsv2_service));
 
     // Cloud Map (servicediscovery) namespace control plane.

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -765,6 +765,34 @@ pub const SERVICES: &[Service] = &[
         deny: &[],
     },
     Service {
+        name: "kinesisanalyticsv2",
+        // Amazon Managed Service for Apache Flink (Kinesis Data Analytics v2) is
+        // a real, persisted control plane. The real Flink-job data plane is
+        // disabled for tfacc via FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND=1
+        // (set in `TestServer::start`), so an application's StartApplication
+        // settles STARTING->RUNNING through the in-memory state machine instead
+        // of racing the provider's status assertions with a real container boot
+        // -- the data plane is proven separately by the kinesisanalyticsv2
+        // Docker E2E. The whole upstream `internal/service/kinesisanalyticsv2`
+        // acceptance suite runs against the auto-settling control plane:
+        //   - SQL + Flink flavor applications (create/describe/update/delete,
+        //     tags, ImportStateVerify, disappears), application_mode,
+        //     application code + environment properties + run configuration +
+        //     service_execution_role updates, and runtime-environment updates,
+        //   - SQL application inputs / input-processing (Lambda) / outputs /
+        //     reference data sources (add/update/delete) -- the request ->
+        //     `*Description` shape transform with minted ids + role propagation,
+        //   - CloudWatch logging options (add/update/delete) and VPC
+        //     configurations (add/update/delete),
+        //   - StartApplication on create + on update (SQL + Flink), restore from
+        //     a snapshot, and the standalone application snapshot resource
+        //     (create/describe/delete + disappears).
+        // The whole `TestAccKinesisAnalyticsV2*` set runs with NO denies, split
+        // into three resource-family shards for the CI wall-clock budget.
+        run_regex: "^TestAccKinesisAnalyticsV2",
+        deny: &[],
+    },
+    Service {
         name: "glacier",
         // Amazon S3 Glacier stores real archive bytes and computes a real
         // SHA-256 tree hash, so the standalone vault resource round-trips
@@ -1735,6 +1763,56 @@ pub const SHARDS: &[Shard] = &[
             "|VPCConnection",
             ")",
         ),
+        extra_deny: &[],
+    },
+    // Amazon Managed Service for Apache Flink: the `kinesisanalyticsv2` suite
+    // (38 tests) is split into three resource-family shards whose union is the
+    // whole suite and whose run_regexes are pairwise disjoint. The `_` after
+    // `Application` in the flink/sql shards excludes the `ApplicationSnapshot`
+    // resource tests, which the third shard claims.
+    Shard {
+        name: "kinesisanalyticsv2-flink",
+        service: "kinesisanalyticsv2",
+        // Flink-flavor application tests + the flavor-agnostic application tests
+        // (basic flink, application mode, application code, environment
+        // properties, run configuration, service execution role, tags,
+        // disappears). `Flink` also captures the Flink VPC / start / snapshot-
+        // restore / runtime-update / environment-property variants.
+        run_regex: concat!(
+            "^TestAccKinesisAnalyticsV2Application_(",
+            "basicFlink",
+            "|Flink",
+            "|applicationMode",
+            "|ApplicationCode",
+            "|EnvironmentProperties",
+            "|RunConfiguration",
+            "|ServiceExecutionRole",
+            "|tags",
+            "|disappears",
+            ")",
+        ),
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kinesisanalyticsv2-sql",
+        service: "kinesisanalyticsv2",
+        // SQL-flavor application tests (inputs, input-processing, outputs,
+        // reference data sources, multiple, updateRunning, start-on-
+        // create/update) + the CloudWatch logging option tests.
+        run_regex: concat!(
+            "^TestAccKinesisAnalyticsV2Application_(",
+            "basicSQL",
+            "|SQL",
+            "|CloudWatchLoggingOptions",
+            ")",
+        ),
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kinesisanalyticsv2-snapshot",
+        service: "kinesisanalyticsv2",
+        // The standalone application snapshot resource tests.
+        run_regex: "^TestAccKinesisAnalyticsV2ApplicationSnapshot",
         extra_deny: &[],
     },
     Shard {

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -1777,13 +1777,51 @@ pub const SHARDS: &[Shard] = &[
     // cancels before the build cache saves, so reruns stay slow). Halving each
     // suite keeps every shard well under the cap. Regexes are exhaustive +
     // pairwise-disjoint over the enumerated provider test names.
+    // The JAR-heavy Flink-flavor application tests are split into small
+    // per-family shards (<=3 tests each) rather than one 11-test shard. These
+    // tests START the application and drive update/VPC lifecycles; on a 2-core
+    // CI runner a shared fakecloud server that has serviced ~6-8 such
+    // started-app lifecycles intermittently stops advancing a status waiter and
+    // the shard stalls to the job-timeout. The suite passes at every
+    // parallelism on a many-core box and each test passes in isolation, so it
+    // is a runner-contention stall, not a correctness bug (root cause not yet
+    // pinned; it does not reproduce off a genuinely 2-core host). Keeping each
+    // long-lived server under ~4 started-app lifecycles avoids the stall. The
+    // config-only `flink-misc` / `sql-rest` shards stay larger (they pass at 7-8
+    // because they do not start applications). Regexes below are exhaustive +
+    // pairwise-disjoint over the enumerated provider test names.
     Shard {
-        name: "kinesisanalyticsv2-flink-core",
+        name: "kinesisanalyticsv2-flink-lifecycle",
         service: "kinesisanalyticsv2",
-        // The JAR-heavy Flink-flavor application tests: basic, snapshot-restore,
-        // update / runtime-update / update-running, environment-properties,
-        // start-on-create/update, and the three VPC variants (all `FlinkApplication*`).
-        run_regex: "^TestAccKinesisAnalyticsV2Application_(basicFlink|FlinkApplication)",
+        // basic + start-on-create/update (3).
+        run_regex:
+            "^TestAccKinesisAnalyticsV2Application_(basicFlink|FlinkApplicationStartApplication)",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kinesisanalyticsv2-flink-update",
+        service: "kinesisanalyticsv2",
+        // update / runtime-update / update-running (3).
+        run_regex: "^TestAccKinesisAnalyticsV2Application_FlinkApplication_update",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kinesisanalyticsv2-flink-restore",
+        service: "kinesisanalyticsv2",
+        // restore-from-snapshot + environment-properties update (2).
+        run_regex: concat!(
+            "^TestAccKinesisAnalyticsV2Application_(",
+            "FlinkApplication_restoreFromSnapshot",
+            "|FlinkApplicationEnvironmentProperties",
+            ")",
+        ),
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kinesisanalyticsv2-flink-vpc",
+        service: "kinesisanalyticsv2",
+        // the three VPC variants (3).
+        run_regex: "^TestAccKinesisAnalyticsV2Application_FlinkApplicationVPC",
         extra_deny: &[],
     },
     Shard {
@@ -1808,13 +1846,26 @@ pub const SHARDS: &[Shard] = &[
     Shard {
         name: "kinesisanalyticsv2-sql-input",
         service: "kinesisanalyticsv2",
-        // SQL basic + input / input-processing tests, start-on-create/update,
-        // and update-running.
+        // SQL basic + input add/update (3). `SQLApplicationInput_` excludes the
+        // `SQLApplicationInputProcessing*` tests (no `_` there), which the
+        // `sql-inputproc` shard claims.
+        run_regex: "^TestAccKinesisAnalyticsV2Application_(basicSQL|SQLApplicationInput_)",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kinesisanalyticsv2-sql-inputproc",
+        service: "kinesisanalyticsv2",
+        // SQL input-processing add/delete/update (3).
+        run_regex: "^TestAccKinesisAnalyticsV2Application_SQLApplicationInputProcessing",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kinesisanalyticsv2-sql-start",
+        service: "kinesisanalyticsv2",
+        // SQL start-on-create/update + update-running (3).
         run_regex: concat!(
             "^TestAccKinesisAnalyticsV2Application_(",
-            "basicSQL",
-            "|SQLApplicationInput",
-            "|SQLApplicationStartApplication",
+            "SQLApplicationStartApplication",
             "|SQLApplication_updateRunning",
             ")",
         ),

--- a/crates/fakecloud-tfacc/src/allowlist.rs
+++ b/crates/fakecloud-tfacc/src/allowlist.rs
@@ -1770,19 +1770,31 @@ pub const SHARDS: &[Shard] = &[
     // whole suite and whose run_regexes are pairwise disjoint. The `_` after
     // `Application` in the flink/sql shards excludes the `ApplicationSnapshot`
     // resource tests, which the third shard claims.
+    // The Flink and SQL application suites are split into two shards each: every
+    // Flink test uploads the 66MB app JAR (twice, count=2) and each acc test
+    // does a full apply/refresh/destroy cycle, so a single ~18-test shard runs
+    // ~54min on a 2-core CI runner and blows the 60min job cap (and the timeout
+    // cancels before the build cache saves, so reruns stay slow). Halving each
+    // suite keeps every shard well under the cap. Regexes are exhaustive +
+    // pairwise-disjoint over the enumerated provider test names.
     Shard {
-        name: "kinesisanalyticsv2-flink",
+        name: "kinesisanalyticsv2-flink-core",
         service: "kinesisanalyticsv2",
-        // Flink-flavor application tests + the flavor-agnostic application tests
-        // (basic flink, application mode, application code, environment
-        // properties, run configuration, service execution role, tags,
-        // disappears). `Flink` also captures the Flink VPC / start / snapshot-
-        // restore / runtime-update / environment-property variants.
+        // The JAR-heavy Flink-flavor application tests: basic, snapshot-restore,
+        // update / runtime-update / update-running, environment-properties,
+        // start-on-create/update, and the three VPC variants (all `FlinkApplication*`).
+        run_regex: "^TestAccKinesisAnalyticsV2Application_(basicFlink|FlinkApplication)",
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kinesisanalyticsv2-flink-misc",
+        service: "kinesisanalyticsv2",
+        // The flavor-agnostic application tests (still Flink-backed): application
+        // mode, application code, environment properties, run configuration,
+        // service execution role, tags, disappears.
         run_regex: concat!(
             "^TestAccKinesisAnalyticsV2Application_(",
-            "basicFlink",
-            "|Flink",
-            "|applicationMode",
+            "applicationMode",
             "|ApplicationCode",
             "|EnvironmentProperties",
             "|RunConfiguration",
@@ -1794,16 +1806,31 @@ pub const SHARDS: &[Shard] = &[
         extra_deny: &[],
     },
     Shard {
-        name: "kinesisanalyticsv2-sql",
+        name: "kinesisanalyticsv2-sql-input",
         service: "kinesisanalyticsv2",
-        // SQL-flavor application tests (inputs, input-processing, outputs,
-        // reference data sources, multiple, updateRunning, start-on-
-        // create/update) + the CloudWatch logging option tests.
+        // SQL basic + input / input-processing tests, start-on-create/update,
+        // and update-running.
         run_regex: concat!(
             "^TestAccKinesisAnalyticsV2Application_(",
             "basicSQL",
-            "|SQL",
-            "|CloudWatchLoggingOptions",
+            "|SQLApplicationInput",
+            "|SQLApplicationStartApplication",
+            "|SQLApplication_updateRunning",
+            ")",
+        ),
+        extra_deny: &[],
+    },
+    Shard {
+        name: "kinesisanalyticsv2-sql-rest",
+        service: "kinesisanalyticsv2",
+        // SQL outputs, reference data sources, multiple-update, and the
+        // CloudWatch logging option tests.
+        run_regex: concat!(
+            "^TestAccKinesisAnalyticsV2Application_(",
+            "CloudWatchLoggingOptions",
+            "|SQLApplicationMultiple",
+            "|SQLApplicationOutput",
+            "|SQLApplicationReferenceDataSource",
             ")",
         ),
         extra_deny: &[],

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -211,18 +211,24 @@ pub struct GoTestRunner<'a> {
 
 /// Go `-parallel` degree for a service's `go test` invocation. Defaults to 4.
 ///
-/// `pipes` is special: unlike every other service it runs a persistent
-/// background execution loop (the Pipes runner) on the fakecloud side. That
-/// constant load *on top of* four concurrent terraform applies oversubscribes a
-/// 2-core CI runner badly enough that the server stops serving the provider's
-/// delete/`gone` poll requests promptly — a pipe hangs in DELETING and even
-/// unrelated SQS DeleteQueue waiters time out. Other services have no such loop,
-/// so parallel-4 is fine for them. Run the pipes acceptance tests serially so
-/// they don't oversubscribe the box; the suite is small and its behaviour is
-/// unchanged, this only bounds concurrency on constrained runners.
+/// Two services run serially because four concurrent terraform applies
+/// oversubscribe a 2-core CI runner badly enough that the fakecloud server
+/// stops serving the provider's poll requests promptly — resources hang in a
+/// transitional state and even unrelated waiters time out:
+/// - `pipes` runs a persistent background execution loop (the Pipes runner)
+///   whose constant load, on top of four applies, starves the server; a pipe
+///   hangs in DELETING and unrelated SQS DeleteQueue waiters time out.
+/// - `kinesisanalyticsv2` acc tests each upload the 66MB Flink app JAR (twice,
+///   count=2) and drive a full application start/update lifecycle; four of those
+///   in parallel saturate the box so the app's status poll never advances and
+///   the whole shard stalls (all tests pass fine serially — and at high
+///   parallelism on an unconstrained machine — so this is pure oversubscription,
+///   not a correctness bug). Serial keeps each test ~90s, so even the 11-test
+///   flink-core shard finishes in ~16min.
+/// Other services have no such heavy per-test load, so parallel-4 is fine.
 fn parallelism_for(service: &str) -> u32 {
     match service {
-        "pipes" => 1,
+        "pipes" | "kinesisanalyticsv2" => 1,
         _ => 4,
     }
 }

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -178,6 +178,11 @@ impl TestServer {
                 // `*.amazonaws.com:9092` the provider asserts; the data plane is
                 // proven separately by the msk-broker Docker E2E.
                 ("FAKECLOUD_KAFKA_DISABLE_BACKEND", "1"),
+                // Amazon Managed Service for Apache Flink: a real Flink-job
+                // container would race the provider's status/attribute
+                // assertions with async job settling; the data plane is proven
+                // separately by the kinesisanalyticsv2 Docker E2E.
+                ("FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND", "1"),
                 ("FAKECLOUD_CODEBUILD_DISABLE_BACKEND", "1"),
             ])
             .await,

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -225,6 +225,7 @@ pub struct GoTestRunner<'a> {
 ///   parallelism on an unconstrained machine — so this is pure oversubscription,
 ///   not a correctness bug). Serial keeps each test ~90s, so even the 11-test
 ///   flink-core shard finishes in ~16min.
+///
 /// Other services have no such heavy per-test load, so parallel-4 is fine.
 fn parallelism_for(service: &str) -> u32 {
     match service {

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -153,8 +153,23 @@ async fn kafka_scram_repl_vpc_acceptance() {
 }
 
 #[tokio::test]
-async fn kinesisanalyticsv2_flink_core_acceptance() {
-    run_shard("kinesisanalyticsv2-flink-core").await;
+async fn kinesisanalyticsv2_flink_lifecycle_acceptance() {
+    run_shard("kinesisanalyticsv2-flink-lifecycle").await;
+}
+
+#[tokio::test]
+async fn kinesisanalyticsv2_flink_update_acceptance() {
+    run_shard("kinesisanalyticsv2-flink-update").await;
+}
+
+#[tokio::test]
+async fn kinesisanalyticsv2_flink_restore_acceptance() {
+    run_shard("kinesisanalyticsv2-flink-restore").await;
+}
+
+#[tokio::test]
+async fn kinesisanalyticsv2_flink_vpc_acceptance() {
+    run_shard("kinesisanalyticsv2-flink-vpc").await;
 }
 
 #[tokio::test]
@@ -165,6 +180,16 @@ async fn kinesisanalyticsv2_flink_misc_acceptance() {
 #[tokio::test]
 async fn kinesisanalyticsv2_sql_input_acceptance() {
     run_shard("kinesisanalyticsv2-sql-input").await;
+}
+
+#[tokio::test]
+async fn kinesisanalyticsv2_sql_inputproc_acceptance() {
+    run_shard("kinesisanalyticsv2-sql-inputproc").await;
+}
+
+#[tokio::test]
+async fn kinesisanalyticsv2_sql_start_acceptance() {
+    run_shard("kinesisanalyticsv2-sql-start").await;
 }
 
 #[tokio::test]

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -153,6 +153,21 @@ async fn kafka_scram_repl_vpc_acceptance() {
 }
 
 #[tokio::test]
+async fn kinesisanalyticsv2_flink_acceptance() {
+    run_shard("kinesisanalyticsv2-flink").await;
+}
+
+#[tokio::test]
+async fn kinesisanalyticsv2_sql_acceptance() {
+    run_shard("kinesisanalyticsv2-sql").await;
+}
+
+#[tokio::test]
+async fn kinesisanalyticsv2_snapshot_acceptance() {
+    run_shard("kinesisanalyticsv2-snapshot").await;
+}
+
+#[tokio::test]
 async fn glacier_acceptance() {
     run_shard("glacier").await;
 }

--- a/crates/fakecloud-tfacc/tests/acc.rs
+++ b/crates/fakecloud-tfacc/tests/acc.rs
@@ -153,13 +153,23 @@ async fn kafka_scram_repl_vpc_acceptance() {
 }
 
 #[tokio::test]
-async fn kinesisanalyticsv2_flink_acceptance() {
-    run_shard("kinesisanalyticsv2-flink").await;
+async fn kinesisanalyticsv2_flink_core_acceptance() {
+    run_shard("kinesisanalyticsv2-flink-core").await;
 }
 
 #[tokio::test]
-async fn kinesisanalyticsv2_sql_acceptance() {
-    run_shard("kinesisanalyticsv2-sql").await;
+async fn kinesisanalyticsv2_flink_misc_acceptance() {
+    run_shard("kinesisanalyticsv2-flink-misc").await;
+}
+
+#[tokio::test]
+async fn kinesisanalyticsv2_sql_input_acceptance() {
+    run_shard("kinesisanalyticsv2-sql-input").await;
+}
+
+#[tokio::test]
+async fn kinesisanalyticsv2_sql_rest_acceptance() {
+    run_shard("kinesisanalyticsv2-sql-rest").await;
 }
 
 #[tokio::test]

--- a/website/content/docs/services/cloudformation.md
+++ b/website/content/docs/services/cloudformation.md
@@ -84,7 +84,9 @@ For **container-backed** services, a CloudFormation-provisioned resource is back
 - **Glue** — `Database`, `Table`, `Partition`
 - **IAM** — `Role`, `User`, `Group`, `Policy`, `ManagedPolicy`, `AccessKey`, `InstanceProfile`, `OIDCProvider`, `SAMLProvider`, `ServiceLinkedRole`, `UserToGroupAddition`, `VirtualMFADevice`
 - **Kinesis** — `Stream`, `StreamConsumer`
+- **Kinesis Analytics v2 (Managed Service for Apache Flink)** — `Application`, `ApplicationOutput`, `ApplicationReferenceDataSource`, `ApplicationCloudWatchLoggingOption`
 - **KMS** — `Key`, `Alias`, `ReplicaKey`
+- **MSK (Managed Streaming for Apache Kafka)** — `Cluster`, `ServerlessCluster`, `Configuration`, `ClusterPolicy`, `BatchScramSecret`, `VpcConnection`, `Replicator`
 - **Lambda** — `Function`, `Version`, `Alias`, `LayerVersion`, `Permission`, `EventSourceMapping`, `Url`
 - **CloudWatch Logs** — `LogGroup`, `LogStream`, `MetricFilter`, `SubscriptionFilter`, `Destination`, `ResourcePolicy`, `QueryDefinition`, `Delivery`, `DeliverySource`, `DeliveryDestination`
 - **Organizations** — `Organization`, `OrganizationalUnit`, `Account`, `Policy`, `ResourcePolicy`

--- a/website/content/docs/services/kinesisanalyticsv2.md
+++ b/website/content/docs/services/kinesisanalyticsv2.md
@@ -99,6 +99,43 @@ machine (`STARTING` -> `RUNNING` in memory) — running arbitrary SQL as a live
 Flink job needs the Flink SQL gateway, which is out of scope for now. Only
 Flink-flavor apps with a JAR get the real runtime.
 
+## CloudFormation
+
+fakecloud provisions every `AWS::KinesisAnalyticsV2::*` resource type through
+CloudFormation:
+
+- `AWS::KinesisAnalyticsV2::Application`
+- `AWS::KinesisAnalyticsV2::ApplicationOutput`
+- `AWS::KinesisAnalyticsV2::ApplicationReferenceDataSource`
+- `AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption`
+
+Each is written through to the `kinesisanalyticsv2` service via the same shared
+record builders the direct API uses, so a CFN-provisioned application (and its
+outputs / reference data sources / CloudWatch logging options) reads back
+identically on `DescribeApplication` and persists across a restart, exactly like
+its direct-API equivalent.
+
+`Ref` follows the AWS resource spec: an `Application` `Ref` resolves to the
+application name (its physical id), and each sub-resource `Ref` resolves to its
+minted id (the output id, reference id, or CloudWatch-logging-option id). The
+`Application` resource exposes no returnable `Fn::GetAtt` attributes. Creating an
+application never starts a Flink job (`StartApplication` is a separate action),
+so CloudFormation provisioning settles the application to `READY` in the control
+plane and never spawns a Flink container.
+
+## Terraform
+
+fakecloud exercises the upstream `terraform-provider-aws`
+`internal/service/kinesisanalyticsv2` acceptance suite in tfacc, split across the
+`kinesisanalyticsv2-flink`, `kinesisanalyticsv2-sql`, and
+`kinesisanalyticsv2-snapshot` jobs: SQL + Flink flavor applications
+(create/describe/update/delete, tags, import, disappears), inputs / outputs /
+reference data sources, CloudWatch logging options, VPC configurations,
+StartApplication on create + update, snapshot restore, and the standalone
+application snapshot resource. The real Flink-job data plane is disabled for
+tfacc (proven separately by the Docker E2E) so the control plane's
+`STARTING -> RUNNING` settle doesn't race the provider's status assertions.
+
 ## Example
 
 ```python


### PR DESCRIPTION
## Summary

Batch 3 of Amazon Managed Service for Apache Flink (`kinesisanalyticsv2`): **CloudFormation provisioning** for all 4 `AWS::KinesisAnalyticsV2::*` resource types + **terraform-provider-aws acceptance coverage**. Control plane (33 ops) shipped batch 1, real Docker-backed Flink-job data plane shipped batch 2 (#2189). This closes the remaining "matched" bar (CFN + tfacc) for the service.

### CloudFormation resource types
Written through to the `kinesisanalyticsv2` service state as the same wire JSON the direct `Create*`/`Add*` handlers store, so they read back identically on `DescribeApplication` and persist via the service snapshot hook (#1766 — no phantom resources on restart):

| Resource | Ref |
|---|---|
| `AWS::KinesisAnalyticsV2::Application` | `ApplicationName` (no GetAtt attributes per spec) |
| `AWS::KinesisAnalyticsV2::ApplicationOutput` | minted output `Id` |
| `AWS::KinesisAnalyticsV2::ApplicationReferenceDataSource` | minted reference `Id` |
| `AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption` | minted option `Id` |

- **No divergence**: new `builders` module in the ka2 crate holds `insert_*`/`remove_*` for the application + 3 sub-resources; the direct handlers were **refactored to call the same builders**, so CFN records are byte-identical to the direct API (#1720/#1766 trap avoided). Conformance unchanged: **33/33 ops, 1232/1232 variants**.
- CFN create settles `READY` and never spawns a Flink container (mirrors the direct `CreateApplication`; `StartApplication` is separate). Sub-resources stash their owning `ApplicationName` in stack attributes so delete can detach.

### tfacc
`kinesisanalyticsv2` Service (`^TestAccKinesisAnalyticsV2`) + **3 pairwise-disjoint, exhaustive shards** over the 38 provider tests (35 `Application_*` + 3 `ApplicationSnapshot_*`): `-flink` / `-sql` / `-snapshot`, each with a matching `acc.rs` `*_acceptance` fn (the MSK-batch-3 vacuous-pass trap avoided). `FAKECLOUD_KINESISANALYTICSV2_DISABLE_BACKEND=1` in the tfacc env so the real Flink data plane can't race provider status assertions.

## Test plan
- Conformance: **33/33 ops, 1232/1232 variants** (builders refactor did not regress).
- `cargo clippy -p fakecloud-cloudformation -p fakecloud-kinesisanalyticsv2 -p fakecloud-tfacc --all-targets -D warnings`: clean.
- Unit: ka2 21 passed, cloudformation 267 passed.
- Control-plane E2E (`--test kinesisanalyticsv2`, backend disabled): PASS.
- CFN E2E (`cloudformation_kinesisanalyticsv2.rs`, backend disabled): stack -> `CREATE_COMPLETE`, `DescribeApplication` confirms write-through (runtime/role/logging option/output ids matching Refs/tag), delete removes the app. PASS.
- tfacc shard generator lists `kinesisanalyticsv2-{flink,sql,snapshot}` mapped to their `*_acceptance` fns; full tfacc suite runs in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for Amazon Managed Service for Apache Flink (`kinesisanalyticsv2`) with write-through provisioning and expanded Terraform acceptance coverage. Aligns describe/update behavior with AWS, stops snapshotting on describe, fixes S3 multipart ETag parsing, and accepts hyphenated `RuntimeEnvironment` values.

- **New Features**
  - CloudFormation for `AWS::KinesisAnalyticsV2::{Application,ApplicationOutput,ApplicationReferenceDataSource,ApplicationCloudWatchLoggingOption}`; `Ref` returns app name or minted sub-id; create settles to READY and never starts Flink.
  - Shared `builders` in `kinesisanalyticsv2` used by both API and CFN; snapshot hook registered; conformance unchanged (33/33 ops).
  - tfacc: service enabled with ten shards to avoid CI stalls — `kinesisanalyticsv2-{flink-lifecycle,flink-update,flink-restore,flink-vpc,flink-misc,sql-input,sql-inputproc,sql-start,sql-rest,snapshot}`; runs serially (`-parallel 1`); backend disabled to avoid data-plane races.

- **Bug Fixes**
  - `kinesisanalyticsv2`: Match AWS on describe/update and runtime values (accept `FLINK-*`/`SQL-*`); stop persisting snapshots on `DescribeApplication`; avoid nested EC2 lock when resolving VPC IDs.
  - S3 CompleteMultipartUpload: strip all quote encodings (`"`, `&quot;`, `&#34;`, `&#x22;`, `&#X22;`) from part ETags to match stored values (fixes aws-sdk-go-v2 multipart uploads, e.g., Terraform `aws_s3_object`).

<sup>Written for commit 1ba67b9e89d4a5aecf592218980a4d2c88e3f9d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

