### PR TITLE
fix(eks,backup,kafka): guard three request-reachable panics

### DIFF
--- a/crates/fakecloud-backup/src/handlers.rs
+++ b/crates/fakecloud-backup/src/handlers.rs
@@ -991,13 +991,31 @@ impl BackupService {
             .vaults
             .get_mut(name)
             .ok_or_else(|| not_found(format!("Backup vault not found: {name}")))?;
+        let changeable = body.get("ChangeableForDays").and_then(|x| x.as_i64());
+        // AWS bounds ChangeableForDays to 3..=36500; validate before the date
+        // arithmetic below (`Utc::now() + Duration::days(d)` panics on overflow
+        // in all build profiles for a hostile value).
+        if let Some(d) = changeable {
+            if !(3..=36500).contains(&d) {
+                return Err(invalid_param(format!(
+                    "ChangeableForDays must be between 3 and 36500, got {d}"
+                )));
+            }
+        }
         v.min_retention_days = body.get("MinRetentionDays").and_then(|x| x.as_i64());
         v.max_retention_days = body.get("MaxRetentionDays").and_then(|x| x.as_i64());
-        v.changeable_for_days = body.get("ChangeableForDays").and_then(|x| x.as_i64());
-        v.locked = v.changeable_for_days.unwrap_or(0) == 0;
-        v.lock_date = v
-            .changeable_for_days
-            .map(|d| Utc::now() + chrono::Duration::days(d));
+        v.changeable_for_days = changeable;
+        v.locked = changeable.unwrap_or(0) == 0;
+        v.lock_date = match changeable {
+            Some(d) => Some(
+                Utc::now()
+                    .checked_add_signed(chrono::Duration::days(d))
+                    .ok_or_else(|| {
+                        invalid_param("ChangeableForDays produces an out-of-range lock date")
+                    })?,
+            ),
+            None => None,
+        };
         Ok(empty(200))
     }
 

--- a/crates/fakecloud-backup/tests/service_tests.rs
+++ b/crates/fakecloud-backup/tests/service_tests.rs
@@ -944,3 +944,48 @@ fn percent(s: &str) -> String {
     }
     out
 }
+
+// ---------------------------------------------------------------------------
+// Vault lock
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn vault_lock_rejects_overflow_changeable_days() {
+    // Regression: a hostile ChangeableForDays used to overflow the
+    // `Utc::now() + Duration::days(d)` lock-date arithmetic and panic.
+    let svc = service();
+    make_vault(&svc, "lockvault").await;
+    let (status, code) = call_err(
+        &svc,
+        req(
+            Method::PUT,
+            "/backup-vaults/lockvault/vault-lock",
+            json!({ "ChangeableForDays": 100_000_000_i64 }),
+        ),
+    )
+    .await;
+    assert_eq!(status, 400);
+    assert_eq!(code, "InvalidParameterValueException");
+}
+
+#[tokio::test]
+async fn vault_lock_accepts_valid_changeable_days() {
+    let svc = service();
+    make_vault(&svc, "lockvault2").await;
+    // In-range value succeeds and does not lock immediately.
+    call(
+        &svc,
+        req(
+            Method::PUT,
+            "/backup-vaults/lockvault2/vault-lock",
+            json!({ "ChangeableForDays": 3 }),
+        ),
+    )
+    .await;
+    let resp = call(
+        &svc,
+        req(Method::GET, "/backup-vaults/lockvault2", json!({})),
+    )
+    .await;
+    assert_eq!(body_of(&resp)["Locked"], false);
+}

