### PR TITLE
fix(iam): validate policy existence on AttachGroupPolicy; DeleteConflict on attached policy; normalize single-object Statement; region-correct ARNs; paginate instance-profile lists

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -3883,3 +3883,133 @@ async fn iam_get_user_no_name_is_deterministic() {
     );
     assert_eq!(ua.user_name(), ub.user_name());
 }
+
+// ---- IAM hardening: policy-existence on AttachGroupPolicy, DeleteConflict on
+//      attached policy, and region-correct instance-profile ARNs ----
+
+#[tokio::test]
+async fn iam_attach_group_policy_nonexistent_policy_fails() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_group()
+        .group_name("hardening-grp")
+        .send()
+        .await
+        .unwrap();
+
+    // Attaching a customer-managed policy ARN that does not exist must fail
+    // with NoSuchEntity, matching AttachRolePolicy/AttachUserPolicy.
+    let err = client
+        .attach_group_policy()
+        .group_name("hardening-grp")
+        .policy_arn("arn:aws:iam::123456789012:policy/does-not-exist")
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("NoSuchEntity"),
+        "expected NoSuchEntity, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn iam_delete_policy_while_attached_fails() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#;
+    let policy_arn = client
+        .create_policy()
+        .policy_name("attached-delete-pol")
+        .policy_document(policy_doc)
+        .send()
+        .await
+        .unwrap()
+        .policy()
+        .unwrap()
+        .arn()
+        .unwrap()
+        .to_string();
+
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    client
+        .create_role()
+        .role_name("delete-guard-role")
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap();
+    client
+        .attach_role_policy()
+        .role_name("delete-guard-role")
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap();
+
+    // DeletePolicy while attached -> DeleteConflict.
+    let err = client
+        .delete_policy()
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("DeleteConflict"),
+        "expected DeleteConflict, got: {msg}"
+    );
+
+    // After detaching, deletion succeeds.
+    client
+        .detach_role_policy()
+        .role_name("delete-guard-role")
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap();
+    client
+        .delete_policy()
+        .policy_arn(&policy_arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn iam_create_instance_profile_govcloud_partition() {
+    use aws_credential_types::Credentials;
+
+    let server = TestServer::start().await;
+
+    // Build an IAM client signing for a GovCloud region so the server derives
+    // the aws-us-gov partition from the SigV4 credential scope.
+    let gov_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-gov-west-1"))
+        .credentials_provider(Credentials::new(
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            None,
+            None,
+            "test",
+        ))
+        .load()
+        .await;
+    let client = aws_sdk_iam::Client::new(&gov_config);
+
+    let resp = client
+        .create_instance_profile()
+        .instance_profile_name("gov-profile")
+        .send()
+        .await
+        .unwrap();
+    let arn = resp.instance_profile().unwrap().arn();
+    assert!(
+        arn.starts_with("arn:aws-us-gov:iam::"),
+        "expected aws-us-gov partition ARN, got: {arn}"
+    );
+}

--- a/crates/fakecloud-iam/src/iam_service/account.rs
+++ b/crates/fakecloud-iam/src/iam_service/account.rs
@@ -7,9 +7,9 @@ use fakecloud_core::validation::*;
 use crate::state::{AccountPasswordPolicy, IamState, VirtualMfaDevice};
 
 use super::{
-    attached_policy_name, empty_response, parse_tags, required_param_with_code,
-    resolve_calling_user, tags_xml, url_encode, validate_optional_string_length_with_code,
-    validate_string_length_with_code, IamService,
+    attached_policy_name, empty_response, is_valid_iam_path, parse_tags, partition_for_region,
+    required_param_with_code, resolve_calling_user, tags_xml, url_encode,
+    validate_optional_string_length_with_code, validate_string_length_with_code, IamService,
 };
 use fakecloud_core::query::required_param;
 
@@ -878,11 +878,13 @@ impl IamService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        // Include path in serial number
+        // Include path in serial number. Derive the ARN partition from the
+        // request region so gov/cn/iso callers get a partition-correct ARN.
+        let partition = partition_for_region(&req.region);
         let path_part = path.trim_start_matches('/');
         let serial_number = format!(
-            "arn:aws:iam::{}:mfa/{}{}",
-            state.account_id, path_part, virtual_mfa_device_name
+            "arn:{}:iam::{}:mfa/{}{}",
+            partition, state.account_id, path_part, virtual_mfa_device_name
         );
 
         if state.virtual_mfa_devices.contains_key(&serial_number) {
@@ -1209,27 +1211,4 @@ impl IamService {
         );
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
-}
-
-fn is_valid_iam_path(path: &str) -> bool {
-    if !path.starts_with('/') || !path.ends_with('/') {
-        return false;
-    }
-    if path.contains("//") {
-        return false;
-    }
-    if path.len() > 512 {
-        return false;
-    }
-    path.chars().all(|c| {
-        c.is_alphanumeric()
-            || c == '/'
-            || c == '-'
-            || c == '_'
-            || c == '.'
-            || c == '+'
-            || c == '='
-            || c == '@'
-            || c == ','
-    })
 }

--- a/crates/fakecloud-iam/src/iam_service/groups.rs
+++ b/crates/fakecloud-iam/src/iam_service/groups.rs
@@ -604,14 +604,28 @@ impl IamService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        let group = state.groups.get_mut(&group_name).ok_or_else(|| {
-            AwsServiceError::aws_error(
+        if !state.groups.contains_key(&group_name) {
+            return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
                 format!("The group with name {group_name} cannot be found."),
-            )
-        })?;
+            ));
+        }
 
