### PR TITLE
fix(core): decode form-body percent-escapes as UTF-8 bytes, not Latin-1

### DIFF
--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -854,22 +854,30 @@ fn decode_form_urlencoded(input: &[u8]) -> HashMap<String, String> {
 }
 
 fn url_decode(input: &str) -> String {
-    let mut result = String::with_capacity(input.len());
+    // Accumulate the decoded RAW BYTES first, then interpret the whole buffer
+    // as UTF-8. Decoding each `%XX` byte straight into a `char` would treat it
+    // as a Unicode codepoint (Latin-1), which corrupts multi-byte UTF-8
+    // sequences (e.g. "caf%C3%A9" -> "cafÃ©" instead of "café"). Reassembling
+    // the bytes lets multi-byte sequences round-trip correctly.
+    let mut buf: Vec<u8> = Vec::with_capacity(input.len());
     let mut bytes = input.bytes();
     while let Some(b) = bytes.next() {
         match b {
-            b'+' => result.push(' '),
+            b'+' => buf.push(b' '),
             b'%' => {
                 let high = bytes.next().and_then(from_hex);
                 let low = bytes.next().and_then(from_hex);
+                // A well-formed `%XX` escape decodes to a single raw byte.
+                // A malformed escape is dropped (best-effort, panic-free),
+                // matching the prior behaviour.
                 if let (Some(h), Some(l)) = (high, low) {
-                    result.push((h << 4 | l) as char);
+                    buf.push((h << 4) | l);
                 }
             }
-            _ => result.push(b as char),
+            _ => buf.push(b),
         }
     }
-    result
+    String::from_utf8_lossy(&buf).into_owned()
 }
 
 fn from_hex(b: u8) -> Option<u8> {
@@ -937,6 +945,67 @@ mod tests {
         let body = Bytes::from("key=value");
         let params = parse_query_body(&body);
         assert_eq!(params.get("key").unwrap(), "value");
+    }
+
+    #[test]
+    fn url_decode_plain_ascii() {
+        assert_eq!(url_decode("hello"), "hello");
+        assert_eq!(url_decode("Action=SendMessage"), "Action=SendMessage");
+    }
+
+    #[test]
+    fn url_decode_plus_is_space() {
+        assert_eq!(url_decode("hello+world"), "hello world");
+        assert_eq!(url_decode("a+b+c"), "a b c");
+    }
+
+    #[test]
+    fn url_decode_multibyte_utf8_accents() {
+        // "café" -> the é is UTF-8 0xC3 0xA9, two %-escapes for one codepoint.
+        assert_eq!(url_decode("caf%C3%A9"), "café");
+    }
+
+    #[test]
+    fn url_decode_multibyte_utf8_cjk() {
+        // "日本" (each char is 3 UTF-8 bytes).
+        assert_eq!(url_decode("%E6%97%A5%E6%9C%AC"), "日本");
+    }
+
+    #[test]
+    fn url_decode_multibyte_utf8_emoji() {
+        // "🚀" is a 4-byte UTF-8 sequence (F0 9F 9A 80).
+        assert_eq!(url_decode("%F0%9F%9A%80"), "🚀");
+    }
+
+    #[test]
+    fn url_decode_mixed_ascii_and_multibyte() {
+        assert_eq!(url_decode("Tag+%3D+caf%C3%A9%21"), "Tag = café!");
+    }
+
+    #[test]
+    fn url_decode_malformed_percent_is_graceful() {
+        // A malformed escape is dropped best-effort and must never panic.
+        assert_eq!(url_decode("100%"), "100");
+        assert_eq!(url_decode("a%zz"), "a");
+        assert_eq!(url_decode("a%4"), "a");
+        // Preceding and following ASCII are preserved either side of the drop.
+        assert_eq!(url_decode("x%y"), "x");
+    }
+
+    #[test]
+    fn url_decode_invalid_utf8_bytes_are_lossy_no_panic() {
+        // 0xFF is not valid UTF-8; must not panic, replaced lossily.
+        let out = url_decode("bad%FFbyte");
+        assert!(out.starts_with("bad"));
+        assert!(out.ends_with("byte"));
+    }
+
+    #[test]
+    fn parse_query_body_multibyte_value_round_trips() {
+        let body = Bytes::from("Tag.Value=caf%C3%A9&Name=%E6%97%A5%E6%9C%AC");
+        let params = parse_query_body(&body);
+        assert_eq!(params.get("Tag.Value").unwrap(), "café");
+        assert_eq!(params.get("Name").unwrap(), "日本");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The form-body percent-decoder in `crates/fakecloud-core/src/protocol.rs` (`url_decode`) decoded each `%XX` escape directly into a `char` via `(h << 4 | l) as char`. That treats every decoded byte as a Unicode codepoint (Latin-1), so multi-byte UTF-8 sequences are corrupted. A body param like `Tag.Value=caf%C3%A9` ("café") round-tripped as "cafÃ©"; CJK and emoji were likewise mangled.

This is the BODY form-decode path used by EC2 and every `awsQuery` service (and by terraform), so it corrupted non-ASCII tags/values across services. The query-string path was unaffected.

### Fix

`url_decode` now accumulates the decoded **raw bytes** into a `Vec<u8>` (literal bytes, `+` -> space, and each `%XX` as one byte), then reassembles them with `String::from_utf8_lossy`. Multi-byte UTF-8 sequences now round-trip correctly. Malformed `%` escapes are still dropped best-effort (unchanged prior behavior) and never panic; invalid UTF-8 bytes are handled lossily.

Only this one copy of the decode pattern existed in the crate. The `as char` uses in `service.rs` are hex *encoding* (ASCII table lookups), not this decode path, so they are correct and untouched.

## Test plan

Added unit tests in `fakecloud-core` covering:
- plain ASCII
- `+` -> space
- multi-byte UTF-8: café (2-byte), 日本 (3-byte), 🚀 (4-byte)
- mixed ASCII + multibyte
- malformed `%` sequences (graceful, no panic)
- invalid UTF-8 bytes (lossy, no panic)
- `parse_query_body` end-to-end round-trip of multibyte values

Verified locally (foreground):
- `cargo test -p fakecloud-core` — 239 passed
- `cargo clippy -p fakecloud-core --all-targets -- -D warnings` — clean
- `cargo build --bin fakecloud` — builds
- `cargo fmt` — no changes

Conformance (`ec2`/`tag` filter) was not run locally: the conformance crate build was too slow under heavy concurrent contention. Relying on CI to gate it. This change only makes decoding more correct, so no conformance regression is expected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes form-body percent-decoding to treat `%XX` as UTF-8 bytes, not Latin-1, so non-ASCII values decode correctly. Prevents mangled characters in EC2 and other `awsQuery` services (e.g., `caf%C3%A9` now becomes "café").

- **Bug Fixes**
  - Rewrote `url_decode` to collect raw bytes (`+` -> space, `%XX` -> one byte) and build the string with `String::from_utf8_lossy`.
  - Preserves best-effort behavior for malformed escapes and invalid UTF-8 (lossy, no panic).
  - Added unit tests for ASCII, multibyte UTF-8 (accents, CJK, emoji), malformed inputs, and `parse_query_body` round-trips.

<sup>Written for commit d21bb96458a83ecc46fd89e18e03fef14bc763d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

