### PR TITLE
fix(iot): return GetJobDocument; real policy-version subsystem; mint Action output IDs; invert principal/thing lists

### DIFF
--- a/crates/fakecloud-e2e/tests/iot.rs
+++ b/crates/fakecloud-e2e/tests/iot.rs
@@ -192,4 +192,100 @@ async fn iot_control_plane_lifecycle() {
         .things()
         .iter()
         .any(|t| t.thing_name() == Some("thermostat")));
+
+    // --- Job document round-trip ---
+    let job_doc = client
+        .get_job_document()
+        .job_id("firmware-1")
+        .send()
+        .await
+        .expect("get_job_document");
+    assert_eq!(job_doc.document(), Some(r#"{"operation":"update"}"#));
+
+    // --- Principal listing is the inverse of the attachment ---
+    let principal_things = client
+        .list_principal_things()
+        .principal(&cert_arn)
+        .send()
+        .await
+        .expect("list_principal_things");
+    assert!(principal_things
+        .things()
+        .iter()
+        .any(|t| t == "thermostat"));
+}
+
+#[tokio::test]
+async fn iot_policy_versioning() {
+    let server = TestServer::start().await;
+    let client = iot_client(&server).await;
+
+    client
+        .create_policy()
+        .policy_name("versioned")
+        .policy_document(r#"{"Version":"2012-10-17","Statement":[]}"#)
+        .send()
+        .await
+        .expect("create_policy");
+
+    // A second version, set as the new default.
+    let v2 = client
+        .create_policy_version()
+        .policy_name("versioned")
+        .policy_document(r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow"}]}"#)
+        .set_as_default(true)
+        .send()
+        .await
+        .expect("create_policy_version");
+    assert_eq!(v2.policy_version_id(), Some("2"));
+    assert!(v2.is_default_version());
+
+    let got = client
+        .get_policy_version()
+        .policy_name("versioned")
+        .policy_version_id("2")
+        .send()
+        .await
+        .expect("get_policy_version");
+    assert_eq!(got.policy_version_id(), Some("2"));
+    assert!(got.is_default_version());
+    assert!(got.policy_document().unwrap().contains("Allow"));
+
+    let versions = client
+        .list_policy_versions()
+        .policy_name("versioned")
+        .send()
+        .await
+        .expect("list_policy_versions");
+    assert_eq!(versions.policy_versions().len(), 2);
+    assert_eq!(
+        versions
+            .policy_versions()
+            .iter()
+            .filter(|v| v.is_default_version())
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn iot_register_thing_returns_resource_arns() {
+    let server = TestServer::start().await;
+    let client = iot_client(&server).await;
+
+    let registered = client
+        .register_thing()
+        .template_body(r#"{"Resources":{}}"#)
+        .send()
+        .await
+        .expect("register_thing");
+    assert!(registered
+        .certificate_pem()
+        .unwrap()
+        .contains("BEGIN CERTIFICATE"));
+    let arns = registered.resource_arns().expect("resourceArns");
+    assert!(arns
+        .get("thing")
+        .map(|a| a.contains(":thing/"))
+        .unwrap_or(false));
 }

--- a/crates/fakecloud-e2e/tests/iot.rs
+++ b/crates/fakecloud-e2e/tests/iot.rs
@@ -209,10 +209,7 @@ async fn iot_control_plane_lifecycle() {
         .send()
         .await
         .expect("list_principal_things");
-    assert!(principal_things
-        .things()
-        .iter()
-        .any(|t| t == "thermostat"));
+    assert!(principal_things.things().iter().any(|t| t == "thermostat"));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-iot/src/service/special.rs
+++ b/crates/fakecloud-iot/src/service/special.rs
@@ -261,46 +261,40 @@ pub(super) fn dispatch(
 
         // Jobs: document read + lifecycle mutations that echo the job identity.
         "GetJobDocument" => Ok(Some(get_job_document(svc, ctx, meta, labels)?)),
-        "AssociateTargetsWithJob" => {
-            Ok(Some(job_lifecycle(svc, ctx, meta, labels, body, false)?))
-        }
+        "AssociateTargetsWithJob" => Ok(Some(job_lifecycle(svc, ctx, meta, labels, body, false)?)),
         "CancelJob" => Ok(Some(job_lifecycle(svc, ctx, meta, labels, body, true)?)),
 
         // Managed IAM-style policy versioning. Versions live in their own
         // `policy-versions` store keyed `policyName/versionId` so the policy
         // list is not polluted; CreatePolicy seeds version 1 as the default.
         "CreatePolicy" => Ok(Some(create_policy(svc, ctx, labels, body)?)),
-        "CreatePolicyVersion" => {
-            Ok(Some(create_policy_version(svc, ctx, meta, labels, query, body)?))
-        }
+        "CreatePolicyVersion" => Ok(Some(create_policy_version(
+            svc, ctx, meta, labels, query, body,
+        )?)),
         "GetPolicyVersion" => Ok(Some(get_policy_version(svc, ctx, meta, labels)?)),
         "ListPolicyVersions" => Ok(Some(list_policy_versions(svc, ctx, meta, labels)?)),
-        "SetDefaultPolicyVersion" => {
-            Ok(Some(set_default_policy_version(svc, ctx, meta, labels)?))
-        }
+        "SetDefaultPolicyVersion" => Ok(Some(set_default_policy_version(svc, ctx, meta, labels)?)),
         "DeletePolicyVersion" => Ok(Some(delete_policy_version(svc, ctx, meta, labels)?)),
 
         // Provisioning templates: persist the template + its versions so the
         // Describe / List reads (generic and version-specific) round-trip, and
         // mint a real (persisted) certificate for the provisioning claim.
-        "CreateProvisioningTemplate" => {
-            Ok(Some(create_provisioning_template(svc, ctx, body)?))
-        }
-        "CreateProvisioningTemplateVersion" => Ok(Some(
-            create_provisioning_template_version(svc, ctx, meta, labels, query, body)?,
-        )),
-        "DescribeProvisioningTemplateVersion" => {
-            Ok(Some(describe_provisioning_template_version(svc, ctx, meta, labels)?))
-        }
-        "ListProvisioningTemplateVersions" => {
-            Ok(Some(list_provisioning_template_versions(svc, ctx, meta, labels)?))
-        }
+        "CreateProvisioningTemplate" => Ok(Some(create_provisioning_template(svc, ctx, body)?)),
+        "CreateProvisioningTemplateVersion" => Ok(Some(create_provisioning_template_version(
+            svc, ctx, meta, labels, query, body,
+        )?)),
+        "DescribeProvisioningTemplateVersion" => Ok(Some(describe_provisioning_template_version(
+            svc, ctx, meta, labels,
+        )?)),
+        "ListProvisioningTemplateVersions" => Ok(Some(list_provisioning_template_versions(
+            svc, ctx, meta, labels,
+        )?)),
         "CreateProvisioningClaim" => Ok(Some(create_provisioning_claim(svc, ctx, meta, labels)?)),
 
         // Certificate transfer + fleet-provisioning thing registration.
-        "TransferCertificate" => {
-            Ok(Some(transfer_certificate(svc, ctx, meta, labels, query, body)?))
-        }
+        "TransferCertificate" => Ok(Some(transfer_certificate(
+            svc, ctx, meta, labels, query, body,
+        )?)),
         "RegisterThing" => Ok(Some(register_thing(svc, ctx))),
 
         // Long-running tasks whose only synchronous output is a minted taskId;
@@ -1187,7 +1181,11 @@ fn create_policy_version(
     let vid = next_policy_version_id(data, &name);
     if set_as_default {
         clear_default_policy_versions(data, &name);
-        if let Some(rec) = data.resources.get_mut("policies").and_then(|m| m.get_mut(&name)) {
+        if let Some(rec) = data
+            .resources
+            .get_mut("policies")
+            .and_then(|m| m.get_mut(&name))
+        {
             if let Some(o) = rec.as_object_mut() {
                 o.insert("defaultVersionId".to_string(), Value::String(vid.clone()));
             }
@@ -1232,7 +1230,10 @@ fn list_policy_versions(
     let name = labels.get("policyName").cloned().unwrap_or_default();
     let g = svc.state.read();
     let data = g.get(&ctx.account);
-    if data.and_then(|d| d.get_resource("policies", &name)).is_none() {
+    if data
+        .and_then(|d| d.get_resource("policies", &name))
+        .is_none()
+    {
         return Err(super::engine::not_found(meta, &name));
     }
     let prefix = format!("{name}/");
@@ -1271,7 +1272,11 @@ fn set_default_policy_version(
             o.insert("isDefaultVersion".to_string(), Value::Bool(true));
         }
     }
-    if let Some(rec) = data.resources.get_mut("policies").and_then(|m| m.get_mut(&name)) {
+    if let Some(rec) = data
+        .resources
+        .get_mut("policies")
+        .and_then(|m| m.get_mut(&name))
+    {
         if let Some(o) = rec.as_object_mut() {
             o.insert("defaultVersionId".to_string(), Value::String(vid.clone()));
         }
@@ -1381,12 +1386,20 @@ fn create_provisioning_template(
     let mut rec = Map::new();
     rec.insert("templateArn".to_string(), Value::String(arn.clone()));
     rec.insert("templateName".to_string(), Value::String(name.clone()));
-    for key in ["description", "provisioningRoleArn", "type", "preProvisioningHook"] {
+    for key in [
+        "description",
+        "provisioningRoleArn",
+        "type",
+        "preProvisioningHook",
+    ] {
         if let Some(v) = body.get(key) {
             rec.insert(key.to_string(), v.clone());
         }
     }
-    rec.insert("templateBody".to_string(), Value::String(template_body.clone()));
+    rec.insert(
+        "templateBody".to_string(),
+        Value::String(template_body.clone()),
+    );
     rec.insert(
         "enabled".to_string(),
         Value::Bool(body.get("enabled").and_then(Value::as_bool).unwrap_or(true)),
@@ -1506,8 +1519,7 @@ fn create_provisioning_claim(
     let name = labels.get("templateName").cloned().unwrap_or_default();
     {
         let g = svc.state.read();
-        if g
-            .get(&ctx.account)
+        if g.get(&ctx.account)
             .and_then(|d| d.get_resource("provisioning-templates", &name))
             .is_none()
         {
@@ -1544,7 +1556,9 @@ fn transfer_certificate(
     body: &Map<String, Value>,
 ) -> Result<(AwsResponse, bool), AwsServiceError> {
     let cert_id = labels.get("certificateId").cloned().unwrap_or_default();
-    let target = query_get(query, "targetAwsAccount").unwrap_or("").to_string();
+    let target = query_get(query, "targetAwsAccount")
+        .unwrap_or("")
+        .to_string();
     let mut g = svc.state.write();
     let data = g.get_or_create(&ctx.account);
     let Some(mut rec) = data.get_resource("certificates", &cert_id).cloned() else {

--- a/crates/fakecloud-iot/src/service/special.rs
+++ b/crates/fakecloud-iot/src/service/special.rs
@@ -259,6 +259,63 @@ pub(super) fn dispatch(
         // the `job` wrapper (the model places it outside the Job struct).
         "DescribeJob" => Ok(Some(describe_job(svc, ctx, meta, labels)?)),
 
+        // Jobs: document read + lifecycle mutations that echo the job identity.
+        "GetJobDocument" => Ok(Some(get_job_document(svc, ctx, meta, labels)?)),
+        "AssociateTargetsWithJob" => {
+            Ok(Some(job_lifecycle(svc, ctx, meta, labels, body, false)?))
+        }
+        "CancelJob" => Ok(Some(job_lifecycle(svc, ctx, meta, labels, body, true)?)),
+
+        // Managed IAM-style policy versioning. Versions live in their own
+        // `policy-versions` store keyed `policyName/versionId` so the policy
+        // list is not polluted; CreatePolicy seeds version 1 as the default.
+        "CreatePolicy" => Ok(Some(create_policy(svc, ctx, labels, body)?)),
+        "CreatePolicyVersion" => {
+            Ok(Some(create_policy_version(svc, ctx, meta, labels, query, body)?))
+        }
+        "GetPolicyVersion" => Ok(Some(get_policy_version(svc, ctx, meta, labels)?)),
+        "ListPolicyVersions" => Ok(Some(list_policy_versions(svc, ctx, meta, labels)?)),
+        "SetDefaultPolicyVersion" => {
+            Ok(Some(set_default_policy_version(svc, ctx, meta, labels)?))
+        }
+        "DeletePolicyVersion" => Ok(Some(delete_policy_version(svc, ctx, meta, labels)?)),
+
+        // Provisioning templates: persist the template + its versions so the
+        // Describe / List reads (generic and version-specific) round-trip, and
+        // mint a real (persisted) certificate for the provisioning claim.
+        "CreateProvisioningTemplate" => {
+            Ok(Some(create_provisioning_template(svc, ctx, body)?))
+        }
+        "CreateProvisioningTemplateVersion" => Ok(Some(
+            create_provisioning_template_version(svc, ctx, meta, labels, query, body)?,
+        )),
+        "DescribeProvisioningTemplateVersion" => {
+            Ok(Some(describe_provisioning_template_version(svc, ctx, meta, labels)?))
+        }
+        "ListProvisioningTemplateVersions" => {
+            Ok(Some(list_provisioning_template_versions(svc, ctx, meta, labels)?))
+        }
+        "CreateProvisioningClaim" => Ok(Some(create_provisioning_claim(svc, ctx, meta, labels)?)),
+
+        // Certificate transfer + fleet-provisioning thing registration.
+        "TransferCertificate" => {
+            Ok(Some(transfer_certificate(svc, ctx, meta, labels, query, body)?))
+        }
+        "RegisterThing" => Ok(Some(register_thing(svc, ctx))),
+
+        // Long-running tasks whose only synchronous output is a minted taskId;
+        // persist a task record so the matching Describe read round-trips.
+        "StartThingRegistrationTask"
+        | "StartOnDemandAuditTask"
+        | "StartAuditMitigationActionsTask"
+        | "StartDetectMitigationActionsTask" => Ok(Some(start_task(svc, ctx, meta, labels, body))),
+
+        // Principal <-> thing and thing <-> group listings are the inverse of
+        // the stored relation edges (mirroring ListAttachedPolicies).
+        "ListPrincipalThings" => Ok(Some(list_principal_things(svc, ctx, meta, headers, false))),
+        "ListPrincipalThingsV2" => Ok(Some(list_principal_things(svc, ctx, meta, headers, true))),
+        "ListThingGroupsForThing" => Ok(Some(list_thing_groups_for_thing(svc, ctx, labels))),
+
         // Topic rules: the rule payload is the request body (`@httpPayload`);
         // GetTopicRule nests it under `rule` alongside the `ruleArn`.
         "CreateTopicRule" | "ReplaceTopicRule" => Ok(Some(put_topic_rule(svc, ctx, labels, body))),
@@ -919,4 +976,722 @@ fn describe_job(
         }
         None => Err(super::engine::not_found(meta, &job_id)),
     }
+}
+
+fn get_job_document(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let job_id = labels.get("jobId").cloned().unwrap_or_default();
+    let g = svc.state.read();
+    match g
+        .get(&ctx.account)
+        .and_then(|d| d.get_resource("jobs", &job_id))
+        .cloned()
+    {
+        Some(record) => {
+            // CreateJob persists the inline `document` on the job record; echo it
+            // back verbatim. A job created from a `documentSource` has no inline
+            // document, so the member is simply absent (a shape-valid response).
+            let mut out = Map::new();
+            if let Some(doc) = record.get("document").filter(|v| v.is_string()) {
+                out.insert("document".to_string(), doc.clone());
+            }
+            Ok((ok_json(Value::Object(out)), false))
+        }
+        None => Err(super::engine::not_found(meta, &job_id)),
+    }
+}
+
+/// AssociateTargetsWithJob (append targets) and CancelJob (mark cancelled) both
+/// mutate the stored job and echo its identity (`jobArn` / `jobId` /
+/// `description`).
+fn job_lifecycle(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+    body: &Map<String, Value>,
+    cancel: bool,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let job_id = labels.get("jobId").cloned().unwrap_or_default();
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let Some(mut record) = data.get_resource("jobs", &job_id).cloned() else {
+        return Err(super::engine::not_found(meta, &job_id));
+    };
+    if let Some(obj) = record.as_object_mut() {
+        if cancel {
+            obj.insert("status".to_string(), Value::String("CANCELED".to_string()));
+            for key in ["reasonCode", "comment"] {
+                if let Some(v) = body.get(key) {
+                    obj.insert(key.to_string(), v.clone());
+                }
+            }
+        } else if let Some(Value::Array(added)) = body.get("targets") {
+            let targets = obj
+                .entry("targets")
+                .or_insert_with(|| Value::Array(Vec::new()));
+            if let Value::Array(existing) = targets {
+                for t in added {
+                    if !existing.contains(t) {
+                        existing.push(t.clone());
+                    }
+                }
+            }
+        }
+        obj.insert("lastUpdatedAt".to_string(), super::now_epoch());
+    }
+    let mut out = Map::new();
+    out.insert("jobId".to_string(), Value::String(job_id.clone()));
+    let arn = record
+        .get("jobArn")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| mint_arn(ctx, "jobs", &job_id));
+    out.insert("jobArn".to_string(), Value::String(arn));
+    if let Some(desc) = record.get("description").filter(|v| v.is_string()) {
+        out.insert("description".to_string(), desc.clone());
+    }
+    data.put_resource("jobs", &job_id, record);
+    Ok((ok_json(Value::Object(out)), true))
+}
+
+// ---------- policies + versions ----------
+
+fn policy_version_key(policy: &str, vid: &str) -> String {
+    format!("{policy}/{vid}")
+}
+
+/// Persist one policy version under `policy-versions`, storing both the wire
+/// name (`policyVersionId` / `creationDate`, used by GetPolicyVersion) and the
+/// list-element name (`versionId` / `createDate`, used by ListPolicyVersions).
+fn store_policy_version(
+    data: &mut IotData,
+    policy: &str,
+    arn: &str,
+    document: &str,
+    vid: &str,
+    is_default: bool,
+) {
+    let rec = json!({
+        "policyName": policy,
+        "policyArn": arn,
+        "policyDocument": document,
+        "policyVersionId": vid,
+        "versionId": vid,
+        "isDefaultVersion": is_default,
+        "creationDate": super::now_epoch(),
+        "createDate": super::now_epoch(),
+        "lastModifiedDate": super::now_epoch(),
+        "generationId": "1",
+    });
+    data.put_resource("policy-versions", &policy_version_key(policy, vid), rec);
+}
+
+/// The next monotonic numeric version id for a policy (max existing + 1).
+fn next_policy_version_id(data: &IotData, policy: &str) -> String {
+    let prefix = format!("{policy}/");
+    let max = data
+        .resources
+        .get("policy-versions")
+        .map(|m| {
+            m.keys()
+                .filter_map(|k| k.strip_prefix(&prefix))
+                .filter_map(|s| s.parse::<u64>().ok())
+                .max()
+                .unwrap_or(0)
+        })
+        .unwrap_or(0);
+    (max + 1).to_string()
+}
+
+fn clear_default_policy_versions(data: &mut IotData, policy: &str) {
+    let prefix = format!("{policy}/");
+    if let Some(m) = data.resources.get_mut("policy-versions") {
+        for (k, rec) in m.iter_mut() {
+            if k.starts_with(&prefix) {
+                if let Some(o) = rec.as_object_mut() {
+                    o.insert("isDefaultVersion".to_string(), Value::Bool(false));
+                }
+            }
+        }
+    }
+}
+
+/// CreatePolicy: persist the policy record and seed version 1 as the default,
+/// so GetPolicy / GetPolicyVersion / ListPolicyVersions all round-trip.
+fn create_policy(
+    svc: &IotService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+    body: &Map<String, Value>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = labels.get("policyName").cloned().unwrap_or_default();
+    let document = body_str(body, "policyDocument").unwrap_or("").to_string();
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    if data.get_resource("policies", &name).is_some() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "ResourceAlreadyExistsException",
+            format!("Policy cannot be created - name already exists (name={name})"),
+        ));
+    }
+    let arn = mint_arn(ctx, "policies", &name);
+    let policy_rec = json!({
+        "policyName": name,
+        "policyArn": arn,
+        "policyDocument": document,
+        "defaultVersionId": "1",
+        "creationDate": super::now_epoch(),
+        "lastModifiedDate": super::now_epoch(),
+        "generationId": "1",
+    });
+    data.put_resource("policies", &name, policy_rec);
+    store_policy_version(data, &name, &arn, &document, "1", true);
+    Ok((
+        ok_json(json!({
+            "policyName": name,
+            "policyArn": arn,
+            "policyDocument": document,
+            "policyVersionId": "1",
+        })),
+        true,
+    ))
+}
+
+fn create_policy_version(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+    query: &[(String, String)],
+    body: &Map<String, Value>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = labels.get("policyName").cloned().unwrap_or_default();
+    let document = body_str(body, "policyDocument").unwrap_or("").to_string();
+    let set_as_default = query_get(query, "setAsDefault") == Some("true");
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let Some(policy) = data.get_resource("policies", &name).cloned() else {
+        return Err(super::engine::not_found(meta, &name));
+    };
+    let arn = policy
+        .get("policyArn")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| mint_arn(ctx, "policies", &name));
+    let vid = next_policy_version_id(data, &name);
+    if set_as_default {
+        clear_default_policy_versions(data, &name);
+        if let Some(rec) = data.resources.get_mut("policies").and_then(|m| m.get_mut(&name)) {
+            if let Some(o) = rec.as_object_mut() {
+                o.insert("defaultVersionId".to_string(), Value::String(vid.clone()));
+            }
+        }
+    }
+    store_policy_version(data, &name, &arn, &document, &vid, set_as_default);
+    Ok((
+        ok_json(json!({
+            "policyArn": arn,
+            "policyDocument": document,
+            "policyVersionId": vid,
+            "isDefaultVersion": set_as_default,
+        })),
+        true,
+    ))
+}
+
+fn get_policy_version(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = labels.get("policyName").cloned().unwrap_or_default();
+    let vid = labels.get("policyVersionId").cloned().unwrap_or_default();
+    let g = svc.state.read();
+    match g
+        .get(&ctx.account)
+        .and_then(|d| d.get_resource("policy-versions", &policy_version_key(&name, &vid)))
+    {
+        Some(rec) => Ok((ok_json(super::build_output(meta, rec)), false)),
+        None => Err(super::engine::not_found(meta, &vid)),
+    }
+}
+
+fn list_policy_versions(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = labels.get("policyName").cloned().unwrap_or_default();
+    let g = svc.state.read();
+    let data = g.get(&ctx.account);
+    if data.and_then(|d| d.get_resource("policies", &name)).is_none() {
+        return Err(super::engine::not_found(meta, &name));
+    }
+    let prefix = format!("{name}/");
+    let mut versions = Vec::new();
+    if let Some(m) = data.and_then(|d| d.resources.get("policy-versions")) {
+        for (k, rec) in m {
+            if k.starts_with(&prefix) {
+                versions.push(super::build_element(meta, rec));
+            }
+        }
+    }
+    Ok((ok_json(json!({ "policyVersions": versions })), false))
+}
+
+fn set_default_policy_version(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = labels.get("policyName").cloned().unwrap_or_default();
+    let vid = labels.get("policyVersionId").cloned().unwrap_or_default();
+    let key = policy_version_key(&name, &vid);
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    if data.get_resource("policy-versions", &key).is_none() {
+        return Err(super::engine::not_found(meta, &vid));
+    }
+    clear_default_policy_versions(data, &name);
+    if let Some(rec) = data
+        .resources
+        .get_mut("policy-versions")
+        .and_then(|m| m.get_mut(&key))
+    {
+        if let Some(o) = rec.as_object_mut() {
+            o.insert("isDefaultVersion".to_string(), Value::Bool(true));
+        }
+    }
+    if let Some(rec) = data.resources.get_mut("policies").and_then(|m| m.get_mut(&name)) {
+        if let Some(o) = rec.as_object_mut() {
+            o.insert("defaultVersionId".to_string(), Value::String(vid.clone()));
+        }
+    }
+    Ok((ok_json(Value::Object(Map::new())), true))
+}
+
+fn delete_policy_version(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = labels.get("policyName").cloned().unwrap_or_default();
+    let vid = labels.get("policyVersionId").cloned().unwrap_or_default();
+    let key = policy_version_key(&name, &vid);
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let Some(rec) = data.get_resource("policy-versions", &key).cloned() else {
+        return Err(super::engine::not_found(meta, &vid));
+    };
+    // AWS forbids deleting the default version (it must be deleted via
+    // DeletePolicy); the operation declares DeleteConflictException for this.
+    if rec.get("isDefaultVersion").and_then(Value::as_bool) == Some(true) {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "DeleteConflictException",
+            "Cannot delete the default version of a policy.".to_string(),
+        ));
+    }
+    data.remove_resource("policy-versions", &key);
+    Ok((ok_json(Value::Object(Map::new())), true))
+}
+
+// ---------- provisioning templates + versions + claim ----------
+
+fn provisioning_version_key(name: &str, vid: i64) -> String {
+    format!("{name}/{vid}")
+}
+
+fn store_provisioning_version(
+    data: &mut IotData,
+    name: &str,
+    vid: i64,
+    template_body: &str,
+    is_default: bool,
+) {
+    let rec = json!({
+        "versionId": vid,
+        "templateBody": template_body,
+        "isDefaultVersion": is_default,
+        "creationDate": super::now_epoch(),
+    });
+    data.put_resource(
+        "provisioning-template-versions",
+        &provisioning_version_key(name, vid),
+        rec,
+    );
+}
+
+fn next_provisioning_version_id(data: &IotData, name: &str) -> i64 {
+    let prefix = format!("{name}/");
+    let max = data
+        .resources
+        .get("provisioning-template-versions")
+        .map(|m| {
+            m.keys()
+                .filter_map(|k| k.strip_prefix(&prefix))
+                .filter_map(|s| s.parse::<i64>().ok())
+                .max()
+                .unwrap_or(0)
+        })
+        .unwrap_or(0);
+    max + 1
+}
+
+fn clear_default_provisioning_versions(data: &mut IotData, name: &str) {
+    let prefix = format!("{name}/");
+    if let Some(m) = data.resources.get_mut("provisioning-template-versions") {
+        for (k, rec) in m.iter_mut() {
+            if k.starts_with(&prefix) {
+                if let Some(o) = rec.as_object_mut() {
+                    o.insert("isDefaultVersion".to_string(), Value::Bool(false));
+                }
+            }
+        }
+    }
+}
+
+fn create_provisioning_template(
+    svc: &IotService,
+    ctx: &Ctx,
+    body: &Map<String, Value>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = body_str(body, "templateName").unwrap_or("").to_string();
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    if data.get_resource("provisioning-templates", &name).is_some() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "ResourceAlreadyExistsException",
+            format!("Template with name {name} already exists."),
+        ));
+    }
+    let arn = mint_arn(ctx, "provisioning-templates", &name);
+    let template_body = body_str(body, "templateBody").unwrap_or("").to_string();
+    let mut rec = Map::new();
+    rec.insert("templateArn".to_string(), Value::String(arn.clone()));
+    rec.insert("templateName".to_string(), Value::String(name.clone()));
+    for key in ["description", "provisioningRoleArn", "type", "preProvisioningHook"] {
+        if let Some(v) = body.get(key) {
+            rec.insert(key.to_string(), v.clone());
+        }
+    }
+    rec.insert("templateBody".to_string(), Value::String(template_body.clone()));
+    rec.insert(
+        "enabled".to_string(),
+        Value::Bool(body.get("enabled").and_then(Value::as_bool).unwrap_or(true)),
+    );
+    rec.insert("defaultVersionId".to_string(), Value::from(1));
+    rec.insert("creationDate".to_string(), super::now_epoch());
+    rec.insert("lastModifiedDate".to_string(), super::now_epoch());
+    data.put_resource("provisioning-templates", &name, Value::Object(rec));
+    store_provisioning_version(data, &name, 1, &template_body, true);
+    Ok((
+        ok_json(json!({
+            "templateArn": arn,
+            "templateName": name,
+            "defaultVersionId": 1,
+        })),
+        true,
+    ))
+}
+
+fn create_provisioning_template_version(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+    query: &[(String, String)],
+    body: &Map<String, Value>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = labels.get("templateName").cloned().unwrap_or_default();
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let Some(template) = data.get_resource("provisioning-templates", &name).cloned() else {
+        return Err(super::engine::not_found(meta, &name));
+    };
+    let arn = template
+        .get("templateArn")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| mint_arn(ctx, "provisioning-templates", &name));
+    let template_body = body_str(body, "templateBody").unwrap_or("").to_string();
+    let vid = next_provisioning_version_id(data, &name);
+    let set_as_default = query_get(query, "setAsDefault") == Some("true");
+    if set_as_default {
+        clear_default_provisioning_versions(data, &name);
+        if let Some(rec) = data
+            .resources
+            .get_mut("provisioning-templates")
+            .and_then(|m| m.get_mut(&name))
+        {
+            if let Some(o) = rec.as_object_mut() {
+                o.insert("defaultVersionId".to_string(), Value::from(vid));
+            }
+        }
+    }
+    store_provisioning_version(data, &name, vid, &template_body, set_as_default);
+    Ok((
+        ok_json(json!({
+            "templateArn": arn,
+            "templateName": name,
+            "versionId": vid,
+            "isDefaultVersion": set_as_default,
+        })),
+        true,
+    ))
+}
+
+fn describe_provisioning_template_version(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = labels.get("templateName").cloned().unwrap_or_default();
+    let vid = labels.get("versionId").cloned().unwrap_or_default();
+    let g = svc.state.read();
+    match g
+        .get(&ctx.account)
+        .and_then(|d| d.get_resource("provisioning-template-versions", &format!("{name}/{vid}")))
+    {
+        Some(rec) => Ok((ok_json(super::build_output(meta, rec)), false)),
+        None => Err(super::engine::not_found(meta, &vid)),
+    }
+}
+
+fn list_provisioning_template_versions(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = labels.get("templateName").cloned().unwrap_or_default();
+    let g = svc.state.read();
+    let data = g.get(&ctx.account);
+    if data
+        .and_then(|d| d.get_resource("provisioning-templates", &name))
+        .is_none()
+    {
+        return Err(super::engine::not_found(meta, &name));
+    }
+    let prefix = format!("{name}/");
+    let mut versions = Vec::new();
+    if let Some(m) = data.and_then(|d| d.resources.get("provisioning-template-versions")) {
+        for (k, rec) in m {
+            if k.starts_with(&prefix) {
+                versions.push(super::build_element(meta, rec));
+            }
+        }
+    }
+    Ok((ok_json(json!({ "versions": versions })), false))
+}
+
+fn create_provisioning_claim(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = labels.get("templateName").cloned().unwrap_or_default();
+    {
+        let g = svc.state.read();
+        if g
+            .get(&ctx.account)
+            .and_then(|d| d.get_resource("provisioning-templates", &name))
+            .is_none()
+        {
+            return Err(super::engine::not_found(meta, &name));
+        }
+    }
+    let seq = { svc.state.write().get_or_create(&ctx.account).next_seq() };
+    let cert_id = mint_hex64(&format!("{}:claim:{name}:{seq}", ctx.account));
+    // The claim's certificate is a real, persisted (temporary) certificate.
+    store_certificate(svc, ctx, "certificates", &cert_id, true);
+    let expiration = {
+        let millis = chrono::Utc::now().timestamp_millis() + 3_600_000;
+        Value::from(millis as f64 / 1000.0)
+    };
+    Ok((
+        ok_json(json!({
+            "certificateId": cert_id,
+            "certificatePem": placeholder_pem("CERTIFICATE", &cert_id),
+            "keyPair": key_pair(&cert_id),
+            "expiration": expiration,
+        })),
+        true,
+    ))
+}
+
+// ---------- certificate transfer + thing registration ----------
+
+fn transfer_certificate(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+    query: &[(String, String)],
+    body: &Map<String, Value>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let cert_id = labels.get("certificateId").cloned().unwrap_or_default();
+    let target = query_get(query, "targetAwsAccount").unwrap_or("").to_string();
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let Some(mut rec) = data.get_resource("certificates", &cert_id).cloned() else {
+        return Err(super::engine::not_found(meta, &cert_id));
+    };
+    let transferred_arn = format!("arn:aws:iot:{}:{}:cert/{}", ctx.region, target, cert_id);
+    if let Some(o) = rec.as_object_mut() {
+        o.insert(
+            "status".to_string(),
+            Value::String("PENDING_TRANSFER".to_string()),
+        );
+        o.insert("transferredTo".to_string(), Value::String(target));
+        if let Some(m) = body.get("transferMessage") {
+            o.insert("transferMessage".to_string(), m.clone());
+        }
+    }
+    data.put_resource("certificates", &cert_id, rec);
+    Ok((
+        ok_json(json!({ "transferredCertificateArn": transferred_arn })),
+        true,
+    ))
+}
+
+/// RegisterThing (fleet provisioning): mint and persist a real certificate and
+/// thing, returning the certificate PEM and the map of provisioned resource
+/// ARNs (`resourceArns`).
+fn register_thing(svc: &IotService, ctx: &Ctx) -> (AwsResponse, bool) {
+    let seq = { svc.state.write().get_or_create(&ctx.account).next_seq() };
+    let thing_name = format!("provisioned-thing-{seq}");
+    let cert_id = mint_hex64(&format!("{}:register:{seq}", ctx.account));
+    let cert_arn = store_certificate(svc, ctx, "certificates", &cert_id, true);
+    let thing_arn = mint_arn(ctx, "things", &thing_name);
+    let thing_id = super::mint_uuid(&format!("{}:things:{thing_name}", ctx.account));
+    {
+        let mut g = svc.state.write();
+        let data = g.get_or_create(&ctx.account);
+        data.put_resource(
+            "things",
+            &thing_name,
+            json!({
+                "thingName": thing_name,
+                "thingArn": thing_arn.clone(),
+                "thingId": thing_id,
+            }),
+        );
+    }
+    (
+        ok_json(json!({
+            "certificatePem": placeholder_pem("CERTIFICATE", &cert_id),
+            "resourceArns": {
+                "thing": thing_arn,
+                "certificate": cert_arn,
+            },
+        })),
+        true,
+    )
+}
+
+// ---------- long-running tasks ----------
+
+/// Start a long-running task. The taskId is either the client-supplied URI
+/// label or, when the operation mints it, a deterministic id; a task record is
+/// persisted under the operation's resource type so the matching Describe reads
+/// back.
+fn start_task(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let rtype = super::resource_type(meta);
+    let task_id = match labels.get("taskId") {
+        Some(id) => id.clone(),
+        None => {
+            let seq = { svc.state.write().get_or_create(&ctx.account).next_seq() };
+            super::mint_uuid(&format!("{}:{rtype}:{seq}", ctx.account))
+        }
+    };
+    let mut rec = body.clone();
+    rec.insert("taskId".to_string(), Value::String(task_id.clone()));
+    rec.entry("status")
+        .or_insert_with(|| Value::String("IN_PROGRESS".to_string()));
+    rec.entry("taskStatus")
+        .or_insert_with(|| Value::String("IN_PROGRESS".to_string()));
+    rec.insert("creationDate".to_string(), super::now_epoch());
+    {
+        let mut g = svc.state.write();
+        let data = g.get_or_create(&ctx.account);
+        data.put_resource(&rtype, &task_id, Value::Object(rec));
+    }
+    (ok_json(json!({ "taskId": task_id })), true)
+}
+
+// ---------- principal/thing/group inversions ----------
+
+/// The suffixes of every `prefix<a>` relation key whose value set contains
+/// `target` — i.e. the inverse of the stored edges.
+fn inverse_relation(data: Option<&IotData>, prefix: &str, target: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(d) = data {
+        for (key, values) in &d.relations {
+            if let Some(a) = key.strip_prefix(prefix) {
+                if values.iter().any(|v| v == target) {
+                    out.push(a.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+fn list_principal_things(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    headers: &HeaderMap,
+    v2: bool,
+) -> (AwsResponse, bool) {
+    let principal = header_principal(meta, headers).unwrap_or("").to_string();
+    let g = svc.state.read();
+    let things = inverse_relation(g.get(&ctx.account), "thing-principals:", &principal);
+    if v2 {
+        let objs: Vec<Value> = things
+            .into_iter()
+            .map(|t| json!({ "thingName": t }))
+            .collect();
+        (ok_json(json!({ "principalThingObjects": objs })), false)
+    } else {
+        (ok_json(json!({ "things": things })), false)
+    }
+}
+
+fn list_thing_groups_for_thing(
+    svc: &IotService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+) -> (AwsResponse, bool) {
+    let thing = lbl(labels, "thingName").unwrap_or("").to_string();
+    let g = svc.state.read();
+    let groups = inverse_relation(g.get(&ctx.account), "group-things:", &thing);
+    let objs: Vec<Value> = groups
+        .into_iter()
+        .map(|grp| {
+            let arn = mint_arn(ctx, "thing-groups", &grp);
+            json!({ "groupName": grp, "groupArn": arn })
+        })
+        .collect();
+    (ok_json(json!({ "thingGroups": objs })), false)
 }

--- a/crates/fakecloud-iot/src/service/tests.rs
+++ b/crates/fakecloud-iot/src/service/tests.rs
@@ -769,7 +769,10 @@ fn policy_version_subsystem_round_trips() {
     let got = body_of(&run(&s, "GET", "/policies/p1/version/2", &[], Value::Null).unwrap());
     assert_eq!(got["policyVersionId"], "2");
     assert_eq!(got["isDefaultVersion"], true);
-    assert!(got["policyDocument"].as_str().unwrap().contains("Statement"));
+    assert!(got["policyDocument"]
+        .as_str()
+        .unwrap()
+        .contains("Statement"));
 
     // ListPolicyVersions lists both, with exactly one default (v2).
     let listed = body_of(&run(&s, "GET", "/policies/p1/version", &[], Value::Null).unwrap());
@@ -783,7 +786,13 @@ fn policy_version_subsystem_round_trips() {
     assert_eq!(defaults[0]["versionId"], "2");
 
     // Deleting the default version is rejected; a non-default version deletes.
-    let err = expect_err(run(&s, "DELETE", "/policies/p1/version/2", &[], Value::Null));
+    let err = expect_err(run(
+        &s,
+        "DELETE",
+        "/policies/p1/version/2",
+        &[],
+        Value::Null,
+    ));
     assert!(is_code(&err, "DeleteConflictException"));
     run(&s, "DELETE", "/policies/p1/version/1", &[], Value::Null).unwrap();
     let listed = body_of(&run(&s, "GET", "/policies/p1/version", &[], Value::Null).unwrap());
@@ -809,7 +818,14 @@ fn provisioning_template_round_trips() {
 
     // DescribeProvisioningTemplate (generic get) round-trips the record.
     let desc = body_of(
-        &run(&s, "GET", "/provisioning-templates/fleet-1", &[], Value::Null).unwrap(),
+        &run(
+            &s,
+            "GET",
+            "/provisioning-templates/fleet-1",
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
     );
     assert_eq!(desc["templateName"], "fleet-1");
     assert_eq!(desc["enabled"], true);
@@ -839,9 +855,7 @@ fn provisioning_template_round_trips() {
     assert_eq!(dv["versionId"], 2);
 
     // ListProvisioningTemplates must NOT include version records.
-    let listed = body_of(
-        &run(&s, "GET", "/provisioning-templates", &[], Value::Null).unwrap(),
-    );
+    let listed = body_of(&run(&s, "GET", "/provisioning-templates", &[], Value::Null).unwrap());
     assert_eq!(listed["templates"].as_array().unwrap().len(), 1);
 
     // A provisioning claim mints a real (persisted) certificate.
@@ -928,7 +942,14 @@ fn start_task_mints_and_persists_task_id() {
     assert!(!task_id.is_empty());
     // DescribeAuditTask reads the persisted task back.
     let desc = body_of(
-        &run(&s, "GET", &format!("/audit/tasks/{task_id}"), &[], Value::Null).unwrap(),
+        &run(
+            &s,
+            "GET",
+            &format!("/audit/tasks/{task_id}"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
     );
     assert_eq!(desc["taskStatus"], "IN_PROGRESS");
 }
@@ -972,8 +993,7 @@ fn list_thing_groups_for_thing_inverts_membership() {
         json!({"thingGroupName": "g1", "thingName": "t1"}),
     )
     .unwrap();
-    let listed =
-        body_of(&run(&s, "GET", "/things/t1/thing-groups", &[], Value::Null).unwrap());
+    let listed = body_of(&run(&s, "GET", "/things/t1/thing-groups", &[], Value::Null).unwrap());
     let groups = listed["thingGroups"].as_array().unwrap();
     assert_eq!(groups.len(), 1);
     assert_eq!(groups[0]["groupName"], "g1");

--- a/crates/fakecloud-iot/src/service/tests.rs
+++ b/crates/fakecloud-iot/src/service/tests.rs
@@ -715,6 +715,274 @@ fn create_job_document_source_round_trips() {
     assert!(desc["job"].get("documentSource").is_none());
 }
 
+#[test]
+fn get_job_document_returns_stored_document() {
+    let s = svc();
+    run(
+        &s,
+        "PUT",
+        "/jobs/j1",
+        &[],
+        json!({"targets": ["arn:aws:iot:us-east-1:000000000000:thing/t1"],
+               "document": "{\"operation\":\"reboot\"}"}),
+    )
+    .unwrap();
+    let doc = body_of(&run(&s, "GET", "/jobs/j1/job-document", &[], Value::Null).unwrap());
+    assert_eq!(doc["document"], "{\"operation\":\"reboot\"}");
+
+    // A missing job is a declared ResourceNotFoundException.
+    let err = expect_err(run(&s, "GET", "/jobs/ghost/job-document", &[], Value::Null));
+    assert!(is_code(&err, "ResourceNotFoundException"));
+}
+
+#[test]
+fn policy_version_subsystem_round_trips() {
+    let s = svc();
+    // CreatePolicy seeds version 1 as the default.
+    let created = body_of(
+        &run(
+            &s,
+            "POST",
+            "/policies/p1",
+            &[],
+            json!({"policyDocument": "{\"Version\":\"2012-10-17\",\"Statement\":[]}"}),
+        )
+        .unwrap(),
+    );
+    assert_eq!(created["policyVersionId"], "1");
+
+    // A new version is minted with the next id; setAsDefault flips the default.
+    let v2 = body_of(
+        &run(
+            &s,
+            "POST",
+            "/policies/p1/version?setAsDefault=true",
+            &[],
+            json!({"policyDocument": "{\"Version\":\"2012-10-17\",\"Statement\":[{}]}"}),
+        )
+        .unwrap(),
+    );
+    assert_eq!(v2["policyVersionId"], "2");
+    assert_eq!(v2["isDefaultVersion"], true);
+
+    // GetPolicyVersion returns the stored document + default flag.
+    let got = body_of(&run(&s, "GET", "/policies/p1/version/2", &[], Value::Null).unwrap());
+    assert_eq!(got["policyVersionId"], "2");
+    assert_eq!(got["isDefaultVersion"], true);
+    assert!(got["policyDocument"].as_str().unwrap().contains("Statement"));
+
+    // ListPolicyVersions lists both, with exactly one default (v2).
+    let listed = body_of(&run(&s, "GET", "/policies/p1/version", &[], Value::Null).unwrap());
+    let versions = listed["policyVersions"].as_array().unwrap();
+    assert_eq!(versions.len(), 2);
+    let defaults: Vec<&Value> = versions
+        .iter()
+        .filter(|v| v["isDefaultVersion"] == Value::Bool(true))
+        .collect();
+    assert_eq!(defaults.len(), 1);
+    assert_eq!(defaults[0]["versionId"], "2");
+
+    // Deleting the default version is rejected; a non-default version deletes.
+    let err = expect_err(run(&s, "DELETE", "/policies/p1/version/2", &[], Value::Null));
+    assert!(is_code(&err, "DeleteConflictException"));
+    run(&s, "DELETE", "/policies/p1/version/1", &[], Value::Null).unwrap();
+    let listed = body_of(&run(&s, "GET", "/policies/p1/version", &[], Value::Null).unwrap());
+    assert_eq!(listed["policyVersions"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn provisioning_template_round_trips() {
+    let s = svc();
+    let created = body_of(
+        &run(
+            &s,
+            "POST",
+            "/provisioning-templates",
+            &[],
+            json!({"templateName": "fleet-1", "templateBody": "{}",
+                   "provisioningRoleArn": "arn:aws:iam::000000000000:role/prov"}),
+        )
+        .unwrap(),
+    );
+    assert_eq!(created["templateName"], "fleet-1");
+    assert_eq!(created["defaultVersionId"], 1);
+
+    // DescribeProvisioningTemplate (generic get) round-trips the record.
+    let desc = body_of(
+        &run(&s, "GET", "/provisioning-templates/fleet-1", &[], Value::Null).unwrap(),
+    );
+    assert_eq!(desc["templateName"], "fleet-1");
+    assert_eq!(desc["enabled"], true);
+
+    // A new version + describe it back.
+    let v2 = body_of(
+        &run(
+            &s,
+            "POST",
+            "/provisioning-templates/fleet-1/versions",
+            &[],
+            json!({"templateBody": "{\"v\":2}"}),
+        )
+        .unwrap(),
+    );
+    assert_eq!(v2["versionId"], 2);
+    let dv = body_of(
+        &run(
+            &s,
+            "GET",
+            "/provisioning-templates/fleet-1/versions/2",
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert_eq!(dv["versionId"], 2);
+
+    // ListProvisioningTemplates must NOT include version records.
+    let listed = body_of(
+        &run(&s, "GET", "/provisioning-templates", &[], Value::Null).unwrap(),
+    );
+    assert_eq!(listed["templates"].as_array().unwrap().len(), 1);
+
+    // A provisioning claim mints a real (persisted) certificate.
+    let claim = body_of(
+        &run(
+            &s,
+            "POST",
+            "/provisioning-templates/fleet-1/provisioning-claim",
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    let claim_cert = claim["certificateId"].as_str().unwrap();
+    assert_eq!(claim_cert.len(), 64);
+    run(
+        &s,
+        "GET",
+        &format!("/certificates/{claim_cert}"),
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+}
+
+#[test]
+fn register_thing_mints_resource_arns() {
+    let s = svc();
+    let doc = body_of(
+        &run(
+            &s,
+            "POST",
+            "/things",
+            &[],
+            json!({"templateBody": "{\"Resources\":{}}"}),
+        )
+        .unwrap(),
+    );
+    assert!(doc["certificatePem"]
+        .as_str()
+        .unwrap()
+        .contains("BEGIN CERTIFICATE"));
+    assert!(doc["resourceArns"]["thing"]
+        .as_str()
+        .unwrap()
+        .contains(":thing/"));
+}
+
+#[test]
+fn transfer_certificate_returns_target_arn() {
+    let s = svc();
+    let cert = body_of(&run(&s, "POST", "/keys-and-certificate", &[], Value::Null).unwrap());
+    let cert_id = cert["certificateId"].as_str().unwrap();
+    let out = body_of(
+        &run(
+            &s,
+            "PATCH",
+            &format!("/transfer-certificate/{cert_id}?targetAwsAccount=111122223333"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert!(out["transferredCertificateArn"]
+        .as_str()
+        .unwrap()
+        .contains(":111122223333:cert/"));
+}
+
+#[test]
+fn start_task_mints_and_persists_task_id() {
+    let s = svc();
+    let out = body_of(
+        &run(
+            &s,
+            "POST",
+            "/audit/tasks",
+            &[],
+            json!({"targetCheckNames": ["LOGGING_DISABLED_CHECK"]}),
+        )
+        .unwrap(),
+    );
+    let task_id = out["taskId"].as_str().unwrap();
+    assert!(!task_id.is_empty());
+    // DescribeAuditTask reads the persisted task back.
+    let desc = body_of(
+        &run(&s, "GET", &format!("/audit/tasks/{task_id}"), &[], Value::Null).unwrap(),
+    );
+    assert_eq!(desc["taskStatus"], "IN_PROGRESS");
+}
+
+#[test]
+fn list_principal_things_inverts_attachment() {
+    let s = svc();
+    let principal = "arn:aws:iot:us-east-1:000000000000:cert/abc";
+    run(&s, "POST", "/things/t1", &[], json!({})).unwrap();
+    run(
+        &s,
+        "PUT",
+        "/things/t1/principals",
+        &[("x-amzn-principal", principal)],
+        Value::Null,
+    )
+    .unwrap();
+    let listed = body_of(
+        &run(
+            &s,
+            "GET",
+            "/principals/things",
+            &[("x-amzn-principal", principal)],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert_eq!(listed["things"], json!(["t1"]));
+}
+
+#[test]
+fn list_thing_groups_for_thing_inverts_membership() {
+    let s = svc();
+    run(&s, "POST", "/things/t1", &[], json!({})).unwrap();
+    run(&s, "POST", "/thing-groups/g1", &[], json!({})).unwrap();
+    run(
+        &s,
+        "PUT",
+        "/thing-groups/addThingToThingGroup",
+        &[],
+        json!({"thingGroupName": "g1", "thingName": "t1"}),
+    )
+    .unwrap();
+    let listed =
+        body_of(&run(&s, "GET", "/things/t1/thing-groups", &[], Value::Null).unwrap());
+    let groups = listed["thingGroups"].as_array().unwrap();
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0]["groupName"], "g1");
+    assert!(groups[0]["groupArn"]
+        .as_str()
+        .unwrap()
+        .contains(":thinggroup/g1"));
+}
+
 // ---------- every operation routes to a handler ----------
 
 #[test]


### PR DESCRIPTION
## Summary

Bug-hunt findings on the newly-merged IoT Core greenfield surface (post-parity-milestone safety pass). Write/read-asymmetry stubs in the `Verb::Action` catch-all, fixed with real behavior (no stubs), persisting where AWS persists.

- **GetJobDocument** returned `{}` though CreateJob persists `document`; now reads it back (`{"document": <stored>}`), 404 on unknown job.
- **Policy-version subsystem** was entirely no-op; now real, stored in a dedicated `policy-versions` type keyed `policyName/versionId`. CreatePolicy seeds version 1 (default); CreatePolicyVersion mints the next id, honors `setAsDefault`, returns policyArn/policyDocument/policyVersionId/isDefaultVersion; Get/ListPolicyVersions read them; SetDefaultPolicyVersion flips default; DeletePolicyVersion removes (rejects the default with model-declared DeleteConflictException).
- **Action ops that mint data**: RegisterThing (mints+persists cert+thing, returns certificatePem + resourceArns), TransferCertificate (transferredCertificateArn from targetAwsAccount, cert -> PENDING_TRANSFER), AssociateTargetsWithJob/CancelJob (persist + echo jobArn/jobId/description), Create{ProvisioningTemplate,ProvisioningTemplateVersion,ProvisioningClaim} (persist records so Describe/List round-trip; claim mints a persisted cert), Start{ThingRegistration,OnDemandAudit,AuditMitigationActions,DetectMitigationActions}Task (taskId minted/echoed + persisted so Describe*Task reads back). Describe/ListProvisioningTemplateVersion routed to special (separate store).
- **Relation inversions**: ListPrincipalThings / ListPrincipalThingsV2 / ListThingGroupsForThing now invert the stored thing-principals / group-things edges instead of returning empty.

### Documented emulation limits
- Analytics ops (GetStatistics/GetCardinality/TestAuthorization, etc.) unchanged — they mint no ids/resources, out of scope for this pass.
- RegisterThing resourceArns keys are representative (template CFN logical IDs need a real provisioning engine), but the ARNs point at genuinely persisted resources.

## Test plan
- New e2e: CreateJob->GetJobDocument; CreatePolicy->CreatePolicyVersion->Get/List; RegisterThing resourceArns; ListPrincipalThings after AttachThingPrincipal.
- `cargo clippy -p fakecloud-iot --all-targets` clean; `cargo test -p fakecloud-iot` 44 pass (incl. 272-op self-test); e2e compiles.

## Surface
Behavioral bug-fix — no new ops/SDK/counts. Non-code surface unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces IoT Core stubs with persisted behavior to fix read/write asymmetry. Adds real policy versioning, returns stored job documents, persists IDs for Action ops, and corrects principal/thing and group listings. No API surface changes.

- **New Features**
  - Real policy versioning: `CreatePolicy` seeds v1 as default; `CreatePolicyVersion` auto-increments and honors `setAsDefault`; `Get/List/SetDefault/DeletePolicyVersion` read/write a dedicated `policy-versions` store and reject deleting the default.
  - Persisted Action outputs: `RegisterThing` (certificatePem + resourceArns), `CreateProvisioningTemplate`/`Version`/`Claim` (separate version store; claim mints a persisted cert), `Start*Task` (mint + persist taskId), `TransferCertificate` (returns transferredCertificateArn and marks status), and `AssociateTargetsWithJob`/`CancelJob` (persist + echo jobArn/jobId/description).

- **Bug Fixes**
  - `GetJobDocument` returns the stored `document` and 404s for unknown jobs.
  - `ListPrincipalThings`, `ListPrincipalThingsV2`, and `ListThingGroupsForThing` now invert stored edges to return correct memberships.

<sup>Written for commit 3515cd7f0eaf64426d04466d4a3c55c96630c4d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

