### PR TITLE
fix(sagemaker): persist Action-created resources; apply List filters; numeric-coerce timestamps; tighten resolve_key

### DIFF
--- a/crates/fakecloud-e2e/tests/sagemaker.rs
+++ b/crates/fakecloud-e2e/tests/sagemaker.rs
@@ -140,3 +140,146 @@ async fn sagemaker_control_plane_lifecycle() {
         .expect_err("describe after delete should fail");
     assert!(format!("{err:?}").contains("ResourceNotFound"));
 }
+
+/// `StartPipelineExecution` is the only creation path for a pipeline execution;
+/// the started execution must then be resolvable by Describe / List.
+#[tokio::test]
+async fn sagemaker_pipeline_execution_round_trip() {
+    let server = TestServer::start().await;
+    let client = sagemaker_client(&server).await;
+
+    let started = client
+        .start_pipeline_execution()
+        .pipeline_name("my-pipeline")
+        .pipeline_execution_display_name("run-1")
+        .send()
+        .await
+        .expect("start_pipeline_execution");
+    let exec_arn = started
+        .pipeline_execution_arn()
+        .expect("pipeline_execution_arn")
+        .to_string();
+    assert!(
+        exec_arn.contains(":pipeline/my-pipeline/execution/"),
+        "unexpected execution arn: {exec_arn}"
+    );
+
+    // Describe resolves the started execution by its minted ARN.
+    let described = client
+        .describe_pipeline_execution()
+        .pipeline_execution_arn(&exec_arn)
+        .send()
+        .await
+        .expect("describe_pipeline_execution");
+    assert_eq!(described.pipeline_execution_arn(), Some(exec_arn.as_str()));
+    assert!(described
+        .pipeline_arn()
+        .unwrap_or_default()
+        .contains(":pipeline/my-pipeline"));
+
+    // List surfaces the execution summary for the pipeline.
+    let listed = client
+        .list_pipeline_executions()
+        .pipeline_name("my-pipeline")
+        .send()
+        .await
+        .expect("list_pipeline_executions");
+    assert!(
+        listed
+            .pipeline_execution_summaries()
+            .iter()
+            .any(|s| s.pipeline_execution_arn() == Some(exec_arn.as_str())),
+        "started execution should appear in the summaries"
+    );
+}
+
+/// `AddAssociation` is the only creation path for a lineage edge; the edge must
+/// then be listed and deletable.
+#[tokio::test]
+async fn sagemaker_association_round_trip() {
+    let server = TestServer::start().await;
+    let client = sagemaker_client(&server).await;
+
+    let src = "arn:aws:sagemaker:us-east-1:000000000000:experiment/exp";
+    let dst = "arn:aws:sagemaker:us-east-1:000000000000:artifact/art";
+    client
+        .add_association()
+        .source_arn(src)
+        .destination_arn(dst)
+        .send()
+        .await
+        .expect("add_association");
+
+    let listed = client
+        .list_associations()
+        .send()
+        .await
+        .expect("list_associations");
+    assert!(
+        listed
+            .association_summaries()
+            .iter()
+            .any(|a| a.source_arn() == Some(src) && a.destination_arn() == Some(dst)),
+        "added association should appear in the summaries"
+    );
+
+    // Delete removes exactly that edge.
+    client
+        .delete_association()
+        .source_arn(src)
+        .destination_arn(dst)
+        .send()
+        .await
+        .expect("delete_association");
+    let listed = client
+        .list_associations()
+        .send()
+        .await
+        .expect("list_associations after delete");
+    assert!(
+        !listed
+            .association_summaries()
+            .iter()
+            .any(|a| a.source_arn() == Some(src)),
+        "deleted association should be gone"
+    );
+}
+
+/// A List operation's `NameContains` filter must narrow the result to matching
+/// records rather than returning the whole family.
+#[tokio::test]
+async fn sagemaker_list_name_contains_filter() {
+    let server = TestServer::start().await;
+    let client = sagemaker_client(&server).await;
+    let role = "arn:aws:iam::000000000000:role/r";
+
+    for name in ["alpha-model", "beta-model"] {
+        client
+            .create_model()
+            .model_name(name)
+            .execution_role_arn(role)
+            .send()
+            .await
+            .expect("create_model");
+    }
+
+    let listed = client
+        .list_models()
+        .name_contains("alpha")
+        .send()
+        .await
+        .expect("list_models with NameContains");
+    let names: Vec<&str> = listed
+        .models()
+        .iter()
+        .filter_map(|m| m.model_name())
+        .collect();
+    assert!(
+        names.contains(&"alpha-model"),
+        "filtered list should contain alpha-model, got {names:?}"
+    );
+    assert!(
+        !names.contains(&"beta-model"),
+        "NameContains=alpha should exclude beta-model, got {names:?}"
+    );
+}

