### PR TITLE
fix(sns): XML-escape user data in subscription/topic/tag read responses; type-aware filter matching

### DIFF
--- a/crates/fakecloud-e2e/tests/sns.rs
+++ b/crates/fakecloud-e2e/tests/sns.rs
@@ -1257,3 +1257,107 @@ async fn sns_publish_batch_applies_filter_policy() {
         "filter policy not applied on batch: {bodies:?}"
     );
 }
+
+/// Regression: user-controlled strings echoed into XML read responses must be
+/// XML-escaped so the client SDK's XML parser never chokes. The most common
+/// trigger is an HTTPS endpoint carrying a query string (`?a=1&b=2`): the raw
+/// `&` would otherwise produce malformed XML on every ListSubscriptionsByTopic
+/// / GetSubscriptionAttributes. Also covers DisplayName `&`/`<` on the topic
+/// attributes and a tag value with `<`.
+#[tokio::test]
+async fn sns_xml_escaping_round_trips_special_chars() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("xml-escape-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    // DisplayName with `&` and angle brackets round-trips via GetTopicAttributes.
+    client
+        .set_topic_attributes()
+        .topic_arn(&topic_arn)
+        .attribute_name("DisplayName")
+        .attribute_value("Acme & Co <inc>")
+        .send()
+        .await
+        .expect("set DisplayName");
+
+    let attrs = client
+        .get_topic_attributes()
+        .topic_arn(&topic_arn)
+        .send()
+        .await
+        .expect("get_topic_attributes must parse")
+        .attributes
+        .unwrap_or_default();
+    assert_eq!(
+        attrs.get("DisplayName").map(String::as_str),
+        Some("Acme & Co <inc>")
+    );
+
+    // Tag value with `<` round-trips via ListTagsForResource.
+    use aws_sdk_sns::types::Tag;
+    client
+        .tag_resource()
+        .resource_arn(&topic_arn)
+        .tags(Tag::builder().key("expr").value("a<b").build().unwrap())
+        .send()
+        .await
+        .expect("tag_resource");
+    let tags = client
+        .list_tags_for_resource()
+        .resource_arn(&topic_arn)
+        .send()
+        .await
+        .expect("list_tags_for_resource must parse");
+    let expr = tags
+        .tags()
+        .iter()
+        .find(|t| t.key() == "expr")
+        .map(|t| t.value());
+    assert_eq!(expr, Some("a<b"));
+
+    // HTTPS endpoint with a query string. ReturnSubscriptionArn=true yields
+    // the real ARN so we can also exercise GetSubscriptionAttributes.
+    let endpoint = "https://example.com/hook?token=a&env=prod";
+    let sub = client
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("https")
+        .endpoint(endpoint)
+        .return_subscription_arn(true)
+        .send()
+        .await
+        .expect("subscribe");
+    let sub_arn = sub.subscription_arn().unwrap().to_string();
+    assert!(sub_arn.contains("xml-escape-topic"));
+
+    // ListSubscriptionsByTopic must parse and echo the endpoint intact.
+    let listed = client
+        .list_subscriptions_by_topic()
+        .topic_arn(&topic_arn)
+        .send()
+        .await
+        .expect("list_subscriptions_by_topic must parse");
+    let listed_endpoint = listed.subscriptions().iter().find_map(|s| s.endpoint());
+    assert_eq!(listed_endpoint, Some(endpoint));
+
+    // GetSubscriptionAttributes must parse and echo the endpoint intact.
+    let sub_attrs = client
+        .get_subscription_attributes()
+        .subscription_arn(&sub_arn)
+        .send()
+        .await
+        .expect("get_subscription_attributes must parse")
+        .attributes
+        .unwrap_or_default();
+    assert_eq!(
+        sub_attrs.get("Endpoint").map(String::as_str),
+        Some(endpoint)
+    );
+}

