### PR TITLE
fix(stepfunctions): ASL error wildcards, retry/backoff, transition ceiling, nested path validation

### DIFF
--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -482,6 +482,234 @@ async fn sfn_create_with_invalid_definition_fails() {
     assert!(err.is_err());
 }
 
+// M5: a malformed InputPath nested inside a Parallel branch must be rejected at
+// CreateStateMachine, just like a top-level malformed path.
+#[tokio::test]
+async fn sfn_create_rejects_malformed_path_in_parallel_branch() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "Par",
+        "States": {
+            "Par": {
+                "Type": "Parallel",
+                "End": true,
+                "Branches": [{
+                    "StartAt": "Inner",
+                    "States": {
+                        "Inner": {
+                            "Type": "Pass",
+                            "InputPath": "not-a-valid-path",
+                            "End": true
+                        }
+                    }
+                }]
+            }
+        }
+    })
+    .to_string();
+
+    let err = client
+        .create_state_machine()
+        .name("bad-parallel-path")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await;
+    assert!(
+        err.is_err(),
+        "malformed InputPath in Parallel branch must fail"
+    );
+}
+
+// M5: a malformed ItemsPath / InputPath inside a Map ItemProcessor must be
+// rejected at CreateStateMachine.
+#[tokio::test]
+async fn sfn_create_rejects_malformed_path_in_map_processor() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "M",
+        "States": {
+            "M": {
+                "Type": "Map",
+                "End": true,
+                "ItemProcessor": {
+                    "StartAt": "Each",
+                    "States": {
+                        "Each": {
+                            "Type": "Pass",
+                            "OutputPath": "bogus",
+                            "End": true
+                        }
+                    }
+                }
+            }
+        }
+    })
+    .to_string();
+
+    let err = client
+        .create_state_machine()
+        .name("bad-map-path")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await;
+    assert!(
+        err.is_err(),
+        "malformed OutputPath in Map processor must fail"
+    );
+}
+
+// L7: a payload-template key ending in `.$` whose value is a bare literal (not a
+// JSONPath reference or intrinsic) must be rejected at CreateStateMachine.
+#[tokio::test]
+async fn sfn_create_rejects_bare_literal_parameters_ref() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "P",
+        "States": {
+            "P": {
+                "Type": "Pass",
+                "Parameters": { "value.$": "just a literal" },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let err = client
+        .create_state_machine()
+        .name("bad-params-literal")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await;
+    assert!(err.is_err(), "bare-literal .$ value must fail validation");
+}
+
+// L7: a payload-template key ending in `.$` whose value is not a string (e.g. a
+// number) must be rejected at CreateStateMachine.
+#[tokio::test]
+async fn sfn_create_rejects_non_string_parameters_ref() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "P",
+        "States": {
+            "P": {
+                "Type": "Pass",
+                "Parameters": { "value.$": 42 },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let err = client
+        .create_state_machine()
+        .name("bad-params-nonstring")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await;
+    assert!(err.is_err(), "non-string .$ value must fail validation");
+}
+
+// L7: a valid `.$` reference / intrinsic must still be accepted.
+#[tokio::test]
+async fn sfn_create_accepts_valid_parameters_ref() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let definition = serde_json::json!({
+        "StartAt": "P",
+        "States": {
+            "P": {
+                "Type": "Pass",
+                "Parameters": {
+                    "copied.$": "$.input",
+                    "computed.$": "States.MathAdd($.n, 1)"
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    client
+        .create_state_machine()
+        .name("good-params-ref")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .expect("valid .$ references must be accepted");
+}
+
+// M4: an execution that performs more than the old 500-transition ceiling must
+// still complete (AWS Standard allows up to 25,000 transitions).
+#[tokio::test]
+async fn sfn_long_loop_exceeds_old_ceiling() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    // ~600 increments => ~1,200 state transitions, well past the old 500 cap.
+    let definition = serde_json::json!({
+        "StartAt": "Init",
+        "States": {
+            "Init": { "Type": "Pass", "Result": {"count": 0}, "Next": "Check" },
+            "Check": {
+                "Type": "Choice",
+                "Choices": [{ "Variable": "$.count", "NumericLessThan": 600, "Next": "Inc" }],
+                "Default": "Done"
+            },
+            "Inc": {
+                "Type": "Pass",
+                "Parameters": { "count.$": "States.MathAdd($.count, 1)" },
+                "Next": "Check"
+            },
+            "Done": { "Type": "Succeed" }
+        }
+    })
+    .to_string();
+
+    let create = client
+        .create_state_machine()
+        .name("long-loop-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input("{}")
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&client, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output["count"], 600);
+}
+
 #[tokio::test]
 async fn sfn_health_includes_states() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-stepfunctions/src/error_handling.rs
+++ b/crates/fakecloud-stepfunctions/src/error_handling.rs
@@ -1,17 +1,47 @@
 use serde_json::Value;
 
+/// Reserved error names that a wildcard `ErrorEquals` never matches. AWS
+/// documents that `States.Runtime` and `States.DataLimitExceeded` always fail
+/// the execution and cannot be caught or retried by a `States.ALL` (or
+/// `States.TaskFailed`) wildcard.
+const NON_WILDCARD_ERRORS: [&str; 2] = ["States.Runtime", "States.DataLimitExceeded"];
+
+/// Decide whether a single `ErrorEquals` pattern matches an actual error name.
+///
+/// * `States.ALL` matches any error except the non-catchable reserved names.
+/// * `States.TaskFailed` acts as a wildcard for task-originated errors: it
+///   matches any of them except `States.Timeout` (and the non-catchable
+///   reserved names). It applies only when the error came from a Task state, so
+///   e.g. a Parallel/Map branch's `States.Runtime` is not swallowed by it.
+/// * Any other pattern is an exact error-name match.
+fn pattern_matches(pattern: &str, error: &str, is_task_error: bool) -> bool {
+    match pattern {
+        "States.ALL" => !NON_WILDCARD_ERRORS.contains(&error),
+        "States.TaskFailed" => {
+            is_task_error && error != "States.Timeout" && !NON_WILDCARD_ERRORS.contains(&error)
+        }
+        exact => exact == error,
+    }
+}
+
 /// Check if an error matches a Catch block and return the target state name.
-pub fn find_catcher(catchers: &[Value], error: &str) -> Option<(String, Option<String>)> {
+///
+/// `is_task_error` indicates the error originated from a Task state, which
+/// governs whether the `States.TaskFailed` wildcard applies.
+pub fn find_catcher(
+    catchers: &[Value],
+    error: &str,
+    is_task_error: bool,
+) -> Option<(String, Option<String>)> {
     for catcher in catchers {
         let error_equals = match catcher["ErrorEquals"].as_array() {
             Some(arr) => arr,
             None => continue,
         };
 
-        let matches = error_equals.iter().any(|e| {
-            let pattern = e.as_str().unwrap_or("");
-            pattern == "States.ALL" || pattern == error
-        });
+        let matches = error_equals
+            .iter()
+            .any(|e| pattern_matches(e.as_str().unwrap_or(""), error, is_task_error));
 
         if matches {
             let next = match catcher["Next"].as_str() {
@@ -32,17 +62,24 @@ pub fn find_catcher(catchers: &[Value], error: &str) -> Option<(String, Option<S
 
 /// Check if we should retry an error based on Retry configuration.
 /// Returns the delay in milliseconds if we should retry, or None if retries are exhausted.
-pub fn should_retry(retriers: &[Value], error: &str, attempt: u32) -> Option<u64> {
+///
+/// `is_task_error` indicates the error originated from a Task state, which
+/// governs whether the `States.TaskFailed` wildcard applies.
+pub fn should_retry(
+    retriers: &[Value],
+    error: &str,
+    attempt: u32,
+    is_task_error: bool,
+) -> Option<u64> {
     for retrier in retriers {
         let error_equals = match retrier["ErrorEquals"].as_array() {
             Some(arr) => arr,
             None => continue,
         };
 
-        let matches = error_equals.iter().any(|e| {
-            let pattern = e.as_str().unwrap_or("");
-            pattern == "States.ALL" || pattern == error
-        });
+        let matches = error_equals
+            .iter()
+            .any(|e| pattern_matches(e.as_str().unwrap_or(""), error, is_task_error));
 
         if matches {
             let max_attempts = retrier["MaxAttempts"].as_u64().unwrap_or(3) as u32;
@@ -74,7 +111,7 @@ mod tests {
             "ErrorEquals": ["CustomError"],
             "Next": "HandleError"
         })];
-        let result = find_catcher(&catchers, "CustomError");
+        let result = find_catcher(&catchers, "CustomError", true);
         assert_eq!(result, Some(("HandleError".to_string(), None)));
     }
 
@@ -84,7 +121,7 @@ mod tests {
             "ErrorEquals": ["States.ALL"],
             "Next": "CatchAll"
         })];
-        let result = find_catcher(&catchers, "AnyError");
+        let result = find_catcher(&catchers, "AnyError", true);
         assert_eq!(result, Some(("CatchAll".to_string(), None)));
     }
 
@@ -94,7 +131,7 @@ mod tests {
             "ErrorEquals": ["SpecificError"],
             "Next": "Handle"
         })];
-        let result = find_catcher(&catchers, "DifferentError");
+        let result = find_catcher(&catchers, "DifferentError", true);
         assert_eq!(result, None);
     }
 
@@ -105,7 +142,7 @@ mod tests {
             "Next": "Handle",
             "ResultPath": "$.error"
         })];
-        let result = find_catcher(&catchers, "AnyError");
+        let result = find_catcher(&catchers, "AnyError", true);
         assert_eq!(
             result,
             Some(("Handle".to_string(), Some("$.error".to_string())))
@@ -125,8 +162,57 @@ mod tests {
                 "Next": "FallbackHandler"
             }),
         ];
-        let result = find_catcher(&catchers, "AnyError");
+        let result = find_catcher(&catchers, "AnyError", true);
         assert_eq!(result, Some(("FallbackHandler".to_string(), None)));
+    }
+
+    // H1: States.TaskFailed is a wildcard for task-originated errors — a custom
+    // Lambda errorType surfaces as the Error name and must be caught.
+    #[test]
+    fn test_find_catcher_task_failed_wildcard_catches_custom_error() {
+        let catchers = vec![json!({
+            "ErrorEquals": ["States.TaskFailed"],
+            "Next": "Handler"
+        })];
+        let result = find_catcher(&catchers, "CustomLambdaError", true);
+        assert_eq!(result, Some(("Handler".to_string(), None)));
+    }
+
+    // H1: States.TaskFailed must NOT match States.Timeout (per AWS).
+    #[test]
+    fn test_find_catcher_task_failed_excludes_timeout() {
+        let catchers = vec![json!({
+            "ErrorEquals": ["States.TaskFailed"],
+            "Next": "Handler"
+        })];
+        assert_eq!(find_catcher(&catchers, "States.Timeout", true), None);
+    }
+
+    // H1: the TaskFailed wildcard only applies to task-originated errors.
+    #[test]
+    fn test_find_catcher_task_failed_only_for_task_errors() {
+        let catchers = vec![json!({
+            "ErrorEquals": ["States.TaskFailed"],
+            "Next": "Handler"
+        })];
+        assert_eq!(find_catcher(&catchers, "SomeBranchError", false), None);
+    }
+
+    // M2: States.ALL must NOT catch States.Runtime or States.DataLimitExceeded.
+    #[test]
+    fn test_find_catcher_states_all_excludes_runtime() {
+        let catchers = vec![json!({
+            "ErrorEquals": ["States.ALL"],
+            "Next": "Handler"
+        })];
+        assert_eq!(find_catcher(&catchers, "States.Runtime", true), None);
+        assert_eq!(
+            find_catcher(&catchers, "States.DataLimitExceeded", true),
+            None
+        );
+        // But States.ALL still catches States.Timeout and ordinary errors.
+        assert!(find_catcher(&catchers, "States.Timeout", true).is_some());
+        assert!(find_catcher(&catchers, "Whatever", true).is_some());
     }
 
     #[test]
@@ -137,7 +223,7 @@ mod tests {
             "MaxAttempts": 3,
             "BackoffRate": 2.0
         })];
