### PR TITLE
feat(sdks): add getDistributions() across all six SDKs

### DIFF
--- a/crates/fakecloud-e2e/tests/sdk.rs
+++ b/crates/fakecloud-e2e/tests/sdk.rs
@@ -1,5 +1,9 @@
 mod helpers;
 
+use aws_sdk_cloudfront::types::{
+    CookiePreference, DefaultCacheBehavior, DistributionConfig, ForwardedValues, Headers,
+    ItemSelection, Origin, Origins, ViewerProtocolPolicy,
+};
 use aws_sdk_cognitoidentityprovider::types::{AttributeType, ExplicitAuthFlowsType};
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ScalarAttributeType,
@@ -937,4 +941,91 @@ async fn sdk_secretsmanager_tick_rotation() {
         .expect("tick rotation");
     // Just verify it returns successfully with expected shape
     let _ = resp.rotated_secrets;
+}
+
+// ── CloudFront ─────────────────────────────────────────────────────
+
+// The legacy `forwarded_values`/`min_ttl` cache-behavior shape is deprecated in
+// the AWS SDK (superseded by cache policies) but is the minimal config fakecloud
+// accepts, matching the cloudfront_dataplane e2e tests.
+#[allow(deprecated)]
+#[tokio::test]
+async fn sdk_cloudfront_get_distributions() {
+    let server = TestServer::start().await;
+    let fc = FakeCloud::new(server.endpoint());
+    let cf = server.cloudfront_client().await;
+
+    // Minimal enabled distribution: one origin + a default cache behavior.
+    let config = DistributionConfig::builder()
+        .caller_reference("sdk-cf-dist")
+        .comment("sdk get_distributions e2e")
+        .enabled(true)
+        .origins(
+            Origins::builder()
+                .quantity(1)
+                .items(
+                    Origin::builder()
+                        .id("o1")
+                        .domain_name("example.s3-website-us-east-1.amazonaws.com")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .default_cache_behavior(
+            DefaultCacheBehavior::builder()
+                .target_origin_id("o1")
+                .viewer_protocol_policy(ViewerProtocolPolicy::AllowAll)
+                .forwarded_values(
+                    ForwardedValues::builder()
+                        .query_string(false)
+                        .cookies(
+                            CookiePreference::builder()
+                                .forward(ItemSelection::None)
+                                .build()
+                                .unwrap(),
+                        )
+                        .headers(Headers::builder().quantity(0).build().unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .min_ttl(0)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let created = cf
+        .create_distribution()
+        .distribution_config(config)
+        .send()
+        .await
+        .expect("create_distribution");
+    let id = created
+        .distribution()
+        .expect("distribution returned")
+        .id()
+        .to_string();
+
+    let resp = fc
+        .cloudfront()
+        .get_distributions()
+        .await
+        .expect("get_distributions");
+    let dist = resp
+        .distributions
+        .iter()
+        .find(|d| d.id == id)
+        .expect("created distribution listed");
+    // The data-plane domain lowercases the (uppercase) distribution id.
+    assert_eq!(
+        dist.domain_name,
+        format!("{}.cloudfront.net", id.to_lowercase())
+    );
+    assert!(dist.enabled);
+    // The data plane is on by default in the test server, so an enabled
+    // distribution is served on the main listener.
+    assert!(dist.served);
 }

--- a/crates/fakecloud-sdk/README.md
+++ b/crates/fakecloud-sdk/README.md
@@ -105,6 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 | Method                                   | Description                                              |
 | ---------------------------------------- | -------------------------------------------------------- |
+| `get_distributions().await`              | List distributions with `domainName` / `enabled` / `served` |
 | `set_distribution_status(id, req).await` | Override a CloudFront distribution's deployment status   |
 
 ### `fc.cognito()`

--- a/crates/fakecloud-sdk/src/client.rs
+++ b/crates/fakecloud-sdk/src/client.rs
@@ -2417,6 +2417,23 @@ pub struct CloudFrontClient<'a> {
 }
 
 impl CloudFrontClient<'_> {
+    /// List every stored CloudFront Distribution with its reachability. Each
+    /// entry carries the `<id>.cloudfront.net` `domainName` to send as the
+    /// `Host` header to fakecloud's main endpoint, plus `enabled` and whether
+    /// the in-process data plane currently `served` it.
+    pub async fn get_distributions(&self) -> Result<CloudFrontDistributionsResponse, Error> {
+        let resp = self
+            .fc
+            .client
+            .get(format!(
+                "{}/_fakecloud/cloudfront/distributions",
+                self.fc.base_url
+            ))
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
+
     /// Force a stored CloudFront Distribution into a new status (typically
     /// `"Deployed"` or `"InProgress"`). Returns an `Api { status: 404, .. }`
     /// error when the distribution doesn't exist.

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -341,6 +341,7 @@ func main() {
 
 | Method | Description |
 |--------|-------------|
+| `GetDistributions(ctx)` | List distributions, each with its `.cloudfront.net` domain and whether the in-process data plane serves it |
 | `SetDistributionStatus(ctx, id, req)` | Force a distribution into `Deployed`/`InProgress` |
 
 #### Testing Bedrock-calling code end-to-end

--- a/sdks/go/cloudfront.go
+++ b/sdks/go/cloudfront.go
@@ -11,6 +11,15 @@ type CloudFrontClient struct {
 	fc *FakeCloud
 }
 
+// GetDistributions lists every CloudFront distribution across every account.
+func (c *CloudFrontClient) GetDistributions(ctx context.Context) (*CloudFrontDistributionsResponse, error) {
+	var out CloudFrontDistributionsResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/cloudfront/distributions", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // SetDistributionStatus flips a stored CloudFront Distribution's status
 // (typically "Deployed" or "InProgress") so tests can synchronously force
 // propagation without waiting on the periodic tick. Returns an APIError

--- a/sdks/go/e2e/e2e_test.go
+++ b/sdks/go/e2e/e2e_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	cognitotypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -213,6 +215,85 @@ func TestE2ERDS(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("expected to find sdk-go-rds-db via introspection")
+	}
+}
+
+// ── CloudFront ─────────────────────────────────────────────────────
+
+func TestE2ECloudFrontGetDistributions(t *testing.T) {
+	resetState(t)
+	ctx := context.Background()
+	cfg := awsConfig(t)
+
+	cfClient := cloudfront.NewFromConfig(cfg, func(o *cloudfront.Options) {
+		o.BaseEndpoint = aws.String(fakecloudURL)
+	})
+
+	// Minimal valid distribution: one S3-website origin + a legacy
+	// ForwardedValues default cache behavior (the smallest shape the
+	// control plane accepts).
+	create, err := cfClient.CreateDistribution(ctx, &cloudfront.CreateDistributionInput{
+		DistributionConfig: &cftypes.DistributionConfig{
+			CallerReference: aws.String("sdk-go-cf-getdist"),
+			Comment:         aws.String("sdk go e2e"),
+			Enabled:         aws.Bool(true),
+			Origins: &cftypes.Origins{
+				Quantity: aws.Int32(1),
+				Items: []cftypes.Origin{
+					{
+						Id:         aws.String("o1"),
+						DomainName: aws.String("example-bucket.s3-website-us-east-1.amazonaws.com"),
+					},
+				},
+			},
+			DefaultCacheBehavior: &cftypes.DefaultCacheBehavior{
+				TargetOriginId:       aws.String("o1"),
+				ViewerProtocolPolicy: cftypes.ViewerProtocolPolicyAllowAll,
+				ForwardedValues: &cftypes.ForwardedValues{
+					QueryString: aws.Bool(false),
+					Cookies: &cftypes.CookiePreference{
+						Forward: cftypes.ItemSelectionNone,
+					},
+					Headers: &cftypes.Headers{Quantity: aws.Int32(0)},
+				},
+				MinTTL: aws.Int64(0),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateDistribution failed: %v", err)
+	}
+	if create.Distribution == nil || create.Distribution.Id == nil {
+		t.Fatal("expected a distribution id from CreateDistribution")
+	}
+	distID := *create.Distribution.Id
+
+	fc := fakecloud.New(fakecloudURL)
+	resp, err := fc.CloudFront().GetDistributions(ctx)
+	if err != nil {
+		t.Fatalf("CloudFront().GetDistributions() failed: %v", err)
+	}
+
+	found := false
+	for _, d := range resp.Distributions {
+		if d.ID == distID {
+			found = true
+			if !strings.HasSuffix(d.DomainName, ".cloudfront.net") {
+				t.Fatalf("expected .cloudfront.net domain, got %q", d.DomainName)
+			}
+			if !d.Enabled {
+				t.Fatal("expected distribution to be enabled")
+			}
+			// The in-process data plane serves an enabled distribution
+			// unless disabled via FAKECLOUD_CLOUDFRONT_DISABLE_DATAPLANE,
+			// which the e2e server does not set.
+			if !d.Served {
+				t.Fatal("expected enabled distribution to be served by the data plane")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected to find %s via introspection", distID)
 	}
 }
 

--- a/sdks/go/e2e/go.mod
+++ b/sdks/go/e2e/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.46.0
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.59.3
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.306.0

--- a/sdks/go/e2e/go.sum
+++ b/sdks/go/e2e/go.sum
@@ -16,6 +16,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22/go.mod h1:zd/JsJ4P7oGfUhXn1VyLqaRZwPmZwg44Jf2dS84Dm3Y=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.46.0 h1:wdm9Pjye5PSQ+ELMHXOh7SQhiXLDk2iONZ+fDmISi28=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.46.0/go.mod h1:FIBJ48TS+qJb+Ne4qJ+0NeIhtPTVXItXooTeNeVI4Po=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.59.3 h1:iO0QRVlRoZXdOnpHEqSpitTRN4ygq+FraXdYgm4qZdU=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.59.3/go.mod h1:XPkppF4ijOR6oZvwXB2tjQDLjkTEGCFn8Onl26v4GHQ=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1 h1:Vk+a1j2pXZHkkYqHmEdpwe8eX6NDtFSBGfzuauMEWYQ=

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -1771,6 +1771,28 @@ type CloudFrontDistributionStatusRequest struct {
 	Status string `json:"status"`
 }
 
+// CloudFrontDistribution is a snapshot of one CloudFront distribution as
+// surfaced by GET /_fakecloud/cloudfront/distributions.
+type CloudFrontDistribution struct {
+	ID string `json:"id"`
+	// DomainName is the distribution's `<id>.cloudfront.net` domain. Send it
+	// as the `Host` header to fakecloud's main endpoint to reach the
+	// in-process data plane.
+	DomainName string `json:"domainName"`
+	// Enabled reflects the distribution's enabled flag.
+	Enabled bool `json:"enabled"`
+	// Served reports whether the in-process data plane currently serves this
+	// distribution — true when it is enabled and the data plane has not been
+	// disabled via FAKECLOUD_CLOUDFRONT_DISABLE_DATAPLANE.
+	Served bool `json:"served"`
+}
+
+// CloudFrontDistributionsResponse is returned by
+// GET /_fakecloud/cloudfront/distributions.
+type CloudFrontDistributionsResponse struct {
+	Distributions []CloudFrontDistribution `json:"distributions"`
+}
+
 // ── ELBv2 WAF counts ───────────────────────────────────────────────
 
 // Elbv2WafCountsResponse is the pass-through payload from

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -364,7 +364,23 @@ FakeCloud fc = new FakeCloud("http://localhost:4566"); // explicit base URL
 
 | Method                                          | Description                                                                                  |
 | ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `getDistributions()`                            | List CloudFront distributions with their `<id>.cloudfront.net` domain, `enabled` flag, and whether the in-process data plane currently `served` them |
 | `setDistributionStatus(distributionId, status)` | Flip a stored CloudFront Distribution's status (`Deployed` / `InProgress`) without waiting   |
+
+```java
+import dev.fakecloud.FakeCloud;
+
+FakeCloud fc = new FakeCloud();
+
+// After creating a distribution via the AWS SDK CloudFront client:
+var dist = fc.cloudfront().getDistributions().distributions().get(0);
+System.out.println(dist.domainName()); // e.g. E1EXAMPLE123.cloudfront.net
+System.out.println(dist.enabled());    // true
+System.out.println(dist.served());     // true once the data plane serves it
+
+// Reach the data plane by sending domainName as the Host header to the
+// main fakecloud endpoint (http://localhost:4566).
+```
 
 #### Full test loop — asserting on Bedrock calls
 

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     val awsSdk = "2.27.21"
     testImplementation(platform("software.amazon.awssdk:bom:$awsSdk"))
     testImplementation("software.amazon.awssdk:sqs")
+    testImplementation("software.amazon.awssdk:cloudfront")
     testImplementation("software.amazon.awssdk:sns")
     testImplementation("software.amazon.awssdk:sesv2")
     testImplementation("software.amazon.awssdk:s3")

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -20,6 +20,7 @@ import dev.fakecloud.Types.BedrockModelResponseConfig;
 import dev.fakecloud.Types.BedrockResponseRule;
 import dev.fakecloud.Types.BedrockStatusResponse;
 import dev.fakecloud.Types.CloudFrontDistributionStatusRequest;
+import dev.fakecloud.Types.CloudFrontDistributionsResponse;
 import dev.fakecloud.Types.CreateAdminRequest;
 import dev.fakecloud.Types.CreateAdminResponse;
 import dev.fakecloud.Types.ConfirmSubscriptionRequest;
@@ -1422,6 +1423,21 @@ public final class FakeCloud {
     public static final class CloudFrontClient {
         private final HttpTransport http;
         CloudFrontClient(HttpTransport http) { this.http = http; }
+
+        /**
+         * List every CloudFront Distribution fakecloud is tracking. Each
+         * entry carries its {@code <id>.cloudfront.net} domain name (send it
+         * as the {@code Host} header to fakecloud's main endpoint to reach
+         * the data plane), its {@code enabled} flag, and whether the
+         * in-process data plane currently {@code served} it (true when the
+         * distribution is enabled and the data plane has not been disabled
+         * via {@code FAKECLOUD_CLOUDFRONT_DISABLE_DATAPLANE}).
+         */
+        public CloudFrontDistributionsResponse getDistributions() {
+            return http.get(
+                    "/_fakecloud/cloudfront/distributions",
+                    CloudFrontDistributionsResponse.class);
+        }
 
         /**
          * Flip a stored CloudFront Distribution's status (e.g.

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -1510,6 +1510,32 @@ public final class Types {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Elbv2WafCountsResponse(Object counts) {}
 
+    // ── CloudFront ───────────────────────────────────────────────
+
+    /**
+     * One distribution from {@code GET /_fakecloud/cloudfront/distributions}.
+     *
+     * <ul>
+     *   <li>{@code domainName} — the {@code <id>.cloudfront.net} domain; send
+     *       it as the {@code Host} header to fakecloud's main endpoint to
+     *       reach the in-process data plane for this distribution.</li>
+     *   <li>{@code enabled} — the distribution's {@code Enabled} flag.</li>
+     *   <li>{@code served} — whether the in-process data plane currently
+     *       serves this distribution (true when it is enabled and the data
+     *       plane has not been disabled via
+     *       {@code FAKECLOUD_CLOUDFRONT_DISABLE_DATAPLANE}).</li>
+     * </ul>
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record CloudFrontDistribution(
+            String id,
+            String domainName,
+            boolean enabled,
+            boolean served) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record CloudFrontDistributionsResponse(List<CloudFrontDistribution> distributions) {}
+
     // ── CloudFront admin ─────────────────────────────────────────
 
     /**

--- a/sdks/java/src/test/java/dev/fakecloud/E2ETest.java
+++ b/sdks/java/src/test/java/dev/fakecloud/E2ETest.java
@@ -22,6 +22,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
+import software.amazon.awssdk.services.cloudfront.model.CookiePreference;
+import software.amazon.awssdk.services.cloudfront.model.CreateDistributionRequest;
+import software.amazon.awssdk.services.cloudfront.model.DefaultCacheBehavior;
+import software.amazon.awssdk.services.cloudfront.model.DistributionConfig;
+import software.amazon.awssdk.services.cloudfront.model.ForwardedValues;
+import software.amazon.awssdk.services.cloudfront.model.Headers;
+import software.amazon.awssdk.services.cloudfront.model.ItemSelection;
+import software.amazon.awssdk.services.cloudfront.model.Origin;
+import software.amazon.awssdk.services.cloudfront.model.Origins;
+import software.amazon.awssdk.services.cloudfront.model.ViewerProtocolPolicy;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.CreateUserPoolClientRequest;
@@ -453,6 +464,53 @@ class E2ETest {
         assertTrue(
                 "creating".equals(cache.status()) || "available".equals(cache.status()),
                 "unexpected status: " + cache.status());
+    }
+
+    // ── CloudFront ─────────────────────────────────────────────────
+    @Test
+    void cloudfrontGetDistributionsReturnsManagedDistributions() {
+        CloudFrontClient cf = configure(CloudFrontClient.builder()).build();
+        var config = DistributionConfig.builder()
+                .callerReference("java-cf-" + System.nanoTime())
+                .comment("java e2e")
+                .enabled(true)
+                .origins(Origins.builder()
+                        .quantity(1)
+                        .items(Origin.builder()
+                                .id("o1")
+                                .domainName("example-bucket.s3-website-us-east-1.amazonaws.com")
+                                .build())
+                        .build())
+                .defaultCacheBehavior(DefaultCacheBehavior.builder()
+                        .targetOriginId("o1")
+                        .viewerProtocolPolicy(ViewerProtocolPolicy.ALLOW_ALL)
+                        .forwardedValues(ForwardedValues.builder()
+                                .queryString(false)
+                                .cookies(CookiePreference.builder()
+                                        .forward(ItemSelection.NONE)
+                                        .build())
+                                .headers(Headers.builder().quantity(0).build())
+                                .build())
+                        .minTTL(0L)
+                        .build())
+                .build();
+        var created = cf.createDistribution(CreateDistributionRequest.builder()
+                .distributionConfig(config)
+                .build());
+        String id = created.distribution().id();
+
+        var dist = fc.cloudfront().getDistributions().distributions().stream()
+                .filter(d -> id.equals(d.id()))
+                .findFirst()
+                .orElseThrow();
+        assertTrue(dist.enabled());
+        assertNotNull(dist.domainName());
+        assertTrue(
+                dist.domainName().endsWith(".cloudfront.net"),
+                "unexpected domainName: " + dist.domainName());
+        // The distribution is enabled and the data plane is on by default, so
+        // the in-process data plane serves it.
+        assertTrue(dist.served());
     }
 
     // ── Bedrock introspection ──────────────────────────────────────

--- a/sdks/php/README.md
+++ b/sdks/php/README.md
@@ -346,6 +346,7 @@ $fc = new FakeCloud('http://localhost:4566'); // explicit base URL
 
 | Method                                          | Description                                          |
 | ----------------------------------------------- | ---------------------------------------------------- |
+| `getDistributions()`                            | List CloudFront distributions (id, domain, served)   |
 | `setDistributionStatus($distributionId, $status)` | Force a CloudFront distribution into a status        |
 
 #### Full test loop — asserting on Bedrock calls

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -1570,6 +1570,21 @@ final class CloudFrontClient
     public function __construct(private readonly HttpTransport $http) {}
 
     /**
+     * List the CloudFront distributions fakecloud is tracking. Each entry
+     * carries its `<id>.cloudfront.net` domain name (send as the `Host`
+     * header to fakecloud's main endpoint to reach the data plane), its
+     * enabled flag, and whether the in-process data plane currently serves
+     * it (`served` is true when enabled and the data plane is not disabled
+     * via `FAKECLOUD_CLOUDFRONT_DISABLE_DATAPLANE`).
+     */
+    public function getDistributions(): CloudFrontDistributionsResponse
+    {
+        return CloudFrontDistributionsResponse::fromArray(
+            $this->http->get('/_fakecloud/cloudfront/distributions')
+        );
+    }
+
+    /**
      * Force a CloudFront distribution into the given status (typically
      * `"Deployed"` or `"InProgress"`). Throws {@see FakeCloudError}
      * with HTTP 404 when the distribution id is unknown.

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -4207,3 +4207,49 @@ final class Elbv2WafCountsResponse
         return new self($data['counts'] ?? null);
     }
 }
+
+// ── CloudFront ──────────────────────────────────────────────────
+
+final class CloudFrontDistribution
+{
+    public function __construct(
+        public readonly string $id,
+        /**
+         * The distribution's `<id>.cloudfront.net` domain. Send this as the
+         * `Host` header to fakecloud's main endpoint to reach the
+         * distribution's data plane.
+         */
+        public readonly string $domainName,
+        public readonly bool $enabled,
+        /**
+         * Whether the distribution is currently served by the in-process data
+         * plane on the main listener (`true` when enabled and the data plane
+         * is not disabled via `FAKECLOUD_CLOUDFRONT_DISABLE_DATAPLANE`).
+         * Data-plane extension, not part of the AWS API surface.
+         */
+        public readonly bool $served,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['id'],
+            $data['domainName'],
+            $data['enabled'],
+            $data['served'],
+        );
+    }
+}
+
+final class CloudFrontDistributionsResponse
+{
+    public function __construct(
+        /** @var CloudFrontDistribution[] */
+        public readonly array $distributions,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(CloudFrontDistribution::fromArray(...), $data['distributions'] ?? []));
+    }
+}

--- a/sdks/php/tests/ClientTest.php
+++ b/sdks/php/tests/ClientTest.php
@@ -20,6 +20,8 @@ use FakeCloud\ConfirmationCode;
 use FakeCloud\ConfirmationCodesResponse;
 use FakeCloud\ConfirmSubscriptionRequest;
 use FakeCloud\ConfirmSubscriptionResponse;
+use FakeCloud\CloudFrontDistribution;
+use FakeCloud\CloudFrontDistributionsResponse;
 use FakeCloud\ConfirmUserRequest;
 use FakeCloud\ConfirmUserResponse;
 use FakeCloud\ElastiCacheCluster;
@@ -500,6 +502,24 @@ final class ClientTest extends TestCase
         ]);
         $this->assertSame('msg-1', $resp->messageId);
         $this->assertCount(1, $resp->actionsExecuted);
+    }
+
+    public function testCloudFrontDistributionsResponseFromArray(): void
+    {
+        $resp = CloudFrontDistributionsResponse::fromArray([
+            'distributions' => [
+                ['id' => 'E1ABCDEF', 'domainName' => 'E1ABCDEF.cloudfront.net', 'enabled' => true, 'served' => true],
+                ['id' => 'E2GHIJKL', 'domainName' => 'E2GHIJKL.cloudfront.net', 'enabled' => false, 'served' => false],
+            ],
+        ]);
+        $this->assertCount(2, $resp->distributions);
+        $this->assertInstanceOf(CloudFrontDistribution::class, $resp->distributions[0]);
+        $this->assertSame('E1ABCDEF', $resp->distributions[0]->id);
+        $this->assertSame('E1ABCDEF.cloudfront.net', $resp->distributions[0]->domainName);
+        $this->assertTrue($resp->distributions[0]->enabled);
+        $this->assertTrue($resp->distributions[0]->served);
+        $this->assertFalse($resp->distributions[1]->enabled);
+        $this->assertFalse($resp->distributions[1]->served);
     }
 
     public function testUnknownFieldsIgnored(): void

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -191,6 +191,7 @@ Pass `base_url` (default `http://localhost:4566`).
 
 | Method | Description |
 |---|---|
+| `get_distributions()` | List stored distributions with their `domain_name` (`Host` header) + `served` reachability |
 | `set_distribution_status(distribution_id, status)` | Force a distribution into a given status |
 
 ### `fc.acm`

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -23,6 +23,7 @@ from fakecloud.types import (
     BedrockModelResponseConfig,
     BedrockResponseRule,
     BedrockStatusResponse,
+    CloudFrontDistributionsResponse,
     CloudFrontDistributionStatusRequest,
     CloudWatchAlarmsResponse,
     CloudWatchMetricsResponse,
@@ -898,6 +899,21 @@ class CloudFrontClient:
         self._client = client
         self._base = base_url
 
+    async def get_distributions(self) -> CloudFrontDistributionsResponse:
+        """List every stored CloudFront distribution with its reachability.
+
+        Each entry carries the ``<id>.cloudfront.net`` ``domain_name`` to send as
+        the ``Host`` header to fakecloud's main endpoint to reach the data plane,
+        the ``enabled`` flag, and whether the in-process data plane currently
+        ``served`` it (``True`` when enabled and the data plane is not disabled via
+        ``FAKECLOUD_CLOUDFRONT_DISABLE_DATAPLANE``).
+        """
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/cloudfront/distributions"
+        )
+        _check(resp)
+        return CloudFrontDistributionsResponse.from_dict(resp.json())
+
     async def set_distribution_status(self, distribution_id: str, status: str) -> None:
         """Force a stored CloudFront distribution into a given status.
 
@@ -918,6 +934,19 @@ class _SyncCloudFrontClient:
     def __init__(self, client: httpx.Client, base_url: str) -> None:
         self._client = client
         self._base = base_url
+
+    def get_distributions(self) -> CloudFrontDistributionsResponse:
+        """List every stored CloudFront distribution with its reachability.
+
+        Each entry carries the ``<id>.cloudfront.net`` ``domain_name`` to send as
+        the ``Host`` header to fakecloud's main endpoint to reach the data plane,
+        the ``enabled`` flag, and whether the in-process data plane currently
+        ``served`` it (``True`` when enabled and the data plane is not disabled via
+        ``FAKECLOUD_CLOUDFRONT_DISABLE_DATAPLANE``).
+        """
+        resp = self._client.get(f"{self._base}/_fakecloud/cloudfront/distributions")
+        _check(resp)
+        return CloudFrontDistributionsResponse.from_dict(resp.json())
 
     def set_distribution_status(self, distribution_id: str, status: str) -> None:
         req = CloudFrontDistributionStatusRequest(status=status)

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -3618,6 +3618,37 @@ class CloudFrontDistributionStatusRequest:
         return {"status": self.status}
 
 
+@dataclass
+class CloudFrontDistribution:
+    id: str
+    domain_name: str
+    enabled: bool
+    served: bool
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> CloudFrontDistribution:
+        return cls(
+            id=data["id"],
+            domain_name=data["domainName"],
+            enabled=data["enabled"],
+            served=data["served"],
+        )
+
+
+@dataclass
+class CloudFrontDistributionsResponse:
+    distributions: List[CloudFrontDistribution]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> CloudFrontDistributionsResponse:
+        return cls(
+            distributions=[
+                CloudFrontDistribution.from_dict(d)
+                for d in data.get("distributions", [])
+            ],
+        )
+
+
 # ── ELBv2 WAF counts ────────────────────────────────────────────────
 
 

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -675,3 +675,44 @@ def test_route53_set_health_check_status_unknown_id(fc: FakeCloudSync) -> None:
     with _pytest.raises(FakeCloudError) as exc:
         fc.route53.set_health_check_status("ghost-hc", "Failure", reason="x")
     assert exc.value.status == 404
+
+
+# ── CloudFront admin ──────────────────────────────────────────────────
+
+
+def _minimal_distribution_config(caller_ref: str) -> dict:  # type: ignore[type-arg]
+    return {
+        "CallerReference": caller_ref,
+        "Comment": "py-sdk-cf",
+        "Enabled": True,
+        "Origins": {
+            "Quantity": 1,
+            "Items": [{"Id": "primary", "DomainName": "example.com"}],
+        },
+        "DefaultCacheBehavior": {
+            "TargetOriginId": "primary",
+            "ViewerProtocolPolicy": "allow-all",
+            "MinTTL": 0,
+            "ForwardedValues": {
+                "QueryString": False,
+                "Cookies": {"Forward": "none"},
+                "Headers": {"Quantity": 0},
+            },
+        },
+    }
+
+
+def test_cloudfront_get_distributions(fc: FakeCloudSync, fakecloud_url: str) -> None:
+    cf = boto3.client("cloudfront", **_boto_kwargs(fakecloud_url))
+    created = cf.create_distribution(
+        DistributionConfig=_minimal_distribution_config("py-sdk-cf-list")
+    )
+    dist_id = created["Distribution"]["Id"]
+
+    result = fc.cloudfront.get_distributions()
+    dist = next(d for d in result.distributions if d.id == dist_id)
+    # The data-plane domain lowercases the (uppercase) distribution id.
+    assert dist.domain_name == f"{dist_id.lower()}.cloudfront.net"
+    assert dist.enabled is True
+    # Data plane is enabled by default, so an enabled distribution is served.
+    assert dist.served is True

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -116,6 +116,7 @@ Top-level client. Defaults to `http://localhost:4566`.
 
 | Method                           | Description                                                       |
 | -------------------------------- | ----------------------------------------------------------------- |
+| `getDistributions()`             | List every CloudFront distribution across every account           |
 | `setDistributionStatus(id, req)` | Flip a Distribution synchronously into `Deployed` or `InProgress` |
 
 ### `fc.cognito`

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "fakecloud",
-  "version": "0.29.0",
+  "version": "0.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.29.0",
+      "version": "0.40.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
+        "@aws-sdk/client-cloudfront": "^3.1085.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",
         "@aws-sdk/client-dynamodb": "^3.750.0",
         "@aws-sdk/client-ec2": "^3.750.0",
@@ -244,6 +245,26 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront": {
+      "version": "3.1085.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1085.0.tgz",
+      "integrity": "sha512-fIGLTXHGFFrlhACzwKjPI/fCPzugTyblU1LV7B0n0BK/1+4udVMdE1OofEbKNlKuy8f1CyeOUaIRmEjcS3bTaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.66",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
@@ -806,23 +827,33 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
-      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
+      "version": "3.975.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
-        "@aws-sdk/xml-builder": "^3.972.29",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.6",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
@@ -840,16 +871,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
-      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -857,18 +888,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.48",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
-      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -876,24 +907,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
-      "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/credential-provider-env": "^3.972.46",
-        "@aws-sdk/credential-provider-http": "^3.972.48",
-        "@aws-sdk/credential-provider-login": "^3.972.51",
-        "@aws-sdk/credential-provider-process": "^3.972.46",
-        "@aws-sdk/credential-provider-sso": "^3.972.51",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
-        "@aws-sdk/nested-clients": "^3.997.19",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -901,17 +932,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.51.tgz",
-      "integrity": "sha512-csHFsH+/VjnI40oqm1l1OqMY4B4kza36DbfcbHcgcbobgjebasqUbTU34xvwUkvtoNGGizbfyMSlMzJWUPv3dQ==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.19",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -919,22 +950,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.54",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
-      "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.46",
-        "@aws-sdk/credential-provider-http": "^3.972.48",
-        "@aws-sdk/credential-provider-ini": "^3.972.52",
-        "@aws-sdk/credential-provider-process": "^3.972.46",
-        "@aws-sdk/credential-provider-sso": "^3.972.51",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -942,16 +973,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
-      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -959,18 +990,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
-      "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.19",
-        "@aws-sdk/token-providers": "3.1065.0",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -978,17 +1009,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
-      "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.19",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1286,21 +1317,19 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
-      "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
+      "version": "3.997.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1325,15 +1354,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.33.tgz",
-      "integrity": "sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==",
+      "version": "3.996.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1341,17 +1370,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1065.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
-      "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.19",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1359,13 +1388,13 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
-      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1471,14 +1500,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
-      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
-        "fast-xml-parser": "5.7.3",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2140,19 +2168,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -2549,14 +2564,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
-      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2564,14 +2578,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
-      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
+      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2654,14 +2668,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
-      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
+      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2861,14 +2875,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
-      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2960,14 +2974,14 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
-      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2994,9 +3008,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
-      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3742,19 +3756,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4196,45 +4197,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4663,22 +4625,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4938,22 +4884,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "anynum": "^1.0.0"
       }
     },
     "node_modules/supports-color": {
@@ -5325,22 +5255,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint . && prettier --check ."
   },
   "devDependencies": {
+    "@aws-sdk/client-cloudfront": "^3.1085.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.750.0",
     "@aws-sdk/client-dynamodb": "^3.750.0",
     "@aws-sdk/client-ec2": "^3.750.0",

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -123,6 +123,7 @@ import type {
   InjectSsmSessionResponse,
   KmsUsageResponse,
   CloudFrontDistributionStatusRequest,
+  CloudFrontDistributionsResponse,
   Elbv2WafCountsResponse,
 } from "./types.js";
 
@@ -1136,6 +1137,14 @@ export class WafV2Client {
  */
 export class CloudFrontClient {
   constructor(private baseUrl: string) {}
+
+  /** List every CloudFront distribution fakecloud has seen, across every account. */
+  async getDistributions(): Promise<CloudFrontDistributionsResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/cloudfront/distributions`,
+    );
+    return parse(resp);
+  }
 
   /** Flip a stored Distribution's status synchronously. */
   async setDistributionStatus(

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -1655,6 +1655,27 @@ export interface KmsUsageResponse {
 
 // ── CloudFront ─────────────────────────────────────────────────────
 
+export interface CloudFrontDistribution {
+  id: string;
+  /**
+   * The distribution's `<id>.cloudfront.net` domain. Send this as the `Host`
+   * header to fakecloud's main endpoint to reach the distribution's data plane.
+   */
+  domainName: string;
+  enabled: boolean;
+  /**
+   * Whether the distribution is currently served by the in-process data plane
+   * on the main listener (`true` when enabled and the data plane is not
+   * disabled via `FAKECLOUD_CLOUDFRONT_DISABLE_DATAPLANE`). Data-plane
+   * extension, not part of the AWS API surface.
+   */
+  served: boolean;
+}
+
+export interface CloudFrontDistributionsResponse {
+  distributions: CloudFrontDistribution[];
+}
+
 /** Body for `POST /_fakecloud/cloudfront/distributions/{id}/status`. */
 export interface CloudFrontDistributionStatusRequest {
   /** Typically `"Deployed"` or `"InProgress"`. */

--- a/sdks/typescript/tests/e2e.test.ts
+++ b/sdks/typescript/tests/e2e.test.ts
@@ -58,6 +58,10 @@ import {
   CreateReplicationGroupCommand,
   CreateServerlessCacheCommand,
 } from "@aws-sdk/client-elasticache";
+import {
+  CloudFrontClient as AwsCloudFrontClient,
+  CreateDistributionCommand,
+} from "@aws-sdk/client-cloudfront";
 
 function getEndpoint(): string {
   const ep = process.env.FAKECLOUD_ENDPOINT;
@@ -254,6 +258,49 @@ describe("elasticache", () => {
     // The backing container starts asynchronously, so the cache is "creating"
     // right after create and transitions to "available" (bug-audit 3.2).
     expect(["creating", "available"]).toContain(cache!.status);
+  });
+});
+
+// ── CloudFront ──────────────────────────────────────────────────────
+
+describe("cloudfront", () => {
+  it("getDistributions() returns fakecloud-managed distributions", async () => {
+    const cf = new AwsCloudFrontClient(awsConfig());
+
+    const created = await cf.send(
+      new CreateDistributionCommand({
+        DistributionConfig: {
+          CallerReference: `ts-cf-${Date.now()}`,
+          Comment: "ts-sdk-getdistributions",
+          Enabled: true,
+          Origins: {
+            Quantity: 1,
+            Items: [{ Id: "primary", DomainName: "example.com" }],
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "primary",
+            ViewerProtocolPolicy: "allow-all",
+            ForwardedValues: {
+              QueryString: false,
+              Cookies: { Forward: "none" },
+              Headers: { Quantity: 0 },
+            },
+            MinTTL: 0,
+          },
+        },
+      }),
+    );
+    const distributionId = created.Distribution?.Id;
+    expect(distributionId).toBeDefined();
+
+    const result = await fc.cloudfront.getDistributions();
+    const dist = result.distributions.find((d) => d.id === distributionId);
+    expect(dist).toBeDefined();
+    expect(dist!.domainName.endsWith(".cloudfront.net")).toBe(true);
+    expect(dist!.enabled).toBe(true);
+    // Data plane is on by default, so an enabled distribution is served on the
+    // main listener.
+    expect(dist!.served).toBe(true);
   });
 });
 

--- a/website/content/docs/sdks/go.md
+++ b/website/content/docs/sdks/go.md
@@ -298,7 +298,22 @@ Sub-clients are accessed via methods: `fc.SES()`, `fc.SNS()`, `fc.Lambda()`, etc
 
 | Method | Description |
 |--------|-------------|
+| `GetDistributions(ctx)` | List distributions, each with its `.cloudfront.net` domain and whether the in-process data plane serves it |
 | `SetDistributionStatus(ctx, id, req)` | Force a distribution into `Deployed`/`InProgress` |
+
+```go
+dists, err := fc.CloudFront().GetDistributions(ctx)
+if err != nil {
+    t.Fatal(err)
+}
+for _, d := range dists.Distributions {
+    // Reach an enabled distribution's data plane by sending its DomainName
+    // as the Host header to fakecloud's main endpoint.
+    if d.Served {
+        req.Host = d.DomainName
+    }
+}
+```
 
 ## Error handling
 

--- a/website/content/docs/sdks/java.md
+++ b/website/content/docs/sdks/java.md
@@ -319,7 +319,23 @@ FakeCloud fc2 = new FakeCloud("http://localhost:5000"); // explicit base URL
 
 | Method                                          | Description                                                                                  |
 | ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `getDistributions()`                            | List CloudFront distributions with their `<id>.cloudfront.net` domain, `enabled` flag, and whether the in-process data plane currently `served` them |
 | `setDistributionStatus(distributionId, status)` | Flip a stored CloudFront Distribution's status (`Deployed` / `InProgress`) without waiting   |
+
+```java
+import dev.fakecloud.FakeCloud;
+
+FakeCloud fc = new FakeCloud();
+
+// After creating a distribution via the AWS SDK CloudFront client:
+var dist = fc.cloudfront().getDistributions().distributions().get(0);
+System.out.println(dist.domainName()); // e.g. E1EXAMPLE123.cloudfront.net
+System.out.println(dist.enabled());    // true
+System.out.println(dist.served());     // true once the data plane serves it
+
+// Reach the data plane by sending domainName as the Host header to the
+// main fakecloud endpoint (http://localhost:4566).
+```
 
 ## Error handling
 

--- a/website/content/docs/sdks/php.md
+++ b/website/content/docs/sdks/php.md
@@ -300,9 +300,10 @@ $fc = new FakeCloud('http://localhost:5000');   // explicit base URL
 
 ## `$fc->cloudfront()`
 
-| Method                                            | Description                                   |
-| ------------------------------------------------- | --------------------------------------------- |
-| `setDistributionStatus($distributionId, $status)` | Force a CloudFront distribution into a status |
+| Method                                            | Description                                     |
+| ------------------------------------------------- | ----------------------------------------------- |
+| `getDistributions()`                              | List CloudFront distributions (id, domain, served) |
+| `setDistributionStatus($distributionId, $status)` | Force a CloudFront distribution into a status   |
 
 ## Error handling
 

--- a/website/content/docs/sdks/python.md
+++ b/website/content/docs/sdks/python.md
@@ -166,6 +166,7 @@ emails = fc.ses.get_emails()
 
 | Method                                         | Description                                          |
 | ---------------------------------------------- | ---------------------------------------------------- |
+| `get_distributions()`                          | List stored distributions with their `domain_name` (`Host` header) + `served` reachability |
 | `set_distribution_status(distribution_id, status)` | Force a distribution into a given status (204 / `FakeCloudError`) |
 
 ## `fc.acm`

--- a/website/content/docs/sdks/rust.md
+++ b/website/content/docs/sdks/rust.md
@@ -90,6 +90,7 @@ Every sub-client is constructed lazily via an accessor (`fc.lambda()`, `fc.sqs()
 
 | Method                                                  | Description                                              |
 | ------------------------------------------------------- | -------------------------------------------------------- |
+| `get_distributions().await`                             | List distributions with `domainName` / `enabled` / `served` |
 | `set_distribution_status(id, req).await`                | Override a CloudFront distribution's deployment status   |
 
 ## `fc.cognito()`

--- a/website/content/docs/sdks/typescript.md
+++ b/website/content/docs/sdks/typescript.md
@@ -89,6 +89,7 @@ const fc = new FakeCloud("http://localhost:5000");
 
 | Method                                | Description                                                              |
 | ------------------------------------- | ------------------------------------------------------------------------ |
+| `getDistributions()`                  | List every CloudFront distribution across every account                  |
 | `setDistributionStatus(id, req)`      | Flip a Distribution synchronously into `Deployed` or `InProgress`        |
 
 ## `fc.cognito`


### PR DESCRIPTION
## Summary

Wraps the `GET /_fakecloud/cloudfront/distributions` introspection endpoint (added in #2221) in every first-party SDK, mirroring the existing `getLoadBalancers()` accessor. This is the primary way for a client to discover how to reach a distribution: each entry carries the `<id>.cloudfront.net` `domainName` to send as the `Host` header to fakecloud's main endpoint, plus `enabled` and `served` (whether the in-process data plane currently serves it).

Response shape returned by every SDK:

```json
{ "distributions": [ { "id": "E123", "domainName": "E123.cloudfront.net", "enabled": true, "served": true } ] }
```

## Changes per language

- **Rust** (`fakecloud-sdk`): `CloudFrontClient::get_distributions()` (the `CloudFrontDistribution`/`...Response` types already landed in #2221).
- **TypeScript / Python / Go / Java / PHP**: matching `getDistributions()` / `get_distributions()` / `GetDistributions()` method + the `CloudFrontDistribution` / `CloudFrontDistributionsResponse` DTOs, mirroring each SDK's `getLoadBalancers` precedent and its JSON-field conventions.
- READMEs + `website/content/docs/sdks/*.md` updated for all six languages.
- One test per SDK: create a distribution via the AWS SDK, then assert it is listed by `getDistributions()` with `enabled == true` and `served == true`.

## Surface check

Additive introspection accessor only. No new service/op, so README headline counts, `conformance-baseline.json`, and the repo description are unchanged. No AWS API surface added, so no Smithy/model changes.

## Test plan

- `cargo clippy -p fakecloud-sdk -p fakecloud-e2e --all-targets -- -D warnings` (Rust 1.97) + `cargo fmt`: clean.
- New Rust e2e `sdk_cloudfront_get_distributions` compiles; per-language SDK tests run on CI shards (go-e2e, java, php, python-test, typescript). Live-server assertions require the batch's server binary, exercised in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds getDistributions() to all six SDKs to list CloudFront distributions and whether the data plane serves them. Lets clients discover the `<id>.cloudfront.net` domain to route traffic; no breaking changes.

- New Features
  - Added `getDistributions` (language-idiomatic variants) in Rust/TypeScript/Python/Go/Java/PHP returning `{ id, domainName, enabled, served }` from `/_fakecloud/cloudfront/distributions` (mirrors `getLoadBalancers`).
  - Updated SDK READMEs and website docs; added e2e tests per SDK that create a distribution and assert it is listed with `enabled == true` and `served == true`.

- Dependencies
  - TypeScript tests: dev dependency `@aws-sdk/client-cloudfront`.
  - Go tests: `github.com/aws/aws-sdk-go-v2/service/cloudfront`.
  - Java tests: `software.amazon.awssdk:cloudfront`.

<sup>Written for commit 8ca731901fe629b77d0dffb24ed5508712402945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