+        // Check policy exists (allow AWS managed policies). Mirrors the
+        // existence check in attach_role_policy / attach_user_policy.
+        if !policy_arn.contains(":aws:policy/") && !state.policies.contains_key(&policy_arn) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchEntity",
+                format!("Policy {policy_arn} does not exist or is not attachable."),
+            ));
+        }
+
+        let group = state
+            .groups
+            .get_mut(&group_name)
+            .expect("group presence checked above");
         if !group.attached_policies.contains(&policy_arn) {
             group.attached_policies.push(policy_arn.clone());
             if let Some(p) = state.policies.get_mut(&policy_arn) {

--- a/crates/fakecloud-iam/src/iam_service/helpers.rs
+++ b/crates/fakecloud-iam/src/iam_service/helpers.rs
@@ -1007,6 +1007,111 @@ pub(crate) fn validate_list_pagination(req: &AwsRequest) -> Result<i64, AwsServi
     Ok(max_items_i64.unwrap_or(100))
 }
 
+/// Validate an IAM `Path` value. IAM paths must begin and end with `/`,
+/// contain no empty segments (`//`), stay within 512 chars, and use only the
+/// permitted character set. Equivalent to the Smithy `pathType` pattern
+/// `^/(.*/)?$` plus the per-character constraint. Shared by CreateRole,
+/// CreatePolicy, and CreateVirtualMFADevice so a malformed path is rejected
+/// up front rather than baked into a broken ARN.
+pub(crate) fn is_valid_iam_path(path: &str) -> bool {
+    if !path.starts_with('/') || !path.ends_with('/') {
+        return false;
+    }
+    if path.contains("//") {
+        return false;
+    }
+    if path.len() > 512 {
+        return false;
+    }
+    path.chars().all(|c| {
+        c.is_alphanumeric()
+            || c == '/'
+            || c == '-'
+            || c == '_'
+            || c == '.'
+            || c == '+'
+            || c == '='
+            || c == '@'
+            || c == ','
+    })
+}
+
+/// Validate an IAM `Path` and return the IAM-declared `InvalidInput` error on
+/// failure, using the exact message AWS emits.
+pub(crate) fn validate_iam_path(path: &str) -> Result<(), AwsServiceError> {
+    if !is_valid_iam_path(path) {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidInput",
+            "The specified value for path is invalid. It must begin and end with / and contain only alphanumeric characters and/or / characters.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Range-check an IAM `MaxSessionDuration` value (seconds). AWS enforces the
+/// Smithy `@range(min: 3600, max: 43200)` constraint and surfaces violations
+/// as a `ValidationError` on CreateRole/UpdateRole.
+pub(crate) fn validate_max_session_duration(seconds: i32) -> Result<(), AwsServiceError> {
+    if seconds < 3600 {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationError",
+            format!(
+                "1 validation error detected: Value '{seconds}' at 'maxSessionDuration' failed to satisfy constraint: Member must have value greater than or equal to 3600"
+            ),
+        ));
+    }
+    if seconds > 43200 {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationError",
+            format!(
+                "1 validation error detected: Value '{seconds}' at 'maxSessionDuration' failed to satisfy constraint: Member must have value less than or equal to 43200"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Parse and range-check an optional `MaxSessionDuration` query parameter.
+/// Returns `None` when the parameter is absent (caller keeps the existing or
+/// default value), `Some(seconds)` when present and valid, or a
+/// `ValidationError` when it is not a valid integer or out of range.
+pub(crate) fn parse_max_session_duration(
+    params: &std::collections::HashMap<String, String>,
+) -> Result<Option<i32>, AwsServiceError> {
+    match params.get("MaxSessionDuration") {
+        Some(raw) => {
+            let seconds: i32 = raw.parse().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!(
+                        "1 validation error detected: Value '{raw}' at 'maxSessionDuration' failed to satisfy constraint: Member must be a valid integer"
+                    ),
+                )
+            })?;
+            validate_max_session_duration(seconds)?;
+            Ok(Some(seconds))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Normalize a policy document's `Statement` element into a slice of statement
+/// values. AWS (and boto3/aws-cli) accept `Statement` as either a JSON array or
+/// a single JSON object; validators that only inspect `as_array()` silently skip
+/// the single-object form. Returns an empty vec when `Statement` is absent or is
+/// neither an array nor an object.
+pub(crate) fn statements_as_slice(doc: &serde_json::Value) -> Vec<&serde_json::Value> {
+    match doc.get("Statement") {
+        Some(serde_json::Value::Array(arr)) => arr.iter().collect(),
+        Some(obj @ serde_json::Value::Object(_)) => vec![obj],
+        _ => Vec::new(),
+    }
+}
+
 pub(crate) fn empty_response(action: &str, request_id: &str) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/crates/fakecloud-iam/src/iam_service/instance_profiles.rs
+++ b/crates/fakecloud-iam/src/iam_service/instance_profiles.rs
@@ -7,7 +7,8 @@ use fakecloud_core::validation::*;
 use crate::state::IamInstanceProfile;
 
 use super::{
-    empty_response, generate_id, parse_tag_keys, parse_tags, tags_xml, url_encode, IamService,
+    empty_response, generate_id, paginated_tags_response, parse_tag_keys, parse_tags,
+    partition_for_region, tags_xml, url_encode, IamService,
 };
 use fakecloud_core::query::required_param;
 
@@ -36,10 +37,12 @@ impl IamService {
             ));
         }
 
+        let partition = partition_for_region(&req.region);
         let ip = IamInstanceProfile {
             instance_profile_id: format!("AIPA{}", generate_id()),
             arn: format!(
-                "arn:aws:iam::{}:instance-profile{}{}",
+                "arn:{}:iam::{}:instance-profile{}{}",
+                partition,
                 state.account_id,
                 if path == "/" { "/" } else { &path },
                 name
@@ -114,13 +117,13 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let _ = super::validate_list_pagination(req)?;
+        let max_items = super::validate_list_pagination(req)? as usize;
         let accounts = self.state.read();
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let path_prefix = req.query_params.get("PathPrefix").cloned();
 
-        let profiles: Vec<&IamInstanceProfile> = state
+        let mut profiles: Vec<&IamInstanceProfile> = state
             .instance_profiles
             .values()
             .filter(|ip| {
@@ -130,18 +133,26 @@ impl IamService {
                     .unwrap_or(true)
             })
             .collect();
+        profiles.sort_by(|a, b| a.instance_profile_name.cmp(&b.instance_profile_name));
 
-        let members: String = profiles
+        let (page, is_truncated, next_marker) =
+            paginate_by_name(&profiles, req, |ip| &ip.instance_profile_name, max_items);
+
+        let members: String = page
             .iter()
             .map(|ip| self.instance_profile_member_xml(ip, state))
             .collect::<Vec<_>>()
             .join("\n");
+        let marker_section = match &next_marker {
+            Some(m) => format!("\n    <Marker>{m}</Marker>"),
+            None => String::new(),
+        };
 
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListInstanceProfilesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListInstanceProfilesResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
     <InstanceProfiles>
 {members}
     </InstanceProfiles>
@@ -230,6 +241,7 @@ impl IamService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let role_name = required_param(&req.query_params, "RoleName")?;
+        let max_items = super::validate_list_pagination(req)? as usize;
         let accounts = self.state.read();
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -242,23 +254,31 @@ impl IamService {
             ));
         }
 
-        let profiles: Vec<&IamInstanceProfile> = state
+        let mut profiles: Vec<&IamInstanceProfile> = state
             .instance_profiles
             .values()
             .filter(|ip| ip.roles.contains(&role_name))
             .collect();
+        profiles.sort_by(|a, b| a.instance_profile_name.cmp(&b.instance_profile_name));
 
-        let members: String = profiles
+        let (page, is_truncated, next_marker) =
+            paginate_by_name(&profiles, req, |ip| &ip.instance_profile_name, max_items);
+
+        let members: String = page
             .iter()
             .map(|ip| self.instance_profile_member_xml(ip, state))
             .collect::<Vec<_>>()
             .join("\n");
+        let marker_section = match &next_marker {
+            Some(m) => format!("\n    <Marker>{m}</Marker>"),
+            None => String::new(),
+        };
 
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <ListInstanceProfilesForRoleResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListInstanceProfilesForRoleResult>
-    <IsTruncated>false</IsTruncated>
+    <IsTruncated>{is_truncated}</IsTruncated>{marker_section}
     <InstanceProfiles>
 {members}
     </InstanceProfiles>
@@ -341,22 +361,7 @@ impl IamService {
             )
         })?;
 
-        let members = tags_xml(&ip.tags);
-        let xml = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<ListInstanceProfileTagsResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
-  <ListInstanceProfileTagsResult>
-    <IsTruncated>false</IsTruncated>
-    <Tags>
-{members}
-    </Tags>
-  </ListInstanceProfileTagsResult>
-  <ResponseMetadata>
-    <RequestId>{}</RequestId>
-  </ResponseMetadata>
-</ListInstanceProfileTagsResponse>"#,
-            req.request_id
-        );
+        let xml = paginated_tags_response("ListInstanceProfileTags", &ip.tags, req)?;
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 
@@ -437,4 +442,39 @@ impl IamService {
             .collect::<Vec<_>>()
             .join("\n")
     }