-        let result = should_retry(&retriers, "AnyError", 0);
+        let result = should_retry(&retriers, "AnyError", 0, true);
         assert_eq!(result, Some(1000)); // 1s * 2^0 = 1s
     }
 
@@ -149,7 +235,7 @@ mod tests {
             "MaxAttempts": 3,
             "BackoffRate": 2.0
         })];
-        let result = should_retry(&retriers, "AnyError", 1);
+        let result = should_retry(&retriers, "AnyError", 1, true);
         assert_eq!(result, Some(2000)); // 1s * 2^1 = 2s
     }
 
@@ -159,7 +245,7 @@ mod tests {
             "ErrorEquals": ["States.ALL"],
             "MaxAttempts": 2
         })];
-        let result = should_retry(&retriers, "AnyError", 2);
+        let result = should_retry(&retriers, "AnyError", 2, true);
         assert_eq!(result, None);
     }
 
@@ -169,7 +255,36 @@ mod tests {
             "ErrorEquals": ["SpecificError"],
             "MaxAttempts": 3
         })];
-        let result = should_retry(&retriers, "DifferentError", 0);
+        let result = should_retry(&retriers, "DifferentError", 0, true);
         assert_eq!(result, None);
+    }
+
+    // H1: Retry on States.TaskFailed retries a custom task error.
+    #[test]
+    fn test_should_retry_task_failed_wildcard() {
+        let retriers = vec![json!({
+            "ErrorEquals": ["States.TaskFailed"],
+            "IntervalSeconds": 1,
+            "MaxAttempts": 3
+        })];
+        assert_eq!(should_retry(&retriers, "CustomError", 0, true), Some(1000));
+        // Not a task error → no retry.
+        assert_eq!(should_retry(&retriers, "CustomError", 0, false), None);
+    }
+
+    // M3: the computed backoff honours MaxDelaySeconds and is not clamped to 5s.
+    #[test]
+    fn test_should_retry_honours_max_delay_seconds() {
+        let retriers = vec![json!({
+            "ErrorEquals": ["States.ALL"],
+            "IntervalSeconds": 30,
+            "MaxAttempts": 5,
+            "BackoffRate": 2.0,
+            "MaxDelaySeconds": 40
+        })];
+        // 30 * 2^1 = 60s, clamped to MaxDelaySeconds (40s), NOT to 5s.
+        assert_eq!(should_retry(&retriers, "AnyError", 1, true), Some(40_000));
+        // First attempt: 30s, well above the old 5s cap.
+        assert_eq!(should_retry(&retriers, "AnyError", 0, true), Some(30_000));
     }
 }

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -217,7 +217,8 @@ async fn run_task_state(
             );
             advance_from_next(state_def, output)
         }
