### PR TITLE
fix(s3): decode XML entities in delete/tagging; persist encryption/rename/metadata-config; guard delivery slices; list-versions prefixes

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -4928,3 +4928,109 @@ async fn list_objects_max_keys_zero_is_empty_not_truncated() {
     assert_eq!(v1.is_truncated(), Some(false));
     assert!(v1.next_marker().is_none());
 }
+
+// XML entity round-trip regression (bug-hunt 2026-07-13): body-sourced keys
+// and tag values arrive XML-encoded (`&` -> `&amp;`) and must be decoded so
+// they match the URL-decoded keys stored via the request path. Before the
+// fix, DeleteObjects on an `&`-containing key falsely reported success while
+// the object survived, and a tag value gained an extra layer of escaping on
+// every GET.
+
+#[tokio::test]
+async fn s3_delete_objects_with_ampersand_key_actually_deletes() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("amp-del")
+        .send()
+        .await
+        .unwrap();
+
+    let key = "reports/2026&2027/summary.txt";
+    client
+        .put_object()
+        .bucket("amp-del")
+        .key(key)
+        .body(ByteStream::from_static(b"data"))
+        .send()
+        .await
+        .unwrap();
+
+    use aws_sdk_s3::types::{Delete, ObjectIdentifier};
+    let delete = Delete::builder()
+        .objects(ObjectIdentifier::builder().key(key).build().unwrap())
+        .build()
+        .unwrap();
+    let resp = client
+        .delete_objects()
+        .bucket("amp-del")
+        .delete(delete)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.deleted().len(), 1);
+    assert_eq!(resp.deleted()[0].key(), Some(key));
+
+    // The object must actually be gone, not merely reported deleted.
+    let list = client
+        .list_objects_v2()
+        .bucket("amp-del")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        list.key_count().unwrap_or(0),
+        0,
+        "object with & key survived delete"
+    );
+}
+
+#[tokio::test]
+async fn s3_object_tagging_round_trips_ampersand_value_unchanged() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("amp-tag")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_object()
+        .bucket("amp-tag")
+        .key("k.txt")
+        .body(ByteStream::from_static(b"data"))
+        .send()
+        .await
+        .unwrap();
+
+    use aws_sdk_s3::types::{Tag, Tagging};
+    let value = "research & development";
+    let tagging = Tagging::builder()
+        .tag_set(Tag::builder().key("dept").value(value).build().unwrap())
+        .build()
+        .unwrap();
+    client
+        .put_object_tagging()
+        .bucket("amp-tag")
+        .key("k.txt")
+        .tagging(tagging)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_object_tagging()
+        .bucket("amp-tag")
+        .key("k.txt")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.tag_set().len(), 1);
+    // The value must come back byte-for-byte, not with extra escaping layers.
+    assert_eq!(resp.tag_set()[0].key(), "dept");
+    assert_eq!(resp.tag_set()[0].value(), value);
+}

