### PR TITLE
fix(pinpoint): 404 on writes to missing app; real RemoveAttributes; journey-metric existence checks

### DIFF
--- a/crates/fakecloud-e2e/tests/pinpoint.rs
+++ b/crates/fakecloud-e2e/tests/pinpoint.rs
@@ -7,7 +7,7 @@
 use aws_sdk_pinpoint::types::{
     ApnsChannelRequest, CreateApplicationRequest, DirectMessageConfiguration, EmailTemplateRequest,
     EndpointRequest, GcmChannelRequest, MessageRequest, SmsChannelRequest, SmsMessage, TagsModel,
-    WriteCampaignRequest, WriteJourneyRequest, WriteSegmentRequest,
+    UpdateAttributesRequest, WriteCampaignRequest, WriteJourneyRequest, WriteSegmentRequest,
 };
 use fakecloud_testkit::TestServer;
 
@@ -242,4 +242,133 @@ async fn pinpoint_full_lifecycle() {
         .expect("delete_app");
     let after = client.get_app().application_id(&app_id).send().await;
     assert!(after.is_err(), "app should be gone after delete");
+}
+
+/// Writing to a non-existent application must 404 (AWS requires the parent app
+/// to exist) and must NOT auto-vivify a phantom app. A phantom app is stored as
+/// a null record, which corrupts the account-wide `GetApps`/`GetApp` reads
+/// (the SDK rejects a null `ApplicationResponse`). Regression guard.
+#[tokio::test]
+async fn pinpoint_write_to_missing_app_404s_without_corrupting_get_apps() {
+    let server = TestServer::start().await;
+    let client = pinpoint_client(&server).await;
+
+    let bogus = "00000000000000000000000000000000";
+
+    // A create/upsert against a missing app must error, not silently succeed.
+    let campaign = client
+        .create_campaign()
+        .application_id(bogus)
+        .write_campaign_request(WriteCampaignRequest::builder().name("nope").build())
+        .send()
+        .await;
+    assert!(campaign.is_err(), "create_campaign on missing app must 404");
+
+    let channel = client
+        .update_sms_channel()
+        .application_id(bogus)
+        .sms_channel_request(SmsChannelRequest::builder().enabled(true).build())
+        .send()
+        .await;
+    assert!(channel.is_err(), "update_sms_channel on missing app must 404");
+
+    let endpoint = client
+        .update_endpoint()
+        .application_id(bogus)
+        .endpoint_id("e1")
+        .endpoint_request(EndpointRequest::builder().channel_type(aws_sdk_pinpoint::types::ChannelType::Sms).build())
+        .send()
+        .await;
+    assert!(endpoint.is_err(), "update_endpoint on missing app must 404");
+
+    // The failed writes must not have poisoned the account: GetApps must still
+    // deserialize (no null element) and must not list the phantom id.
+    let apps = client
+        .get_apps()
+        .send()
+        .await
+        .expect("get_apps must still deserialize after failed writes");
+    let listed: Vec<String> = apps
+        .applications_response()
+        .and_then(|r| r.item())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|a| a.id().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        !listed.iter().any(|id| id == bogus),
+        "phantom app must not appear in GetApps"
+    );
+}
+
+/// `RemoveAttributes` must actually strip the blacklisted keys from every
+/// endpoint's attribute map, not return an empty no-op envelope.
+#[tokio::test]
+async fn pinpoint_remove_attributes_strips_endpoint_attributes() {
+    let server = TestServer::start().await;
+    let client = pinpoint_client(&server).await;
+
+    let app = client
+        .create_app()
+        .create_application_request(CreateApplicationRequest::builder().name("attr-app").build())
+        .send()
+        .await
+        .expect("create_app");
+    let app_id = app
+        .application_response()
+        .and_then(|a| a.id())
+        .expect("app id")
+        .to_string();
+
+    client
+        .update_endpoint()
+        .application_id(&app_id)
+        .endpoint_id("ep1")
+        .endpoint_request(
+            EndpointRequest::builder()
+                .channel_type(aws_sdk_pinpoint::types::ChannelType::Sms)
+                .attributes("interests", vec!["a".into(), "b".into()])
+                .attributes("keep", vec!["x".into()])
+                .build(),
+        )
+        .send()
+        .await
+        .expect("update_endpoint");
+
+    let removed = client
+        .remove_attributes()
+        .application_id(&app_id)
+        .attribute_type("endpoint-custom-attributes")
+        .update_attributes_request(
+            UpdateAttributesRequest::builder().blacklist("interests").build(),
+        )
+        .send()
+        .await
+        .expect("remove_attributes");
+    assert!(
+        removed
+            .attributes_resource()
+            .and_then(|r| r.attributes())
+            .map(|a| a.iter().any(|k| k == "interests"))
+            .unwrap_or(false),
+        "response should report the removed attribute"
+    );
+
+    let ep = client
+        .get_endpoint()
+        .application_id(&app_id)
+        .endpoint_id("ep1")
+        .send()
+        .await
+        .expect("get_endpoint");
+    let attrs = ep
+        .endpoint_response()
+        .and_then(|e| e.attributes())
+        .cloned()
+        .unwrap_or_default();
+    assert!(!attrs.contains_key("interests"), "removed key must be gone");
+    assert!(attrs.contains_key("keep"), "other keys must remain");
 }

