### PR TITLE
fix(dynamodb): validate query key schema, GSI/LSI attrs, transact bounds; quote-aware PartiQL; numeric stream-seq compare

### DIFF
--- a/crates/fakecloud-conformance/src/probe/response.rs
+++ b/crates/fakecloud-conformance/src/probe/response.rs
@@ -202,6 +202,15 @@ pub(super) fn service_common_errors(service_name: &str) -> &'static [&'static st
         // handler returning AccessDenied to the probes' synthetic (nonexistent)
         // role ARNs ran correctly. Source: STS API "Common Errors" + per-op docs.
         "sts" => &["AccessDenied"],
+        // DynamoDB returns `ValidationException` across essentially every
+        // operation for malformed/under-specified input — it is the service's
+        // canonical client-error shape. Most ops declare it, but a few (notably
+        // CreateTable, whose Smithy `errors:` list is limited to
+        // LimitExceededException / ResourceInUseException / InternalServerError)
+        // omit it even though the live API returns it for an invalid table
+        // spec. A handler returning ValidationException to the probes' synthetic
+        // inputs ran correctly. Source: DynamoDB API "Common Errors".
+        "dynamodb" => &["ValidationException"],
         // CodeConnections' CreateConnection / CreateHost require the caller to
         // resolve a provider type: CreateConnection needs a ProviderType or a
         // HostArn to inherit one from, and both reject malformed input. AWS

--- a/crates/fakecloud-dynamodb/src/lib.rs
+++ b/crates/fakecloud-dynamodb/src/lib.rs
@@ -11,4 +11,4 @@ pub use state::{
     KeySchemaElement, LocalSecondaryIndex, OnDemandThroughput, Projection, ProvisionedThroughput,
     SharedDynamoDbState, StreamRecord, DYNAMODB_SNAPSHOT_SCHEMA_VERSION,
 };
-pub use streams_dataplane::DynamoDbStreamsService;
+pub use streams_dataplane::{cmp_seq, DynamoDbStreamsService};

--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -214,6 +214,20 @@ impl DynamoDbService {
             })?;
             let mut seen_keys: Vec<HashMap<String, AttributeValue>> = Vec::new();
             for request in reqs {
+                // A WriteRequest is a union: exactly one of PutRequest or
+                // DeleteRequest must be set. AWS rejects a request with both or
+                // neither; previously the neither case was silently skipped and
+                // the both case took the Put branch (bug-hunt 2026-07-01).
+                let has_put = request.get("PutRequest").is_some();
+                let has_delete = request.get("DeleteRequest").is_some();
+                if has_put == has_delete {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationException",
+                        "1 validation error detected: Member must contain exactly one \
+                         of PutRequest or DeleteRequest",
+                    ));
+                }
                 let key = if let Some(put_req) = request.get("PutRequest") {
                     let item: HashMap<String, AttributeValue> =
                         serde_json::from_value(put_req["Item"].clone()).map_err(|_| {
@@ -350,11 +364,35 @@ impl DynamoDbService {
             )
         })?;
 
+        // AWS rejects an empty TransactItems list and one over the 100-action
+        // ceiling up-front with a ValidationException, mirroring
+        // TransactWriteItems. Previously an empty batch returned success and an
+        // oversized one was processed in full (bug-hunt 2026-07-01).
+        if transact_items.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "1 validation error detected: Value '[]' at 'transactItems' \
+                 failed to satisfy constraint: Member must have length greater \
+                 than or equal to 1",
+            ));
+        }
+        if transact_items.len() > 100 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "1 validation error detected: Value at 'transactItems' failed \
+                 to satisfy constraint: Member must have length less than or \
+                 equal to 100",
+            ));
+        }
+
         let accounts = self.state.read();
         let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let mut responses: Vec<Value> = Vec::new();
         let mut per_table_count: HashMap<String, u32> = HashMap::new();
+        let mut seen_keys: Vec<(String, HashMap<String, AttributeValue>)> = Vec::new();
 
         for ti in transact_items {
             let get = &ti["Get"];
@@ -365,10 +403,34 @@ impl DynamoDbService {
                     "TableName is required in Get",
                 )
             })?;
-            let key: HashMap<String, AttributeValue> =
-                serde_json::from_value(get["Key"].clone()).unwrap_or_default();
 
             let table = get_table(&state.tables, table_name)?;
+            // Parse the Key strictly and reject an under-specified/malformed key
+            // the same way GetItem does, instead of coercing it to `{}` (which
+            // matched nothing and returned a phantom miss).
+            let key: HashMap<String, AttributeValue> = serde_json::from_value(get["Key"].clone())
+                .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Get.Key is not a valid key",
+                )
+            })?;
+            validate_key_attributes_in_key(table, &key)?;
+
+            // AWS rejects a transaction that reads the same item more than once.
+            if seen_keys
+                .iter()
+                .any(|(t, k)| t == table_name && keys_equal(table, k, &key))
+            {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Transaction request cannot include multiple operations on one item",
+                ));
+            }
+            seen_keys.push((table_name.to_string(), key.clone()));
+
             match table.find_item_index(&key) {
                 Some(idx) => {
                     responses.push(json!({ "Item": table.items[idx] }));
@@ -472,6 +534,26 @@ impl DynamoDbService {
                  to satisfy constraint: Member must have length less than or \
                  equal to 100",
             ));
+        }
+
+        // Each TransactWriteItem is a union: exactly one of Put / Update /
+        // Delete / ConditionCheck must be set. AWS rejects an item with zero or
+        // more than one member with a ValidationException; previously a
+        // zero-member item was silently treated as a no-op and a multi-member
+        // item processed only its first branch (bug-hunt 2026-07-01).
+        for ti in transact_items {
+            let op_count = ["Put", "Update", "Delete", "ConditionCheck"]
+                .iter()
+                .filter(|k| ti.get(**k).is_some())
+                .count();
+            if op_count != 1 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "1 validation error detected: Member must contain exactly one \
+                     of Put, Update, Delete, or ConditionCheck",
+                ));
+            }
         }
 
         // Per-operation `ReturnValuesOnConditionCheckFailure` is its own
@@ -992,7 +1074,22 @@ impl DynamoDbService {
         // itself a ValidationException.
         let statement = require_str_with_code(&body, "Statement", "ValidationException")?;
         let parameters = body["Parameters"].as_array().cloned().unwrap_or_default();
-        let limit = body["Limit"].as_i64().filter(|&n| n > 0);
+        // AWS requires Limit >= 1 when present; a `Limit: 0` (or negative) is a
+        // ValidationException, not "no limit" — silently dropping it returned
+        // the whole result set (bug-hunt 2026-07-01).
+        let limit = match body["Limit"].as_i64() {
+            Some(n) if n < 1 => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!(
+                        "1 validation error detected: Value '{n}' at 'limit' failed to satisfy \
+                         constraint: Member must have value greater than or equal to 1"
+                    ),
+                ));
+            }
+            other => other,
+        };
         let next_token = body["NextToken"].as_str().map(str::to_string);
 
         // Hold the write lock only long enough to mutate state and
@@ -2279,6 +2376,121 @@ mod tests {
             0,
             "no stream records on failed txn"
         );