--- a/crates/fakecloud-eks/src/service.rs
+++ b/crates/fakecloud-eks/src/service.rs
@@ -3086,6 +3086,14 @@ impl EksService {
             .filter(|v| v.is_object())
             .ok_or_else(|| invalid_parameter("term is required"))?;
         let term_duration = term.get("duration").and_then(|v| v.as_i64()).unwrap_or(12);
+        // AWS EKS Anywhere subscriptions use month-based terms (12 or 36); bound
+        // the value so a hostile `duration` can't overflow the date arithmetic
+        // below (`DateTime + Duration` panics on overflow in all build profiles).
+        if !(1..=120).contains(&term_duration) {
+            return Err(invalid_parameter(format!(
+                "term.duration must be between 1 and 120 months, got {term_duration}"
+            )));
+        }
         let term_unit = term
             .get("unit")
             .and_then(|v| v.as_str())
@@ -3115,7 +3123,11 @@ impl EksService {
         let id = raw[..17.min(raw.len())].to_string();
         let arn = eks_anywhere_subscription_arn(&region, &account_id, &id);
         let now = Utc::now();
-        let expiration = now + chrono::Duration::days(term_duration * 30);
+        let expiration = now
+            .checked_add_signed(chrono::Duration::days(term_duration * 30))
+            .ok_or_else(|| {
+                invalid_parameter("term.duration produces an out-of-range expiration date")
+            })?;
         let subscription = EksAnywhereSubscription {
             id: id.clone(),
             arn,
@@ -6911,5 +6923,41 @@ mod tests {
             .err()
             .unwrap();
         assert_eq!(err.code(), "InvalidParameterException");
+    }
+
+    #[tokio::test]
+    async fn subscription_rejects_overflow_duration() {
+        // Regression: a hostile `term.duration` used to overflow the
+        // `DateTime + Duration` expiration arithmetic and panic the handler.
+        let svc = EksService::new(make_state());
+        let err = svc
+            .handle(make_request(
+                Method::POST,
+                "/eks-anywhere-subscriptions",
+                &json!({ "name": "sub", "term": { "duration": 100_000_000_i64, "unit": "MONTHS" } })
+                    .to_string(),
+            ))
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.code(), "InvalidParameterException");
+    }
+
+    #[tokio::test]
+    async fn subscription_accepts_valid_duration() {
+        let svc = EksService::new(make_state());
+        let resp = svc
+            .handle(make_request(
+                Method::POST,
+                "/eks-anywhere-subscriptions",
+                &json!({ "name": "sub-ok", "term": { "duration": 36, "unit": "MONTHS" } })
+                    .to_string(),
+            ))
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(v["subscription"]["term"]["duration"], 36);
+        assert_eq!(v["subscription"]["status"], "ACTIVE");
     }
 }

--- a/crates/fakecloud-kafka/src/service.rs
+++ b/crates/fakecloud-kafka/src/service.rs
@@ -600,11 +600,14 @@ fn merge_replication_sub(info: &mut Map<String, Value>, key: &str, incoming: Opt
     let Some(incoming) = incoming.as_ref().and_then(Value::as_object) else {
         return;
     };
-    let target = info
-        .entry(key.to_string())
-        .or_insert_with(|| json!({}))
-        .as_object_mut()
-        .expect("replication sub-object");
+    let slot = info.entry(key.to_string()).or_insert_with(|| json!({}));
+    // A stored value that a prior create left as a non-object (create does not
+    // normalize it) would make `as_object_mut()` return None; reset it rather
+    // than panicking on the update path.
+    if !slot.is_object() {
+        *slot = Value::Object(Map::new());
+    }
+    let target = slot.as_object_mut().expect("slot set to object above");
     for (k, v) in incoming {
         target.insert(k.clone(), v.clone());
     }
@@ -3366,6 +3369,25 @@ mod tests {
         let (action, labels) = KafkaService::resolve_action(&req).unwrap();
         assert_eq!(action, "ListNodes");
         assert_eq!(labels[0], "arn:aws:kafka:us-east-1:123:cluster/x/u-1");
+    }
+
+    #[test]
+    fn merge_replication_sub_overwrites_non_object() {
+        // Regression: a stored non-object sub-value (a prior create does not
+        // normalize it) used to panic the UpdateReplicationInfo path via
+        // `.as_object_mut().expect(...)`.
+        let mut info = Map::new();
+        info.insert("topicReplication".into(), json!("notanobject"));
+        merge_replication_sub(
+            &mut info,
+            "topicReplication",
+            Some(json!({ "topicNameConfiguration": { "type": "PREFIX" } })),
+        );
+        assert!(info["topicReplication"].is_object());
+        assert_eq!(
+            info["topicReplication"]["topicNameConfiguration"]["type"],
+            "PREFIX"
+        );
     }
 
     fn test_req() -> AwsRequest {


### PR DESCRIPTION
## Summary

Quality-audit 2026-07-13 (error-handling category) found three production panics reachable from untrusted request input. All three are missing-guard bugs where a hostile numeric/JSON value drives arithmetic that panics in **all** build profiles (chrono `DateTime + Duration` overflow) or a `.expect()` on a stored value.

- **eks `CreateEksAnywhereSubscription`** (`service.rs:3118`): `now + Duration::days(term_duration*30)` overflowed chrono's date range on a hostile `term.duration`. Now bounds duration to `1..=120` months (`InvalidParameterException` otherwise) and uses `checked_add_signed`.
- **backup `PutBackupVaultLock`** (`handlers.rs:1000`): `Utc::now() + Duration::days(d)` overflowed on a hostile `ChangeableForDays`. Now validates AWS's `3..=36500` range (`InvalidParameterValueException`) and uses `checked_add_signed`.
- **kafka `UpdateReplicationInfo`** (`service.rs:607`, `merge_replication_sub`): a stored non-object replication sub-value (create does not normalize it) panicked via `.as_object_mut().expect(...)`. Now resets the slot to an object before merging.

## Test plan

- `subscription_rejects_overflow_duration` / `subscription_accepts_valid_duration` (eks)
- `vault_lock_rejects_overflow_changeable_days` / `vault_lock_accepts_valid_changeable_days` (backup)
- `merge_replication_sub_overwrites_non_object` (kafka)
- `cargo test -p fakecloud-eks -p fakecloud-backup -p fakecloud-kafka` green; `cargo clippy --all-targets -D warnings` clean; `cargo fmt` applied.

## Surface impact

No new API surface: these are input-validation guards only, and the behavior change (rejecting out-of-range input) matches AWS. No SDK / docs / website / conformance-baseline / count changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents three request-triggered panics in EKS, Backup, and Kafka by validating inputs and using checked date math. No API changes; behavior matches AWS.

- **Bug Fixes**
  - `fakecloud-eks`: `CreateEksAnywhereSubscription` bounds `term.duration` to 1–120 months and uses `checked_add_signed`; out-of-range returns InvalidParameterException.
  - `fakecloud-backup`: `PutBackupVaultLock` validates `ChangeableForDays` in 3–36500 and uses `checked_add_signed`; out-of-range returns InvalidParameterValueException.
  - `fakecloud-kafka`: `UpdateReplicationInfo` resets a non-object replication sub-value to an object before merge to avoid panic.

<sup>Written for commit b353fb6e426753e81b1959872ea2960ae91297ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

