### PR TITLE
ci(docker): checkout repo in scan job so Trivy finds .trivyignore

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -166,6 +166,12 @@ jobs:
       packages: read
 
     steps:
+      # The Trivy step reads .trivyignore from the workspace, so the repo must be
+      # checked out here — the scan job otherwise starts from an empty workspace
+      # (it only pulls the published image), and trivy-action fails hard with
+      # "cannot find ignorefile '.trivyignore'".
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:


### PR DESCRIPTION
## Summary

The Docker `scan` job runs Trivy against the published image but never checked out the repo, so its workspace was empty and `trivy-action` failed hard:

```
ERROR: cannot find ignorefile '.trivyignore'.
##[error]Process completed with exit code 1.
```

The `.trivyignore` CVE-2026-39822 suppression added in #2225 / wired via `trivyignores:` in #2226 could therefore never be read — the scan kept failing on main. Fix: add `actions/checkout` before the Trivy step so `.trivyignore` is present in the workspace.

## Test plan
- `build` + `merge` (sign) already pass; only `scan` was red.
- Runs on push to main after merge; confirm the `scan` job goes green (Trivy reads the ignore file, CVE-2026-39822 suppressed, no other CRITICAL/HIGH).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `actions/checkout` to the Docker `scan` job so `trivy-action` can read `.trivyignore`, enabling the CVE-2026-39822 suppression and fixing the failing scan on main.

<sup>Written for commit 7c4c12a7619ff6090b415c89e9a94af787f4ad25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

