### PR TITLE
ci(docker): apply .trivyignore via trivyignores input

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -189,5 +189,6 @@ jobs:
           format: table
           exit-code: '1'
           ignore-unfixed: true
+          trivyignores: .trivyignore
           vuln-type: os,library
           severity: CRITICAL,HIGH


### PR DESCRIPTION
## Summary
Follow-up to #2225. The trivy-action does NOT auto-read `.trivyignore` from the repo root — the scan job's `INPUT_TRIVYIGNORES` was empty, so `CVE-2026-39822` was still flagged and the Docker scan gate stayed red on `main`.

Sets `trivyignores: .trivyignore` on the Trivy step so the ignore file (added in #2225) is actually applied. Every other CRITICAL/HIGH still gates.

## Test plan
- Docker workflow runs on `main` push; the scan step will now load `.trivyignore` and pass on the single not-exploitable, not-yet-fixable Go-stdlib finding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly pass `.trivyignore` to the Trivy scan so the Docker workflow honors our ignore list. Prevents failures on the single allowed finding while keeping CRITICAL/HIGH gating unchanged.

- **Bug Fixes**
  - Set `trivyignores: .trivyignore` in `.github/workflows/docker.yml` because the action doesn’t auto-load it, ensuring the not‑exploitable, unfixed Go stdlib CVE is ignored.

<sup>Written for commit f49872a6c0fe7ea0e7b8d77d32a47a06d5b01aa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

