### PR TITLE
fix(ci): relocate e2e container data-root to /mnt to stop disk-full flakes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -144,10 +144,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # No free-disk and no rust-cache here: this job runs prebuilt test binaries
       # from the archive and never compiles. It downloads the archive + the
-      # fakecloud binary and pulls a few container images (<~10G); the runner's
-      # single ~145G root already has ~117G free, so the free-disk reclaim (a
-      # variable 2-4 min, measured as the single biggest per-partition overhead)
-      # is wasted work on the workflow's critical path.
+      # fakecloud binary and pulls container images; the compile-oriented
+      # free-disk reclaim (a variable 2-4 min) is not what this job needs — it
+      # needs its container data-root on the large disk (see the relocate step
+      # below), not preinstalled-SDK cleanup on the root fs.
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
 
@@ -155,14 +155,30 @@ jobs:
         if: matrix.install_podman
         run: sudo apt-get update && sudo apt-get install -y podman
 
-      # NOTE: an earlier "Relocate container storage to /mnt" step was removed
-      # here. It existed to escape a small root filesystem when /mnt was a large
-      # separate ephemeral disk, but current GitHub-hosted runners have a single
-      # ~145G root (~117G free) and no separate /mnt, so the relocation rsynced
-      # docker's data-root from root back onto root — pure overhead with no
-      # headroom gained. With that much free space the free-disk reclaim is
-      # unnecessary too (removed above); container images for a single partition
-      # stay well under the available room.
+      # Relocate the container data-root to /mnt BEFORE any image pull. Current
+      # GitHub-hosted Ubuntu runners expose a ~72G root `/` with only ~16G free
+      # (the runner image already uses ~56G) plus a SEPARATE ~74G `/mnt`
+      # (/dev/sdb1) that is ~66G free. Docker's default data-root lives on `/`,
+      # so a partition that pulls several runtime images (e.g.
+      # lambda-runtimes-python pulls python:3.9 .. python:3.14) exhausts the 16G
+      # and dies with `write /var/lib/docker/...: no space left on device`.
+      # Pointing the data-root at the near-empty /mnt yields ~66G of headroom.
+      # (An earlier revision claimed a single ~145G root with no /mnt and dropped
+      # this step; `df -h` on the current runners shows that assumption is false.)
+      - name: Relocate container storage to /mnt (large disk)
+        run: |
+          sudo systemctl stop docker docker.socket || true
+          sudo mkdir -p /mnt/docker
+          printf '{ "data-root": "/mnt/docker" }\n' | sudo tee /etc/docker/daemon.json
+          sudo rm -rf /var/lib/docker
+          sudo systemctl start docker
+          if [ "$INSTALL_PODMAN" = "true" ]; then
+            sudo mkdir -p /mnt/containers /etc/containers
+            printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/containers"\n' | sudo tee /etc/containers/storage.conf
+          fi
+          echo "=== df -h after relocate ==="
+          df -h / /mnt
+
       - name: Prune container state before tests
         run: |
           docker system prune -af --volumes || true


### PR DESCRIPTION
## Problem

Every recent E2E run (main + service PRs) has been flaking with:

```
Lambda execution failed: container failed to start: Unable to find image
'public.ecr.aws/lambda/python:3.12' locally ... write /var/lib/docker/tmp/
GetImageBlob...: no space left on device
```

The shared `e2e` partition job pulls container images into Docker's default
data-root on `/`. On the current GitHub-hosted Ubuntu runners that root is only
~72G with **~16G free** (the runner image already uses ~56G). Partitions that
pull several runtime images — notably `lambda-runtimes-python`, which invokes
`python:3.9` through `python:3.14` — exhaust that headroom and ENOSPC.

Confirmed from the failing job's own `df -h` diagnostics step:

```
/dev/root   72G   56G used   16G free   /
/dev/sdb1   74G    4G used   66G free   /mnt
```

The runner has a **separate ~74G `/mnt` that is ~66G free**. A prior revision
removed the container-storage relocation under a "single ~145G root, no /mnt"
assumption that is false on today's runners.

## Fix

Restore a relocation step in the `e2e` job that points Docker's `data-root`
(and podman's `graphroot` on podman partitions) at `/mnt` **before** any image
pull, giving ~66G of headroom. Also refreshes the misleading comment.

## Test plan

- [x] `e2e.yml` parses as valid YAML
- [x] This PR's own E2E run exercises the change (the workflow is read from the PR branch), so a green `lambda-runtimes-python-*` partition here is the verification
- [x] `df -h` echoed after relocation for future diagnostics

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the e2e job’s container storage to `/mnt` to stop disk-full flakes on GitHub Ubuntu runners. This restores ~66 GB of free space and stabilizes image pulls, especially for `lambda-runtimes-python`.

- **Bug Fixes**
  - Set Docker `data-root` to `/mnt/docker` and restart Docker before any image pull.
  - When `podman` is enabled, set `graphroot` to `/mnt/containers`.
  - Echo `df -h / /mnt` after relocation for quick diagnostics.

<sup>Written for commit 5debe3429db0a7a648661b7ce2db6d8f05f5bd54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