-        Err((error, cause)) => advance_from_error(state_def, &input, error, cause),
+        // Task-originated error → the States.TaskFailed wildcard applies.
+        Err((error, cause)) => advance_from_error(state_def, &input, error, cause, true),
     }
 }
 
@@ -268,7 +269,9 @@ async fn run_parallel_state(
             );
             advance_from_next(state_def, output)
         }
-        Err((error, cause)) => advance_from_error(state_def, &input, error, cause),
+        // A Parallel branch failure is not itself a task error; the
+        // States.TaskFailed wildcard must not swallow branch-level errors.
+        Err((error, cause)) => advance_from_error(state_def, &input, error, cause, false),
     }
 }
 
@@ -319,7 +322,9 @@ async fn run_map_state(
             );
             advance_from_next(state_def, output)
         }
-        Err((error, cause)) => advance_from_error(state_def, &input, error, cause),
+        // A Map iteration failure is not itself a task error; the
+        // States.TaskFailed wildcard must not swallow iteration-level errors.
+        Err((error, cause)) => advance_from_error(state_def, &input, error, cause, false),
     }
 }
 
@@ -536,13 +541,12 @@ async fn execute_task_state(
                                 json!({ "error": error, "cause": cause }),
                             );
 
-                            if let Some(delay_ms) = should_retry(&retriers, &error, attempt) {
+                            if let Some(delay_ms) = should_retry(&retriers, &error, attempt, true) {
                                 attempt += 1;
-                                let actual_delay = delay_ms.min(5000);
-                                tokio::time::sleep(tokio::time::Duration::from_millis(
-                                    actual_delay,
-                                ))
-                                .await;
+                                // Honour the ASL-computed backoff (already bounded
+                                // by MaxDelaySeconds inside `should_retry`).
+                                tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms))
+                                    .await;
                                 continue;
                             }
 
