### PR TITLE
fix(sqs): validate VisibilityTimeout range (no receive-time panic); AWS-shaped FIFO SequenceNumber; stale-handle + DLQ fixes

### DIFF
--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -1971,3 +1971,68 @@ async fn approximate_first_receive_timestamp_is_constant() {
         "ApproximateFirstReceiveTimestamp must stay pinned to the first receipt"
     );
 }
+
+/// A queue-level VisibilityTimeout outside 0..=43200 must be rejected with
+/// InvalidAttributeValue (not a panic / dropped connection), and a subsequent
+/// ReceiveMessage on the queue must still succeed. Regression test for a DoS
+/// where an unchecked huge value overflowed `now + Duration::seconds(v)` on the
+/// receive path and panicked the worker thread.
+#[tokio::test]
+async fn sqs_set_visibility_timeout_out_of_range_rejected() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+
+    let queue_url = client
+        .create_queue()
+        .queue_name("vt-guard-queue")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+
+    // A value that used to overflow chrono at receive time.
+    let err = client
+        .set_queue_attributes()
+        .queue_url(&queue_url)
+        .attributes(QueueAttributeName::VisibilityTimeout, "9000000000000")
+        .send()
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err.into_service_error().meta().code(),
+        Some("InvalidAttributeValue")
+    );
+
+    // A merely out-of-range value (one past the 12 h max) is rejected too.
+    let err = client
+        .set_queue_attributes()
+        .queue_url(&queue_url)
+        .attributes(QueueAttributeName::VisibilityTimeout, "43201")
+        .send()
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err.into_service_error().meta().code(),
+        Some("InvalidAttributeValue")
+    );
+
+    // The queue kept its valid default, so send + receive still work — the
+    // out-of-range value was never stored, so nothing panics.
+    client
+        .send_message()
+        .queue_url(&queue_url)
+        .message_body("still-alive")
+        .send()
+        .await
+        .unwrap();
+    let recv = client
+        .receive_message()
+        .queue_url(&queue_url)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(recv.messages().len(), 1);
+    assert_eq!(recv.messages()[0].body().unwrap(), "still-alive");
+}

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -156,10 +156,17 @@ impl SqsDelivery for SqsDeliveryImpl {
         // and replay detection. The sync SendMessage path already does
         // this; cross-service deliveries used to leave it as None,
         // which broke FIFO consumers downstream.
+        // Render the SequenceNumber with the same ~20-digit AWS shape the
+        // direct SendMessage / SendMessageBatch paths use
+        // (`format_sequence_number`), not a bare counter. Both paths share
+        // `queue.next_sequence_number`, so emitting `seq.to_string()` here
+        // produced tiny values like "1" that sort BELOW the base-offset
+        // values a direct send returns for a later message — breaking the
+        // numeric ordering FIFO consumers rely on.
         let sequence_number = if queue.is_fifo {
             let seq = queue.next_sequence_number;
             queue.next_sequence_number = queue.next_sequence_number.saturating_add(1);
-            Some(seq.to_string())
+            Some(crate::service::format_sequence_number(seq))
         } else {
             None
         };
@@ -407,6 +414,15 @@ mod tests {
         let n0: u64 = s0.parse().expect("decimal sequence number");
         let n1: u64 = s1.parse().expect("decimal sequence number");
         assert_eq!(n1, n0 + 1, "sequence_number must be monotonic");
+        // Cross-service delivery must emit the same ~20-digit AWS-shaped
+        // SequenceNumber as the direct SendMessage path, not a bare counter,
+        // so values from both paths sort consistently for FIFO consumers.
+        assert_eq!(s0, crate::service::format_sequence_number(0));
+        assert_eq!(s1, crate::service::format_sequence_number(1));
+        assert!(
+            n0 >= crate::service::SEQUENCE_NUMBER_BASE,
+            "sequence number must use the AWS base offset"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-sqs/src/helpers.rs
+++ b/crates/fakecloud-sqs/src/helpers.rs
@@ -26,10 +26,10 @@ pub(crate) fn looks_like_fakecloud_envelope(body: &str) -> bool {
     }
 }
 
-/// Validate DelaySeconds (0–900) and MaximumMessageSize (1024–1 MiB) if
-/// present in the caller-supplied queue attributes. Both match AWS's
-/// documented ranges; we return the same error code/message the real
-/// service does.
+/// Validate DelaySeconds (0–900), VisibilityTimeout (0–43200), and
+/// MaximumMessageSize (1024–1 MiB) if present in the caller-supplied queue
+/// attributes. All match AWS's documented ranges; we return the same error
+/// code/message the real service does.
 pub(crate) fn validate_create_queue_attributes(
     attrs: &BTreeMap<String, String>,
 ) -> Result<(), AwsServiceError> {
@@ -46,6 +46,13 @@ pub(crate) fn validate_create_queue_attributes(
         }
     }
 
+    // VisibilityTimeout must be an integer in 0..=43200 (12 h). Without this
+    // guard a huge value is stored on the queue and later blows up the
+    // receive path: `now + Duration::seconds(v)` overflows and PANICS the
+    // worker thread (DoS), and values in 43201..8e12 are silently accepted.
+    // AWS returns InvalidAttributeValue for an out-of-range queue attribute.
+    validate_visibility_timeout_attr(attrs.get("VisibilityTimeout").map(String::as_str))?;
+
     if let Some(mms) = attrs.get("MaximumMessageSize") {
         if let Ok(size) = mms.parse::<u64>() {
             if !(1024..=1_048_576).contains(&size) {
@@ -58,6 +65,26 @@ pub(crate) fn validate_create_queue_attributes(
         }
     }
 
+    Ok(())
+}
+
+/// Validate the queue-level `VisibilityTimeout` attribute: it must be an
+/// integer in `0..=43200` seconds (12 h). Shared by CreateQueue and
+/// SetQueueAttributes so both paths reject the same out-of-range values AWS
+/// does with `InvalidAttributeValue`. `None` (attribute not supplied) is OK.
+pub(crate) fn validate_visibility_timeout_attr(value: Option<&str>) -> Result<(), AwsServiceError> {
+    if let Some(vt) = value {
+        match vt.parse::<i64>() {
+            Ok(v) if (0..=43200).contains(&v) => {}
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidAttributeValue",
+                    "Invalid value for the parameter VisibilityTimeout.".to_string(),
+                ));
+            }
+        }
+    }
     Ok(())
 }
 