--- a/crates/fakecloud-sns/src/helpers.rs
+++ b/crates/fakecloud-sns/src/helpers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use fakecloud_aws::xml::xml_escape;
 
 /// Actions that mutate SNS state.
 pub(crate) fn is_mutating_action(action: &str) -> bool {
@@ -420,7 +421,14 @@ pub(crate) fn build_sns_envelope(
 }
 
 pub(crate) fn format_attr(name: &str, value: &str) -> String {
-    format!("      <entry><key>{name}</key><value>{value}</value></entry>")
+    // Both the attribute name and value can carry user-controlled data
+    // (e.g. Endpoint URLs with query strings, DisplayName, DeliveryPolicy).
+    // Escape both so the emitted XML stays well-formed for client SDK parsers.
+    format!(
+        "      <entry><key>{}</key><value>{}</value></entry>",
+        xml_escape(name),
+        xml_escape(value)
+    )
 }
 
 pub(crate) fn format_sub_member(sub: &SnsSubscription) -> String {
@@ -437,7 +445,11 @@ pub(crate) fn format_sub_member(sub: &SnsSubscription) -> String {
         <Endpoint>{}</Endpoint>
         <Owner>{}</Owner>
       </member>"#,
-        display_arn, sub.topic_arn, sub.protocol, sub.endpoint, sub.owner,
+        xml_escape(display_arn),
+        xml_escape(&sub.topic_arn),
+        xml_escape(&sub.protocol),
+        xml_escape(&sub.endpoint),
+        xml_escape(&sub.owner),
     )
 }
 
@@ -772,7 +784,11 @@ pub(crate) fn matches_filter_policy(
                             if let Some(arr) = vals.as_array() {
                                 if let Some(msg_attr) = message_attributes.get(key) {
                                     let val = msg_attr.string_value.as_deref().unwrap_or("");
-                                    check_filter_values(arr, val)
+                                    // Type-aware, matching the non-$or path: a
+                                    // numeric filter must not match a string
+                                    // attribute (and vice versa).
+                                    let is_numeric_type = msg_attr.data_type == "Number";
+                                    check_filter_values_typed(arr, val, Some(is_numeric_type))
                                 } else {
                                     false
                                 }
@@ -1018,7 +1034,12 @@ pub(crate) fn check_filter_values_typed(
                         }
                         if let Ok(attr_num) = attr_value.parse::<f64>() {
                             if let Some(filter_num) = n.as_f64() {
-                                (attr_num - filter_num).abs() >= f64::EPSILON
+                                // Exclude when the value equals the filter number
+                                // using the same limited precision (~1e-5) that
+                                // every other numeric comparison uses, so a
+                                // single-value anything-but is consistent with the
+                                // array form, `=`, and numeric ranges.
+                                !numbers_equal(attr_num, filter_num)
                             } else {
                                 true
                             }
@@ -1519,5 +1540,117 @@ mod confirmation_envelope_tests {
             &policy,
             r#"{"category":"normal","price":10}"#
         ));
+    }
+}
+
+#[cfg(test)]
+mod xml_escape_render_tests {
+    use super::{format_attr, format_sub_member};
+    use crate::state::SnsSubscription;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn format_attr_escapes_endpoint_query_string() {
+        // The most common reachable trigger: an HTTPS endpoint with a query
+        // string. The raw `&` must become `&amp;` or the client XML parser
+        // hard-errors on ListSubscriptions/GetSubscriptionAttributes.
+        let out = format_attr("Endpoint", "https://example.com/hook?token=a&env=prod");
+        assert!(out.contains("token=a&amp;env=prod"), "got: {out}");
+        assert!(!out.contains("a&env"), "raw ampersand leaked: {out}");
+    }
+
+    #[test]
+    fn format_attr_escapes_display_name_and_angle_brackets() {
+        let out = format_attr("DisplayName", "Acme & Co <inc>");
+        assert!(out.contains("Acme &amp; Co &lt;inc&gt;"), "got: {out}");
+    }
+
+    #[test]
+    fn format_sub_member_escapes_endpoint() {
+        let sub = SnsSubscription {
+            subscription_arn: "arn:aws:sns:us-east-1:123456789012:t:sub".to_string(),
+            topic_arn: "arn:aws:sns:us-east-1:123456789012:t".to_string(),
+            protocol: "https".to_string(),
+            endpoint: "https://example.com/hook?a=1&b=2".to_string(),
+            owner: "123456789012".to_string(),
+            attributes: BTreeMap::new(),
+            confirmed: true,
+            confirmation_token: None,
+        };
+        let out = format_sub_member(&sub);
+        assert!(out.contains("<Endpoint>https://example.com/hook?a=1&amp;b=2</Endpoint>"));
+        assert!(!out.contains("a=1&b=2"), "raw ampersand leaked: {out}");
+    }
+}
+
+#[cfg(test)]
+mod filter_consistency_tests {
+    use super::{check_filter_values_typed, matches_filter_policy};
+    use crate::state::{MessageAttribute, SnsSubscription};
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn num_attr(v: &str) -> MessageAttribute {
+        MessageAttribute {
+            data_type: "Number".to_string(),
+            string_value: Some(v.to_string()),
+            binary_value: None,
+        }
+    }
+
+    fn str_attr(v: &str) -> MessageAttribute {
+        MessageAttribute {
+            data_type: "String".to_string(),
+            string_value: Some(v.to_string()),
+            binary_value: None,
+        }
+    }
+
+    fn sub_with_filter(policy: serde_json::Value) -> SnsSubscription {
+        let mut attributes = BTreeMap::new();
+        attributes.insert("FilterPolicy".to_string(), policy.to_string());
+        SnsSubscription {
+            subscription_arn: "arn:aws:sns:us-east-1:123456789012:t:sub".to_string(),
+            topic_arn: "arn:aws:sns:us-east-1:123456789012:t".to_string(),
+            protocol: "sqs".to_string(),
+            endpoint: "arn:aws:sqs:us-east-1:123456789012:q".to_string(),
+            owner: "123456789012".to_string(),
+            attributes,
+            confirmed: true,
+            confirmation_token: None,
+        }
+    }
+
+    #[test]
+    fn single_value_anything_but_uses_limited_precision() {
+        // A value within ~1e-5 of the filter number is "equal" and must be
+        // excluded, consistent with `=`, ranges, and array anything-but.
+        let filter = vec![json!({"anything-but": 100})];
+        // 100 is equal -> excluded -> no match.
+        assert!(!check_filter_values_typed(&filter, "100", Some(true)));
+        // 100.0000001 is within tolerance -> still treated as equal -> excluded.
+        assert!(!check_filter_values_typed(
+            &filter,
+            "100.0000001",
+            Some(true)
+        ));
+        // 101 differs -> not excluded -> matches.
+        assert!(check_filter_values_typed(&filter, "101", Some(true)));
+    }
+
+    #[test]
+    fn or_branch_is_type_aware() {
+        // A numeric filter inside $or must NOT match a string attribute.
+        let policy = json!({ "$or": [ { "price": [100] } ] });
+        let sub = sub_with_filter(policy);
+
+        let mut numeric_attrs = BTreeMap::new();
+        numeric_attrs.insert("price".to_string(), num_attr("100"));
+        assert!(matches_filter_policy(&sub, &numeric_attrs, ""));
+
+        // Same textual value but the attribute is a String -> no match.
+        let mut string_attrs = BTreeMap::new();
+        string_attrs.insert("price".to_string(), str_attr("100"));
+        assert!(!matches_filter_policy(&sub, &string_attrs, ""));
     }
 }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -981,7 +981,13 @@ impl SnsService {
 
         // HTTP/HTTPS subscriptions start as pending (require confirmation)
         let confirmed = protocol != "http" && protocol != "https";
-        let response_arn = if confirmed {
+        // AWS returns the literal "pending confirmation" for an unconfirmed
+        // subscription unless the caller sets ReturnSubscriptionArn=true, in
+        // which case the real ARN is returned even while pending.
+        let return_arn = param(req, "ReturnSubscriptionArn")
+            .map(|v| v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let response_arn = if confirmed || return_arn {
             sub_arn.clone()
         } else {
             "pending confirmation".to_string()
@@ -1504,7 +1510,13 @@ impl SnsService {
         let members: String = topic
             .tags
             .iter()
-            .map(|(k, v)| format!("      <member><Key>{k}</Key><Value>{v}</Value></member>"))
+            .map(|(k, v)| {
+                format!(
+                    "      <member><Key>{}</Key><Value>{}</Value></member>",
+                    xml_escape(k),
+                    xml_escape(v)
+                )
+            })
             .collect::<Vec<_>>()
             .join("\n");
 

--- a/crates/fakecloud-sns/src/service_sms.rs
+++ b/crates/fakecloud-sns/src/service_sms.rs
@@ -134,7 +134,7 @@ impl SnsService {
         let members: String = state
             .opted_out_numbers
             .iter()
-            .map(|n| format!("      <member>{n}</member>"))
+            .map(|n| format!("      <member>{}</member>", xml_escape(n)))
             .collect::<Vec<_>>()
             .join("\n");
 


### PR DESCRIPTION
## Summary

Pre-Show-HN hardening of SNS (next-tier bug-hunt: SQS/SNS/IAM). Panics, persistence, and cross-service delivery came up clean; this is the real defect found.

**HIGH — user data not XML-escaped in read responses → malformed XML → client SDK parser hard-errors.** Response builders interpolated user strings with `format!` and no escaping (`xml_escape` was imported and used elsewhere but these hot paths were missed). The common trigger: a Subscribe with an HTTPS endpoint containing a query string (`https://ex.com/hook?token=a&env=prod`) made every subsequent `ListSubscriptionsByTopic`/`GetSubscriptionAttributes` emit a raw `&`, breaking the client XML parse. Also DisplayName `Acme & Co`, tag values `a<b`. Fixed by wrapping user values in `xml_escape` at each render site (`format_attr`, `format_sub_member`, `list_tags_for_resource`, `list_phone_numbers_opted_out`) after a crate-wide audit confirmed all other `format!` XML sites interpolate only server-generated (safe) data.

**Filter-policy correctness (confirmed from the suspicious tail):**
- Single-value numeric `anything-but` used `f64::EPSILON` while `=`/ranges/array-form use `numbers_equal` (1e-5) — now consistent.
- `$or` branch leaves matched untyped, letting a numeric filter match a string attribute — now type-aware, matching the non-`$or` path.
- (Verified false-positive, left as-is: the `1E9` match-value → 500 vs operand → 400 split mirrors real AWS.)

Also implemented `ReturnSubscriptionArn=true` (AWS-faithful) so an unconfirmed HTTPS subscription returns its real ARN.

## Test plan
- E2E `sns_xml_escaping_round_trips_special_chars`: HTTPS endpoint with `?token=a&env=prod`, DisplayName + tag with `&`/`<`/`>` — GetTopicAttributes/ListTagsForResource/ListSubscriptionsByTopic/GetSubscriptionAttributes all parse and return values intact.
- Unit: xml_escape render sites + filter consistency.
- `cargo clippy -p fakecloud-sns --all-targets` clean; `cargo test -p fakecloud-sns` 223 pass; fmt clean; e2e compiles.

## Surface
Behavioral bug-fix — no new ops/SDK/counts. Non-code surface unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes user data in SNS XML read responses to prevent malformed XML that breaks client SDK parsing. Also makes filter-policy matching type-aware and consistent, and adds `ReturnSubscriptionArn=true` support.

- **Bug Fixes**
  - XML-escape user-controlled fields in read responses: attributes, subscription members, tag keys/values, and opted-out phone numbers.
  - Fix common breakage from endpoints like `https://ex.com/hook?token=a&env=prod` and DisplayName/tag values with `&`/`<`/`>`.
  - Make `$or` filter-policy matching type-aware so numeric filters do not match string attributes.
  - Use consistent numeric precision for single-value `anything-but` to match `=`/ranges/array forms.

- **New Features**
  - Support `ReturnSubscriptionArn=true` so pending HTTPS subscriptions return their real ARN.

<sup>Written for commit 84a3d4c5817290b39f52d00612de39946ea16270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

