### PR TITLE
ci(e2e): extract nextest archive on /mnt to fix general-* ENOSPC flake

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -211,11 +211,23 @@ jobs:
 
       # Run the prebuilt test binaries straight from the archive — no compilation.
       # --workspace-remap . points runtime workspace lookups at this checkout (the
-      # path matches the build runner on GitHub-hosted runners). nextest extracts
-      # to its own temp dir under /tmp (ample free space on the root fs);
-      # container images still land on the /mnt-relocated docker root.
+      # path matches the build runner on GitHub-hosted runners).
+      #
+      # nextest extracts the archive to a temp dir under $TMPDIR. The default
+      # ($TMPDIR unset -> /tmp) lives on the root fs, which on current
+      # GitHub-hosted Ubuntu runners is only ~72G with ~16G free (the runner
+      # image already uses ~56G). The archive holds every E2E test binary and
+      # grows with each new service crate, so extracting it onto the small root
+      # eventually ENOSPCs ("No space left on device (os error 28)" while
+      # unpacking target/debug/deps/*). Point TMPDIR at the near-empty ~74G
+      # /mnt (same large disk #2200 relocated docker to) so the extract has
+      # ~66G of headroom. Container images still land on the /mnt docker root.
       - name: Run nextest partition
+        env:
+          TMPDIR: /mnt/nextest-tmp
         run: |
+          sudo mkdir -p /mnt/nextest-tmp
+          sudo chmod 1777 /mnt/nextest-tmp
           cmd=(cargo nextest run -P ci
             --archive-file e2e-archive.tar.zst
             --workspace-remap .


### PR DESCRIPTION
## Summary

The `E2E general-*` partition jobs intermittently fail ~2 minutes in with:

```
failed to unpack `target/debug/deps/<test>` into `/tmp/nextest-archive-XXXX/...`
No space left on device (os error 28)
```

Root cause: those jobs run prebuilt test binaries via `cargo nextest run --archive-file`, which **extracts the archive to a temp dir under $TMPDIR** (default `/tmp`, on the root fs). Current GitHub-hosted Ubuntu runners have only **~16G free on root** (`/dev/root` ~72G, runner image already uses ~56G) versus a near-empty **~74G `/mnt`**. The archive holds every E2E test binary and grows with each new service crate, so unpacking it onto the small root eventually ENOSPCs mid-extract.

[#2200](https://github.com/faiscadev/fakecloud/pull/2200) relocated the **container data-root** to `/mnt`, but the nextest archive extraction still targeted `/tmp` on root — a different consumer of the same scarce disk.

## Fix

Point `TMPDIR` at `/mnt/nextest-tmp` (world-writable + sticky) for the partition `Run nextest partition` step, so nextest extracts to the large disk with ~66G headroom. Container images continue to land on the `/mnt` docker root; this only moves the archive extraction. Also corrects the stale comment that claimed `/tmp` had "ample free space on the root fs."

Scope: only the archive-extract partition job (the lambda/container jobs at the same file compile their test binaries and don't extract the archive, so they're unaffected).

## Test plan
- CI runs this workflow on the PR; the `E2E general-*` partitions should extract to `/mnt` and stop ENOSPCing. `Disk diagnostics before/after nextest` steps show the mount usage.
- No code/behavior change — infra only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `cargo nextest` archive extraction to `/mnt` to stop flaky ENOSPC errors in `E2E general-*` partitions. Archives now unpack on the larger disk instead of `/tmp` on root.

- **Bug Fixes**
  - Set `TMPDIR=/mnt/nextest-tmp` for the "Run nextest partition" step so `cargo nextest run --archive-file` extracts on `/mnt`.
  - Create `/mnt/nextest-tmp` and apply `1777` permissions.
  - Affects only the archive-extract partition job. Container images still use the `/mnt` Docker root. No product code changes.

<sup>Written for commit 91e2764100970ba219ac1990c2aa3ba033009167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

