### PR TITLE
fix(eventbridge): correct event-pattern matching + scheduler target delivery

### DIFF
--- a/crates/fakecloud-eventbridge/src/delivery.rs
+++ b/crates/fakecloud-eventbridge/src/delivery.rs
@@ -79,7 +79,7 @@ impl EventBridgeDeliveryImpl {
         // Find matching rules and their targets
         let account_id = state.account_id.clone();
         let region = state.region.clone();
-        let matching_targets: Vec<_> = state
+        let matching_targets: Vec<(String, crate::state::EventTarget)> = state
             .rules
             .values()
             .filter(|r| {
@@ -93,9 +93,11 @@ impl EventBridgeDeliveryImpl {
                         &account_id,
                         &region,
                         &[],
+                        &event_id,
+                        &now.to_rfc3339(),
                     )
             })
-            .flat_map(|r| r.targets.clone())
+            .flat_map(|r| r.targets.iter().map(|t| (r.arn.clone(), t.clone())))
             .collect();
 
         // Drop the lock before delivering
@@ -136,8 +138,15 @@ impl EventBridgeDeliveryImpl {
             account_id: &resolved_account,
             region: &region,
         };
-        for target in matching_targets {
-            dispatch_event_target(&ctx, &target, &event_json, &event_id, detail_type);
+        for (rule_arn, target) in matching_targets {
+            dispatch_event_target(
+                &ctx,
+                &target,
+                &event_json,
+                &event_id,
+                detail_type,
+                Some(&rule_arn),
+            );
         }
     }
 }

--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -27,11 +27,18 @@ pub(crate) fn validate_put_events_entry(
             "ErrorMessage": "Parameter Detail is not valid. Reason: Detail is a required argument.",
         }));
     }
-    if serde_json::from_str::<Value>(detail).is_err() {
-        return Err(json!({
-            "ErrorCode": "MalformedDetail",
-            "ErrorMessage": "Detail is malformed.",
-        }));
+    // AWS requires Detail to be a well-formed JSON *object* (`{...}`).
+    // A syntactically valid but non-object payload (e.g. `"a string"`,
+    // `123`, or `[...]`) is rejected with MalformedDetail, matching the
+    // real service; previously any valid JSON was accepted.
+    match serde_json::from_str::<Value>(detail) {
+        Ok(v) if v.is_object() => {}
+        _ => {
+            return Err(json!({
+                "ErrorCode": "MalformedDetail",
+                "ErrorMessage": "Detail is malformed.",
+            }));
+        }
     }
     Ok(())
 }
