### PR TITLE
style: fix clippy lints surfaced by rust 1.97

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/elasticbeanstalk.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/elasticbeanstalk.rs
@@ -671,7 +671,7 @@ fn build_endpoint_url(env_id: &str, region: &str) -> String {
     let hash = Uuid::new_v4().simple().to_string();
     format!(
         "awseb-{env_id}-AWSEBLoa{}-{}.{region}.elb.amazonaws.com",
-        &hash[..8].to_uppercase(),
+        hash[..8].to_uppercase(),
         &hash[8..16]
     )
 }

--- a/crates/fakecloud-cognito/src/service/identity_pools.rs
+++ b/crates/fakecloud-cognito/src/service/identity_pools.rs
@@ -857,7 +857,7 @@ impl CognitoIdentityService {
                 .and_then(|s| s.roles.get(role_name).map(|r| r.role_id.clone()))
                 .unwrap_or_else(generate_role_id)
         };
-        let session_name = format!("CognitoIdentityCredentials-{}", &identity_id);
+        let session_name = format!("CognitoIdentityCredentials-{}", identity_id);
         let assumed_role_arn =
             format!("arn:aws:sts::{target_account}:assumed-role/{role_name}/{session_name}");
         let assumed_role_id = format!("{role_id}:{session_name}");