--- a/crates/fakecloud-e2e/tests/pinpoint.rs
+++ b/crates/fakecloud-e2e/tests/pinpoint.rs
@@ -270,13 +270,20 @@ async fn pinpoint_write_to_missing_app_404s_without_corrupting_get_apps() {
         .sms_channel_request(SmsChannelRequest::builder().enabled(true).build())
         .send()
         .await;
-    assert!(channel.is_err(), "update_sms_channel on missing app must 404");
+    assert!(
+        channel.is_err(),
+        "update_sms_channel on missing app must 404"
+    );
 
     let endpoint = client
         .update_endpoint()
         .application_id(bogus)
         .endpoint_id("e1")
-        .endpoint_request(EndpointRequest::builder().channel_type(aws_sdk_pinpoint::types::ChannelType::Sms).build())
+        .endpoint_request(
+            EndpointRequest::builder()
+                .channel_type(aws_sdk_pinpoint::types::ChannelType::Sms)
+                .build(),
+        )
         .send()
         .await;
     assert!(endpoint.is_err(), "update_endpoint on missing app must 404");
@@ -343,7 +350,9 @@ async fn pinpoint_remove_attributes_strips_endpoint_attributes() {
         .application_id(&app_id)
         .attribute_type("endpoint-custom-attributes")
         .update_attributes_request(
-            UpdateAttributesRequest::builder().blacklist("interests").build(),
+            UpdateAttributesRequest::builder()
+                .blacklist("interests")
+                .build(),
         )
         .send()
         .await

--- a/crates/fakecloud-e2e/tests/pinpoint.rs
+++ b/crates/fakecloud-e2e/tests/pinpoint.rs
@@ -297,14 +297,11 @@ async fn pinpoint_write_to_missing_app_404s_without_corrupting_get_apps() {
         .expect("get_apps must still deserialize after failed writes");
     let listed: Vec<String> = apps
         .applications_response()
-        .and_then(|r| r.item())
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(|a| a.id().map(str::to_string))
-                .collect()
-        })
-        .unwrap_or_default();
+        .map(|r| r.item())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|a| a.id().map(str::to_string))
+        .collect();
     assert!(
         !listed.iter().any(|id| id == bogus),
         "phantom app must not appear in GetApps"
@@ -360,9 +357,10 @@ async fn pinpoint_remove_attributes_strips_endpoint_attributes() {
     assert!(
         removed
             .attributes_resource()
-            .and_then(|r| r.attributes())
-            .map(|a| a.iter().any(|k| k == "interests"))
-            .unwrap_or(false),
+            .map(|r| r.attributes())
+            .unwrap_or_default()
+            .iter()
+            .any(|k| k == "interests"),
         "response should report the removed attribute"
     );
 

--- a/crates/fakecloud-pinpoint/src/service.rs
+++ b/crates/fakecloud-pinpoint/src/service.rs
@@ -519,7 +519,10 @@ fn is_mutating(action: &str) -> bool {
     action.starts_with("Create")
         || action.starts_with("Update")
         || action.starts_with("Delete")
-        || action.starts_with("Put")
+        // `PutEvents` ingests analytics events but persists nothing here, so it
+        // must not trigger a snapshot (unlike `PutEventStream`, which writes the
+        // app's event-stream config).
+        || (action.starts_with("Put") && action != "PutEvents")
         || action == "TagResource"
         || action == "UntagResource"
         || action == "RemoveAttributes"

--- a/crates/fakecloud-pinpoint/src/service/campaigns.rs
+++ b/crates/fakecloud-pinpoint/src/service/campaigns.rs
@@ -32,10 +32,9 @@ impl PinpointService {
         let id = shared::hex_id();
         let mut guard = self.state.write();
         let app = guard
-            .get_or_create(&ctx.account)
-            .apps
-            .entry(app_id.to_string())
-            .or_default();
+            .get_mut(&ctx.account)
+            .and_then(|d| d.apps.get_mut(app_id))
+            .ok_or_else(|| super::not_found_app(app_id))?;
         let record = build_campaign(ctx, app_id, &id, 1, body);
         app.campaigns.insert(
             id,

--- a/crates/fakecloud-pinpoint/src/service/channels.rs
+++ b/crates/fakecloud-pinpoint/src/service/channels.rs
@@ -40,10 +40,9 @@ impl PinpointService {
         let record = build_channel(app_id, channel, body);
         let mut guard = self.state.write();
         let app = guard
-            .get_or_create(&ctx.account)
-            .apps
-            .entry(app_id.to_string())
-            .or_default();
+            .get_mut(&ctx.account)
+            .and_then(|d| d.apps.get_mut(app_id))
+            .ok_or_else(|| super::not_found_app(app_id))?;
         app.channels.insert(channel.to_string(), record.clone());
         ok(record)
     }

--- a/crates/fakecloud-pinpoint/src/service/endpoints.rs
+++ b/crates/fakecloud-pinpoint/src/service/endpoints.rs
@@ -52,10 +52,9 @@ impl PinpointService {
         let record = build_endpoint(app_id, eid, body);
         let mut guard = self.state.write();
         let app = guard
-            .get_or_create(&ctx.account)
-            .apps
-            .entry(app_id.to_string())
-            .or_default();
+            .get_mut(&ctx.account)
+            .and_then(|d| d.apps.get_mut(app_id))
+            .ok_or_else(|| super::not_found_app(app_id))?;
         app.endpoints.insert(eid.to_string(), record);
         accepted(json!({ "Message": "Accepted", "RequestID": shared::hex_id() }))
     }
@@ -90,10 +89,9 @@ impl PinpointService {
             .unwrap_or_default();
         let mut guard = self.state.write();
         let app = guard
-            .get_or_create(&ctx.account)
-            .apps
-            .entry(app_id.to_string())
-            .or_default();
+            .get_mut(&ctx.account)
+            .and_then(|d| d.apps.get_mut(app_id))
+            .ok_or_else(|| super::not_found_app(app_id))?;
         for item in &items {
             let eid = item
                 .get("Id")
@@ -111,16 +109,51 @@ impl PinpointService {
         ctx: &Ctx,
         app_id: &str,
         attr_type: &str,
-        _body: &Value,
+        body: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
-        self.with_app(&ctx.account, app_id, |_| {
-            Ok(json!({
-                "ApplicationId": app_id,
-                "AttributeType": attr_type,
-                "Attributes": [],
-            }))
-        })
-        .and_then(ok)
+        // `AttributeType` selects which endpoint sub-map the blacklisted keys are
+        // stripped from, mirroring AWS: custom attributes + metrics live at the
+        // endpoint top level, user attributes under `User.UserAttributes`.
+        let field = match attr_type {
+            "endpoint-custom-metrics" => "Metrics",
+            "endpoint-user-attributes" => "UserAttributes",
+            _ => "Attributes",
+        };
+        let blacklist: Vec<String> = body
+            .get("Blacklist")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(Value::as_str)
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut guard = self.state.write();
+        let app = guard
+            .get_mut(&ctx.account)
+            .and_then(|d| d.apps.get_mut(app_id))
+            .ok_or_else(|| not_found_app(app_id))?;
+        for endpoint in app.endpoints.values_mut() {
+            let target = if field == "UserAttributes" {
+                endpoint
+                    .get_mut("User")
+                    .and_then(|u| u.get_mut("UserAttributes"))
+            } else {
+                endpoint.get_mut(field)
+            };
+            if let Some(Value::Object(map)) = target {
+                for key in &blacklist {
+                    map.remove(key);
+                }
+            }
+        }
+        ok(json!({
+            "ApplicationId": app_id,
+            "AttributeType": attr_type,
+            "Attributes": blacklist,
+        }))
     }
 
     pub(super) fn get_user_endpoints(

--- a/crates/fakecloud-pinpoint/src/service/jobs.rs
+++ b/crates/fakecloud-pinpoint/src/service/jobs.rs
@@ -22,10 +22,9 @@ impl PinpointService {
         let record = build_import_job(app_id, &id, body);
         let mut guard = self.state.write();
         let app = guard
-            .get_or_create(&ctx.account)
-            .apps
-            .entry(app_id.to_string())
-            .or_default();
+            .get_mut(&ctx.account)
+            .and_then(|d| d.apps.get_mut(app_id))
+            .ok_or_else(|| super::not_found_app(app_id))?;
         app.import_jobs.insert(id, record.clone());
         created(record)
     }
@@ -67,10 +66,9 @@ impl PinpointService {
         let record = build_export_job(app_id, &id, body);
         let mut guard = self.state.write();
         let app = guard
-            .get_or_create(&ctx.account)
-            .apps
-            .entry(app_id.to_string())
-            .or_default();
+            .get_mut(&ctx.account)
+            .and_then(|d| d.apps.get_mut(app_id))
+            .ok_or_else(|| super::not_found_app(app_id))?;
         app.export_jobs.insert(id, record.clone());
         created(record)
     }

--- a/crates/fakecloud-pinpoint/src/service/journeys.rs
+++ b/crates/fakecloud-pinpoint/src/service/journeys.rs
@@ -156,12 +156,7 @@ impl PinpointService {
     /// Error `NotFoundException` unless both the app and the journey exist — the
     /// KPI / execution-metric reads are journey-scoped, so AWS 404s on a missing
     /// app or journey rather than returning an empty metric envelope.
-    fn require_journey(
-        &self,
-        ctx: &Ctx,
-        app_id: &str,
-        jid: &str,
-    ) -> Result<(), AwsServiceError> {
+    fn require_journey(&self, ctx: &Ctx, app_id: &str, jid: &str) -> Result<(), AwsServiceError> {
         self.with_app(&ctx.account, app_id, |app| {
             app.journeys
                 .get(jid)

--- a/crates/fakecloud-pinpoint/src/service/journeys.rs
+++ b/crates/fakecloud-pinpoint/src/service/journeys.rs
@@ -32,10 +32,9 @@ impl PinpointService {
         let record = build_journey(app_id, &id, "DRAFT", body);
         let mut guard = self.state.write();
         let app = guard
-            .get_or_create(&ctx.account)
-            .apps
-            .entry(app_id.to_string())
-            .or_default();
+            .get_mut(&ctx.account)
+            .and_then(|d| d.apps.get_mut(app_id))
+            .ok_or_else(|| super::not_found_app(app_id))?;
         app.journeys.insert(id, record.clone());
         created(record)
     }
@@ -154,13 +153,31 @@ impl PinpointService {
         ok(json!({ "Item": [] }))
     }
 
+    /// Error `NotFoundException` unless both the app and the journey exist — the
+    /// KPI / execution-metric reads are journey-scoped, so AWS 404s on a missing
+    /// app or journey rather than returning an empty metric envelope.
+    fn require_journey(
+        &self,
+        ctx: &Ctx,
+        app_id: &str,
+        jid: &str,
+    ) -> Result<(), AwsServiceError> {
+        self.with_app(&ctx.account, app_id, |app| {
+            app.journeys
+                .get(jid)
+                .map(|_| ())
+                .ok_or_else(|| not_found_journey(jid))
+        })
+    }
+
     pub(super) fn get_journey_kpi(
         &self,
-        _ctx: &Ctx,
+        ctx: &Ctx,
         app_id: &str,
         jid: &str,
         kpi_name: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
+        self.require_journey(ctx, app_id, jid)?;
         ok(json!({
             "ApplicationId": app_id,
             "JourneyId": jid,
@@ -173,10 +190,11 @@ impl PinpointService {
 
     pub(super) fn get_journey_execution_metrics(
         &self,
-        _ctx: &Ctx,
+        ctx: &Ctx,
         app_id: &str,
         jid: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
+        self.require_journey(ctx, app_id, jid)?;
         ok(json!({
             "ApplicationId": app_id,
             "JourneyId": jid,
@@ -187,11 +205,12 @@ impl PinpointService {
 
     pub(super) fn get_journey_execution_activity_metrics(
         &self,
-        _ctx: &Ctx,
+        ctx: &Ctx,
         app_id: &str,
         jid: &str,
         activity_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
+        self.require_journey(ctx, app_id, jid)?;
         ok(json!({
             "ApplicationId": app_id,
             "JourneyId": jid,
@@ -204,11 +223,12 @@ impl PinpointService {
 
     pub(super) fn get_journey_run_execution_metrics(
         &self,
-        _ctx: &Ctx,
+        ctx: &Ctx,
         app_id: &str,
         jid: &str,
         run_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
+        self.require_journey(ctx, app_id, jid)?;
         ok(json!({
             "ApplicationId": app_id,
             "JourneyId": jid,
@@ -220,12 +240,13 @@ impl PinpointService {
 
     pub(super) fn get_journey_run_execution_activity_metrics(
         &self,
-        _ctx: &Ctx,
+        ctx: &Ctx,
         app_id: &str,
         jid: &str,
         activity_id: &str,
         run_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
+        self.require_journey(ctx, app_id, jid)?;
         ok(json!({
             "ApplicationId": app_id,
             "JourneyId": jid,

--- a/crates/fakecloud-pinpoint/src/service/messaging.rs
+++ b/crates/fakecloud-pinpoint/src/service/messaging.rs
@@ -112,10 +112,9 @@ impl PinpointService {
         });
         let mut guard = self.state.write();
         let app = guard
-            .get_or_create(&ctx.account)
-            .apps
-            .entry(app_id.to_string())
-            .or_default();
+            .get_mut(&ctx.account)
+            .and_then(|d| d.apps.get_mut(app_id))
+            .ok_or_else(|| super::not_found_app(app_id))?;
         app.event_stream = Some(record.clone());
         ok(record)
     }

--- a/crates/fakecloud-pinpoint/src/service/segments.rs
+++ b/crates/fakecloud-pinpoint/src/service/segments.rs
@@ -19,10 +19,9 @@ impl PinpointService {
         let id = shared::hex_id();
         let mut guard = self.state.write();
         let app = guard
-            .get_or_create(&ctx.account)
-            .apps
-            .entry(app_id.to_string())
-            .or_default();
+            .get_mut(&ctx.account)
+            .and_then(|d| d.apps.get_mut(app_id))
+            .ok_or_else(|| super::not_found_app(app_id))?;
         let record = build_segment(ctx, app_id, &id, 1, body);
         app.segments.insert(
             id,


### PR DESCRIPTION
## Summary

Bug-hunt findings on the newly-merged Pinpoint greenfield surface (post-parity-milestone safety pass).

**HIGH — phantom-app auto-vivification (account-wide corruption).** Nine create/upsert handlers used `get_or_create(account).apps.entry(app_id).or_default()`. A write to a non-existent application:
1. returned 2xx instead of AWS's `404 NotFoundException`, and
2. inserted a phantom `App` whose record is `null`.

That null poisons the account: `GetApp` returns `null` and `GetApps` returns an `Item` array containing a null element, which the aws-sdk deserializer rejects (`ApplicationResponse` requires `Arn`/`Id`/`Name`). A single stray write permanently breaks `GetApps` for the whole account until restart. All nine handlers now match the already-correct Update/Delete pattern: `get_mut(account).and_then(|d| d.apps.get_mut(app_id)).ok_or_else(not_found_app)?`.

**Also fixed (same crate, no-deferral):**
- `RemoveAttributes` was a no-op returning `{"Attributes":[]}`; now strips the blacklisted keys from every endpoint's target map (custom attributes/metrics at top level, user attributes under `User.UserAttributes`) and returns the removed keys.
- Journey KPI / execution-metric reads (`GetJourneyDateRangeKpi` + the four execution-metric ops) ignored `ctx` and returned 200 for a non-existent app/journey; now 404 via a `require_journey` existence check.
- `PutEvents` no longer trips `is_mutating` (persists nothing, unlike `PutEventStream`) — no needless snapshot save per analytics call.

Sibling greenfield crates from this cycle (iotwireless / iot / sagemaker) have their own follow-up PRs. IoT Data came up clean.

## Test plan
- New e2e `pinpoint_write_to_missing_app_404s_without_corrupting_get_apps`: create/update on a bogus app id all error; `GetApps` still deserializes and omits the phantom id.
- New e2e `pinpoint_remove_attributes_strips_endpoint_attributes`: attribute is gone after removal, siblings retained.
- Crate builds clean under `clippy --all-targets`; e2e compiles.

## Surface
Behavioral bug-fix only — no new ops, SDK surface, endpoints, or counts. Non-code surface unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Pinpoint writes that created phantom apps and corrupted reads. Writes to missing apps now 404, with fixes for attribute removal, journey metrics, and event snapshots.

- **Bug Fixes**
  - Return 404 on all create/update when the app is missing; stop auto-creating null apps that broke `GetApps`/`GetApp` (campaigns, channels, endpoints single/batch, journeys, segments, import/export jobs, event stream).
  - Implement `RemoveAttributes`: strip blacklisted keys from endpoint `Attributes`, `Metrics`, or `User.UserAttributes`, and return the removed keys.
  - Enforce existence checks for journey KPIs and execution metrics; 404 if app or journey is missing.
  - Treat `PutEvents` as non-mutating to avoid unnecessary snapshot saves.

<sup>Written for commit ae330b9855d803f3ad456ef9f3d836867bb6842f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

