### PR TITLE
ci(e2e): adapt disk provisioning to runner layout (fix ENOSPC on no-/mnt runners)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -142,12 +142,9 @@ jobs:
       INSTALL_PODMAN: ${{ matrix.install_podman }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      # No free-disk and no rust-cache here: this job runs prebuilt test binaries
-      # from the archive and never compiles. It downloads the archive + the
-      # fakecloud binary and pulls container images; the compile-oriented
-      # free-disk reclaim (a variable 2-4 min) is not what this job needs — it
-      # needs its container data-root on the large disk (see the relocate step
-      # below), not preinstalled-SDK cleanup on the root fs.
+      # No rust-cache here: this job runs prebuilt test binaries from the archive
+      # and never compiles. Disk provisioning is handled by the step below, which
+      # adapts to whichever disk layout the assigned runner actually has.
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
 
@@ -155,29 +152,54 @@ jobs:
         if: matrix.install_podman
         run: sudo apt-get update && sudo apt-get install -y podman
 
-      # Relocate the container data-root to /mnt BEFORE any image pull. Current
-      # GitHub-hosted Ubuntu runners expose a ~72G root `/` with only ~16G free
-      # (the runner image already uses ~56G) plus a SEPARATE ~74G `/mnt`
-      # (/dev/sdb1) that is ~66G free. Docker's default data-root lives on `/`,
-      # so a partition that pulls several runtime images (e.g.
-      # lambda-runtimes-python pulls python:3.9 .. python:3.14) exhausts the 16G
-      # and dies with `write /var/lib/docker/...: no space left on device`.
-      # Pointing the data-root at the near-empty /mnt yields ~66G of headroom.
-      # (An earlier revision claimed a single ~145G root with no /mnt and dropped
-      # this step; `df -h` on the current runners shows that assumption is false.)
-      - name: Relocate container storage to /mnt (large disk)
+      # Provision disk for BOTH the container data-root AND the nextest archive
+      # extraction, adapting to the runner's actual disk layout. Two consumers
+      # compete for space here: (1) container images a partition pulls (e.g.
+      # lambda-runtimes-python pulls python:3.9 .. python:3.14), and (2) nextest
+      # extracting the E2E test archive (every test binary, grows with each new
+      # service crate) to its temp dir.
+      #
+      # MOST GitHub-hosted Ubuntu runners expose a ~72G root `/` with only ~16G
+      # free (the image already uses ~56G) plus a SEPARATE ~74G `/mnt`
+      # (/dev/sdb1, ~66G free). On those we point docker's data-root AND nextest's
+      # TMPDIR at /mnt. But SOME runners have no separate /mnt (it's just a dir on
+      # the root fs); there, sending both consumers to "/mnt" leaves them on the
+      # 14-16G root and the archive extract dies with `No space left on device
+      # (os error 28)` — which is exactly the flake #2200/#2205 chased on the
+      # wrong assumption that /mnt is always separate. So: detect a real, roomy
+      # separate /mnt; if absent, reclaim the root fs (drop preinstalled SDKs)
+      # and keep both consumers on the freed root. Export the chosen temp base as
+      # NEXTEST_TMPDIR for the run step.
+      - name: Provision disk for containers + test archive
         run: |
-          sudo systemctl stop docker docker.socket || true
-          sudo mkdir -p /mnt/docker
-          printf '{ "data-root": "/mnt/docker" }\n' | sudo tee /etc/docker/daemon.json
-          sudo rm -rf /var/lib/docker
-          sudo systemctl start docker
-          if [ "$INSTALL_PODMAN" = "true" ]; then
-            sudo mkdir -p /mnt/containers /etc/containers
-            printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/containers"\n' | sudo tee /etc/containers/storage.conf
+          mnt_src=$(df --output=source /mnt 2>/dev/null | tail -1)
+          root_src=$(df --output=source / | tail -1)
+          mnt_avail_g=$(df -BG --output=avail /mnt 2>/dev/null | tail -1 | tr -dc '0-9')
+          if [ -n "$mnt_src" ] && [ "$mnt_src" != "$root_src" ] && [ "${mnt_avail_g:-0}" -ge 40 ]; then
+            tmpbase=/mnt
+            echo "Separate /mnt detected ($mnt_src, ${mnt_avail_g}G free) — relocating docker + archive there"
+            sudo systemctl stop docker docker.socket || true
+            sudo mkdir -p /mnt/docker
+            printf '{ "data-root": "/mnt/docker" }\n' | sudo tee /etc/docker/daemon.json
+            sudo rm -rf /var/lib/docker
+            sudo systemctl start docker
+            if [ "$INSTALL_PODMAN" = "true" ]; then
+              sudo mkdir -p /mnt/containers /etc/containers
+              printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/containers"\n' | sudo tee /etc/containers/storage.conf
+            fi
+          else
+            tmpbase=/tmp
+            echo "No separate /mnt (mnt_src=$mnt_src root_src=$root_src avail=${mnt_avail_g:-0}G) — reclaiming root fs instead"
+            sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+              /opt/hostedtoolcache/CodeQL /usr/local/share/boost \
+              "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" 2>/dev/null || true
+            sudo docker image prune -af || true
           fi
-          echo "=== df -h after relocate ==="
-          df -h / /mnt
+          sudo mkdir -p "$tmpbase/nextest-tmp"
+          sudo chmod 1777 "$tmpbase/nextest-tmp"
+          echo "NEXTEST_TMPDIR=$tmpbase/nextest-tmp" >> "$GITHUB_ENV"
+          echo "=== df -h after provision ==="
+          df -h
 
       - name: Prune container state before tests
         run: |
@@ -213,18 +235,14 @@ jobs:
       # --workspace-remap . points runtime workspace lookups at this checkout (the
       # path matches the build runner on GitHub-hosted runners).
       #
-      # nextest extracts the archive to a temp dir under $TMPDIR. The default
-      # ($TMPDIR unset -> /tmp) lives on the root fs, which on current
-      # GitHub-hosted Ubuntu runners is only ~72G with ~16G free (the runner
-      # image already uses ~56G). The archive holds every E2E test binary and
-      # grows with each new service crate, so extracting it onto the small root
-      # eventually ENOSPCs ("No space left on device (os error 28)" while
-      # unpacking target/debug/deps/*). Point TMPDIR at the near-empty ~74G
-      # /mnt (same large disk #2200 relocated docker to) so the extract has
-      # ~66G of headroom. Container images still land on the /mnt docker root.
+      # nextest extracts the archive to a temp dir under $TMPDIR. The provision
+      # step above chose a temp base with room (separate /mnt when present, else
+      # the reclaimed root) and exported it as NEXTEST_TMPDIR; point TMPDIR there
+      # so the extract doesn't ENOSPC unpacking target/debug/deps/* on the small
+      # root fs.
       - name: Run nextest partition
         env:
-          TMPDIR: /mnt/nextest-tmp
+          TMPDIR: ${{ env.NEXTEST_TMPDIR }}
         run: |
           sudo mkdir -p /mnt/nextest-tmp
           sudo chmod 1777 /mnt/nextest-tmp


### PR DESCRIPTION
## Summary

Follow-up to #2200 / #2205. Both assumed **every** GitHub-hosted Ubuntu runner exposes a separate ~74G `/mnt` (`/dev/sdb1`) and relocated the container data-root + nextest archive `TMPDIR` there. But **some runners have no separate `/mnt`** — it's just a directory on the ~72G root (only ~14G free). On those, both the container images and the E2E archive extraction land on the small root and the extract dies:

```
error extracting archive `e2e-archive.tar.zst`
No space left on device (os error 28)
```

Disk diagnostics from a failed `E2E lambda-container-docker` run confirmed it: `df -h` showed only `/dev/root 72G 14G-free /` and **no `/mnt` line** — the relocation to "/mnt" was silently writing to the root fs. This recurred as a flaky failure on whatever fraction of runs drew a no-`/mnt` runner.

## Fix

Replace the unconditional relocate step with a **layout-adaptive provision step**:
- **Separate `/mnt` with ≥40G free present** → relocate docker data-root (+ podman graphroot) to `/mnt` and put nextest's `TMPDIR` there, exactly as before.
- **No separate `/mnt`** → reclaim the root fs instead (drop preinstalled `dotnet`/`android`/`ghc`/`CodeQL`/`boost`/toolcache, prune docker images) and keep both consumers on the freed root.

The chosen temp base is exported as `NEXTEST_TMPDIR` via `$GITHUB_ENV` and consumed by the run step's `TMPDIR`, replacing the hardcoded `/mnt/nextest-tmp`. Detection uses `df --output=source` to compare the `/mnt` and `/` backing devices.

## Test plan
- CI runs this workflow; the `Provision disk` step logs which branch it took and `df -h` after. Both runner layouts now have headroom for the container images + archive extract. Infra-only, no code/behavior change.

## Note
Supersedes the fragile assumption in #2200/#2205 that `/mnt` is always a separate large disk. The memory of this class of flake is that the relevant question is *which device backs the temp dir*, not *how full `/` looks*.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the e2e workflow adapt disk provisioning to each runner to prevent “No space left on device” on hosts without a separate `/mnt`. The job now picks a safe temp dir and container storage based on actual disk layout.

- **Bug Fixes**
  - Detect if `/mnt` is a separate device with ≥40G free; if yes, move Docker/Podman storage and set `TMPDIR` to `/mnt`.
  - If not, reclaim space on `/` (remove preinstalled SDKs, prune images) and keep both storage and temp on root.
  - Export the chosen temp base as `NEXTEST_TMPDIR` and use it for nextest extraction (replaces hardcoded `/mnt/nextest-tmp`).
  - Log the chosen path and post-provision `df -h` for visibility.

<sup>Written for commit b0da465954ea5f877a9d79b0ccdf4c36fe35c3db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

