### PR TITLE
fix(kms): per-key RSA material, import-length guard, state/MAC validation

### DIFF
--- a/crates/fakecloud-kms/src/asym.rs
+++ b/crates/fakecloud-kms/src/asym.rs
@@ -26,16 +26,6 @@ pub enum AsymError {
 
 pub type KeyPair = (Vec<u8>, Vec<u8>);
 
-// One precomputed keypair per RSA bit width, shared across every CreateKey.
-// RSA-4096 keygen is ~20 seconds on CI; the conformance harness exercises
-// every enum value per operation, and earlier we hit 30s read timeouts
-// (surfaced as CRASH) when several RSA-4096 CreateKey variants ran in
-// parallel. Reuse is invisible to clients — each KMS key still has its
-// own ARN, metadata, and lifecycle, only the raw key material is shared.
-static RSA_2048_KEY: std::sync::OnceLock<KeyPair> = std::sync::OnceLock::new();
-static RSA_3072_KEY: std::sync::OnceLock<KeyPair> = std::sync::OnceLock::new();
-static RSA_4096_KEY: std::sync::OnceLock<KeyPair> = std::sync::OnceLock::new();
-
 fn generate_rsa(bits: usize) -> Result<KeyPair, AsymError> {
     let mut rng = rand::thread_rng();
     let private = RsaPrivateKey::new(&mut rng, bits)
@@ -54,25 +44,22 @@ fn generate_rsa(bits: usize) -> Result<KeyPair, AsymError> {
     Ok((priv_der, pub_der))
 }
 
-fn cached_rsa(
-    slot: &'static std::sync::OnceLock<KeyPair>,
-    bits: usize,
-) -> Result<KeyPair, AsymError> {
-    if let Some(kp) = slot.get() {
-        return Ok(kp.clone());
-    }
-    let kp = generate_rsa(bits)?;
-    Ok(slot.get_or_init(|| kp).clone())
-}
-
 /// Returns (private_pkcs8_der, public_spki_der) for the given KMS
 /// `KeySpec`. Returns `None` for symmetric / HMAC / unsupported specs
 /// so the caller can keep the existing fake-bytes path for those.
+///
+/// Each call mints a **fresh** keypair. AWS KMS guarantees every CMK has
+/// its own unique key material, so two RSA_2048 keys must return
+/// different public keys and a signature made under one must never verify
+/// under another. An earlier build cached one keypair per bit-width and
+/// shared it across every CreateKey, which broke that guarantee (all
+/// same-width keys were cryptographically identical). Correctness wins
+/// over the keygen cost the cache was avoiding.
 pub fn generate_keypair(key_spec: &str) -> Result<Option<KeyPair>, AsymError> {
     let kp = match key_spec {
-        "RSA_2048" => cached_rsa(&RSA_2048_KEY, 2048)?,
-        "RSA_3072" => cached_rsa(&RSA_3072_KEY, 3072)?,
-        "RSA_4096" => cached_rsa(&RSA_4096_KEY, 4096)?,
+        "RSA_2048" => generate_rsa(2048)?,
+        "RSA_3072" => generate_rsa(3072)?,
+        "RSA_4096" => generate_rsa(4096)?,
         // ECDSA / ECDH / SM2 specs are out of scope for G1; G2 covers
         // ECDSA. Falling through to None keeps the fake-bytes legacy
         // path in place for those.
@@ -332,6 +319,26 @@ mod tests {
     fn unsupported_spec_returns_none() {
         assert!(generate_keypair("SYMMETRIC_DEFAULT").unwrap().is_none());
         assert!(generate_keypair("HMAC_256").unwrap().is_none());
+    }
+
+    #[test]
+    fn two_rsa_keys_have_distinct_material() {
+        // AWS mints unique key material per CMK. Two RSA_2048 keys must
+        // not share a public key, and a signature under key A must not
+        // verify under key B (regression: a shared per-bit-width cache
+        // once made all same-width keys byte-identical).
+        let (priv_a, pub_a) = generate_keypair("RSA_2048").unwrap().unwrap();
+        let (priv_b, pub_b) = generate_keypair("RSA_2048").unwrap().unwrap();
+        assert_ne!(pub_a, pub_b, "distinct keys must have distinct public keys");
+        assert_ne!(priv_a, priv_b);
+
+        let msg = b"cross-key forgery attempt";
+        let sig_a = rsa_sign(&priv_a, "RSASSA_PSS_SHA_256", msg, false).unwrap();
+        assert!(rsa_verify(&priv_a, "RSASSA_PSS_SHA_256", msg, &sig_a, false).unwrap());
+        assert!(
+            !rsa_verify(&priv_b, "RSASSA_PSS_SHA_256", msg, &sig_a, false).unwrap(),
+            "signature under key A must not verify under key B"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-kms/src/helpers.rs
+++ b/crates/fakecloud-kms/src/helpers.rs
@@ -5,18 +5,33 @@ use super::*;
 /// sorted via `BTreeMap`'s ordering and the result is JSON-encoded
 /// without whitespace. An empty EC produces zero bytes so blobs
 /// encoded without EC stay byte-compatible with the original AAD shape.
-pub(crate) fn canonical_encryption_context(value: &serde_json::Value) -> Vec<u8> {
+///
+/// KMS's `EncryptionContextType` is `map<String, String>`. A value that
+/// isn't a string is rejected — AWS refuses such a request rather than
+/// silently dropping the offending entry, which is what the old
+/// `filter_map` did (it discarded non-string values, so the AAD bound at
+/// encrypt time could differ from what the caller intended).
+pub(crate) fn canonical_encryption_context(
+    value: &serde_json::Value,
+) -> Result<Vec<u8>, AwsServiceError> {
     let Some(obj) = value.as_object() else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     if obj.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
-    let sorted: std::collections::BTreeMap<&str, String> = obj
-        .iter()
-        .filter_map(|(k, v)| v.as_str().map(|s| (k.as_str(), s.to_string())))
-        .collect();
-    serde_json::to_vec(&sorted).unwrap_or_default()
+    let mut sorted: std::collections::BTreeMap<&str, &str> = std::collections::BTreeMap::new();
+    for (k, v) in obj {
+        let s = v.as_str().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!("EncryptionContext value for key '{k}' must be a string"),
+            )
+        })?;
+        sorted.insert(k.as_str(), s);
+    }
+    Ok(serde_json::to_vec(&sorted).unwrap_or_default())
 }
 
 /// Decode a FakeCloud KMS ciphertext envelope back into its plaintext.
@@ -187,6 +202,7 @@ pub(crate) fn is_mutating_action(action: &str) -> bool {
             | "RevokeGrant"
             | "RetireGrant"
             | "ReplicateKey"
+            | "GetParametersForImport"
             | "ImportKeyMaterial"
             | "DeleteImportedKeyMaterial"
             | "UpdatePrimaryRegion"
@@ -500,7 +516,14 @@ pub(crate) fn require_usable_key_state(key: &KmsKey) -> Result<(), AwsServiceErr
     if key.key_state == "Enabled" {
         return Ok(());
     }
-    if key.key_state == "Disabled" || !key.enabled {
+    // Only the `Disabled` state maps to `DisabledException`. Every other
+    // non-Enabled lifecycle state (`PendingDeletion`, `PendingImport`,
+    // `Unavailable`, `Updating`, `Creating`) is a `KMSInvalidStateException`.
+    // The previous `|| !key.enabled` clause misrouted PendingDeletion and
+    // PendingImport keys (both have `enabled == false`) to
+    // `DisabledException`, so the `KMSInvalidStateException` arm below was
+    // unreachable.
+    if key.key_state == "Disabled" {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "DisabledException",

--- a/crates/fakecloud-kms/src/mac.rs
+++ b/crates/fakecloud-kms/src/mac.rs
@@ -7,7 +7,7 @@
 //! constant-time comparison.
 
 use hmac::{Hmac, Mac};
-use sha2::{Sha256, Sha384, Sha512};
+use sha2::{Sha224, Sha256, Sha384, Sha512};
 
 #[derive(Debug, thiserror::Error)]
 pub enum MacError {
@@ -17,11 +17,17 @@ pub enum MacError {
 
 /// Compute the MAC of `message` keyed by `key_bytes`. Algorithm names
 /// match KMS's `MacAlgorithmSpec` enum (`HMAC_SHA_224` / `_256` /
-/// `_384` / `_512`). HMAC-SHA-224 is intentionally rejected — the
-/// `sha2::Sha224` digest exists, but AWS dropped HMAC_SHA_224 from
-/// supported MacAlgorithmSpec values, and we mirror that.
+/// `_384` / `_512`). All four are supported — an HMAC_224 key advertises
+/// `HMAC_SHA_224`, so rejecting it here made GenerateMac/VerifyMac
+/// unusable for that key spec.
 pub fn compute(algorithm: &str, key_bytes: &[u8], message: &[u8]) -> Result<Vec<u8>, MacError> {
     match algorithm {
+        "HMAC_SHA_224" => {
+            let mut mac = <Hmac<Sha224> as Mac>::new_from_slice(key_bytes)
+                .expect("HMAC accepts any key length");
+            mac.update(message);
+            Ok(mac.finalize().into_bytes().to_vec())
+        }
         "HMAC_SHA_256" => {
             let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(key_bytes)
                 .expect("HMAC accepts any key length");
@@ -54,6 +60,12 @@ pub fn verify(
     mac_bytes: &[u8],
 ) -> Result<bool, MacError> {
     match algorithm {
+        "HMAC_SHA_224" => {
+            let mut mac = <Hmac<Sha224> as Mac>::new_from_slice(key_bytes)
+                .expect("HMAC accepts any key length");
+            mac.update(message);
+            Ok(mac.verify_slice(mac_bytes).is_ok())
+        }
         "HMAC_SHA_256" => {
             let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(key_bytes)
                 .expect("HMAC accepts any key length");
@@ -79,6 +91,20 @@ pub fn verify(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn round_trip_sha224() {
+        // HMAC_224 keys advertise HMAC_SHA_224; the round trip must work
+        // and produce a 28-byte (224-bit) tag.
+        let key = b"sample-key-material";
+        let msg = b"the quick brown fox";
+        let mac = compute("HMAC_SHA_224", key, msg).unwrap();
+        assert_eq!(mac.len(), 28);
+        assert!(verify("HMAC_SHA_224", key, msg, &mac).unwrap());
+        let mut tampered = mac.clone();
+        tampered[0] ^= 0xff;
+        assert!(!verify("HMAC_SHA_224", key, msg, &tampered).unwrap());
+    }
 
     #[test]
     fn round_trip_sha256() {

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -480,6 +480,16 @@ impl KmsService {
             // Could be key ARN or alias ARN
             if key_id_or_arn.contains(":key/") {
                 if let Some(id) = key_id_or_arn.rsplit('/').next() {
+                    // Multi-region replicas are stored under a region-scoped
+                    // composite key ("{region}:{id}") because the primary and
+                    // every replica share the same bare id. Resolve the ARN's
+                    // own region first so a DescribeKey on a replica ARN returns
+                    // the replica entry, not the primary that also matches `id`.
+                    let region = key_id_or_arn.split(':').nth(3).unwrap_or("");
+                    let scoped = format!("{region}:{id}");
+                    if state.keys.contains_key(&scoped) {
+                        return Some(scoped);
+                    }
                     if state.keys.contains_key(id) {
                         return Some(id.to_string());
                     }
@@ -844,6 +854,19 @@ impl KmsService {
         let body = req.json_body();
         let resolved = self.resolve_required_key(req, &body)?;
         let pending_days = body["PendingWindowInDays"].as_i64().unwrap_or(30);
+
+        // AWS enforces a 7..=30 day waiting period; anything outside that
+        // range is a ValidationException. Previously any value (including 0
+        // or negative) was accepted verbatim and echoed back.
+        if !(7..=30).contains(&pending_days) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "1 validation error detected: Value '{pending_days}' at 'pendingWindowInDays' failed to satisfy constraint: Member must have value less than or equal to 30 and greater than or equal to 7"
+                ),
+            ));
+        }
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -1395,7 +1418,11 @@ impl KmsService {
             imported_key_material: false,
             imported_material_bytes: None,
             private_key_seed: rand_bytes(32),
-            primary_region: None,
+            // Record which region holds the primary so a later DescribeKey on
+            // this replica renders MultiRegionKeyType=REPLICA (and the correct
+            // primary region/ARN). Leaving this None made the stored replica
+            // look like a PRIMARY on read-back.
+            primary_region: Some(source_region.clone()),
             ..source_key
         };
 

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -66,7 +66,7 @@ impl KmsService {
         }
 
         let requested_alg = body["EncryptionAlgorithm"].as_str();
-        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"])?;
 
         let (ciphertext_b64, echoed_alg) = if key.key_spec.starts_with("RSA_") {
             // Asymmetric ENCRYPT_DECRYPT (RSA): real RSA-OAEP under the key's
@@ -161,7 +161,7 @@ impl KmsService {
         let accounts = self.state.read();
         let empty = KmsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"])?;
         let decoded = decode_ciphertext_envelope(state, ciphertext_b64, &ec_aad)?;
 
         // When the caller supplies KeyId for a symmetric decrypt, AWS
@@ -268,8 +268,8 @@ impl KmsService {
         let accounts = self.state.read();
         let empty = KmsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let source_ec_aad = canonical_encryption_context(&body["SourceEncryptionContext"]);
-        let dest_ec_aad = canonical_encryption_context(&body["DestinationEncryptionContext"]);
+        let source_ec_aad = canonical_encryption_context(&body["SourceEncryptionContext"])?;
+        let dest_ec_aad = canonical_encryption_context(&body["DestinationEncryptionContext"])?;
         let decoded = decode_ciphertext_envelope(state, ciphertext_b64, &source_ec_aad)?;
 
         let dest_resolved =
@@ -290,6 +290,22 @@ impl KmsService {
         })?;
         require_usable_key_state(dest_key)?;
 
+        // The destination CMK must be an encryption key. Re-encrypting into a
+        // SIGN_VERIFY / GENERATE_VERIFY_MAC / KEY_AGREEMENT key is invalid;
+        // AWS rejects it with InvalidKeyUsageException. Previously any dest key
+        // was accepted and its plaintext silently wrapped under the symmetric
+        // path regardless of usage or spec.
+        if dest_key.key_usage != "ENCRYPT_DECRYPT" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidKeyUsageException",
+                format!(
+                    "The operation failed because the KMS key {} is not enabled for the requested operation. The key usage must be ENCRYPT_DECRYPT but is {}.",
+                    dest_key.arn, dest_key.key_usage
+                ),
+            ));
+        }
+
         // Source key gate too — AWS rejects ReEncrypt when either side
         // is in a non-Enabled state.
         if let Some(src_key_id) = decoded.source_arn.rsplit('/').next() {
@@ -301,7 +317,44 @@ impl KmsService {
         let plaintext_bytes = base64::engine::general_purpose::STANDARD
             .decode(&decoded.plaintext_b64)
             .unwrap_or_default();
-        let new_ciphertext_b64 = if let Some(ref material) = dest_key.imported_material_bytes {
+        let (new_ciphertext_b64, dest_algorithm) = if dest_key.key_spec.starts_with("RSA_") {
+            // Asymmetric destination: produce a real RSA-OAEP ciphertext under
+            // the destination key's public half, mirroring the Encrypt path,
+            // rather than the symmetric AES blob the old code emitted for every
+            // destination. The echoed DestinationEncryptionAlgorithm reflects
+            // the algorithm actually used.
+            let alg = body["DestinationEncryptionAlgorithm"]
+                .as_str()
+                .unwrap_or("RSAES_OAEP_SHA_256");
+            if alg != "RSAES_OAEP_SHA_1" && alg != "RSAES_OAEP_SHA_256" {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidKeyUsageException",
+                    format!(
+                        "Algorithm '{alg}' is incompatible with the key spec '{}'.",
+                        dest_key.key_spec
+                    ),
+                ));
+            }
+            let pub_der = dest_key.asymmetric_public_key_der.as_ref().ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "KMSInternalException",
+                    "asymmetric public key missing",
+                )
+            })?;
+            let raw = super::asym::rsa_oaep_wrap(pub_der, alg, &plaintext_bytes).map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidKeyUsageException",
+                    format!("RSA re-encrypt failed: {e}"),
+                )
+            })?;
+            let raw_b64 = base64::engine::general_purpose::STANDARD.encode(&raw);
+            let envelope = format!("fakecloud-rsa:{}:{}:{}", dest_key.key_id, alg, raw_b64);
+            let env_b64 = base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes());
+            (env_b64, alg.to_string())
+        } else if let Some(ref material) = dest_key.imported_material_bytes {
             // Imported-key path: keep the legacy XOR envelope so consumers
             // that already round-trip via key material can still decrypt.
             let xored: Vec<u8> = plaintext_bytes
@@ -311,7 +364,10 @@ impl KmsService {
                 .collect();
             let xored_b64 = base64::engine::general_purpose::STANDARD.encode(&xored);
             let envelope = format!("fakecloud-imported:{}:{xored_b64}", dest_key.key_id);
-            base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes())
+            (
+                base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes()),
+                "SYMMETRIC_DEFAULT".to_string(),
+            )
         } else {
             // Default path: wrap the recovered plaintext under the
             // destination key with the AWS-shaped binary blob, binding
@@ -322,7 +378,10 @@ impl KmsService {
                 &plaintext_bytes,
                 &dest_ec_aad,
             );
-            base64::engine::general_purpose::STANDARD.encode(&blob)
+            (
+                base64::engine::general_purpose::STANDARD.encode(&blob),
+                "SYMMETRIC_DEFAULT".to_string(),
+            )
         };
 
         Ok(AwsResponse::json(
@@ -331,8 +390,8 @@ impl KmsService {
                 "CiphertextBlob": new_ciphertext_b64,
                 "KeyId": dest_key.arn,
                 "SourceKeyId": decoded.source_arn,
-                "SourceEncryptionAlgorithm": "SYMMETRIC_DEFAULT",
-                "DestinationEncryptionAlgorithm": "SYMMETRIC_DEFAULT",
+                "SourceEncryptionAlgorithm": decoded.encryption_algorithm,
+                "DestinationEncryptionAlgorithm": dest_algorithm,
             }))
             .unwrap(),
         ))
@@ -378,7 +437,7 @@ impl KmsService {
         // matching real KMS and the Encrypt/ReEncrypt paths. Previously the
         // context was ignored, so the recommended envelope-encryption pattern
         // (GenerateDataKey + EncryptionContext) could never decrypt its key.
-        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"])?;
         let blob = crate::blob::encode_with_context(
             &state.master_key_bytes,
             &key.key_id,
@@ -436,7 +495,7 @@ impl KmsService {
         // with an EncryptionContext could never be decrypted with that context
         // (AEAD mismatch -> InvalidCiphertextException) and Decrypt with no
         // context wrongly succeeded.
-        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"])?;
         let blob = crate::blob::encode_with_context(
             &state.master_key_bytes,
             &key.key_id,
@@ -802,11 +861,27 @@ impl KmsService {
         }
 
         // Validate key spec supports MAC
-        if key.mac_algorithms.is_none() {
-            return Err(AwsServiceError::aws_error(
+        let mac_algs = key.mac_algorithms.as_deref().ok_or_else(|| {
+            AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidKeyUsageException",
                 format!("Key '{}' does not support MAC operations", key.arn),
+            )
+        })?;
+
+        // The requested MacAlgorithm must be one the key actually advertises
+        // (an HMAC_256 key supports only HMAC_SHA_256, etc.). AWS rejects a
+        // mismatch with InvalidKeyUsageException; previously any spec-shaped
+        // string was accepted and silently HMAC'd, so a HMAC_512 request
+        // against a HMAC_256 key wrongly succeeded.
+        if !mac_algs.iter().any(|a| a == &mac_algorithm) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidKeyUsageException",
+                format!(
+                    "1 validation error detected: Value '{mac_algorithm}' at 'MacAlgorithm' failed to satisfy constraint: Member must satisfy enum value set: {}",
+                    fmt_enum_set(mac_algs)
+                ),
             ));
         }
 
@@ -879,6 +954,29 @@ impl KmsService {
                 StatusCode::BAD_REQUEST,
                 "InvalidKeyUsageException",
                 format!("Key '{}' is not a GENERATE_VERIFY_MAC key", key.arn),
+            ));
+        }
+
+        // The requested MacAlgorithm must be one the key advertises — same
+        // rule as GenerateMac. Without this, VerifyMac against a HMAC_256
+        // key with MacAlgorithm=HMAC_SHA_512 would recompute under the wrong
+        // digest and report a spurious KMSInvalidMacException instead of the
+        // AWS InvalidKeyUsageException.
+        let mac_algs = key.mac_algorithms.as_deref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidKeyUsageException",
+                format!("Key '{}' does not support MAC operations", key.arn),
+            )
+        })?;
+        if !mac_algs.iter().any(|a| a == &mac_algorithm) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidKeyUsageException",
+                format!(
+                    "1 validation error detected: Value '{mac_algorithm}' at 'MacAlgorithm' failed to satisfy constraint: Member must satisfy enum value set: {}",
+                    fmt_enum_set(mac_algs)
+                ),
             ));
         }
 
@@ -976,7 +1074,7 @@ impl KmsService {
 
         // Wrap the private key in the AWS-shaped binary blob, binding the
         // caller's EncryptionContext into the AAD (see GenerateDataKey).
-        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"])?;
         let blob = crate::blob::encode_with_context(
             &state.master_key_bytes,
             &key.key_id,
@@ -1038,7 +1136,7 @@ impl KmsService {
         // GenerateDataKeyPair (with-plaintext) sibling. Previously this used
         // crate::blob::encode (AAD = key-id only), so the private key could
         // never be decrypted with its EncryptionContext.
-        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"])?;
         let blob = crate::blob::encode_with_context(
             &state.master_key_bytes,
             &key.key_id,

--- a/crates/fakecloud-kms/src/service_custom_store.rs
+++ b/crates/fakecloud-kms/src/service_custom_store.rs
@@ -212,6 +212,22 @@ impl KmsService {
             )
         })?;
 
+        // AWS KMS requires symmetric imported key material to be exactly
+        // 256 bits (32 bytes). Reject anything else before it reaches the
+        // encrypt/decrypt XOR path — zero-length material there would
+        // panic with a divide-by-zero (`byte ^ material[i % material.len()]`),
+        // turning a malformed import into a server crash (DoS).
+        if unwrapped.len() != 32 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "Key material must be exactly 256 bits (32 bytes); got {} bytes",
+                    unwrapped.len()
+                ),
+            ));
+        }
+
         key.imported_key_material = true;
         key.imported_material_bytes = Some(unwrapped);
         key.enabled = true;

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -805,7 +805,7 @@ fn imported_key_material_encrypt_decrypt_roundtrip() {
 fn imported_key_material_decrypt_fails_after_deletion() {
     let svc = make_service();
     let key_id = create_key_with_opts(&svc, json!({ "Origin": "EXTERNAL" }));
-    import_external_material(&svc, &key_id, b"some-key-material-32bytes!!");
+    import_external_material(&svc, &key_id, b"my-secret-aes-key-material!12345");
 
     let plaintext_b64 = base64::engine::general_purpose::STANDARD.encode(b"secret");
     let resp = svc
@@ -2728,7 +2728,11 @@ fn import_key_material_token_is_single_use() {
     let public = rsa::RsaPublicKey::from_public_key_der(&pub_der).unwrap();
     let mut rng = rand::thread_rng();
     let wrapped = public
-        .encrypt(&mut rng, rsa::Oaep::new::<rsa::sha2::Sha256>(), b"material")
+        .encrypt(
+            &mut rng,
+            rsa::Oaep::new::<rsa::sha2::Sha256>(),
+            b"my-secret-aes-key-material!12345",
+        )
         .unwrap();
     let wrapped_b64 = base64::engine::general_purpose::STANDARD.encode(&wrapped);
 
@@ -3267,4 +3271,377 @@ fn generate_data_key_pair_without_plaintext_binds_encryption_context() {
         .err()
         .expect("missing EC must error");
     assert!(format!("{err:?}").contains("InvalidCiphertextException"));
+}
+
+// ---- Hardening regression tests (kms hardening batch) ----
+
+/// H2: empty/short imported key material must be rejected, not stored —
+/// storing zero-length material later panics with a divide-by-zero in the
+/// XOR encrypt/decrypt path (`byte ^ material[i % material.len()]`).
+#[test]
+fn import_key_material_rejects_wrong_length_no_panic() {
+    use base64::Engine;
+    use rsa::pkcs8::DecodePublicKey;
+
+    let svc = make_service();
+    let key_id = create_key_with_opts(&svc, json!({ "Origin": "EXTERNAL" }));
+
+    let resp = svc
+        .get_parameters_for_import(&make_request(
+            "GetParametersForImport",
+            json!({"KeyId": key_id, "WrappingAlgorithm": "RSAES_OAEP_SHA_256"}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let token = body["ImportToken"].as_str().unwrap().to_string();
+    let pub_der = base64::engine::general_purpose::STANDARD
+        .decode(body["PublicKey"].as_str().unwrap())
+        .unwrap();
+    let public = rsa::RsaPublicKey::from_public_key_der(&pub_der).unwrap();
+    let mut rng = rand::thread_rng();
+    // Zero-length material is the divide-by-zero vector.
+    let wrapped = public
+        .encrypt(&mut rng, rsa::Oaep::new::<rsa::sha2::Sha256>(), b"")
+        .unwrap();
+    let wrapped_b64 = base64::engine::general_purpose::STANDARD.encode(&wrapped);
+
+    let err = svc
+        .import_key_material(&make_request(
+            "ImportKeyMaterial",
+            json!({
+                "KeyId": key_id,
+                "ImportToken": token,
+                "EncryptedKeyMaterial": wrapped_b64,
+                "WrappingAlgorithm": "RSAES_OAEP_SHA_256",
+            }),
+        ))
+        .err()
+        .expect("empty imported material must be rejected");
+    assert!(
+        format!("{err:?}").contains("ValidationException"),
+        "got {err:?}"
+    );
+}
+
+/// M1: a key scheduled for deletion is `PendingDeletion` — crypto ops on it
+/// return `KMSInvalidStateException`, not `DisabledException`.
+#[test]
+fn encrypt_on_pending_deletion_key_is_invalid_state() {
+    use base64::Engine;
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    svc.schedule_key_deletion(&make_request(
+        "ScheduleKeyDeletion",
+        json!({"KeyId": key_id, "PendingWindowInDays": 7}),
+    ))
+    .unwrap();
+
+    let err = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({
+                "KeyId": key_id,
+                "Plaintext": base64::engine::general_purpose::STANDARD.encode(b"hi"),
+            }),
+        ))
+        .err()
+        .expect("encrypt on pending-deletion key must fail");
+    assert!(
+        format!("{err:?}").contains("KMSInvalidStateException"),
+        "got {err:?}"
+    );
+}
+
+/// M1 (companion): a `Disabled` key still returns `DisabledException`.
+#[test]
+fn encrypt_on_disabled_key_is_disabled_exception() {
+    use base64::Engine;
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    svc.disable_key(&make_request("DisableKey", json!({"KeyId": key_id})))
+        .unwrap();
+
+    let err = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({
+                "KeyId": key_id,
+                "Plaintext": base64::engine::general_purpose::STANDARD.encode(b"hi"),
+            }),
+        ))
+        .err()
+        .expect("encrypt on disabled key must fail");
+    assert!(
+        format!("{err:?}").contains("DisabledException"),
+        "got {err:?}"
+    );
+}
+
+/// M2: GenerateMac / VerifyMac reject a MacAlgorithm the key does not
+/// advertise (a HMAC_256 key only supports HMAC_SHA_256).
+#[test]
+fn mac_rejects_algorithm_not_advertised_by_key() {
+    use base64::Engine;
+    let svc = make_service();
+    let key_id = create_key_with_opts(
+        &svc,
+        json!({ "KeyUsage": "GENERATE_VERIFY_MAC", "KeySpec": "HMAC_256" }),
+    );
+    let msg_b64 = base64::engine::general_purpose::STANDARD.encode(b"payload");
+
+    let err = svc
+        .generate_mac(&make_request(
+            "GenerateMac",
+            json!({"KeyId": key_id, "Message": msg_b64, "MacAlgorithm": "HMAC_SHA_512"}),
+        ))
+        .err()
+        .expect("mismatched MacAlgorithm must be rejected");
+    assert!(
+        format!("{err:?}").contains("InvalidKeyUsageException"),
+        "got {err:?}"
+    );
+
+    let err = svc
+        .verify_mac(&make_request(
+            "VerifyMac",
+            json!({
+                "KeyId": key_id,
+                "Message": msg_b64,
+                "Mac": base64::engine::general_purpose::STANDARD.encode(b"whatever"),
+                "MacAlgorithm": "HMAC_SHA_512",
+            }),
+        ))
+        .err()
+        .expect("mismatched MacAlgorithm must be rejected on verify too");
+    assert!(
+        format!("{err:?}").contains("InvalidKeyUsageException"),
+        "got {err:?}"
+    );
+}
+
+/// M3: HMAC_224 keys advertise HMAC_SHA_224 and must round-trip through
+/// GenerateMac -> VerifyMac.
+#[test]
+fn hmac_224_generate_and_verify_round_trip() {
+    use base64::Engine;
+    let svc = make_service();
+    let key_id = create_key_with_opts(
+        &svc,
+        json!({ "KeyUsage": "GENERATE_VERIFY_MAC", "KeySpec": "HMAC_224" }),
+    );
+    let msg_b64 = base64::engine::general_purpose::STANDARD.encode(b"mac me");
+
+    let resp = svc
+        .generate_mac(&make_request(
+            "GenerateMac",
+            json!({"KeyId": key_id, "Message": msg_b64, "MacAlgorithm": "HMAC_SHA_224"}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let mac = body["Mac"].as_str().unwrap().to_string();
+
+    let resp = svc
+        .verify_mac(&make_request(
+            "VerifyMac",
+            json!({
+                "KeyId": key_id,
+                "Message": msg_b64,
+                "Mac": mac,
+                "MacAlgorithm": "HMAC_SHA_224",
+            }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["MacValid"].as_bool(), Some(true));
+}
+
+/// M7: DescribeKey on a replica ARN returns the replica (REPLICA type, its
+/// own region), not the primary that shares the same bare key id.
+#[test]
+fn describe_key_on_replica_arn_returns_replica() {
+    let svc = make_service();
+    let key_id = create_key_with_opts(&svc, json!({ "MultiRegion": true }));
+
+    let resp = svc
+        .replicate_key(&make_request(
+            "ReplicateKey",
+            json!({"KeyId": key_id, "ReplicaRegion": "us-west-2"}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let replica_arn = body["ReplicaKeyMetadata"]["Arn"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(replica_arn.contains(":us-west-2:"), "got {replica_arn}");
+
+    let resp = svc
+        .describe_key(&make_request("DescribeKey", json!({"KeyId": replica_arn})))
+        .unwrap();
+    let meta: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let meta = &meta["KeyMetadata"];
+    assert!(meta["Arn"].as_str().unwrap().contains(":us-west-2:"));
+    assert_eq!(
+        meta["MultiRegionConfiguration"]["MultiRegionKeyType"].as_str(),
+        Some("REPLICA")
+    );
+    assert_eq!(
+        meta["MultiRegionConfiguration"]["PrimaryKey"]["Region"].as_str(),
+        Some("us-east-1")
+    );
+
+    // The primary ARN still describes as PRIMARY.
+    let resp = svc
+        .describe_key(&make_request("DescribeKey", json!({"KeyId": key_id})))
+        .unwrap();
+    let meta: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        meta["KeyMetadata"]["MultiRegionConfiguration"]["MultiRegionKeyType"].as_str(),
+        Some("PRIMARY")
+    );
+}
+
+/// L2: ScheduleKeyDeletion enforces the 7..=30 day window.
+#[test]
+fn schedule_key_deletion_rejects_out_of_range_window() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    for bad in [0_i64, 3, 31, 400] {
+        let err = svc
+            .schedule_key_deletion(&make_request(
+                "ScheduleKeyDeletion",
+                json!({"KeyId": key_id, "PendingWindowInDays": bad}),
+            ))
+            .err()
+            .unwrap_or_else(|| panic!("window {bad} must be rejected"));
+        assert!(
+            format!("{err:?}").contains("ValidationException"),
+            "window {bad}: got {err:?}"
+        );
+    }
+    // A valid window still works.
+    svc.schedule_key_deletion(&make_request(
+        "ScheduleKeyDeletion",
+        json!({"KeyId": key_id, "PendingWindowInDays": 7}),
+    ))
+    .unwrap();
+}
+
+/// L3: ReEncrypt refuses a destination key that is not ENCRYPT_DECRYPT.
+#[test]
+fn re_encrypt_rejects_non_encrypt_destination() {
+    use base64::Engine;
+    let svc = make_service();
+    let src = create_key(&svc);
+    let ciphertext = {
+        let resp = svc
+            .encrypt(&make_request(
+                "Encrypt",
+                json!({
+                    "KeyId": src,
+                    "Plaintext": base64::engine::general_purpose::STANDARD.encode(b"secret"),
+                }),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        body["CiphertextBlob"].as_str().unwrap().to_string()
+    };
+
+    let signing_key = create_key_with_opts(
+        &svc,
+        json!({ "KeyUsage": "SIGN_VERIFY", "KeySpec": "RSA_2048" }),
+    );
+    let err = svc
+        .re_encrypt(&make_request(
+            "ReEncrypt",
+            json!({"CiphertextBlob": ciphertext, "DestinationKeyId": signing_key}),
+        ))
+        .err()
+        .expect("re-encrypt into a SIGN_VERIFY key must fail");
+    assert!(
+        format!("{err:?}").contains("InvalidKeyUsageException"),
+        "got {err:?}"
+    );
+}
+
+/// L3: ReEncrypt into an RSA ENCRYPT_DECRYPT key produces a real RSA-OAEP
+/// ciphertext that Decrypt recovers, and echoes the true source/dest
+/// algorithms rather than a hardcoded SYMMETRIC_DEFAULT pair.
+#[test]
+fn re_encrypt_to_rsa_destination_round_trips() {
+    use base64::Engine;
+    let svc = make_service();
+    let src = create_key(&svc);
+    let resp = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({
+                "KeyId": src,
+                "Plaintext": base64::engine::general_purpose::STANDARD.encode(b"top secret"),
+            }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let ciphertext = body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    let rsa_key = create_key_with_opts(
+        &svc,
+        json!({ "KeyUsage": "ENCRYPT_DECRYPT", "KeySpec": "RSA_2048" }),
+    );
+    let resp = svc
+        .re_encrypt(&make_request(
+            "ReEncrypt",
+            json!({"CiphertextBlob": ciphertext, "DestinationKeyId": rsa_key}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        body["SourceEncryptionAlgorithm"].as_str(),
+        Some("SYMMETRIC_DEFAULT")
+    );
+    assert_eq!(
+        body["DestinationEncryptionAlgorithm"].as_str(),
+        Some("RSAES_OAEP_SHA_256")
+    );
+    let new_ct = body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    let resp = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({
+                "CiphertextBlob": new_ct,
+                "KeyId": rsa_key,
+                "EncryptionAlgorithm": "RSAES_OAEP_SHA_256",
+            }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let recovered = base64::engine::general_purpose::STANDARD
+        .decode(body["Plaintext"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(recovered, b"top secret");
+}
+
+/// L5: a non-string EncryptionContext value is rejected, not silently
+/// dropped (which would change the AAD bound at encrypt time).
+#[test]
+fn encrypt_rejects_non_string_encryption_context_value() {
+    use base64::Engine;
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    let err = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({
+                "KeyId": key_id,
+                "Plaintext": base64::engine::general_purpose::STANDARD.encode(b"hi"),
+                "EncryptionContext": { "purpose": 42 },
+            }),
+        ))
+        .err()
+        .expect("non-string EC value must be rejected");
+    assert!(
+        format!("{err:?}").contains("ValidationException"),
+        "got {err:?}"
+    );
 }


### PR DESCRIPTION
## Summary
Behavioral hardening of `fakecloud-kms` — divergences from real AWS KMS that the conformance probe cannot see (it checks each op's response shape in isolation with clean, well-formed input).

- **H1 (crypto correctness)** every RSA CMK of a given bit-width shared identical cached key material, so a signature under key A verified under key B and A's ciphertext decrypted under B. Now each `CreateKey` mints an independent RSA keypair (matching how ECC keys already worked).
- **H2 (DoS)** importing zero-length key material caused a divide-by-zero panic (`i % material.len()`). Non-256-bit imported material is now rejected.
- **M1** non-`Enabled` keys all returned `DisabledException`; `PendingDeletion`/`PendingImport` now correctly return `KMSInvalidStateException`.
- **M2** `GenerateMac`/`VerifyMac` now validate `MacAlgorithm` against the key's advertised algorithms (`InvalidKeyUsageException`).
- **M3** `HMAC_224` keys were advertised but rejected at use; `HMAC_SHA_224` is now supported.
- **M4** `GetParametersForImport` now persists its wrapping key, so the import token survives a restart.
- **M5** resolving a multi-region replica ARN returned the primary's metadata; it now resolves to the replica entry.
- **L2/L3/L5** `ScheduleKeyDeletion` window validated (7..=30); `ReEncrypt` honors real source/dest algorithms and checks destination `KeyUsage`; non-string `EncryptionContext` values rejected.

## Test plan
- `cargo test -p fakecloud-kms` — 201 passed, 0 failed. New tests: per-key RSA independence, import-length no-panic, pending/disabled state errors, MAC-algorithm mismatch, HMAC_224 round-trip, replica-ARN describe, deletion-window range, ReEncrypt dest checks, non-string EC rejection.
- Conformance unaffected (behavior fixes, probe shapes unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens `fakecloud-kms` to better match AWS KMS behavior: unique RSA material per key, strict input/state validation, and accurate ReEncrypt/EncryptionContext handling. Also adds `HMAC_SHA_224` support and persists import parameters across restarts.

- **Bug Fixes**
  - RSA keys: each `CreateKey` now mints a unique keypair; prevents cross-key verify/decrypt.
  - Import material: reject non-32-byte inputs to avoid divide-by-zero and DoS.
  - Key state: non-`Enabled` states return `KMSInvalidStateException`; `Disabled` remains `DisabledException`.
  - MAC: validate `MacAlgorithm` against the key’s advertised algorithms.
  - Multi-Region: resolving a replica ARN returns the replica; replicas record their `primary_region`.
  - Schedule deletion: enforce a 7–30 day `PendingWindowInDays`.
  - EncryptionContext: reject non-string values; propagate errors to Encrypt/Decrypt and data key pair APIs.
  - ReEncrypt: require destination `ENCRYPT_DECRYPT`; honor real source/destination algorithms; asymmetric destinations use RSA-OAEP.
  - Import flow: `GetParametersForImport` persists the wrapping key so the token survives restarts.

- **New Features**
  - Support `HMAC_SHA_224` in `GenerateMac` and `VerifyMac`.

<sup>Written for commit 0324723027585fceb63a757961cad57207d49530. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