@@ -181,8 +208,11 @@ pub(crate) fn batch_failure(id: &str, code: &str, message: impl Into<String>) ->
 
 /// Process a single SendMessageBatch entry: validate per-entry constraints,
 /// enqueue the message, and return either a successful or failed response
-/// fragment. Returns `Err` only for errors that AWS signals at the
-/// *batch* level (missing MessageGroupId / dedup on FIFO queues).
+/// fragment. Per-entry validation failures (including FIFO MessageGroupId /
+/// dedup requirements) are returned as `Ok(BatchEntryOutcome::Failure(..))`
+/// so one bad entry never aborts the rest of the batch — matching AWS's
+/// partial-success batch semantics. `Err` is reserved for hard failures the
+/// caller must propagate.
 ///
 /// `stored_body_override` lets the caller pre-encrypt the message body
 /// for SSE-KMS queues without losing the plaintext MD5 the response
@@ -248,20 +278,24 @@ pub(crate) fn process_batch_send_entry(
         .map(|s| s.to_string());
 
     if cfg.is_fifo {
+        // Per-entry validation failures on a FIFO queue are reported in the
+        // batch's Failed list (BatchResultErrorEntry), NOT as a request-level
+        // 400 — a single bad entry must not abort the sibling entries that are
+        // valid. Real AWS SendMessageBatch surfaces these per entry.
         if message_group_id.is_none() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
+            return Ok(BatchEntryOutcome::Failure(batch_failure(
+                &id,
                 "MissingParameter",
                 "The request must contain the parameter MessageGroupId.",
-            ));
+            )));
         }
         if message_dedup_id.is_none() && !cfg.content_based_dedup {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
+            return Ok(BatchEntryOutcome::Failure(batch_failure(
+                &id,
                 "InvalidParameterValue",
                 "The queue should either have ContentBasedDeduplication enabled \
                  or MessageDeduplicationId provided explicitly",
-            ));
+            )));
         }
     }
 
@@ -1248,10 +1282,14 @@ pub(crate) fn resolve_queue_url(input: &str, state: &crate::state::SqsState) -> 
     if state.queues.contains_key(input) {
         return Some(input.to_string());
     }
