### PR TITLE
fix(kinesis): record/batch size limits, shard-lineage on reshard, cheap reads

### DIFF
--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -431,13 +431,18 @@ impl KinesisService {
         let mut names: Vec<String> = state.streams.keys().cloned().collect();
         names.sort();
 
+        // Resume at the first name strictly greater than the cursor. The cursor
+        // (last stream name of the previous page) is a stable total-ordering key
+        // over the sorted names, so if the stream it named was deleted between
+        // pages we still resume at the right offset instead of restarting from 0
+        // and re-emitting the whole list (which an exact-match lookup did).
         let start = resume_after
             .as_deref()
-            .and_then(|name| {
+            .map(|cursor| {
                 names
                     .iter()
-                    .position(|candidate| candidate == name)
-                    .map(|idx| idx + 1)
+                    .position(|candidate| candidate.as_str() > cursor)
+                    .unwrap_or(names.len())
             })
             .unwrap_or(0);
         let remaining = names.len().saturating_sub(start);
@@ -706,6 +711,15 @@ impl KinesisService {
 
         let partition_key = require_partition_key(&body)?;
         let data = decode_record_data(&body["Data"])?;
+        // Data + PartitionKey must fit the per-record ceiling (1 MiB, or the
+        // stream's configured MaxRecordSizeInKiB). AWS rejects an oversized
+        // single record with ValidationException before it is written.
+        let max_record_bytes = effective_max_record_bytes(stream);
+        if data.len() + partition_key.len() > max_record_bytes {
+            return Err(validation_exception(format!(
+                "Record size (Data + PartitionKey) exceeds the {max_record_bytes}-byte per-record limit"
+            )));
+        }
         let encryption_type = stream.encryption_type.clone();
         let explicit_hash_key = body["ExplicitHashKey"].as_str();
         let shard = select_shard_mut(stream, partition_key, explicit_hash_key)?;
@@ -738,6 +752,23 @@ impl KinesisService {
             .ok_or_else(|| invalid_argument("Records must be an array"))?;
         if entries.is_empty() {
             return Err(invalid_argument("Records must not be empty"));
+        }
+        // Whole-request limits AWS rejects up front with ValidationException,
+        // before any record is written: at most 500 records, and at most 5 MiB
+        // (or the stream's larger ceiling) of aggregate Data + PartitionKey.
+        if entries.len() > MAX_PUT_RECORDS_COUNT {
+            return Err(validation_exception(format!(
+                "1 validation error detected: Value at 'records' failed to satisfy \
+                 constraint: Member must have length less than or equal to {MAX_PUT_RECORDS_COUNT}"
+            )));
+        }
+        let max_batch_bytes = effective_max_batch_bytes(stream);
+        let aggregate_bytes: usize = entries.iter().map(put_records_entry_size).sum();
+        if aggregate_bytes > max_batch_bytes {
+            return Err(validation_exception(format!(
+                "PutRecords aggregate payload ({aggregate_bytes} bytes) exceeds the \
+                 {max_batch_bytes}-byte per-request limit"
+            )));
         }
 
         // A record that fails validation (e.g. empty PartitionKey) is reported
@@ -1814,21 +1845,49 @@ impl KinesisService {
             })
             .collect();
 
+        // Capture (id, start, end) of the pre-scale open shards *before*
+        // closing them, so the new shards can record them as parents — the
+        // lineage a consumer walks via `ChildShards` to discover the post-scale
+        // shards. Every refinement interval falls entirely inside exactly one
+        // of these (the cut points include every original start key).
+        let original_open: Vec<(String, u128, u128)> = stream
+            .shards
+            .iter()
+            .filter(|s| s.is_open)
+            .map(|s| {
+                (
+                    s.shard_id.clone(),
+                    s.starting_hash_key.parse::<u128>().unwrap_or(0),
+                    s.ending_hash_key.parse::<u128>().unwrap_or(MAX_HASH_KEY),
+                )
+            })
+            .collect();
+        let parent_for = |start: u128, end: u128| -> Option<String> {
+            original_open
+                .iter()
+                .find(|(_, ostart, oend)| start >= *ostart && end <= *oend)
+                .map(|(id, _, _)| id.clone())
+        };
+
         // Close every current open shard — they are all split away.
         for shard in &mut stream.shards {
             shard.is_open = false;
         }
 
-        // Materialise each refinement interval as a shard, recording its id so
-        // multi-piece target shards can reference their merge parents.
+        // Materialise each refinement interval as a shard whose parent is the
+        // pre-scale shard that contained it. Every original shard thus becomes
+        // the parent of at least one new shard, so GetRecords on a drained
+        // original returns non-empty `ChildShards` instead of stranding the
+        // consumer at the closed parent.
         let mut piece_ids: Vec<(u128, u128, String)> = Vec::new();
         for (start, end) in &refinement {
             let new_id = next_shard_id(stream);
+            let parent = parent_for(*start, *end);
             stream.shards.push(KinesisShard {
                 shard_id: new_id.clone(),
                 starting_hash_key: start.to_string(),
                 ending_hash_key: end.to_string(),
-                parent_shard_id: None,
+                parent_shard_id: parent,
                 adjacent_parent_shard_id: None,
                 is_open: true,
                 next_sequence_number: 1,
@@ -1838,37 +1897,43 @@ impl KinesisService {
         }
 
         // For each target shard, gather the refinement pieces inside it. A
-        // single-piece target keeps that piece open; a multi-piece target
-        // closes its pieces and opens one merged shard spanning the range.
+        // single-piece target keeps that piece open. A multi-piece target folds
+        // its pieces left-to-right into pairwise merges, closing each piece and
+        // every intermediate merge and leaving one open shard spanning the
+        // target range — so every piece has an open descendant and the lineage
+        // from each original shard stays connected end to end.
         for (tstart, tend) in &target_ranges {
-            let pieces: Vec<usize> = piece_ids
+            let pieces: Vec<(u128, String)> = piece_ids
                 .iter()
-                .enumerate()
-                .filter(|(_, (ps, pe, _))| ps >= tstart && pe <= tend)
-                .map(|(i, _)| i)
+                .filter(|(ps, pe, _)| ps >= tstart && pe <= tend)
+                .map(|(_, pe, id)| (*pe, id.clone()))
                 .collect();
             if pieces.len() <= 1 {
                 continue;
             }
-            let parent = piece_ids[pieces[0]].2.clone();
-            let adjacent = piece_ids[pieces[1]].2.clone();
-            for &i in &pieces {
-                let id = &piece_ids[i].2;
-                if let Some(sh) = stream.shards.iter_mut().find(|s| &s.shard_id == id) {
-                    sh.is_open = false;
-                }
+            // Fold: `acc` is the current open head of the merge chain, `acc_end`
+            // its ending hash key. Each step closes `acc` and the next piece and
+            // opens a merged shard parented on both.
+            let (_, mut acc) = pieces[0].clone();
+            close_shard(stream, &acc);
+            for (next_end, next_id) in &pieces[1..] {
+                close_shard(stream, next_id);
+                let merged_id = next_shard_id(stream);
+                stream.shards.push(KinesisShard {
+                    shard_id: merged_id.clone(),
+                    starting_hash_key: tstart.to_string(),
+                    ending_hash_key: next_end.to_string(),
+                    parent_shard_id: Some(acc.clone()),
+                    adjacent_parent_shard_id: Some(next_id.clone()),
+                    is_open: true,
+                    next_sequence_number: 1,
+                    records: Vec::new(),
+                });
+                // The previous head is now an interior (closed) merge node; the
+                // freshly pushed `merged_id` is the new open head.
+                close_shard(stream, &acc);
+                acc = merged_id;
             }
-            let merged_id = next_shard_id(stream);
-            stream.shards.push(KinesisShard {
-                shard_id: merged_id,
-                starting_hash_key: tstart.to_string(),
-                ending_hash_key: tend.to_string(),
-                parent_shard_id: Some(parent),
-                adjacent_parent_shard_id: Some(adjacent),
-                is_open: true,
-                next_sequence_number: 1,
-                records: Vec::new(),
-            });
         }
 
         stream.shard_count = stream.shards.len() as i32;

--- a/crates/fakecloud-kinesis/src/service_helpers.rs
+++ b/crates/fakecloud-kinesis/src/service_helpers.rs
@@ -30,9 +30,21 @@ pub(crate) fn next_shard_id(stream: &mut KinesisStream) -> String {
     id
 }
 
-/// Actions that mutate Kinesis state. Note: GetShardIterator also
-/// writes (it records a lease in `iterators`), and GetRecords advances
-/// that lease, so both are treated as mutating.
+/// Mark the shard with `shard_id` closed, if it is present. Idempotent, so
+/// callers can close an already-closed shard without a membership check.
+pub(crate) fn close_shard(stream: &mut KinesisStream, shard_id: &str) {
+    if let Some(shard) = stream.shards.iter_mut().find(|s| s.shard_id == shard_id) {
+        shard.is_open = false;
+    }
+}
+
+/// Actions that mutate *durable* Kinesis state and therefore warrant a
+/// snapshot save. GetShardIterator / GetRecords are deliberately excluded:
+/// the only thing they touch is the shard-iterator lease map, which is
+/// `#[serde(skip)]` (ephemeral, never persisted). Treating those read polls
+/// as mutating meant every GetRecords cloned + serialized + disk-wrote the
+/// whole multi-account state for zero durable effect — a per-read cost that
+/// turns a read-heavy consumer into a serialization bottleneck.
 pub(crate) fn is_mutating_action(action: &str) -> bool {
     matches!(
         action,
@@ -61,9 +73,36 @@ pub(crate) fn is_mutating_action(action: &str) -> bool {
             | "MergeShards"
             | "SplitShard"
             | "UpdateShardCount"
-            | "GetShardIterator"
-            | "GetRecords"
     )
+}
+
+/// PutRecord: default single-record payload limit (Data + PartitionKey) is
+/// 1 MiB. AWS raises the ceiling to `MaxRecordSizeInKiB` when the stream
+/// opts into larger records.
+pub(crate) const DEFAULT_MAX_RECORD_BYTES: usize = 1024 * 1024;
+/// PutRecords: a single call carries at most 500 records.
+pub(crate) const MAX_PUT_RECORDS_COUNT: usize = 500;
+/// PutRecords: a single call carries at most 5 MiB of aggregate payload
+/// (default). Streams that raise `MaxRecordSizeInKiB` above 5 MiB get the
+/// larger ceiling so a single legal record can never exceed the batch limit.
+pub(crate) const DEFAULT_MAX_PUT_RECORDS_BYTES: usize = 5 * 1024 * 1024;
+/// PartitionKey is a Unicode string of 1..=256 characters.
+pub(crate) const MAX_PARTITION_KEY_CHARS: usize = 256;
+
+/// Effective per-record payload ceiling for a stream: `MaxRecordSizeInKiB`
+/// when configured, otherwise the 1 MiB default.
+pub(crate) fn effective_max_record_bytes(stream: &KinesisStream) -> usize {
+    stream
+        .max_record_size_kib
+        .filter(|kib| *kib > 0)
+        .map(|kib| (kib as usize) * 1024)
+        .unwrap_or(DEFAULT_MAX_RECORD_BYTES)
+}
+
+/// Aggregate payload ceiling for a PutRecords call: the larger of the 5 MiB
+/// default and the stream's per-record ceiling.
+pub(crate) fn effective_max_batch_bytes(stream: &KinesisStream) -> usize {
+    effective_max_record_bytes(stream).max(DEFAULT_MAX_PUT_RECORDS_BYTES)
 }
 
 pub(crate) fn require_stream_name(body: &Value) -> Result<&str, AwsServiceError> {
@@ -163,10 +202,17 @@ pub fn build_stream_shards(shard_count: i32) -> Vec<KinesisShard> {
 }
 
 pub(crate) fn require_partition_key(body: &Value) -> Result<&str, AwsServiceError> {
-    body["PartitionKey"]
+    let partition_key = body["PartitionKey"]
         .as_str()
         .filter(|value| !value.is_empty())
-        .ok_or_else(|| invalid_argument("PartitionKey is required"))
+        .ok_or_else(|| invalid_argument("PartitionKey is required"))?;
+    if partition_key.chars().count() > MAX_PARTITION_KEY_CHARS {
+        return Err(validation_exception(format!(
+            "1 validation error detected: Value at 'partitionKey' failed to satisfy \
+             constraint: Member must have length less than or equal to {MAX_PARTITION_KEY_CHARS}"
+        )));
+    }
+    Ok(partition_key)
 }
 
 pub(crate) fn require_shard_id(body: &Value) -> Result<&str, AwsServiceError> {
@@ -239,6 +285,13 @@ pub(crate) fn select_shard_mut<'a>(
     partition_key: &str,
     explicit_hash_key: Option<&str>,
 ) -> Result<&'a mut KinesisShard, AwsServiceError> {
+    // `select_shard_index_for_hash` falls back to `shards.len() - 1`, which
+    // wraps to index 0 on an empty shard list — an out-of-bounds index panic.
+    // No create path leaves a stream shard-less today, but guard it the same
+    // way the fan-in delivery path already does rather than risk a panic.
+    if stream.shards.is_empty() {
+        return Err(invalid_argument("Stream has no shards to route to"));
+    }
     let hash = routing_hash(partition_key, explicit_hash_key)?;
     let idx = select_shard_index_for_hash(stream, hash);
     Ok(&mut stream.shards[idx])
@@ -273,12 +326,34 @@ pub(crate) fn put_records_entry(
         .as_str()
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "PartitionKey is required".to_string())?;
+    if partition_key.chars().count() > MAX_PARTITION_KEY_CHARS {
+        return Err(format!(
+            "PartitionKey must have length less than or equal to {MAX_PARTITION_KEY_CHARS}"
+        ));
+    }
     let data = decode_record_data(&entry["Data"]).map_err(|error| error.message())?;
+    let max_record_bytes = effective_max_record_bytes(stream);
+    if data.len() + partition_key.len() > max_record_bytes {
+        return Err(format!(
+            "Record size (Data + PartitionKey) exceeds the {max_record_bytes}-byte per-record limit"
+        ));
+    }
     let explicit_hash_key = entry["ExplicitHashKey"].as_str();
     let shard = select_shard_mut(stream, partition_key, explicit_hash_key)
         .map_err(|error| error.message())?;
     let sequence_number = append_record(shard, partition_key, data);
     Ok((shard.shard_id.clone(), sequence_number))
+}
+
+/// Decoded byte size of a PutRecords entry's payload (Data + PartitionKey),
+/// used for the aggregate-size pre-check. Undecodable data counts as 0 here;
+/// the per-record loop reports it as a per-record failure.
+pub(crate) fn put_records_entry_size(entry: &Value) -> usize {
+    let data_len = decode_record_data(&entry["Data"])
+        .map(|bytes| bytes.len())
+        .unwrap_or(0);
+    let key_len = entry["PartitionKey"].as_str().map(str::len).unwrap_or(0);
+    data_len + key_len
 }
 
 pub(crate) fn shard_iterator_start_index(
@@ -291,11 +366,11 @@ pub(crate) fn shard_iterator_start_index(
         "LATEST" => Ok(shard.records.len()),
         "AT_SEQUENCE_NUMBER" => {
             let sequence_number = require_starting_sequence_number(body)?;
-            find_record_index_by_sequence_number(shard, sequence_number)
+            resolve_sequence_number_index(shard, sequence_number, false)
         }
         "AFTER_SEQUENCE_NUMBER" => {
             let sequence_number = require_starting_sequence_number(body)?;
-            Ok(find_record_index_by_sequence_number(shard, sequence_number)? + 1)
+            resolve_sequence_number_index(shard, sequence_number, true)
         }
         "AT_TIMESTAMP" => {
             // AWS encodes Timestamp as epoch seconds (float, with optional
@@ -331,15 +406,36 @@ pub(crate) fn require_starting_sequence_number(body: &Value) -> Result<&str, Aws
         .ok_or_else(|| invalid_argument("StartingSequenceNumber is required"))
 }
 
-pub(crate) fn find_record_index_by_sequence_number(
+/// Resolve an `AT_/AFTER_SEQUENCE_NUMBER` iterator start index.
+///
+/// When the exact sequence number is still present we return its index (or
+/// the next one for `AFTER`). When it is *not* present but sorts before the
+/// earliest retained record, the record it named was aged out by the
+/// retention window, so — like real Kinesis — we resolve to the trim horizon
+/// (the earliest available record) instead of raising InvalidArgumentException.
+/// A sequence number that is neither present nor below the horizon is a
+/// genuinely invalid argument.
+pub(crate) fn resolve_sequence_number_index(
     shard: &KinesisShard,
     sequence_number: &str,
+    after: bool,
 ) -> Result<usize, AwsServiceError> {
-    shard
+    if let Some(pos) = shard
         .records
         .iter()
         .position(|record| record.sequence_number == sequence_number)
-        .ok_or_else(|| invalid_argument("StartingSequenceNumber is invalid"))
+    {
+        return Ok(if after { pos + 1 } else { pos });
+    }
+    // Sequence numbers are fixed-width, zero-padded and per-shard monotonic,
+    // so a lexicographic comparison against the earliest retained record is
+    // an exact numeric ordering — a smaller value was trimmed off the front.
+    if let Some(first) = shard.records.first() {
+        if sequence_number < first.sequence_number.as_str() {
+            return Ok(0);
+        }
+    }
+    Err(invalid_argument("StartingSequenceNumber is invalid"))
 }
 
 /// Encode a `ListShards` continuation token. AWS returns an opaque base64
@@ -442,6 +538,13 @@ pub(crate) fn resource_not_found_arn(arn: &str) -> AwsServiceError {
 
 pub(crate) fn invalid_argument(message: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "InvalidArgumentException", message)
+}
+
+/// AWS returns `ValidationException` (HTTP 400) for constraint violations the
+/// front end rejects before the operation runs — an oversized record payload,
+/// too-long partition key, or a PutRecords batch over its count/size limits.
+pub(crate) fn validation_exception(message: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationException", message)
 }
 
 pub(crate) fn stream_not_found(account_id: &str, stream_name: &str) -> AwsServiceError {

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -2028,3 +2028,361 @@ fn create_stream_persists_initial_tags() {
         "initial CreateStream tags should persist, got {body}"
     );
 }
+
+// ── H1: record-size / batch-count / batch-size limits ──
+
+fn b64(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+#[test]
+fn put_record_rejects_payload_over_one_mib() {
+    let (svc, _) = make_service();
+    create_stream_action(&svc, "orders", 1);
+    // Data alone is 1 MiB + 1 byte, over the 1 MiB (Data + PartitionKey) limit.
+    let oversized = vec![b'x'; 1024 * 1024 + 1];
+    let res = svc.put_record(&request(
+        "PutRecord",
+        json!({
+            "StreamName": "orders",
+            "Data": b64(&oversized),
+            "PartitionKey": "k1",
+        }),
+    ));
+    assert_code_kinesis(res, "ValidationException");
+}
+
+#[test]
+fn put_record_within_limit_is_accepted() {
+    let (svc, _) = make_service();
+    create_stream_action(&svc, "orders", 1);
+    // 512 KiB is comfortably under the 1 MiB ceiling.
+    let ok = vec![b'x'; 512 * 1024];
+    svc.put_record(&request(
+        "PutRecord",
+        json!({
+            "StreamName": "orders",
+            "Data": b64(&ok),
+            "PartitionKey": "k1",
+        }),
+    ))
+    .unwrap();
+}
+
+#[test]
+fn put_records_rejects_more_than_500_records() {
+    let (svc, _) = make_service();
+    create_stream_action(&svc, "orders", 1);
+    let entries: Vec<Value> = (0..501)
+        .map(|i| json!({ "Data": b64(b"a"), "PartitionKey": format!("k{i}") }))
+        .collect();
+    let res = svc.put_records(&request(
+        "PutRecords",
+        json!({ "StreamName": "orders", "Records": entries }),
+    ));
+    assert_code_kinesis(res, "ValidationException");
+}
+
+#[test]
+fn put_records_rejects_aggregate_over_five_mib() {
+    let (svc, _) = make_service();
+    create_stream_action(&svc, "orders", 1);
+    // 6 records of ~1 MiB each = ~6 MiB aggregate, over the 5 MiB batch limit
+    // while each individual record stays within the 1 MiB per-record ceiling.
+    let chunk = vec![b'x'; 1000 * 1024];
+    let entries: Vec<Value> = (0..6)
+        .map(|i| json!({ "Data": b64(&chunk), "PartitionKey": format!("k{i}") }))
+        .collect();
+    let res = svc.put_records(&request(
+        "PutRecords",
+        json!({ "StreamName": "orders", "Records": entries }),
+    ));
+    assert_code_kinesis(res, "ValidationException");
+}
+
+#[test]
+fn put_record_honors_configured_max_record_size() {
+    let (svc, state) = make_service();
+    create_stream_action(&svc, "orders", 1);
+    // Raise the per-record ceiling to 2 MiB for this stream.
+    state
+        .write()
+        .default_mut()
+        .streams
+        .get_mut("orders")
+        .unwrap()
+        .max_record_size_kib = Some(2048);
+    // 1.5 MiB is over the 1 MiB default but under the configured 2 MiB.
+    let payload = vec![b'x'; 1536 * 1024];
+    svc.put_record(&request(
+        "PutRecord",
+        json!({
+            "StreamName": "orders",
+            "Data": b64(&payload),
+            "PartitionKey": "k1",
+        }),
+    ))
+    .unwrap();
+}
+
+// ── M3: PartitionKey length ──
+
+#[test]
+fn put_record_rejects_partition_key_over_256_chars() {
+    let (svc, _) = make_service();
+    create_stream_action(&svc, "orders", 1);
+    let long_key = "p".repeat(257);
+    let res = svc.put_record(&request(
+        "PutRecord",
+        json!({
+            "StreamName": "orders",
+            "Data": b64(b"a"),
+            "PartitionKey": long_key,
+        }),
+    ));
+    assert_code_kinesis(res, "ValidationException");
+}
+
+#[test]
+fn put_records_reports_long_partition_key_as_per_record_failure() {
+    let (svc, _) = make_service();
+    create_stream_action(&svc, "orders", 1);
+    let long_key = "p".repeat(257);
+    let resp = svc
+        .put_records(&request(
+            "PutRecords",
+            json!({
+                "StreamName": "orders",
+                "Records": [
+                    { "Data": b64(b"a"), "PartitionKey": "ok" },
+                    { "Data": b64(b"b"), "PartitionKey": long_key },
+                ]
+            }),
+        ))
+        .unwrap();
+    let body = json_response(resp);
+    assert_eq!(body["FailedRecordCount"], json!(1));
+    let records = body["Records"].as_array().unwrap();
+    assert!(records[0].get("SequenceNumber").is_some());
+    assert!(records[1].get("ErrorCode").is_some());
+}
+
+// ── M2: read ops are not durable-mutating ──
+
+#[test]
+fn read_ops_are_not_mutating_actions() {
+    // GetRecords / GetShardIterator only touch the ephemeral (serde-skipped)
+    // iterator lease map, so they must not trigger a full-state snapshot save.
+    assert!(!is_mutating_action("GetRecords"));
+    assert!(!is_mutating_action("GetShardIterator"));
+    // Writes still are.
+    assert!(is_mutating_action("PutRecord"));
+    assert!(is_mutating_action("PutRecords"));
+}
+
+// ── M1: UpdateShardCount lineage ──
+
+#[test]
+fn update_shard_count_preserves_parent_lineage() {
+    let (svc, state) = make_service();
+    create_stream_action(&svc, "orders", 2);
+
+    // Capture the pre-scale open shard ids and force a record onto shard 0
+    // (ExplicitHashKey 0 always routes to the shard covering hash 0).
+    let original_ids: Vec<String> = {
+        let g = state.read();
+        g.default_ref()
+            .streams
+            .get("orders")
+            .unwrap()
+            .shards
+            .iter()
+            .map(|s| s.shard_id.clone())
+            .collect()
+    };
+    svc.put_record(&request(
+        "PutRecord",
+        json!({
+            "StreamName": "orders",
+            "Data": b64(b"hi"),
+            "PartitionKey": "k1",
+            "ExplicitHashKey": "0",
+        }),
+    ))
+    .unwrap();
+
+    svc.update_shard_count(&request(
+        "UpdateShardCount",
+        json!({
+            "StreamName": "orders",
+            "TargetShardCount": 4,
+            "ScalingType": "UNIFORM_SCALING",
+        }),
+    ))
+    .unwrap();
+
+    // Every original shard must now be a parent of at least one new shard, so
+    // consumers can discover the post-scale shards from the closed originals.
+    {
+        let g = state.read();
+        let stream = g.default_ref().streams.get("orders").unwrap();
+        for original in &original_ids {
+            let is_parent = stream.shards.iter().any(|s| {
+                s.parent_shard_id.as_deref() == Some(original.as_str())
+                    || s.adjacent_parent_shard_id.as_deref() == Some(original.as_str())
+            });
+            assert!(
+                is_parent,
+                "original shard {original} has no child after scaling"
+            );
+        }
+    }
+
+    // GetRecords draining a closed original returns non-empty ChildShards.
+    let closed_original = &original_ids[0];
+    let iter = json_response(
+        svc.get_shard_iterator(&request(
+            "GetShardIterator",
+            json!({
+                "StreamName": "orders",
+                "ShardId": closed_original,
+                "ShardIteratorType": "TRIM_HORIZON",
+            }),
+        ))
+        .unwrap(),
+    )["ShardIterator"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let body = json_response(
+        svc.get_records(&request("GetRecords", json!({ "ShardIterator": iter })))
+            .unwrap(),
+    );
+    let children = body["ChildShards"].as_array();
+    assert!(
+        children.map(|c| !c.is_empty()).unwrap_or(false),
+        "closed original shard should report ChildShards, got {body}"
+    );
+}
+
+// ── L1: below-horizon sequence number resolves to trim horizon ──
+
+#[test]
+fn at_sequence_number_below_trim_horizon_resolves_to_earliest() {
+    let (svc, state) = make_service();
+    create_stream_action(&svc, "orders", 1);
+
+    // Two records; capture the first sequence number, then simulate retention
+    // trimming it away so only the second remains.
+    let first_seq = json_response(
+        svc.put_record(&request(
+            "PutRecord",
+            json!({ "StreamName": "orders", "Data": b64(b"one"), "PartitionKey": "k" }),
+        ))
+        .unwrap(),
+    )["SequenceNumber"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    svc.put_record(&request(
+        "PutRecord",
+        json!({ "StreamName": "orders", "Data": b64(b"two"), "PartitionKey": "k" }),
+    ))
+    .unwrap();
+    {
+        let mut g = state.write();
+        let stream = g.default_mut().streams.get_mut("orders").unwrap();
+        stream.shards[0].records.remove(0); // drop the trimmed record
+    }
+
+    // AT_SEQUENCE_NUMBER on the trimmed seq must resolve to the earliest
+    // available record instead of raising InvalidArgumentException.
+    let iter = json_response(
+        svc.get_shard_iterator(&request(
+            "GetShardIterator",
+            json!({
+                "StreamName": "orders",
+                "ShardId": "shardId-000000000000",
+                "ShardIteratorType": "AT_SEQUENCE_NUMBER",
+                "StartingSequenceNumber": first_seq,
+            }),
+        ))
+        .unwrap(),
+    )["ShardIterator"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let body = json_response(
+        svc.get_records(&request("GetRecords", json!({ "ShardIterator": iter })))
+            .unwrap(),
+    );
+    let records = body["Records"].as_array().unwrap();
+    assert_eq!(records.len(), 1, "resolves to the surviving record");
+}
+
+// ── L2: shard-iterator tokens are unique per insert ──
+
+#[test]
+fn insert_iterator_tokens_are_distinct_after_eviction() {
+    let mut st = KinesisState::new("123456789012", "us-east-1");
+    let t1 = st.insert_iterator("s", "shardId-000000000000", 0);
+    // Simulate the lease being evicted so the map size returns to its prior
+    // value — the exact case where the old `iterators.len()` tie-breaker
+    // produced a duplicate token within the same millisecond.
+    st.iterators.clear();
+    let t2 = st.insert_iterator("s", "shardId-000000000000", 0);
+    assert_ne!(t1, t2, "same-ms iterator tokens must not collide");
+}
+
+// ── L3: ListStreams resumes correctly after the cursor stream is deleted ──
+
+#[test]
+fn list_streams_resumes_after_deleted_cursor() {
+    let (svc, _) = make_service();
+    for name in ["a", "b", "c", "d"] {
+        create_stream_action(&svc, name, 1);
+    }
+    // First page of two returns [a, b] with a NextToken keyed on "b".
+    let page1 = json_response(
+        svc.list_streams(&request("ListStreams", json!({ "Limit": 2 })))
+            .unwrap(),
+    );
+    assert_eq!(page1["StreamNames"], json!(["a", "b"]));
+    let token = page1["NextToken"].as_str().unwrap().to_string();
+
+    // Delete the cursor stream "b" before resuming.
+    svc.delete_stream(&request("DeleteStream", json!({ "StreamName": "b" })))
+        .unwrap();
+
+    let page2 = json_response(
+        svc.list_streams(&request("ListStreams", json!({ "NextToken": token })))
+            .unwrap(),
+    );
+    assert_eq!(
+        page2["StreamNames"],
+        json!(["c", "d"]),
+        "resume must continue past the deleted cursor, not restart"
+    );
+}
+
+// ── Cheap guard: routing on a shard-less stream errors instead of panicking ──
+
+#[test]
+fn put_record_on_shardless_stream_errors_without_panic() {
+    let (svc, state) = make_service();
+    create_stream_action(&svc, "orders", 1);
+    // Force the (unreachable-via-API) shard-less state.
+    state
+        .write()
+        .default_mut()
+        .streams
+        .get_mut("orders")
+        .unwrap()
+        .shards
+        .clear();
+    let res = svc.put_record(&request(
+        "PutRecord",
+        json!({ "StreamName": "orders", "Data": b64(b"a"), "PartitionKey": "k" }),
+    ));
+    assert_code_kinesis(res, "InvalidArgumentException");
+}

--- a/crates/fakecloud-kinesis/src/state.rs
+++ b/crates/fakecloud-kinesis/src/state.rs
@@ -29,6 +29,13 @@ pub struct KinesisState {
     /// (bug-hunt 2026-06-24, 4.2).
     #[serde(skip)]
     pub iterators: BTreeMap<String, ShardIteratorLease>,
+    /// Monotonic counter feeding the shard-iterator token's tie-breaker. Using
+    /// `iterators.len()` collided when two tokens were minted in the same
+    /// millisecond after an eviction rebalanced the map size; a strictly
+    /// increasing counter guarantees a distinct token per insert. Ephemeral,
+    /// like the leases it names.
+    #[serde(skip)]
+    pub iterator_counter: u64,
     pub lambda_checkpoints: BTreeMap<String, usize>,
     pub consumers: BTreeMap<String, KinesisConsumer>,
     pub resource_policies: BTreeMap<String, String>,
@@ -102,6 +109,7 @@ impl KinesisState {
             region: region.to_string(),
             streams: BTreeMap::new(),
             iterators: BTreeMap::new(),
+            iterator_counter: 0,
             lambda_checkpoints: BTreeMap::new(),
             consumers: BTreeMap::new(),
             resource_policies: BTreeMap::new(),
@@ -142,13 +150,14 @@ impl KinesisState {
     ) -> String {
         self.iterators
             .retain(|_, lease| lease.expires_at >= Utc::now());
+        self.iterator_counter = self.iterator_counter.wrapping_add(1);
         let token = format!(
             "{}:{}:{}:{}:{}",
             stream_name,
             shard_id,
             next_record_index,
             Utc::now().timestamp_millis(),
-            self.iterators.len() + 1
+            self.iterator_counter
         );
         self.iterators.insert(
             token.clone(),


### PR DESCRIPTION
## Summary
Behavioral hardening of `fakecloud-kinesis` — divergences the conformance probe can't see (it sends one small well-formed record and checks response shape).

- **H1** no record-size / batch-count / batch-size limits were enforced and `MaxRecordSizeInKiB` was dead config. Now enforces PutRecord ≤1 MiB, PutRecords ≤500 records and ≤5 MiB aggregate, and honors the configured max.
- **M1** `UpdateShardCount` orphaned the closed original shards (refinement pieces had `parent_shard_id: None`), so a KCL/Lambda-ESM consumer couldn't discover post-scale shards via `ChildShards`. Parent/adjacent-parent lineage is now set like Split/Merge.
- **M2** `GetRecords`/`GetShardIterator` were flagged mutating, so every read poll serialized and disk-wrote the entire multi-account state for zero durable effect (iterators are `#[serde(skip)]`). Removed from the mutating set.
- **M3** `PartitionKey` length (max 256) now validated.
- **L1-L3** below-horizon sequence resolves to trim horizon; monotonic iterator token (no same-millisecond collision); stable `ListStreams` `NextToken` position. Plus a defensive empty-shards guard.

## Test plan
- `cargo test -p fakecloud-kinesis` unit tests: oversized record/batch rejected, reshard lineage, is_mutating excludes reads, partition-key length, iterator-token uniqueness.
- Persistence/restore path unchanged. CI runs full clippy + conformance + e2e.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `fakecloud-kinesis` to better match AWS: enforce record and batch limits, preserve shard lineage on reshard, and make reads cheap by not treating them as mutating. Also adds `PartitionKey` length validation and fixes iterator/pagination edge cases.

- **Bug Fixes**
  - Enforce PutRecord 1 MiB and PutRecords 500-record/5 MiB limits; honor per-stream `MaxRecordSizeInKiB`.
  - Preserve parent/adjacent-parent lineage in `UpdateShardCount`, so closed shards expose `ChildShards`.
  - Treat `GetRecords` and `GetShardIterator` as non-mutating to avoid full-state snapshot writes on reads.
  - Validate `PartitionKey` length (<=256); report as a per-record error in `PutRecords`.
  - Edge cases: below-horizon `AT_/AFTER_SEQUENCE_NUMBER` resolves to trim horizon; stable `ListStreams` resume when the cursor stream is deleted; unique shard-iterator tokens; guard empty-shard routing to avoid panics.

<sup>Written for commit e29a7237927ea06cde0e26a827e585467e71937d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

