### PR TITLE
ci(docker): trivyignore CVE-2026-39822 (Go stdlib in bundled docker CLI)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,15 @@
+# CVE-2026-39822 — Go stdlib os.Root symlink-following vulnerability (HIGH),
+# fixed upstream in go1.26.5 / 1.27.0-rc.2.
+#
+# Present ONLY in the bundled static Docker CLI (/usr/local/bin/docker, from the
+# docker-cli build stage), which is compiled with go1.26.4. As of 2026-07-12 no
+# Docker static release ships a go>=1.26.5 toolchain (latest 29.6.1 is still on
+# go1.26.4), so the CLI version cannot yet be bumped past it.
+#
+# Not exploitable in fakecloud's usage: fakecloud shells out to the docker CLI
+# purely for container lifecycle (run/exec/cp/rm) and never invokes the os.Root
+# symlink-traversal code path. Our own binary is Rust.
+#
+# REMOVE this entry once a Docker static release built with go>=1.26.5 exists and
+# DOCKER_CLI_VERSION in the Dockerfile is bumped to it.
+CVE-2026-39822


### PR DESCRIPTION
## Summary
The `Docker` workflow's Trivy scan gate started failing on `main` (SageMaker merge 02ec8ef and every subsequent merge) with one HIGH finding:

`CVE-2026-39822` — Go stdlib `os.Root` symlink-following, fixed in go1.26.5 / 1.27.0-rc.2.

It's in the **bundled static Docker CLI** (`/usr/local/bin/docker`, docker-cli build stage), compiled with go1.26.4. As of 2026-07-12 **no Docker static release ships go≥1.26.5** (latest 29.6.1 is still go1.26.4), so `DOCKER_CLI_VERSION` cannot yet be bumped past it (which is how the prior Go-stdlib CVE was cleared).

Not exploitable in fakecloud's usage — the CLI is shelled out purely for container lifecycle (run/exec/cp/rm) and never invokes the `os.Root` traversal path; fakecloud's own binary is Rust. This is a newly-published CVE (time-based DB update), unrelated to any code change.

Adds a scoped, dated `.trivyignore` (read by the trivy-action from the repo root) with an explicit **remove-when** condition: drop it once a docker static build with go≥1.26.5 exists and the Dockerfile is bumped to it.

## Test plan
- Docker build + push already succeed; only the scan gate failed.
- With `.trivyignore` present, the Trivy step no longer fails on this single not-exploitable, not-yet-fixable finding; the CRITICAL/HIGH gate still enforces every other vuln.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `.trivyignore` entry to suppress CVE-2026-39822 in the bundled static Docker CLI so the Docker workflow’s Trivy gate passes until Docker ships a Go ≥1.26.5 build. The CRITICAL/HIGH gate stays on for all other issues; we’ll remove this after bumping `DOCKER_CLI_VERSION` in the `Dockerfile`.

<sup>Written for commit 0ade3b63b593bfcba347a13d1c2b29327fdcff8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