@@ -591,10 +595,11 @@ async fn execute_task_state(
                     json!({ "error": error, "cause": cause }),
                 );
 
-                if let Some(delay_ms) = should_retry(&retriers, &error, attempt) {
+                if let Some(delay_ms) = should_retry(&retriers, &error, attempt, true) {
                     attempt += 1;
-                    let actual_delay = delay_ms.min(5000);
-                    tokio::time::sleep(tokio::time::Duration::from_millis(actual_delay)).await;
+                    // Honour the ASL-computed backoff (already bounded by
+                    // MaxDelaySeconds inside `should_retry`).
+                    tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
                     continue;
                 }
 

--- a/crates/fakecloud-stepfunctions/src/interpreter_helpers.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_helpers.rs
@@ -32,7 +32,9 @@ pub(crate) fn run_states<'a>(
         let mut current_state = start_at;
         let mut effective_input = input;
         let mut iteration = 0;
-        let max_iterations = 500;
+        // AWS Standard workflows allow up to 25,000 state transitions per
+        // execution before failing with States.Runtime.
+        let max_iterations = 25_000;
 
         loop {
             iteration += 1;
@@ -176,8 +178,9 @@ pub(crate) fn advance_from_error(
     input: &Value,
     error: String,
     cause: String,
+    is_task_error: bool,
 ) -> Advance {
-    match apply_state_catcher(state_def, input, &error, &cause) {
+    match apply_state_catcher(state_def, input, &error, &cause, is_task_error) {
         Some((next, new_input)) => Advance::Next(next, new_input),
         None => Advance::Fail(error, cause),
     }
@@ -1227,9 +1230,10 @@ pub(crate) fn apply_state_catcher(
     effective_input: &Value,
     error: &str,
     cause: &str,
+    is_task_error: bool,
 ) -> Option<(String, Value)> {
     let catchers = state_def["Catch"].as_array().cloned().unwrap_or_default();
-    let (next, result_path) = find_catcher(&catchers, error)?;
+    let (next, result_path) = find_catcher(&catchers, error, is_task_error)?;
     let error_output = json!({
         "Error": error,
         "Cause": cause,

--- a/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
@@ -914,7 +914,8 @@ fn apply_state_catcher_matches_wildcard_and_stashes_error() {
         ]
     });
     let input = json!({ "a": 1 });
-    let (next, new_input) = apply_state_catcher(&state_def, &input, "Boom", "it exploded").unwrap();
+    let (next, new_input) =
+        apply_state_catcher(&state_def, &input, "Boom", "it exploded", true).unwrap();
     assert_eq!(next, "H");
     assert_eq!(new_input["a"], json!(1));
     assert_eq!(new_input["caught"]["Error"], json!("Boom"));
@@ -929,7 +930,7 @@ fn apply_state_catcher_returns_none_without_match() {
         ]
     });
     let input = json!({});
-    assert!(apply_state_catcher(&state_def, &input, "Other", "why").is_none());
+    assert!(apply_state_catcher(&state_def, &input, "Other", "why", true).is_none());
 }
 
 #[test]
@@ -1584,6 +1585,85 @@ fn lambda_transport_error_fails_as_lambda_unknown() {
     read_exec(&state, &arn, |exec| {
         assert_eq!(exec.status, ExecutionStatus::Failed);
         assert_eq!(exec.error.as_deref(), Some("Lambda.Unknown"));
+    });
+}
+
+// H1: Catch on States.TaskFailed is a wildcard for a task's custom errorType.
+#[test]
+fn lambda_catch_on_states_task_failed_wildcard_routes() {
+    let state = make_state();
+    let arn = arn_for("lambda-taskfailed-wildcard");
+    let (bus, _calls) = StubLambda::bus(vec![Ok(
+        br#"{"errorMessage":"boom","errorType":"MyCustomError"}"#.to_vec(),
+    )]);
+    let def = lambda_invoke_def(json!({
+        "Catch": [{
+            "ErrorEquals": ["States.TaskFailed"],
+            "Next": "Handler",
+            "ResultPath": "$.err"
+        }]
+    }));
+    let mut def = def;
+    def["States"]["Handler"] = json!({ "Type": "Pass", "End": true });
+    drive_with_delivery(&state, &arn, def, Some(r#"{"orig":"v"}"#), bus);
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        // The custom errorType was caught by the States.TaskFailed wildcard.
+        assert_eq!(output["err"]["Error"], json!("MyCustomError"));
+        assert_eq!(output["orig"], json!("v"));
+    });
+}
+
+// H1: Retry on States.TaskFailed wildcard retries a custom task errorType.
+#[test]
+fn lambda_retry_on_states_task_failed_wildcard() {
+    let state = make_state();
+    let arn = arn_for("lambda-taskfailed-retry");
+    let (bus, calls) = StubLambda::bus(vec![
+        Ok(br#"{"errorMessage":"boom","errorType":"MyCustomError"}"#.to_vec()),
+        Ok(br#"{"ok":true}"#.to_vec()),
+    ]);
+    let def = lambda_invoke_def(json!({
+        "Retry": [{ "ErrorEquals": ["States.TaskFailed"], "MaxAttempts": 2, "IntervalSeconds": 0 }]
+    }));
+    drive_with_delivery(&state, &arn, def, Some("{}"), bus);
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+    });
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
+// M4: an execution exceeding the old 500-transition ceiling still completes.
+#[test]
+fn long_loop_exceeds_old_ceiling_completes() {
+    let state = make_state();
+    let arn = arn_for("long-loop");
+    let def = json!({
+        "StartAt": "Init",
+        "States": {
+            "Init": { "Type": "Pass", "Result": {"count": 0}, "Next": "Check" },
+            "Check": {
+                "Type": "Choice",
+                "Choices": [{ "Variable": "$.count", "NumericLessThan": 600, "Next": "Inc" }],
+                "Default": "Done"
+            },
+            "Inc": {
+                "Type": "Pass",
+                "Parameters": { "count.$": "States.MathAdd($.count, 1)" },
+                "Next": "Check"
+            },
+            "Done": { "Type": "Succeed" }
+        }
+    });
+    drive(&state, &arn, def, Some("{}"));
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        assert_eq!(output["count"], json!(600));
     });
 }
 

--- a/crates/fakecloud-stepfunctions/src/intrinsics.rs
+++ b/crates/fakecloud-stepfunctions/src/intrinsics.rs
@@ -181,6 +181,11 @@ fn arg_as_i64(v: &Value) -> Result<i64, IntrinsicError> {
         .ok_or_else(|| IntrinsicError(format!("expected integer, got {v}")))
 }
 
+fn arg_as_f64(v: &Value) -> Result<f64, IntrinsicError> {
+    v.as_f64()
+        .ok_or_else(|| IntrinsicError(format!("expected number, got {v}")))
+}
+
 fn need_args(args: &[Value], expected: usize, name: &str) -> Result<(), IntrinsicError> {
     if args.len() != expected {
         Err(IntrinsicError(format!(
@@ -439,8 +444,22 @@ fn fn_math_random(args: &[Value]) -> Result<Value, IntrinsicError> {
 
 fn fn_math_add(args: &[Value]) -> Result<Value, IntrinsicError> {
     need_args(args, 2, "States.MathAdd")?;
-    let a = arg_as_i64(&args[0])?;
-    let b = arg_as_i64(&args[1])?;
+    // Integer operands add with 64-bit integer semantics, but a genuine
+    // overflow errors instead of panicking (debug) or silently wrapping
+    // (release).
+    if let (Some(a), Some(b)) = (args[0].as_i64(), args[1].as_i64()) {
+        return match a.checked_add(b) {
+            Some(sum) => Ok(json!(sum)),
+            None => Err(IntrinsicError(
+                "States.MathAdd result overflows a 64-bit integer".into(),
+            )),
+        };
+    }
+    // Otherwise fall back to floating-point addition. This covers fractional
+    // operands (which the old i64 coercion truncated) and integers too large
+    // for i64. AWS treats numbers as given, so no truncation is applied.
+    let a = arg_as_f64(&args[0])?;
+    let b = arg_as_f64(&args[1])?;
     Ok(json!(a + b))
 }
 
@@ -570,6 +589,25 @@ mod tests {
         let r = evaluate("States.MathRandom(0, 10)", &Value::Null).unwrap();
         let n = r.as_i64().unwrap();
         assert!((0..10).contains(&n));
+    }
+
+    // L6: MathAdd must not panic (debug) or wrap (release) on i64 overflow, and
+    // must not truncate fractional operands.
+    #[test]
+    fn math_add_overflow_and_floats() {
+        // i64::MAX + 1 overflows → error rather than panic/wrap.
+        let expr = format!("States.MathAdd({}, 1)", i64::MAX);
+        assert!(evaluate(&expr, &Value::Null).is_err());
+
+        // Fractional operands are preserved, not truncated to int.
+        assert_eq!(
+            fn_math_add(&[json!(1.5), json!(2.25)]).unwrap(),
+            json!(3.75)
+        );
+        // Mixed int + float stays a float.
+        assert_eq!(fn_math_add(&[json!(2), json!(0.5)]).unwrap(), json!(2.5));
+        // Negative integers still work.
+        assert_eq!(fn_math_add(&[json!(-4), json!(1)]).unwrap(), json!(-3));
     }
 
     #[test]

--- a/crates/fakecloud-stepfunctions/src/io_processing.rs
+++ b/crates/fakecloud-stepfunctions/src/io_processing.rs
@@ -65,33 +65,62 @@ pub fn resolve_path(root: &Value, path: &str) -> Value {
     current.clone()
 }
 
-/// Set a value at a simple JsonPath within a JSON structure.
+/// Set a value at a simple JsonPath within a JSON structure. Handles both plain
+/// object fields (`$.a.b`) and array-index segments (`$.a[0].b`). An index
+/// segment `name[idx]` descends into element `idx` of the array stored at
+/// `name`, growing the array with nulls as needed.
 fn set_at_path(root: &Value, path: &str, value: &Value) -> Value {
     let mut result = root.clone();
     let path = path.strip_prefix("$.").unwrap_or(path);
-    let segments: Vec<&str> = path.split('.').collect();
+    let segments = split_path_segments(path);
 
-    let mut current = &mut result;
-    for (i, segment) in segments.iter().enumerate() {
-        if i == segments.len() - 1 {
-            // Last segment — set the value
-            if let Some(obj) = current.as_object_mut() {
-                obj.insert(segment.to_string(), value.clone());
-            }
-        } else {
-            // Intermediate — ensure object exists
-            if current.get(*segment).is_none() {
+    fn assign(current: &mut Value, segments: &[PathSegment<'_>], value: &Value) {
+        let (segment, rest) = match segments.split_first() {
+            Some(pair) => pair,
+            None => return,
+        };
+        let is_last = rest.is_empty();
+        match segment {
+            PathSegment::Field(name) => {
                 if let Some(obj) = current.as_object_mut() {
-                    obj.insert(segment.to_string(), serde_json::json!({}));
+                    if is_last {
+                        obj.insert(name.to_string(), value.clone());
+                    } else {
+                        let child = obj
+                            .entry(name.to_string())
+                            .or_insert_with(|| serde_json::json!({}));
+                        assign(child, rest, value);
+                    }
                 }
             }
-            match current.get_mut(*segment) {
-                Some(v) => current = v,
-                None => return result, // non-object intermediate, bail out
+            PathSegment::Index(name, idx) => {
+                // Ensure `name` holds an array long enough to index `idx`.
+                if let Some(obj) = current.as_object_mut() {
+                    let arr_val = obj
+                        .entry(name.to_string())
+                        .or_insert_with(|| Value::Array(Vec::new()));
+                    if !arr_val.is_array() {
+                        *arr_val = Value::Array(Vec::new());
+                    }
+                    if let Some(arr) = arr_val.as_array_mut() {
+                        if arr.len() <= *idx {
+                            arr.resize(idx + 1, Value::Null);
+                        }
+                        if is_last {
+                            arr[*idx] = value.clone();
+                        } else {
+                            if !arr[*idx].is_object() && !arr[*idx].is_array() {
+                                arr[*idx] = serde_json::json!({});
+                            }
+                            assign(&mut arr[*idx], rest, value);
+                        }
+                    }
+                }
             }
         }
     }
 
+    assign(&mut result, &segments, value);
     result
 }
 
@@ -216,6 +245,34 @@ mod tests {
         let output = apply_result_path(&input, &result, Some("$.x.nested"));
         // x is a number, can't set nested on it — should return input unchanged
         assert_eq!(output, json!({"x": 42}));
+    }
+
+    // L8: ResultPath with an array-index segment must descend into the array,
+    // not insert a literal key like "a[0]".
+    #[test]
+    fn test_set_at_path_array_index_leaf() {
+        let input = json!({"a": [1, 2, 3]});
+        let result = json!(99);
+        let output = apply_result_path(&input, &result, Some("$.a[1]"));
+        assert_eq!(output, json!({"a": [1, 99, 3]}));
+        // No stray literal "a[1]" key was created.
+        assert!(output.get("a[1]").is_none());
+    }
+
+    #[test]
+    fn test_set_at_path_array_index_then_field() {
+        let input = json!({"items": [{"v": 1}]});
+        let result = json!("done");
+        let output = apply_result_path(&input, &result, Some("$.items[0].status"));
+        assert_eq!(output, json!({"items": [{"v": 1, "status": "done"}]}));
+    }
+
+    #[test]
+    fn test_set_at_path_array_index_grows_array() {
+        let input = json!({});
+        let result = json!("x");
+        let output = apply_result_path(&input, &result, Some("$.a[2]"));
+        assert_eq!(output, json!({"a": [null, null, "x"]}));
     }
 
     #[test]

--- a/crates/fakecloud-stepfunctions/src/service/mod.rs
+++ b/crates/fakecloud-stepfunctions/src/service/mod.rs
@@ -599,8 +599,9 @@ fn validate_definition(definition: &str) -> Result<(), AwsServiceError> {
 }
 
 /// Validate the JSONPath reference fields of a single state. Recurses into the
-/// `Choices` array of Choice states. Returns an `InvalidDefinition` error for
-/// any syntactically malformed path.
+/// `Choices` array of Choice states, the `Branches` of Parallel states, and the
+/// `Iterator`/`ItemProcessor` of Map states. Returns an `InvalidDefinition`
+/// error for any syntactically malformed path or payload-template key.
 fn validate_state_paths(state_name: &str, state: &Value) -> Result<(), AwsServiceError> {
     for field in ["InputPath", "OutputPath", "ResultPath"] {
         if let Some(p) = state.get(field).and_then(|v| v.as_str()) {
@@ -614,15 +615,143 @@ fn validate_state_paths(state_name: &str, state: &Value) -> Result<(), AwsServic
         }
     }
 
-    if state.get("Type").and_then(|v| v.as_str()) == Some("Choice") {
-        if let Some(choices) = state.get("Choices").and_then(|v| v.as_array()) {
-            for rule in choices {
-                validate_choice_variables(state_name, rule)?;
+    // Reference-path fields that select a value from the input (or the context
+    // object). Unlike Input/Output/ResultPath they do not accept the literal
+    // "null", but they may reference the context object via `$$`.
+    for field in [
+        "SecondsPath",
+        "TimestampPath",
+        "ItemsPath",
+        "MaxConcurrencyPath",
+        "ToleratedFailureCountPath",
+        "ToleratedFailurePercentagePath",
+    ] {
+        if let Some(p) = state.get(field).and_then(|v| v.as_str()) {
+            if is_reference_or_context_path(p) {
+                continue;
             }
+            return Err(invalid_reference_path(state_name, field, p));
         }
     }
 
+    // Payload templates: every key ending in `.$` must carry a string value
+    // that is either a JSONPath reference (`$`/`$$`) or an intrinsic call. AWS
+    // rejects non-string and bare-literal `.$` values at CreateStateMachine.
+    for field in ["Parameters", "ResultSelector", "ItemSelector"] {
+        if let Some(template) = state.get(field) {
+            validate_payload_template(state_name, field, template)?;
+        }
+    }
+
+    match state.get("Type").and_then(|v| v.as_str()) {
+        Some("Choice") => {
+            if let Some(choices) = state.get("Choices").and_then(|v| v.as_array()) {
+                for rule in choices {
+                    validate_choice_variables(state_name, rule)?;
+                }
+            }
+        }
+        Some("Parallel") => {
+            if let Some(branches) = state.get("Branches").and_then(|v| v.as_array()) {
+                for branch in branches {
+                    validate_nested_definition(state_name, branch)?;
+                }
+            }
+        }
+        Some("Map") => {
+            // Distributed Map uses `ItemProcessor`; legacy inline Map uses
+            // `Iterator`. Both carry a nested `States` block.
+            for key in ["ItemProcessor", "Iterator"] {
+                if let Some(processor) = state.get(key) {
+                    validate_nested_definition(state_name, processor)?;
+                }
+            }
+        }
+        _ => {}
+    }
+
     Ok(())
+}
+
+/// Validate every state inside a nested definition (a Parallel branch or a Map
+/// processor). Errors are attributed to the enclosing state so the message
+/// still points at a real state name.
+fn validate_nested_definition(parent: &str, def: &Value) -> Result<(), AwsServiceError> {
+    if let Some(states) = def.get("States").and_then(|v| v.as_object()) {
+        for (name, state) in states {
+            validate_state_paths(&format!("{parent}/{name}"), state)?;
+        }
+    }
+    Ok(())
+}
+
+/// Recursively validate a payload template (Parameters / ResultSelector /
+/// ItemSelector). Any object key ending in `.$` must map to a string that is a
+/// JSONPath reference or an intrinsic-function invocation.
+fn validate_payload_template(
+    state_name: &str,
+    field: &str,
+    template: &Value,
+) -> Result<(), AwsServiceError> {
+    match template {
+        Value::Object(map) => {
+            for (key, value) in map {
+                if let Some(stripped) = key.strip_suffix(".$") {
+                    let expr = value.as_str().ok_or_else(|| {
+                        invalid_payload_template(
+                            state_name,
+                            field,
+                            &format!(
+                                "the '{key}' field must be a JSONPath or intrinsic string, \
+                                 not {value}"
+                            ),
+                        )
+                    })?;
+                    let is_ref = expr.starts_with('$');
+                    if !is_ref && !crate::intrinsics::is_intrinsic_call(expr) {
+                        return Err(invalid_payload_template(
+                            state_name,
+                            field,
+                            &format!(
+                                "the '{stripped}.$' field value '{expr}' is neither a JSONPath \
+                                 reference nor an intrinsic function"
+                            ),
+                        ));
+                    }
+                } else {
+                    validate_payload_template(state_name, field, value)?;
+                }
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                validate_payload_template(state_name, field, v)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// A `*Path` field value: either a `$`-rooted reference path the interpreter can
+/// parse, or a `$$`-rooted context-object reference.
+fn is_reference_or_context_path(p: &str) -> bool {
+    if let Some(rest) = p.strip_prefix("$$") {
+        // "$$" alone, or "$$.Foo.Bar" — accept any context reference.
+        return rest.is_empty() || rest.starts_with('.') || rest.starts_with('[');
+    }
+    is_valid_reference_path(p)
+}
+
+fn invalid_payload_template(state_name: &str, field: &str, detail: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidDefinition",
+        format!(
+            "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED' \
+             (The {field} of state '{state_name}' is invalid: {detail})"
+        ),
+    )
 }
 
 /// Validate `Variable` reference paths inside a Choice rule, recursing through
@@ -1662,6 +1791,54 @@ mod tests {
             "S":{"Type":"Succeed","InputPath":"null"}
         }}"#;
         assert!(validate_definition(def).is_ok());
+    }
+
+    // M5: malformed paths nested inside Parallel branches and Map processors
+    // must be rejected.
+    #[test]
+    fn test_validate_definition_recurses_into_parallel_and_map() {
+        let par = r#"{"StartAt":"Par","States":{"Par":{"Type":"Parallel","End":true,
+            "Branches":[{"StartAt":"I","States":{"I":{"Type":"Pass","InputPath":"nope","End":true}}}]}}}"#;
+        assert!(validate_definition(par).is_err());
+
+        let map = r#"{"StartAt":"M","States":{"M":{"Type":"Map","End":true,
+            "ItemProcessor":{"StartAt":"E","States":{"E":{"Type":"Pass","OutputPath":"nope","End":true}}}}}}"#;
+        assert!(validate_definition(map).is_err());
+
+        // Legacy inline Map uses `Iterator`.
+        let iter = r#"{"StartAt":"M","States":{"M":{"Type":"Map","End":true,
+            "Iterator":{"StartAt":"E","States":{"E":{"Type":"Pass","ResultPath":"$.x[]","End":true}}}}}}"#;
+        assert!(validate_definition(iter).is_err());
+
+        // A well-formed Parallel/Map still validates.
+        let ok = r#"{"StartAt":"M","States":{"M":{"Type":"Map","ItemsPath":"$.items","End":true,
+            "ItemProcessor":{"StartAt":"E","States":{"E":{"Type":"Pass","InputPath":"$.a","End":true}}}}}}"#;
+        assert!(validate_definition(ok).is_ok());
+    }
+
+    // L7: `.$` payload-template keys must carry a JSONPath/intrinsic string.
+    #[test]
+    fn test_validate_definition_payload_template_dollar_keys() {
+        // Bare literal value.
+        let lit = r#"{"StartAt":"P","States":{"P":{"Type":"Pass",
+            "Parameters":{"v.$":"just text"},"End":true}}}"#;
+        assert!(validate_definition(lit).is_err());
+
+        // Non-string value.
+        let num = r#"{"StartAt":"P","States":{"P":{"Type":"Pass",
+            "Parameters":{"v.$":42},"End":true}}}"#;
+        assert!(validate_definition(num).is_err());
+
+        // Valid: JSONPath reference, context-object ref, and intrinsic.
+        let ok = r#"{"StartAt":"P","States":{"P":{"Type":"Pass","Parameters":{
+            "a.$":"$.input","b.$":"$$.Execution.Id","c.$":"States.Format('{}',$.n)",
+            "nested":{"d.$":"$.x"},"plain":"literal-ok"},"End":true}}}"#;
+        assert!(validate_definition(ok).is_ok());
+
+        // A bad `.$` nested inside an array under a plain key is also caught.
+        let arr = r#"{"StartAt":"P","States":{"P":{"Type":"Pass",
+            "ResultSelector":{"items":[{"bad.$":"literal"}]},"End":true}}}"#;
+        assert!(validate_definition(arr).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Behavioral hardening of the Step Functions ASL interpreter — semantics the conformance probe never executes (it checks op shapes, not state-machine execution).

- **H1** `States.TaskFailed` was matched literally, so it didn't catch custom-named task errors — silently breaking the most common Retry/Catch idiom. It now matches any task-originated error except `States.Timeout` (per AWS).
- **M2** `States.ALL` wrongly caught `States.Runtime`; it now excludes `States.Runtime` and `States.DataLimitExceeded`.
- **M3** retry delay was clamped to 5s, ignoring `IntervalSeconds`/`MaxDelaySeconds`; the interpreter now honors the ASL-computed backoff.
- **M4** the state-transition ceiling was 500; raised to AWS Standard's 25,000.
- **M5** `*Path` reference paths inside `Parallel` branches and `Map` processors weren't validated at create; nested validation added (plus SecondsPath/ItemsPath/MaxConcurrencyPath/TimestampPath).
- **L6-L8** `States.MathAdd` overflow/float handling, `.$` template validation, `ResultPath` array-index segments.

## Test plan
- `cargo test -p fakecloud-stepfunctions` unit tests: TaskFailed wildcard catch, States.ALL excludes Runtime, backoff honored, >500-transition loop completes, nested-path InvalidDefinition.
- Interpreter's panic-safety (spawn-catch, panic-safe JSONPath) and RUNNING-restart reconcile untouched. CI runs full clippy + conformance + e2e.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Step Functions ASL interpreter to better match AWS: fixes error wildcard matching, honors ASL retry/backoff, raises the transition limit, validates nested `*Path` and `.$` templates, and improves `States.MathAdd` and `ResultPath` array indexing.

- **Bug Fixes**
  - `States.TaskFailed` now catches any task error except `States.Timeout`; `States.ALL` no longer matches `States.Runtime` or `States.DataLimitExceeded`.
  - Retries now use ASL-computed backoff with `IntervalSeconds`/`BackoffRate` and `MaxDelaySeconds` (no 5s clamp).
  - State transition ceiling increased to 25,000 (from 500).
  - Create-time validation recurses into `Parallel` branches and `Map` `ItemProcessor`/`Iterator`; validates `SecondsPath`/`TimestampPath`/`ItemsPath`/`MaxConcurrencyPath` and `.$` keys in `Parameters`/`ResultSelector`/`ItemSelector`.
  - `States.MathAdd` checks 64-bit overflow (returns error) and supports floats.
  - `ResultPath` correctly handles array indexes like `$.a[1]` (no literal keys created).

<sup>Written for commit cbb24fc25a7019b95af810f2798a9fe8915b763c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