+}
+
+/// Apply the IAM `Marker`/`MaxItems` pagination triad to an already-sorted
+/// slice of items, using each item's name (via `name_of`) as the opaque
+/// cursor. Returns the page, the truncation flag, and the next `Marker`.
+/// Shared by the ListInstanceProfiles family, which previously returned every
+/// item with a hardcoded `IsTruncated=false`.
+fn paginate_by_name<'a, T, F>(
+    items: &[&'a T],
+    req: &AwsRequest,
+    name_of: F,
+    max_items: usize,
+) -> (Vec<&'a T>, bool, Option<String>)
+where
+    F: Fn(&T) -> &str,
+{
+    let marker = req.query_params.get("Marker").cloned();
+    let start = marker
+        .as_ref()
+        .and_then(|m| items.iter().position(|it| name_of(it) == m).map(|p| p + 1))
+        .unwrap_or(0)
+        .min(items.len());
+    let rest = &items[start..];
+    let is_truncated = rest.len() > max_items;
+    let page: Vec<&'a T> = if is_truncated {
+        rest[..max_items].to_vec()
+    } else {
+        rest.to_vec()
+    };
+    let next_marker = if is_truncated {
+        page.last().map(|it| name_of(it).to_string())
+    } else {
+        None
+    };
+    (page, is_truncated, next_marker)
 }