--- a/crates/fakecloud-sagemaker/src/service/engine.rs
+++ b/crates/fakecloud-sagemaker/src/service/engine.rs
@@ -178,13 +178,54 @@ fn fill_required(
 pub(crate) fn kind_matches(kind: K, v: &Value) -> bool {
     match kind {
         K::Str | K::Blob => v.is_string(),
-        // awsJson1.1 timestamps wire-encode as epoch-second JSON numbers; accept
-        // a string too so any legacy/ISO stored value still projects.
-        K::Ts => v.is_string() || v.is_number(),
+        // awsJson1.1 timestamps wire-encode as epoch-second JSON numbers only; a
+        // string (e.g. an ISO-8601 value a raw client posted into a timestamp
+        // input member) is *not* a valid on-wire timestamp and would be rejected
+        // by the SDK deserialiser. Such values are coerced to a number at
+        // projection time (see `coerce_ts`), never echoed as a string.
+        K::Ts => v.is_number(),
         K::Int | K::Num => v.is_number(),
         K::Bool => v.is_boolean(),
         K::List => v.is_array(),
         K::Map | K::Struct => v.is_object(),
+    }
+}
+
+/// Coerce a stored timestamp value into the awsJson1.1 wire form (epoch-second
+/// JSON number). A number passes through; a string is parsed as epoch seconds or
+/// RFC3339 and converted; anything else yields `None` so the member is dropped
+/// rather than emitted as an SDK-rejecting string.
+fn coerce_ts(v: &Value) -> Option<Value> {
+    if v.is_number() {
+        return Some(v.clone());
+    }
+    let s = v.as_str()?;
+    if let Ok(n) = s.parse::<f64>() {
+        return Some(Value::from(n));
+    }
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(Value::from(dt.timestamp_millis() as f64 / 1000.0));
+    }
+    None
+}
+
+/// Project a stored record's members onto the given `(wire, kind)` projection,
+/// keeping members whose JSON type matches the modelled kind and coercing
+/// timestamps to their numeric wire form.
+fn project(obj: Option<&Map<String, Value>>, members: &[(&str, K)], out: &mut Map<String, Value>) {
+    let Some(obj) = obj else { return };
+    for (wire, kind) in members {
+        let Some(v) = obj.get(*wire) else { continue };
+        if v.is_null() {
+            continue;
+        }
+        if *kind == K::Ts {
+            if let Some(n) = coerce_ts(v) {
+                out.insert((*wire).to_string(), n);
+            }
+        } else if kind_matches(*kind, v) {
+            out.insert((*wire).to_string(), v.clone());
+        }
     }
 }
 
@@ -194,15 +235,7 @@ pub(crate) fn kind_matches(kind: K, v: &Value) -> bool {
 /// response is valid against the model's output shape.
 pub(crate) fn build_output(ctx: &Ctx, meta: &OpMeta, key: &str, record: &Value) -> Value {
     let mut out = Map::new();
-    if let Some(obj) = record.as_object() {
-        for (wire, kind) in meta.omembers {
-            if let Some(v) = obj.get(*wire) {
-                if !v.is_null() && kind_matches(*kind, v) {
-                    out.insert((*wire).to_string(), v.clone());
-                }
-            }
-        }
-    }
+    project(record.as_object(), meta.omembers, &mut out);
     fill_required(ctx, meta, key, &mut out, meta.req_out);
     Value::Object(out)
 }
@@ -212,15 +245,7 @@ pub(crate) fn build_output(ctx: &Ctx, meta: &OpMeta, key: &str, record: &Value) 
 /// fields the shape validator checks, e.g. a summary's status).
 fn build_element(ctx: &Ctx, meta: &OpMeta, key: &str, record: &Value) -> Value {
     let mut out = Map::new();
-    if let Some(obj) = record.as_object() {
-        for (wire, kind) in meta.list_elems {
-            if let Some(v) = obj.get(*wire) {
-                if !v.is_null() && kind_matches(*kind, v) {
-                    out.insert((*wire).to_string(), v.clone());
-                }
-            }
-        }
-    }
+    project(record.as_object(), meta.list_elems, &mut out);
     fill_required(ctx, meta, key, &mut out, meta.req_elem);
     Value::Object(out)
 }
@@ -399,15 +424,92 @@ pub(super) fn action(ctx: &Ctx, meta: &OpMeta, body: &Map<String, Value>) -> Aws
     ok_json(out)
 }
 