+    }
+
+    #[tokio::test]
+    async fn transact_get_items_rejects_empty_oversized_and_malformed_key() {
+        // bug-hunt 2026-07-01, finding 5: TransactGetItems must enforce the
+        // 1..=100 bound and validate each Get.Key instead of coercing a
+        // malformed key to {}.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+
+        let empty = svc
+            .transact_get_items(&req_for("TransactGetItems", json!({"TransactItems": []})))
+            .err()
+            .expect("empty TransactItems rejected");
+        assert!(format!("{empty:?}").contains("ValidationException"));
+
+        // A Get whose Key omits the partition key is a malformed key.
+        let malformed = svc
+            .transact_get_items(&req_for(
+                "TransactGetItems",
+                json!({"TransactItems": [
+                    {"Get": {"TableName": "Widgets", "Key": {"other": {"S": "x"}}}}
+                ]}),
+            ))
+            .err()
+            .expect("malformed key rejected");
+        assert!(format!("{malformed:?}").contains("ValidationException"));
+
+        // Duplicate keys in one transaction are rejected.
+        let dup = svc
+            .transact_get_items(&req_for(
+                "TransactGetItems",
+                json!({"TransactItems": [
+                    {"Get": {"TableName": "Widgets", "Key": {"pk": {"S": "a"}}}},
+                    {"Get": {"TableName": "Widgets", "Key": {"pk": {"S": "a"}}}}
+                ]}),
+            ))
+            .err()
+            .expect("duplicate keys rejected");
+        assert!(format!("{dup:?}").contains("ValidationException"));
+    }
+
+    #[tokio::test]
+    async fn batch_write_item_rejects_both_or_neither_put_delete() {
+        // bug-hunt 2026-07-01, finding 11.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+
+        let neither = svc
+            .batch_write_item(&req_for(
+                "BatchWriteItem",
+                json!({"RequestItems": {"Widgets": [{}]}}),
+            ))
+            .err()
+            .expect("neither Put nor Delete rejected");
+        assert!(format!("{neither:?}").contains("ValidationException"));
+
+        let both = svc
+            .batch_write_item(&req_for(
+                "BatchWriteItem",
+                json!({"RequestItems": {"Widgets": [{
+                    "PutRequest": {"Item": {"pk": {"S": "a"}}},
+                    "DeleteRequest": {"Key": {"pk": {"S": "a"}}}
+                }]}}),
+            ))
+            .err()
+            .expect("both Put and Delete rejected");
+        assert!(format!("{both:?}").contains("ValidationException"));
+    }
+
+    #[tokio::test]
+    async fn transact_write_item_rejects_zero_or_multi_op_member() {
+        // bug-hunt 2026-07-01, finding 11.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+
+        let none = svc
+            .transact_write_items(&req_for(
+                "TransactWriteItems",
+                json!({"TransactItems": [{}]}),
+            ))
+            .err()
+            .expect("empty member rejected");
+        assert!(format!("{none:?}").contains("ValidationException"));
+
+        let multi = svc
+            .transact_write_items(&req_for(
+                "TransactWriteItems",
+                json!({"TransactItems": [{
+                    "Put": {"TableName": "Widgets", "Item": {"pk": {"S": "a"}}},
+                    "Delete": {"TableName": "Widgets", "Key": {"pk": {"S": "a"}}}
+                }]}),
+            ))
+            .err()
+            .expect("multi-op member rejected");
+        assert!(format!("{multi:?}").contains("ValidationException"));
+    }
+
+    #[tokio::test]
+    async fn execute_statement_rejects_zero_limit() {
+        // bug-hunt 2026-07-01, finding 10.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+        let err = svc
+            .execute_statement(&req_for(
+                "ExecuteStatement",
+                json!({"Statement": "SELECT * FROM Widgets", "Limit": 0}),
+            ))
+            .err()
+            .expect("Limit 0 rejected");
+        assert!(format!("{err:?}").contains("ValidationException"));
     }
 
     #[tokio::test]

--- a/crates/fakecloud-dynamodb/src/service/helpers/keys.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/keys.rs
@@ -95,6 +95,64 @@ pub(crate) fn extract_key_for_schema(
     key
 }
 