--- a/crates/fakecloud-iam/src/iam_service/policies.rs
+++ b/crates/fakecloud-iam/src/iam_service/policies.rs
@@ -114,7 +114,7 @@ impl IamService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        if state.policies.remove(&policy_arn).is_none() {
+        if !state.policies.contains_key(&policy_arn) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",
@@ -122,16 +122,30 @@ impl IamService {
             ));
         }
 
-        // Remove from any attachments
-        for arns in state.role_policies.values_mut() {
-            arns.retain(|a| a != &policy_arn);
+        // AWS rejects DeletePolicy while the policy is still attached to any
+        // entity; the caller must detach it first. Match the DeleteConflict
+        // error rather than silently stripping attachments.
+        let still_attached = state
+            .role_policies
+            .values()
+            .any(|arns| arns.contains(&policy_arn))
+            || state
+                .user_policies
+                .values()
+                .any(|arns| arns.contains(&policy_arn))
+            || state
+                .groups
+                .values()
+                .any(|g| g.attached_policies.contains(&policy_arn));
+        if still_attached {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::CONFLICT,
+                "DeleteConflict",
+                "Cannot delete a policy attached to entities.".to_string(),
+            ));
         }
-        for arns in state.user_policies.values_mut() {
-            arns.retain(|a| a != &policy_arn);
-        }
-        for group in state.groups.values_mut() {
-            group.attached_policies.retain(|a| a != &policy_arn);
-        }
+
+        state.policies.remove(&policy_arn);
 
         let xml = empty_response("DeletePolicy", &req.request_id);
         Ok(AwsResponse::xml(StatusCode::OK, xml))