+/// Persist a resource whose *only* creation path is an Action verb (e.g. a
+/// pipeline execution started by `StartPipelineExecution`), so the sibling
+/// Describe / List / Update / Delete operations resolve it. Builds the standard
+/// record — the caller-provided `seed` (request body plus any pre-minted ARNs /
+/// status the handler set), completed with minted ARNs/ids and creation /
+/// last-modified timestamps — stores it under `key` in the family, and returns
+/// the action's declared output projection.
+pub(super) fn action_create(
+    data: &mut SageMakerData,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    key: &str,
+    seed: &Map<String, Value>,
+) -> AwsResponse {
+    let record = build_record(ctx, meta, key, seed);
+    let out = build_output(ctx, meta, key, &record);
+    data.put_resource(meta.family, key, record);
+    ok_json(out)
+}
+
+/// Apply the common request-side List filters an operation carries generically,
+/// comparing against the stored record. Filters not present in `body` are
+/// ignored; a record is kept only if it satisfies every present filter:
+///
+/// * `NameContains` — substring of the storage key or any `*Name` member.
+/// * `CreationTimeAfter` / `CreationTimeBefore` — numeric bounds on the record's
+///   `CreationTime` (a record without one fails a present bound).
+/// * `StatusEquals` — equality against any `*Status` member the record carries
+///   (a record that stores no status member is excluded when this filter is set,
+///   since its state is not persisted).
+///
+/// Deliberately not mapped generically (skipped): sort (`SortBy`/`SortOrder`),
+/// type/label filters keyed to a specific member name (`SourceType`,
+/// `LabelingJobStatus`-style per-op enums already covered by `*Status`), and
+/// resource-scoping members (e.g. `PipelineName` on `ListPipelineExecutions`)
+/// whose semantics vary per op.
+fn passes_filters(id: &str, record: &Value, body: &Map<String, Value>) -> bool {
+    let obj = record.as_object();
+    if let Some(needle) = body.get("NameContains").and_then(Value::as_str) {
+        let hit = id.contains(needle)
+            || obj
+                .map(|o| {
+                    o.iter().any(|(k, v)| {
+                        k.ends_with("Name") && v.as_str().is_some_and(|s| s.contains(needle))
+                    })
+                })
+                .unwrap_or(false);
+        if !hit {
+            return false;
+        }
+    }
+    let creation = obj.and_then(|o| o.get("CreationTime")).and_then(Value::as_f64);
+    if let Some(after) = body.get("CreationTimeAfter").and_then(Value::as_f64) {
+        if creation.map(|c| c >= after) != Some(true) {
+            return false;
+        }
+    }
+    if let Some(before) = body.get("CreationTimeBefore").and_then(Value::as_f64) {
+        if creation.map(|c| c <= before) != Some(true) {
+            return false;
+        }
+    }
+    if let Some(status) = body.get("StatusEquals").and_then(Value::as_str) {
+        let hit = obj
+            .map(|o| {
+                o.iter()
+                    .any(|(k, v)| k.ends_with("Status") && v.as_str() == Some(status))
+            })
+            .unwrap_or(false);
+        if !hit {
+            return false;
+        }
+    }
+    true
+}
+
 pub(super) fn list(
     data: Option<&SageMakerData>,
     ctx: &Ctx,
     meta: &OpMeta,
     body: &Map<String, Value>,
 ) -> AwsResponse {
-    let entries = data
+    let mut entries = data
         .map(|d| d.list_resource_entries(meta.family))
         .unwrap_or_default();
+    entries.retain(|(id, r)| passes_filters(id, r, body));
 
     // A `list<string>` element serialises as the resource's identifier string
     // (its storage key); otherwise each element is the projected object.

--- a/crates/fakecloud-sagemaker/src/service/engine.rs
+++ b/crates/fakecloud-sagemaker/src/service/engine.rs
@@ -475,7 +475,9 @@ fn passes_filters(id: &str, record: &Value, body: &Map<String, Value>) -> bool {
             return false;
         }
     }