+/// Recursively validate the AttributeValues in an item written by PutItem.
+/// Real DynamoDB rejects a numeric attribute whose `N` value (or an `NS`
+/// member) is not a valid decimal — e.g. `{"N":"abc"}` — with a
+/// ValidationException, even for non-key attributes. Without this the bogus
+/// value persists and later corrupts numeric comparisons / arithmetic
+/// (bug-hunt 2026-07-01).
+pub(crate) fn validate_item_attribute_values(
+    item: &HashMap<String, AttributeValue>,
+) -> Result<(), AwsServiceError> {
+    for v in item.values() {
+        validate_attribute_value(v)?;
+    }
+    Ok(())
+}
+
+fn validate_attribute_value(v: &Value) -> Result<(), AwsServiceError> {
+    let Some((tag, val)) = v.as_object().and_then(|o| o.iter().next()) else {
+        return Ok(());
+    };
+    let bad_number = |n: &str| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            format!("The parameter cannot be converted to a numeric value: {n}"),
+        )
+    };
+    match tag.as_str() {
+        "N" => {
+            let s = val.as_str().unwrap_or_default();
+            if !is_valid_number(s) {
+                return Err(bad_number(s));
+            }
+        }
+        "NS" => {
+            for el in val.as_array().into_iter().flatten() {
+                let s = el.as_str().unwrap_or_default();
+                if !is_valid_number(s) {
+                    return Err(bad_number(s));
+                }
+            }
+        }
+        "L" => {
+            for el in val.as_array().into_iter().flatten() {
+                validate_attribute_value(el)?;
+            }
+        }
+        "M" => {
+            if let Some(m) = val.as_object() {
+                for el in m.values() {
+                    validate_attribute_value(el)?;
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_key_in_item(
     table: &DynamoTable,
     item: &HashMap<String, AttributeValue>,
@@ -190,4 +248,45 @@ fn check_key_type(
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod attr_value_validation_tests {
+    use super::*;
+    use serde_json::json;
+
+    // bug-hunt 2026-07-01: a non-key attribute with a malformed Number is a
+    // ValidationException in real DynamoDB (it must not silently persist).
+    #[test]
+    fn rejects_invalid_number_attribute() {
+        let item: HashMap<String, AttributeValue> =
+            HashMap::from([("n".to_string(), json!({"N": "abc"}))]);
+        assert!(validate_item_attribute_values(&item).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_number_nested_in_list_and_map() {
+        let item: HashMap<String, AttributeValue> = HashMap::from([(
+            "l".to_string(),
+            json!({"L": [{"N": "1"}, {"M": {"x": {"N": "oops"}}}]}),
+        )]);
+        assert!(validate_item_attribute_values(&item).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_number_set_member() {
+        let item: HashMap<String, AttributeValue> =
+            HashMap::from([("ns".to_string(), json!({"NS": ["1", "x"]}))]);
+        assert!(validate_item_attribute_values(&item).is_err());
+    }
+
+    #[test]
+    fn accepts_valid_values() {
+        let item: HashMap<String, AttributeValue> = HashMap::from([
+            ("n".to_string(), json!({"N": "3.14"})),
+            ("s".to_string(), json!({"S": "hi"})),
+            ("ns".to_string(), json!({"NS": ["1", "2.5"]})),
+        ]);
+        assert!(validate_item_attribute_values(&item).is_ok());
+    }
 }

--- a/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
@@ -824,9 +824,22 @@ pub(crate) enum PartiqlCond {
     AttributeNotExists(String),
 }
 
-/// Count ? parameters in a string.
+/// Count positional `?` parameters in a PartiQL clause, ignoring any `?` that
+/// appears inside a single-quoted string literal (e.g. `SET note = 'done?'`).
+/// The UPDATE executor uses this count to slice parameters between the SET and
+/// WHERE clauses, so a `?` counted inside a literal would shift every WHERE
+/// binding by one and silently no-op the update (bug-hunt 2026-07-01).
 pub(crate) fn count_params_in_str(s: &str) -> usize {
-    s.chars().filter(|c| *c == '?').count()
+    let mut in_quote = false;
+    let mut count = 0;
+    for c in s.chars() {
+        match c {
+            '\'' => in_quote = !in_quote,
+            '?' if !in_quote => count += 1,
+            _ => {}
+        }
+    }
+    count
 }
 
 mod conditions;
@@ -849,6 +862,20 @@ pub(crate) use schemas::*;
 pub(crate) use table_descriptions::*;
 pub(crate) use table_lookup::*;
 pub(crate) use updates::*;
+
+#[cfg(test)]
+mod count_params_tests {
+    use super::*;
+
+    // bug-hunt 2026-07-01: a `?` inside a single-quoted literal must NOT be
+    // counted, else the SET/WHERE parameter split shifts and no-ops the update.
+    #[test]
+    fn count_params_ignores_quoted_question_marks() {
+        assert_eq!(count_params_in_str("SET note = 'done?' WHERE id = ?"), 1);
+        assert_eq!(count_params_in_str("a = ? AND b = ?"), 2);
+        assert_eq!(count_params_in_str("note = 'a?b?c'"), 0);
+    }
+}
 
 #[cfg(test)]
 mod set_rhs_tests {

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -2,6 +2,37 @@
 
 use super::*;
 
+/// Find the first byte offset of `needle` in `hay` that lies OUTSIDE any
+/// single-quoted string literal.
+///
+/// PartiQL string literals are delimited by single quotes, so operator and
+/// clause-keyword scanning must ignore anything inside them: a `<` in
+/// `'https://x?a<b'`, a `WHERE` in `SET note = 'go WHERE you want'`, or an
+/// ` IN ` in `name = 'go IN store'` are all data, not syntax. A doubled `''`
+/// (PartiQL's escaped quote) has no characters between the two quotes, so the
+/// brief toggle it produces can never straddle a real needle.
+pub(crate) fn find_outside_quotes(hay: &str, needle: &str) -> Option<usize> {
+    if needle.is_empty() {
+        return None;
+    }
+    let bytes = hay.as_bytes();
+    let nbytes = needle.as_bytes();
+    let mut in_quote = false;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'\'' {
+            in_quote = !in_quote;
+            i += 1;
+            continue;
+        }
+        if !in_quote && i + nbytes.len() <= bytes.len() && &bytes[i..i + nbytes.len()] == nbytes {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
 /// Compare two DynamoDB numeric attribute strings with full precision.
 ///
 /// DynamoDB numbers are arbitrary-precision decimals; parsing to `f64`
@@ -324,7 +355,7 @@ pub(crate) fn execute_partiql_in_state(
     let upper = trimmed.to_ascii_uppercase();
 
     if upper.starts_with("SELECT") {
-        let from_pos = upper.find("FROM").ok_or_else(|| {
+        let from_pos = find_outside_quotes(&upper, "FROM").ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationException",
@@ -353,7 +384,7 @@ pub(crate) fn execute_partiql_in_state(
             new_image: None,
         })
     } else if upper.starts_with("INSERT") {
-        let into_pos = upper.find("INTO").ok_or_else(|| {
+        let into_pos = find_outside_quotes(&upper, "INTO").ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationException",
@@ -363,7 +394,7 @@ pub(crate) fn execute_partiql_in_state(
         let after_into = trimmed[into_pos + 4..].trim();
         let (table_name, rest) = parse_partiql_table_name(after_into);
         let rest_upper = rest.trim().to_ascii_uppercase();
-        let value_pos = rest_upper.find("VALUE").ok_or_else(|| {
+        let value_pos = find_outside_quotes(&rest_upper, "VALUE").ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationException",
@@ -396,7 +427,7 @@ pub(crate) fn execute_partiql_in_state(
         let after_update = trimmed[6..].trim();
         let (table_name, rest) = parse_partiql_table_name(after_update);
         let rest_upper = rest.trim().to_ascii_uppercase();
-        let set_pos = rest_upper.find("SET").ok_or_else(|| {
+        let set_pos = find_outside_quotes(&rest_upper, "SET").ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationException",
@@ -404,7 +435,7 @@ pub(crate) fn execute_partiql_in_state(
             )
         })?;
         let after_set = rest.trim()[set_pos + 3..].trim();
-        let where_pos = after_set.to_ascii_uppercase().find("WHERE");
+        let where_pos = find_outside_quotes(&after_set.to_ascii_uppercase(), "WHERE");
         let (set_clause, where_clause) = if let Some(wp) = where_pos {
             (&after_set[..wp], after_set[wp + 5..].trim())
         } else {
@@ -456,7 +487,7 @@ pub(crate) fn execute_partiql_in_state(
             new_image: last_new,
         })
     } else if upper.starts_with("DELETE") {
-        let from_pos = upper.find("FROM").ok_or_else(|| {
+        let from_pos = find_outside_quotes(&upper, "FROM").ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationException",
@@ -989,6 +1020,13 @@ pub(crate) fn compare_attr(lhs: Option<&Value>, rhs: &Value) -> Option<i32> {
         l.get("N").and_then(|v| v.as_str()),
         r.get("N").and_then(|v| v.as_str()),
     ) {
+        // A malformed Number operand (`{"N":"abc"}`) has no defined ordering:
+        // `compare_number_strings` falls back to `Equal` for it, which would
+        // spuriously satisfy `<=`/`>=`/BETWEEN. Return `None` so the predicate
+        // evaluates to false instead (bug-hunt 2026-07-01).
+        if !is_valid_number(a) || !is_valid_number(b) {
+            return None;
+        }
         // Compare the decimal strings directly: parsing to f64 silently rounds
         // past 2^53, so two distinct large integers would compare Equal.
         return Some(match compare_number_strings(a, b) {
@@ -1059,11 +1097,13 @@ fn parse_one_partiql_condition(
 
     // BETWEEN: `attr BETWEEN lo AND hi`. The split-on-AND step
     // already preserved the inner AND, so we see the full clause.
-    if let Some(b) = upper.find(" BETWEEN ") {
+    // Keyword scans skip single-quoted spans so a literal like
+    // `'x BETWEEN y'` on the RHS never fools the parser.
+    if let Some(b) = find_outside_quotes(&upper, " BETWEEN ") {
         let attr = cond[..b].trim().trim_matches('"').to_string();
         let rest = cond[b + 9..].trim();
         let rest_upper = rest.to_ascii_uppercase();
-        if let Some(a) = rest_upper.find(" AND ") {
+        if let Some(a) = find_outside_quotes(&rest_upper, " AND ") {
             let lo = parse_partiql_literal(rest[..a].trim(), parameters, param_idx)?;
             let hi = parse_partiql_literal(rest[a + 5..].trim(), parameters, param_idx)?;
             return Some(PartiqlCond::Between(attr, lo, hi));
@@ -1071,7 +1111,7 @@ fn parse_one_partiql_condition(
     }
 
     // IN: `attr IN (a, b, c)`.
-    if let Some(i) = upper.find(" IN ") {
+    if let Some(i) = find_outside_quotes(&upper, " IN ") {
         let attr = cond[..i].trim().trim_matches('"').to_string();
         let after = cond[i + 4..].trim();
         let inner = after
@@ -1090,7 +1130,7 @@ fn parse_one_partiql_condition(
     // LIKE: `attr LIKE 'pattern'` (with `%` and `_` wildcards). The
     // pattern is always a string; we unwrap the {"S": ...} payload at
     // parse time so the evaluator can stay scalar-only.
-    if let Some(l) = upper.find(" LIKE ") {
+    if let Some(l) = find_outside_quotes(&upper, " LIKE ") {
         let attr = cond[..l].trim().trim_matches('"').to_string();
         let rhs = cond[l + 6..].trim();
         let pattern_val = parse_partiql_literal(rhs, parameters, param_idx)?;
@@ -1103,9 +1143,11 @@ fn parse_one_partiql_condition(
     }
 
     // Operator-style. Order matters: longest operator first so `<=`
-    // doesn't get parsed as `<`.
+    // doesn't get parsed as `<`. The operator must sit OUTSIDE any
+    // single-quoted literal, so a value like `'https://x?a<b'` is not
+    // split at the `<` inside the string (bug-hunt 2026-07-01).
     for op in ["<>", "<=", ">=", "<", ">", "="] {
-        if let Some(idx) = cond.find(op) {
+        if let Some(idx) = find_outside_quotes(cond, op) {
             let attr = cond[..idx].trim().trim_matches('"').to_string();
             let rhs = cond[idx + op.len()..].trim();
 
@@ -1221,6 +1263,13 @@ pub(crate) fn parse_partiql_literal(
         let inner = &s[1..s.len() - 1];
         Some(json!({"S": inner}))
     } else if let Ok(n) = s.parse::<f64>() {
+        // `f64::parse` accepts `inf`, `-inf`, and `NaN`, and overflows a
+        // literal like `1e999` to infinity. DynamoDB Numbers are finite
+        // decimals, so reject any non-finite literal rather than persisting a
+        // bogus `{"N":"inf"}` / `{"N":"NaN"}` (bug-hunt 2026-07-01).
+        if !n.is_finite() {
+            return None;
+        }
         // Preserve the exact decimal text for integer literals — going through
         // f64 silently rounds past 2^53, so a 17+ digit id would be stored
         // wrong. Fractional/scientific literals still normalize via f64.
@@ -1391,6 +1440,65 @@ mod number_compare_tests {
         assert_eq!(decimal_add_sub("1", "0.001", false).unwrap(), "0.999");
         // Non-numeric operand is rejected.
         assert!(decimal_add_sub("abc", "1", true).is_none());
+    }
+}
+
+#[cfg(test)]
+mod quote_aware_tests {
+    use super::*;
+
+    // bug-hunt 2026-07-01: operator/keyword scans must skip single-quoted
+    // literals so a `<` or `WHERE`/`IN` inside a string is treated as data.
+    #[test]
+    fn find_outside_quotes_skips_quoted_spans() {
+        assert_eq!(find_outside_quotes("url = 'https://x?a<b'", "<"), None);
+        assert_eq!(find_outside_quotes("url = 'a<b'", "="), Some(4));
+        // The literal WHERE is skipped; the real (last) one is found.
+        let s = "note = 'go WHERE you' WHERE id = 1";
+        assert_eq!(find_outside_quotes(s, "WHERE"), s.rfind("WHERE"));
+    }
+
+    #[test]
+    fn operator_scan_ignores_operator_inside_string_literal() {
+        let mut idx = 0;
+        let cond = parse_one_partiql_condition("url = 'https://x?a<b'", &[], &mut idx).unwrap();
+        match cond {
+            PartiqlCond::Eq(attr, val) => {
+                assert_eq!(attr, "url");
+                assert_eq!(val, json!({"S": "https://x?a<b"}));
+            }
+            other => panic!("expected Eq, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_literal_rejects_non_finite_numbers() {
+        let mut idx = 0;
+        assert_eq!(parse_partiql_literal("1e999", &[], &mut idx), None);
+        assert_eq!(parse_partiql_literal("inf", &[], &mut idx), None);
+        assert_eq!(parse_partiql_literal("NaN", &[], &mut idx), None);
+        assert_eq!(
+            parse_partiql_literal("42", &[], &mut idx),
+            Some(json!({"N": "42"}))
+        );
+    }
+
+    // A malformed stored Number operand must not spuriously satisfy a
+    // relational predicate (compare_attr returns None -> predicate false).
+    #[test]
+    fn compare_attr_rejects_malformed_number_operand() {
+        assert_eq!(
+            compare_attr(Some(&json!({"N": "abc"})), &json!({"N": "5"})),
+            None
+        );
+        assert_eq!(
+            compare_attr(Some(&json!({"N": "5"})), &json!({"N": "xyz"})),
+            None
+        );
+        assert_eq!(
+            compare_attr(Some(&json!({"N": "5"})), &json!({"N": "5"})),
+            Some(0)
+        );
     }
 }
 

--- a/crates/fakecloud-dynamodb/src/service/helpers/schemas.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/schemas.rs
@@ -10,16 +10,120 @@ pub(crate) fn parse_key_schema(val: &Value) -> Result<Vec<KeySchemaElement>, Aws
             "KeySchema is required",
         )
     })?;
-    Ok(arr
-        .iter()
-        .map(|elem| KeySchemaElement {
-            attribute_name: elem["AttributeName"]
+    let err = |m: &str| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            m.to_string(),
+        )
+    };
+    // A DynamoDB key schema has exactly one HASH element and at most one
+    // RANGE element (1 or 2 total). Previously the schema was parsed
+    // permissively: a missing KeyType defaulted to HASH, an empty
+    // AttributeName was accepted, and a two-HASH / zero-HASH / oversized
+    // schema was stored as-is — all of which real DDB rejects with a
+    // ValidationException (bug-hunt 2026-07-01, finding 7).
+    if arr.is_empty() || arr.len() > 2 {
+        return Err(err(
+            "1 validation error detected: KeySchema must contain 1 or 2 elements",
+        ));
+    }
+    let mut elements = Vec::with_capacity(arr.len());
+    let mut hash_count = 0usize;
+    for elem in arr {
+        let attribute_name = elem["AttributeName"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        if attribute_name.is_empty() {
+            return Err(err(
+                "1 validation error detected: KeySchema AttributeName must not be empty",
+            ));
+        }
+        let key_type = match elem["KeyType"].as_str() {
+            Some("HASH") => "HASH",
+            Some("RANGE") => "RANGE",
+            _ => {
+                return Err(err(
+                    "1 validation error detected: Value at 'keySchema' failed to satisfy \
+                     constraint: KeyType must be one of HASH or RANGE",
+                ));
+            }
+        };
+        if key_type == "HASH" {
+            hash_count += 1;
+        }
+        elements.push(KeySchemaElement {
+            attribute_name,
+            key_type: key_type.to_string(),
+        });
+    }
+    if hash_count != 1 {
+        return Err(err(
+            "1 validation error detected: KeySchema must specify exactly one HASH key",
+        ));
+    }
+    Ok(elements)
+}
+
+/// Validate `GlobalSecondaryIndexes` / `LocalSecondaryIndexes` definitions on
+/// CreateTable. Each index must carry a non-empty `IndexName`, a well-formed
+/// `KeySchema` (validated through [`parse_key_schema`], which rejects a
+/// non-array or structurally-invalid schema), and every one of its key
+/// attributes must be declared in the table's AttributeDefinitions. Real DDB
+/// returns a ValidationException for any of these; `parse_gsi`/`parse_lsi`
+/// otherwise SILENTLY DROP a malformed index (bug-hunt 2026-07-01, finding 6).
+pub(crate) fn validate_index_definitions(
+    gsi_val: &Value,
+    lsi_val: &Value,
+    attribute_definitions: &[AttributeDefinition],
+) -> Result<(), AwsServiceError> {
+    for (val, label) in [
+        (gsi_val, "GlobalSecondaryIndexes"),
+        (lsi_val, "LocalSecondaryIndexes"),
+    ] {
+        let Some(arr) = val.as_array() else { continue };
+        for idx in arr {
+            if idx["IndexName"]
                 .as_str()
-                .unwrap_or_default()
-                .to_string(),
-            key_type: elem["KeyType"].as_str().unwrap_or("HASH").to_string(),
-        })
-        .collect())
+                .filter(|s| !s.is_empty())
+                .is_none()
+            {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!(
+                        "One or more parameter values were invalid: {label} entry is missing IndexName"
+                    ),
+                ));
+            }
+            // Rejects a non-array / structurally-invalid index KeySchema.
+            let key_schema = parse_key_schema(&idx["KeySchema"])?;
+            for ks in &key_schema {
+                if !attribute_definitions
+                    .iter()
+                    .any(|ad| ad.attribute_name == ks.attribute_name)
+                {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationException",
+                        format!(
+                            "One or more parameter values were invalid: \
+                             Some index key attributes are not defined in AttributeDefinitions. \
+                             Keys: [{}], AttributeDefinitions: [{}]",
+                            ks.attribute_name,
+                            attribute_definitions
+                                .iter()
+                                .map(|ad| ad.attribute_name.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn parse_attribute_definitions(
@@ -139,4 +243,94 @@ pub(crate) fn parse_expression_attribute_values(body: &Value) -> HashMap<String,
         }
     }
     values
+}
+
+#[cfg(test)]
+mod schema_validation_tests {
+    use super::*;
+    use serde_json::json;
+
+    // bug-hunt 2026-07-01, finding 7: key-schema structure is validated.
+    #[test]
+    fn parse_key_schema_rejects_missing_keytype() {
+        assert!(parse_key_schema(&json!([{"AttributeName": "pk"}])).is_err());
+    }
+
+    #[test]
+    fn parse_key_schema_rejects_two_hash() {
+        assert!(parse_key_schema(&json!([
+            {"AttributeName": "a", "KeyType": "HASH"},
+            {"AttributeName": "b", "KeyType": "HASH"}
+        ]))
+        .is_err());
+    }
+
+    #[test]
+    fn parse_key_schema_rejects_empty_oversized_and_bad_name() {
+        assert!(parse_key_schema(&json!([])).is_err());
+        assert!(parse_key_schema(&json!([
+            {"AttributeName": "a", "KeyType": "HASH"},
+            {"AttributeName": "b", "KeyType": "RANGE"},
+            {"AttributeName": "c", "KeyType": "RANGE"}
+        ]))
+        .is_err());
+        assert!(parse_key_schema(&json!([{"AttributeName": "", "KeyType": "HASH"}])).is_err());
+    }
+
+    #[test]
+    fn parse_key_schema_accepts_valid_composite() {
+        let ks = parse_key_schema(&json!([
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"}
+        ]))
+        .unwrap();
+        assert_eq!(ks.len(), 2);
+    }
+
+    // bug-hunt 2026-07-01, finding 6: index key attrs validated against defs,
+    // malformed index rejected rather than silently dropped.
+    #[test]
+    fn validate_index_definitions_rejects_undefined_attr() {
+        let defs = vec![AttributeDefinition {
+            attribute_name: "pk".into(),
+            attribute_type: "S".into(),
+        }];
+        let gsi = json!([{
+            "IndexName": "g",
+            "KeySchema": [{"AttributeName": "ghost", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "ALL"}
+        }]);
+        let err = validate_index_definitions(&gsi, &Value::Null, &defs).unwrap_err();
+        assert!(format!("{err:?}").contains("not defined in AttributeDefinitions"));
+    }
+
+    #[test]
+    fn validate_index_definitions_rejects_missing_index_name() {
+        let defs = vec![AttributeDefinition {
+            attribute_name: "pk".into(),
+            attribute_type: "S".into(),
+        }];
+        let gsi = json!([{"KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}]}]);
+        assert!(validate_index_definitions(&gsi, &Value::Null, &defs).is_err());
+    }
+
+    #[test]
+    fn validate_index_definitions_accepts_valid() {
+        let defs = vec![
+            AttributeDefinition {
+                attribute_name: "pk".into(),
+                attribute_type: "S".into(),
+            },
+            AttributeDefinition {
+                attribute_name: "gpk".into(),
+                attribute_type: "S".into(),
+            },
+        ];
+        let gsi = json!([{
+            "IndexName": "g",
+            "KeySchema": [{"AttributeName": "gpk", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "ALL"}
+        }]);
+        assert!(validate_index_definitions(&gsi, &Value::Null, &defs).is_ok());
+    }
 }

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -11,7 +11,8 @@ use super::{
     evaluate_condition_with_return, extract_key, get_table, get_table_mut,
     parse_expression_attribute_names, parse_expression_attribute_values, project_item,
     require_object, require_str, resolve_write_condition, return_consumed_mode, return_icm_mode,
-    validate_key_attributes_in_key, validate_key_in_item, AttributeValue, DynamoDbService,
+    validate_item_attribute_values, validate_key_attributes_in_key, validate_key_in_item,
+    AttributeValue, DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -40,6 +41,9 @@ impl DynamoDbService {
             let table = get_table_mut(&mut state.tables, table_name)?;
 
             validate_key_in_item(table, &item)?;
+            // Validate every attribute value (not just keys): a malformed number
+            // like {"N":"abc"} is a ValidationException in real DynamoDB.
+            validate_item_attribute_values(&item)?;
 
             let key = extract_key(table, &item);
             let existing_idx = table.find_item_index(&key);

--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -11,8 +11,8 @@ use super::{
     build_consumed_capacity, compare_attribute_values, evaluate_filter_expression,
     evaluate_key_condition, extract_key_for_schema, get_table, item_matches_key,
     parse_expression_attribute_names, parse_expression_attribute_values, parse_key_map,
-    project_item, require_str, return_consumed_mode, translate_legacy_conditions, DynamoDbService,
-    LegacyConditionRole,
+    project_item, require_str, resolve_attr_name, return_consumed_mode, split_on_and,
+    strip_outer_parens, translate_legacy_conditions, DynamoDbService, LegacyConditionRole,
 };
 
 impl DynamoDbService {
@@ -123,6 +123,13 @@ impl DynamoDbService {
                 table.range_key_name().map(|s| s.to_string()),
             )
         };
+
+        // The partition key MUST be constrained with `=`. Without this check a
+        // condition that omits the partition key (or uses a range operator on
+        // it, e.g. `sk = :v` or `pk > :v`) would fall through to a generic
+        // filter over EVERY partition and silently return cross-partition
+        // matches (bug-hunt 2026-07-01).
+        validate_partition_key_condition(&key_condition, &hash_key_name, &expr_attr_names)?;
 
         let mut matched: Vec<&HashMap<String, AttributeValue>> = items_to_scan
             .iter()
@@ -674,6 +681,76 @@ fn validate_limit(body: &Value) -> Result<Option<usize>, AwsServiceError> {
     }
 }
 
+/// A Query's `KeyConditionExpression` must constrain the table (or index)
+/// partition key with an equality (`=`). Real DynamoDB rejects a condition
+/// that omits the partition key with "Query condition missed key schema
+/// element: <pk>", and one that uses any non-`=` operator on the partition
+/// key with "Query key condition not supported" — rather than evaluating the
+/// expression as a generic filter over every partition.
+fn validate_partition_key_condition(
+    key_condition: &str,
+    partition_key: &str,
+    expr_attr_names: &HashMap<String, String>,
+) -> Result<(), AwsServiceError> {
+    let mut pk_seen = false;
+    for raw in split_on_and(key_condition) {
+        let part = strip_outer_parens(raw.trim()).trim();
+
+        // begins_with(...) targets the sort key, never the partition key.
+        let lower = part.to_ascii_lowercase();
+        if lower.starts_with("begins_with(") || lower.starts_with("begins_with (") {
+            continue;
+        }
+
+        // A word-boundaried BETWEEN is a range condition (sort key only). If it
+        // sits on the partition key it's an unsupported non-`=` condition.
+        let part_upper = part.to_ascii_uppercase();
+        let between_at = part_upper.match_indices("BETWEEN").find(|(i, _)| {
+            let before_ws = *i == 0 || part_upper.as_bytes()[*i - 1].is_ascii_whitespace();
+            let after = *i + "BETWEEN".len();
+            let after_ws =
+                after >= part_upper.len() || part_upper.as_bytes()[after].is_ascii_whitespace();
+            before_ws && after_ws
+        });
+
+        let (op, left): (&str, &str) = if let Some((bpos, _)) = between_at {
+            ("BETWEEN", part[..bpos].trim())
+        } else {
+            let mut found: Option<(&'static str, &str)> = None;
+            for cand in ["<=", ">=", "<>", "=", "<", ">"] {
+                if let Some(pos) = part.find(cand) {
+                    found = Some((cand, part[..pos].trim()));
+                    break;
+                }
+            }
+            match found {
+                Some(v) => v,
+                None => continue,
+            }
+        };
+
+        if resolve_attr_name(left.trim_matches('"'), expr_attr_names) == partition_key {
+            pk_seen = true;
+            if op != "=" {
+                return Err(AwsServiceError::aws_error(
+                    http::StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Query key condition not supported",
+                ));
+            }
+        }
+    }
+
+    if !pk_seen {
+        return Err(AwsServiceError::aws_error(
+            http::StatusCode::BAD_REQUEST,
+            "ValidationException",
+            format!("Query condition missed key schema element: {partition_key}"),
+        ));
+    }
+    Ok(())
+}
+
 /// Validate the `Select` parameter for a Query/Scan and decide whether
 /// the operation returns only a count. `is_index_query` is true when an
 /// IndexName is present (only then is ALL_PROJECTED_ATTRIBUTES legal).
@@ -1101,6 +1178,63 @@ mod tests {
             16,
             "every item must land in exactly one segment"
         );
+    }
+
+    // bug-hunt 2026-07-01, finding 1: a Query MUST constrain the partition key
+    // with `=`. Omitting it, or using a range operator on it, is a
+    // ValidationException — not a silent cross-partition filter.
+    #[tokio::test]
+    async fn query_requires_partition_key_equality() {
+        let state = make_state();
+        seed_table(&state, "T", vec![item("a"), item("b")]);
+        let svc = DynamoDbService::new(state);
+
+        // Condition references a non-key attribute -> partition key missing.
+        let missing = svc
+            .query(&req_for(
+                "Query",
+                json!({
+                    "TableName": "T",
+                    "KeyConditionExpression": "sk = :v",
+                    "ExpressionAttributeValues": {":v": {"S": "a"}},
+                }),
+            ))
+            .err()
+            .expect("missing partition key rejected");
+        assert!(format!("{missing:?}").contains("missed key schema element"));
+
+        // Range operator on the partition key -> unsupported.
+        let non_eq = svc
+            .query(&req_for(
+                "Query",
+                json!({
+                    "TableName": "T",
+                    "KeyConditionExpression": "pk > :v",
+                    "ExpressionAttributeValues": {":v": {"S": "a"}},
+                }),
+            ))
+            .err()
+            .expect("non-equality partition key rejected");
+        assert!(format!("{non_eq:?}").contains("Query key condition not supported"));
+    }
+
+    #[tokio::test]
+    async fn query_accepts_partition_key_equality() {
+        let state = make_state();
+        seed_table(&state, "T", vec![item("a"), item("b")]);
+        let svc = DynamoDbService::new(state);
+        let resp = svc
+            .query(&req_for(
+                "Query",
+                json!({
+                    "TableName": "T",
+                    "KeyConditionExpression": "pk = :v",
+                    "ExpressionAttributeValues": {":v": {"S": "a"}},
+                }),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Count"].as_i64().unwrap(), 1);
     }
 
     #[tokio::test]

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -20,7 +20,8 @@ use super::{
     build_table_description, build_table_description_json, find_table_by_arn,
     find_table_by_arn_mut, get_table, get_table_mut, get_table_mut_with_code, get_table_with_code,
     parse_attribute_definitions, parse_gsi, parse_gsi_throughput, parse_key_schema, parse_lsi,
-    parse_provisioned_throughput, parse_tags, require_str, DynamoDbService,
+    parse_provisioned_throughput, parse_tags, require_str, validate_index_definitions,
+    DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -33,6 +34,9 @@ impl DynamoDbService {
         // ValidationException for malformed input on this op, but the strict
         // probe rejects undeclared codes, so we surface LimitExceeded for
         // structurally-invalid table specs.
+        // A missing TableName stays LimitExceededException: CreateTable's
+        // Smithy `errors:` list omits ValidationException, and a pinned test
+        // depends on this code (the request never reaches the shared parsers).
         let table_name = body["TableName"]
             .as_str()
             .ok_or_else(|| {
@@ -44,19 +48,14 @@ impl DynamoDbService {
             })?
             .to_string();
 
-        let key_schema = parse_key_schema(&body["KeySchema"]).map_err(remap_create_table_error)?;
-        let attribute_definitions = parse_attribute_definitions(&body["AttributeDefinitions"])
-            .map_err(remap_create_table_error)?;
+        // Structural request errors below are AWS-faithful ValidationExceptions.
+        // The conformance probe accepts them via `service_common_errors`
+        // ("dynamodb" => ValidationException), since real DynamoDB returns this
+        // code across essentially every operation for malformed input.
+        let key_schema = parse_key_schema(&body["KeySchema"])?;
+        let attribute_definitions = parse_attribute_definitions(&body["AttributeDefinitions"])?;
 
-        if key_schema.is_empty() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "LimitExceededException",
-                "KeySchema must contain at least one element",
-            ));
-        }
-
-        // Validate that key schema attributes are defined
+        // Validate that the base-table key schema attributes are defined.
         for ks in &key_schema {
             if !attribute_definitions
                 .iter()
@@ -64,7 +63,7 @@ impl DynamoDbService {
             {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
-                    "LimitExceededException",
+                    "ValidationException",
                     format!(
                         "One or more parameter values were invalid: \
                          Some index key attributes are not defined in AttributeDefinitions. \
@@ -80,10 +79,31 @@ impl DynamoDbService {
             }
         }
 
-        let billing_mode = body["BillingMode"]
-            .as_str()
-            .unwrap_or("PROVISIONED")
-            .to_string();
+        // Validate GSI/LSI index key attributes against AttributeDefinitions and
+        // reject a malformed index instead of silently dropping it.
+        validate_index_definitions(
+            &body["GlobalSecondaryIndexes"],
+            &body["LocalSecondaryIndexes"],
+            &attribute_definitions,
+        )?;
+
+        // BillingMode must be one of the two documented enum values.
+        let billing_mode = match body.get("BillingMode") {
+            None | Some(Value::Null) => "PROVISIONED".to_string(),
+            Some(Value::String(s)) if s == "PROVISIONED" || s == "PAY_PER_REQUEST" => s.clone(),
+            Some(other) => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!(
+                        "1 validation error detected: Value '{}' at 'billingMode' failed to \
+                         satisfy constraint: Member must satisfy enum value set: \
+                         [PROVISIONED, PAY_PER_REQUEST]",
+                        other.as_str().unwrap_or("")
+                    ),
+                ));
+            }
+        };
 
         let provisioned_throughput = if billing_mode == "PAY_PER_REQUEST" {
             ProvisionedThroughput {
@@ -91,8 +111,17 @@ impl DynamoDbService {
                 write_capacity_units: 0,
             }
         } else {
-            parse_provisioned_throughput(&body["ProvisionedThroughput"])
-                .map_err(remap_create_table_error)?
+            // PROVISIONED billing requires an explicit ProvisionedThroughput;
+            // AWS rejects its omission rather than silently defaulting to 5/5.
+            if !body["ProvisionedThroughput"].is_object() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "One or more parameter values were invalid: \
+                     ProvisionedThroughput must be specified when BillingMode is PROVISIONED",
+                ));
+            }
+            parse_provisioned_throughput(&body["ProvisionedThroughput"])?
         };
 
         let gsi = parse_gsi(&body["GlobalSecondaryIndexes"], &billing_mode);
@@ -1857,26 +1886,4 @@ fn policy_revision_id(policy: &str) -> String {
     let mut h = std::collections::hash_map::DefaultHasher::new();
     policy.hash(&mut h);
     format!("{:016x}", h.finish())
-}
-
-/// Rewrite a `ValidationException` from the shared schema/throughput parsers
-/// into `LimitExceededException`, which is the closest declared error on
-/// `CreateTable`. Other (non-validation) errors are passed through unchanged.
-fn remap_create_table_error(err: AwsServiceError) -> AwsServiceError {
-    match err {
-        AwsServiceError::AwsError {
-            status,
-            code,
-            message,
-            extra_fields,
-            headers,
-        } if code == "ValidationException" => AwsServiceError::AwsError {
-            status,
-            code: "LimitExceededException".to_string(),
-            message,
-            extra_fields,
-            headers,
-        },
-        other => other,
-    }
 }

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -3121,9 +3121,10 @@ fn create_table_missing_key_attr_in_definitions() {
         }),
     );
     let err = expect_err(svc.create_table(&req));
-    // CreateTable doesn't declare ValidationException; we remap to
-    // LimitExceededException to stay Smithy-compliant.
-    assert!(err.to_string().contains("LimitExceededException"));
+    // A base-key attribute missing from AttributeDefinitions is a
+    // ValidationException, matching real DynamoDB (accepted by the conformance
+    // probe via service_common_errors for dynamodb).
+    assert!(err.to_string().contains("ValidationException"));
 }
 
 // ── DescribeTable ──

--- a/crates/fakecloud-dynamodb/src/streams_dataplane.rs
+++ b/crates/fakecloud-dynamodb/src/streams_dataplane.rs
@@ -177,11 +177,14 @@ impl DynamoDbStreamsService {
                 .map(|r| r.dynamodb.sequence_number.clone())
                 .max_by(|a, b| cmp_seq(a, b))
                 .unwrap_or_else(|| "0".to_string()),
-            // Inclusive of the named record: anchor just below it.
+            // Inclusive of the named record: anchor just below it. A sequence
+            // number that isn't present has aged out of the retained window (or
+            // never existed): AWS answers AT/AFTER_SEQUENCE_NUMBER for such a
+            // sequence with TrimmedDataAccessException, not ValidationException.
             "AT_SEQUENCE_NUMBER" => {
                 let seq = require_string(body, "SequenceNumber")?;
                 if !records.iter().any(|r| r.dynamodb.sequence_number == seq) {
-                    return Err(invalid_argument("SequenceNumber not found"));
+                    return Err(trimmed_data_access(&seq));
                 }
                 exclusive_before(&seq)
             }
@@ -189,7 +192,7 @@ impl DynamoDbStreamsService {
             "AFTER_SEQUENCE_NUMBER" => {
                 let seq = require_string(body, "SequenceNumber")?;
                 if !records.iter().any(|r| r.dynamodb.sequence_number == seq) {
-                    return Err(invalid_argument("SequenceNumber not found"));
+                    return Err(trimmed_data_access(&seq));
                 }
                 seq
             }
@@ -303,7 +306,11 @@ fn stream_label(stream_arn: &str) -> String {
 /// are minted by an atomic counter and zero-padded to a fixed width, so they
 /// are also lexicographically ordered; we still parse to `u128` so that an
 /// un-padded legacy value (or one of a different width) compares correctly.
-fn cmp_seq(a: &str, b: &str) -> std::cmp::Ordering {
+///
+/// Exported (via `lib.rs`) so the Streams->Lambda poller compares checkpoints
+/// with the exact same numeric ordering as GetRecords, instead of raw string
+/// order (which straddles the old->fixed-width sequence-format change).
+pub fn cmp_seq(a: &str, b: &str) -> std::cmp::Ordering {
     match (a.parse::<u128>(), b.parse::<u128>()) {
         (Ok(x), Ok(y)) => x.cmp(&y),
         // Non-numeric values fall back to byte order (deterministic, total).
@@ -335,6 +342,17 @@ fn require_string(body: &Value, field: &str) -> Result<String, AwsServiceError> 
 
 fn invalid_argument(msg: &str) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationException", msg)
+}
+
+/// A request to read from a sequence number that is no longer retained (or
+/// never existed) on the stream. DynamoDB Streams returns this on
+/// GetShardIterator for AT/AFTER_SEQUENCE_NUMBER against trimmed/absent data.
+fn trimmed_data_access(seq: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "TrimmedDataAccessException",
+        format!("Attempted access to a trimmed data: sequence number {seq} is no longer available in the stream"),
+    )
 }
 
 fn not_found(kind: &str, target: &str) -> AwsServiceError {
@@ -617,6 +635,35 @@ mod tests {
         );
         assert_eq!(recs2[0]["eventID"].as_str().unwrap(), "e4");
         assert_eq!(recs2[1]["eventID"].as_str().unwrap(), "e5");
+    }
+
+    // bug-hunt 2026-07-01, finding 8: AT/AFTER_SEQUENCE_NUMBER against a
+    // sequence number that has aged out (or never existed) is a
+    // TrimmedDataAccessException, not a ValidationException.
+    #[tokio::test]
+    async fn get_shard_iterator_absent_sequence_is_trimmed_data_access() {
+        let state = make_state();
+        let arn = seed_table(&state); // seeds one record, seq "1"
+        let svc = DynamoDbStreamsService::new(state);
+        for iter_type in ["AT_SEQUENCE_NUMBER", "AFTER_SEQUENCE_NUMBER"] {
+            let err = svc
+                .handle(req(
+                    "GetShardIterator",
+                    json!({
+                        "StreamArn": arn,
+                        "ShardId": "shardId-00000000000000000000-00000001",
+                        "ShardIteratorType": iter_type,
+                        "SequenceNumber": "999999999",
+                    }),
+                ))
+                .await
+                .err()
+                .expect("absent sequence must be rejected");
+            assert!(
+                format!("{err:?}").contains("TrimmedDataAccessException"),
+                "{iter_type}: {err:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
+++ b/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
@@ -524,3 +524,36 @@ async fn ddb_partiql_execute_statement_paginates() {
     assert_eq!(page2.items().len(), 1, "remaining item on page 2");
     assert!(page2.next_token().is_none(), "last page has no NextToken");
 }
+
+// bug-hunt 2026-07-01, finding 2: a PartiQL SELECT whose string literal
+// contains a `<` (or other operator char) must not be split inside the quotes
+// — the operator scan skips single-quoted spans, so the equality still parses
+// and matches the stored row.
+#[tokio::test]
+async fn ddb_partiql_select_operator_char_inside_string_literal() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    create_streamed_table(&ddb, "Urls").await;
+
+    let url = "https://x?a<b";
+    ddb.put_item()
+        .table_name("Urls")
+        .item("pk", AttributeValue::S("row1".into()))
+        .item("s", AttributeValue::S(url.into()))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = ddb
+        .execute_statement()
+        .statement(format!("SELECT pk FROM \"Urls\" WHERE s = '{url}'"))
+        .send()
+        .await
+        .expect("SELECT with a `<` inside the string literal must succeed");
+    let pks: Vec<String> = resp
+        .items()
+        .iter()
+        .map(|it| it.get("pk").unwrap().as_s().unwrap().clone())
+        .collect();
+    assert_eq!(pks, vec!["row1".to_string()]);
+}

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -6264,3 +6264,100 @@ async fn dynamodb_ttl_expiry_emits_remove_stream_record() {
     assert_eq!(ui.principal_id(), Some("dynamodb.amazonaws.com"));
     assert_eq!(ui.r#type(), Some("Service"));
 }
+
+// bug-hunt 2026-07-01, finding 1: a Query that omits the partition key from the
+// KeyConditionExpression is a ValidationException, not a silent cross-partition
+// scan.
+#[tokio::test]
+async fn dynamodb_query_missing_partition_key_errors() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("QMissingPk")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .query()
+        .table_name("QMissingPk")
+        // References a non-key attribute -> partition key never constrained.
+        .key_condition_expression("sk = :v")
+        .expression_attribute_values(":v", AttributeValue::S("x".to_string()))
+        .send()
+        .await
+        .expect_err("a Query missing the partition key must be rejected");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("ValidationException"), "{msg}");
+}
+
+// bug-hunt 2026-07-01, finding 6: a CreateTable whose GSI references an
+// attribute that is not defined in AttributeDefinitions is a
+// ValidationException (the index is not silently dropped).
+#[tokio::test]
+async fn dynamodb_create_table_gsi_undefined_attribute_errors() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    let err = client
+        .create_table()
+        .table_name("BadGsi")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_indexes(
+            GlobalSecondaryIndex::builder()
+                .index_name("by-ghost")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("ghost")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::All)
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .expect_err("a GSI referencing an undefined attribute must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("ValidationException") || msg.contains("not defined in AttributeDefinitions"),
+        "{msg}"
+    );
+}

--- a/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
+++ b/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
@@ -11,7 +11,7 @@ use chrono::Utc;
 use serde_json::json;
 
 use fakecloud_core::delivery::LambdaDelivery;
-use fakecloud_dynamodb::SharedDynamoDbState;
+use fakecloud_dynamodb::{cmp_seq, SharedDynamoDbState};
 use fakecloud_lambda::filter::FilterSet;
 use fakecloud_lambda::{LambdaInvocation, SharedLambdaState};
 
@@ -137,7 +137,7 @@ impl DynamoDbStreamsLambdaPoller {
                             "LATEST" => stream_records
                                 .iter()
                                 .map(|r| r.dynamodb.sequence_number.clone())
-                                .max()
+                                .max_by(|a, b| cmp_seq(a, b))
                                 .unwrap_or_default(),
                             _ => String::new(),
                         };
@@ -170,16 +170,19 @@ impl DynamoDbStreamsLambdaPoller {
                 let mut filtered: Vec<_> = stream_records
                     .iter()
                     .filter(|r| match checkpoint.as_deref() {
-                        Some(cp) if !cp.is_empty() => r.dynamodb.sequence_number.as_str() > cp,
+                        Some(cp) if !cp.is_empty() => {
+                            cmp_seq(&r.dynamodb.sequence_number, cp) == std::cmp::Ordering::Greater
+                        }
                         _ => true,
                     })
                     .take(batch_size.max(0) as usize)
                     .cloned()
                     .collect();
 
-                // Sort by sequence number to ensure order
-                filtered
-                    .sort_by(|a, b| a.dynamodb.sequence_number.cmp(&b.dynamodb.sequence_number));
+                // Sort by sequence number (numeric) to ensure delivery order.
+                filtered.sort_by(|a, b| {
+                    cmp_seq(&a.dynamodb.sequence_number, &b.dynamodb.sequence_number)
+                });
 
                 filtered
             };


### PR DESCRIPTION
## Summary

Pre-Show-HN hardening of DynamoDB (bug-hunt on the crown-jewel trio). No panics or persistence bugs were found — the crate is well-hardened; these are correctness/fidelity gaps where a malformed request silently returned wrong results instead of AWS's `ValidationException`, plus PartiQL quoted-literal parsing bugs.

**Correctness (silent-wrong-output):**
- **Query** now requires partition-key equality (`validate_partition_key_condition`): a KeyConditionExpression omitting the pk or using non-`=` on it was evaluated as a filter over ALL items (cross-partition wrong results). Now "Query condition missed key schema element: <pk>" / "Query key condition not supported".
- **PartiQL quote-awareness** (new `find_outside_quotes`): operator scan (`<`/`>`/`=`) and clause keywords (FROM/INTO/VALUE/SET/WHERE/BETWEEN/IN/LIKE) no longer split inside single-quoted string literals — e.g. `WHERE url = 'https://x?a<b'` and `SET note = 'go WHERE you want'` now parse correctly instead of silently failing.
- **`count_params_in_str`** now quote-aware — a `?` inside a string literal no longer corrupts the positional-parameter slice (was a silent no-op update).

**Validation gaps (too-lenient → now AWS-faithful errors):**
- **TransactGetItems**: 1..=100 bound, per-`Get.Key` attribute validation (no `{}` coercion), duplicate-key rejection (mirrors TransactWriteItems).
- **CreateTable GSI/LSI**: index key attrs validated against AttributeDefinitions; a malformed index (missing IndexName / non-array KeySchema) is now rejected, not silently dropped.
- **`parse_key_schema`**: 1..=2 elements, exactly one HASH, non-empty AttributeName, valid KeyType (no default-to-HASH).
- **CreateTable errors**: base-key-undefined / unknown BillingMode / PROVISIONED-without-throughput → ValidationException (was LimitExceededException / silent default).
- **ExecuteStatement Limit:0** → ValidationException; **BatchWrite/Transact** members require exactly one operation.
- **GetShardIterator**: aged-out/absent AT/AFTER_SEQUENCE_NUMBER → `TrimmedDataAccessException` (was ValidationException).
- Confirmed suspicious leads all fixed: reject inf/NaN/1e999 literals; `compare` treats an unparseable stored `{"N":"abc"}` as non-matching; PutItem validates non-key attribute values.

**Cross-crate:** the DynamoDB-Streams→Lambda poller (`fakecloud-server`) compared sequence numbers as raw strings; now routed through the exported numeric `cmp_seq` so a snapshot straddling the old→fixed-width sequence-format change can't permanently skip records for an ESM.

Conformance: CreateTable's Smithy list omits ValidationException, so per house style the AWS-faithful error is paired with a `service_common_errors` `dynamodb => [ValidationException]` entry (not a baseline regen). The pinned missing-TableName→LimitExceeded test is left intact.

## Test plan
- E2E: Query missing pk errors; PartiQL SELECT with `<` inside a string literal succeeds; CreateTable GSI referencing an undefined attribute errors.
- `cargo test -p fakecloud-dynamodb` 372 pass (+23 new); clippy `-p fakecloud-dynamodb` and `-p fakecloud` clean; fmt clean; both e2e tests compile.

## Surface
Behavioral bug-fix — no new ops/SDK/counts. Non-code surface unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the DynamoDB emulator to match AWS validation and parsing: Query now requires partition-key equality, PartiQL parsing is quote-aware, and Streams sequence numbers are compared numerically to prevent skipped records.

- **Bug Fixes**
  - Query: require partition key `=` in `KeyConditionExpression`; missing or non-`=` on the pk now returns ValidationException (“missed key schema element” / “key condition not supported”).
  - PartiQL: operator/keyword scans skip single-quoted literals; `count_params_in_str` ignores `?` in quotes; literals reject non-finite numbers (`inf`/`NaN`/overflow).
  - CreateTable: validate GSI/LSI key attrs against `AttributeDefinitions`; enforce key schema structure (1–2 elems, exactly one HASH); unknown `BillingMode` and `PROVISIONED` without throughput now error with ValidationException.
  - Transactions/Batch: `TransactGetItems` enforces 1..=100, strict `Get.Key` parsing, and duplicate-key rejection; `BatchWriteItem` and `TransactWriteItems` require exactly one operation per member.
  - ExecuteStatement: `Limit` must be ≥ 1.
  - PutItem: validate all attribute values (reject malformed Numbers like `{"N":"abc"}`); comparison in PartiQL returns non-match for malformed Number operands.
  - Streams: `GetShardIterator` for absent/aged-out sequence returns `TrimmedDataAccessException`; exported numeric `cmp_seq` used by the Streams→Lambda poller to order and checkpoint correctly across format changes.
  - Conformance: add `ValidationException` to DynamoDB in `service_common_errors` (affects `CreateTable` path).

<sup>Written for commit 342beb505f81e63fd8269f4333c13a2b8fa8212d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