@@ -283,7 +290,18 @@ pub(crate) fn validate_pattern_values(value: &Value, path: &str) -> Result<(), A
                 };
                 match val {
                     Value::Object(_) => validate_pattern_values(val, &new_path)?,
-                    Value::Array(_) => {} // Arrays are fine at leaf level
+                    Value::Array(items) => {
+                        // Validate matcher objects that appear in a leaf list
+                        // (e.g. `{"numeric": [...]}`), rejecting malformed
+                        // ones at PutRule/TestEventPattern time.
+                        for item in items {
+                            if let Value::Object(m) = item {
+                                if let Some(num) = m.get("numeric") {
+                                    validate_numeric_matcher(num, &new_path)?;
+                                }
+                            }
+                        }
+                    }
                     _ => {
                         return Err(AwsServiceError::aws_error(
                             StatusCode::BAD_REQUEST,
@@ -386,6 +404,12 @@ fn sanitize_invocation_http_params(inv: &Value) -> Value {
 }
 
 /// Match an event against an EventBridge event pattern.
+///
+/// `id` and `time` are the event's generated envelope fields; they are
+/// woven into the synthetic match event (alongside the constant
+/// `version` of `"0"`) so patterns targeting `id`/`time`/`version` are
+/// matchable, which they previously were not.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn matches_pattern(
     pattern_json: Option<&str>,
     source: &str,
@@ -394,6 +418,8 @@ pub(crate) fn matches_pattern(
     account: &str,
     region: &str,
     resources: &[String],
+    id: &str,
+    time: &str,
 ) -> bool {
     let pattern_json = match pattern_json {
         Some(p) => p,
@@ -411,12 +437,15 @@ pub(crate) fn matches_pattern(
 
     let detail_value: Value = serde_json::from_str(detail).unwrap_or(json!({}));
     let event = json!({
+        "version": "0",
+        "id": id,
         "source": source,
         "detail-type": detail_type,
         "detail": detail_value,
         "account": account,
         "region": region,
         "resources": resources,
+        "time": time,
     });
 
     matches_value(&pattern, &event)
@@ -425,13 +454,12 @@ pub(crate) fn matches_pattern(
 pub(crate) fn matches_value(pattern: &Value, event_value: &Value) -> bool {
     match pattern {
         Value::Object(obj) => {
-            // `$or` is a sibling-level alternation: any alternative pattern
-            // matched against this same event level passes the whole object.
-            if let Some(Value::Array(alternatives)) = obj.get("$or") {
-                return alternatives
-                    .iter()
-                    .any(|alt| matches_value(alt, event_value));
-            }
+            // All sibling keys are ANDed together, and `$or` is a
+            // sibling-level alternation group that is *also* ANDed with the
+            // rest of the object. Previously `$or` short-circuited and the
+            // sibling constraints were never evaluated, so a pattern like
+            // `{"source": ["aws.ec2"], "$or": [...]}` matched events from any
+            // source as long as one alternative matched.
             for (key, sub_pattern) in obj {
                 if key == "$or" {
                     continue;
@@ -441,9 +469,26 @@ pub(crate) fn matches_value(pattern: &Value, event_value: &Value) -> bool {
                     return false;
                 }
             }
+            if let Some(Value::Array(alternatives)) = obj.get("$or") {
+                if !alternatives
+                    .iter()
+                    .any(|alt| matches_value(alt, event_value))
+                {
+                    return false;
+                }
+            }
             true
         }
-        Value::Array(arr) => arr.iter().any(|elem| matches_single(elem, event_value)),
+        // A content-filter list matches if ANY of its elements matches the
+        // event value. When the event value is itself an array, AWS matches
+        // if ANY element of the event array satisfies the filter element
+        // (the whole array is still passed first so presence-style matchers
+        // like `exists` see it), so array-valued event fields are matchable.
+        Value::Array(arr) => arr.iter().any(|elem| {
+            matches_single(elem, event_value)
+                || matches!(event_value, Value::Array(items)
+                    if items.iter().any(|item| matches_single(elem, item)))
+        }),
         _ => false,
     }
 }
@@ -493,24 +538,13 @@ pub(crate) fn matches_single(pattern_elem: &Value, event_value: &Value) -> bool 
                     Value::Number(_) => event_value != anything_but_val,
                     // Nested-matcher negation, e.g.
                     // {"anything-but": {"prefix": "x"}} matches when the
-                    // field does NOT start with "x". Previously the object
-                    // form always matched, so excluded events were still
-                    // delivered (bug-audit 2026-05-28, 1.14).
-                    Value::Object(nested) => {
-                        let fv = event_value.as_str();
-                        if let Some(p) = nested.get("prefix").and_then(|v| v.as_str()) {
-                            !fv.is_some_and(|s| s.starts_with(p))
-                        } else if let Some(suf) = nested.get("suffix").and_then(|v| v.as_str()) {
-                            !fv.is_some_and(|s| s.ends_with(suf))
-                        } else if let Some(eic) =
-                            nested.get("equals-ignore-case").and_then(|v| v.as_str())
-                        {
-                            !fv.is_some_and(|s| s.eq_ignore_ascii_case(eic))
-                        } else {
-                            // Unknown nested matcher: default to matching.
-                            true
-                        }
-                    }
+                    // field does NOT start with "x". Each inner matcher
+                    // accepts a single string or a list of strings; `cidr`
+                    // and `wildcard` are supported too. An unknown/malformed
+                    // inner matcher is conservatively treated as excluding
+                    // the event rather than always delivering it (which the
+                    // previous `else => true` did).
+                    Value::Object(nested) => matches_anything_but_nested(nested, event_value),
                     _ => true,
                 };
             }
@@ -520,6 +554,56 @@ pub(crate) fn matches_single(pattern_elem: &Value, event_value: &Value) -> bool 
             false
         }
         _ => values_equal(pattern_elem, event_value),
+    }
+}
+
+/// Evaluate a nested `anything-but` matcher (e.g.
+/// `{"anything-but": {"prefix": "x"}}`). Returns `true` when the field does
+/// NOT satisfy the inner matcher. Each inner matcher accepts a single string
+/// or a list of strings. Unknown or malformed inner matchers return `false`
+/// (exclude the event) so a filter the caller intended never over-delivers.
+fn matches_anything_but_nested(
+    nested: &serde_json::Map<String, Value>,
+    event_value: &Value,
+) -> bool {
+    let fv = event_value.as_str();
+    // Apply `pred` to a single-string or list-of-strings inner value and
+    // return whether ANY entry matched. A non-string inner value is
+    // malformed and reported as "no decision" via None.
+    fn any_str_hit(v: &Value, pred: &dyn Fn(&str) -> bool) -> Option<bool> {
+        match v {
+            Value::String(s) => Some(pred(s)),
+            Value::Array(a) => Some(a.iter().filter_map(|x| x.as_str()).any(pred)),
+            _ => None,
+        }
+    }
+
+    if let Some(p) = nested.get("prefix") {
+        match any_str_hit(p, &|s| fv.is_some_and(|x| x.starts_with(s))) {
+            Some(hit) => !hit,
+            None => false,
+        }
+    } else if let Some(p) = nested.get("suffix") {
+        match any_str_hit(p, &|s| fv.is_some_and(|x| x.ends_with(s))) {
+            Some(hit) => !hit,
+            None => false,
+        }
+    } else if let Some(p) = nested.get("equals-ignore-case") {
+        match any_str_hit(p, &|s| fv.is_some_and(|x| x.eq_ignore_ascii_case(s))) {
+            Some(hit) => !hit,
+            None => false,
+        }
+    } else if let Some(p) = nested.get("wildcard") {
+        match any_str_hit(p, &|s| fv.is_some_and(|x| wildcard_matches(s, x))) {
+            Some(hit) => !hit,
+            None => false,
+        }
+    } else if let Some(c) = nested.get("cidr").and_then(|v| v.as_str()) {
+        !fv.is_some_and(|x| cidr_matches(c, x))
+    } else {
+        // Unknown / unsupported nested matcher: cannot evaluate, so
+        // conservatively exclude rather than deliver.
+        false
     }
 }
 
@@ -647,6 +731,8 @@ pub(crate) fn archive_matching_event(
             account_id,
             region,
             resources,
+            &event.event_id,
+            &event.time.to_rfc3339(),
         );
         if !pattern_matches {
             continue;
@@ -700,6 +786,8 @@ pub(crate) fn collect_replay_events_with_targets(
                         account_id,
                         region,
                         &event.resources,
+                        &event.event_id,
+                        &event.time.to_rfc3339(),
                     )
             })
             .flat_map(|r| r.targets.clone())
@@ -717,12 +805,19 @@ pub(crate) fn matches_numeric(numeric_arr: &Value, event_value: &Value) -> bool 
         Some(a) => a,
         None => return false,
     };
+    // An empty matcher (`{"numeric": []}`) or one with a dangling trailing
+    // operator (odd length) is invalid and must not match anything; the
+    // old `while i + 1 < arr.len()` loop silently accepted both, so an
+    // empty matcher matched every value.
+    if arr.is_empty() || arr.len() % 2 != 0 {
+        return false;
+    }
     let actual = match event_value.as_f64() {
         Some(n) => n,
         None => return false,
     };
     let mut i = 0;
-    while i + 1 < arr.len() {
+    while i < arr.len() {
         let op = match arr[i].as_str() {
             Some(s) => s,
             None => return false,
@@ -736,7 +831,10 @@ pub(crate) fn matches_numeric(numeric_arr: &Value, event_value: &Value) -> bool 
             ">=" => actual >= threshold,
             "<" => actual < threshold,
             "<=" => actual <= threshold,
-            "=" => (actual - threshold).abs() < f64::EPSILON,
+            // Exact double equality, matching AWS. The previous absolute
+            // `f64::EPSILON` comparison was wrong at large magnitudes (e.g.
+            // 1e18 vs 1e18 + 1000 compared equal).
+            "=" => actual == threshold,
             _ => return false,
         };
         if !ok {
@@ -745,6 +843,39 @@ pub(crate) fn matches_numeric(numeric_arr: &Value, event_value: &Value) -> bool 
         i += 2;
     }
     true
+}
+
+/// Validate the shape of a `{"numeric": [...]}` matcher at pattern-validation
+/// time so malformed matchers surface as `InvalidEventPatternException`
+/// rather than silently never (or always) matching.
+fn validate_numeric_matcher(numeric: &Value, path: &str) -> Result<(), AwsServiceError> {
+    let invalid = |reason: &str| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidEventPatternException",
+            format!("Event pattern is not valid. Reason: {reason} at '{path}'"),
+        )
+    };
+    let arr = numeric
+        .as_array()
+        .ok_or_else(|| invalid("\"numeric\" must be an array"))?;
+    if arr.is_empty() || arr.len() % 2 != 0 {
+        return Err(invalid("\"numeric\" must be operator/value pairs"));
+    }
+    let mut i = 0;
+    while i < arr.len() {
+        let op = arr[i]
+            .as_str()
+            .ok_or_else(|| invalid("\"numeric\" operator must be a string"))?;
+        if !matches!(op, ">" | ">=" | "<" | "<=" | "=") {
+            return Err(invalid("unsupported \"numeric\" operator"));
+        }
+        if arr[i + 1].as_f64().is_none() {
+            return Err(invalid("\"numeric\" value must be a number"));
+        }
+        i += 2;
+    }
+    Ok(())
 }
 
 pub(crate) fn values_equal(a: &Value, b: &Value) -> bool {
@@ -765,7 +896,17 @@ pub(crate) fn resolve_json_path(event: &Value, path: &str) -> Option<Value> {
 }
 
 /// Apply an EventBridge InputTransformer to an event.
-pub(crate) fn apply_input_transformer(transformer: &Value, event: &Value) -> String {
+///
+/// Besides user-defined `InputPathsMap` variables, EventBridge exposes a set
+/// of predefined reserved variables that are resolved here:
+///   * `<aws.events.event.json>` — the whole matched event as JSON.
+///   * `<aws.events.event.ingestion-time>` — the event's `time` field.
+///   * `<aws.events.rule-arn>` — the ARN of the matching rule (when known).
+pub(crate) fn apply_input_transformer(
+    transformer: &Value,
+    event: &Value,
+    rule_arn: Option<&str>,
+) -> String {
     let input_paths_map = transformer
         .get("InputPathsMap")
         .and_then(|v| v.as_object())
@@ -796,6 +937,22 @@ pub(crate) fn apply_input_transformer(transformer: &Value, event: &Value) -> Str
             other => other.to_string(),
         };
         result = result.replace(&placeholder, &replacement);
+    }
+
+    // Resolve EventBridge's predefined reserved variables.
+    if result.contains("<aws.events.event.json>") {
+        result = result.replace("<aws.events.event.json>", &event.to_string());
+    }
+    if result.contains("<aws.events.event.ingestion-time>") {
+        let ingestion_time = event
+            .get("time")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| Utc::now().to_rfc3339());
+        result = result.replace("<aws.events.event.ingestion-time>", &ingestion_time);
+    }
+    if let Some(arn) = rule_arn {
+        result = result.replace("<aws.events.rule-arn>", arn);
     }
 
     result
@@ -1038,11 +1195,12 @@ pub(crate) fn dispatch_event_target(
     event_json: &Value,
     event_id: &str,
     detail_type: &str,
+    rule_arn: Option<&str>,
 ) {
     let arn = &target.arn;
     let event_str = event_json.to_string();
     let body_str = if let Some(ref transformer) = target.input_transformer {
-        apply_input_transformer(transformer, event_json)
+        apply_input_transformer(transformer, event_json, rule_arn)
     } else if let Some(ref input) = target.input {
         input.clone()
     } else if let Some(ref input_path) = target.input_path {

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_lambda::runtime::ContainerRuntime;
-use fakecloud_lambda::{LambdaInvocation, SharedLambdaState};
+use fakecloud_lambda::SharedLambdaState;
 use fakecloud_logs::SharedLogsState;
 
 use crate::state::SharedEventBridgeState;
@@ -111,21 +111,41 @@ fn parse_schedule(expr: &str) -> Option<Schedule> {
     None
 }
 
+/// Returns whether `expr` is a syntactically valid EventBridge schedule
+/// expression (`rate(...)` or `cron(...)`). Used by `PutRule` to reject a
+/// malformed `ScheduleExpression` with a `ValidationException` instead of
+/// silently storing a rule that never fires.
+pub(crate) fn is_valid_schedule_expression(expr: &str) -> bool {
+    parse_schedule(expr).is_some()
+}
+
 fn parse_rate(inner: &str) -> Option<Schedule> {
     let parts: Vec<&str> = inner.split_whitespace().collect();
     if parts.len() != 2 {
         return None;
     }
     let value: u64 = parts[0].parse().ok()?;
-    let unit = parts[1];
-    let secs = match unit {
-        "second" | "seconds" => value,
-        "minute" | "minutes" => value * 60,
-        "hour" | "hours" => value * 3600,
-        "day" | "days" => value * 86400,
+    // AWS requires a positive value: `rate(0 ...)` is rejected.
+    if value == 0 {
+        return None;
+    }
+    // The unit must be singular iff the value is 1 (`rate(1 minute)` /
+    // `rate(5 minutes)`); a singular/plural mismatch is rejected.
+    let (secs_per, singular) = match parts[1] {
+        "second" => (1, true),
+        "seconds" => (1, false),
+        "minute" => (60, true),
+        "minutes" => (60, false),
+        "hour" => (3600, true),
+        "hours" => (3600, false),
+        "day" => (86400, true),
+        "days" => (86400, false),
         _ => return None,
     };
-    Some(Schedule::Rate(Duration::from_secs(secs)))
+    if singular != (value == 1) {
+        return None;
+    }
+    Some(Schedule::Rate(Duration::from_secs(value * secs_per)))
 }
 
 fn parse_cron(inner: &str) -> Option<Schedule> {
@@ -335,8 +355,15 @@ impl Scheduler {
         let now = Utc::now();
 
         // Collect rules that need to fire (to avoid holding lock during delivery)
-        // Each entry includes the account_id that owns the rule
-        let mut to_fire: Vec<(String, String, String, Vec<crate::state::EventTarget>)> = Vec::new();
+        // Each entry includes the account_id that owns the rule and the rule
+        // ARN (so InputTransformer can resolve `<aws.events.rule-arn>`).
+        let mut to_fire: Vec<(
+            String,
+            String,
+            String,
+            String,
+            Vec<crate::state::EventTarget>,
+        )> = Vec::new();
 
         {
             let mut accounts = self.state.write();
@@ -397,125 +424,57 @@ impl Scheduler {
 
                     if should_fire {
                         let targets = rule.targets.clone();
+                        let rule_arn = rule.arn.clone();
                         // Update last_fired while we hold the write lock
                         if let Some(r) = state.rules.get_mut(&key) {
                             r.last_fired = Some(now);
                         }
-                        to_fire.push((account_id.clone(), region.clone(), name, targets));
+                        to_fire.push((account_id.clone(), region.clone(), name, rule_arn, targets));
                     }
                 }
             }
         }
         // Lock is dropped here
 
-        // Deliver events
-        for (account_id, region, rule_name, targets) in to_fire {
+        // Deliver events. Reuse the shared single-target dispatch so scheduled
+        // rules honour the same target shape as PutEvents-driven rules —
+        // Input / InputPath / InputTransformer resolution plus the Kinesis,
+        // api-destination and FIFO MessageGroupId branches — instead of the
+        // scheduler's previous reduced delivery path.
+        for (account_id, region, rule_name, rule_arn, targets) in to_fire {
             let event_id = uuid::Uuid::new_v4().to_string();
             let event_json = json!({
                 "version": "0",
                 "id": event_id,
                 "source": "aws.events",
+                "account": account_id,
                 "detail-type": "Scheduled Event",
                 "detail": {},
                 "time": now.to_rfc3339(),
                 "region": region,
+                "resources": [],
             });
-            let event_str = event_json.to_string();
 
             tracing::debug!(rule = %rule_name, targets = targets.len(), "scheduler firing");
 
+            let ctx = crate::service::EventDispatchContext {
+                state: &self.state,
+                delivery: &self.delivery,
+                lambda_state: self.lambda_state.as_ref(),
+                logs_state: self.logs_state.as_ref(),
+                container_runtime: &self.container_runtime,
+                account_id: &account_id,
+                region: &region,
+            };
             for target in &targets {
-                let arn = &target.arn;
-                if arn.contains(":sqs:") {
-                    self.delivery.send_to_sqs(arn, &event_str, &HashMap::new());
-                } else if arn.contains(":sns:") {
-                    self.delivery
-                        .publish_to_sns(arn, &event_str, Some("Scheduled Event"));
-                } else if arn.contains(":lambda:") {
-                    tracing::info!(
-                        function_arn = %arn,
-                        payload = %event_str,
-                        "Scheduler delivering to Lambda function"
-                    );
-                    let mut eb_accounts = self.state.write();
-                    let eb_state = eb_accounts.get_or_create(&account_id);
-                    eb_state
-                        .lambda_invocations
-                        .push(crate::state::LambdaInvocation {
-                            function_arn: arn.clone(),
-                            payload: event_str.clone(),
-                            timestamp: now,
-                        });
-                    drop(eb_accounts);
-                    if let Some(ref ls) = self.lambda_state {
-                        ls.write()
-                            .get_or_create(&account_id)
-                            .invocations
-                            .push(LambdaInvocation {
-                                function_arn: arn.clone(),
-                                payload: event_str.clone(),
-                                timestamp: now,
-                                source: "aws:events".to_string(),
-                            });
-                    }
-                    crate::service::invoke_lambda_async(
-                        &self.container_runtime,
-                        &self.lambda_state,
-                        arn,
-                        &event_str,
-                    );
-                } else if arn.contains(":logs:") {
-                    tracing::info!(
-                        log_group_arn = %arn,
-                        payload = %event_str,
-                        "Scheduler delivering to CloudWatch Logs"
-                    );
-                    let mut eb_accounts = self.state.write();
-                    let eb_state = eb_accounts.get_or_create(&account_id);
-                    eb_state.log_deliveries.push(crate::state::LogDelivery {
-                        log_group_arn: arn.clone(),
-                        payload: event_str.clone(),
-                        timestamp: now,
-                    });
-                    drop(eb_accounts);
-                    if let Some(ref log_state) = self.logs_state {
-                        crate::service::deliver_to_logs(log_state, arn, &event_str, now);
-                    }
-                } else if arn.contains(":states:") {
-                    tracing::info!(
-                        state_machine_arn = %arn,
-                        "Scheduler delivering to Step Functions"
-                    );
-                    self.delivery.start_stepfunctions_execution(arn, &event_str);
-                    let mut eb_accounts = self.state.write();
-                    let eb_state = eb_accounts.get_or_create(&account_id);
-                    eb_state
-                        .step_function_executions
-                        .push(crate::state::StepFunctionExecution {
-                            state_machine_arn: arn.clone(),
-                            payload: event_str.clone(),
-                            timestamp: now,
-                        });
-                } else if arn.starts_with("https://") || arn.starts_with("http://") {
-                    let url = arn.clone();
-                    let payload = event_str.clone();
-                    tokio::spawn(async move {
-                        let client = reqwest::Client::new();
-                        let result = client
-                            .post(&url)
-                            .header("Content-Type", "application/json")
-                            .body(payload)
-                            .send()
-                            .await;
-                        if let Err(e) = result {
-                            tracing::warn!(
-                                endpoint = %url,
-                                error = %e,
-                                "Scheduler HTTP target delivery failed"
-                            );
-                        }
-                    });
-                }
+                crate::service::dispatch_event_target(
+                    &ctx,
+                    target,
+                    &event_json,
+                    &event_id,
+                    "Scheduled Event",
+                    Some(&rule_arn),
+                );
             }
         }
     }
@@ -580,9 +539,19 @@ mod tests {
     }
 
     #[test]
-    fn parse_rate_zero_is_valid() {
-        let s = parse_schedule("rate(0 seconds)");
-        assert!(matches!(s, Some(Schedule::Rate(d)) if d == Duration::ZERO));
+    fn parse_rate_zero_is_rejected() {
+        // AWS requires a positive value; `rate(0 ...)` is invalid.
+        assert!(parse_schedule("rate(0 seconds)").is_none());
+        assert!(parse_schedule("rate(0 minutes)").is_none());
+    }
+
+    #[test]
+    fn parse_rate_singular_plural_mismatch_rejected() {
+        // Unit must be singular iff value == 1.
+        assert!(parse_schedule("rate(1 minutes)").is_none());
+        assert!(parse_schedule("rate(5 minute)").is_none());
+        assert!(parse_schedule("rate(1 minute)").is_some());
+        assert!(parse_schedule("rate(5 minutes)").is_some());
     }
 
     #[test]
@@ -884,6 +853,58 @@ mod tests {
             let payload: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
             assert_eq!(payload["detail-type"], "Scheduled Event");
             assert_eq!(payload["source"], "aws.events");
+        }
+
+        #[test]
+        fn tick_delivers_constant_input_to_sqs() {
+            // H3: the scheduler now reuses the shared dispatch, so a target
+            // with a constant Input delivers that constant instead of the
+            // full scheduled-event envelope.
+            let (shared, _) = make_state();
+            let q_arn = "arn:aws:sqs:us-east-1:123456789012:q-input".to_string();
+            {
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
+                let mut rule = make_rule("r", "rate(1 second)", &q_arn);
+                rule.targets[0].input = Some("{\"constant\":42}".to_string());
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let scheduler = build_scheduler(shared.clone(), recorder.clone());
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            scheduler.tick(&mut last);
+            let calls = recorder.sqs.lock().unwrap();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0].0, q_arn);
+            assert_eq!(calls[0].1, "{\"constant\":42}");
+        }
+
+        #[test]
+        fn tick_delivers_to_kinesis_target() {
+            // H3: the scheduler previously had no Kinesis branch.
+            let (shared, _) = make_state();
+            let stream_arn = "arn:aws:kinesis:us-east-1:123456789012:stream/s".to_string();
+            {
+                let mut s_accounts = shared.write();
+                let s = s_accounts.default_mut();
+                let rule = make_rule("r", "rate(1 second)", &stream_arn);
+                s.rules
+                    .insert(("default".to_string(), "r".to_string()), rule);
+            }
+            let recorder = Arc::new(Recorder::default());
+            let bus = Arc::new(DeliveryBus::new().with_kinesis(recorder.clone()));
+            let scheduler = Scheduler::new(shared.clone(), bus);
+            let mut last = HashMap::<RuleKey, (u32, u32)>::new();
+            // Should not panic and should mark the rule fired.
+            scheduler.tick(&mut last);
+            let mas = shared.read();
+            let rule = mas
+                .default_ref()
+                .rules
+                .get(&("default".to_string(), "r".to_string()))
+                .unwrap();
+            assert!(rule.last_fired.is_some());
         }
 
         #[test]

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -637,6 +637,23 @@ impl EventBridgeService {
         if let Some(pattern) = body["EventPattern"].as_str().filter(|s| !s.is_empty()) {
             validate_event_pattern(pattern)?;
         }
+        // Reject a malformed ScheduleExpression up front, like AWS. Previously
+        // only the length was checked, so a rule with e.g. `rate(5 minute)` or
+        // `cron(bad)` was stored and simply never fired.
+        if let Some(schedule) = body["ScheduleExpression"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+        {
+            if !crate::scheduler::is_valid_schedule_expression(schedule) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!(
+                        "Parameter ScheduleExpression is not valid. Reason: {schedule} is not a valid expression."
+                    ),
+                ));
+            }
+        }
         validate_optional_enum_value(
             "State",
             &body["State"],
@@ -1196,7 +1213,7 @@ impl EventBridgeService {
         })?;
 
         // Parse the pattern JSON
-        let _pattern: Value = serde_json::from_str(event_pattern).map_err(|_| {
+        let pattern: Value = serde_json::from_str(event_pattern).map_err(|_| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidEventPatternException",
@@ -1204,32 +1221,15 @@ impl EventBridgeService {
             )
         })?;
 
-        let source = event["source"].as_str().unwrap_or("");
-        let detail_type = event["detail-type"].as_str().unwrap_or("");
-        let detail = event
-            .get("detail")
-            .map(|v| serde_json::to_string(v).unwrap_or_default())
-            .unwrap_or_else(|| "{}".to_string());
-        let account = event["account"].as_str().unwrap_or("");
-        let region = event["region"].as_str().unwrap_or("");
-        let resources: Vec<String> = event["resources"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect()
-            })
-            .unwrap_or_default();
+        // Reject an invalid pattern (scalar leaf, malformed numeric matcher,
+        // etc.) with InvalidEventPatternException instead of silently
+        // returning {"Result": false}.
+        validate_pattern_values(&pattern, "")?;
 
-        let result = matches_pattern(
-            Some(event_pattern),
-            source,
-            detail_type,
-            &detail,
-            account,
-            region,
-            &resources,
-        );
+        // Match directly against the caller-supplied event so all of its
+        // fields — including id / time / version — are matchable, rather than
+        // reconstructing a partial synthetic event that dropped them.
+        let result = matches_value(&pattern, &event);
 
         Ok(AwsResponse::ok_json(json!({ "Result": result })))
     }
@@ -1425,8 +1425,9 @@ impl EventBridgeService {
 
             state.events.push(event);
 
-            // Find matching rules and their targets
-            let matching_targets: Vec<EventTarget> = state
+            // Find matching rules and their targets, carrying each rule's ARN
+            // so the InputTransformer can resolve `<aws.events.rule-arn>`.
+            let matching_targets: Vec<(String, EventTarget)> = state
                 .rules
                 .values()
                 .filter(|r| {
@@ -1440,9 +1441,11 @@ impl EventBridgeService {
                             &req.account_id,
                             &req.region,
                             &resources,
+                            &event_id,
+                            &time.to_rfc3339(),
                         )
                 })
-                .flat_map(|r| r.targets.clone())
+                .flat_map(|r| r.targets.iter().map(|t| (r.arn.clone(), t.clone())))
                 .collect();
 
             if !matching_targets.is_empty() {
@@ -1490,8 +1493,15 @@ impl EventBridgeService {
                 account_id: &req.account_id,
                 region: &req.region,
             };
-            for target in targets {
-                dispatch_event_target(&ctx, &target, &event_json, &event_id, &detail_type);
+            for (rule_arn, target) in targets {
+                dispatch_event_target(
+                    &ctx,
+                    &target,
+                    &event_json,
+                    &event_id,
+                    &detail_type,
+                    Some(&rule_arn),
+                );
             }
         }
 

--- a/crates/fakecloud-eventbridge/src/service_archives_replays.rs
+++ b/crates/fakecloud-eventbridge/src/service_archives_replays.rs
@@ -475,7 +475,9 @@ impl EventBridgeService {
     ) {
         let target_arn = &target.arn;
         let body_str = if let Some(ref transformer) = target.input_transformer {
-            apply_input_transformer(transformer, event_json)
+            // Replay does not track which rule matched, so the rule-arn
+            // reserved variable is left unresolved here.
+            apply_input_transformer(transformer, event_json, None)
         } else if let Some(ref input) = target.input {
             input.clone()
         } else if let Some(ref input_path) = target.input_path {

--- a/crates/fakecloud-eventbridge/src/service_partner_sources.rs
+++ b/crates/fakecloud-eventbridge/src/service_partner_sources.rs
@@ -386,7 +386,7 @@ impl EventBridgeService {
             state.events.push(event);
 
             // Route to rules attached to the partner event bus.
-            let matching_targets: Vec<EventTarget> = state
+            let matching_targets: Vec<(String, EventTarget)> = state
                 .rules
                 .values()
                 .filter(|r| {
@@ -400,9 +400,11 @@ impl EventBridgeService {
                             &req.account_id,
                             &req.region,
                             &resources,
+                            &event_id,
+                            &time.to_rfc3339(),
                         )
                 })
-                .flat_map(|r| r.targets.clone())
+                .flat_map(|r| r.targets.iter().map(|t| (r.arn.clone(), t.clone())))
                 .collect();
 
             if !matching_targets.is_empty() {
@@ -445,8 +447,15 @@ impl EventBridgeService {
                 account_id: &req.account_id,
                 region: &req.region,
             };
-            for target in targets {
-                dispatch_event_target(&ctx, &target, &event_json, &event_id, &detail_type);
+            for (rule_arn, target) in targets {
+                dispatch_event_target(
+                    &ctx,
+                    &target,
+                    &event_json,
+                    &event_id,
+                    &detail_type,
+                    Some(&rule_arn),
+                );
             }
         }
 

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -10,6 +10,8 @@ fn test_matches(pattern_json: Option<&str>, source: &str, detail_type: &str, det
         "123456789012",
         "us-east-1",
         &[],
+        "test-event-id",
+        "2026-01-01T00:00:00Z",
     )
 }
 
@@ -300,6 +302,191 @@ fn mixed_matchers_and_literals() {
         "{}"
     ));
     assert!(!test_matches(Some(pattern), "other.source", "Event", "{}"));
+}
+
+// ---- $or ANDs its sibling constraints (H1) ----
+
+#[test]
+fn or_group_is_anded_with_siblings() {
+    let pattern = r#"{"source":["aws.ec2"],"$or":[{"detail":{"state":["running"]}},{"detail":{"state":["stopped"]}}]}"#;
+    // Sibling source must still hold: an s3 event does NOT match even though
+    // an $or alternative would.
+    assert!(!test_matches(
+        Some(pattern),
+        "aws.s3",
+        "Event",
+        r#"{"state":"running"}"#
+    ));
+    // Matching source AND one $or alternative matches.
+    assert!(test_matches(
+        Some(pattern),
+        "aws.ec2",
+        "Event",
+        r#"{"state":"stopped"}"#
+    ));
+    // Matching source but NO $or alternative does not match.
+    assert!(!test_matches(
+        Some(pattern),
+        "aws.ec2",
+        "Event",
+        r#"{"state":"terminated"}"#
+    ));
+}
+
+// ---- array-valued event fields match content filters (H2) ----
+
+#[test]
+fn array_valued_field_matches_content_filter() {
+    // event tags is an array; pattern lists a single wanted value.
+    assert!(test_matches(
+        Some(r#"{"detail":{"tags":["b"]}}"#),
+        "app",
+        "Event",
+        r#"{"tags":["a","b"]}"#
+    ));
+    assert!(!test_matches(
+        Some(r#"{"detail":{"tags":["z"]}}"#),
+        "app",
+        "Event",
+        r#"{"tags":["a","b"]}"#
+    ));
+}
+
+#[test]
+fn array_valued_field_matches_prefix_filter() {
+    assert!(test_matches(
+        Some(r#"{"detail":{"tags":[{"prefix":"pre"}]}}"#),
+        "app",
+        "Event",
+        r#"{"tags":["nope","prefixed"]}"#
+    ));
+    assert!(!test_matches(
+        Some(r#"{"detail":{"tags":[{"prefix":"pre"}]}}"#),
+        "app",
+        "Event",
+        r#"{"tags":["nope","other"]}"#
+    ));
+}
+
+// ---- anything-but nested matchers (L1) ----
+
+#[test]
+fn anything_but_nested_prefix_excludes() {
+    let pattern = r#"{"detail":{"name":[{"anything-but":{"prefix":"tmp-"}}]}}"#;
+    // Value starting with tmp- is excluded (no match).
+    assert!(!test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"name":"tmp-file"}"#
+    ));
+    // Any other value matches.
+    assert!(test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"name":"prod-file"}"#
+    ));
+}
+
+#[test]
+fn anything_but_nested_cidr_excludes() {
+    let pattern = r#"{"detail":{"ip":[{"anything-but":{"cidr":"10.0.0.0/8"}}]}}"#;
+    assert!(!test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"ip":"10.1.2.3"}"#
+    ));
+    assert!(test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"ip":"192.168.0.1"}"#
+    ));
+}
+
+// ---- numeric matcher exactness / validation (L2) ----
+
+#[test]
+fn numeric_equals_is_exact_at_large_magnitude() {
+    // 1e18 vs 1e18 + 1000 must NOT be equal (old absolute-epsilon bug).
+    assert!(!test_matches(
+        Some(r#"{"detail":{"n":[{"numeric":["=",1e18]}]}}"#),
+        "app",
+        "Event",
+        r#"{"n":1.000000000000001e18}"#
+    ));
+    assert!(test_matches(
+        Some(r#"{"detail":{"n":[{"numeric":["=",1e18]}]}}"#),
+        "app",
+        "Event",
+        r#"{"n":1e18}"#
+    ));
+}
+
+#[test]
+fn empty_numeric_matcher_matches_nothing() {
+    // Runtime matcher must not match everything; validation also rejects it.
+    assert!(!matches_numeric(&json!([]), &json!(5)));
+}
+
+// ---- id / time / version become matchable (L4) ----
+
+#[test]
+fn version_field_is_matchable() {
+    assert!(test_matches(
+        Some(r#"{"version":["0"]}"#),
+        "app",
+        "Event",
+        "{}"
+    ));
+    assert!(!test_matches(
+        Some(r#"{"version":["9"]}"#),
+        "app",
+        "Event",
+        "{}"
+    ));
+}
+
+#[test]
+fn id_field_is_matchable() {
+    // The synthetic event now carries the id passed to matches_pattern.
+    assert!(test_matches(
+        Some(r#"{"id":["test-event-id"]}"#),
+        "app",
+        "Event",
+        "{}"
+    ));
+}
+
+// ---- InputTransformer reserved variables (M2) ----
+
+#[test]
+fn input_transformer_resolves_reserved_variables() {
+    let event = json!({
+        "id": "evt-1",
+        "source": "aws.ec2",
+        "detail-type": "State Change",
+        "detail": {"state": "running"},
+        "time": "2026-01-02T03:04:05Z",
+    });
+    let transformer = json!({
+        "InputPathsMap": {"st": "$.detail.state"},
+        "InputTemplate": "\"<st> at <aws.events.event.ingestion-time> rule <aws.events.rule-arn> json=<aws.events.event.json>\""
+    });
+    let out = apply_input_transformer(
+        &transformer,
+        &event,
+        Some("arn:aws:events:us-east-1:123456789012:rule/r"),
+    );
+    assert!(out.contains("running"));
+    assert!(out.contains("2026-01-02T03:04:05Z"));
+    assert!(out.contains("arn:aws:events:us-east-1:123456789012:rule/r"));
+    // <aws.events.event.json> expands to the full event JSON.
+    assert!(out.contains("\\\"state\\\":\\\"running\\\"") || out.contains("aws.ec2"));
+    // No unresolved reserved placeholders remain.
+    assert!(!out.contains("<aws.events."));
 }
 
 // ---- list_connections / list_api_destinations filtering & pagination ----
@@ -820,6 +1007,39 @@ fn test_event_pattern_no_match() {
     let resp = svc.test_event_pattern(&req).unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(body["Result"], false);
+}
+
+#[test]
+fn test_event_pattern_invalid_pattern_errors() {
+    // A scalar leaf (must be an object or array) is an invalid pattern and
+    // must surface InvalidEventPatternException, not {"Result": false}.
+    let svc = make_service();
+    let req = make_request(
+        "TestEventPattern",
+        json!({
+            "EventPattern": r#"{"source": "my.app"}"#,
+            "Event": r#"{"source": "my.app"}"#
+        }),
+    );
+    let err = svc.test_event_pattern(&req).err().expect("expected error");
+    assert_eq!(err.code(), "InvalidEventPatternException");
+}
+
+#[test]
+fn test_event_pattern_matches_id_field() {
+    // Matching directly against the caller-supplied event makes id/time/
+    // version matchable (previously dropped by a synthetic rebuild).
+    let svc = make_service();
+    let req = make_request(
+        "TestEventPattern",
+        json!({
+            "EventPattern": r#"{"id": ["abc-123"]}"#,
+            "Event": r#"{"id": "abc-123", "source": "my.app", "detail": {}}"#
+        }),
+    );
+    let resp = svc.test_event_pattern(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Result"], true);
 }
 
 #[test]
@@ -1632,6 +1852,41 @@ fn put_rule_accepts_schedule_on_non_default_bus() {
 }
 
 #[test]
+fn put_rule_rejects_malformed_schedule_expression() {
+    let svc = make_service();
+    // Singular/plural mismatch.
+    let req = make_request(
+        "PutRule",
+        json!({ "Name": "bad-rate", "ScheduleExpression": "rate(5 minute)" }),
+    );
+    let err = svc.put_rule(&req).err().expect("expected error");
+    assert_eq!(err.code(), "ValidationException");
+
+    // Malformed cron.
+    let req = make_request(
+        "PutRule",
+        json!({ "Name": "bad-cron", "ScheduleExpression": "cron(bad)" }),
+    );
+    let err = svc.put_rule(&req).err().expect("expected error");
+    assert_eq!(err.code(), "ValidationException");
+}
+
+#[test]
+fn put_rule_accepts_valid_schedule_expression() {
+    let svc = make_service();
+    let req = make_request(
+        "PutRule",
+        json!({ "Name": "ok-rate", "ScheduleExpression": "rate(5 minutes)" }),
+    );
+    svc.put_rule(&req).expect("valid rate is accepted");
+    let req = make_request(
+        "PutRule",
+        json!({ "Name": "ok-cron", "ScheduleExpression": "cron(0 12 * * ? *)" }),
+    );
+    svc.put_rule(&req).expect("valid cron is accepted");
+}
+
+#[test]
 fn put_rule_rejects_unknown_event_bus() {
     let svc = make_service();
     let req = make_request(
@@ -2399,6 +2654,32 @@ fn put_events_basic() {
         .unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(body["FailedEntryCount"], 0);
+}
+
+#[test]
+fn put_events_rejects_non_object_detail() {
+    // AWS requires Detail to be a JSON object. A valid-JSON-but-non-object
+    // payload (a bare string / number / array) is rejected with
+    // MalformedDetail rather than accepted.
+    let svc = make_service();
+    let resp = svc
+        .put_events(&make_request(
+            "PutEvents",
+            json!({
+                "Entries": [
+                    {"Source": "aws.s3", "DetailType": "T", "Detail": "\"just a string\""},
+                    {"Source": "aws.s3", "DetailType": "T", "Detail": "[1,2,3]"},
+                    {"Source": "aws.s3", "DetailType": "T", "Detail": "{}"},
+                ]
+            }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["FailedEntryCount"], 2);
+    assert_eq!(body["Entries"][0]["ErrorCode"], "MalformedDetail");
+    assert_eq!(body["Entries"][1]["ErrorCode"], "MalformedDetail");
+    // The object detail succeeds and gets an EventId.
+    assert!(body["Entries"][2]["EventId"].is_string());
 }
 
 // ── Archives ──

--- a/crates/fakecloud-eventbridge/src/simulation.rs
+++ b/crates/fakecloud-eventbridge/src/simulation.rs
@@ -1,14 +1,13 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::Utc;
 use serde_json::json;
 
 use fakecloud_core::delivery::DeliveryBus;
-use fakecloud_lambda::{LambdaInvocation, SharedLambdaState};
+use fakecloud_lambda::SharedLambdaState;
 use fakecloud_logs::SharedLogsState;
 
-use crate::state::{EventTarget, SharedEventBridgeState};
+use crate::state::SharedEventBridgeState;
 
 /// Result of firing a rule via simulation.
 #[derive(Debug)]
@@ -46,7 +45,7 @@ pub fn fire_rule(
     let logs_state = ctx.logs_state;
     let container_runtime = ctx.container_runtime;
 
-    let (targets, account_id, region) = {
+    let (targets, rule_arn, account_id, region) = {
         let eb_accounts = state.read();
         let eb_state = eb_accounts.default_ref();
 
@@ -63,6 +62,7 @@ pub fn fire_rule(
 
         (
             rule.targets.clone(),
+            rule.arn.clone(),
             eb_state.account_id.clone(),
             eb_state.region.clone(),
         )
@@ -87,7 +87,6 @@ pub fn fire_rule(
         "region": region,
         "resources": [],
     });
-    let event_str = event_json.to_string();
 
     // Record the event in state
     {
@@ -104,78 +103,35 @@ pub fn fire_rule(
         });
     }
 
+    // Deliver through the shared single-target dispatch so the simulation
+    // endpoint honours exactly the same target handling as real PutEvents /
+    // scheduler delivery — Input / InputPath / InputTransformer resolution and
+    // the SQS(FIFO) / SNS / Lambda / Logs / Kinesis / StepFunctions /
+    // api-destination / HTTP branches — instead of a reduced local copy.
+    let ctx = crate::service::EventDispatchContext {
+        state,
+        delivery,
+        lambda_state: lambda_state.as_ref(),
+        logs_state: logs_state.as_ref(),
+        container_runtime,
+        account_id: &account_id,
+        region: &region,
+    };
+
     let mut fired = Vec::new();
-
     for target in &targets {
-        let arn = &target.arn;
-        let body_str = resolve_target_body(target, &event_json, &event_str);
-
-        if arn.contains(":sqs:") {
-            // Extract MessageGroupId from SqsParameters if present (required for FIFO queues)
-            let message_group_id = target
-                .sqs_parameters
-                .as_ref()
-                .and_then(|sp| sp["MessageGroupId"].as_str())
-                .map(|s| s.to_string());
-
-            if message_group_id.is_some() {
-                delivery.send_to_sqs_with_attrs(
-                    arn,
-                    &body_str,
-                    &HashMap::new(),
-                    message_group_id.as_deref(),
-                    None,
-                );
-            } else {
-                delivery.send_to_sqs(arn, &body_str, &HashMap::new());
-            }
+        crate::service::dispatch_event_target(
+            &ctx,
+            target,
+            &event_json,
+            &event_id,
+            "Scheduled Event",
+            Some(&rule_arn),
+        );
+        if let Some(target_type) = classify_target_type(&target.arn) {
             fired.push(FiredTarget {
-                target_type: "sqs".to_string(),
-                arn: arn.clone(),
-            });
-        } else if arn.contains(":sns:") {
-            delivery.publish_to_sns(arn, &body_str, Some("Scheduled Event"));
-            fired.push(FiredTarget {
-                target_type: "sns".to_string(),
-                arn: arn.clone(),
-            });
-        } else if arn.contains(":lambda:") {
-            let mut s_accounts = state.write();
-            let s = s_accounts.default_mut();
-            s.lambda_invocations.push(crate::state::LambdaInvocation {
-                function_arn: arn.clone(),
-                payload: body_str.clone(),
-                timestamp: now,
-            });
-            drop(s_accounts);
-            if let Some(ref ls) = lambda_state {
-                ls.write().default_mut().invocations.push(LambdaInvocation {
-                    function_arn: arn.clone(),
-                    payload: body_str.clone(),
-                    timestamp: now,
-                    source: "aws:events".to_string(),
-                });
-            }
-            crate::service::invoke_lambda_async(container_runtime, lambda_state, arn, &body_str);
-            fired.push(FiredTarget {
-                target_type: "lambda".to_string(),
-                arn: arn.clone(),
-            });
-        } else if arn.contains(":logs:") {
-            let mut s_accounts = state.write();
-            let s = s_accounts.default_mut();
-            s.log_deliveries.push(crate::state::LogDelivery {
-                log_group_arn: arn.clone(),
-                payload: body_str.clone(),
-                timestamp: now,
-            });
-            drop(s_accounts);
-            if let Some(ref log_state) = logs_state {
-                crate::service::deliver_to_logs(log_state, arn, &body_str, now);
-            }
-            fired.push(FiredTarget {
-                target_type: "logs".to_string(),
-                arn: arn.clone(),
+                target_type,
+                arn: target.arn.clone(),
             });
         }
     }
@@ -183,44 +139,35 @@ pub fn fire_rule(
     Ok(fired)
 }
 
-/// Compute the message body for a target, applying Input / InputPath if
-/// present.
-///
-/// **Limitations**: `InputTransformer` is not yet implemented — if a target
-/// has one configured, we fall through to the full event envelope. Real AWS
-/// evaluates the `InputPathsMap` + `InputTemplate` to build the payload;
-/// implementing that requires a JSONPath evaluator. `InputPath` supports
-/// only the simple `$.field` case (single top-level key); deeper paths
-/// fall back to the full event.
-fn resolve_target_body(
-    target: &EventTarget,
-    event_json: &serde_json::Value,
-    event_str: &str,
-) -> String {
-    if let Some(ref input) = target.input {
-        return input.clone();
-    }
-
-    if let Some(ref input_path) = target.input_path {
-        // Support simple top-level JSONPath like "$.detail"
-        if let Some(key) = input_path.strip_prefix("$.") {
-            if !key.contains('.') && !key.contains('[') {
-                if let Some(val) = event_json.get(key) {
-                    return val.to_string();
-                }
-            }
-        }
-    }
-
-    // InputTransformer is not yet supported — fall through to full event.
-
-    event_str.to_string()
+/// Map a target ARN to the target-type label reported by the simulation
+/// endpoint. Mirrors the branch selection in `dispatch_event_target`.
+fn classify_target_type(arn: &str) -> Option<String> {
+    let ty = if arn.contains(":sqs:") {
+        "sqs"
+    } else if arn.contains(":sns:") {
+        "sns"
+    } else if arn.contains(":lambda:") {
+        "lambda"
+    } else if arn.contains(":logs:") {
+        "logs"
+    } else if arn.contains(":kinesis:") {
+        "kinesis"
+    } else if arn.contains(":states:") {
+        "stepfunctions"
+    } else if arn.contains(":api-destination/") {
+        "api-destination"
+    } else if arn.starts_with("https://") || arn.starts_with("http://") {
+        "http"
+    } else {
+        return None;
+    };
+    Some(ty.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::EventRule;
+    use crate::state::{EventRule, EventTarget};
     use fakecloud_aws::arn::Arn;
     use parking_lot::RwLock;
     use std::collections::BTreeMap;
@@ -477,63 +424,72 @@ mod tests {
     }
 
     #[test]
-    fn resolve_target_body_uses_literal_input() {
-        let target = EventTarget {
-            id: "t".to_string(),
-            arn: "arn:aws:sqs:us-east-1:123:q".to_string(),
-            input: Some("{\"literal\":true}".to_string()),
-            input_path: None,
-            input_transformer: None,
-            sqs_parameters: None,
-            ..Default::default()
+    fn fire_rule_constant_input_delivered_via_shared_dispatch() {
+        // The simulation path now reuses dispatch_event_target, so a target
+        // with a constant Input delivers that constant, and InputPath /
+        // InputTransformer resolution is honoured identically to PutEvents.
+        let state = make_state();
+        let recorder = Arc::new(TestRecorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        add_rule(
+            &state,
+            "default",
+            "constant",
+            true,
+            vec![EventTarget {
+                id: "t1".to_string(),
+                arn: "arn:aws:sqs:us-east-1:123456789012:q".to_string(),
+                input: Some("{\"constant\":true}".to_string()),
+                ..Default::default()
+            }],
+        );
+        let ctx = FireRuleContext {
+            state: &state,
+            delivery: &bus,
+            lambda_state: &None,
+            logs_state: &None,
+            container_runtime: &None,
         };
-        let body = resolve_target_body(&target, &json!({"ignored": 1}), "ignored");
-        assert_eq!(body, "{\"literal\":true}");
+        let fired = fire_rule(&ctx, "default", "constant").unwrap();
+        assert_eq!(fired.len(), 1);
+        let calls = recorder.sqs.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, "{\"constant\":true}");
     }
 
-    #[test]
-    fn resolve_target_body_uses_input_path_for_top_level() {
-        let target = EventTarget {
-            id: "t".to_string(),
-            arn: "arn:aws:sqs:us-east-1:123:q".to_string(),
-            input: None,
-            input_path: Some("$.detail".to_string()),
-            input_transformer: None,
-            sqs_parameters: None,
-            ..Default::default()
-        };
-        let event = json!({"detail": {"k": 1}, "other": 2});
-        let body = resolve_target_body(&target, &event, "fallback");
-        assert!(body.contains("\"k\""));
+    #[derive(Default)]
+    struct TestRecorder {
+        sqs: std::sync::Mutex<Vec<(String, String)>>,
     }
 
-    #[test]
-    fn resolve_target_body_falls_back_for_nested_input_path() {
-        let target = EventTarget {
-            id: "t".to_string(),
-            arn: "arn:aws:sqs:us-east-1:123:q".to_string(),
-            input: None,
-            input_path: Some("$.detail.nested".to_string()),
-            input_transformer: None,
-            sqs_parameters: None,
-            ..Default::default()
-        };
-        let body = resolve_target_body(&target, &json!({}), "full-event");
-        assert_eq!(body, "full-event");
-    }
+    impl fakecloud_core::delivery::SqsDelivery for TestRecorder {
+        fn deliver_to_queue(
+            &self,
+            arn: &str,
+            body: &str,
+            _attrs: &std::collections::HashMap<String, String>,
+        ) {
+            self.sqs
+                .lock()
+                .unwrap()
+                .push((arn.to_string(), body.to_string()));
+        }
 
-    #[test]
-    fn resolve_target_body_no_transform_returns_full_event() {
-        let target = EventTarget {
-            id: "t".to_string(),
-            arn: "arn:aws:sqs:us-east-1:123:q".to_string(),
-            input: None,
-            input_path: None,
-            input_transformer: None,
-            sqs_parameters: None,
-            ..Default::default()
-        };
-        let body = resolve_target_body(&target, &json!({}), "full-event");
-        assert_eq!(body, "full-event");
+        fn deliver_to_queue_with_attrs(
+            &self,
+            arn: &str,
+            body: &str,
+            _attrs: &std::collections::HashMap<
+                String,
+                fakecloud_core::delivery::SqsMessageAttribute,
+            >,
+            _group: Option<&str>,
+            _dedup: Option<&str>,
+        ) {
+            self.sqs
+                .lock()
+                .unwrap()
+                .push((arn.to_string(), body.to_string()));
+        }
     }
 }


### PR DESCRIPTION
## Summary
Behavioral hardening of `fakecloud-eventbridge` — routing/matching divergences the conformance probe can't see (it checks each op's response shape in isolation, never which events route where).

- **H1** `$or` short-circuited and ignored sibling constraints -> events delivered to the wrong targets. Siblings are now ANDed with the `$or` group.
- **H2** array-valued event fields never matched content filters (core "any element matches" feature) -> silent under-delivery. Now matches element-wise.
- **H3** the schedule tick ignored target `Input`/`InputPath`/`InputTransformer` and had no Kinesis / API-destination / FIFO branches (unlike `PutEvents` delivery). Scheduled deliveries now share the full target-resolution path.
- **M1** `PutRule` didn't validate `ScheduleExpression` (malformed = silent never-fires) -> now `ValidationException`.
- **M2** `InputTransformer` reserved vars (`<aws.events.event.json>` etc.) left literal -> now resolved.
- **M3** `TestEventPattern` accepted invalid patterns -> now `InvalidEventPatternException`.
- **L1-L6** anything-but nested matchers, numeric exact-compare + validation, non-object Detail rejection, id/time/version matchability, simulation-path alignment, rate() strictness.

## Test plan
- `cargo test -p fakecloud-eventbridge` unit tests for each finding (pattern matching, scheduler delivery, validation).
- Conformance unaffected (behavior fixes; default probe shapes unchanged). CI runs full clippy + conformance + e2e.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes event pattern matching and scheduler delivery in `fakecloud-eventbridge` to align routing with AWS and prevent over/under-delivery. Adds stricter validation and resolves InputTransformer reserved variables.

- **Bug Fixes**
  - Pattern matching: `$or` now ANDs with siblings; array-valued fields match element-wise; nested `anything-but` supported; numeric `"="` is exact and validated; `id`/`time`/`version` are matchable.
  - Scheduler: scheduled targets use the same delivery path as PutEvents, honoring `Input`, `InputPath`, `InputTransformer`, and delivering to Kinesis, API destinations, and SQS FIFO.
  - Validation: `PutRule` rejects malformed `ScheduleExpression` (rate must be >0 with correct singular/plural; cron syntax checked); `TestEventPattern` errors on invalid patterns; `PutEvents` rejects non-object `Detail`.
  - InputTransformer: resolves `<aws.events.event.json>`, `<aws.events.event.ingestion-time>`, and `<aws.events.rule-arn>`.

- **Refactors**
  - Reused the single-target dispatch for scheduler and simulation to keep behavior consistent with PutEvents.
  - Carried rule ARN through delivery so InputTransformer can resolve `<aws.events.rule-arn>`.

<sup>Written for commit eb9ac293fe5edbeddd866cbb590262bca8b21e01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