--- a/crates/fakecloud-dms/src/service.rs
+++ b/crates/fakecloud-dms/src/service.rs
@@ -2228,7 +2228,7 @@ impl DmsService {
         let name = opt_str(b, "DataProviderName")
             .filter(|s| !s.is_empty())
             .map(String::from)
-            .unwrap_or_else(|| format!("data-provider-{}", &res_id()[..8].to_lowercase()));
+            .unwrap_or_else(|| format!("data-provider-{}", res_id()[..8].to_lowercase()));
         let mut guard = self.state.write();
         let data = guard.get_or_create(&ctx.account);
         if data
@@ -2374,7 +2374,7 @@ impl DmsService {
         let name = opt_str(b, "InstanceProfileName")
             .filter(|s| !s.is_empty())
             .map(String::from)
-            .unwrap_or_else(|| format!("instance-profile-{}", &res_id()[..8].to_lowercase()));
+            .unwrap_or_else(|| format!("instance-profile-{}", res_id()[..8].to_lowercase()));
         let mut guard = self.state.write();
         let data = guard.get_or_create(&ctx.account);
         if data
@@ -2524,7 +2524,7 @@ impl DmsService {
         let name = opt_str(b, "MigrationProjectName")
             .filter(|s| !s.is_empty())
             .map(String::from)
-            .unwrap_or_else(|| format!("migration-project-{}", &res_id()[..8].to_lowercase()));
+            .unwrap_or_else(|| format!("migration-project-{}", res_id()[..8].to_lowercase()));
         let mut guard = self.state.write();
         let data = guard.get_or_create(&ctx.account);
         if data
@@ -2890,7 +2890,7 @@ impl DmsService {
         let name = opt_str(b, "DataMigrationName")
             .filter(|s| !s.is_empty())
             .map(String::from)
-            .unwrap_or_else(|| format!("data-migration-{}", &res_id()[..8].to_lowercase()));
+            .unwrap_or_else(|| format!("data-migration-{}", res_id()[..8].to_lowercase()));
         let mut guard = self.state.write();
         let data = guard.get_or_create(&ctx.account);
         if data

--- a/crates/fakecloud-docdb/src/service.rs
+++ b/crates/fakecloud-docdb/src/service.rs
@@ -1302,7 +1302,7 @@ impl DocDbService {
                 req.region, req.account_id
             ),
             db_subnet_group_description: description,
-            vpc_id: format!("vpc-{}", &resource_token()[..12].to_lowercase()),
+            vpc_id: format!("vpc-{}", resource_token()[..12].to_lowercase()),
             subnet_group_status: "Complete".to_string(),
             subnets,
             tags: parse_tags(req),

--- a/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
@@ -402,10 +402,9 @@ pub(crate) fn evaluate_size_comparison(
         ("<", rest.trim())
     } else if let Some(rest) = remainder.strip_prefix('>') {
         (">", rest.trim())
-    } else if let Some(rest) = remainder.strip_prefix('=') {
-        ("=", rest.trim())
     } else {
-        return None;
+        let rest = remainder.strip_prefix('=')?;
+        ("=", rest.trim())
     };
 
     let actual_owned = resolve_path(path, item, expr_attr_names)?;

--- a/crates/fakecloud-elasticbeanstalk/src/service.rs
+++ b/crates/fakecloud-elasticbeanstalk/src/service.rs
@@ -578,7 +578,7 @@ fn build_endpoint_url(env_id: &str, region: &str) -> String {
     let hash = Uuid::new_v4().simple().to_string();
     format!(
         "awseb-{env_id}-AWSEBLoa{}-{}.{region}.elb.amazonaws.com",
-        &hash[..8].to_uppercase(),
+        hash[..8].to_uppercase(),
         &hash[8..16]
     )
 }

--- a/crates/fakecloud-elbv2/src/dataplane.rs
+++ b/crates/fakecloud-elbv2/src/dataplane.rs
@@ -954,7 +954,7 @@ fn redirect_action(
     };
     let port = cfg.port.clone();
     let port_seg = port
-        .and_then(|p| if p == "#{port}" { None } else { Some(p) })
+        .filter(|p| p != "#{port}")
         .map(|p| format!(":{p}"))
         .unwrap_or_default();
     // Only the scheme and host are case-insensitive; path and query

--- a/crates/fakecloud-iam/src/sts_service/assume.rs
+++ b/crates/fakecloud-iam/src/sts_service/assume.rs
@@ -672,7 +672,7 @@ impl StsService {
         let role_name = role_arn.rsplit('/').next().unwrap_or("unknown");
         let assumed_role_arn = format!(
             "arn:{}:sts::{}:assumed-role/{}/{}",
-            partition, account_id, role_name, &role_session_name
+            partition, account_id, role_name, role_session_name
         );
         let assumed_role_id_str = format!("{}:{}", role_id, role_session_name);
 

--- a/crates/fakecloud-neptune/src/service.rs
+++ b/crates/fakecloud-neptune/src/service.rs
@@ -1780,7 +1780,7 @@ impl NeptuneService {
                 req.region, req.account_id
             ),
             db_subnet_group_description: description,
-            vpc_id: format!("vpc-{}", &resource_token()[..12].to_lowercase()),
+            vpc_id: format!("vpc-{}", resource_token()[..12].to_lowercase()),
             subnet_group_status: "Complete".to_string(),
             subnets,
             tags: parse_tags(req),

--- a/crates/fakecloud-organizations/src/service/tests.rs
+++ b/crates/fakecloud-organizations/src/service/tests.rs
@@ -130,7 +130,7 @@ async fn member_non_management_delete_returns_access_denied() {
         let org_id = org.org_id.clone();
         let arn = format!(
             "arn:aws:organizations::111111111111:account/{}/{}",
-            org_id, &account_id
+            org_id, account_id
         );
         org.accounts.insert(
             account_id.clone(),

--- a/crates/fakecloud-route53/src/service/mod.rs
+++ b/crates/fakecloud-route53/src/service/mod.rs
@@ -867,10 +867,9 @@ fn lookup_s3_addresses(
         &lower[..idx]
     } else if let Some(idx) = lower.find(".s3.") {
         &lower[..idx]
-    } else if let Some(idx) = lower.find(".s3-") {
-        &lower[..idx]
     } else {
-        return None;
+        let idx = lower.find(".s3-")?;
+        &lower[..idx]
     };
     if bucket.is_empty() {
         return None;

--- a/crates/fakecloud-scheduler/src/ticker.rs
+++ b/crates/fakecloud-scheduler/src/ticker.rs
@@ -705,12 +705,12 @@ mod tests {
         // Tick 1: initial fire fails, retry queued.
         ticker.tick(&mut cron, &mut pending, &mut retries);
         // Manually advance the pending fire so the next tick can pick it up.
-        for (_, p) in pending.iter_mut() {
+        for p in pending.values_mut() {
             p.fire_at = Utc::now() - chrono::Duration::seconds(1);
         }
         // Tick 2: first retry, fails, second retry queued.
         ticker.tick(&mut cron, &mut pending, &mut retries);
-        for (_, p) in pending.iter_mut() {
+        for p in pending.values_mut() {
             p.fire_at = Utc::now() - chrono::Duration::seconds(1);
         }
         // Tick 3: second retry, fails, retry budget exhausted -> DLQ.
@@ -773,7 +773,7 @@ mod tests {
         );
 
         // Advance the pending timestamp into the past and tick again.
-        for (_, p) in pending.iter_mut() {
+        for p in pending.values_mut() {
             p.fire_at = Utc::now() - chrono::Duration::seconds(1);
         }
         ticker.tick(&mut cron, &mut pending, &mut retries);
@@ -905,12 +905,12 @@ mod tests {
         // Tick 1: initial fire fails (call #1), retry queued.
         ticker.tick(&mut cron, &mut pending, &mut retries);
         assert_eq!(retries.len(), 1, "retry state must be tracked");
-        for (_, p) in pending.iter_mut() {
+        for p in pending.values_mut() {
             p.fire_at = Utc::now() - chrono::Duration::seconds(1);
         }
         // Tick 2: first retry fails (call #2), retry queued.
         ticker.tick(&mut cron, &mut pending, &mut retries);
-        for (_, p) in pending.iter_mut() {
+        for p in pending.values_mut() {
             p.fire_at = Utc::now() - chrono::Duration::seconds(1);
         }
         // Tick 3: second retry succeeds (call #3) -> retry state cleared.

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -10881,7 +10881,7 @@ async fn main() {
                 move || async move {
                     let accounts = bas.read();
                     let mut out: Vec<serde_json::Value> = Vec::new();
-                    for (_acct, state) in accounts.accounts.iter() {
+                    for state in accounts.accounts.values() {
                         for (agent_id, agent) in state.agents.iter() {
                             let aliases: Vec<serde_json::Value> = state
                                 .agent_aliases
@@ -10970,7 +10970,7 @@ async fn main() {
                 move || async move {
                     let accounts = bars.read();
                     let mut out: Vec<serde_json::Value> = Vec::new();
-                    for (_acct, state) in accounts.accounts.iter() {
+                    for state in accounts.accounts.values() {
                         for inv in state.invocations.iter() {
                             out.push(serde_json::json!({
                                 "invocationId": inv.invocation_id,

--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -403,7 +403,7 @@ impl SsmService {
         let target_id = format!(
             "{}-{}",
             window_id,
-            &uuid::Uuid::new_v4().to_string().replace('-', "")
+            uuid::Uuid::new_v4().to_string().replace('-', "")
         );
 
         let mut accounts = self.state.write();
@@ -524,7 +524,7 @@ impl SsmService {
         let task_id = format!(
             "{}-{}",
             window_id,
-            &uuid::Uuid::new_v4().to_string().replace('-', "")
+            uuid::Uuid::new_v4().to_string().replace('-', "")
         );
 
         let mut accounts = self.state.write();


### PR DESCRIPTION
## Summary
Rust 1.97 stable tightened `clippy::useless_borrows_in_formatting` and `clippy::question_mark`, turning previously-clean code across 14 crates into `-D warnings` failures. CI's clippy job (floating stable) now fails on `main` and every open PR.

Mechanical fixes via `cargo clippy --workspace --all-targets --fix` (rustfix-verified semantic-equivalent). No behavior change. Unblocks all in-flight PRs.

Crates touched: cloudformation, cognito, dms, docdb, dynamodb, elasticbeanstalk, elbv2, iam, neptune, organizations(tests), route53, scheduler, server, ssm.

## Test plan
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo build --workspace` — clean.
- `cargo fmt --all --check` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Clippy lints introduced in Rust 1.97 across 14 crates to restore green CI. Mechanical cleanups only; no behavior changes.

- **Refactors**
  - Address `clippy::useless_borrows_in_formatting` by removing needless `&` in `format!` and slices.
  - Address `clippy::question_mark` by using `?`/Option combinators (e.g., `strip_prefix('=')?`, `.filter(|p| p != "#{port}")`).
  - Simplify iteration by using `.values()`/`.values_mut()` and avoiding unused tuple bindings.

<sup>Written for commit 62fa5564e182ae108d3130de941cdc88245d70b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