@@ -892,6 +906,7 @@ impl CreatePolicyInput {
             .get("Path")
             .cloned()
             .unwrap_or_else(|| "/".to_string());
+        super::validate_iam_path(&path)?;
         let description = params.get("Description").cloned().unwrap_or_default();
         let tags = parse_tags(params);
         validate_tags(&tags, 0)?;

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -285,6 +285,9 @@ impl IamService {
     pub(super) fn update_role(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let role_name = required_param(&req.query_params, "RoleName")?;
         validate_string_length("roleName", &role_name, 1, 64)?;
+        // Range-check MaxSessionDuration before mutating anything so an
+        // out-of-range value is rejected (ValidationError) rather than stored.
+        let new_duration = super::parse_max_session_duration(&req.query_params)?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
@@ -303,11 +306,7 @@ impl IamService {
         if let Some(desc) = req.query_params.get("Description") {
             role.description = Some(desc.clone());
         }
-        if let Some(dur) = req
-            .query_params
-            .get("MaxSessionDuration")
-            .and_then(|v| v.parse().ok())
-        {
+        if let Some(dur) = new_duration {
             role.max_session_duration = dur;
         }
 
@@ -363,9 +362,11 @@ impl IamService {
             }
         };
 
-        // Validate trust policy constraints
-        if let Some(statements) = doc.get("Statement").and_then(|s| s.as_array()) {
-            for stmt in statements {
+        // Validate trust policy constraints. `Statement` may be a JSON array or
+        // a single JSON object (boto3/aws-cli accept a dict); normalize so the
+        // single-object form is validated identically instead of bypassed.
+        {
+            for stmt in super::statements_as_slice(&doc) {
                 // Check for prohibited Resource field
                 if stmt.get("Resource").is_some() {
                     return Err(AwsServiceError::aws_error(
@@ -1054,11 +1055,9 @@ impl CreateRoleInput {
             .get("Path")
             .cloned()
             .unwrap_or_else(|| "/".to_string());
+        super::validate_iam_path(&path)?;
         let description = params.get("Description").cloned();
-        let max_session_duration = params
-            .get("MaxSessionDuration")
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(3600);
+        let max_session_duration = super::parse_max_session_duration(params)?.unwrap_or(3600);
         let tags = parse_tags(params);
         validate_tags(&tags, 0)?;
         let permissions_boundary = params.get("PermissionsBoundary").cloned();

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -4890,3 +4890,396 @@ fn list_entities_for_managed_policy_counts_attachments() {
         "attachment count not reflected: {gp_body}"
     );
 }
+
+// ---- Hardening: policy-existence, DeleteConflict, single-object Statement,
+//      region partitions, path + MaxSessionDuration validation, and
+//      instance-profile pagination (pre-Show-HN bug-hunt fixes) ----
+
+/// Create a managed policy and return its ARN, extracted from the response.
+fn create_managed_policy(svc: &IamService, name: &str) -> String {
+    let doc =
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+    let resp = svc
+        .create_policy(&make_request(
+            "CreatePolicy",
+            vec![("PolicyName", name), ("PolicyDocument", doc)],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    extract_xml_tag(&body, "Arn").to_string()
+}
+
+#[test]
+fn attach_group_policy_missing_policy_errors() {
+    let svc = make_service();
+    svc.create_group(&make_request("CreateGroup", vec![("GroupName", "grp")]))
+        .unwrap();
+
+    // A customer-managed ARN that was never created must be rejected, matching
+    // attach_role_policy / attach_user_policy behavior.
+    let err = svc
+        .attach_group_policy(&make_request(
+            "AttachGroupPolicy",
+            vec![
+                ("GroupName", "grp"),
+                ("PolicyArn", "arn:aws:iam::123456789012:policy/ghost"),
+            ],
+        ))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "NoSuchEntity");
+    assert!(
+        err.message()
+            .contains("does not exist or is not attachable"),
+        "unexpected message: {}",
+        err.message()
+    );
+}
+
+#[test]
+fn attach_group_policy_missing_group_errors() {
+    let svc = make_service();
+    let err = svc
+        .attach_group_policy(&make_request(
+            "AttachGroupPolicy",
+            vec![
+                ("GroupName", "nope"),
+                ("PolicyArn", "arn:aws:iam::aws:policy/AdministratorAccess"),
+            ],
+        ))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "NoSuchEntity");
+    assert!(err.message().contains("group"));
+}
+
+#[test]
+fn attach_group_policy_aws_managed_ok() {
+    let svc = make_service();
+    svc.create_group(&make_request("CreateGroup", vec![("GroupName", "grp")]))
+        .unwrap();
+    // AWS-managed ARNs are accepted without being present in state.
+    svc.attach_group_policy(&make_request(
+        "AttachGroupPolicy",
+        vec![
+            ("GroupName", "grp"),
+            ("PolicyArn", "arn:aws:iam::aws:policy/AdministratorAccess"),
+        ],
+    ))
+    .unwrap();
+}
+
+#[test]
+fn delete_policy_attached_to_group_conflicts() {
+    let svc = make_service();
+    let arn = create_managed_policy(&svc, "attached-pol");
+    svc.create_group(&make_request("CreateGroup", vec![("GroupName", "g")]))
+        .unwrap();
+    svc.attach_group_policy(&make_request(
+        "AttachGroupPolicy",
+        vec![("GroupName", "g"), ("PolicyArn", &arn)],
+    ))
+    .unwrap();
+
+    let err = svc
+        .delete_policy(&make_request("DeletePolicy", vec![("PolicyArn", &arn)]))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "DeleteConflict");
+    assert!(err.message().contains("attached to entities"));
+
+    // After detaching, the delete succeeds.
+    svc.detach_group_policy(&make_request(
+        "DetachGroupPolicy",
+        vec![("GroupName", "g"), ("PolicyArn", &arn)],
+    ))
+    .unwrap();
+    svc.delete_policy(&make_request("DeletePolicy", vec![("PolicyArn", &arn)]))
+        .unwrap();
+}
+
+#[test]
+fn delete_policy_attached_to_role_conflicts() {
+    let svc = make_service();
+    let arn = create_managed_policy(&svc, "role-attached");
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    svc.create_role(&make_request(
+        "CreateRole",
+        vec![("RoleName", "r"), ("AssumeRolePolicyDocument", trust)],
+    ))
+    .unwrap();
+    svc.attach_role_policy(&make_request(
+        "AttachRolePolicy",
+        vec![("RoleName", "r"), ("PolicyArn", &arn)],
+    ))
+    .unwrap();
+
+    let err = svc
+        .delete_policy(&make_request("DeletePolicy", vec![("PolicyArn", &arn)]))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "DeleteConflict");
+}
+
+#[test]
+fn delete_policy_unattached_succeeds() {
+    let svc = make_service();
+    let arn = create_managed_policy(&svc, "lonely-pol");
+    svc.delete_policy(&make_request("DeletePolicy", vec![("PolicyArn", &arn)]))
+        .unwrap();
+}
+
+#[test]
+fn update_assume_role_policy_single_object_statement_validated() {
+    let svc = make_service();
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    svc.create_role(&make_request(
+        "CreateRole",
+        vec![("RoleName", "r"), ("AssumeRolePolicyDocument", trust)],
+    ))
+    .unwrap();
+
+    // Statement passed as a single object (not an array) with a prohibited
+    // Resource field must still be rejected.
+    let bad = r#"{"Version":"2012-10-17","Statement":{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole","Resource":"*"}}"#;
+    let err = svc
+        .update_assume_role_policy(&make_request(
+            "UpdateAssumeRolePolicy",
+            vec![("RoleName", "r"), ("PolicyDocument", bad)],
+        ))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "MalformedPolicyDocument");
+    assert!(err.message().contains("Resource"));
+
+    // Single-object Statement with a disallowed action is also rejected.
+    let bad_action = r#"{"Version":"2012-10-17","Statement":{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"s3:GetObject"}}"#;
+    let err = svc
+        .update_assume_role_policy(&make_request(
+            "UpdateAssumeRolePolicy",
+            vec![("RoleName", "r"), ("PolicyDocument", bad_action)],
+        ))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "MalformedPolicyDocument");
+
+    // A valid single-object Statement is accepted.
+    let good = r#"{"Version":"2012-10-17","Statement":{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}}"#;
+    svc.update_assume_role_policy(&make_request(
+        "UpdateAssumeRolePolicy",
+        vec![("RoleName", "r"), ("PolicyDocument", good)],
+    ))
+    .unwrap();
+}
+
+#[test]
+fn create_instance_profile_uses_region_partition() {
+    let svc = make_service();
+    let mut req = make_request(
+        "CreateInstanceProfile",
+        vec![("InstanceProfileName", "gov-ip")],
+    );
+    req.region = "us-gov-west-1".to_string();
+    let resp = svc.create_instance_profile(&req).unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(
+        body.contains("arn:aws-us-gov:iam::"),
+        "expected gov partition ARN, got: {body}"
+    );
+    assert!(!body.contains("arn:aws:iam::"));
+}
+
+#[test]
+fn create_virtual_mfa_device_uses_region_partition() {
+    let svc = make_service();
+    let mut req = make_request(
+        "CreateVirtualMFADevice",
+        vec![("VirtualMFADeviceName", "gov-mfa")],
+    );
+    req.region = "us-gov-west-1".to_string();
+    let resp = svc.create_virtual_mfa_device(&req).unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(
+        body.contains("arn:aws-us-gov:iam::"),
+        "expected gov partition serial number, got: {body}"
+    );
+}
+
+#[test]
+fn create_role_rejects_invalid_path() {
+    let svc = make_service();
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    // Path without leading/trailing slash is malformed.
+    let err = svc
+        .create_role(&make_request(
+            "CreateRole",
+            vec![
+                ("RoleName", "r"),
+                ("AssumeRolePolicyDocument", trust),
+                ("Path", "engineering"),
+            ],
+        ))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "InvalidInput");
+    assert!(err.message().contains("path"));
+}
+
+#[test]
+fn create_policy_rejects_invalid_path() {
+    let svc = make_service();
+    let doc =
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#;
+    let err = svc
+        .create_policy(&make_request(
+            "CreatePolicy",
+            vec![
+                ("PolicyName", "p"),
+                ("PolicyDocument", doc),
+                ("Path", "/missing-trailing"),
+            ],
+        ))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "InvalidInput");
+}
+
+#[test]
+fn create_role_valid_nested_path_ok() {
+    let svc = make_service();
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    let resp = svc
+        .create_role(&make_request(
+            "CreateRole",
+            vec![
+                ("RoleName", "r"),
+                ("AssumeRolePolicyDocument", trust),
+                ("Path", "/dept/eng/"),
+            ],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(body.contains(":role/dept/eng/r"));
+}
+
+#[test]
+fn create_role_rejects_out_of_range_max_session_duration() {
+    let svc = make_service();
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    // Below 3600.
+    let err = svc
+        .create_role(&make_request(
+            "CreateRole",
+            vec![
+                ("RoleName", "lo"),
+                ("AssumeRolePolicyDocument", trust),
+                ("MaxSessionDuration", "1800"),
+            ],
+        ))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "ValidationError");
+    assert!(err.message().contains("maxSessionDuration"));
+
+    // Above 43200.
+    let err = svc
+        .create_role(&make_request(
+            "CreateRole",
+            vec![
+                ("RoleName", "hi"),
+                ("AssumeRolePolicyDocument", trust),
+                ("MaxSessionDuration", "50000"),
+            ],
+        ))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "ValidationError");
+
+    // Boundary values are accepted.
+    for dur in ["3600", "43200"] {
+        svc.create_role(&make_request(
+            "CreateRole",
+            vec![
+                ("RoleName", &format!("ok-{dur}")),
+                ("AssumeRolePolicyDocument", trust),
+                ("MaxSessionDuration", dur),
+            ],
+        ))
+        .unwrap();
+    }
+}
+
+#[test]
+fn update_role_rejects_out_of_range_max_session_duration() {
+    let svc = make_service();
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    svc.create_role(&make_request(
+        "CreateRole",
+        vec![("RoleName", "r"), ("AssumeRolePolicyDocument", trust)],
+    ))
+    .unwrap();
+
+    let err = svc
+        .update_role(&make_request(
+            "UpdateRole",
+            vec![("RoleName", "r"), ("MaxSessionDuration", "100")],
+        ))
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), "ValidationError");
+
+    // Valid update is applied.
+    svc.update_role(&make_request(
+        "UpdateRole",
+        vec![("RoleName", "r"), ("MaxSessionDuration", "7200")],
+    ))
+    .unwrap();
+    let body = String::from_utf8_lossy(
+        svc.get_role(&make_request("GetRole", vec![("RoleName", "r")]))
+            .unwrap()
+            .body
+            .expect_bytes(),
+    )
+    .to_string();
+    assert!(body.contains("<MaxSessionDuration>7200</MaxSessionDuration>"));
+}
+
+#[test]
+fn list_instance_profiles_paginates() {
+    let svc = make_service();
+    for n in ["ip-a", "ip-b", "ip-c"] {
+        svc.create_instance_profile(&make_request(
+            "CreateInstanceProfile",
+            vec![("InstanceProfileName", n)],
+        ))
+        .unwrap();
+    }
+
+    // First page: MaxItems=2 -> truncated with a marker.
+    let resp = svc
+        .list_instance_profiles(&make_request(
+            "ListInstanceProfiles",
+            vec![("MaxItems", "2")],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(body.contains("<IsTruncated>true</IsTruncated>"), "{body}");
+    assert!(body.contains("ip-a"));
+    assert!(body.contains("ip-b"));
+    assert!(!body.contains("ip-c"));
+    let marker = extract_xml_tag(&body, "Marker").to_string();
+    assert_eq!(marker, "ip-b");
+
+    // Second page: resume after the marker.
+    let resp = svc
+        .list_instance_profiles(&make_request(
+            "ListInstanceProfiles",
+            vec![("MaxItems", "2"), ("Marker", &marker)],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(body.contains("<IsTruncated>false</IsTruncated>"), "{body}");
+    assert!(body.contains("ip-c"));
+    assert!(!body.contains("ip-a"));
+    assert!(!body.contains("ip-b"));
+}


### PR DESCRIPTION
## Summary

Pre-Show-HN hardening of IAM (next-tier bug-hunt). Panics and persistence came up clean; these are correctness/consistency gaps (mostly where the group path or instance-profile lists lagged behind their already-fixed role/user siblings).

- **MEDIUM — AttachGroupPolicy** didn't validate the policy exists (unlike attach_role_policy / attach_user_policy) → a typo'd ARN was accepted and surfaced in ListAttachedGroupPolicies. Now returns `NoSuchEntity`.
- **LOW — DeletePolicy** succeeded while still attached, silently stripping attachments. Now returns `DeleteConflict` (detach-first required).
- **LOW — UpdateAssumeRolePolicy** skipped trust-policy validation when `Statement` was a single object (boto3/CLI accept a dict) because the check gated on `as_array()`. Added a `statements_as_slice` normalizer; audited the crate (only this site was affected).
- **LOW — instance-profile + virtual-MFA ARNs** hardcoded the `aws` partition → wrong in GovCloud/China. Now derive via `partition_for_region`.
- **LOW — ListInstanceProfiles / …ForRole / …Tags** ignored Marker/MaxItems (hardcoded `IsTruncated=false`). Now paginate like the role/user/group/policy lists.

**Confirmed + fixed from the suspicious tail:**
- CreatePolicy/CreateRole `Path` unvalidated → malformed ARN; now `InvalidInput` (shared `validate_iam_path`).
- CreateRole/UpdateRole `MaxSessionDuration` unvalidated; now `ValidationError` on out-of-`3600..=43200` / non-integer.

The full-snapshot-on-authenticated-read behavior was left untouched (known perf concern, out of scope here).

## Test plan
- E2E: AttachGroupPolicy with a non-existent ARN → NoSuchEntity; DeletePolicy while attached → DeleteConflict; region-correct instance-profile ARN.
- Unit: single-object Statement normalization, Path + MaxSessionDuration validation, pagination.
- `cargo clippy -p fakecloud-iam --all-targets` clean; `cargo test -p fakecloud-iam` 513 pass (+16 new); fmt clean; e2e compiles.

## Surface
Behavioral bug-fix — no new ops/SDK/counts. Non-code surface unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened IAM correctness and parity with AWS: stricter validation, region-correct ARNs, and proper pagination for instance-profile APIs. These changes prevent bad state and align errors with AWS.

- **Bug Fixes**
  - AttachGroupPolicy: reject non‑existent customer‑managed `PolicyArn` with `NoSuchEntity` (AWS‑managed ARNs still allowed).
  - DeletePolicy: return `DeleteConflict` when the policy is attached to any role/user/group (detach first).
  - UpdateAssumeRolePolicy: validate trust policy when `Statement` is a single object (normalized via a helper).
  - Instance profile + virtual MFA ARNs: derive partition from request region (correct for GovCloud/China).
  - ListInstanceProfiles / …ForRole / …Tags: honor `Marker` and `MaxItems`; include `IsTruncated` and `Marker`.
  - CreateRole/CreatePolicy: validate `Path`; return `InvalidInput` on malformed paths.
  - CreateRole/UpdateRole: validate `MaxSessionDuration` is an integer within 3600–43200; return `ValidationError` on violations.

<sup>Written for commit 3bb7da0907ba259716ffb443e21d62474f110f60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

