### PR TITLE
fix(apigateway): $default routing, integration method/params, execute-api host resolution

### DIFF
--- a/crates/fakecloud-apigateway/src/data_plane/integrations.rs
+++ b/crates/fakecloud-apigateway/src/data_plane/integrations.rs
@@ -2,16 +2,30 @@
 
 use super::*;
 
+/// Resolve the outgoing backend method for a **non-proxy** `HTTP`
+/// integration: AWS calls the backend with the configured
+/// `integrationHttpMethod`, not the client's front-facing method (a
+/// `GET` resource can be wired to `POST` the backend). Returns `None`
+/// when unset so callers keep the client method as the fallback.
+pub(super) fn integration_method_override(integration: &Integration) -> Option<Method> {
+    integration
+        .integration_http_method
+        .as_deref()
+        .and_then(|m| Method::from_bytes(m.to_ascii_uppercase().as_bytes()).ok())
+}
+
 pub(super) async fn http_proxy(
     req: &AwsRequest,
     integration: &Integration,
     body_override: Option<bytes::Bytes>,
+    method_override: Option<Method>,
 ) -> Result<AwsResponse, AwsServiceError> {
     let url = integration
         .uri
         .as_ref()
         .ok_or_else(|| bad_gateway("HTTP integration missing uri"))?;
-    let method = match req.method {
+    let effective_method = method_override.as_ref().unwrap_or(&req.method);
+    let method = match *effective_method {
         Method::GET => reqwest::Method::GET,
         Method::POST => reqwest::Method::POST,
         Method::PUT => reqwest::Method::PUT,
@@ -149,7 +163,8 @@ pub(super) async fn vpc_link_proxy(
 
     let mut proxy_integration = integration.clone();
     proxy_integration.uri = Some(backend_url);
-    http_proxy(req, &proxy_integration, None).await
+    let method_override = integration_method_override(integration);
+    http_proxy(req, &proxy_integration, None, method_override).await
 }
 
 /// Apply the integration's `requestTemplates` to the request body.
@@ -199,12 +214,10 @@ pub(super) async fn apply_response_template(
     );
     let accounts = service.state_handle().read();
     let state = accounts.get(&req.account_id);
-    let resp_template = state.and_then(|st| {
-        st.integration_responses
-            .get(&key)
-            .and_then(|v| v.get("responseTemplates"))
-            .and_then(|t| t.as_object())
-    });
+    let resp_record = state.and_then(|st| st.integration_responses.get(&key));
+    let resp_template = resp_record
+        .and_then(|v| v.get("responseTemplates"))
+        .and_then(|t| t.as_object());
     let content_type = backend_resp
         .content_type
         .as_str()
@@ -225,12 +238,63 @@ pub(super) async fn apply_response_template(
     } else {
         backend_resp.body.expect_bytes().to_vec()
     };
+    // Apply the integration response's responseParameters (mapped/static
+    // headers) onto the client response. Source expressions read the
+    // original backend headers, so clone before mutating.
+    let mut headers = backend_resp.headers.clone();
+    apply_response_parameters(&mut headers, resp_record, Some(&backend_resp));
     Ok(AwsResponse {
         status: backend_resp.status,
         content_type: backend_resp.content_type,
-        headers: backend_resp.headers,
+        headers,
         body: bytes::Bytes::from(body).into(),
     })
+}
+
+/// Apply an integration response's `responseParameters` map to the
+/// outgoing response headers. Keys are `method.response.header.<Name>`;
+/// values are either a `'literal'` (single-quoted static value) or a
+/// mapping expression `integration.response.header.<X>` sourced from the
+/// backend response. This is what makes a MOCK-based CORS preflight
+/// return its `Access-Control-Allow-*` headers, and lets non-proxy HTTP
+/// integrations project backend headers onto the client response.
+fn apply_response_parameters(
+    headers: &mut http::HeaderMap,
+    resp_record: Option<&Value>,
+    backend: Option<&AwsResponse>,
+) {
+    let Some(params) = resp_record
+        .and_then(|r| r.get("responseParameters"))
+        .and_then(|v| v.as_object())
+    else {
+        return;
+    };
+    for (key, value) in params {
+        let Some(header_name) = key.strip_prefix("method.response.header.") else {
+            continue;
+        };
+        let raw = value.as_str().unwrap_or_default();
+        let resolved = if raw.len() >= 2 && raw.starts_with('\'') && raw.ends_with('\'') {
+            Some(raw[1..raw.len() - 1].to_string())
+        } else if let Some(src) = raw.strip_prefix("integration.response.header.") {
+            backend
+                .and_then(|b| b.headers.get(src))
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+        } else if !raw.is_empty() {
+            Some(raw.to_string())
+        } else {
+            None
+        };
+        if let (Ok(name), Some(v)) = (
+            http::HeaderName::from_bytes(header_name.as_bytes()),
+            resolved
+                .as_deref()
+                .and_then(|v| http::HeaderValue::from_str(v).ok()),
+        ) {
+            headers.insert(name, v);
+        }
+    }
 }
 
 /// Build a MOCK integration response by looking up the integration
@@ -246,13 +310,24 @@ pub(super) async fn mock_response(
     service: &ApiGatewayService,
 ) -> Result<AwsResponse, AwsServiceError> {
     let method = integration.http_method.as_str();
-    // Default to 200 when no explicit status code is configured.
+    // MOCK integrations select the integration response via the request
+    // template, which conventionally emits `{"statusCode": NNN}`. Render
+    // the application/json request template and read that selector; fall
+    // back to 200 when there is no template or no statusCode field.
     let default_status = "200";
-    let key = response_key(api_id, resource_path, method, default_status);
+    let selected_status = integration
+        .request_templates
+        .get("application/json")
+        .map(|tpl| crate::vtl::render(tpl, vtl_ctx))
+        .and_then(|rendered| serde_json::from_str::<Value>(&rendered).ok())
+        .and_then(|v| v.get("statusCode").and_then(|s| s.as_i64()))
+        .map(|n| n.to_string());
+    let lookup_status = selected_status.as_deref().unwrap_or(default_status);
+    let key = response_key(api_id, resource_path, method, lookup_status);
     let accounts = service.state_handle().read();
     let state = accounts.get(&req.account_id);
-    // Try the 200 response first; if absent scan for any integration
-    // response registered for this method and use its configured status.
+    // Try the selected-status response first; if absent scan for any
+    // integration response registered for this method and use its status.
     let resp_record = state.and_then(|st| {
         st.integration_responses.get(&key).or_else(|| {
             let prefix = format!("{api_id}/{resource_path}/{method}/");
@@ -266,11 +341,11 @@ pub(super) async fn mock_response(
         let status = record
             .get("statusCode")
             .and_then(|v| v.as_str())
-            .unwrap_or(default_status);
+            .unwrap_or(lookup_status);
         let templates = record.get("responseTemplates").and_then(|v| v.as_object());
         (status, templates)
     } else {
-        (default_status, None)
+        (lookup_status, None)
     };
     let status = status
         .parse::<u16>()
@@ -287,10 +362,13 @@ pub(super) async fn mock_response(
     } else {
         String::new()
     };
+    // Apply responseParameters (e.g. static CORS headers) to the response.
+    let mut headers = http::HeaderMap::new();
+    apply_response_parameters(&mut headers, resp_record, None);
     Ok(AwsResponse {
         status,
         content_type: content_type.to_string(),
-        headers: http::HeaderMap::new(),
+        headers,
         body: bytes::Bytes::from(body).into(),
     })
 }

--- a/crates/fakecloud-apigateway/src/data_plane/mod.rs
+++ b/crates/fakecloud-apigateway/src/data_plane/mod.rs
@@ -88,13 +88,18 @@ pub async fn handle(
     // When the Host header matches a DomainName's regionalDomainName,
     // look up BasePathMappings to determine the target API + stage.
     // The longest matching basePath prefix wins (AWS behavior).
-    let (stage_name, remaining, custom_domain_api_hint) = match resolve_custom_domain(service, req)
-    {
+    let custom = resolve_custom_domain(service, req);
+    let via_custom_domain = custom.is_some();
+    let (stage_name, remaining, custom_domain_api_hint) = match custom {
         Some(triple) => triple,
         None => {
             let stage = req.path_segments[0].clone();
             let rest = req.path_segments[1..].to_vec();
-            (Some(stage), rest, None)
+            // Default execute-api endpoint: pin resolution to the API id
+            // carried in the Host header (`{api-id}.execute-api...`) so two
+            // APIs sharing a stage name don't collide.
+            let hint = host_api_id(req);
+            (Some(stage), rest, hint)
         }
     };
     let stage_name = stage_name.unwrap_or_else(|| req.path_segments[0].clone());
@@ -140,6 +145,9 @@ pub async fn handle(
                 Some(r) => r,
                 None => continue,
             };
+            // Rank candidate resources by specificity so a static route
+            // (`/health`) beats a `{proxy+}` catch-all when both match.
+            let mut best_score: Option<Vec<u8>> = None;
             for resource in resources.values() {
                 if let Some(params) = match_resource_path(&resource.path, &remaining) {
                     let exact_key = format!(
@@ -207,22 +215,25 @@ pub async fn handle(
                             .get(api_id)
                             .map(|api| api.binary_media_types.clone())
                             .unwrap_or_default();
-                        found = Some(DataPlaneMatch {
-                            api_id: api_id.clone(),
-                            integration,
-                            path_params: params,
-                            resource_path: resource.path.clone(),
-                            stage_vars,
-                            authorization_type,
-                            authorizer,
-                            request_parameters,
-                            request_models,
-                            request_validator_id,
-                            api_key_required,
-                            stage_web_acl_arn,
-                            binary_media_types,
-                        });
-                        break;
+                        let score = resource_specificity(&resource.path);
+                        if best_score.as_ref().map(|b| score > *b).unwrap_or(true) {
+                            best_score = Some(score);
+                            found = Some(DataPlaneMatch {
+                                api_id: api_id.clone(),
+                                integration,
+                                path_params: params,
+                                resource_path: resource.path.clone(),
+                                stage_vars,
+                                authorization_type,
+                                authorizer,
+                                request_parameters,
+                                request_models,
+                                request_validator_id,
+                                api_key_required,
+                                stage_web_acl_arn,
+                                binary_media_types,
+                            });
+                        }
                     }
                 }
             }
@@ -240,6 +251,30 @@ pub async fn handle(
             }
         }
     };
+
+    // Enforce `disableExecuteApiEndpoint`: when set, the default
+    // execute-api endpoint returns 403. Custom-domain traffic is exempt —
+    // disabling the default endpoint is what forces callers onto the
+    // custom domain.
+    if !via_custom_domain {
+        let disabled = {
+            let accounts = service.state_handle().read();
+            accounts
+                .get(&req.account_id)
+                .and_then(|st| st.apis.get(&api_id))
+                .map(|api| api.disable_execute_api_endpoint)
+                .unwrap_or(false)
+        };
+        if disabled {
+            let err = AwsServiceError::aws_error(
+                StatusCode::FORBIDDEN,
+                "ForbiddenException",
+                "The execute-api endpoint is disabled for this API",
+            );
+            service.record_request(&req.account_id, &api_id, &stage_name, req, err.status());
+            return Err(err);
+        }
+    }
 
     // WAFv2 inspection: when the matched stage's ARN is associated
     // with a WebACL and the service was wired with WAF state,
@@ -388,14 +423,18 @@ pub async fn handle(
                 .ok_or_else(|| bad_gateway("Lambda delivery not configured"))?;
             lambda_proxy::invoke_lambda(delivery, &function_arn, event).await
         }
-        "HTTP_PROXY" => http_proxy(req, &integration, None).await,
+        "HTTP_PROXY" => http_proxy(req, &integration, None, None).await,
         "HTTP" => {
             if integration.connection_type.as_deref() == Some("VPC_LINK") {
                 vpc_link_proxy(req, &integration, service).await
             } else {
                 // Apply request template before sending to backend.
                 let transformed_body = apply_request_template(req, &integration, &mut vtl_ctx);
-                let backend_resp = http_proxy(req, &integration, transformed_body).await?;
+                // Non-proxy HTTP calls the backend with the configured
+                // integrationHttpMethod, not the client's method.
+                let method_override = integration_method_override(&integration);
+                let backend_resp =
+                    http_proxy(req, &integration, transformed_body, method_override).await?;
                 // Apply response template after receiving from backend.
                 apply_response_template(
                     backend_resp,
@@ -632,12 +671,17 @@ fn resolve_custom_domain(
     let accounts = service.state_handle().read();
     let state = accounts.get(&req.account_id)?;
 
-    // Find domain whose regionalDomainName matches the Host header.
-    let domain_entry = state.domain_names.iter().find(|(_name, value)| {
-        value
-            .get("regionalDomainName")
-            .and_then(Value::as_str)
-            .is_some_and(|rdn| rdn.eq_ignore_ascii_case(host))
+    // Find the domain whose name key OR regionalDomainName matches the
+    // Host header. Real clients send the custom domain name itself
+    // (`api.example.com`) as Host; the regionalDomainName is the internal
+    // CloudFront/regional alias. Matching only the latter missed every
+    // request that used the actual domain name.
+    let domain_entry = state.domain_names.iter().find(|(name, value)| {
+        name.eq_ignore_ascii_case(host)
+            || value
+                .get("regionalDomainName")
+                .and_then(Value::as_str)
+                .is_some_and(|rdn| rdn.eq_ignore_ascii_case(host))
     });
     let (domain_name, _domain_value) = domain_entry?;
 
@@ -675,6 +719,45 @@ fn resolve_custom_domain(
     }
 
     None
+}
+
+/// Extract the API id from the execute-api `Host` header
+/// (`{api-id}.execute-api.<region>.amazonaws.com`). Returns `None` when
+/// the header is absent or is not an execute-api host, so unit tests and
+/// custom-domain traffic fall through to the legacy stage scan.
+fn host_api_id(req: &AwsRequest) -> Option<String> {
+    let host = req.headers.get("host").and_then(|v| v.to_str().ok())?;
+    if !host.contains("execute-api") {
+        return None;
+    }
+    let id = host.split('.').next()?;
+    if id.is_empty() {
+        return None;
+    }
+    Some(id.to_string())
+}
+
+/// Score a resource path's specificity, one entry per segment: a static
+/// segment (`items`) outranks a `{var}` placeholder, which outranks a
+/// `{proxy+}` greedy catch-all. Comparing the resulting vectors with the
+/// derived `Ord` picks the most specific matching resource — so `/health`
+/// wins over `/{proxy+}` and `/items/special` wins over `/items/{id}`.
+fn resource_specificity(path: &str) -> Vec<u8> {
+    path.split('/')
+        .filter(|s| !s.is_empty())
+        .map(|seg| {
+            if seg.starts_with('{') && seg.ends_with('}') {
+                let inner = seg.trim_start_matches('{').trim_end_matches('}');
+                if inner.ends_with('+') {
+                    0 // greedy {proxy+}
+                } else {
+                    1 // {var}
+                }
+            } else {
+                2 // static
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -2366,7 +2449,7 @@ mod tests {
             tls_config: None,
         };
         let req = make_request(HeaderMap::new());
-        let err = match http_proxy(&req, &integration, None).await {
+        let err = match http_proxy(&req, &integration, None, None).await {
             Err(e) => e,
             Ok(_) => panic!("hung backend must time out, not return a response"),
         };
@@ -2535,6 +2618,409 @@ mod tests {
         let dispatched = locked.as_ref().expect("stub must have received a request");
         assert_eq!(dispatched.raw_path, "/");
         assert_eq!(dispatched.path_segments, vec![""]); // path/ splits to [""]
+    }
+
+    // ── H1: non-proxy HTTP uses integrationHttpMethod ──
+
+    #[tokio::test]
+    async fn non_proxy_http_integration_uses_integration_method() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let mut buf = [0u8; 1024];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                let line = String::from_utf8_lossy(&buf[..n])
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                let _ = tx.send(line);
+                let _ = stream
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                    .await;
+            }
+        });
+        let integration = StateIntegration {
+            rest_api_id: "api1".to_string(),
+            resource_id: "res1".to_string(),
+            http_method: "GET".to_string(),
+            integration_type: "HTTP".to_string(),
+            // Client method is GET (make_request default); backend must POST.
+            integration_http_method: Some("POST".to_string()),
+            uri: Some(format!("http://{addr}/items")),
+            credentials: None,
+            request_parameters: BTreeMap::new(),
+            request_templates: BTreeMap::new(),
+            passthrough_behavior: "WHEN_NO_MATCH".to_string(),
+            timeout_in_millis: Some(5000),
+            cache_namespace: None,
+            cache_key_parameters: vec![],
+            content_handling: None,
+            connection_type: None,
+            connection_id: None,
+            tls_config: None,
+        };
+        let req = make_request(HeaderMap::new());
+        let resp = http_proxy(
+            &req,
+            &integration,
+            None,
+            integration_method_override(&integration),
+        )
+        .await
+        .expect("backend must respond");
+        assert_eq!(resp.status, StatusCode::OK);
+        let line = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("backend must have received a request");
+        assert!(
+            line.starts_with("POST "),
+            "backend must be called with the integrationHttpMethod (POST), got: {line}"
+        );
+    }
+
+    // ── H2 + M1: MOCK statusCode selector + responseParameters (CORS) ──
+
+    #[tokio::test]
+    async fn mock_integration_selects_status_and_applies_response_parameters() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let key = format!("{TEST_API_ID}/{RES_ID}/GET");
+            let integ = st.integrations.get_mut(&key).unwrap();
+            integ.integration_type = "MOCK".to_string();
+            integ.uri = None;
+            // Request template selects HTTP 201 (M1).
+            integ.request_templates.insert(
+                "application/json".to_string(),
+                r#"{"statusCode": 201}"#.to_string(),
+            );
+            // Register both 200 and 201 responses; the 201 one carries a
+            // static CORS header via responseParameters (H2).
+            let rk201 = response_key(TEST_API_ID, "/items", "GET", "201");
+            st.integration_responses.insert(
+                rk201,
+                json!({
+                    "statusCode": "201",
+                    "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                    },
+                    "responseTemplates": {"application/json": r#"{"picked":201}"#}
+                }),
+            );
+            let rk200 = response_key(TEST_API_ID, "/items", "GET", "200");
+            st.integration_responses.insert(
+                rk200,
+                json!({
+                    "statusCode": "200",
+                    "responseTemplates": {"application/json": r#"{"picked":200}"#}
+                }),
+            );
+        }
+        let lambda = Arc::new(StubLambda::new());
+        let service = build_service(state, lambda, None);
+        let resp = handle(&service, &make_request(HeaderMap::new()))
+            .await
+            .expect("MOCK integration must succeed");
+        assert_eq!(resp.status, StatusCode::CREATED);
+        assert_eq!(
+            resp.headers
+                .get("Access-Control-Allow-Origin")
+                .and_then(|v| v.to_str().ok()),
+            Some("*")
+        );
+        let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+        assert!(
+            body.contains("201"),
+            "selected-status body expected, got: {body}"
+        );
+    }
+
+    // ── H3: Host api-id scopes stage resolution across APIs ──
+
+    fn install_full_api(state: &SharedApiGatewayState, api_id: &str, backend_arn: &str) {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create(TEST_ACCOUNT);
+        st.apis.insert(
+            api_id.to_string(),
+            RestApi {
+                id: api_id.to_string(),
+                name: api_id.to_string(),
+                description: None,
+                version: None,
+                created_date: Utc::now(),
+                api_key_source: "HEADER".to_string(),
+                endpoint_configuration: json!({}),
+                policy: None,
+                binary_media_types: vec![],
+                minimum_compression_size: None,
+                disable_execute_api_endpoint: false,
+                root_resource_id: "root".to_string(),
+                tags: BTreeMap::new(),
+                import_source: None,
+            },
+        );
+        let mut resources = BTreeMap::new();
+        let res_id = format!("{api_id}items");
+        resources.insert(
+            res_id.clone(),
+            StateResource {
+                id: res_id.clone(),
+                parent_id: Some("root".to_string()),
+                path_part: Some("items".to_string()),
+                path: "/items".to_string(),
+            },
+        );
+        st.resources.insert(api_id.to_string(), resources);
+        let key = format!("{api_id}/{res_id}/GET");
+        st.methods.insert(
+            key.clone(),
+            StateMethod {
+                rest_api_id: api_id.to_string(),
+                resource_id: res_id.clone(),
+                http_method: "GET".to_string(),
+                authorization_type: "NONE".to_string(),
+                authorizer_id: None,
+                api_key_required: false,
+                operation_name: None,
+                request_parameters: BTreeMap::new(),
+                request_models: BTreeMap::new(),
+                request_validator_id: None,
+                authorization_scopes: vec![],
+            },
+        );
+        st.integrations.insert(
+            key,
+            StateIntegration {
+                rest_api_id: api_id.to_string(),
+                resource_id: res_id,
+                http_method: "GET".to_string(),
+                integration_type: "AWS_PROXY".to_string(),
+                integration_http_method: Some("POST".to_string()),
+                uri: Some(format!(
+                    "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/{backend_arn}/invocations"
+                )),
+                credentials: None,
+                request_parameters: BTreeMap::new(),
+                request_templates: BTreeMap::new(),
+                passthrough_behavior: "WHEN_NO_MATCH".to_string(),
+                timeout_in_millis: None,
+                cache_namespace: None,
+                cache_key_parameters: vec![],
+                content_handling: None,
+                connection_type: None,
+                connection_id: None,
+                tls_config: None,
+            },
+        );
+        let mut stages = BTreeMap::new();
+        stages.insert(
+            "prod".to_string(),
+            StateStage {
+                stage_name: "prod".to_string(),
+                deployment_id: "dep1".to_string(),
+                description: None,
+                cache_cluster_enabled: false,
+                cache_cluster_size: None,
+                variables: BTreeMap::new(),
+                method_settings: BTreeMap::new(),
+                created_date: Utc::now(),
+                last_updated_date: Utc::now(),
+                tracing_enabled: false,
+                web_acl_arn: None,
+                canary_settings: None,
+                access_log_settings: None,
+                tags: BTreeMap::new(),
+            },
+        );
+        st.stages.insert(api_id.to_string(), stages);
+    }
+
+    #[tokio::test]
+    async fn host_api_id_scopes_stage_resolution_across_apis() {
+        // build_state installs API `abc123` (prod /items -> BACKEND_ARN).
+        // Add a second API `zzz999` sharing the `prod` stage + `/items`
+        // but wired to a different backend.
+        const SECOND_ARN: &str = "arn:aws:lambda:us-east-1:000000000000:function:second";
+        let state = build_state("NONE", None);
+        install_full_api(&state, "zzz999", SECOND_ARN);
+        let lambda = Arc::new(StubLambda::new());
+        lambda.set(BACKEND_ARN, json!({"statusCode": 200, "body": "a"}));
+        lambda.set(SECOND_ARN, json!({"statusCode": 200, "body": "z"}));
+        let service = build_service(state, lambda.clone(), None);
+
+        // Request pinned to the SECOND API via its execute-api Host.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "host",
+            "zzz999.execute-api.us-east-1.amazonaws.com"
+                .parse()
+                .unwrap(),
+        );
+        let resp = handle(&service, &make_request(headers))
+            .await
+            .expect("request scoped to second API must succeed");
+        assert_eq!(resp.status, StatusCode::OK);
+        // Only the Host-selected API's backend runs, even though `abc123`
+        // sorts first and also has a `prod`/`/items`.
+        assert_eq!(lambda.invocation_count(SECOND_ARN), 1);
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 0);
+    }
+
+    // ── H4: static resource beats {proxy+} catch-all ──
+
+    fn install_resource_lambda(
+        state: &SharedApiGatewayState,
+        res_id: &str,
+        path: &str,
+        backend_arn: &str,
+    ) {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create(TEST_ACCOUNT);
+        st.resources.get_mut(TEST_API_ID).unwrap().insert(
+            res_id.to_string(),
+            StateResource {
+                id: res_id.to_string(),
+                parent_id: Some("root".to_string()),
+                path_part: Some(path.trim_start_matches('/').to_string()),
+                path: path.to_string(),
+            },
+        );
+        let key = format!("{TEST_API_ID}/{res_id}/GET");
+        st.methods.insert(
+            key.clone(),
+            StateMethod {
+                rest_api_id: TEST_API_ID.to_string(),
+                resource_id: res_id.to_string(),
+                http_method: "GET".to_string(),
+                authorization_type: "NONE".to_string(),
+                authorizer_id: None,
+                api_key_required: false,
+                operation_name: None,
+                request_parameters: BTreeMap::new(),
+                request_models: BTreeMap::new(),
+                request_validator_id: None,
+                authorization_scopes: vec![],
+            },
+        );
+        st.integrations.insert(
+            key,
+            StateIntegration {
+                rest_api_id: TEST_API_ID.to_string(),
+                resource_id: res_id.to_string(),
+                http_method: "GET".to_string(),
+                integration_type: "AWS_PROXY".to_string(),
+                integration_http_method: Some("POST".to_string()),
+                uri: Some(format!(
+                    "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/{backend_arn}/invocations"
+                )),
+                credentials: None,
+                request_parameters: BTreeMap::new(),
+                request_templates: BTreeMap::new(),
+                passthrough_behavior: "WHEN_NO_MATCH".to_string(),
+                timeout_in_millis: None,
+                cache_namespace: None,
+                cache_key_parameters: vec![],
+                content_handling: None,
+                connection_type: None,
+                connection_id: None,
+                tls_config: None,
+            },
+        );
+    }
+
+    #[test]
+    fn resource_specificity_ranks_static_over_param_over_greedy() {
+        assert!(resource_specificity("/health") > resource_specificity("/{proxy+}"));
+        assert!(resource_specificity("/items/special") > resource_specificity("/items/{id}"));
+        assert!(resource_specificity("/items/{id}") > resource_specificity("/items/{p+}"));
+    }
+
+    #[tokio::test]
+    async fn static_resource_beats_proxy_catchall() {
+        const HEALTH_ARN: &str = "arn:aws:lambda:us-east-1:000000000000:function:health";
+        const PROXY_ARN: &str = "arn:aws:lambda:us-east-1:000000000000:function:proxy";
+        let state = build_state("NONE", None);
+        install_resource_lambda(&state, "health01", "/health", HEALTH_ARN);
+        install_resource_lambda(&state, "proxy01", "/{proxy+}", PROXY_ARN);
+        let lambda = Arc::new(StubLambda::new());
+        lambda.set(HEALTH_ARN, json!({"statusCode": 200, "body": "h"}));
+        lambda.set(PROXY_ARN, json!({"statusCode": 200, "body": "p"}));
+        let service = build_service(state, lambda.clone(), None);
+        let mut req = make_request(HeaderMap::new());
+        req.raw_path = "/prod/health".to_string();
+        req.path_segments = vec!["prod".to_string(), "health".to_string()];
+        let resp = handle(&service, &req).await.expect("static route must win");
+        assert_eq!(resp.status, StatusCode::OK);
+        assert_eq!(lambda.invocation_count(HEALTH_ARN), 1);
+        assert_eq!(lambda.invocation_count(PROXY_ARN), 0);
+    }
+
+    // ── M2: custom domain matches the domain-name key ──
+
+    #[test]
+    fn resolve_custom_domain_matches_domain_name_key() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_or_create(TEST_ACCOUNT);
+            s.domain_names.insert(
+                "api.example.com".to_string(),
+                json!({"regionalDomainName": "d-abc.execute-api.us-east-1.amazonaws.com"}),
+            );
+            let mut mappings = BTreeMap::new();
+            mappings.insert(
+                "(none)".to_string(),
+                json!({"restApiId": TEST_API_ID, "stage": "prod"}),
+            );
+            s.base_path_mappings
+                .insert("api.example.com".to_string(), mappings);
+        }
+        let service = ApiGatewayService::new(state);
+        let mut headers = HeaderMap::new();
+        // Host is the domain NAME, not the regionalDomainName.
+        headers.insert("host", "api.example.com".parse().unwrap());
+        let mut req = make_request(headers);
+        req.path_segments = vec!["items".to_string()];
+        let (stage, remaining, api) = resolve_custom_domain(&service, &req).unwrap();
+        assert_eq!(stage, Some("prod".to_string()));
+        assert_eq!(remaining, vec!["items".to_string()]);
+        assert_eq!(api, Some(TEST_API_ID.to_string()));
+    }
+
+    // ── M5: disableExecuteApiEndpoint returns 403 on the default endpoint ──
+
+    #[tokio::test]
+    async fn disable_execute_api_endpoint_returns_403_on_default_endpoint() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            st.apis
+                .get_mut(TEST_API_ID)
+                .unwrap()
+                .disable_execute_api_endpoint = true;
+        }
+        let lambda = Arc::new(StubLambda::new());
+        let service = build_service(state, lambda.clone(), None);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "host",
+            "abc123.execute-api.us-east-1.amazonaws.com"
+                .parse()
+                .unwrap(),
+        );
+        let err = match handle(&service, &make_request(headers)).await {
+            Err(e) => e,
+            Ok(_) => panic!("disabled default endpoint must 403"),
+        };
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 0);
     }
 }
 

--- a/crates/fakecloud-apigateway/src/vtl.rs
+++ b/crates/fakecloud-apigateway/src/vtl.rs
@@ -9,8 +9,42 @@ use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
+/// Maximum nesting depth for recursive block rendering (`#if`/`#foreach`).
+/// A pathological template (deeply nested or self-referential via
+/// `#set`-driven templates) would otherwise recurse until the thread's
+/// stack overflows and aborts the process; capping it turns that into a
+/// recoverable render error.
+pub const MAX_RENDER_DEPTH: usize = 64;
+
 /// Render a VTL template string using the supplied variable context.
+///
+/// Infallible wrapper around [`try_render`]: on a render error (currently
+/// only the recursion-depth cap) it yields the output accumulated so far
+/// rather than propagating, preserving the historical `-> String` API.
 pub fn render(template: &str, ctx: &mut Context) -> String {
+    match try_render(template, ctx) {
+        Ok(s) => s,
+        Err((partial, _)) => partial,
+    }
+}
+
+/// Render a VTL template, returning an error (with the partial output)
+/// when the recursion-depth cap is exceeded.
+pub fn try_render(template: &str, ctx: &mut Context) -> Result<String, (String, String)> {
+    render_depth(template, ctx, 0)
+}
+
+fn render_depth(
+    template: &str,
+    ctx: &mut Context,
+    depth: usize,
+) -> Result<String, (String, String)> {
+    if depth > MAX_RENDER_DEPTH {
+        return Err((
+            String::new(),
+            format!("VTL render exceeded maximum nesting depth of {MAX_RENDER_DEPTH}"),
+        ));
+    }
     let mut out = String::new();
     let mut i = 0;
     while i < template.len() {
@@ -40,7 +74,13 @@ pub fn render(template: &str, ctx: &mut Context) -> String {
             let (then_block, else_block, consumed) = parse_if_blocks(template, i);
             i = consumed;
             let block = if truthy { then_block } else { else_block };
-            out.push_str(&render(block, ctx));
+            match render_depth(block, ctx, depth + 1) {
+                Ok(s) => out.push_str(&s),
+                Err((partial, msg)) => {
+                    out.push_str(&partial);
+                    return Err((out, msg));
+                }
+            }
         } else if rest.starts_with("#foreach(") {
             i += 9;
             let (header, consumed) = parse_expr(template, i);
@@ -56,16 +96,30 @@ pub fn render(template: &str, ctx: &mut Context) -> String {
                 for item in arr {
                     ctx.push_scope();
                     ctx.set(item_var, item.clone());
-                    out.push_str(&render(body, ctx));
+                    let rendered = render_depth(body, ctx, depth + 1);
                     ctx.pop_scope();
+                    match rendered {
+                        Ok(s) => out.push_str(&s),
+                        Err((partial, msg)) => {
+                            out.push_str(&partial);
+                            return Err((out, msg));
+                        }
+                    }
                 }
             } else if let Some(obj) = items.as_object() {
                 for (key, val) in obj {
                     ctx.push_scope();
                     ctx.set(item_var, Value::String(key.clone()));
                     ctx.set(&format!("{item_var}_value"), val.clone());
-                    out.push_str(&render(body, ctx));
+                    let rendered = render_depth(body, ctx, depth + 1);
                     ctx.pop_scope();
+                    match rendered {
+                        Ok(s) => out.push_str(&s),
+                        Err((partial, msg)) => {
+                            out.push_str(&partial);
+                            return Err((out, msg));
+                        }
+                    }
                 }
             }
         } else if rest.starts_with("##") {
@@ -100,7 +154,7 @@ pub fn render(template: &str, ctx: &mut Context) -> String {
             i += template[i..].chars().next().unwrap().len_utf8();
         }
     }
-    out
+    Ok(out)
 }
 
 // ── Context ──
@@ -992,6 +1046,33 @@ mod tests {
         let mut ctx = Context::new().with_var("util", json!({"_type":"util"}));
         let out = render(r#"$util.urlEncode('hello world')"#, &mut ctx);
         assert_eq!(out, "hello%20world");
+    }
+
+    #[test]
+    fn recursion_depth_cap_returns_error() {
+        // A template nested far deeper than the cap must surface a render
+        // error instead of overflowing the stack.
+        let depth = MAX_RENDER_DEPTH + 5;
+        let mut tpl = String::new();
+        for _ in 0..depth {
+            tpl.push_str("#if(true)");
+        }
+        tpl.push('x');
+        for _ in 0..depth {
+            tpl.push_str("#end");
+        }
+        let mut ctx = Context::new();
+        let err = try_render(&tpl, &mut ctx);
+        assert!(err.is_err(), "deeply nested template must error");
+        assert!(err.unwrap_err().1.contains("maximum nesting depth"));
+    }
+
+    #[test]
+    fn shallow_nesting_still_renders() {
+        // Nesting well within the cap keeps working.
+        let mut ctx = Context::new().with_var("ok", true.into());
+        let out = render("#if($ok)#if($ok)deep#end#end", &mut ctx);
+        assert_eq!(out, "deep");
     }
 
     #[test]

--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -396,6 +396,16 @@ fn build_api_from_spec(
                             .and_then(|v| v.as_str())
                             .map(|s| s.to_ascii_uppercase())
                             .unwrap_or_else(|| "INTERNET".to_string()),
+                        request_parameters: integ
+                            .get("requestParameters")
+                            .and_then(|v| v.as_object())
+                            .map(|o| {
+                                o.iter()
+                                    .filter_map(|(k, v)| {
+                                        v.as_str().map(|s| (k.clone(), s.to_string()))
+                                    })
+                                    .collect()
+                            }),
                     };
                     integrations.insert(integration_id.clone(), integration);
                     target = Some(format!("integrations/{integration_id}"));
@@ -419,16 +429,25 @@ fn build_api_from_spec(
 fn export_openapi(api: &HttpApi, routes: &[Route]) -> Value {
     let mut paths = serde_json::Map::new();
     for route in routes {
-        // route_key is "<METHOD> <path>"; "$default" carries no method/path.
-        let Some((method, path)) = route.route_key.split_once(' ') else {
-            continue;
+        // route_key is "<METHOD> <path>"; the `$default` catch-all carries
+        // no method/path split. Export it under the `$default` path with the
+        // any-method key so a round-tripped spec preserves the fallback route.
+        let (method_key, path) = match route.route_key.split_once(' ') {
+            Some((method, path)) => {
+                let method_key = if method.eq_ignore_ascii_case("ANY") {
+                    "x-amazon-apigateway-any-method".to_string()
+                } else {
+                    method.to_ascii_lowercase()
+                };
+                (method_key, path.to_string())
+            }
+            None if route.route_key.trim() == "$default" => (
+                "x-amazon-apigateway-any-method".to_string(),
+                "$default".to_string(),
+            ),
+            None => continue,
         };
-        let method_key = if method.eq_ignore_ascii_case("ANY") {
-            "x-amazon-apigateway-any-method".to_string()
-        } else {
-            method.to_ascii_lowercase()
-        };
-        let entry = paths.entry(path.to_string()).or_insert_with(|| json!({}));
+        let entry = paths.entry(path.clone()).or_insert_with(|| json!({}));
         if let Some(obj) = entry.as_object_mut() {
             obj.insert(
                 method_key,

--- a/crates/fakecloud-apigatewayv2/src/http_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/http_proxy.rs
@@ -2,12 +2,19 @@ use bytes::Bytes;
 use http::{HeaderMap, StatusCode};
 use std::time::Duration;
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+use fakecloud_core::service::{AwsResponse, AwsServiceError};
 
-/// Forwards an HTTP request to an external endpoint
+/// Forwards an HTTP request to an external endpoint.
+///
+/// `target_url` must already include any query string — the caller is
+/// responsible for `{proxy}` path substitution and `requestParameters`
+/// mapping. `method` is the effective outgoing method (the integration's
+/// `integrationMethod` when set, otherwise the client's method).
 pub async fn forward_request(
     target_url: &str,
-    req: &AwsRequest,
+    method: &http::Method,
+    headers: &HeaderMap,
+    body: &Bytes,
     timeout_millis: Option<i64>,
 ) -> Result<AwsResponse, AwsServiceError> {
     let client = reqwest::Client::builder()
@@ -23,18 +30,11 @@ pub async fn forward_request(
             )
         })?;
 
-    // Build request URL with query parameters
-    let url = if req.raw_query.is_empty() {
-        target_url.to_string()
-    } else {
-        format!("{}?{}", target_url, req.raw_query)
-    };
-
     // Build the request
-    let mut request_builder = client.request(req.method.clone(), &url);
+    let mut request_builder = client.request(method.clone(), target_url);
 
     // Copy headers (skip host and authorization)
-    for (key, value) in &req.headers {
+    for (key, value) in headers {
         let key_str = key.as_str();
         if key_str != "host" && key_str != "authorization" {
             request_builder = request_builder.header(key, value);
@@ -42,8 +42,8 @@ pub async fn forward_request(
     }
 
     // Add body
-    if !req.body.is_empty() {
-        request_builder = request_builder.body(req.body.clone());
+    if !body.is_empty() {
+        request_builder = request_builder.body(body.clone());
     }
 
     // Execute request
@@ -91,6 +91,7 @@ pub async fn forward_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fakecloud_core::service::AwsRequest;
     use http::Method;
     use std::collections::HashMap;
 
@@ -124,7 +125,14 @@ mod tests {
     #[tokio::test]
     async fn test_forward_request_invalid_url() {
         let req = create_test_request();
-        let result = forward_request("not-a-valid-url", &req, Some(5000)).await;
+        let result = forward_request(
+            "not-a-valid-url",
+            &req.method,
+            &req.headers,
+            &req.body,
+            Some(5000),
+        )
+        .await;
         assert!(result.is_err());
     }
 
@@ -132,14 +140,28 @@ mod tests {
     async fn test_forward_request_unreachable_host_errors() {
         let req = create_test_request();
         // Non-existent port on localhost should fail quickly
-        let result = forward_request("http://127.0.0.1:1/unreachable", &req, Some(200)).await;
+        let result = forward_request(
+            "http://127.0.0.1:1/unreachable",
+            &req.method,
+            &req.headers,
+            &req.body,
+            Some(200),
+        )
+        .await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_forward_request_default_timeout() {
         let req = create_test_request();
-        let result = forward_request("http://127.0.0.1:1/x", &req, None).await;
+        let result = forward_request(
+            "http://127.0.0.1:1/x",
+            &req.method,
+            &req.headers,
+            &req.body,
+            None,
+        )
+        .await;
         assert!(result.is_err());
     }
 }

--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -104,6 +104,120 @@ pub fn construct_event(
     })
 }
 
+/// Constructs a Lambda proxy integration event in the **1.0** payload
+/// format for an HTTP API whose integration set
+/// `payloadFormatVersion = "1.0"`. This is the same envelope REST APIs
+/// (API Gateway v1) send, so a Lambda written for a REST proxy keeps
+/// working behind an HTTP API. See the payload-format-version docs:
+/// https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+pub fn construct_event_v1(
+    req: &AwsRequest,
+    route_key: &str,
+    stage: &str,
+    path_parameters: HashMap<String, String>,
+    authorizer: Option<AuthorizerInfo>,
+) -> serde_json::Value {
+    let (is_base64_encoded, body) = encode_body(req);
+
+    // The `resource` field is the route's path template (the part of the
+    // route key after the method), defaulting to the raw path.
+    let resource = route_key
+        .split_once(' ')
+        .map(|(_, path)| path.to_string())
+        .unwrap_or_else(|| req.raw_path.clone());
+
+    // Single-value + multi-value header maps.
+    let mut headers = serde_json::Map::new();
+    let mut multi_value_headers = serde_json::Map::new();
+    for (k, v) in req.headers.iter() {
+        if let Ok(v_str) = v.to_str() {
+            headers.insert(k.as_str().to_string(), json!(v_str));
+            multi_value_headers
+                .entry(k.as_str().to_string())
+                .or_insert_with(|| json!([]))
+                .as_array_mut()
+                .unwrap()
+                .push(json!(v_str));
+        }
+    }
+
+    let query_string_parameters = if req.query_params.is_empty() {
+        serde_json::Value::Null
+    } else {
+        json!(req.query_params)
+    };
+    let multi_value_query_string_parameters = if req.query_params.is_empty() {
+        serde_json::Value::Null
+    } else {
+        let mut m = serde_json::Map::new();
+        for (k, v) in &req.query_params {
+            m.insert(k.clone(), json!([v]));
+        }
+        serde_json::Value::Object(m)
+    };
+
+    let path_parameters = if path_parameters.is_empty() {
+        serde_json::Value::Null
+    } else {
+        json!(path_parameters)
+    };
+
+    let mut request_context = serde_json::Map::new();
+    request_context.insert("accountId".to_string(), json!(&req.account_id));
+    request_context.insert("apiId".to_string(), json!(host_api_id(req)));
+    request_context.insert("domainName".to_string(), json!("localhost"));
+    request_context.insert("httpMethod".to_string(), json!(req.method.as_str()));
+    request_context.insert("path".to_string(), json!(req.raw_path));
+    request_context.insert("protocol".to_string(), json!("HTTP/1.1"));
+    request_context.insert("requestId".to_string(), json!(&req.request_id));
+    request_context.insert("resourcePath".to_string(), json!(resource));
+    request_context.insert("stage".to_string(), json!(stage));
+    request_context.insert("identity".to_string(), json!({ "sourceIp": "127.0.0.1" }));
+    request_context.insert(
+        "requestTimeEpoch".to_string(),
+        json!(chrono::Utc::now().timestamp_millis()),
+    );
+
+    if let Some(auth) = authorizer {
+        // 1.0 exposes the authorizer object directly under
+        // `requestContext.authorizer` (JWT claims land under a `claims`
+        // key, matching REST Cognito behaviour).
+        let value = match auth {
+            AuthorizerInfo::Jwt { claims } => json!({ "claims": claims }),
+            AuthorizerInfo::Lambda { context } => context,
+        };
+        request_context.insert("authorizer".to_string(), value);
+    }
+
+    json!({
+        "version": "1.0",
+        "resource": resource,
+        "path": req.raw_path,
+        "httpMethod": req.method.as_str(),
+        "headers": serde_json::Value::Object(headers),
+        "multiValueHeaders": serde_json::Value::Object(multi_value_headers),
+        "queryStringParameters": query_string_parameters,
+        "multiValueQueryStringParameters": multi_value_query_string_parameters,
+        "pathParameters": path_parameters,
+        "stageVariables": serde_json::Value::Null,
+        "requestContext": serde_json::Value::Object(request_context),
+        "body": body,
+        "isBase64Encoded": is_base64_encoded,
+    })
+}
+
+/// Best-effort extraction of the API id from the execute-api Host header
+/// (`{api-id}.execute-api.<region>.amazonaws.com`). Falls back to an
+/// empty string when the header is absent.
+fn host_api_id(req: &AwsRequest) -> String {
+    req.headers
+        .get("host")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.split('.').next())
+        .unwrap_or("")
+        .to_string()
+}
+
 fn encode_body(req: &AwsRequest) -> (bool, Option<String>) {
     if req.body.is_empty() {
         return (false, None);
@@ -298,6 +412,50 @@ mod tests {
         assert_eq!(event["queryStringParameters"]["filter"], "available");
         assert_eq!(event["body"], r#"{"name":"Fluffy"}"#);
         assert_eq!(event["isBase64Encoded"], false);
+    }
+
+    #[test]
+    fn test_construct_event_v1_shape() {
+        // payloadFormatVersion "1.0" produces the REST-style envelope:
+        // httpMethod / multiValueHeaders / requestContext.identity etc.
+        let req = create_test_request();
+        let path_params = HashMap::from([("id".to_string(), "123".to_string())]);
+        let event = construct_event_v1(&req, "POST /pets/{id}", "prod", path_params, None);
+
+        assert_eq!(event["version"], "1.0");
+        assert_eq!(event["httpMethod"], "POST");
+        assert_eq!(event["resource"], "/pets/{id}");
+        assert_eq!(event["path"], "/prod/pets");
+        // 2.0-only fields must be absent.
+        assert!(event["routeKey"].is_null());
+        assert!(event["rawPath"].is_null());
+        // Multi-value maps + identity present.
+        assert_eq!(
+            event["multiValueHeaders"]["content-type"][0],
+            "application/json"
+        );
+        assert_eq!(event["requestContext"]["identity"]["sourceIp"], "127.0.0.1");
+        assert_eq!(event["requestContext"]["httpMethod"], "POST");
+        assert_eq!(event["requestContext"]["stage"], "prod");
+        assert_eq!(event["pathParameters"]["id"], "123");
+        assert_eq!(
+            event["multiValueQueryStringParameters"]["filter"][0],
+            "available"
+        );
+    }
+
+    #[test]
+    fn test_construct_event_v1_lambda_authorizer_context() {
+        let req = create_test_request();
+        let ctx = json!({"principalId": "u", "role": "admin"});
+        let event = construct_event_v1(
+            &req,
+            "GET /pets",
+            "prod",
+            HashMap::new(),
+            Some(AuthorizerInfo::Lambda { context: ctx }),
+        );
+        assert_eq!(event["requestContext"]["authorizer"]["role"], "admin");
     }
 
     #[test]

--- a/crates/fakecloud-apigatewayv2/src/router.rs
+++ b/crates/fakecloud-apigatewayv2/src/router.rs
@@ -12,6 +12,10 @@ struct ParsedRoute {
     method: String,
     segments: Vec<RouteSegment>,
     priority: i32,
+    /// The `$default` catch-all route: matches any method and any path
+    /// (including the root) that no more-specific route matched. Given
+    /// the lowest possible priority so specific routes always win.
+    catch_all: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -23,6 +27,20 @@ enum RouteSegment {
 
 impl ParsedRoute {
     fn from_route_key(route_key: &str) -> Option<Self> {
+        // The `$default` catch-all route key carries no `METHOD path`
+        // split — it's a single token. Treat it as a route that matches
+        // any request, ranked below every specific route. This is the
+        // canonical SAM/CDK/Serverless HTTP-API topology and, without it,
+        // an HTTP API whose only route is `$default` 404s every request.
+        if route_key.trim() == "$default" {
+            return Some(Self {
+                method: "ANY".to_string(),
+                segments: Vec::new(),
+                priority: i32::MIN,
+                catch_all: true,
+            });
+        }
+
         let parts: Vec<&str> = route_key.splitn(2, ' ').collect();
         if parts.len() != 2 {
             return None;
@@ -38,6 +56,7 @@ impl ParsedRoute {
             method,
             segments,
             priority,
+            catch_all: false,
         })
     }
 
@@ -77,6 +96,11 @@ impl ParsedRoute {
     }
 
     fn matches(&self, method: &str, path_segments: &[String]) -> Option<HashMap<String, String>> {
+        // The `$default` catch-all matches any method + any path.
+        if self.catch_all {
+            return Some(HashMap::new());
+        }
+
         // Check method match (ANY matches all methods)
         if self.method != "ANY" && self.method != method {
             return None;
@@ -313,6 +337,66 @@ mod tests {
         let router = Router::new(routes);
         assert!(router.match_route("GET", "/users").is_none());
         assert!(router.match_route("POST", "/pets").is_none());
+    }
+
+    #[test]
+    fn test_default_route_matches_any_request() {
+        // An HTTP API whose only route is `$default` must route every
+        // request to that route's integration (regression for C1: the
+        // route key was silently dropped, 404ing all traffic).
+        let routes = vec![Route {
+            route_id: "def".to_string(),
+            route_key: "$default".to_string(),
+            ..Default::default()
+        }];
+
+        let router = Router::new(routes);
+        assert_eq!(
+            router
+                .match_route("GET", "/anything")
+                .unwrap()
+                .route
+                .route_id,
+            "def"
+        );
+        assert_eq!(
+            router.match_route("POST", "/a/b/c").unwrap().route.route_id,
+            "def"
+        );
+        // Also matches the bare root path.
+        assert_eq!(
+            router.match_route("DELETE", "/").unwrap().route.route_id,
+            "def"
+        );
+    }
+
+    #[test]
+    fn test_specific_route_wins_over_default() {
+        // `$default` is the lowest-priority fallback: a specific route
+        // that matches must be preferred.
+        let routes = vec![
+            Route {
+                route_id: "def".to_string(),
+                route_key: "$default".to_string(),
+                ..Default::default()
+            },
+            Route {
+                route_id: "specific".to_string(),
+                route_key: "GET /health".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let router = Router::new(routes);
+        assert_eq!(
+            router.match_route("GET", "/health").unwrap().route.route_id,
+            "specific"
+        );
+        // A path with no specific route still falls back to `$default`.
+        assert_eq!(
+            router.match_route("GET", "/other").unwrap().route.route_id,
+            "def"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-apigatewayv2/src/service/apis.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/apis.rs
@@ -84,6 +84,9 @@ impl ApiGatewayV2Service {
         if let Some(ip) = requested_ip_type {
             api.ip_address_type = ip;
         }
+        if let Some(disabled) = body["disableExecuteApiEndpoint"].as_bool() {
+            api.disable_execute_api_endpoint = disabled;
+        }
         if protocol_type == "WEBSOCKET" {
             // WebSocket APIs use a body-based selection expression by default
             // and have no implicit api-key header selector.

--- a/crates/fakecloud-apigatewayv2/src/service/execute.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/execute.rs
@@ -265,7 +265,7 @@ impl ApiGatewayV2Service {
 
         let result: Result<AwsResponse, AwsServiceError> = async {
             // Try custom domain resolution first.
-            let (a, s, stage_vars) = {
+            let (a, s, stage_vars, via_custom_domain) = {
                 let accounts = self.state.read();
                 let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
                 let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -279,7 +279,40 @@ impl ApiGatewayV2Service {
                         .and_then(|stages| stages.get(&s))
                         .and_then(|st| st.stage_variables.clone())
                         .unwrap_or_default();
-                    (a, s, stage_vars)
+                    (a, s, stage_vars, true)
+                } else if let Some(a) = host_api_id(&req).filter(|id| state.apis.contains_key(id)) {
+                    // Default execute-api endpoint: the API is keyed on the
+                    // Host header (`{api-id}.execute-api.<region>...`). Scope
+                    // stage/route resolution to that API so two APIs sharing a
+                    // stage name don't collide, and honour the `$default`
+                    // stage — whose URL omits the stage segment entirely
+                    // (`https://{api-id}.execute-api.../items`).
+                    let stages = state.stages.get(&a);
+                    let first = req.path_segments.first().cloned();
+                    let stage_name = match (&first, stages) {
+                        (Some(seg), Some(st)) if st.contains_key(seg) => {
+                            // Named stage in the first path segment; consume it.
+                            req.path_segments.remove(0);
+                            seg.clone()
+                        }
+                        (_, Some(st)) if st.contains_key("$default") => {
+                            // `$default` stage serves the path directly; do not
+                            // consume a segment.
+                            "$default".to_string()
+                        }
+                        _ => {
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::NOT_FOUND,
+                                "NotFoundException",
+                                format!("Stage not found for API {}", a),
+                            ));
+                        }
+                    };
+                    let stage_vars = stages
+                        .and_then(|st| st.get(&stage_name))
+                        .and_then(|st| st.stage_variables.clone())
+                        .unwrap_or_default();
+                    (a, stage_name, stage_vars, false)
                 } else {
                     // Execute API format: /{stage}/{path...}
                     if req.path_segments.is_empty() {
@@ -314,12 +347,34 @@ impl ApiGatewayV2Service {
                             format!("Stage not found: {}", s),
                         )
                     })?;
-                    (a, s, stage_vars)
+                    (a, s, stage_vars, false)
                 }
             };
 
             api_id = a;
             stage_name = s;
+
+            // Enforce `disableExecuteApiEndpoint`: when set, the default
+            // `execute-api` endpoint returns 403. Custom-domain traffic is
+            // unaffected — that's the whole point of disabling the default
+            // endpoint.
+            if !via_custom_domain {
+                let disabled = {
+                    let accounts = self.state.read();
+                    accounts
+                        .get(&req.account_id)
+                        .and_then(|st| st.apis.get(&api_id))
+                        .map(|api| api.disable_execute_api_endpoint)
+                        .unwrap_or(false)
+                };
+                if disabled {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::FORBIDDEN,
+                        "ForbiddenException",
+                        "The execute-api endpoint is disabled for this API",
+                    ));
+                }
+            }
 
             resource_path = if req.path_segments.is_empty() {
                 "/".to_string()
@@ -442,13 +497,31 @@ impl ApiGatewayV2Service {
                         })?;
 
                     if is_lambda_arn(integration_uri) {
-                        let event = lambda_proxy::construct_event(
-                            &req,
-                            &route_match.route.route_key,
-                            &stage_name,
-                            route_match.path_parameters,
-                            authorizer_info,
-                        );
+                        // Honour the integration's payloadFormatVersion:
+                        // "1.0" sends the REST-shaped envelope, "2.0" (the
+                        // default) sends the HTTP-API envelope.
+                        let event = if integration
+                            .payload_format_version
+                            .as_deref()
+                            .map(|v| v == "1.0")
+                            .unwrap_or(false)
+                        {
+                            lambda_proxy::construct_event_v1(
+                                &req,
+                                &route_match.route.route_key,
+                                &stage_name,
+                                route_match.path_parameters,
+                                authorizer_info,
+                            )
+                        } else {
+                            lambda_proxy::construct_event(
+                                &req,
+                                &route_match.route.route_key,
+                                &stage_name,
+                                route_match.path_parameters,
+                                authorizer_info,
+                            )
+                        };
                         lambda_proxy::invoke_lambda(delivery, integration_uri, event).await?
                     } else {
                         dispatch_aws_service_integration(delivery, integration_uri, &req)?
@@ -464,8 +537,35 @@ impl ApiGatewayV2Service {
                         )
                     })?;
 
-                    http_proxy::forward_request(target_url, &req, integration.timeout_in_millis)
-                        .await?
+                    // Substitute `{proxy}` / `{var}` path placeholders from the
+                    // matched route into the backend URL.
+                    let mut url = target_url.clone();
+                    for (name, value) in &route_match.path_parameters {
+                        url = url.replace(&format!("{{{name}}}"), value);
+                    }
+                    // Apply `requestParameters` parameter mappings + append the
+                    // client query string, then forward with the integration's
+                    // method (`integrationMethod`) when configured.
+                    let (url, headers) = apply_request_parameters(
+                        &url,
+                        integration.request_parameters.as_ref(),
+                        &req,
+                    );
+                    let method = integration
+                        .integration_method
+                        .as_deref()
+                        .and_then(|m| {
+                            http::Method::from_bytes(m.to_ascii_uppercase().as_bytes()).ok()
+                        })
+                        .unwrap_or_else(|| req.method.clone());
+                    http_proxy::forward_request(
+                        &url,
+                        &method,
+                        &headers,
+                        &req.body,
+                        integration.timeout_in_millis,
+                    )
+                    .await?
                 }
                 "MOCK" => {
                     // Mock integration
@@ -504,5 +604,249 @@ impl ApiGatewayV2Service {
         self.emit_access_log(&req, &api_id, &stage_name, &matched_route_key, status_code);
 
         result
+    }
+}
+
+/// Extract the API id from the execute-api `Host` header
+/// (`{api-id}.execute-api.<region>.amazonaws.com`). Returns `None` when
+/// the header is absent/empty so the caller falls back to stage scanning.
+fn host_api_id(req: &AwsRequest) -> Option<String> {
+    let host = req.headers.get("host").and_then(|v| v.to_str().ok())?;
+    let id = host.split('.').next()?;
+    if id.is_empty() || !host.contains("execute-api") {
+        return None;
+    }
+    Some(id.to_string())
+}
+
+/// Resolve a `requestParameters` mapping value: a `$request.*` source
+/// expression pulled from the incoming request, or a literal.
+fn resolve_param_value(spec: &str, req: &AwsRequest) -> Option<String> {
+    if let Some(name) = spec.strip_prefix("$request.header.") {
+        return req
+            .headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+    }
+    if let Some(name) = spec.strip_prefix("$request.querystring.") {
+        return req.query_params.get(name).cloned();
+    }
+    if spec.starts_with("$request.") {
+        // Unsupported source expression (e.g. $request.path.*) — drop it
+        // rather than forward a literal `$request...` string.
+        return None;
+    }
+    // Static value: accept both the plain HTTP-API form and the
+    // single-quoted REST-style form.
+    let literal = if spec.len() >= 2 && spec.starts_with('\'') && spec.ends_with('\'') {
+        &spec[1..spec.len() - 1]
+    } else {
+        spec
+    };
+    Some(literal.to_string())
+}
+
+/// Apply an HTTP-API integration's `requestParameters` parameter mappings
+/// to the outgoing request, returning the final URL (path + query) and the
+/// header map to forward. Supported keys follow the AWS format
+/// `<action>:<location>.<name>` where action ∈ {overwrite, append, remove}
+/// and location ∈ {header, querystring, path}.
+fn apply_request_parameters(
+    base_url: &str,
+    mappings: Option<&std::collections::BTreeMap<String, String>>,
+    req: &AwsRequest,
+) -> (String, http::HeaderMap) {
+    let mut headers = req.headers.clone();
+
+    // Split the base URL into `scheme://authority`, path, and query.
+    let (prefix, mut path, base_query) = match base_url.parse::<http::Uri>() {
+        Ok(u) if u.authority().is_some() => {
+            let prefix = format!(
+                "{}://{}",
+                u.scheme_str().unwrap_or("http"),
+                u.authority().map(|a| a.as_str()).unwrap_or("")
+            );
+            (
+                prefix,
+                u.path().to_string(),
+                u.query().unwrap_or("").to_string(),
+            )
+        }
+        _ => (base_url.to_string(), String::new(), String::new()),
+    };
+
+    // Seed the query params from the URL's own query plus the client's.
+    let mut query: Vec<(String, String)> = Vec::new();
+    for raw in [base_query.as_str(), req.raw_query.as_str()] {
+        for pair in raw.split('&').filter(|s| !s.is_empty()) {
+            let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+            query.push((k.to_string(), v.to_string()));
+        }
+    }
+
+    if let Some(mappings) = mappings {
+        for (key, spec) in mappings {
+            let Some((action, target)) = key.split_once(':') else {
+                continue;
+            };
+            let (location, name) = match target.split_once('.') {
+                Some((l, n)) => (l, n),
+                None => (target, ""),
+            };
+            let value = if action == "remove" {
+                None
+            } else {
+                resolve_param_value(spec, req)
+            };
+            match (action, location) {
+                ("overwrite", "header") | ("append", "header") => {
+                    if let (Ok(hn), Some(v)) = (
+                        http::HeaderName::from_bytes(name.as_bytes()),
+                        value
+                            .as_deref()
+                            .and_then(|v| http::HeaderValue::from_str(v).ok()),
+                    ) {
+                        if action == "overwrite" {
+                            headers.insert(hn, v);
+                        } else {
+                            headers.append(hn, v);
+                        }
+                    }
+                }
+                ("remove", "header") => {
+                    headers.remove(name);
+                }
+                ("overwrite", "querystring") => {
+                    query.retain(|(k, _)| k != name);
+                    if let Some(v) = value {
+                        query.push((name.to_string(), v));
+                    }
+                }
+                ("append", "querystring") => {
+                    if let Some(v) = value {
+                        query.push((name.to_string(), v));
+                    }
+                }
+                ("remove", "querystring") => {
+                    query.retain(|(k, _)| k != name);
+                }
+                ("overwrite", "path") => {
+                    if let Some(v) = value {
+                        path = if v.starts_with('/') {
+                            v
+                        } else {
+                            format!("/{v}")
+                        };
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let query_string = query
+        .iter()
+        .map(|(k, v)| {
+            if v.is_empty() {
+                k.clone()
+            } else {
+                format!("{k}={v}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+    let url = if query_string.is_empty() {
+        format!("{prefix}{path}")
+    } else {
+        format!("{prefix}{path}?{query_string}")
+    };
+    (url, headers)
+}
+
+#[cfg(test)]
+mod request_param_tests {
+    use super::*;
+    use bytes::Bytes;
+    use http::HeaderMap;
+    use std::collections::HashMap;
+
+    fn req_with(headers: &[(&str, &str)], query: &[(&str, &str)]) -> AwsRequest {
+        let mut hm = HeaderMap::new();
+        for (k, v) in headers {
+            hm.insert(
+                http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        let qp: HashMap<String, String> = query
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        let raw_query = query
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join("&");
+        AwsRequest {
+            service: "apigateway".to_string(),
+            action: String::new(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "rid".to_string(),
+            headers: hm,
+            query_params: qp,
+            body: Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/items".to_string(),
+            raw_query,
+            method: http::Method::GET,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn host_api_id_only_for_execute_api_host() {
+        let req = req_with(
+            &[("host", "abc123.execute-api.us-east-1.amazonaws.com")],
+            &[],
+        );
+        assert_eq!(host_api_id(&req).as_deref(), Some("abc123"));
+        let custom = req_with(&[("host", "api.example.com")], &[]);
+        assert_eq!(host_api_id(&custom), None);
+        assert_eq!(host_api_id(&req_with(&[], &[])), None);
+    }
+
+    #[test]
+    fn request_parameters_overwrite_header_and_query() {
+        let req = req_with(&[("x-user", "orig")], &[("a", "1")]);
+        let mut mappings = std::collections::BTreeMap::new();
+        mappings.insert("overwrite:header.x-user".to_string(), "'admin'".to_string());
+        mappings.insert("append:querystring.trace".to_string(), "'on'".to_string());
+        mappings.insert(
+            "overwrite:header.x-from".to_string(),
+            "$request.header.x-user".to_string(),
+        );
+        let (url, headers) =
+            apply_request_parameters("http://backend.local/base", Some(&mappings), &req);
+        // Static overwrite wins.
+        assert_eq!(headers.get("x-user").unwrap(), "admin");
+        // Source-expression header copies the ORIGINAL client value.
+        assert_eq!(headers.get("x-from").unwrap(), "orig");
+        // Query carries the client param plus the appended one.
+        assert!(url.contains("a=1"), "url: {url}");
+        assert!(url.contains("trace=on"), "url: {url}");
+    }
+
+    #[test]
+    fn request_parameters_overwrite_path() {
+        let req = req_with(&[], &[]);
+        let mut mappings = std::collections::BTreeMap::new();
+        mappings.insert("overwrite:path".to_string(), "'/rewritten'".to_string());
+        let (url, _) = apply_request_parameters("http://backend.local/orig", Some(&mappings), &req);
+        assert_eq!(url, "http://backend.local/rewritten");
     }
 }

--- a/crates/fakecloud-apigatewayv2/src/service/integrations.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/integrations.rs
@@ -40,6 +40,7 @@ impl ApiGatewayV2Service {
             .as_str()
             .unwrap_or("INTERNET")
             .to_string();
+        let request_parameters = parse_string_map(&body["requestParameters"]);
 
         let integration_id = generate_id("integration");
 
@@ -90,6 +91,7 @@ impl ApiGatewayV2Service {
             payload_format_version,
             timeout_in_millis,
             connection_type,
+            request_parameters,
         };
 
         state
@@ -256,6 +258,9 @@ impl ApiGatewayV2Service {
         }
         if let Some(expr) = body["integrationResponseSelectionExpression"].as_str() {
             integration.integration_response_selection_expression = Some(expr.to_string());
+        }
+        if let Some(params) = parse_string_map(&body["requestParameters"]) {
+            integration.request_parameters = Some(params);
         }
 
         Ok(AwsResponse::ok_json(json!(integration)))

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -3210,3 +3210,217 @@ async fn get_model_template_derives_from_schema() {
     assert_eq!(tmpl["count"], 0);
     assert_eq!(tmpl["active"], false);
 }
+
+// ── C1 / H7 / M4 / M5 / L2: routing + endpoint hardening ──
+
+/// Helper: create an integration of the given type and return its id.
+async fn create_integration_typed(
+    svc: &ApiGatewayV2Service,
+    api_id: &str,
+    body: serde_json::Value,
+) -> String {
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn create_route_target(
+    svc: &ApiGatewayV2Service,
+    api_id: &str,
+    route_key: &str,
+    int_id: &str,
+) {
+    let body = serde_json::json!({
+        "routeKey": route_key,
+        "target": format!("integrations/{int_id}")
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+}
+
+async fn create_stage_named(svc: &ApiGatewayV2Service, api_id: &str, stage: &str) {
+    let body = serde_json::json!({"stageName": stage});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+}
+
+#[tokio::test]
+async fn execute_api_default_route_matches_any_request() {
+    // C1: an HTTP API whose only route is `$default` must route every
+    // request to that route (was 404ing all traffic).
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+    let int_id = create_integration_typed(
+        &svc,
+        &api_id,
+        serde_json::json!({"integrationType": "MOCK"}),
+    )
+    .await;
+    create_route_target(&svc, &api_id, "$default", &int_id).await;
+    create_stage_named(&svc, &api_id, "prod").await;
+
+    // Any method + any path routes to the $default integration.
+    let req = make_request(Method::GET, "/prod/literally/anything", "");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, http::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn execute_api_default_stage_serves_path_without_stage_segment() {
+    // H7: with a `$default` stage, the default endpoint serves `/items`
+    // directly (no stage segment in the path), keyed on the Host api-id.
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+    let int_id = create_integration_typed(
+        &svc,
+        &api_id,
+        serde_json::json!({"integrationType": "MOCK"}),
+    )
+    .await;
+    create_route_target(&svc, &api_id, "GET /items", &int_id).await;
+    create_stage_named(&svc, &api_id, "$default").await;
+
+    let mut req = make_request(Method::GET, "/items", "");
+    req.headers.insert(
+        "host",
+        format!("{api_id}.execute-api.us-east-1.amazonaws.com")
+            .parse()
+            .unwrap(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, http::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn execute_api_host_scopes_stage_across_apis() {
+    // H7: two APIs sharing a stage name resolve independently by Host.
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state.clone());
+    let api_a = create_api(&svc);
+    let int_a =
+        create_integration_typed(&svc, &api_a, serde_json::json!({"integrationType": "MOCK"}))
+            .await;
+    create_route_target(&svc, &api_a, "GET /items", &int_a).await;
+    create_stage_named(&svc, &api_a, "prod").await;
+
+    let api_b = create_api(&svc);
+    // API B has a `prod` stage but NO `/items` route — a request pinned to
+    // B's Host must 404 rather than resolve against A's `/items`.
+    create_stage_named(&svc, &api_b, "prod").await;
+
+    let mut req = make_request(Method::GET, "/prod/items", "");
+    req.headers.insert(
+        "host",
+        format!("{api_b}.execute-api.us-east-1.amazonaws.com")
+            .parse()
+            .unwrap(),
+    );
+    let err = svc.handle(req).await;
+    assert!(err.is_err(), "request scoped to API B (no /items) must 404");
+}
+
+#[tokio::test]
+async fn integration_request_parameters_round_trip() {
+    // M4: requestParameters must persist on create and come back on get.
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+    let body = serde_json::json!({
+        "integrationType": "HTTP_PROXY",
+        "integrationUri": "https://example.com/{proxy}",
+        "integrationMethod": "POST",
+        "requestParameters": {
+            "overwrite:header.x-user": "'admin'",
+            "append:querystring.trace": "'1'"
+        }
+    });
+    let int_id = create_integration_typed(&svc, &api_id, body).await;
+
+    let req = make_request(
+        Method::GET,
+        &format!("/v2/apis/{api_id}/integrations/{int_id}"),
+        "",
+    );
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["requestParameters"]["overwrite:header.x-user"], "'admin'");
+    assert_eq!(b["requestParameters"]["append:querystring.trace"], "'1'");
+}
+
+#[tokio::test]
+async fn disable_execute_api_endpoint_returns_403() {
+    // M5: the default execute-api endpoint returns 403 when disabled.
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let body = serde_json::json!({
+        "name": "locked",
+        "protocolType": "HTTP",
+        "disableExecuteApiEndpoint": true
+    });
+    let req = make_request(Method::POST, "/v2/apis", &body.to_string());
+    let api_id = body_json(&svc.create_api(&req).unwrap())["apiId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let int_id = create_integration_typed(
+        &svc,
+        &api_id,
+        serde_json::json!({"integrationType": "MOCK"}),
+    )
+    .await;
+    create_route_target(&svc, &api_id, "GET /items", &int_id).await;
+    create_stage_named(&svc, &api_id, "prod").await;
+
+    let mut req = make_request(Method::GET, "/prod/items", "");
+    req.headers.insert(
+        "host",
+        format!("{api_id}.execute-api.us-east-1.amazonaws.com")
+            .parse()
+            .unwrap(),
+    );
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), http::StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn export_api_includes_default_route() {
+    // L2: ExportApi must not silently drop the `$default` route.
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+    let int_id = create_integration_typed(
+        &svc,
+        &api_id,
+        serde_json::json!({"integrationType": "MOCK"}),
+    )
+    .await;
+    create_route_target(&svc, &api_id, "$default", &int_id).await;
+
+    let mut req = make_request(Method::GET, &format!("/v2/apis/{api_id}/exports/OAS30"), "");
+    req.query_params
+        .insert("outputType".to_string(), "JSON".to_string());
+    let resp = svc.handle(req).await.unwrap();
+    // ExportApi returns the document in a `body` blob member.
+    let outer: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let spec: Value = serde_json::from_str(outer["body"].as_str().unwrap()).unwrap();
+    assert!(
+        spec["paths"]["$default"].is_object(),
+        "exported spec must contain the $default path, got: {spec}"
+    );
+}

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -333,6 +333,13 @@ pub struct Integration {
     /// omits it.
     #[serde(default = "default_connection_type")]
     pub connection_type: String,
+    /// HTTP API parameter-mapping expressions keyed by
+    /// `<action>:<location>.<name>` (e.g. `overwrite:path`,
+    /// `append:header.x-user`). Values are either literals or `$request.*`
+    /// source expressions. Applied to the outgoing request for HTTP_PROXY
+    /// integrations. Round-tripped so the Terraform provider doesn't re-plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_parameters: Option<BTreeMap<String, String>>,
 }
 
 fn default_connection_type() -> String {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/apigwv2.rs
@@ -325,6 +325,14 @@ impl ResourceProvisioner {
                 .and_then(|v| v.as_str())
                 .unwrap_or("INTERNET")
                 .to_string(),
+            request_parameters: props
+                .get("RequestParameters")
+                .and_then(|v| v.as_object())
+                .map(|o| {
+                    o.iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                        .collect()
+                }),
         };
         state
             .integrations


### PR DESCRIPTION
## Summary
Behavioral hardening of API Gateway v1 (REST) + v2 (HTTP/WebSocket) — real-tool-facing divergences the conformance probe can't see (it round-trips control-plane CRUD but never drives an execute-api request).

**CRITICAL** — v2 `$default` route was silently dropped by the router (`splitn(' ')` gave one token → `None` → filtered out), so every SAM/CDK/Serverless HTTP API (whose only route is `$default`) 404'd on **every** request. Now routed as the catch-all.

**v1 data plane** (all invisible to CRUD-only conformance):
- H1 non-proxy HTTP integration now calls the backend with `integrationHttpMethod`, not the client method (the #1776 class, previously fixed only on the AWS/AWS_PROXY path).
- H2 integration-response `responseParameters` now applied → MOCK/CORS preflight headers returned.
- H3 execute-api scoped to the Host api-id → no cross-API `prod`-stage collision.
- H4 resource matching by specificity (static > `{var}` > `{proxy+}`).
- M1 MOCK honors the request-template statusCode selector; M2 custom-domain resolves by domain name; L1 VTL depth cap.

**v2**: H5 payloadFormatVersion 1.0 vs 2.0 event shape; H6 Host-based execute-api + `$default`-stage default endpoint reachable; M3 HTTP_PROXY `{proxy}` substitution + integrationMethod; M4 requestParameters persisted/applied (fixes a Terraform perpetual diff); M5 disableExecuteApiEndpoint enforced; L2 `$default` in ExportApi.

## Test plan
- `cargo test -p fakecloud-apigateway -p fakecloud-apigatewayv2` — 101 + 161 + 10 pass, incl. new tests for $default routing, integration method, CORS headers, payload-format shapes, host resolution.
- Both crates + fakecloud-cloudformation build clean. Conformance unaffected (control-plane shapes unchanged); CI runs full clippy + conformance + e2e.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes real execute-api behavior for API Gateway v1 and v2: routes `$default` correctly, uses the configured integration method, scopes resolution by Host, and applies parameter/header mappings. This stops HTTP APIs with only `$default` from 404ing and aligns events/headers with AWS.

- **Bug Fixes**
  - v2 routing and endpoint: route `$default` as catch‑all; `$default` stage serves paths without a stage segment; resolve API by the execute‑api Host id; return 403 when `disableExecuteApiEndpoint` is set.
  - v2 integrations: honor `payloadFormatVersion` 1.0 vs 2.0 for Lambda events; HTTP_PROXY uses `integrationMethod`, substitutes `{proxy}`/`{var}`; apply `requestParameters` to headers/query/path.
  - v1 data plane: non‑proxy HTTP uses `integrationHttpMethod`; apply integration‑response `responseParameters` (e.g., CORS headers); match resources by specificity (static > `{var}` > `{proxy+}`); resolve custom domains by domain name; MOCK selects status from request‑template `statusCode`.

- **New Features**
  - Persist, round‑trip, and enforce HTTP API `requestParameters` (fixes Terraform diffs); include `$default` in ExportApi output.
  - Add a VTL render depth cap to prevent runaway recursion.

<sup>Written for commit 6a50d7c8e750e970065048248d1d68b2b8e6dd69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