-    // ARN form: extract queue name (last segment after the colon-prefix)
-    if let Some(rest) = input.strip_prefix("arn:aws:sqs:") {
-        // rest = "REGION:ACCOUNT:queue-name"
-        if let Some(name) = rest.rsplit(':').next() {
+    // ARN form: extract queue name (last colon-separated segment). Accept any
+    // partition (`aws`, `aws-cn`, `aws-us-gov`, ...) rather than hardcoding
+    // `aws`, so cn/gov-cloud ARNs — which is what the queue's own ARN uses in
+    // those regions — resolve too. Shape: arn:PARTITION:sqs:REGION:ACCOUNT:name.
+    {
+        let parts: Vec<&str> = input.split(':').collect();
+        if parts.len() == 6 && parts[0] == "arn" && parts[2] == "sqs" {
+            let name = parts[5];
             if !name.is_empty() {
                 if let Some(url) = state.name_to_url.get(name) {
                     return Some(url.clone());

--- a/crates/fakecloud-sqs/src/service/messages.rs
+++ b/crates/fakecloud-sqs/src/service/messages.rs
@@ -572,14 +572,26 @@ impl SqsService {
             }
             true
         });
+        // Once a message's visibility window lapses and it becomes visible
+        // again, its prior receipt handle is invalidated — real SQS at-least-
+        // once semantics: a stale handle must not act on a message that may
+        // now be (re)delivered to another consumer. Without this, a late
+        // DeleteMessage carrying the OLD handle still resolves via
+        // `receipt_handle_map` and deletes the redelivered copy. Pruning the
+        // map entry here also bounds its growth under redelivery churn (each
+        // redelivery would otherwise append another handle that never leaves).
         // For FIFO queues, push returned messages to the FRONT to maintain order
         if is_fifo {
             for mut m in returned.into_iter().rev() {
+                queue.receipt_handle_map.remove(&m.message_id);
+                m.receipt_handle = None;
                 m.visible_at = None;
                 queue.messages.push_front(m);
             }
         } else {
             for mut m in returned {
+                queue.receipt_handle_map.remove(&m.message_id);
+                m.receipt_handle = None;
                 m.visible_at = None;
                 queue.messages.push_back(m);
             }
@@ -752,6 +764,14 @@ impl SqsService {
             msg.receipt_handle = None;
             msg.visible_at = None;
             if let Some(dlq) = state.queues.values_mut().find(|q| q.arn == dlq_arn) {
+                // A message that lands in the DLQ starts a fresh receive
+                // history there: AWS resets ApproximateReceiveCount when a
+                // message is moved to its dead-letter queue. Carrying the
+                // source-queue count over would immediately re-redrive the
+                // message on its first receive from a DLQ that has its own
+                // redrive policy (count already past maxReceiveCount).
+                msg.receive_count = 0;
+                msg.first_received_at = None;
                 dlq.messages.push_back(msg);
             } else {
                 tracing::warn!(

--- a/crates/fakecloud-sqs/src/service/queues.rs
+++ b/crates/fakecloud-sqs/src/service/queues.rs
@@ -182,8 +182,11 @@ impl SqsService {
 
         let queue = SqsQueue {
             arn: format!(
-                "arn:aws:sqs:{}:{}:{}",
-                state.region, state.account_id, queue_name
+                "arn:{}:sqs:{}:{}:{}",
+                fakecloud_aws::arn::partition_for(&state.region),
+                state.region,
+                state.account_id,
+                queue_name
             ),
             queue_name: queue_name.clone(),
             queue_url: queue_url.clone(),
@@ -524,6 +527,18 @@ impl SqsService {
                     }
                 }
             }
+        }
+
+        // Validate VisibilityTimeout (0–43200 inclusive) before applying.
+        // An unchecked value is stored and later overflows the receive-path
+        // arithmetic (`now + Duration::seconds(v)`), panicking the worker
+        // thread — a DoS. AWS returns InvalidAttributeValue for the queue
+        // attribute (as opposed to InvalidParameterValue for the per-request
+        // VisibilityTimeout on ReceiveMessage/ChangeMessageVisibility).
+        if let Some(attrs) = body["Attributes"].as_object() {
+            validate_visibility_timeout_attr(
+                attrs.get("VisibilityTimeout").and_then(|v| v.as_str()),
+            )?;
         }
 
         if let Some(attrs) = body["Attributes"].as_object() {

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -2982,3 +2982,243 @@ fn list_queues_token_survives_interleaved_delete() {
     assert!(urls2[0].ends_with("/q2"), "resumed at q2, got {}", urls2[0]);
     assert!(urls2[1].ends_with("/q3"));
 }
+
+// ── VisibilityTimeout queue-attribute range validation (DoS guard) ──
+
+/// CreateQueue must reject an out-of-range VisibilityTimeout with
+/// InvalidAttributeValue rather than storing a value that later overflows the
+/// receive-path arithmetic and panics the worker thread.
+#[test]
+fn create_queue_rejects_out_of_range_visibility_timeout() {
+    let svc = make_service();
+    let req = make_request(
+        "CreateQueue",
+        json!({
+            "QueueName": "vt-create",
+            "Attributes": { "VisibilityTimeout": "9000000000000" }
+        }),
+    );
+    let err = expect_err(svc.create_queue(&req));
+    assert_eq!(err.code(), "InvalidAttributeValue");
+
+    // 43201 (one past the 12 h max) is rejected too.
+    let req = make_request(
+        "CreateQueue",
+        json!({ "QueueName": "vt-create2", "Attributes": { "VisibilityTimeout": "43201" } }),
+    );
+    assert_eq!(
+        expect_err(svc.create_queue(&req)).code(),
+        "InvalidAttributeValue"
+    );
+}
+
+/// SetQueueAttributes must reject an out-of-range VisibilityTimeout with
+/// InvalidAttributeValue, and a subsequent ReceiveMessage must still succeed
+/// (i.e. the bad value was never stored, so nothing panics).
+#[tokio::test]
+async fn set_queue_attributes_rejects_out_of_range_visibility_timeout_no_panic() {
+    let svc = make_service();
+    let url = create_queue(&svc, "vt-set");
+
+    // The value that overflowed the receive-path arithmetic before this guard.
+    let req = make_request(
+        "SetQueueAttributes",
+        json!({ "QueueUrl": url, "Attributes": { "VisibilityTimeout": "9000000000000" } }),
+    );
+    assert_eq!(
+        expect_err(svc.set_queue_attributes(&req)).code(),
+        "InvalidAttributeValue"
+    );
+
+    // 43201 is rejected; the 43200 boundary is accepted.
+    let req = make_request(
+        "SetQueueAttributes",
+        json!({ "QueueUrl": url, "Attributes": { "VisibilityTimeout": "43201" } }),
+    );
+    assert_eq!(
+        expect_err(svc.set_queue_attributes(&req)).code(),
+        "InvalidAttributeValue"
+    );
+    let req = make_request(
+        "SetQueueAttributes",
+        json!({ "QueueUrl": url, "Attributes": { "VisibilityTimeout": "43200" } }),
+    );
+    svc.set_queue_attributes(&req).expect("43200 is in range");
+
+    // ReceiveMessage still works — no panic from a stored overflow value.
+    send_msg(&svc, &url, "hi");
+    let resp = svc
+        .receive_message(&make_request("ReceiveMessage", json!({ "QueueUrl": url })))
+        .await
+        .expect("receive must not panic");
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Messages"].as_array().unwrap().len(), 1);
+}
+
+/// After a message's visibility window lapses and it is redelivered under a
+/// fresh receipt handle, a DeleteMessage carrying the STALE handle must fail
+/// instead of deleting the redelivered copy (AWS at-least-once semantics).
+#[tokio::test]
+async fn stale_receipt_handle_cannot_delete_redelivered_message() {
+    let svc = make_service();
+    let url = create_queue(&svc, "stale-rh");
+    send_msg(&svc, &url, "m");
+
+    // First receive with VisibilityTimeout=0 -> immediately eligible for
+    // redelivery; capture the first handle (rh1).
+    let first = svc
+        .receive_message(&make_request(
+            "ReceiveMessage",
+            json!({ "QueueUrl": url, "VisibilityTimeout": 0 }),
+        ))
+        .await
+        .unwrap();
+    let b: Value = serde_json::from_slice(first.body.expect_bytes()).unwrap();
+    let rh1 = b["Messages"][0]["ReceiptHandle"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Second receive returns the now-visible message under a NEW handle (rh2);
+    // rh1 must be invalidated at this point.
+    let second = svc
+        .receive_message(&make_request(
+            "ReceiveMessage",
+            json!({ "QueueUrl": url, "VisibilityTimeout": 30 }),
+        ))
+        .await
+        .unwrap();
+    let b2: Value = serde_json::from_slice(second.body.expect_bytes()).unwrap();
+    let rh2 = b2["Messages"][0]["ReceiptHandle"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_ne!(rh1, rh2, "redelivery must issue a fresh receipt handle");
+
+    // Deleting with the stale handle must fail, not remove the live message.
+    let stale = svc.delete_message(&make_request(
+        "DeleteMessage",
+        json!({ "QueueUrl": url, "ReceiptHandle": rh1 }),
+    ));
+    assert_eq!(expect_err(stale).code(), "ReceiptHandleIsInvalid");
+
+    // The current handle still deletes the message.
+    svc.delete_message(&make_request(
+        "DeleteMessage",
+        json!({ "QueueUrl": url, "ReceiptHandle": rh2 }),
+    ))
+    .expect("current handle deletes");
+}
+
+/// A SendMessageBatch to a FIFO queue where one entry omits MessageGroupId
+/// must report that entry as a per-entry BatchResultErrorEntry (partial
+/// success), not abort the whole batch with a request-level 400.
+#[test]
+fn send_message_batch_fifo_missing_group_id_is_per_entry_failure() {
+    let svc = make_service();
+    let url = create_queue(&svc, "batch.fifo");
+
+    let req = make_request(
+        "SendMessageBatch",
+        json!({
+            "QueueUrl": url,
+            "Entries": [
+                { "Id": "a", "MessageBody": "x", "MessageGroupId": "g", "MessageDeduplicationId": "d1" },
+                { "Id": "b", "MessageBody": "y" }
+            ]
+        }),
+    );
+    let resp = svc.send_message_batch(&req).expect("batch must not 400");
+    let body = body_json(resp);
+    let successful = body["Successful"].as_array().unwrap();
+    let failed = body["Failed"].as_array().unwrap();
+    assert_eq!(successful.len(), 1);
+    assert_eq!(successful[0]["Id"], "a");
+    assert_eq!(failed.len(), 1);
+    assert_eq!(failed[0]["Id"], "b");
+    assert_eq!(failed[0]["Code"], "MissingParameter");
+    assert_eq!(failed[0]["SenderFault"], true);
+}
+
+/// A message redriven to a DLQ starts a fresh receive history: its
+/// ApproximateReceiveCount resets so a DLQ with its own redrive policy does
+/// not immediately re-redrive the message on first receive.
+#[tokio::test]
+async fn redriven_message_resets_receive_count_in_dlq() {
+    let svc = make_service();
+    let dlq_url = create_queue(&svc, "reset-dlq");
+    let src_url = create_queue(&svc, "reset-src");
+    let dlq_arn = "arn:aws:sqs:us-east-1:123456789012:reset-dlq";
+    let redrive = json!({ "deadLetterTargetArn": dlq_arn, "maxReceiveCount": "1" }).to_string();
+    svc.set_queue_attributes(&make_request(
+        "SetQueueAttributes",
+        json!({ "QueueUrl": src_url, "Attributes": { "RedrivePolicy": redrive } }),
+    ))
+    .unwrap();
+
+    send_msg(&svc, &src_url, "over-limit");
+    // First receive (count 1 == max) delivers; second crosses max and redrives.
+    // Use VisibilityTimeout=0 so the message is immediately eligible again.
+    let req1 = make_request(
+        "ReceiveMessage",
+        json!({ "QueueUrl": src_url, "VisibilityTimeout": 0 }),
+    );
+    let first = body_json(svc.receive_message(&req1).await.unwrap());
+    assert_eq!(first["Messages"].as_array().unwrap().len(), 1);
+    let req2 = make_request(
+        "ReceiveMessage",
+        json!({ "QueueUrl": src_url, "VisibilityTimeout": 0 }),
+    );
+    let second = body_json(svc.receive_message(&req2).await.unwrap());
+    assert_eq!(
+        second["Messages"].as_array().map(|m| m.len()).unwrap_or(0),
+        0
+    );
+
+    // First receive from the DLQ: ApproximateReceiveCount must be "1" (fresh),
+    // not carried over from the source queue.
+    let resp = svc
+        .receive_message(&make_request(
+            "ReceiveMessage",
+            json!({ "QueueUrl": dlq_url, "AttributeNames": ["ApproximateReceiveCount"] }),
+        ))
+        .await
+        .unwrap();
+    let body = body_json(resp);
+    let msgs = body["Messages"].as_array().unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0]["Attributes"]["ApproximateReceiveCount"], "1");
+}
+
+/// In a non-`aws` partition (cn / gov-cloud) the queue ARN must carry the
+/// region's partition, and that partition-correct ARN must resolve back to the
+/// queue on send/receive.
+#[test]
+fn queue_arn_uses_region_partition_and_resolves() {
+    let state: SharedSqsState = Arc::new(RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new(
+            "123456789012",
+            "cn-north-1",
+            "http://localhost:4566",
+        ),
+    ));
+    let svc = SqsService::new(state);
+    let url = create_queue(&svc, "cn-queue");
+    let arn = "arn:aws-cn:sqs:cn-north-1:123456789012:cn-queue";
+
+    // GetQueueAttributes reports the aws-cn ARN.
+    let resp = svc
+        .get_queue_attributes(&make_request(
+            "GetQueueAttributes",
+            json!({ "QueueUrl": url, "AttributeNames": ["QueueArn"] }),
+        ))
+        .unwrap();
+    assert_eq!(body_json(resp)["Attributes"]["QueueArn"], arn);
+
+    // Sending via that partition-correct ARN resolves the queue.
+    let id = send_msg(&svc, arn, "ni-hao");
+    assert!(!id.is_empty());
+    let msgs = receive_msgs(&svc, arn, 1);
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0]["Body"], "ni-hao");
+}


### PR DESCRIPTION
## Summary

Pre-Show-HN hardening of SQS (next-tier bug-hunt). MD5, DLQ-destruction (#1675), persistence, and dual query/JSON protocol came up clean; these are the real defects found.

**HIGH — unvalidated queue-level VisibilityTimeout → chrono overflow panic (DoS).** `create_queue`/`set_queue_attributes` didn't range-check VisibilityTimeout; at ReceiveMessage, `now + Duration::seconds(v)` panics (500/dropped connection) for large `v`. The request-level VT path was already guarded — the queue-attribute default path wasn't. Added `validate_visibility_timeout_attr` enforcing integer `0..=43200` → `InvalidAttributeValue` in both paths (also fixes the silent acceptance of 43201..8e12). Reachable via Terraform `visibility_timeout_seconds`.

**MEDIUM — FIFO SequenceNumber format diverged** between cross-service delivery (bare `"1"`) and SendMessage (~20-digit). `delivery.rs` now uses `format_sequence_number`, so SNS-FIFO→SQS-FIFO and direct sends sort consistently.

**Confirmed + fixed from the suspicious tail:**
- **Stale receipt handle** deleted a redelivered message: when an expired inflight message becomes visible again its prior handle is now pruned; a late DeleteMessage with the old handle returns `ReceiptHandleIsInvalid` (was silently deleting the redelivered copy — an at-least-once/data-loss violation). Also bounds `receipt_handle_map` growth.
- **SendMessageBatch FIFO** missing MessageGroupId aborted the whole batch → now a per-entry `BatchResultErrorEntry` (valid siblings succeed), matching AWS.
- **Queue ARN** hardcoded `aws` partition → derived from region; `resolve_queue_url` accepts cn/gov-cloud partition prefixes.
- **DLQ redrive** now resets receive_count on arrival so a DLQ with its own redrive policy doesn't immediately re-redrive (scoped to the resolvable-DLQ branch; the unresolvable-DLQ bounce-back is unchanged).

## Test plan
- E2E `sqs_set_visibility_timeout_out_of_range_rejected`: 9e12 and 43201 both → InvalidAttributeValue, then ReceiveMessage succeeds (no panic).
- Unit: VT validation (create+set, 43200 boundary), stale-handle invalidation, per-entry FIFO batch failure, DLQ receive-count reset, region-partition ARN, FIFO SequenceNumber shape from delivery.
- `cargo clippy -p fakecloud-sqs --all-targets` clean; `cargo test -p fakecloud-sqs` 183 pass; fmt clean; e2e compiles.

## Surface
Behavioral bug-fix — no new ops/SDK/counts. Non-code surface unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a receive-time panic by validating queue `VisibilityTimeout`, and aligns FIFO `SequenceNumber` formatting so deliveries order correctly. Also tightens SQS correctness around handles, batches, ARNs, and DLQs.

- **Bug Fixes**
  - Prunes stale receipt handles on redelivery; deletes with old handles return `ReceiptHandleIsInvalid`.
  - `SendMessageBatch` on FIFO: missing `MessageGroupId` (or dedup without content-based dedup) is a per-entry failure; valid siblings succeed.
  - Queue ARN uses the region’s partition; ARN resolution accepts `aws`, `aws-cn`, and `aws-us-gov`.
  - DLQ redrive resets `ApproximateReceiveCount` on arrival to avoid immediate re-redrive.

<sup>Written for commit 0a370bd43c604cb9088ab06440533611a600f6d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