-    let creation = obj.and_then(|o| o.get("CreationTime")).and_then(Value::as_f64);
+    let creation = obj
+        .and_then(|o| o.get("CreationTime"))
+        .and_then(Value::as_f64);
     if let Some(after) = body.get("CreationTimeAfter").and_then(Value::as_f64) {
         if creation.map(|c| c >= after) != Some(true) {
             return false;

--- a/crates/fakecloud-sagemaker/src/service/special.rs
+++ b/crates/fakecloud-sagemaker/src/service/special.rs
@@ -1,6 +1,21 @@
 //! Resource-specific SageMaker handlers that fall outside the generic resource
-//! engine: tagging (`AddTags` / `ListTags` / `DeleteTags`), which persists tags
-//! keyed by resource ARN.
+//! engine:
+//!
+//! * tagging (`AddTags` / `ListTags` / `DeleteTags`), which persists tags keyed
+//!   by resource ARN; and
+//! * a small set of **Action verbs that are the only creation path for their
+//!   resource family** (`StartPipelineExecution`, `ImportHubContent`,
+//!   `AddAssociation`). The generic Action arm is a stateless no-op, so without
+//!   these handlers the family's Describe / List / Update / Delete siblings
+//!   would 404 / return empty. Each mints the family's identifier, builds a
+//!   record carrying the required output members, and inserts it into the
+//!   resource family so those siblings resolve it. (`DeleteAssociation` is also
+//!   claimed here so the composite source+destination edge is removed exactly.)
+//!
+//! These are distinct from the intentional Start/Stop *lifecycle* no-ops
+//! (`StartNotebookInstance`, `StopTrainingJob`, `StopPipelineExecution`, ...)
+//! which advance state on a resource that already exists — a documented
+//! emulation limit left to the generic Action arm.
 
 use serde_json::{Map, Value};
 
@@ -8,7 +23,7 @@ use fakecloud_core::service::{AwsResponse, AwsServiceError};
 
 use crate::generated::OpMeta;
 
-use super::{ok_json, Ctx, SageMakerService};
+use super::{engine, ok_json, now_epoch, Ctx, SageMakerService};
 
 /// Dispatch an operation to a resource-specific handler. Returns `Ok(None)` if
 /// the operation is not claimed here (the caller then falls through to the
@@ -23,8 +38,127 @@ pub(super) fn dispatch(
         "AddTags" => Ok(Some(add_tags(svc, ctx, body))),
         "ListTags" => Ok(Some(list_tags(svc, ctx, body))),
         "DeleteTags" => Ok(Some(delete_tags(svc, ctx, body))),
+        "StartPipelineExecution" => Ok(Some(start_pipeline_execution(svc, ctx, meta, body))),
+        "ImportHubContent" => Ok(Some(import_hub_content(svc, ctx, meta, body))),
+        "AddAssociation" => Ok(Some(add_association(svc, ctx, meta, body))),
+        "DeleteAssociation" => Ok(Some(delete_association(svc, ctx, body))),
         _ => Ok(None),
     }
+}
+
+fn str_member(body: &Map<String, Value>, key: &str) -> String {
+    body.get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// `StartPipelineExecution` — persist a pipeline-execution record so
+/// DescribePipelineExecution / ListPipelineExecutions / UpdatePipelineExecution
+/// / StopPipelineExecution operate on the minted `PipelineExecutionArn`.
+fn start_pipeline_execution(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let pipeline_name = str_member(body, "PipelineName");
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let exec_id = super::mint_id(&ctx.account, "PipelineExecution", &data.next_seq().to_string());
+    let arn = format!(
+        "arn:aws:sagemaker:{}:{}:pipeline/{}/execution/{}",
+        ctx.region, ctx.account, pipeline_name, exec_id
+    );
+    let mut seed = body.clone();
+    seed.insert("PipelineExecutionArn".to_string(), Value::String(arn.clone()));
+    seed.insert(
+        "PipelineArn".to_string(),
+        Value::String(format!(
+            "arn:aws:sagemaker:{}:{}:pipeline/{}",
+            ctx.region, ctx.account, pipeline_name
+        )),
+    );
+    seed.entry("PipelineExecutionStatus".to_string())
+        .or_insert_with(|| Value::String("Executing".to_string()));
+    seed.insert("StartTime".to_string(), now_epoch());
+    (engine::action_create(data, ctx, meta, &arn, &seed), true)
+}
+
+/// `ImportHubContent` — persist a hub-content record so DescribeHubContent /
+/// ListHubContents / DeleteHubContent operate on it. Keyed by `HubContentName`
+/// (the family's Describe/Delete key member).
+fn import_hub_content(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let hub_content_name = str_member(body, "HubContentName");
+    let hub_name = str_member(body, "HubName");
+    let mut seed = body.clone();
+    seed.insert(
+        "HubArn".to_string(),
+        Value::String(format!(
+            "arn:aws:sagemaker:{}:{}:hub/{}",
+            ctx.region, ctx.account, hub_name
+        )),
+    );
+    seed.entry("HubContentStatus".to_string())
+        .or_insert_with(|| Value::String("Available".to_string()));
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    (
+        engine::action_create(data, ctx, meta, &hub_content_name, &seed),
+        true,
+    )
+}
+
+/// `AddAssociation` — persist the lineage edge so ListAssociations returns it.
+/// Keyed by the composite `SourceArn|DestinationArn` so multiple destinations
+/// from one source coexist (each is a distinct edge).
+fn add_association(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let key = association_key(body);
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    (engine::action_create(data, ctx, meta, &key, body), true)
+}
+
+/// `DeleteAssociation` — remove exactly the (source, destination) edge and echo
+/// the two ARNs. Idempotent: deleting an absent edge is a success.
+fn delete_association(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let key = association_key(body);
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.remove_resource("Association", &key);
+    let mut out = Map::new();
+    out.insert(
+        "SourceArn".to_string(),
+        Value::String(str_member(body, "SourceArn")),
+    );
+    out.insert(
+        "DestinationArn".to_string(),
+        Value::String(str_member(body, "DestinationArn")),
+    );
+    (ok_json(Value::Object(out)), true)
+}
+
+/// The composite storage key for an association edge.
+fn association_key(body: &Map<String, Value>) -> String {
+    format!(
+        "{}|{}",
+        str_member(body, "SourceArn"),
+        str_member(body, "DestinationArn")
+    )
 }
 
 fn tags_to_array(tags: &std::collections::BTreeMap<String, String>) -> Value {

--- a/crates/fakecloud-sagemaker/src/service/special.rs
+++ b/crates/fakecloud-sagemaker/src/service/special.rs
@@ -23,7 +23,7 @@ use fakecloud_core::service::{AwsResponse, AwsServiceError};
 
 use crate::generated::OpMeta;
 
-use super::{engine, ok_json, now_epoch, Ctx, SageMakerService};
+use super::{engine, now_epoch, ok_json, Ctx, SageMakerService};
 
 /// Dispatch an operation to a resource-specific handler. Returns `Ok(None)` if
 /// the operation is not claimed here (the caller then falls through to the
@@ -65,13 +65,20 @@ fn start_pipeline_execution(
     let pipeline_name = str_member(body, "PipelineName");
     let mut g = svc.state.write();
     let data = g.get_or_create(&ctx.account);
-    let exec_id = super::mint_id(&ctx.account, "PipelineExecution", &data.next_seq().to_string());
+    let exec_id = super::mint_id(
+        &ctx.account,
+        "PipelineExecution",
+        &data.next_seq().to_string(),
+    );
     let arn = format!(
         "arn:aws:sagemaker:{}:{}:pipeline/{}/execution/{}",
         ctx.region, ctx.account, pipeline_name, exec_id
     );
     let mut seed = body.clone();
-    seed.insert("PipelineExecutionArn".to_string(), Value::String(arn.clone()));
+    seed.insert(
+        "PipelineExecutionArn".to_string(),
+        Value::String(arn.clone()),
+    );
     seed.insert(
         "PipelineArn".to_string(),
         Value::String(format!(

--- a/crates/fakecloud-sagemaker/src/service/tests.rs
+++ b/crates/fakecloud-sagemaker/src/service/tests.rs
@@ -418,7 +418,10 @@ fn pipeline_execution_action_persists() {
         )
         .unwrap(),
     );
-    let arn = started["PipelineExecutionArn"].as_str().unwrap().to_string();
+    let arn = started["PipelineExecutionArn"]
+        .as_str()
+        .unwrap()
+        .to_string();
     assert!(arn.contains(":pipeline/p1/execution/"), "arn: {arn}");
 
     let described = resp_json(
@@ -432,9 +435,8 @@ fn pipeline_execution_action_persists() {
     assert_eq!(described["PipelineExecutionArn"], arn);
     assert_eq!(described["PipelineExecutionStatus"], "Executing");
 
-    let listed = resp_json(
-        &run(&s, "ListPipelineExecutions", json!({"PipelineName": "p1"})).unwrap(),
-    );
+    let listed =
+        resp_json(&run(&s, "ListPipelineExecutions", json!({"PipelineName": "p1"})).unwrap());
     let sums = listed["PipelineExecutionSummaries"].as_array().unwrap();
     assert!(sums.iter().any(|x| x["PipelineExecutionArn"] == arn));
 }
@@ -497,7 +499,10 @@ fn association_action_persists_and_deletes() {
     )
     .unwrap();
     let listed = resp_json(&run(&s, "ListAssociations", Value::Null).unwrap());
-    assert!(listed["AssociationSummaries"].as_array().unwrap().is_empty());
+    assert!(listed["AssociationSummaries"]
+        .as_array()
+        .unwrap()
+        .is_empty());
 }
 
 // NameContains must narrow a List result to matching records.

--- a/crates/fakecloud-sagemaker/src/service/tests.rs
+++ b/crates/fakecloud-sagemaker/src/service/tests.rs
@@ -404,3 +404,133 @@ fn unknown_action_is_not_implemented() {
     let err = expect_err(run(&s, "NotARealSageMakerOp", Value::Null));
     assert!(matches!(err, AwsServiceError::ActionNotImplemented { .. }));
 }
+
+// StartPipelineExecution is the only creation path for a pipeline execution, so
+// it must persist a record the Describe / List siblings can resolve.
+#[test]
+fn pipeline_execution_action_persists() {
+    let s = svc();
+    let started = resp_json(
+        &run(
+            &s,
+            "StartPipelineExecution",
+            json!({"PipelineName": "p1", "ClientRequestToken": "a".repeat(32)}),
+        )
+        .unwrap(),
+    );
+    let arn = started["PipelineExecutionArn"].as_str().unwrap().to_string();
+    assert!(arn.contains(":pipeline/p1/execution/"), "arn: {arn}");
+
+    let described = resp_json(
+        &run(
+            &s,
+            "DescribePipelineExecution",
+            json!({"PipelineExecutionArn": arn}),
+        )
+        .unwrap(),
+    );
+    assert_eq!(described["PipelineExecutionArn"], arn);
+    assert_eq!(described["PipelineExecutionStatus"], "Executing");
+
+    let listed = resp_json(
+        &run(&s, "ListPipelineExecutions", json!({"PipelineName": "p1"})).unwrap(),
+    );
+    let sums = listed["PipelineExecutionSummaries"].as_array().unwrap();
+    assert!(sums.iter().any(|x| x["PipelineExecutionArn"] == arn));
+}
+
+// ImportHubContent is the only creation path for hub content.
+#[test]
+fn import_hub_content_action_persists() {
+    let s = svc();
+    let imported = resp_json(
+        &run(
+            &s,
+            "ImportHubContent",
+            json!({
+                "HubName": "h1",
+                "HubContentName": "c1",
+                "HubContentType": "Model",
+                "DocumentSchemaVersion": "1.0.0",
+                "HubContentDocument": "{}"
+            }),
+        )
+        .unwrap(),
+    );
+    assert!(imported["HubContentArn"].as_str().unwrap().contains("c1"));
+    assert!(imported["HubArn"].as_str().unwrap().contains("h1"));
+
+    let described = resp_json(
+        &run(
+            &s,
+            "DescribeHubContent",
+            json!({"HubName": "h1", "HubContentType": "Model", "HubContentName": "c1"}),
+        )
+        .unwrap(),
+    );
+    assert_eq!(described["HubContentName"], "c1");
+    assert_eq!(described["HubName"], "h1");
+}
+
+// AddAssociation persists the edge; DeleteAssociation removes exactly it.
+#[test]
+fn association_action_persists_and_deletes() {
+    let s = svc();
+    let src = "arn:aws:sagemaker:us-east-1:000000000000:experiment/e";
+    let dst = "arn:aws:sagemaker:us-east-1:000000000000:artifact/a";
+    run(
+        &s,
+        "AddAssociation",
+        json!({"SourceArn": src, "DestinationArn": dst}),
+    )
+    .unwrap();
+    let listed = resp_json(&run(&s, "ListAssociations", Value::Null).unwrap());
+    let sums = listed["AssociationSummaries"].as_array().unwrap();
+    assert!(sums
+        .iter()
+        .any(|x| x["SourceArn"] == src && x["DestinationArn"] == dst));
+
+    run(
+        &s,
+        "DeleteAssociation",
+        json!({"SourceArn": src, "DestinationArn": dst}),
+    )
+    .unwrap();
+    let listed = resp_json(&run(&s, "ListAssociations", Value::Null).unwrap());
+    assert!(listed["AssociationSummaries"].as_array().unwrap().is_empty());
+}
+
+// NameContains must narrow a List result to matching records.
+#[test]
+fn list_name_contains_filters_results() {
+    let s = svc();
+    for name in ["alpha-model", "beta-model"] {
+        run(&s, "CreateModel", json!({ "ModelName": name })).unwrap();
+    }
+    let listed = resp_json(&run(&s, "ListModels", json!({"NameContains": "alpha"})).unwrap());
+    let models = listed["Models"].as_array().unwrap();
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0]["ModelName"], "alpha-model");
+}
+
+// A stored string timestamp must project to a numeric epoch on read, never an
+// SDK-rejecting string.
+#[test]
+fn string_timestamp_coerced_to_number_on_read() {
+    let s = svc();
+    {
+        let mut g = s.state.write();
+        let data = g.get_or_create("000000000000");
+        data.put_resource(
+            "Model",
+            "m",
+            json!({"ModelName": "m", "CreationTime": "1752324947.041"}),
+        );
+    }
+    let described = resp_json(&run(&s, "DescribeModel", json!({"ModelName": "m"})).unwrap());
+    assert!(
+        described["CreationTime"].is_number(),
+        "CreationTime must coerce to a number, got {:?}",
+        described["CreationTime"]
+    );
+}

--- a/crates/fakecloud-sagemaker/src/state.rs
+++ b/crates/fakecloud-sagemaker/src/state.rs
@@ -68,23 +68,33 @@ impl SageMakerData {
     }
 
     /// Resolve a caller-supplied identifier value to a stored key within a
-    /// family. Matches the direct storage key first, then falls back to any
-    /// record whose Name / Id / Arn-shaped identifier member equals the value
-    /// (so a resource keyed by its Name can still be described by the minted
-    /// Id or ARN the create returned).
+    /// family. Matches the direct storage key first, then falls back to a record
+    /// whose *canonical* identifier member — `{Family}Name`, `{Family}Id` or
+    /// `{Family}Arn` — equals the value (so a resource keyed by its Name can
+    /// still be described by the minted Id or ARN the create returned).
+    ///
+    /// The fallback is restricted to the family's own canonical members rather
+    /// than any suffix-matching `*Name` / `*Id` / `*Arn` member, so an unrelated
+    /// member that happens to carry an equal value (e.g. a shared `RoleArn`, or a
+    /// cross-referenced `SourceArn`) on a sibling record cannot mis-resolve to
+    /// the wrong record.
     pub fn resolve_key(&self, family: &str, value: &str) -> Option<String> {
         let m = self.resources.get(family)?;
         if m.contains_key(value) {
             return Some(value.to_string());
         }
+        let canonical = [
+            format!("{family}Name"),
+            format!("{family}Id"),
+            format!("{family}Arn"),
+        ];
         for (k, rec) in m {
             if let Some(obj) = rec.as_object() {
-                for (mk, mv) in obj {
-                    if (mk.ends_with("Name") || mk.ends_with("Id") || mk.ends_with("Arn"))
-                        && mv.as_str() == Some(value)
-                    {
-                        return Some(k.clone());
-                    }
+                if canonical
+                    .iter()
+                    .any(|cand| obj.get(cand).and_then(Value::as_str) == Some(value))
+                {
+                    return Some(k.clone());
                 }
             }
         }
@@ -150,5 +160,18 @@ mod tests {
         );
         assert!(d.remove_resource("Model", "m1").is_some());
         assert!(d.get_resource("Model", "m1").is_none());
+    }
+
+    #[test]
+    fn resolve_key_ignores_noncanonical_sibling_member() {
+        let mut d = SageMakerData::default();
+        let shared = "arn:aws:iam::0:role/shared";
+        // A record keyed by its name, carrying an unrelated RoleArn member.
+        d.put_resource("Model", "m1", json!({"ModelName": "m1", "RoleArn": shared}));
+        // Resolving by the shared RoleArn must NOT mis-match m1: RoleArn is not a
+        // canonical Model identifier member.
+        assert_eq!(d.resolve_key("Model", shared), None);
+        // The canonical ModelName still resolves.
+        assert_eq!(d.resolve_key("Model", "m1").as_deref(), Some("m1"));
     }
 }


### PR DESCRIPTION
## Summary

Bug-hunt findings on the newly-merged SageMaker greenfield surface (post-parity-milestone safety pass).

- **MEDIUM — Action-created resources now persist.** The generic Action arm stored nothing, but for three ops the Action verb is the ONLY creation path, so Describe/List/Delete on them immediately 404'd. New `engine::action_create` helper mints the family id, builds the record with required output members + timestamps, and inserts it:
  - `StartPipelineExecution` -> PipelineExecution record (minted PipelineExecutionArn, PipelineArn, status Executing). Describe/List/Update/Stop resolve it.
  - `ImportHubContent` -> HubContent record (minted HubArn/HubContentArn, status Available). Describe/List/Delete work.
  - `AddAssociation` -> lineage edge keyed by SourceArn|DestinationArn; DeleteAssociation removes the exact edge; ListAssociations returns them.
- **LOW — List filters.** `engine::list` now applies NameContains (substring), CreationTimeAfter/Before (numeric CreationTime), StatusEquals (equality) generically before pagination.
- **LOW — timestamp coercion.** K::Ts output is number-only; a stored string timestamp is coerced (epoch/RFC3339 -> number) or dropped, never echoed as a string the SDK would reject.
- **LOW — resolve_key.** ARN/Id-scan fallback restricted to the family's canonical Name/Id/Arn members, so a sibling carrying an equal unrelated member (e.g. shared RoleArn) can't mis-resolve. Exact-key match still first.

### Documented emulation limits (in code)
- StatusEquals skips records that don't persist a `*Status` (state not stored at create). Sort (SortBy/SortOrder) + per-op resource-scoping members not mapped generically. Start/Stop lifecycle no-ops (StopPipelineExecution etc.) left to the generic Action arm — they act on already-existing resources.

## Test plan
- New e2e: StartPipelineExecution->Describe/List; AddAssociation->ListAssociations; List NameContains filter.
- `cargo clippy -p fakecloud-sagemaker --all-targets` clean; `cargo test -p fakecloud-sagemaker` 22 pass; e2e compiles.

## Surface
Behavioral bug-fix — no new ops/SDK/counts. Non-code surface unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted SageMaker resources created via Action APIs and added generic List filtering; also normalized timestamps and tightened ID resolution to stop 404s and SDK type errors.

- **Bug Fixes**
  - Persist Action-created resources so siblings resolve:
    - `StartPipelineExecution` stores a pipeline execution with minted ARN and status.
    - `ImportHubContent` stores hub content by `HubContentName` with `HubArn` and status.
    - `AddAssociation` stores a lineage edge keyed `SourceArn|DestinationArn`; `DeleteAssociation` removes that exact edge.
  - Apply common List filters before pagination: `NameContains`, `CreationTimeAfter`/`CreationTimeBefore`, `StatusEquals` (records without a status are skipped when set).
  - Coerce timestamp outputs to numeric epoch seconds; string timestamps are parsed or dropped, never echoed as strings.
  - Restrict `resolve_key` fallback to `{Family}Name`/`{Family}Id`/`{Family}Arn` to avoid mis-resolving via unrelated members.

<sup>Written for commit 7066604df358c03467c4d64b6a2435feeec78b5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

