### PR TITLE
feat(s3): implement POST Object (browser-form POST Policy uploads)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5381,6 +5381,8 @@ dependencies = [
  "fakecloud-testkit",
  "flate2",
  "futures-util",
+ "hex",
+ "hmac 0.12.1",
  "mail-parser",
  "md-5 0.10.6",
  "mysql_async",
@@ -5396,6 +5398,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-tungstenite 0.29.0",
+ "uuid",
  "x509-cert",
  "zip",
 ]
@@ -6390,6 +6393,7 @@ dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
  "aws-smithy-http 0.63.6",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "bytes-utils",
@@ -6401,8 +6405,10 @@ dependencies = [
  "fakecloud-core",
  "fakecloud-kms",
  "fakecloud-persistence",
+ "futures-util",
  "http 1.4.0",
  "md-5 0.10.6",
+ "multer",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
@@ -8614,6 +8620,23 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ glob = "0.3"
 regex = "1"
 tokio-postgres = "0.7"
 sqlparser = "0.61"
+multer = "3"
+futures-util = "0.3"
 
 [profile.test]
 debug = "line-tables-only"
@@ -112,7 +114,7 @@ features = [ "encryption", "pem",]
 
 [workspace.dependencies.reqwest]
 version = "0.13"
-features = [ "json",]
+features = [ "json", "multipart",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"

--- a/crates/fakecloud-aws/src/sigv4.rs
+++ b/crates/fakecloud-aws/src/sigv4.rs
@@ -593,7 +593,13 @@ pub fn verify_signature(
     string_to_sign: &str,
     provided_signature: &str,
 ) -> bool {
-    let expected = sign_string(secret_access_key, date_stamp, region, service, string_to_sign);
+    let expected = sign_string(
+        secret_access_key,
+        date_stamp,
+        region,
+        service,
+        string_to_sign,
+    );
     constant_time_eq(
         expected.as_bytes(),
         provided_signature.to_ascii_lowercase().as_bytes(),

--- a/crates/fakecloud-aws/src/sigv4.rs
+++ b/crates/fakecloud-aws/src/sigv4.rs
@@ -577,6 +577,29 @@ pub fn sign_string(
     hex::encode(hmac_sha256(&signing_key, string_to_sign.as_bytes()))
 }
 
+/// Verify a client-supplied hex signature against the one derived from
+/// `string_to_sign`, in constant time.
+///
+/// Companion to [`sign_string`] for the S3 POST-Policy path. The comparison
+/// uses the same constant-time primitive as the header/query SigV4 path so a
+/// signature check can't leak via timing. `sign_string` emits lowercase hex;
+/// the provided signature is lowercased first (case normalization is not
+/// secret-dependent) so a valid uppercase-hex signature still matches.
+pub fn verify_signature(
+    secret_access_key: &str,
+    date_stamp: &str,
+    region: &str,
+    service: &str,
+    string_to_sign: &str,
+    provided_signature: &str,
+) -> bool {
+    let expected = sign_string(secret_access_key, date_stamp, region, service, string_to_sign);
+    constant_time_eq(
+        expected.as_bytes(),
+        provided_signature.to_ascii_lowercase().as_bytes(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/fakecloud-aws/src/sigv4.rs
+++ b/crates/fakecloud-aws/src/sigv4.rs
@@ -557,6 +557,26 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     a.ct_eq(b).into()
 }
 
+/// Compute a hex-encoded SigV4 signature for an arbitrary string-to-sign.
+///
+/// Used by wire formats that don't fit the header/query SigV4 grammar
+/// [`verify`] handles — notably S3 POST-Policy (browser-form) uploads, whose
+/// "string to sign" is the base64-encoded policy document rather than a
+/// canonical-request hash. The signing-key derivation (date -> region ->
+/// service -> `aws4_request`) is identical; only the string being signed
+/// differs, so this exposes just that derivation + final HMAC rather than
+/// duplicating it at each call site.
+pub fn sign_string(
+    secret_access_key: &str,
+    date_stamp: &str,
+    region: &str,
+    service: &str,
+    string_to_sign: &str,
+) -> String {
+    let signing_key = derive_signing_key(secret_access_key, date_stamp, region, service);
+    hex::encode(hmac_sha256(&signing_key, string_to_sign.as_bytes()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/fakecloud-e2e/Cargo.toml
+++ b/crates/fakecloud-e2e/Cargo.toml
@@ -119,3 +119,6 @@ rsa = { workspace = true }
 rand = { workspace = true }
 serde_urlencoded = "0.7"
 x509-cert = { version = "0.2", features = ["pem"] }
+hmac = { workspace = true }
+hex = "0.4"
+uuid = { workspace = true }

--- a/crates/fakecloud-e2e/tests/s3_post_object.rs
+++ b/crates/fakecloud-e2e/tests/s3_post_object.rs
@@ -1,0 +1,368 @@
+//! End-to-end tests for S3 POST Object (the browser-form "POST Policy"
+//! upload flow targeted by boto3's `generate_presigned_post`).
+//!
+//! The AWS SDK has no client method for this flow — it's meant to be driven
+//! by an untrusted browser posting a raw `multipart/form-data` body — so
+//! these tests hand-craft the request with `reqwest`, following the pattern
+//! `sigv4_verification.rs` uses for its own hand-signed requests.
+
+mod helpers;
+
+use base64::Engine as _;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use helpers::TestServer;
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// Re-derive the SigV4 signing key + sign an arbitrary string, matching
+/// `fakecloud_aws::sigv4::sign_string` (the production implementation). The
+/// test recomputes it independently rather than depending on `fakecloud-aws`
+/// so it exercises the wire contract end-to-end rather than sharing code
+/// with what it's testing.
+fn sign_policy(
+    secret: &str,
+    date_stamp: &str,
+    region: &str,
+    service: &str,
+    policy_b64: &str,
+) -> String {
+    let k_date = hmac_sha256(format!("AWS4{secret}").as_bytes(), date_stamp.as_bytes());
+    let k_region = hmac_sha256(&k_date, region.as_bytes());
+    let k_service = hmac_sha256(&k_region, service.as_bytes());
+    let k_signing = hmac_sha256(&k_service, b"aws4_request");
+    hex::encode(hmac_sha256(&k_signing, policy_b64.as_bytes()))
+}
+
+struct PostPolicy {
+    policy_b64: String,
+    credential: String,
+    date_stamp: String,
+    amz_date: String,
+    region: String,
+}
+
+fn build_policy(
+    bucket: &str,
+    key_prefix: &str,
+    akid: &str,
+    region: &str,
+    max_bytes: u64,
+) -> PostPolicy {
+    let now = chrono::Utc::now();
+    let date_stamp = now.format("%Y%m%d").to_string();
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let expiration = (now + chrono::Duration::minutes(15)).to_rfc3339();
+    let credential = format!("{akid}/{date_stamp}/{region}/s3/aws4_request");
+
+    let policy = serde_json::json!({
+        "expiration": expiration,
+        "conditions": [
+            {"bucket": bucket},
+            ["starts-with", "$key", key_prefix],
+            ["content-length-range", 1, max_bytes],
+            {"x-amz-algorithm": "AWS4-HMAC-SHA256"},
+            {"x-amz-credential": credential},
+            {"x-amz-date": amz_date},
+        ]
+    });
+    let policy_b64 = base64::engine::general_purpose::STANDARD.encode(policy.to_string());
+
+    PostPolicy {
+        policy_b64,
+        credential,
+        date_stamp,
+        amz_date,
+        region: region.to_string(),
+    }
+}
+
+fn post_form(
+    policy: &PostPolicy,
+    key: &str,
+    signature: &str,
+    file_bytes: Vec<u8>,
+) -> reqwest::multipart::Form {
+    reqwest::multipart::Form::new()
+        .text("key", key.to_string())
+        .text("Content-Type", "text/plain")
+        .text("x-amz-algorithm", "AWS4-HMAC-SHA256")
+        .text("x-amz-credential", policy.credential.clone())
+        .text("x-amz-date", policy.amz_date.clone())
+        .text("policy", policy.policy_b64.clone())
+        .text("x-amz-signature", signature.to_string())
+        .text("success_action_status", "201")
+        .part(
+            "file",
+            reqwest::multipart::Part::bytes(file_bytes).file_name("upload.txt"),
+        )
+}
+
+#[tokio::test]
+async fn valid_post_policy_upload_stores_the_object() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket()
+        .bucket("post-policy-bucket")
+        .send()
+        .await
+        .expect("create bucket");
+
+    // Root-bypass ("test"/"test") credentials: signature is not
+    // cryptographically checked (matches `is_root_bypass`'s codebase-wide
+    // convention), so any hex string works as long as the policy itself is
+    // well-formed and its conditions are satisfied.
+    let policy = build_policy(
+        "post-policy-bucket",
+        "uploads/",
+        "test",
+        "us-east-1",
+        1_000_000,
+    );
+    let body = b"hello from post policy".to_vec();
+    let form = post_form(
+        &policy,
+        "uploads/hello.txt",
+        "0".repeat(64).as_str(),
+        body.clone(),
+    );
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/post-policy-bucket", server.endpoint()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("POST Object request should succeed at the transport level");
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    assert_eq!(
+        status,
+        reqwest::StatusCode::CREATED,
+        "expected 201 (success_action_status) POST response, got {status}: {text}"
+    );
+    assert!(
+        text.contains("<Key>uploads/hello.txt</Key>"),
+        "PostResponse body should echo the resolved key: {text}"
+    );
+
+    // Retrievable via a normal GET afterwards.
+    let get = s3
+        .get_object()
+        .bucket("post-policy-bucket")
+        .key("uploads/hello.txt")
+        .send()
+        .await
+        .expect("uploaded object should be retrievable");
+    let bytes = get.body.collect().await.unwrap().into_bytes();
+    assert_eq!(bytes.as_ref(), body.as_slice());
+}
+
+#[tokio::test]
+async fn oversized_upload_violates_content_length_range_and_is_not_stored() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket()
+        .bucket("post-policy-bucket-oversize")
+        .send()
+        .await
+        .expect("create bucket");
+
+    // content-length-range caps the upload at 10 bytes; send more than that.
+    let policy = build_policy(
+        "post-policy-bucket-oversize",
+        "uploads/",
+        "test",
+        "us-east-1",
+        10,
+    );
+    let body = b"this body is definitely longer than ten bytes".to_vec();
+    let form = post_form(&policy, "uploads/big.txt", "0".repeat(64).as_str(), body);
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/post-policy-bucket-oversize", server.endpoint()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("POST Object request should succeed at the transport level");
+
+    assert!(
+        resp.status().is_client_error(),
+        "expected a 4xx rejection for a content-length-range violation, got {}",
+        resp.status()
+    );
+
+    let err = s3
+        .get_object()
+        .bucket("post-policy-bucket-oversize")
+        .key("uploads/big.txt")
+        .send()
+        .await
+        .expect_err("object exceeding content-length-range must not be stored");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("NoSuchKey") || msg.contains("404"),
+        "expected NoSuchKey, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn signature_mismatch_is_rejected() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket()
+        .bucket("post-policy-bucket-sig")
+        .send()
+        .await
+        .expect("create bucket");
+
+    // Bootstrap a real IAM user (non-root access key) via root-bypass creds
+    // so the server's credential_resolver has a real secret to check the
+    // POST-Policy signature against.
+    let iam = server.iam_client().await;
+    iam.create_user()
+        .user_name("post-policy-user")
+        .send()
+        .await
+        .expect("create iam user");
+    let ak = iam
+        .create_access_key()
+        .user_name("post-policy-user")
+        .send()
+        .await
+        .expect("create access key");
+    let key = ak.access_key().expect("access key present");
+    let akid = key.access_key_id().to_string();
+    // Deliberately unused: this test signs with the wrong secret below to
+    // exercise the SignatureDoesNotMatch path.
+    let _secret = key.secret_access_key().to_string();
+
+    let policy = build_policy(
+        "post-policy-bucket-sig",
+        "uploads/",
+        &akid,
+        "us-east-1",
+        1_000_000,
+    );
+
+    // Correct signature would be `sign_policy(&secret, ...)`; sign with the
+    // wrong secret instead so the server's recomputed signature can never
+    // match what we send.
+    let bad_signature = sign_policy(
+        "definitely-the-wrong-secret",
+        &policy.date_stamp,
+        &policy.region,
+        "s3",
+        &policy.policy_b64,
+    );
+    let body = b"should never be stored".to_vec();
+    let form = post_form(&policy, "uploads/tampered.txt", &bad_signature, body);
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/post-policy-bucket-sig", server.endpoint()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("POST Object request should succeed at the transport level");
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    assert_eq!(
+        status,
+        reqwest::StatusCode::FORBIDDEN,
+        "expected 403 SignatureDoesNotMatch, got {status}: {text}"
+    );
+    assert!(
+        text.contains("SignatureDoesNotMatch"),
+        "expected SignatureDoesNotMatch in the error body: {text}"
+    );
+
+    let err = s3
+        .get_object()
+        .bucket("post-policy-bucket-sig")
+        .key("uploads/tampered.txt")
+        .send()
+        .await
+        .expect_err("object with a bad signature must not be stored");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("NoSuchKey") || msg.contains("404"),
+        "expected NoSuchKey, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn correct_signature_from_a_real_iam_user_is_accepted() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket()
+        .bucket("post-policy-bucket-iam")
+        .send()
+        .await
+        .expect("create bucket");
+
+    let iam = server.iam_client().await;
+    iam.create_user()
+        .user_name("post-policy-user-2")
+        .send()
+        .await
+        .expect("create iam user");
+    let ak = iam
+        .create_access_key()
+        .user_name("post-policy-user-2")
+        .send()
+        .await
+        .expect("create access key");
+    let key = ak.access_key().expect("access key present");
+    let akid = key.access_key_id().to_string();
+    let secret = key.secret_access_key().to_string();
+
+    let policy = build_policy(
+        "post-policy-bucket-iam",
+        "uploads/",
+        &akid,
+        "us-east-1",
+        1_000_000,
+    );
+    let signature = sign_policy(
+        &secret,
+        &policy.date_stamp,
+        &policy.region,
+        "s3",
+        &policy.policy_b64,
+    );
+    let body = b"signed by a real iam user".to_vec();
+    let form = post_form(&policy, "uploads/iam-signed.txt", &signature, body.clone());
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/post-policy-bucket-iam", server.endpoint()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("POST Object request should succeed at the transport level");
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    assert_eq!(
+        status,
+        reqwest::StatusCode::CREATED,
+        "expected 201 for a correctly-signed IAM-user upload, got {status}: {text}"
+    );
+
+    let get = s3
+        .get_object()
+        .bucket("post-policy-bucket-iam")
+        .key("uploads/iam-signed.txt")
+        .send()
+        .await
+        .expect("uploaded object should be retrievable");
+    let bytes = get.body.collect().await.unwrap().into_bytes();
+    assert_eq!(bytes.as_ref(), body.as_slice());
+}

--- a/crates/fakecloud-e2e/tests/s3_post_object.rs
+++ b/crates/fakecloud-e2e/tests/s3_post_object.rs
@@ -384,7 +384,13 @@ async fn unauthorized_extra_form_field_is_rejected() {
         .await
         .expect("create bucket");
 
-    let policy = build_policy("post-policy-extra", "uploads/", "test", "us-east-1", 1_000_000);
+    let policy = build_policy(
+        "post-policy-extra",
+        "uploads/",
+        "test",
+        "us-east-1",
+        1_000_000,
+    );
     // `x-amz-meta-foo` is not covered by any condition in `build_policy`.
     let form = post_form(
         &policy,
@@ -402,7 +408,11 @@ async fn unauthorized_extra_form_field_is_rejected() {
         .expect("transport ok");
     let status = resp.status();
     let text = resp.text().await.unwrap_or_default();
-    assert_eq!(status, reqwest::StatusCode::FORBIDDEN, "got {status}: {text}");
+    assert_eq!(
+        status,
+        reqwest::StatusCode::FORBIDDEN,
+        "got {status}: {text}"
+    );
     assert!(
         text.contains("Extra input fields"),
         "expected extra-field AccessDenied: {text}"
@@ -437,11 +447,13 @@ async fn policy_without_expiration_is_rejected() {
             ["starts-with", "$key", "uploads/"],
         ]
     });
-    let policy_b64 =
-        base64::engine::general_purpose::STANDARD.encode(policy_json.to_string());
+    let policy_b64 = base64::engine::general_purpose::STANDARD.encode(policy_json.to_string());
     let form = reqwest::multipart::Form::new()
         .text("key", "uploads/x.txt")
-        .text("x-amz-credential", "test/20240101/us-east-1/s3/aws4_request")
+        .text(
+            "x-amz-credential",
+            "test/20240101/us-east-1/s3/aws4_request",
+        )
         .text("policy", policy_b64)
         .text("x-amz-signature", "0".repeat(64))
         .part(
@@ -484,11 +496,13 @@ async fn success_action_redirect_returns_303() {
             {"success_action_redirect": "https://example.com/done"},
         ]
     });
-    let policy_b64 =
-        base64::engine::general_purpose::STANDARD.encode(policy_json.to_string());
+    let policy_b64 = base64::engine::general_purpose::STANDARD.encode(policy_json.to_string());
     let form = reqwest::multipart::Form::new()
         .text("key", "uploads/r.txt")
-        .text("x-amz-credential", "test/20240101/us-east-1/s3/aws4_request")
+        .text(
+            "x-amz-credential",
+            "test/20240101/us-east-1/s3/aws4_request",
+        )
         .text("policy", policy_b64)
         .text("x-amz-signature", "0".repeat(64))
         .text("success_action_redirect", "https://example.com/done")
@@ -514,8 +528,14 @@ async fn success_action_redirect_returns_303() {
         .and_then(|v| v.to_str().ok())
         .unwrap_or_default()
         .to_string();
-    assert!(location.starts_with("https://example.com/done?"), "loc={location}");
-    assert!(location.contains("bucket=post-policy-redirect"), "loc={location}");
+    assert!(
+        location.starts_with("https://example.com/done?"),
+        "loc={location}"
+    );
+    assert!(
+        location.contains("bucket=post-policy-redirect"),
+        "loc={location}"
+    );
     assert!(location.contains("key=uploads"), "loc={location}");
 
     // The object still got stored.

--- a/crates/fakecloud-e2e/tests/s3_post_object.rs
+++ b/crates/fakecloud-e2e/tests/s3_post_object.rs
@@ -68,6 +68,10 @@ fn build_policy(
             {"bucket": bucket},
             ["starts-with", "$key", key_prefix],
             ["content-length-range", 1, max_bytes],
+            // Every field the browser posts must be authorized by a condition,
+            // just as boto3's `generate_presigned_post` emits them.
+            ["starts-with", "$Content-Type", ""],
+            {"success_action_status": "201"},
             {"x-amz-algorithm": "AWS4-HMAC-SHA256"},
             {"x-amz-credential": credential},
             {"x-amz-date": amz_date},
@@ -365,4 +369,160 @@ async fn correct_signature_from_a_real_iam_user_is_accepted() {
         .expect("uploaded object should be retrievable");
     let bytes = get.body.collect().await.unwrap().into_bytes();
     assert_eq!(bytes.as_ref(), body.as_slice());
+}
+
+/// A form field carrying no matching policy condition is rejected the way real
+/// S3 rejects it: `AccessDenied` "Extra input fields". This is the whole point
+/// of POST Policy -- the signed policy enumerates exactly what may be posted.
+#[tokio::test]
+async fn unauthorized_extra_form_field_is_rejected() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket()
+        .bucket("post-policy-extra")
+        .send()
+        .await
+        .expect("create bucket");
+
+    let policy = build_policy("post-policy-extra", "uploads/", "test", "us-east-1", 1_000_000);
+    // `x-amz-meta-foo` is not covered by any condition in `build_policy`.
+    let form = post_form(
+        &policy,
+        "uploads/extra.txt",
+        "0".repeat(64).as_str(),
+        b"body".to_vec(),
+    )
+    .text("x-amz-meta-foo", "bar");
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/post-policy-extra", server.endpoint()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("transport ok");
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    assert_eq!(status, reqwest::StatusCode::FORBIDDEN, "got {status}: {text}");
+    assert!(
+        text.contains("Extra input fields"),
+        "expected extra-field AccessDenied: {text}"
+    );
+
+    let err = s3
+        .get_object()
+        .bucket("post-policy-extra")
+        .key("uploads/extra.txt")
+        .send()
+        .await
+        .expect_err("object with an unauthorized field must not be stored");
+    assert!(format!("{err:?}").contains("NoSuchKey") || format!("{err:?}").contains("404"));
+}
+
+/// A policy document without an `expiration` is rejected (real S3 requires it).
+#[tokio::test]
+async fn policy_without_expiration_is_rejected() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket()
+        .bucket("post-policy-noexp")
+        .send()
+        .await
+        .expect("create bucket");
+
+    // Hand-build a policy with no `expiration` field; root-bypass creds so the
+    // signature isn't checked and we exercise the policy-validation path.
+    let policy_json = serde_json::json!({
+        "conditions": [
+            {"bucket": "post-policy-noexp"},
+            ["starts-with", "$key", "uploads/"],
+        ]
+    });
+    let policy_b64 =
+        base64::engine::general_purpose::STANDARD.encode(policy_json.to_string());
+    let form = reqwest::multipart::Form::new()
+        .text("key", "uploads/x.txt")
+        .text("x-amz-credential", "test/20240101/us-east-1/s3/aws4_request")
+        .text("policy", policy_b64)
+        .text("x-amz-signature", "0".repeat(64))
+        .part(
+            "file",
+            reqwest::multipart::Part::bytes(b"body".to_vec()).file_name("x.txt"),
+        );
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/post-policy-noexp", server.endpoint()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("transport ok");
+    assert!(
+        resp.status().is_client_error(),
+        "expected 4xx for a policy missing expiration, got {}",
+        resp.status()
+    );
+}
+
+/// `success_action_redirect` yields a 303 to the given URL with `bucket`,
+/// `key`, and `etag` appended, taking precedence over `success_action_status`.
+#[tokio::test]
+async fn success_action_redirect_returns_303() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket()
+        .bucket("post-policy-redirect")
+        .send()
+        .await
+        .expect("create bucket");
+
+    let now = chrono::Utc::now();
+    let expiration = (now + chrono::Duration::minutes(15)).to_rfc3339();
+    let policy_json = serde_json::json!({
+        "expiration": expiration,
+        "conditions": [
+            {"bucket": "post-policy-redirect"},
+            ["starts-with", "$key", "uploads/"],
+            {"success_action_redirect": "https://example.com/done"},
+        ]
+    });
+    let policy_b64 =
+        base64::engine::general_purpose::STANDARD.encode(policy_json.to_string());
+    let form = reqwest::multipart::Form::new()
+        .text("key", "uploads/r.txt")
+        .text("x-amz-credential", "test/20240101/us-east-1/s3/aws4_request")
+        .text("policy", policy_b64)
+        .text("x-amz-signature", "0".repeat(64))
+        .text("success_action_redirect", "https://example.com/done")
+        .part(
+            "file",
+            reqwest::multipart::Part::bytes(b"body".to_vec()).file_name("r.txt"),
+        );
+
+    // Don't follow the redirect -- assert the 303 + Location directly.
+    let resp = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
+        .post(format!("{}/post-policy-redirect", server.endpoint()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("transport ok");
+    assert_eq!(resp.status(), reqwest::StatusCode::SEE_OTHER);
+    let location = resp
+        .headers()
+        .get("location")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(location.starts_with("https://example.com/done?"), "loc={location}");
+    assert!(location.contains("bucket=post-policy-redirect"), "loc={location}");
+    assert!(location.contains("key=uploads"), "loc={location}");
+
+    // The object still got stored.
+    s3.get_object()
+        .bucket("post-policy-redirect")
+        .key("uploads/r.txt")
+        .send()
+        .await
+        .expect("redirect upload should still be stored");
 }

--- a/crates/fakecloud-s3/Cargo.toml
+++ b/crates/fakecloud-s3/Cargo.toml
@@ -32,6 +32,9 @@ crc32fast = { workspace = true }
 crc64fast-nvme = { workspace = true }
 quick-xml = { workspace = true }
 toml = { workspace = true }
+multer = { workspace = true }
+futures-util = { workspace = true }
+axum = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -52,6 +52,15 @@ pub struct S3Service {
     kms_state: Option<SharedKmsState>,
     pub(crate) kms_hook: Option<Arc<dyn fakecloud_core::delivery::KmsHook>>,
     store: Arc<dyn S3Store>,
+    /// Resolves an access key ID to its secret + principal. Used only by
+    /// POST Object (browser-form "POST Policy" upload) to verify the
+    /// `x-amz-signature` form field cryptographically — that wire format
+    /// carries no `Authorization` header, so dispatch's normal SigV4
+    /// verification path never sees it. `None` when unwired (e.g. most
+    /// unit tests): POST Policy signature checks then only accept the
+    /// `test*` root-bypass access key, matching [`fakecloud_core::auth::is_root_bypass`]'s
+    /// "always skip crypto" convention used everywhere else in the codebase.
+    pub(crate) credential_resolver: Option<Arc<dyn fakecloud_core::auth::CredentialResolver>>,
 }
 
 /// Map a [`StoreError`] from the persistence layer to a 500 InternalError
@@ -92,6 +101,7 @@ impl S3Service {
             kms_state: None,
             kms_hook: None,
             store,
+            credential_resolver: None,
         }
     }
 
@@ -102,6 +112,17 @@ impl S3Service {
 
     pub fn with_kms_hook(mut self, hook: Arc<dyn fakecloud_core::delivery::KmsHook>) -> Self {
         self.kms_hook = Some(hook);
+        self
+    }
+
+    /// Wire a [`fakecloud_core::auth::CredentialResolver`] so POST Object
+    /// (browser-form POST Policy upload) can verify the form-carried
+    /// `x-amz-signature` against a non-root IAM access key's real secret.
+    pub fn with_credential_resolver(
+        mut self,
+        resolver: Arc<dyn fakecloud_core::auth::CredentialResolver>,
+    ) -> Self {
+        self.credential_resolver = Some(resolver);
         self
     }
 
@@ -854,6 +875,24 @@ impl AwsService for S3Service {
             }
             (&Method::POST, Some("WriteGetObjectResponse"), None) => {
                 self.write_get_object_response(account_id, &req)
+            }
+
+            // POST /{bucket} with a multipart/form-data body — POST Object
+            // (browser-form "POST Policy" upload, the target of boto3's
+            // `generate_presigned_post`). Guarded on Content-Type so it
+            // doesn't shadow the `?delete` / metadata-config arms above,
+            // which also match `(POST, Some(b), None)` but carry their own
+            // query-param guards.
+            (&Method::POST, Some(b), None)
+                if req
+                    .headers
+                    .get(http::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .is_some_and(|ct| {
+                        ct.to_ascii_lowercase().starts_with("multipart/form-data")
+                    }) =>
+            {
+                self.post_object(account_id, &req, b).await
             }
 
             _ => Err(AwsServiceError::aws_error(

--- a/crates/fakecloud-s3/src/service/objects/mod.rs
+++ b/crates/fakecloud-s3/src/service/objects/mod.rs
@@ -22,6 +22,7 @@ use super::{
 
 mod delete;
 mod list;
+mod post_policy;
 mod read;
 mod website;
 mod write;

--- a/crates/fakecloud-s3/src/service/objects/post_policy.rs
+++ b/crates/fakecloud-s3/src/service/objects/post_policy.rs
@@ -1,0 +1,546 @@
+//! S3 POST Object — the browser-form "POST Policy" upload flow targeted by
+//! `generate_presigned_post` (boto3) / `createPresignedPost` (JS SDK).
+//!
+//! Unlike every other S3 write, the caller never signs the HTTP request
+//! itself: a trusted party (the presigning caller) hands the browser a
+//! base64 JSON "policy" document plus a signature over that document, and
+//! the browser POSTs both — along with the object key/metadata and the file
+//! bytes — as a single `multipart/form-data` body straight to the bucket
+//! root. There is no `Authorization` header and no signed query string, so
+//! this endpoint parses its own signature material out of the form fields
+//! instead of going through [`fakecloud_aws::sigv4::verify`].
+
+use std::collections::HashMap;
+
+use base64::Engine as _;
+use http::Method;
+
+use fakecloud_core::auth::is_root_bypass;
+
+use super::*;
+
+/// One parsed multipart form field: original (as-submitted) name + value.
+/// Lookups against the policy's conditions are case-insensitive per the S3
+/// POST Policy spec, so callers normally match on `name.to_ascii_lowercase()`.
+struct FormField {
+    name: String,
+    value: String,
+}
+
+struct ParsedForm {
+    fields: Vec<FormField>,
+    file_name: Option<String>,
+    file_content_type: Option<String>,
+    file_bytes: Bytes,
+    file_present: bool,
+}
+
+impl ParsedForm {
+    fn field_lower(&self, lower_name: &str) -> Option<&str> {
+        self.fields
+            .iter()
+            .find(|f| f.name.eq_ignore_ascii_case(lower_name))
+            .map(|f| f.value.as_str())
+    }
+}
+
+fn invalid_argument(message: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "InvalidArgument", message)
+}
+
+fn access_denied(message: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::FORBIDDEN, "AccessDenied", message)
+}
+
+fn signature_does_not_match(message: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::FORBIDDEN, "SignatureDoesNotMatch", message)
+}
+
+async fn multer_field_bytes(field: multer::Field<'_>) -> Result<Bytes, AwsServiceError> {
+    field
+        .bytes()
+        .await
+        .map_err(|err| invalid_argument(format!("failed to read multipart field body: {err}")))
+}
+
+/// Parse the `multipart/form-data` body into form fields + the `file` part.
+/// Field names carry no ordering guarantee from the caller's perspective —
+/// we just collect whatever we're handed, matching real S3's tolerance for
+/// field order (aside from `file` needing to be read after the fields that
+/// govern it, which multer's streaming parser naturally enforces since the
+/// browser always places `file` last).
+async fn parse_multipart_form(
+    content_type: &str,
+    body: Bytes,
+) -> Result<ParsedForm, AwsServiceError> {
+    let boundary = multer::parse_boundary(content_type)
+        .map_err(|_| invalid_argument("POST Object requires a multipart/form-data body"))?;
+
+    let stream = futures_util::stream::once(async move { Ok::<Bytes, std::io::Error>(body) });
+    let mut multipart = multer::Multipart::new(stream, boundary);
+
+    let mut fields = Vec::new();
+    let mut file_name = None;
+    let mut file_content_type = None;
+    let mut file_bytes = Bytes::new();
+    let mut file_present = false;
+
+    loop {
+        let next = multipart
+            .next_field()
+            .await
+            .map_err(|err| invalid_argument(format!("malformed multipart body: {err}")))?;
+        let Some(field) = next else { break };
+
+        let name = field.name().unwrap_or("").to_string();
+        if name.eq_ignore_ascii_case("file") {
+            file_present = true;
+            file_name = field.file_name().map(|s| s.to_string());
+            file_content_type = field.content_type().map(|m| m.to_string());
+            file_bytes = multer_field_bytes(field).await?;
+        } else {
+            let value = field
+                .text()
+                .await
+                .map_err(|err| invalid_argument(format!("malformed multipart field: {err}")))?;
+            fields.push(FormField { name, value });
+        }
+    }
+
+    Ok(ParsedForm {
+        fields,
+        file_name,
+        file_content_type,
+        file_bytes,
+        file_present,
+    })
+}
+
+/// Resolve the `key` form field, substituting the S3-documented
+/// `${filename}` placeholder with the uploaded part's filename.
+fn resolve_key(key_field: &str, file_name: Option<&str>) -> String {
+    if key_field.contains("${filename}") {
+        key_field.replace("${filename}", file_name.unwrap_or_default())
+    } else {
+        key_field.to_string()
+    }
+}
+
+/// A single parsed POST-Policy condition. S3's policy document allows two
+/// shapes: an exact-match object `{"field": "value"}` and a 3-element array
+/// `["op", "$field", value_or_prefix]` (or `["content-length-range", min,
+/// max]`, which has no field name).
+enum PolicyCondition {
+    Eq { field: String, value: String },
+    StartsWith { field: String, prefix: String },
+    ContentLengthRange { min: u64, max: u64 },
+}
+
+fn parse_conditions(policy: &serde_json::Value) -> Result<Vec<PolicyCondition>, AwsServiceError> {
+    let raw = policy
+        .get("conditions")
+        .and_then(|c| c.as_array())
+        .ok_or_else(|| invalid_argument("policy document is missing a `conditions` array"))?;
+
+    let mut out = Vec::with_capacity(raw.len());
+    for cond in raw {
+        if let Some(obj) = cond.as_object() {
+            // Exact-match object form: `{"field": "value"}`.
+            for (field, value) in obj {
+                let value = value
+                    .as_str()
+                    .ok_or_else(|| invalid_argument("policy condition value must be a string"))?
+                    .to_string();
+                out.push(PolicyCondition::Eq {
+                    field: field.trim_start_matches('$').to_ascii_lowercase(),
+                    value,
+                });
+            }
+        } else if let Some(arr) = cond.as_array() {
+            if arr.len() != 3 {
+                return Err(invalid_argument(
+                    "policy condition array must have exactly 3 elements",
+                ));
+            }
+            let op = arr[0]
+                .as_str()
+                .ok_or_else(|| invalid_argument("policy condition operator must be a string"))?;
+            match op {
+                "eq" => {
+                    let field = arr[1]
+                        .as_str()
+                        .ok_or_else(|| invalid_argument("policy condition field must be a string"))?
+                        .trim_start_matches('$')
+                        .to_ascii_lowercase();
+                    let value = arr[2]
+                        .as_str()
+                        .ok_or_else(|| invalid_argument("policy condition value must be a string"))?
+                        .to_string();
+                    out.push(PolicyCondition::Eq { field, value });
+                }
+                "starts-with" => {
+                    let field = arr[1]
+                        .as_str()
+                        .ok_or_else(|| invalid_argument("policy condition field must be a string"))?
+                        .trim_start_matches('$')
+                        .to_ascii_lowercase();
+                    let prefix = arr[2]
+                        .as_str()
+                        .ok_or_else(|| {
+                            invalid_argument("policy condition prefix must be a string")
+                        })?
+                        .to_string();
+                    out.push(PolicyCondition::StartsWith { field, prefix });
+                }
+                "content-length-range" => {
+                    let min = arr[1].as_u64().ok_or_else(|| {
+                        invalid_argument("content-length-range min must be a number")
+                    })?;
+                    let max = arr[2].as_u64().ok_or_else(|| {
+                        invalid_argument("content-length-range max must be a number")
+                    })?;
+                    out.push(PolicyCondition::ContentLengthRange { min, max });
+                }
+                other => {
+                    return Err(invalid_argument(format!(
+                        "unsupported policy condition operator: {other}"
+                    )));
+                }
+            }
+        } else {
+            return Err(invalid_argument(
+                "policy condition must be an object or a 3-element array",
+            ));
+        }
+    }
+    Ok(out)
+}
+
+/// Look up the submitted value for a condition's field name (lowercased),
+/// consulting the well-known derived fields (`bucket`, `key`, `file`'s
+/// resolved content-type) before falling back to the raw submitted form
+/// fields.
+fn submitted_value<'a>(
+    field: &str,
+    bucket: &'a str,
+    resolved_key: &'a str,
+    content_type: &'a str,
+    form: &'a ParsedForm,
+) -> Option<&'a str> {
+    match field {
+        "bucket" => Some(bucket),
+        "key" => Some(resolved_key),
+        "content-type" => Some(content_type),
+        other => form.field_lower(other),
+    }
+}
+
+fn enforce_conditions(
+    conditions: &[PolicyCondition],
+    bucket: &str,
+    resolved_key: &str,
+    content_type: &str,
+    file_size: u64,
+    form: &ParsedForm,
+) -> Result<(), AwsServiceError> {
+    for cond in conditions {
+        match cond {
+            PolicyCondition::Eq { field, value } => {
+                let actual = submitted_value(field, bucket, resolved_key, content_type, form);
+                if actual != Some(value.as_str()) {
+                    return Err(access_denied(format!(
+                        "Policy Condition failed: [\"eq\", \"${field}\", \"{value}\"]"
+                    )));
+                }
+            }
+            PolicyCondition::StartsWith { field, prefix } => {
+                let actual = submitted_value(field, bucket, resolved_key, content_type, form);
+                if !actual.is_some_and(|v| v.starts_with(prefix.as_str())) {
+                    return Err(access_denied(format!(
+                        "Policy Condition failed: [\"starts-with\", \"${field}\", \"{prefix}\"]"
+                    )));
+                }
+            }
+            PolicyCondition::ContentLengthRange { min, max } => {
+                if file_size < *min {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "EntityTooSmall",
+                        "Your proposed upload is smaller than the minimum allowed size",
+                    ));
+                }
+                if file_size > *max {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "EntityTooLarge",
+                        "Your proposed upload exceeds the maximum allowed size",
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `x-amz-credential` is `{access_key}/{date}/{region}/{service}/aws4_request`.
+struct ParsedCredential {
+    access_key: String,
+    date_stamp: String,
+    region: String,
+    service: String,
+}
+
+fn parse_credential(raw: &str) -> Result<ParsedCredential, AwsServiceError> {
+    let parts: Vec<&str> = raw.split('/').collect();
+    if parts.len() != 5 || parts[4] != "aws4_request" {
+        return Err(invalid_argument("malformed x-amz-credential"));
+    }
+    Ok(ParsedCredential {
+        access_key: parts[0].to_string(),
+        date_stamp: parts[1].to_string(),
+        region: parts[2].to_string(),
+        service: parts[3].to_string(),
+    })
+}
+
+impl S3Service {
+    /// `POST /{bucket}` with a `multipart/form-data` body — S3 POST Object
+    /// (browser-form "POST Policy" upload). See module docs for the wire
+    /// contract.
+    pub(crate) async fn post_object(
+        &self,
+        account_id: &str,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let content_type = req
+            .headers
+            .get(http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+
+        // The bucket must already exist (mirrors PutObject's NoSuchBucket
+        // check); do this before spending effort parsing the multipart body.
+        {
+            let accounts = self.state.read();
+            let empty = crate::state::S3State::new(account_id, &req.region);
+            let state = accounts.get(account_id).unwrap_or(&empty);
+            if !state.buckets.contains_key(bucket) {
+                return Err(no_such_bucket(bucket));
+            }
+        }
+
+        let form = parse_multipart_form(&content_type, req.body.clone()).await?;
+
+        let key_field = form
+            .field_lower("key")
+            .ok_or_else(|| invalid_argument("POST Object requires a `key` form field"))?;
+        let resolved_key = resolve_key(key_field, form.file_name.as_deref());
+        if resolved_key.is_empty() {
+            return Err(invalid_argument(
+                "POST Object requires a non-empty resolved key",
+            ));
+        }
+        if !form.file_present {
+            return Err(invalid_argument("POST Object requires a `file` form field"));
+        }
+
+        let object_content_type = form
+            .field_lower("content-type")
+            .map(|s| s.to_string())
+            .or_else(|| form.file_content_type.clone())
+            .unwrap_or_else(|| "binary/octet-stream".to_string());
+
+        // --- Policy validation ---
+        let policy_b64 = form
+            .field_lower("policy")
+            .ok_or_else(|| invalid_argument("POST Object requires a `policy` form field"))?
+            .to_string();
+        let policy_bytes = base64::engine::general_purpose::STANDARD
+            .decode(policy_b64.as_bytes())
+            .map_err(|_| invalid_argument("`policy` is not valid base64"))?;
+        let policy: serde_json::Value = serde_json::from_slice(&policy_bytes)
+            .map_err(|_| invalid_argument("`policy` is not valid JSON"))?;
+
+        if let Some(expiration) = policy.get("expiration").and_then(|v| v.as_str()) {
+            let expires_at = chrono::DateTime::parse_from_rfc3339(expiration)
+                .map_err(|_| invalid_argument("policy `expiration` is not valid RFC3339"))?
+                .with_timezone(&Utc);
+            if Utc::now() > expires_at {
+                return Err(access_denied(
+                    "Invalid according to Policy: Policy expired.",
+                ));
+            }
+        }
+
+        let conditions = parse_conditions(&policy)?;
+        enforce_conditions(
+            &conditions,
+            bucket,
+            &resolved_key,
+            &object_content_type,
+            form.file_bytes.len() as u64,
+            &form,
+        )?;
+
+        // --- Signature verification ---
+        let algorithm = form.field_lower("x-amz-algorithm").unwrap_or_default();
+        if !algorithm.is_empty() && !algorithm.eq_ignore_ascii_case("AWS4-HMAC-SHA256") {
+            return Err(invalid_argument(format!(
+                "unsupported x-amz-algorithm: {algorithm}"
+            )));
+        }
+        let credential_raw = form.field_lower("x-amz-credential").ok_or_else(|| {
+            invalid_argument("POST Object requires an `x-amz-credential` form field")
+        })?;
+        let credential = parse_credential(credential_raw)?;
+        let signature = form.field_lower("x-amz-signature").ok_or_else(|| {
+            invalid_argument("POST Object requires an `x-amz-signature` form field")
+        })?;
+
+        if is_root_bypass(&credential.access_key) {
+            // Matches the codebase-wide `test*` root-bypass convention
+            // (`fakecloud_core::auth::is_root_bypass`): local-dev root
+            // credentials always pass, signature not cryptographically
+            // checked.
+        } else {
+            let resolver = self.credential_resolver.as_ref().ok_or_else(|| {
+                signature_does_not_match(
+                    "The request signature we calculated does not match the signature you provided",
+                )
+            })?;
+            let resolved = resolver.resolve(&credential.access_key).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::FORBIDDEN,
+                    "InvalidAccessKeyId",
+                    "The AWS Access Key Id you provided does not exist in our records.",
+                )
+            })?;
+            let expected = fakecloud_aws::sigv4::sign_string(
+                &resolved.secret_access_key,
+                &credential.date_stamp,
+                &credential.region,
+                &credential.service,
+                &policy_b64,
+            );
+            if !expected.eq_ignore_ascii_case(signature) {
+                return Err(signature_does_not_match(
+                    "The request signature we calculated does not match the signature you provided",
+                ));
+            }
+        }
+
+        // --- Store the object via the existing PutObject sink ---
+        let mut synth_headers = HeaderMap::new();
+        synth_headers.insert(
+            http::header::CONTENT_TYPE,
+            object_content_type
+                .parse()
+                .unwrap_or_else(|_| http::HeaderValue::from_static("binary/octet-stream")),
+        );
+        // Forward any other AWS-meaningful fields the caller supplied
+        // (storage class, ACL, user metadata, cache/content headers) as if
+        // they were the equivalent PutObject headers — POST Object form
+        // field names match their header counterparts verbatim.
+        for f in &form.fields {
+            let lower = f.name.to_ascii_lowercase();
+            let forwardable = lower == "cache-control"
+                || lower == "content-disposition"
+                || lower == "content-encoding"
+                || lower == "content-language"
+                || lower == "expires"
+                || lower.starts_with("x-amz-");
+            if !forwardable {
+                continue;
+            }
+            if let (Ok(name), Ok(value)) = (
+                lower.parse::<http::header::HeaderName>(),
+                f.value.parse::<http::HeaderValue>(),
+            ) {
+                synth_headers.insert(name, value);
+            }
+        }
+
+        let synth_req = AwsRequest {
+            service: "s3".to_string(),
+            action: "PutObject".to_string(),
+            region: req.region.clone(),
+            account_id: account_id.to_string(),
+            request_id: req.request_id.clone(),
+            headers: synth_headers,
+            query_params: HashMap::new(),
+            body: Bytes::new(),
+            body_stream: parking_lot::Mutex::new(Some(axum::body::Body::from(
+                form.file_bytes.clone(),
+            ))),
+            path_segments: vec![bucket.to_string(), resolved_key.clone()],
+            raw_path: format!("/{bucket}/{resolved_key}"),
+            raw_query: String::new(),
+            method: Method::PUT,
+            is_query_protocol: false,
+            access_key_id: req.access_key_id.clone(),
+            principal: req.principal.clone(),
+        };
+
+        let put_response = self
+            .put_object(account_id, &synth_req, bucket, &resolved_key)
+            .await?;
+        let etag = put_response
+            .headers
+            .get("etag")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("\"\"")
+            .to_string();
+
+        // --- Build the POST Object response ---
+        let success_status = form
+            .field_lower("success_action_status")
+            .and_then(|s| s.parse::<u16>().ok())
+            .unwrap_or(204);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "etag",
+            etag.parse()
+                .unwrap_or_else(|_| http::HeaderValue::from_static("\"\"")),
+        );
+
+        match success_status {
+            200 => Ok(AwsResponse {
+                status: StatusCode::OK,
+                content_type: String::new(),
+                body: Bytes::new().into(),
+                headers,
+            }),
+            201 => {
+                let location = format!("/{bucket}/{resolved_key}");
+                headers.insert(
+                    "location",
+                    location
+                        .parse()
+                        .unwrap_or_else(|_| http::HeaderValue::from_static("/")),
+                );
+                let body = format!(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<PostResponse><Location>{}</Location><Bucket>{}</Bucket><Key>{}</Key><ETag>{}</ETag></PostResponse>",
+                    crate::service::xml_escape(&location),
+                    crate::service::xml_escape(bucket),
+                    crate::service::xml_escape(&resolved_key),
+                    crate::service::xml_escape(&etag),
+                );
+                Ok(AwsResponse {
+                    status: StatusCode::CREATED,
+                    content_type: "application/xml".to_string(),
+                    body: Bytes::from(body).into(),
+                    headers,
+                })
+            }
+            _ => Ok(AwsResponse {
+                status: StatusCode::NO_CONTENT,
+                content_type: String::new(),
+                body: Bytes::new().into(),
+                headers,
+            }),
+        }
+    }
+}

--- a/crates/fakecloud-s3/src/service/objects/post_policy.rs
+++ b/crates/fakecloud-s3/src/service/objects/post_policy.rs
@@ -282,6 +282,65 @@ fn enforce_conditions(
     Ok(())
 }
 
+/// Reject any submitted form field that the signed policy does not authorize.
+/// The whole POST-Policy security model is that the signed `conditions` list
+/// enumerates exactly which fields (and values) the browser may post; real S3
+/// rejects a request carrying a field with no matching condition with
+/// `AccessDenied` "Invalid according to Policy: Extra input fields: X". Only a
+/// small set of fields is exempt (they carry the signature material itself or
+/// are ignored by convention): `policy`, `x-amz-signature`, the `file` part,
+/// and any `x-ignore-*` field. `content-length-range` has no field name, so it
+/// authorizes nothing here (it governs the file size, checked separately).
+fn enforce_no_extra_fields(
+    conditions: &[PolicyCondition],
+    form: &ParsedForm,
+) -> Result<(), AwsServiceError> {
+    let mut authorized: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for cond in conditions {
+        match cond {
+            PolicyCondition::Eq { field, .. } => {
+                authorized.insert(field.as_str());
+            }
+            PolicyCondition::StartsWith { field, .. } => {
+                authorized.insert(field.as_str());
+            }
+            PolicyCondition::ContentLengthRange { .. } => {}
+        }
+    }
+    for f in &form.fields {
+        let lower = f.name.to_ascii_lowercase();
+        let exempt = lower == "policy"
+            || lower == "x-amz-signature"
+            || lower == "file"
+            || lower.starts_with("x-ignore-");
+        if exempt {
+            continue;
+        }
+        if !authorized.contains(lower.as_str()) {
+            return Err(access_denied(format!(
+                "Invalid according to Policy: Extra input fields: {lower}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Absolute, path-style URL for a stored object, derived from the request's
+/// `Host` header (matching fakecloud's path-style addressing). Falls back to a
+/// root-relative path when no usable host is present. Used for the `Location`
+/// response header / `PostResponse` XML and `success_action_redirect`.
+fn object_url(req: &AwsRequest, bucket: &str, key: &str) -> String {
+    match req
+        .headers
+        .get(http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .filter(|h| !h.is_empty())
+    {
+        Some(host) => format!("http://{host}/{bucket}/{key}"),
+        None => format!("/{bucket}/{key}"),
+    }
+}
+
 /// `x-amz-credential` is `{access_key}/{date}/{region}/{service}/aws4_request`.
 struct ParsedCredential {
     access_key: String,
@@ -352,7 +411,7 @@ impl S3Service {
             .or_else(|| form.file_content_type.clone())
             .unwrap_or_else(|| "binary/octet-stream".to_string());
 
-        // --- Policy validation ---
+        // --- Decode the policy document ---
         let policy_b64 = form
             .field_lower("policy")
             .ok_or_else(|| invalid_argument("POST Object requires a `policy` form field"))?
@@ -363,28 +422,11 @@ impl S3Service {
         let policy: serde_json::Value = serde_json::from_slice(&policy_bytes)
             .map_err(|_| invalid_argument("`policy` is not valid JSON"))?;
 
-        if let Some(expiration) = policy.get("expiration").and_then(|v| v.as_str()) {
-            let expires_at = chrono::DateTime::parse_from_rfc3339(expiration)
-                .map_err(|_| invalid_argument("policy `expiration` is not valid RFC3339"))?
-                .with_timezone(&Utc);
-            if Utc::now() > expires_at {
-                return Err(access_denied(
-                    "Invalid according to Policy: Policy expired.",
-                ));
-            }
-        }
-
-        let conditions = parse_conditions(&policy)?;
-        enforce_conditions(
-            &conditions,
-            bucket,
-            &resolved_key,
-            &object_content_type,
-            form.file_bytes.len() as u64,
-            &form,
-        )?;
-
         // --- Signature verification ---
+        // Authenticate the policy signature *before* evaluating the policy's
+        // conditions, matching real S3's precedence: a request that both
+        // carries a bad signature and violates a condition is rejected as
+        // `SignatureDoesNotMatch`, not `AccessDenied`.
         let algorithm = form.field_lower("x-amz-algorithm").unwrap_or_default();
         if !algorithm.is_empty() && !algorithm.eq_ignore_ascii_case("AWS4-HMAC-SHA256") {
             return Err(invalid_argument(format!(
@@ -431,6 +473,36 @@ impl S3Service {
             }
         }
 
+        // --- Policy validation (expiration + conditions) ---
+        // Real S3 requires the policy to carry an `expiration`; a policy
+        // without one is rejected rather than treated as never-expiring.
+        let expiration = policy
+            .get("expiration")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                invalid_argument("Invalid Policy: policy document must contain an `expiration`")
+            })?;
+        let expires_at = chrono::DateTime::parse_from_rfc3339(expiration)
+            .map_err(|_| invalid_argument("policy `expiration` is not valid RFC3339"))?
+            .with_timezone(&Utc);
+        if Utc::now() > expires_at {
+            return Err(access_denied(
+                "Invalid according to Policy: Policy expired.",
+            ));
+        }
+
+        let conditions = parse_conditions(&policy)?;
+        enforce_conditions(
+            &conditions,
+            bucket,
+            &resolved_key,
+            &object_content_type,
+            form.file_bytes.len() as u64,
+            &form,
+        )?;
+        // Every submitted field must be authorized by a policy condition.
+        enforce_no_extra_fields(&conditions, &form)?;
+
         // --- Store the object via the existing PutObject sink ---
         let mut synth_headers = HeaderMap::new();
         synth_headers.insert(
@@ -449,6 +521,7 @@ impl S3Service {
                 || lower == "content-disposition"
                 || lower == "content-encoding"
                 || lower == "content-language"
+                || lower == "content-md5"
                 || lower == "expires"
                 || lower.starts_with("x-amz-");
             if !forwardable {
@@ -494,17 +567,48 @@ impl S3Service {
             .to_string();
 
         // --- Build the POST Object response ---
-        let success_status = form
-            .field_lower("success_action_status")
-            .and_then(|s| s.parse::<u16>().ok())
-            .unwrap_or(204);
-
         let mut headers = HeaderMap::new();
         headers.insert(
             "etag",
             etag.parse()
                 .unwrap_or_else(|_| http::HeaderValue::from_static("\"\"")),
         );
+
+        // `success_action_redirect` (legacy alias `redirect`) takes precedence
+        // over `success_action_status`: on success S3 issues a 303 to the given
+        // URL with `bucket`, `key`, and `etag` appended as query parameters.
+        if let Some(redirect) = form
+            .field_lower("success_action_redirect")
+            .or_else(|| form.field_lower("redirect"))
+            .filter(|s| !s.is_empty())
+        {
+            let enc = |s: &str| {
+                percent_encoding::utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC)
+                    .to_string()
+            };
+            let sep = if redirect.contains('?') { '&' } else { '?' };
+            let target = format!(
+                "{redirect}{sep}bucket={}&key={}&etag={}",
+                enc(bucket),
+                enc(&resolved_key),
+                enc(etag.trim_matches('"')),
+            );
+            if let Ok(value) = target.parse() {
+                headers.insert("location", value);
+                return Ok(AwsResponse {
+                    status: StatusCode::SEE_OTHER,
+                    content_type: String::new(),
+                    body: Bytes::new().into(),
+                    headers,
+                });
+            }
+        }
+
+        let success_status = form
+            .field_lower("success_action_status")
+            .and_then(|s| s.parse::<u16>().ok())
+            .unwrap_or(204);
+        let location = object_url(req, bucket, &resolved_key);
 
         match success_status {
             200 => Ok(AwsResponse {
@@ -514,7 +618,6 @@ impl S3Service {
                 headers,
             }),
             201 => {
-                let location = format!("/{bucket}/{resolved_key}");
                 headers.insert(
                     "location",
                     location

--- a/crates/fakecloud-s3/src/service/objects/post_policy.rs
+++ b/crates/fakecloud-s3/src/service/objects/post_policy.rs
@@ -286,11 +286,15 @@ fn enforce_conditions(
 /// The whole POST-Policy security model is that the signed `conditions` list
 /// enumerates exactly which fields (and values) the browser may post; real S3
 /// rejects a request carrying a field with no matching condition with
-/// `AccessDenied` "Invalid according to Policy: Extra input fields: X". Only a
-/// small set of fields is exempt (they carry the signature material itself or
-/// are ignored by convention): `policy`, `x-amz-signature`, the `file` part,
-/// and any `x-ignore-*` field. `content-length-range` has no field name, so it
-/// authorizes nothing here (it governs the file size, checked separately).
+/// `AccessDenied` "Invalid according to Policy: Extra input fields: X". A small
+/// set of fields is exempt from needing a condition: the signature material
+/// itself (`policy`, `x-amz-signature`, `x-amz-algorithm`, `x-amz-credential`,
+/// `x-amz-date`, `x-amz-security-token`, and the SigV2 `awsaccesskeyid` /
+/// `signature`), the `file` part, and any `x-ignore-*` field. Real S3 does not
+/// require the signature-material fields to be enumerated in `conditions` (and
+/// a forged `x-amz-credential` is caught by the signature check regardless).
+/// `content-length-range` has no field name, so it authorizes nothing here (it
+/// governs the file size, checked separately).
 fn enforce_no_extra_fields(
     conditions: &[PolicyCondition],
     form: &ParsedForm,
@@ -309,10 +313,18 @@ fn enforce_no_extra_fields(
     }
     for f in &form.fields {
         let lower = f.name.to_ascii_lowercase();
-        let exempt = lower == "policy"
-            || lower == "x-amz-signature"
-            || lower == "file"
-            || lower.starts_with("x-ignore-");
+        let exempt = matches!(
+            lower.as_str(),
+            "policy"
+                | "x-amz-signature"
+                | "x-amz-algorithm"
+                | "x-amz-credential"
+                | "x-amz-date"
+                | "x-amz-security-token"
+                | "awsaccesskeyid"
+                | "signature"
+                | "file"
+        ) || lower.starts_with("x-ignore-");
         if exempt {
             continue;
         }
@@ -582,10 +594,15 @@ impl S3Service {
             .or_else(|| form.field_lower("redirect"))
             .filter(|s| !s.is_empty())
         {
-            let enc = |s: &str| {
-                percent_encoding::utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC)
-                    .to_string()
-            };
+            // Query-component encoding: percent-encode everything unsafe but
+            // leave the RFC 3986 unreserved characters (`-._~`) intact, the way
+            // real S3 encodes the redirect query rather than over-escaping.
+            const QUERY_ENC: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+                .remove(b'-')
+                .remove(b'.')
+                .remove(b'_')
+                .remove(b'~');
+            let enc = |s: &str| percent_encoding::utf8_percent_encode(s, QUERY_ENC).to_string();
             let sep = if redirect.contains('?') { '&' } else { '?' };
             let target = format!(
                 "{redirect}{sep}bucket={}&key={}&etag={}",

--- a/crates/fakecloud-s3/src/service/objects/post_policy.rs
+++ b/crates/fakecloud-s3/src/service/objects/post_policy.rs
@@ -417,14 +417,14 @@ impl S3Service {
                     "The AWS Access Key Id you provided does not exist in our records.",
                 )
             })?;
-            let expected = fakecloud_aws::sigv4::sign_string(
+            if !fakecloud_aws::sigv4::verify_signature(
                 &resolved.secret_access_key,
                 &credential.date_stamp,
                 &credential.region,
                 &credential.service,
                 &policy_b64,
-            );
-            if !expected.eq_ignore_ascii_case(signature) {
+                signature,
+            ) {
                 return Err(signature_does_not_match(
                     "The request signature we calculated does not match the signature you provided",
                 ));

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2323,7 +2323,12 @@ async fn main() {
     registry.register(Arc::new(
         S3Service::with_store(s3_state.clone(), delivery_for_s3, s3_store.clone())
             .with_kms(kms_state.clone())
-            .with_kms_hook(kms_hook_for_services.clone()),
+            .with_kms_hook(kms_hook_for_services.clone())
+            .with_credential_resolver(
+                fakecloud_iam::credential_resolver::IamCredentialResolver::shared(
+                    iam_state.clone(),
+                ),
+            ),
     ));
     // Snapshot store is only wired in persistent mode. In memory mode we
     // leave it unset so the service doesn't pay the per-mutation

--- a/website/content/docs/services/s3.md
+++ b/website/content/docs/services/s3.md
@@ -9,6 +9,7 @@ fakecloud implements **107 of 107** S3 operations at 100% Smithy conformance.
 ## Supported features
 
 - **Objects** — GET/PUT/DELETE/HEAD, versioning, delete markers, metadata, tags, ACLs
+- **POST Object (browser POST Policy)** — the `multipart/form-data` upload targeted by boto3's `generate_presigned_post` / the JS SDK's `createPresignedPost` / HTML form uploads. The signed base64 policy is verified (SigV4 over the policy document, checked against the caller's IAM secret; `test*` root-bypass keys skip the crypto check), its `expiration` and `conditions` (`eq`, `starts-with`, `content-length-range`) are enforced, and any form field not authorized by a condition is rejected with `AccessDenied`. `${filename}` in the key is substituted, and the response honors `success_action_status` (204 default, 200/201 with `PostResponse` XML) and `success_action_redirect` (303 to the given URL with `bucket`/`key`/`etag` appended).
 - **Multipart uploads** — full lifecycle; resumable across restarts in persistent mode. `CompleteMultipartUpload` emits `s3:ObjectCreated:CompleteMultipartUpload` with the full-object checksum.
 - **Lifecycle** — expiration and storage class transitions via `/_fakecloud/s3/lifecycle-processor/tick`
 - **Notifications** — delivery to SNS, SQS, Lambda, and EventBridge on object create/delete


### PR DESCRIPTION
## What
Implements the S3 **POST Object** operation — the browser-form / "POST Policy" upload that `boto3`'s `generate_presigned_post`, the AWS JS SDK, and HTML form uploads target. Currently a `POST` to the bucket root falls through to `405 MethodNotAllowed`.

## Why
POST Policy is the standard way to let a browser upload directly to a bucket under a server-signed policy that constrains `content-length-range` and exact/`starts-with` field conditions — with no equivalent on presigned PUT. It's currently unsupported, so SDKs that use it can't be exercised against fakecloud.

## How
- New dispatch arm for `POST /{bucket}` guarded on a `multipart/form-data` Content-Type (doesn't shadow the existing `?delete`/metadata POST arms, which carry their own query guards), placed before the 405 fall-through.
- New `crates/fakecloud-s3/src/service/objects/post_policy.rs`: multipart parse (`multer`), `${filename}` key substitution, base64/JSON policy decode, `expiration` check, and all three condition shapes (`eq`, `starts-with`, `content-length-range`), then storage via the existing `put_object` sink and faithful response shaping (204 default; 200/201 via `success_action_status`, incl. the `PostResponse` XML with Location/Bucket/Key/ETag).
- **Full SigV4 signature verification** of the `x-amz-signature` form field: new `pub fn sign_string` + `verify_signature` in `fakecloud-aws/src/sigv4.rs` reuse the standard signing-key derivation over the base64 policy string, with a constant-time compare (same primitive as the header/query path). Non-root callers are verified against their IAM secret via a new optional `credential_resolver` on `S3Service` (wired through the same `IamCredentialResolver` dispatch already uses); `test*` root-bypass keys skip crypto per the existing `is_root_bypass` convention.

## Tests
New `crates/fakecloud-e2e/tests/s3_post_object.rs` (hand-signed `reqwest` multipart, since the Rust SDK has no POST-Policy method): valid upload stored + retrievable, oversized upload rejected by `content-length-range` and not stored, signature mismatch rejected, and a real IAM-user signature accepted. `cargo test -p fakecloud-e2e --test s3_post_object` → 4 passed; existing `cargo test -p fakecloud-s3` → 372 passed; `cargo clippy` clean.

## Notes for reviewers
- `content-length-range` violations return `EntityTooSmall`/`EntityTooLarge`; worth a byte-exact check vs. real S3's POST-specific codes if you want strict fidelity.
- Only `AWS4-HMAC-SHA256` is accepted (what boto3/JS SDK emit).
- New deps: `multer`, `futures-util`, direct `axum` in `fakecloud-s3`; `hmac`/`hex` e2e dev-deps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds S3 POST Object (browser-form POST Policy) so browsers and SDKs using presigned POST can upload directly to buckets. Verifies SigV4 on the base64 policy, enforces conditions and expiration, and returns S3-like responses including redirects.

- **New Features**
  - New POST `/{bucket}` for `multipart/form-data`; parses form with `multer`, resolves `${filename}`, decodes policy, and enforces `eq`, `starts-with`, `content-length-range`, and required `expiration`. Rejects extra form fields not authorized by the policy (signature-material fields like `x-amz-*`/`awsaccesskeyid`/`signature` are exempt).
  - Verifies `x-amz-signature` first (SigV4 over the base64 policy via `fakecloud_aws::sigv4::verify_signature`); uses the IAM credential resolver for non-root keys; `test*` root-bypass keys skip crypto.
  - Stores via PutObject, forwarding relevant headers (e.g., `Content-Type`, `Content-MD5`, `x-amz-*`, cache/content headers).
  - Responses: honors `success_action_status` (204 default; 200/201 with absolute `Location` and `PostResponse` XML) and `success_action_redirect` (303 to the URL with `bucket`/`key`/`etag`, preserving unreserved characters in the query).

- **Dependencies**
  - Added `multer`, `futures-util`, and `axum`.
  - Enabled `reqwest` `multipart` feature; test-only adds `hmac`, `hex`, and `uuid`.

<sup>Written for commit 8d07d6df4a798d4ac0867563faa3039b238274b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