--- a/crates/fakecloud-s3/src/inventory.rs
+++ b/crates/fakecloud-s3/src/inventory.rs
@@ -13,14 +13,17 @@ struct InventoryDestination {
 
 /// Parse the destination from an `<InventoryConfiguration>` XML body.
 fn parse_inventory_destination(xml: &str) -> Option<InventoryDestination> {
-    let dest_start = xml.find("<Destination>")?;
-    let dest_end = xml.find("</Destination>")?;
-    let dest_body = &xml[dest_start + 13..dest_end];
+    // Locate each closing tag relative to its opening tag so a malformed body
+    // (closing before opening, or a duplicated/inverted tag) can't slice with
+    // begin > end and panic — a reachable DoS under eager delivery.
+    let dest_content = xml.find("<Destination>")? + "<Destination>".len();
+    let dest_end = xml[dest_content..].find("</Destination>")? + dest_content;
+    let dest_body = &xml[dest_content..dest_end];
 
     // Look for <S3BucketDestination>
-    let s3_start = dest_body.find("<S3BucketDestination>")?;
-    let s3_end = dest_body.find("</S3BucketDestination>")?;
-    let s3_body = &dest_body[s3_start + 21..s3_end];
+    let s3_content = dest_body.find("<S3BucketDestination>")? + "<S3BucketDestination>".len();
+    let s3_end = dest_body[s3_content..].find("</S3BucketDestination>")? + s3_content;
+    let s3_body = &dest_body[s3_content..s3_end];
 
     let bucket_arn = extract_tag(s3_body, "Bucket")?;
     let prefix = extract_tag(s3_body, "Prefix");
@@ -231,6 +234,17 @@ mod tests {
             </Destination>
         </InventoryConfiguration>";
         assert!(parse_inventory_destination(xml).is_none());
+    }
+
+    // Inverted/duplicated tags (closing before opening) used to slice with
+    // begin > end and panic (a reachable DoS under eager delivery); each guard
+    // must return None instead.
+    #[test]
+    fn parse_inventory_inverted_tags_does_not_panic() {
+        assert!(parse_inventory_destination("</Destination>x<Destination>").is_none());
+        let inverted_inner =
+            "<Destination></S3BucketDestination>y<S3BucketDestination></Destination>";
+        assert!(parse_inventory_destination(inverted_inner).is_none());
     }
 
     #[test]

--- a/crates/fakecloud-s3/src/logging.rs
+++ b/crates/fakecloud-s3/src/logging.rs
@@ -39,9 +39,12 @@ pub struct LoggingConfig {
 /// Parse a `<BucketLoggingStatus>` XML body into a `LoggingConfig`, if logging
 /// is enabled (i.e. the `<LoggingEnabled>` element is present).
 pub(crate) fn parse_logging_config(xml: &str) -> Option<LoggingConfig> {
-    let le_start = xml.find("<LoggingEnabled>")?;
-    let le_end = xml.find("</LoggingEnabled>")?;
-    let le_body = &xml[le_start + 16..le_end];
+    // Locate the closing tag relative to the opening one so a malformed body
+    // (closing before opening, or a duplicated/inverted tag) can't slice with
+    // begin > end and panic — a reachable DoS under eager delivery.
+    let le_content = xml.find("<LoggingEnabled>")? + "<LoggingEnabled>".len();
+    let le_end = xml[le_content..].find("</LoggingEnabled>")? + le_content;
+    let le_body = &xml[le_content..le_end];
 
     let target_bucket = extract_tag(le_body, "TargetBucket")?;
     let target_prefix = extract_tag(le_body, "TargetPrefix").unwrap_or_default();
@@ -275,6 +278,15 @@ mod tests {
         let cfg = parse_logging_config(xml).unwrap();
         assert_eq!(cfg.target_bucket, "log");
         assert_eq!(cfg.target_prefix, "");
+    }
+
+    // A malformed body whose closing tag precedes its opening tag used to
+    // slice with begin > end and panic (a reachable DoS under eager delivery);
+    // it must return None instead.
+    #[test]
+    fn parse_logging_config_inverted_tags_does_not_panic() {
+        let xml = "</LoggingEnabled>garbage<LoggingEnabled>";
+        assert!(parse_logging_config(xml).is_none());
     }
 
     #[test]

--- a/crates/fakecloud-s3/src/service/config/mod.rs
+++ b/crates/fakecloud-s3/src/service/config/mod.rs
@@ -7,7 +7,7 @@ use fakecloud_persistence::{
 };
 
 use crate::inventory;
-use crate::persistence::bucket_meta_snapshot;
+use crate::persistence::{bucket_meta_snapshot, object_meta_snapshot};
 
 use super::{
     build_acl_xml, canned_acl_grants, empty_response, extract_xml_value, no_such_bucket,
@@ -517,18 +517,27 @@ impl S3Service {
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
-        let mut accts = self.state.write();
-        let state = accts.get_or_create(account_id);
-        let b = state
-            .buckets
-            .get_mut(bucket)
-            .ok_or_else(|| no_such_bucket(bucket))?;
-        // Composite metadata configuration: append/replace inventory table block.
-        let combined = match b.metadata_configuration.as_deref() {
-            Some(prev) => format!("{prev}\n<InventoryTable>{body_str}</InventoryTable>"),
-            None => format!("<InventoryTable>{body_str}</InventoryTable>"),
+        let combined = {
+            let mut accts = self.state.write();
+            let state = accts.get_or_create(account_id);
+            let b = state
+                .buckets
+                .get_mut(bucket)
+                .ok_or_else(|| no_such_bucket(bucket))?;
+            // Composite metadata configuration: append/replace inventory table block.
+            let combined = match b.metadata_configuration.as_deref() {
+                Some(prev) => format!("{prev}\n<InventoryTable>{body_str}</InventoryTable>"),
+                None => format!("<InventoryTable>{body_str}</InventoryTable>"),
+            };
+            b.metadata_configuration = Some(combined.clone());
+            combined
         };
-        b.metadata_configuration = Some(combined);
+        // Persist the updated composite configuration the same way the create
+        // path does, so the inventory-table block survives a restart instead
+        // of living only in RAM.
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::MetadataConfiguration, &combined)
+            .map_err(crate::service::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
     pub(super) fn update_bucket_metadata_journal_table(
@@ -538,17 +547,25 @@ impl S3Service {
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
-        let mut accts = self.state.write();
-        let state = accts.get_or_create(account_id);
-        let b = state
-            .buckets
-            .get_mut(bucket)
-            .ok_or_else(|| no_such_bucket(bucket))?;
-        let combined = match b.metadata_configuration.as_deref() {
-            Some(prev) => format!("{prev}\n<JournalTable>{body_str}</JournalTable>"),
-            None => format!("<JournalTable>{body_str}</JournalTable>"),
+        let combined = {
+            let mut accts = self.state.write();
+            let state = accts.get_or_create(account_id);
+            let b = state
+                .buckets
+                .get_mut(bucket)
+                .ok_or_else(|| no_such_bucket(bucket))?;
+            let combined = match b.metadata_configuration.as_deref() {
+                Some(prev) => format!("{prev}\n<JournalTable>{body_str}</JournalTable>"),
+                None => format!("<JournalTable>{body_str}</JournalTable>"),
+            };
+            b.metadata_configuration = Some(combined.clone());
+            combined
         };
-        b.metadata_configuration = Some(combined);
+        // Persist the updated composite configuration (see the inventory-table
+        // sibling above) so the journal-table block survives a restart.
+        self.store
+            .put_bucket_subresource(bucket, BucketSubresource::MetadataConfiguration, &combined)
+            .map_err(crate::service::persistence_error)?;
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -637,7 +654,43 @@ impl S3Service {
                 format!("Source key {source_key} does not exist."),
             )
         })?;
+        let src_version = obj.version_id.clone();
         b.objects.insert(key.to_string(), obj);
+
+        // Persist the move through the store: write the object under the new
+        // key and delete the old key. Without this the rename lived only in
+        // memory and reverted to the old key on restart in disk mode.
+        let (meta, body_bytes) = {
+            let o = state
+                .buckets
+                .get(bucket)
+                .and_then(|bb| bb.objects.get(key))
+                .ok_or_else(|| no_such_bucket(bucket))?;
+            let bytes = state
+                .read_body(&o.body)
+                .map_err(crate::service::io_to_aws)?;
+            (object_meta_snapshot(o), bytes)
+        };
+        let new_body = crate::service::objects::run_blocking_io(|| {
+            self.store.put_object(
+                bucket,
+                key,
+                meta.version_id.as_deref(),
+                fakecloud_persistence::BodySource::Bytes(body_bytes),
+                &meta,
+            )
+        })
+        .map_err(crate::service::persistence_error)?;
+        self.store
+            .delete_object(bucket, &source_key, src_version.as_deref())
+            .map_err(crate::service::persistence_error)?;
+        if let Some(o) = state
+            .buckets
+            .get_mut(bucket)
+            .and_then(|bb| bb.objects.get_mut(key))
+        {
+            o.body = new_body;
+        }
         Ok(empty_response(StatusCode::OK))
     }
 
@@ -727,10 +780,44 @@ impl S3Service {
         if let Some(kid) = new_kms_key_id {
             obj.sse_kms_key_id = if kid.is_empty() { None } else { Some(kid) };
         }
-        if !same_alg {
-            obj.body = crate::state::memory_body(new_bytes);
-        }
         let _ = body_handle; // silence unused when same_alg branch wins
+
+        // Snapshot the just-mutated metadata and persist through the store so
+        // the re-encrypted body + updated SSE metadata survive a restart.
+        // Previously this handler mutated RAM only: on restart disk mode
+        // rehydrated the stale on-disk ciphertext and old key id, which is
+        // undecryptable when this call had removed the KMS key.
+        let meta = object_meta_snapshot(
+            state
+                .buckets
+                .get(bucket)
+                .and_then(|bb| bb.objects.get(key))
+                .ok_or_else(|| no_such_bucket(bucket))?,
+        );
+        if same_alg {
+            // Body unchanged; only the metadata (kms key id) may have moved.
+            self.store
+                .put_object_meta(bucket, key, meta.version_id.as_deref(), &meta)
+                .map_err(crate::service::persistence_error)?;
+        } else {
+            let new_body = crate::service::objects::run_blocking_io(|| {
+                self.store.put_object(
+                    bucket,
+                    key,
+                    meta.version_id.as_deref(),
+                    fakecloud_persistence::BodySource::Bytes(new_bytes),
+                    &meta,
+                )
+            })
+            .map_err(crate::service::persistence_error)?;
+            if let Some(o) = state
+                .buckets
+                .get_mut(bucket)
+                .and_then(|bb| bb.objects.get_mut(key))
+            {
+                o.body = new_body;
+            }
+        }
         Ok(empty_response(StatusCode::OK))
     }
 

--- a/crates/fakecloud-s3/src/service/lock.rs
+++ b/crates/fakecloud-s3/src/service/lock.rs
@@ -30,8 +30,20 @@ impl S3Service {
                 return Err(malformed_object_lock("Mode", m));
             }
         }
-        let retain_until = extract_xml_value(body_str, "RetainUntilDate")
+        let retain_until_raw = extract_xml_value(body_str, "RetainUntilDate");
+        let retain_until = retain_until_raw
+            .as_deref()
             .and_then(|s| s.parse::<DateTime<Utc>>().ok());
+        // A retention with a Mode must carry a valid RetainUntilDate. AWS
+        // rejects a Mode-only (or unparseable-date) body with 400 MalformedXML
+        // rather than persisting a mode that would later round-trip into the
+        // x-amz-object-lock-mode header with no expiry.
+        if mode.is_some() && retain_until.is_none() {
+            return Err(malformed_object_lock(
+                "RetainUntilDate",
+                retain_until_raw.as_deref().unwrap_or(""),
+            ));
+        }
 
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2576,7 +2576,69 @@ pub(crate) fn extract_xml_value(xml: &str, tag: &str) -> Option<String> {
     // (closing tag before opening) can't make end < start and panic the
     // slice (bug-audit 2026-05-28, 2.2).
     let end = xml[start..].find(&close)? + start;
-    Some(xml[start..end].to_string())
+    // Decode XML entities in the text node. S3 request bodies arrive
+    // XML-encoded — every SDK escapes `&`, `<`, `>` (and sometimes `"`/`'`
+    // plus numeric refs) — so a key/value like `a&b` is on the wire as
+    // `a&amp;b`. Without decoding, an object keyed `a&b` (the key arrives
+    // URL-decoded from the request path) is never matched by a
+    // DeleteObjects/PutObjectTagging body, and a tag value round-trips with
+    // an extra layer of escaping on every GET.
+    Some(decode_xml_entities(&xml[start..end]))
+}
+
+/// Decode the standard XML entities in a text node value using a single
+/// left-to-right pass. A chain of `str::replace` calls would double-decode
+/// (e.g. `&amp;lt;` — the escaped literal text `&lt;` — must decode to
+/// `&lt;`, not to `<`), so the scan resolves each `&…;` exactly once.
+/// Handles the named entities (`amp`, `lt`, `gt`, `quot`, `apos`) and both
+/// decimal (`&#38;`) and hex (`&#x26;`) numeric character references; an
+/// unrecognized `&…` sequence is emitted verbatim, matching how lenient XML
+/// readers treat a bare ampersand.
+pub(crate) fn decode_xml_entities(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < s.len() {
+        if bytes[i] == b'&' {
+            // Bound the entity name so a stray '&' followed by a distant ';'
+            // doesn't swallow a long span of text.
+            if let Some(rel) = s[i + 1..].find(';') {
+                if rel <= 10 {
+                    let entity = &s[i + 1..i + 1 + rel];
+                    let decoded = match entity {
+                        "amp" => Some('&'),
+                        "lt" => Some('<'),
+                        "gt" => Some('>'),
+                        "quot" => Some('"'),
+                        "apos" => Some('\''),
+                        _ => entity
+                            .strip_prefix("#x")
+                            .or_else(|| entity.strip_prefix("#X"))
+                            .and_then(|hex| u32::from_str_radix(hex, 16).ok())
+                            .or_else(|| {
+                                entity.strip_prefix('#').and_then(|d| d.parse::<u32>().ok())
+                            })
+                            .and_then(char::from_u32),
+                    };
+                    if let Some(c) = decoded {
+                        out.push(c);
+                        i += 1 + rel + 1;
+                        continue;
+                    }
+                }
+            }
+            out.push('&');
+            i += 1;
+        } else {
+            let ch = s[i..].chars().next().unwrap();
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+    out
 }
 
 /// Parse the CompleteMultipartUpload XML body into (part_number, etag) pairs.
@@ -3047,7 +3109,7 @@ mod s3_iam_service_prefix_tests {
 
 #[cfg(test)]
 mod extract_xml_value_tests {
-    use super::extract_xml_value;
+    use super::{decode_xml_entities, extract_xml_value};
 
     #[test]
     fn returns_inner_value() {
@@ -3055,6 +3117,42 @@ mod extract_xml_value_tests {
             extract_xml_value("<Root><Key>value</Key></Root>", "Key"),
             Some("value".to_string())
         );
+    }
+
+    // The wire form of a key `a&b` is `<Key>a&amp;b</Key>`; the parsed value
+    // must decode back to `a&b` so it matches the URL-decoded key that
+    // arrives via the request path (otherwise DeleteObjects/Tagging silently
+    // miss the object).
+    #[test]
+    fn decodes_named_and_numeric_entities() {
+        assert_eq!(
+            extract_xml_value("<Key>a&amp;b</Key>", "Key"),
+            Some("a&b".to_string())
+        );
+        assert_eq!(
+            extract_xml_value("<Key>&lt;x&gt; &quot;y&quot; &apos;z&apos;</Key>", "Key"),
+            Some("<x> \"y\" 'z'".to_string())
+        );
+        assert_eq!(
+            extract_xml_value("<Key>a&#38;b&#x26;c</Key>", "Key"),
+            Some("a&b&c".to_string())
+        );
+    }
+
+    // A single left-to-right pass must resolve each entity exactly once:
+    // `&amp;lt;` is the escaped literal text `&lt;`, so it decodes to `&lt;`,
+    // NOT to `<` (which a chain of `str::replace` calls would wrongly produce).
+    #[test]
+    fn does_not_double_decode() {
+        assert_eq!(decode_xml_entities("&amp;lt;"), "&lt;");
+        assert_eq!(decode_xml_entities("&amp;amp;"), "&amp;");
+    }
+
+    #[test]
+    fn leaves_bare_ampersand_and_unknown_entities_verbatim() {
+        assert_eq!(decode_xml_entities("a & b"), "a & b");
+        assert_eq!(decode_xml_entities("50% &bogus; done"), "50% &bogus; done");
+        assert_eq!(decode_xml_entities("no entities here"), "no entities here");
     }
 
     #[test]

--- a/crates/fakecloud-s3/src/service/objects/list.rs
+++ b/crates/fakecloud-s3/src/service/objects/list.rs
@@ -2,6 +2,30 @@
 
 use super::*;
 
+/// Parse the `max-keys` query parameter. Absent -> AWS's default page size of
+/// 1000. Present-but-invalid (non-integer, negative, or outside the signed
+/// 32-bit range AWS accepts) -> 400 `InvalidArgument`, rather than the silent
+/// coercion-to-1000 that used to mask client bugs. A valid value is capped at
+/// 1000, the most keys AWS returns in one page.
+fn parse_max_keys(req: &AwsRequest) -> Result<usize, AwsServiceError> {
+    let raw = match req.query_params.get("max-keys") {
+        Some(v) => v,
+        None => return Ok(1000),
+    };
+    match raw.trim().parse::<i64>() {
+        Ok(n) if (0..=2_147_483_647).contains(&n) => Ok((n as usize).min(1000)),
+        _ => Err(AwsServiceError::aws_error_with_fields(
+            StatusCode::BAD_REQUEST,
+            "InvalidArgument",
+            "Provided max-keys not an integer or within integer range",
+            vec![
+                ("ArgumentName".to_string(), "max-keys".to_string()),
+                ("ArgumentValue".to_string(), raw.clone()),
+            ],
+        )),
+    }
+}
+
 impl S3Service {
     pub(crate) fn list_objects_v1(
         &self,
@@ -26,13 +50,9 @@ impl S3Service {
             .cloned();
         // AWS caps max-keys at 1000 regardless of the requested value, so
         // clients that don't paginate still see truncation (bug-audit
-        // 2026-05-28, 1.4 — we used the requested value verbatim).
-        let max_keys: usize = req
-            .query_params
-            .get("max-keys")
-            .and_then(|v| v.parse().ok())
-            .map(|n: usize| n.min(1000))
-            .unwrap_or(1000);
+        // 2026-05-28, 1.4 — we used the requested value verbatim). An invalid
+        // value is a 400, not a silent 1000.
+        let max_keys = parse_max_keys(req)?;
         let marker = req.query_params.get("marker").cloned().unwrap_or_default();
         let encoding_type = req.query_params.get("encoding-type").cloned();
 
@@ -209,13 +229,9 @@ impl S3Service {
             .get("delimiter")
             .cloned()
             .unwrap_or_default();
-        // AWS caps max-keys at 1000 (bug-audit 2026-05-28, 1.4).
-        let max_keys: usize = req
-            .query_params
-            .get("max-keys")
-            .and_then(|v| v.parse().ok())
-            .map(|n: usize| n.min(1000))
-            .unwrap_or(1000);
+        // AWS caps max-keys at 1000 (bug-audit 2026-05-28, 1.4); an invalid
+        // value is a 400, not a silent 1000.
+        let max_keys = parse_max_keys(req)?;
         let start_after = req
             .query_params
             .get("start-after")
@@ -449,13 +465,9 @@ impl S3Service {
             .cloned()
             .unwrap_or_default();
         let version_id_marker = req.query_params.get("version-id-marker").cloned();
-        // AWS caps max-keys at 1000 (bug-audit 2026-05-28, 1.4).
-        let max_keys: usize = req
-            .query_params
-            .get("max-keys")
-            .and_then(|s| s.parse().ok())
-            .map(|n: usize| n.min(1000))
-            .unwrap_or(1000);
+        // AWS caps max-keys at 1000 (bug-audit 2026-05-28, 1.4); an invalid
+        // value is a 400, not a silent 1000.
+        let max_keys = parse_max_keys(req)?;
 
         let owner_id = &b.acl_owner_id;
 
@@ -503,6 +515,16 @@ impl S3Service {
                 if !skip {
                     return true;
                 }
+                // If the marker is itself a delimiter-rolled CommonPrefix (it
+                // ends with the delimiter), skip every entry that rolls into it
+                // so resuming a page that ended on a CommonPrefix doesn't
+                // re-emit that same prefix.
+                if let Some(ref delim) = delimiter {
+                    if key_marker.ends_with(delim.as_str()) && key.starts_with(key_marker.as_str())
+                    {
+                        return false;
+                    }
+                }
                 if *key < key_marker.as_str() {
                     return false; // before marker, skip
                 }
@@ -524,46 +546,6 @@ impl S3Service {
             });
         }
 
-        // Handle delimiter: collect common prefixes
-        let mut common_prefixes: Vec<String> = Vec::new();
-        if let Some(ref delim) = delimiter {
-            let mut filtered_entries = Vec::new();
-            let mut seen_prefixes = std::collections::HashSet::new();
-            for entry @ (key, _, _) in &all_entries {
-                let after_prefix = &key[prefix.len()..];
-                if let Some(pos) = after_prefix.find(delim.as_str()) {
-                    let cp = format!("{}{}", prefix, &after_prefix[..pos + delim.len()]);
-                    if seen_prefixes.insert(cp.clone()) {
-                        common_prefixes.push(cp);
-                    }
-                } else {
-                    filtered_entries.push(*entry);
-                }
-            }
-            all_entries = filtered_entries;
-        }
-
-        // Pagination: truncate at max_keys (count versions + delete markers + common prefixes).
-        // Both `all_entries` and `common_prefixes` count against max_keys —
-        // truncate each so the combined emit length never exceeds the cap.
-        let total_items = all_entries.len() + common_prefixes.len();
-        let is_truncated = total_items > max_keys;
-        let truncated_entries: Vec<_> = all_entries.iter().take(max_keys).collect();
-        let remaining_slots = max_keys.saturating_sub(truncated_entries.len());
-        common_prefixes.truncate(remaining_slots);
-        let next_markers = if is_truncated && !truncated_entries.is_empty() {
-            let last = truncated_entries.last().unwrap();
-            Some((
-                last.0.to_string(),
-                last.1
-                    .version_id
-                    .clone()
-                    .unwrap_or_else(|| "null".to_string()),
-            ))
-        } else {
-            None
-        };
-
         // encoding-type=url: AWS url-encodes the key-type fields (Key, Prefix,
         // KeyMarker, NextKeyMarker, Delimiter, CommonPrefixes.Prefix) so keys
         // with XML-illegal control characters are still parseable. Unlike
@@ -577,9 +559,54 @@ impl S3Service {
             }
         };
 
-        // Build XML
+        // Single sorted pass interleaving version entries and delimiter-rolled
+        // CommonPrefixes, so truncation lands at a consistent point in the
+        // sorted stream and a CommonPrefix that sorts before the truncation
+        // boundary is never dropped across pages. The previous approach rolled
+        // every prefix up front and appended them AFTER the entries, so entries
+        // filling max-keys could push a lower-sorting prefix off the page while
+        // NextKeyMarker advanced past it — losing that prefix entirely. This
+        // mirrors the ListObjectsV1/V2 single-pass model.
         let mut versions_xml = String::new();
-        for (key, obj, is_latest) in &truncated_entries {
+        let mut cp_xml = String::new();
+        let mut seen_prefixes = std::collections::HashSet::new();
+        let mut count = 0usize;
+        let mut is_truncated = false;
+        // Cursor for the next page: (key, Some(version_id)) for a version
+        // entry, (common_prefix, None) for a rolled-up prefix (AWS omits
+        // NextVersionIdMarker when the page ends on a CommonPrefix).
+        let mut next_markers: Option<(String, Option<String>)> = None;
+
+        for (key, obj, is_latest) in &all_entries {
+            let rolled = delimiter.as_ref().and_then(|delim| {
+                let after_prefix = &key[prefix.len()..];
+                after_prefix
+                    .find(delim.as_str())
+                    .map(|pos| format!("{}{}", prefix, &after_prefix[..pos + delim.len()]))
+            });
+
+            if let Some(cp) = rolled {
+                if seen_prefixes.contains(&cp) {
+                    continue; // this CommonPrefix was already emitted
+                }
+                if count >= max_keys {
+                    is_truncated = true;
+                    break;
+                }
+                cp_xml.push_str(&format!(
+                    "<CommonPrefixes><Prefix>{}</Prefix></CommonPrefixes>",
+                    enc(&cp),
+                ));
+                next_markers = Some((cp.clone(), None));
+                seen_prefixes.insert(cp);
+                count += 1;
+                continue;
+            }
+
+            if count >= max_keys {
+                is_truncated = true;
+                break;
+            }
             if obj.is_delete_marker {
                 versions_xml.push_str(&format!(
                     "<DeleteMarker>\
@@ -615,27 +642,26 @@ impl S3Service {
                     obj.storage_class,
                 ));
             }
+            next_markers = Some((
+                key.to_string(),
+                Some(obj.version_id.as_deref().unwrap_or("null").to_string()),
+            ));
+            count += 1;
         }
 
-        // Common prefixes
-        let mut cp_xml = String::new();
-        for cp in &common_prefixes {
-            cp_xml.push_str(&format!(
-                "<CommonPrefixes><Prefix>{}</Prefix></CommonPrefixes>",
-                enc(cp),
-            ));
-        }
+        // Markers are only meaningful for a truncated listing.
+        let next_markers = if is_truncated { next_markers } else { None };
 
         // Pagination markers
-        let marker_xml = if let Some((ref nk, ref nv)) = next_markers {
-            format!(
+        let marker_xml = match &next_markers {
+            Some((nk, Some(nv))) => format!(
                 "<NextKeyMarker>{}</NextKeyMarker>\
                  <NextVersionIdMarker>{}</NextVersionIdMarker>",
                 enc(nk),
                 xml_escape(nv),
-            )
-        } else {
-            String::new()
+            ),
+            Some((nk, None)) => format!("<NextKeyMarker>{}</NextKeyMarker>", enc(nk)),
+            None => String::new(),
         };
 
         let delimiter_xml = delimiter

--- a/crates/fakecloud-s3/src/service/objects/write.rs
+++ b/crates/fakecloud-s3/src/service/objects/write.rs
@@ -640,6 +640,16 @@ impl S3Service {
         dest_bucket: &str,
         dest_key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
+        // Validate destination key length, matching PutObject (AWS caps keys at
+        // 1024 bytes and rejects a longer one with KeyTooLongError).
+        if dest_key.len() > 1024 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "KeyTooLongError",
+                "Your key is too long",
+            ));
+        }
+
         let copy_source = req
             .headers
             .get("x-amz-copy-source")

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -4771,3 +4771,332 @@ async fn mpu_complete_on_versioned_bucket_pushes_new_version() {
         versions.len()
     );
 }
+
+// ────────────────────────────────────────────────────────────────
+// Persistence regression tests (bug-hunt 2026-07-13).
+//
+// RenameObject, UpdateObjectEncryption, and the metadata
+// inventory/journal-table updates used to mutate RAM only and never
+// call the store, so they silently reverted on restart in disk mode.
+// A recording store proves the handler now drives the store write
+// path (the harness can't restart the server in-sandbox).
+// ────────────────────────────────────────────────────────────────
+
+struct RecordingStore {
+    inner: fakecloud_persistence::MemoryS3Store,
+    calls: parking_lot::Mutex<Vec<String>>,
+}
+
+impl RecordingStore {
+    fn new() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            inner: fakecloud_persistence::MemoryS3Store::new(),
+            calls: parking_lot::Mutex::new(Vec::new()),
+        })
+    }
+    fn record(&self, call: String) {
+        self.calls.lock().push(call);
+    }
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().clone()
+    }
+}
+
+impl fakecloud_persistence::S3Store for RecordingStore {
+    fn load(&self) -> fakecloud_persistence::StoreResult<fakecloud_persistence::S3StateSnapshot> {
+        self.inner.load()
+    }
+    fn put_bucket_meta(
+        &self,
+        bucket: &str,
+        meta: &fakecloud_persistence::BucketMeta,
+    ) -> fakecloud_persistence::StoreResult<()> {
+        self.record(format!("put_bucket_meta:{bucket}"));
+        self.inner.put_bucket_meta(bucket, meta)
+    }
+    fn put_bucket_subresource(
+        &self,
+        bucket: &str,
+        kind: fakecloud_persistence::BucketSubresource,
+        payload: &str,
+    ) -> fakecloud_persistence::StoreResult<()> {
+        self.record(format!("put_bucket_subresource:{bucket}:{kind:?}"));
+        self.inner.put_bucket_subresource(bucket, kind, payload)
+    }
+    fn delete_bucket_subresource(
+        &self,
+        bucket: &str,
+        kind: fakecloud_persistence::BucketSubresource,
+    ) -> fakecloud_persistence::StoreResult<()> {
+        self.record(format!("delete_bucket_subresource:{bucket}:{kind:?}"));
+        self.inner.delete_bucket_subresource(bucket, kind)
+    }
+    fn delete_bucket(&self, bucket: &str) -> fakecloud_persistence::StoreResult<()> {
+        self.record(format!("delete_bucket:{bucket}"));
+        self.inner.delete_bucket(bucket)
+    }
+    fn put_object(
+        &self,
+        bucket: &str,
+        key: &str,
+        version: Option<&str>,
+        body: fakecloud_persistence::BodySource,
+        meta: &fakecloud_persistence::ObjectMeta,
+    ) -> fakecloud_persistence::StoreResult<fakecloud_persistence::BodyRef> {
+        self.record(format!("put_object:{bucket}/{key}"));
+        self.inner.put_object(bucket, key, version, body, meta)
+    }
+    fn put_object_meta(
+        &self,
+        bucket: &str,
+        key: &str,
+        version: Option<&str>,
+        meta: &fakecloud_persistence::ObjectMeta,
+    ) -> fakecloud_persistence::StoreResult<()> {
+        self.record(format!("put_object_meta:{bucket}/{key}"));
+        self.inner.put_object_meta(bucket, key, version, meta)
+    }
+    fn delete_object(
+        &self,
+        bucket: &str,
+        key: &str,
+        version: Option<&str>,
+    ) -> fakecloud_persistence::StoreResult<()> {
+        self.record(format!("delete_object:{bucket}/{key}"));
+        self.inner.delete_object(bucket, key, version)
+    }
+    fn open_object_body(
+        &self,
+        body: &fakecloud_persistence::BodyRef,
+    ) -> fakecloud_persistence::StoreResult<Bytes> {
+        self.inner.open_object_body(body)
+    }
+    fn mpu_create(
+        &self,
+        bucket: &str,
+        upload_id: &str,
+        init: &fakecloud_persistence::MpuInit,
+    ) -> fakecloud_persistence::StoreResult<()> {
+        self.inner.mpu_create(bucket, upload_id, init)
+    }
+    fn mpu_put_part(
+        &self,
+        bucket: &str,
+        upload_id: &str,
+        part_number: u32,
+        body: fakecloud_persistence::BodySource,
+        etag: &str,
+    ) -> fakecloud_persistence::StoreResult<fakecloud_persistence::BodyRef> {
+        self.inner
+            .mpu_put_part(bucket, upload_id, part_number, body, etag)
+    }
+    fn mpu_abort(&self, bucket: &str, upload_id: &str) -> fakecloud_persistence::StoreResult<()> {
+        self.inner.mpu_abort(bucket, upload_id)
+    }
+    fn mpu_complete(
+        &self,
+        bucket: &str,
+        upload_id: &str,
+        final_key: &str,
+        version: Option<&str>,
+        meta: &fakecloud_persistence::ObjectMeta,
+    ) -> fakecloud_persistence::StoreResult<fakecloud_persistence::BodyRef> {
+        self.inner
+            .mpu_complete(bucket, upload_id, final_key, version, meta)
+    }
+}
+
+fn make_recording_service() -> (S3Service, std::sync::Arc<RecordingStore>) {
+    let state: SharedS3State = Arc::new(RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ));
+    let store = RecordingStore::new();
+    let svc = S3Service::with_store(state, Arc::new(DeliveryBus::new()), store.clone());
+    (svc, store)
+}
+
+#[test]
+fn rename_object_persists_move_through_store() {
+    let (svc, store) = make_recording_service();
+    seed_bucket(&svc, "b");
+    seed_object(&svc, "b", "old", b"payload");
+
+    let mut req = make_request(Method::PUT, "/b/new", &[("renameObject", "")], b"");
+    req.headers
+        .insert("x-amz-rename-source", "/old".parse().unwrap());
+    svc.rename_object("123456789012", &req, "b", "new").unwrap();
+
+    // In-memory move happened.
+    {
+        let mas = svc.state.read();
+        let b = mas.default_ref().buckets.get("b").unwrap();
+        assert!(b.objects.contains_key("new"));
+        assert!(!b.objects.contains_key("old"));
+    }
+    // …and it was persisted: the new key written, the old key deleted.
+    let calls = store.calls();
+    assert!(
+        calls.iter().any(|c| c == "put_object:b/new"),
+        "expected put_object for the new key, got {calls:?}"
+    );
+    assert!(
+        calls.iter().any(|c| c == "delete_object:b/old"),
+        "expected delete_object for the old key, got {calls:?}"
+    );
+}
+
+#[test]
+fn update_object_encryption_persists_reencrypted_body() {
+    let (svc, store) = make_recording_service();
+    seed_bucket(&svc, "b");
+    seed_object(&svc, "b", "k", b"payload");
+
+    let mut req = make_request(Method::PUT, "/b/k", &[("encryption", "")], b"");
+    req.headers
+        .insert("x-amz-server-side-encryption", "AES256".parse().unwrap());
+    svc.update_object_encryption("123456789012", &req, "b", "k")
+        .unwrap();
+
+    // Algorithm changed -> the body path must be re-persisted, not RAM-only.
+    let calls = store.calls();
+    assert!(
+        calls.iter().any(|c| c == "put_object:b/k"),
+        "expected put_object to persist the re-encrypted body, got {calls:?}"
+    );
+    // Metadata reflects the new algorithm in memory too.
+    let mas = svc.state.read();
+    let obj = mas
+        .default_ref()
+        .buckets
+        .get("b")
+        .unwrap()
+        .objects
+        .get("k")
+        .unwrap();
+    assert_eq!(obj.sse_algorithm.as_deref(), Some("AES256"));
+}
+
+#[test]
+fn update_metadata_inventory_table_persists_config() {
+    let (svc, store) = make_recording_service();
+    seed_bucket(&svc, "b");
+
+    let body = b"<InventoryTableConfiguration><ConfigurationState>ENABLED</ConfigurationState></InventoryTableConfiguration>";
+    let req = make_request(Method::PUT, "/b", &[("metadataInventoryTable", "")], body);
+    svc.update_bucket_metadata_inventory_table("123456789012", &req, "b")
+        .unwrap();
+
+    let calls = store.calls();
+    assert!(
+        calls
+            .iter()
+            .any(|c| c == "put_bucket_subresource:b:MetadataConfiguration"),
+        "inventory-table update must persist the composite metadata config, got {calls:?}"
+    );
+    // Journal-table sibling persists the same way.
+    let req2 = make_request(Method::PUT, "/b", &[("metadataJournalTable", "")], body);
+    svc.update_bucket_metadata_journal_table("123456789012", &req2, "b")
+        .unwrap();
+    let calls = store.calls();
+    assert!(
+        calls
+            .iter()
+            .filter(|c| *c == "put_bucket_subresource:b:MetadataConfiguration")
+            .count()
+            >= 2,
+        "journal-table update must persist too, got {calls:?}"
+    );
+}
+
+#[test]
+fn put_object_retention_mode_without_date_is_malformed_xml() {
+    // A retention carrying a Mode but no valid RetainUntilDate is rejected by
+    // AWS with 400 MalformedXML, not silently stored (bug-hunt 2026-07-13).
+    let svc = make_service();
+    seed_bucket(&svc, "b");
+    seed_object(&svc, "b", "k", b"payload");
+
+    let body = b"<Retention><Mode>GOVERNANCE</Mode></Retention>";
+    let req = make_request(Method::PUT, "/b/k", &[("retention", "")], body);
+    let err = match svc.put_object_retention("123456789012", &req, "b", "k") {
+        Ok(_) => panic!("mode without retain-until must be rejected"),
+        Err(e) => e,
+    };
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(err.code(), "MalformedXML");
+
+    // A well-formed retention (mode + date) still succeeds.
+    let ok_body =
+        b"<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2099-01-01T00:00:00Z</RetainUntilDate></Retention>";
+    let ok_req = make_request(Method::PUT, "/b/k", &[("retention", "")], ok_body);
+    svc.put_object_retention("123456789012", &ok_req, "b", "k")
+        .expect("valid retention must succeed");
+}
+
+#[test]
+fn list_objects_v2_rejects_non_integer_max_keys() {
+    // A non-integer / out-of-range max-keys is a 400 InvalidArgument, not a
+    // silent coercion to 1000 (bug-hunt 2026-07-13).
+    let svc = make_service();
+    seed_bucket(&svc, "b");
+
+    for bad in ["abc", "-1", "99999999999999999999"] {
+        let req = make_request(
+            Method::GET,
+            "/b",
+            &[("list-type", "2"), ("max-keys", bad)],
+            b"",
+        );
+        let err = match svc.list_objects_v2("123456789012", &req, "b") {
+            Ok(_) => panic!("max-keys={bad} must be rejected"),
+            Err(e) => e,
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST, "max-keys={bad}");
+        assert_eq!(err.code(), "InvalidArgument", "max-keys={bad}");
+    }
+
+    // A valid value still works and caps at 1000.
+    let ok = make_request(
+        Method::GET,
+        "/b",
+        &[("list-type", "2"), ("max-keys", "5000")],
+        b"",
+    );
+    let resp = svc.list_objects_v2("123456789012", &ok, "b").unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(body.contains("<MaxKeys>1000</MaxKeys>"), "body: {body}");
+}
+
+#[test]
+fn list_object_versions_keeps_low_sorting_common_prefix_on_first_page() {
+    // When plain keys fill max-keys before a lower-sorting delimiter-rolled
+    // prefix, the prefix must still appear on the page it belongs to instead
+    // of being dropped as the marker advances past it (bug-hunt 2026-07-13).
+    let svc = make_service();
+    seed_bucket(&svc, "b");
+    seed_object(&svc, "b", "a/x", b"1");
+    seed_object(&svc, "b", "bb", b"2");
+    seed_object(&svc, "b", "cc", b"3");
+
+    let req = make_request(
+        Method::GET,
+        "/b",
+        &[("versions", ""), ("delimiter", "/"), ("max-keys", "2")],
+        b"",
+    );
+    let resp = svc.list_object_versions("123456789012", &req, "b").unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+
+    // "a/" sorts before "bb"/"cc" so it must be emitted on page 1, not lost.
+    assert!(
+        body.contains("<CommonPrefixes><Prefix>a/</Prefix></CommonPrefixes>"),
+        "page 1 must keep the a/ CommonPrefix, body: {body}"
+    );
+    assert!(
+        body.contains("<IsTruncated>true</IsTruncated>"),
+        "body: {body}"
+    );
+    assert!(body.contains("<Key>bb</Key>"), "body: {body}");
+    // The page is capped at max-keys: "cc" spills to the next page.
+    assert!(!body.contains("<Key>cc</Key>"), "body: {body}");
+}


### PR DESCRIPTION
## Summary

Pre-Show-HN hardening of the #1 service (bug-hunt on the crown-jewel trio; Lambda came up clean). Panic/DoS surface and addressing/presign compat were already solid — these are the real defects found and fixed.

**HIGH — XML entities not decoded (silent data-integrity failure).** `extract_xml_value` returned raw slices, so `DeleteObjects` with a key like `a&b` (every SDK sends `<Key>a&amp;b</Key>`) parsed the literal `a&amp;b`, missed the object, and — delete being idempotent — FALSELY reported success while the object survived. Same gap double-escaped tag round-trips. Added a single-pass `decode_xml_entities` (named + decimal/hex numeric refs; single left-to-right scan to avoid double-decode) in `extract_xml_value`; verified the GET-path escape now escapes the decoded value exactly once. Breaks aws-cli/all SDKs/Terraform on any key/tag containing `&`/`<`/`>`.

**HIGH — UpdateObjectEncryption was RAM-only → restart corruption.** Re-encrypted body lived only in memory; on-disk bytes+metadata went stale (undecryptable ciphertext if KMS removed). Now store-first (`put_object`/`put_object_meta`).

**MEDIUM — RenameObject + Metadata Inventory/Journal-table config were RAM-only** → reverted/vanished on restart. Both now persist through the store like their sibling create paths.

**LOW — reachable find-then-slice panics** in the opt-in delivery path (`logging.rs`, `inventory.rs`, only under `FAKECLOUD_S3_EAGER_DELIVERY=1`): closing tags now located relative to their opening tag (end ≥ start), matching `extract_xml_value`.

**LOW — PutObjectRetention** with a Mode but missing/malformed RetainUntilDate now returns 400 `MalformedXML` (was 200, leaving the object flagged-locked with nothing to enforce).

**Confirmed + fixed from the suspicious tail:**
- `ListObjectVersions` dropped a low-sorting `CommonPrefix` when version entries filled `max-keys` (permanent cross-page loss) — rewrote as a single sorted interleaved pass (mirrors V1/V2).
- `CopyObject` now returns `KeyTooLongError` for dest key >1024 (matched PutObject).
- Non-integer/negative `max-keys` now returns 400 `InvalidArgument` (was silently coerced to 1000) across ListObjects v1/v2 + ListObjectVersions.

## Test plan
- E2E (`s3.rs`): DeleteObjects on an `&`-key actually deletes; Put/GetObjectTagging round-trips an `&` value unchanged.
- Unit: entity decode (named/numeric, no-double-decode, bare-`&` verbatim); inverted-tag guards; retention→400; max-keys→400; ListObjectVersions prefix retained; `RecordingStore` proves rename/encryption/metadata-config drive the store write path.
- `cargo clippy -p fakecloud-s3 --all-targets` clean; `cargo test -p fakecloud-s3` 383 pass; fmt clean; e2e compiles.

## Surface
Behavioral bug-fix — no new ops/SDK/counts. Non-code surface unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes critical S3 correctness and persistence issues and tightens XML parsing and listing semantics. Deletes and tagging now handle `&`/`<` keys and tags correctly, and rename/encryption/metadata config updates persist to the store across restarts.

- **Bug Fixes**
  - Decode XML entities when parsing request XML (DeleteObjects, Put/GetObjectTagging) so `a&b` keys match and tag values don’t double-escape.
  - Persist `UpdateObjectEncryption` (store body and/or metadata) to avoid restart corruption with stale ciphertext or KMS ids.
  - Persist `RenameObject` (write new key + delete old key) and metadata inventory/journal-table config via the store.
  - Guard delivery-path XML parsing in logging/inventory to prevent panics on inverted/duplicated tags.
  - Require `RetainUntilDate` when `Mode` is set in PutObjectRetention; return 400 `MalformedXML` if missing/invalid.
  - Rework `ListObjectVersions` to interleave CommonPrefixes with entries in a single sorted pass; keep low-sorting prefixes across pages and handle markers that are prefixes.
  - Validate `max-keys` (v1, v2, versions): non-integer/negative/out-of-range → 400 `InvalidArgument`; cap valid values at 1000.
  - `CopyObject` now returns `KeyTooLongError` when the destination key exceeds 1024 bytes (matches PutObject).

<sup>Written for commit 9cd369372c32bfe51195f3fb6020d2554c2295e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

