### PR TITLE
fix(cloudwatch): guard Insights/filter-pattern panics, evaluate metric+composite alarms, list pagination

### DIFF
--- a/crates/fakecloud-cloudwatch/src/alarm_eval.rs
+++ b/crates/fakecloud-cloudwatch/src/alarm_eval.rs
@@ -1,0 +1,613 @@
+//! Alarm evaluation.
+//!
+//! CloudWatch alarms are not just stored — they transition state based on the
+//! metric data they watch. This module implements two real evaluators:
+//!
+//! - [`evaluate_metric_alarm`] computes a single-metric alarm's state from the
+//!   stored datapoints over its `evaluation_periods` x `period` window,
+//!   applying the comparison operator, threshold, statistic,
+//!   `datapoints_to_alarm` and `treat_missing_data`.
+//! - Composite alarms are evaluated by parsing the `AlarmRule` boolean
+//!   expression (`ALARM(x)` / `OK(x)` / `INSUFFICIENT_DATA(x)`, `AND`/`OR`/
+//!   `NOT`, parentheses, `TRUE`/`FALSE`) and evaluating it against the current
+//!   states of the referenced alarms.
+//!
+//! [`evaluate_alarms`] recomputes every alarm in a region and records state
+//! transitions in the alarm history. It is invoked from `DescribeAlarms` so a
+//! `PutMetricData` -> `DescribeAlarms` sequence reflects the alarm firing.
+//!
+//! Evaluation never clobbers an alarm whose watched metric has no datapoints in
+//! the window when `treat_missing_data` is the default `missing` (or `ignore`):
+//! such an alarm keeps whatever state it already holds — including one set
+//! explicitly via `SetAlarmState`.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use crate::service::{collect_metric_buckets, resolve_stat};
+use crate::state::{AlarmState, CloudWatchState, MetricAlarm, MetricDatum};
+
+/// Evaluate every alarm in `region` against the stored metric data at `now`,
+/// updating states and recording transitions in the alarm history.
+pub(crate) fn evaluate_alarms(state: &mut CloudWatchState, region: &str, now: DateTime<Utc>) {
+    // ---- Metric alarms ----
+    let mut transitions: Vec<(String, String, AlarmState, String)> = Vec::new();
+    {
+        // Disjoint field borrows: `metrics` shared, `alarms` mutable.
+        let data_map = state.metrics.get(region);
+        if let Some(alarms) = state.alarms.get_mut(region) {
+            for alarm in alarms.values_mut() {
+                let data: Option<&[MetricDatum]> = alarm
+                    .namespace
+                    .as_ref()
+                    .and_then(|ns| data_map.and_then(|m| m.get(ns)))
+                    .map(|v| v.as_slice());
+                if let Some((new_state, reason)) = evaluate_metric_alarm(alarm, data, now) {
+                    if new_state != alarm.state_value {
+                        let old = alarm.state_value.as_str().to_string();
+                        alarm.state_value = new_state;
+                        alarm.state_reason = reason.clone();
+                        alarm.state_updated_timestamp = now;
+                        transitions.push((alarm.alarm_name.clone(), old, new_state, reason));
+                    }
+                }
+            }
+        }
+    }
+    for (name, old, new, reason) in &transitions {
+        record_transition(state, region, name, "MetricAlarm", old, *new, reason, now);
+    }
+
+    // ---- Composite alarms ----
+    evaluate_composite_alarms(state, region, now);
+}
+
+/// Evaluate the composite alarms in `region`, propagating child states through
+/// the rule expressions. Runs to a fixpoint so a composite that references
+/// another composite settles.
+fn evaluate_composite_alarms(state: &mut CloudWatchState, region: &str, now: DateTime<Utc>) {
+    let composite_names: Vec<String> = match state.composite_alarms.get(region) {
+        Some(c) if !c.is_empty() => c.keys().cloned().collect(),
+        _ => return,
+    };
+
+    // Seed the state map from all metric + composite alarms.
+    let mut states: HashMap<String, AlarmState> = HashMap::new();
+    if let Some(a) = state.alarms.get(region) {
+        for (n, al) in a.iter() {
+            states.insert(n.clone(), al.state_value);
+        }
+    }
+    if let Some(c) = state.composite_alarms.get(region) {
+        for (n, al) in c.iter() {
+            states.insert(n.clone(), al.state_value);
+        }
+    }
+
+    // Recompute composite states until stable (bounded by the composite count
+    // so a reference cycle can't loop forever).
+    for _ in 0..composite_names.len() {
+        let mut changed = false;
+        for name in &composite_names {
+            let Some(rule) = state
+                .composite_alarms
+                .get(region)
+                .and_then(|c| c.get(name))
+                .map(|a| a.alarm_rule.clone())
+            else {
+                continue;
+            };
+            if let Some(new_state) = evaluate_rule(&rule, &states) {
+                if states.get(name) != Some(&new_state) {
+                    states.insert(name.clone(), new_state);
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    // Apply the computed states and collect transitions.
+    let mut transitions: Vec<(String, String, AlarmState)> = Vec::new();
+    if let Some(c) = state.composite_alarms.get_mut(region) {
+        for (name, al) in c.iter_mut() {
+            let Some(&new_state) = states.get(name) else {
+                continue;
+            };
+            if new_state != al.state_value {
+                let old = al.state_value.as_str().to_string();
+                al.state_value = new_state;
+                al.state_reason = format!(
+                    "The composite alarm rule evaluated to {}.",
+                    new_state.as_str()
+                );
+                al.state_updated_timestamp = now;
+                transitions.push((name.clone(), old, new_state));
+            }
+        }
+    }
+    for (name, old, new) in &transitions {
+        let reason = format!("The composite alarm rule evaluated to {}.", new.as_str());
+        record_transition(
+            state,
+            region,
+            name,
+            "CompositeAlarm",
+            old,
+            *new,
+            &reason,
+            now,
+        );
+    }
+}
+
+/// Compute the state a single-metric alarm should hold, or `None` to leave the
+/// current state unchanged (metric-math / anomaly alarms, or a metric with no
+/// datapoints under the default missing-data treatment).
+pub(crate) fn evaluate_metric_alarm(
+    alarm: &MetricAlarm,
+    data: Option<&[MetricDatum]>,
+    now: DateTime<Utc>,
+) -> Option<(AlarmState, String)> {
+    // Only plain single-metric alarms with a static threshold are evaluated.
+    // Metric-math (`Metrics`) and anomaly-detection (`ThresholdMetricId`)
+    // alarms are left untouched.
+    if !alarm.metrics.is_empty() || alarm.threshold_metric_id.is_some() {
+        return None;
+    }
+    let threshold = alarm.threshold?;
+    // A namespace is required for a single-metric alarm; the datapoints handed
+    // in are already those for this alarm's namespace.
+    alarm.namespace.as_ref()?;
+    let metric_name = alarm.metric_name.as_ref()?;
+    let stat = alarm
+        .extended_statistic
+        .clone()
+        .or_else(|| alarm.statistic.clone())?;
+    let period = alarm.period.unwrap_or(60).max(1);
+    let eval_periods = alarm.evaluation_periods.max(1);
+    let m = alarm.datapoints_to_alarm.unwrap_or(eval_periods).max(1);
+    let treat = alarm
+        .treat_missing_data
+        .as_deref()
+        .unwrap_or("missing")
+        .to_ascii_lowercase();
+
+    // The most recent period boundary at/just before `now`, then the
+    // `eval_periods` slots ending there.
+    let now_secs = now.timestamp();
+    let latest = now_secs - now_secs.rem_euclid(period);
+    let window_start = latest - (eval_periods - 1) * period;
+    let window_end = latest + period; // exclusive; covers the latest bucket
+    let start_ts = DateTime::<Utc>::from_timestamp(window_start, 0)?;
+    let end_ts = DateTime::<Utc>::from_timestamp(window_end, 0)?;
+
+    let buckets = match data {
+        Some(d) => collect_metric_buckets(
+            d,
+            metric_name,
+            &alarm.dimensions,
+            alarm.unit.as_deref(),
+            period,
+            start_ts,
+            end_ts,
+        ),
+        None => Default::default(),
+    };
+
+    // Gather one value per slot (most recent first) plus the breaching flags.
+    let mut present = 0i64;
+    let mut breaching = 0i64;
+    let mut latest_value: Option<f64> = None;
+    for i in 0..eval_periods {
+        let slot_secs = latest - i * period;
+        let Some(slot_ts) = DateTime::<Utc>::from_timestamp(slot_secs, 0) else {
+            continue;
+        };
+        if let Some(bucket) = buckets.get(&slot_ts) {
+            let mut sorted = bucket.samples.clone();
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            if let Some(v) = resolve_stat(&stat, bucket, &sorted) {
+                present += 1;
+                if latest_value.is_none() {
+                    latest_value = Some(v);
+                }
+                if breaches(&alarm.comparison_operator, v, threshold) {
+                    breaching += 1;
+                }
+            }
+        }
+    }
+    let missing = eval_periods - present;
+
+    // No real datapoints: don't clobber the current state unless the caller
+    // explicitly asked to treat missing data as (not)breaching.
+    if present == 0 {
+        return match treat.as_str() {
+            "breaching" => Some((
+                AlarmState::Alarm,
+                "Insufficient data treated as breaching.".to_string(),
+            )),
+            "notbreaching" => Some((
+                AlarmState::Ok,
+                "Insufficient data treated as not breaching.".to_string(),
+            )),
+            _ => None,
+        };
+    }
+
+    let effective_breaching = match treat.as_str() {
+        "breaching" => breaching + missing,
+        _ => breaching,
+    };
+
+    if effective_breaching >= m {
+        let reason = format!(
+            "Threshold Crossed: {effective_breaching} out of the last {eval_periods} datapoints \
+             [{}] was {} the threshold ({threshold}).",
+            latest_value.map(|v| v.to_string()).unwrap_or_default(),
+            operator_phrase(&alarm.comparison_operator),
+        );
+        Some((AlarmState::Alarm, reason))
+    } else {
+        let reason = format!(
+            "Threshold not crossed: {breaching} out of the last {eval_periods} datapoints was {} \
+             the threshold ({threshold}).",
+            operator_phrase(&alarm.comparison_operator),
+        );
+        Some((AlarmState::Ok, reason))
+    }
+}
+
+/// Whether `value` breaches `threshold` under `comparison_operator`. Band
+/// operators (which require a `ThresholdMetricId`) never breach here.
+fn breaches(op: &str, value: f64, threshold: f64) -> bool {
+    match op {
+        "GreaterThanThreshold" => value > threshold,
+        "GreaterThanOrEqualToThreshold" => value >= threshold,
+        "LessThanThreshold" => value < threshold,
+        "LessThanOrEqualToThreshold" => value <= threshold,
+        _ => false,
+    }
+}
+
+fn operator_phrase(op: &str) -> &'static str {
+    match op {
+        "GreaterThanThreshold" => "greater than",
+        "GreaterThanOrEqualToThreshold" => "greater than or equal to",
+        "LessThanThreshold" => "less than",
+        "LessThanOrEqualToThreshold" => "less than or equal to",
+        _ => "compared against",
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_transition(
+    state: &mut CloudWatchState,
+    region: &str,
+    name: &str,
+    alarm_type: &str,
+    old: &str,
+    new: AlarmState,
+    reason: &str,
+    _now: DateTime<Utc>,
+) {
+    let new_str = new.as_str();
+    let summary = format!("Alarm updated from {old} to {new_str}");
+    let history_data = format!(
+        "{{\"oldState\":{{\"stateValue\":\"{old}\"}},\"newState\":{{\"stateValue\":\"{new_str}\",\"stateReason\":\"{}\"}}}}",
+        reason.replace('"', "\\\"")
+    );
+    crate::service::push_alarm_history(
+        state,
+        region,
+        name,
+        alarm_type,
+        "StateUpdate",
+        summary,
+        history_data,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Composite alarm rule parser + evaluator.
+// ---------------------------------------------------------------------------
+
+/// A parsed `AlarmRule` expression node.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum RuleNode {
+    And(Box<RuleNode>, Box<RuleNode>),
+    Or(Box<RuleNode>, Box<RuleNode>),
+    Not(Box<RuleNode>),
+    /// A state predicate: the target alarm name must currently hold this state.
+    State(AlarmState, String),
+    True,
+    False,
+}
+
+/// Evaluate a rule string against the current alarm states, returning the
+/// composite's state (`ALARM` when the rule is true, otherwise `OK`), or `None`
+/// if the rule doesn't parse.
+fn evaluate_rule(rule: &str, states: &HashMap<String, AlarmState>) -> Option<AlarmState> {
+    let node = parse_alarm_rule(rule).ok()?;
+    Some(if eval_node(&node, states) {
+        AlarmState::Alarm
+    } else {
+        AlarmState::Ok
+    })
+}
+
+fn eval_node(node: &RuleNode, states: &HashMap<String, AlarmState>) -> bool {
+    match node {
+        RuleNode::And(a, b) => eval_node(a, states) && eval_node(b, states),
+        RuleNode::Or(a, b) => eval_node(a, states) || eval_node(b, states),
+        RuleNode::Not(a) => !eval_node(a, states),
+        RuleNode::True => true,
+        RuleNode::False => false,
+        RuleNode::State(want, name) => states.get(name.as_str()) == Some(want),
+    }
+}
+
+/// Parse an `AlarmRule` boolean expression. Returns an error string for a
+/// malformed rule so `PutCompositeAlarm` can reject it.
+pub(crate) fn parse_alarm_rule(rule: &str) -> Result<RuleNode, String> {
+    let chars: Vec<char> = rule.chars().collect();
+    let mut p = RuleParser { chars, pos: 0 };
+    p.skip_ws();
+    if p.pos >= p.chars.len() {
+        return Err("empty alarm rule".to_string());
+    }
+    let node = p.parse_or()?;
+    p.skip_ws();
+    if p.pos != p.chars.len() {
+        return Err(format!(
+            "unexpected trailing input in alarm rule at {}",
+            p.pos
+        ));
+    }
+    Ok(node)
+}
+
+struct RuleParser {
+    chars: Vec<char>,
+    pos: usize,
+}
+
+impl RuleParser {
+    fn skip_ws(&mut self) {
+        while self.pos < self.chars.len() && self.chars[self.pos].is_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.chars.get(self.pos).copied()
+    }
+
+    /// Peek an upper-cased keyword (a run of ASCII letters) without consuming.
+    fn peek_keyword(&self) -> Option<String> {
+        let mut i = self.pos;
+        while i < self.chars.len() && self.chars[i].is_whitespace() {
+            i += 1;
+        }
+        let start = i;
+        while i < self.chars.len() && (self.chars[i].is_ascii_alphabetic() || self.chars[i] == '_')
+        {
+            i += 1;
+        }
+        if i == start {
+            None
+        } else {
+            Some(
+                self.chars[start..i]
+                    .iter()
+                    .collect::<String>()
+                    .to_ascii_uppercase(),
+            )
+        }
+    }
+
+    fn consume_keyword(&mut self, kw: &str) {
+        self.skip_ws();
+        self.pos += kw.len();
+    }
+
+    fn parse_or(&mut self) -> Result<RuleNode, String> {
+        let mut left = self.parse_and()?;
+        while self.peek_keyword().as_deref() == Some("OR") {
+            self.consume_keyword("OR");
+            let right = self.parse_and()?;
+            left = RuleNode::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_and(&mut self) -> Result<RuleNode, String> {
+        let mut left = self.parse_unary()?;
+        while self.peek_keyword().as_deref() == Some("AND") {
+            self.consume_keyword("AND");
+            let right = self.parse_unary()?;
+            left = RuleNode::And(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_unary(&mut self) -> Result<RuleNode, String> {
+        if self.peek_keyword().as_deref() == Some("NOT") {
+            self.consume_keyword("NOT");
+            let inner = self.parse_unary()?;
+            return Ok(RuleNode::Not(Box::new(inner)));
+        }
+        self.parse_primary()
+    }
+
+    fn parse_primary(&mut self) -> Result<RuleNode, String> {
+        self.skip_ws();
+        match self.peek() {
+            Some('(') => {
+                self.pos += 1;
+                let node = self.parse_or()?;
+                self.skip_ws();
+                if self.peek() != Some(')') {
+                    return Err("expected ')' in alarm rule".to_string());
+                }
+                self.pos += 1;
+                Ok(node)
+            }
+            Some(_) => {
+                let kw = self
+                    .peek_keyword()
+                    .ok_or_else(|| "expected a token in alarm rule".to_string())?;
+                match kw.as_str() {
+                    "TRUE" => {
+                        self.consume_keyword("TRUE");
+                        Ok(RuleNode::True)
+                    }
+                    "FALSE" => {
+                        self.consume_keyword("FALSE");
+                        Ok(RuleNode::False)
+                    }
+                    "ALARM" | "OK" | "INSUFFICIENT_DATA" => self.parse_func(&kw),
+                    other => Err(format!("unexpected token '{other}' in alarm rule")),
+                }
+            }
+            None => Err("unexpected end of alarm rule".to_string()),
+        }
+    }
+
+    /// Parse `KIND ( ref )` where `ref` is a quoted string, an alarm name, or an
+    /// alarm ARN.
+    fn parse_func(&mut self, kind: &str) -> Result<RuleNode, String> {
+        // `INSUFFICIENT_DATA` contains an underscore, so consume the exact
+        // keyword text (letters + underscores) rather than a fixed length.
+        self.skip_ws();
+        while self.pos < self.chars.len()
+            && (self.chars[self.pos].is_ascii_alphabetic() || self.chars[self.pos] == '_')
+        {
+            self.pos += 1;
+        }
+        self.skip_ws();
+        if self.peek() != Some('(') {
+            return Err(format!("expected '(' after {kind} in alarm rule"));
+        }
+        self.pos += 1;
+        // Read the reference up to the closing paren.
+        let start = self.pos;
+        while self.pos < self.chars.len() && self.chars[self.pos] != ')' {
+            self.pos += 1;
+        }
+        if self.peek() != Some(')') {
+            return Err(format!("unterminated {kind}(...) in alarm rule"));
+        }
+        let raw: String = self.chars[start..self.pos].iter().collect();
+        self.pos += 1; // consume ')'
+        let name = normalize_ref(raw.trim());
+        if name.is_empty() {
+            return Err(format!("empty reference in {kind}(...)"));
+        }
+        let state = match kind {
+            "ALARM" => AlarmState::Alarm,
+            "OK" => AlarmState::Ok,
+            "INSUFFICIENT_DATA" => AlarmState::InsufficientData,
+            _ => unreachable!(),
+        };
+        Ok(RuleNode::State(state, name))
+    }
+}
+
+/// Normalize an alarm reference: strip surrounding quotes and resolve an ARN to
+/// its trailing alarm name.
+fn normalize_ref(raw: &str) -> String {
+    let unquoted = raw
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .or_else(|| raw.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
+        .unwrap_or(raw)
+        .trim();
+    if let Some(idx) = unquoted.find(":alarm:") {
+        return unquoted[idx + ":alarm:".len()..].to_string();
+    }
+    unquoted.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn states(pairs: &[(&str, AlarmState)]) -> HashMap<String, AlarmState> {
+        pairs.iter().map(|(n, s)| (n.to_string(), *s)).collect()
+    }
+
+    #[test]
+    fn parses_and_evaluates_simple_alarm_predicate() {
+        let node = parse_alarm_rule("ALARM(a)").unwrap();
+        assert!(eval_node(&node, &states(&[("a", AlarmState::Alarm)])));
+        assert!(!eval_node(&node, &states(&[("a", AlarmState::Ok)])));
+        // Missing referenced alarm -> predicate false.
+        assert!(!eval_node(&node, &states(&[])));
+    }
+
+    #[test]
+    fn evaluates_and_or_not_and_parens() {
+        let node = parse_alarm_rule("(ALARM(a) AND ALARM(b)) OR NOT OK(c)").unwrap();
+        let s = states(&[
+            ("a", AlarmState::Alarm),
+            ("b", AlarmState::Alarm),
+            ("c", AlarmState::Ok),
+        ]);
+        // a AND b true -> whole true.
+        assert!(eval_node(&node, &s));
+        let s2 = states(&[
+            ("a", AlarmState::Ok),
+            ("b", AlarmState::Alarm),
+            ("c", AlarmState::Alarm),
+        ]);
+        // a AND b false; NOT OK(c) -> c is ALARM not OK -> NOT false -> true.
+        assert!(eval_node(&node, &s2));
+    }
+
+    #[test]
+    fn quoted_and_arn_references_resolve() {
+        let node = parse_alarm_rule("ALARM(\"my-alarm\")").unwrap();
+        assert!(eval_node(
+            &node,
+            &states(&[("my-alarm", AlarmState::Alarm)])
+        ));
+        let node =
+            parse_alarm_rule("ALARM(arn:aws:cloudwatch:us-east-1:123456789012:alarm:my-alarm)")
+                .unwrap();
+        assert!(eval_node(
+            &node,
+            &states(&[("my-alarm", AlarmState::Alarm)])
+        ));
+    }
+
+    #[test]
+    fn insufficient_data_predicate() {
+        let node = parse_alarm_rule("INSUFFICIENT_DATA(a)").unwrap();
+        assert!(eval_node(
+            &node,
+            &states(&[("a", AlarmState::InsufficientData)])
+        ));
+    }
+
+    #[test]
+    fn malformed_rules_error() {
+        assert!(parse_alarm_rule("").is_err());
+        assert!(parse_alarm_rule("ALARM(").is_err());
+        assert!(parse_alarm_rule("ALARM(a) AND").is_err());
+        assert!(parse_alarm_rule("BOGUS(a)").is_err());
+        assert!(parse_alarm_rule("ALARM(a) garbage").is_err());
+    }
+
+    #[test]
+    fn evaluate_rule_maps_to_alarm_or_ok() {
+        let s = states(&[("a", AlarmState::Alarm)]);
+        assert_eq!(evaluate_rule("ALARM(a)", &s), Some(AlarmState::Alarm));
+        assert_eq!(evaluate_rule("OK(a)", &s), Some(AlarmState::Ok));
+        assert_eq!(evaluate_rule("!!!", &s), None);
+    }
+}

--- a/crates/fakecloud-cloudwatch/src/composite_alarms.rs
+++ b/crates/fakecloud-cloudwatch/src/composite_alarms.rs
@@ -9,6 +9,7 @@
 //! undeclared error on a well-formed (Success-class) request.
 
 use chrono::Utc;
+use http::StatusCode;
 
 use fakecloud_core::query::{optional_query_param, required_query_param};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
@@ -29,6 +30,16 @@ impl CloudWatchService {
         validate_len(req, "ActionsSuppressor", 1, 1600)?;
         let alarm_name = required_query_param(req, "AlarmName")?;
         let alarm_rule = required_query_param(req, "AlarmRule")?;
+        // The AlarmRule must be a well-formed boolean expression over
+        // ALARM/OK/INSUFFICIENT_DATA predicates; reject a malformed rule rather
+        // than storing an inert one that never evaluates.
+        if let Err(e) = crate::alarm_eval::parse_alarm_rule(&alarm_rule) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                format!("Invalid AlarmRule: {e}"),
+            ));
+        }
         let alarm_description = optional_query_param(req, "AlarmDescription");
         let actions_enabled = optional_query_param(req, "ActionsEnabled")
             .map(|s| s.eq_ignore_ascii_case("true"))

--- a/crates/fakecloud-cloudwatch/src/lib.rs
+++ b/crates/fakecloud-cloudwatch/src/lib.rs
@@ -1,3 +1,4 @@
+pub(crate) mod alarm_eval;
 pub(crate) mod anomaly_detectors;
 pub(crate) mod composite_alarms;
 pub(crate) mod datasets;

--- a/crates/fakecloud-cloudwatch/src/metric_math.rs
+++ b/crates/fakecloud-cloudwatch/src/metric_math.rs
@@ -113,15 +113,34 @@ fn tokenize(expr: &str) -> Result<Vec<Token>, String> {
     Ok(tokens)
 }
 
+/// Maximum parser recursion depth. Guards against a stack overflow on a
+/// pathologically deep expression (e.g. thousands of nested parentheses)
+/// arriving from an untrusted `GetMetricData` request.
+const MAX_DEPTH: usize = 256;
+
 struct Parser<'a> {
     tokens: Vec<Token>,
     pos: usize,
+    depth: usize,
     metrics: &'a BTreeMap<String, Series>,
 }
 
 impl Parser<'_> {
     fn peek(&self) -> Option<&Token> {
         self.tokens.get(self.pos)
+    }
+
+    /// Enter one level of recursion, erroring if the nesting limit is reached.
+    fn enter(&mut self) -> Result<(), String> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            return Err("expression nesting is too deep".to_string());
+        }
+        Ok(())
+    }
+
+    fn leave(&mut self) {
+        self.depth -= 1;
     }
 
     fn next(&mut self) -> Option<Token> {
@@ -170,6 +189,13 @@ impl Parser<'_> {
     }
 
     fn parse_factor(&mut self) -> Result<Value, String> {
+        self.enter()?;
+        let result = self.parse_factor_inner();
+        self.leave();
+        result
+    }
+
+    fn parse_factor_inner(&mut self) -> Result<Value, String> {
         match self.next() {
             Some(Token::Number(n)) => Ok(Value::Scalar(n)),
             Some(Token::Minus) => {
@@ -319,6 +345,7 @@ pub fn evaluate(expr: &str, metrics: &BTreeMap<String, Series>) -> Result<Series
     let mut parser = Parser {
         tokens,
         pos: 0,
+        depth: 0,
         metrics,
     };
     let value = parser.parse_expr()?;
@@ -399,5 +426,15 @@ mod tests {
     fn unknown_id_errors() {
         let m = BTreeMap::new();
         assert!(evaluate("m1+m2", &m).is_err());
+    }
+
+    #[test]
+    fn deeply_nested_parens_error_not_overflow() {
+        // A pathologically deep expression must return an Err rather than
+        // overflowing the stack.
+        let m = BTreeMap::new();
+        let expr = format!("{}1{}", "(".repeat(5000), ")".repeat(5000));
+        let out = evaluate(&expr, &m);
+        assert!(out.is_err());
     }
 }

--- a/crates/fakecloud-cloudwatch/src/mute_rules.rs
+++ b/crates/fakecloud-cloudwatch/src/mute_rules.rs
@@ -12,15 +12,14 @@ use fakecloud_core::query::{optional_query_param, required_query_param};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::{
-    collect_member_values, empty_metadata_response, missing_param, not_found, validate_len,
-    validate_range_i64, xml_escape, xml_response, CloudWatchService,
+    collect_member_values, empty_metadata_response, missing_param, not_found,
+    parse_input_timestamp, validate_len, validate_range_i64, xml_escape, xml_response,
+    CloudWatchService,
 };
 use crate::state::AlarmMuteRule;
 
 fn parse_ts(req: &AwsRequest, name: &str) -> Option<DateTime<Utc>> {
-    optional_query_param(req, name)
-        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
-        .map(|d| d.with_timezone(&Utc))
+    optional_query_param(req, name).and_then(|s| parse_input_timestamp(&s))
 }
 
 /// Compute the wire status of a mute rule from its start/expire dates.
@@ -90,7 +89,10 @@ impl CloudWatchService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let name = optional_query_param(req, "AlarmMuteRuleName").unwrap_or_default();
+        // A required name that is omitted is a validation error; a present but
+        // unknown name is the declared ResourceNotFoundException below.
+        let name = optional_query_param(req, "AlarmMuteRuleName")
+            .ok_or_else(|| missing_param("AlarmMuteRuleName"))?;
         let state = self.state.read();
         let rule = state
             .get(&req.account_id)

--- a/crates/fakecloud-cloudwatch/src/otel.rs
+++ b/crates/fakecloud-cloudwatch/src/otel.rs
@@ -53,10 +53,11 @@ impl CloudWatchService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        // AlarmName is required and the op declares ResourceNotFoundException;
-        // reject missing / unknown alarms with that declared error.
-        let alarm_name = optional_query_param(req, "AlarmName")
-            .ok_or_else(|| not_found("Alarm does not exist"))?;
+        // AlarmName is a required parameter: an omitted name is a missing-
+        // parameter validation error, whereas a present-but-unknown alarm is
+        // the declared ResourceNotFoundException.
+        let alarm_name =
+            optional_query_param(req, "AlarmName").ok_or_else(|| missing_param("AlarmName"))?;
         let state = self.state.read();
         let exists = state
             .get(&req.account_id)

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -647,6 +647,26 @@ pub(crate) fn decode_offset_token(token: Option<&String>) -> usize {
         .unwrap_or(0)
 }
 
+/// Parse an input timestamp, accepting either RFC3339 (the query-protocol
+/// form) or a numeric epoch-seconds value (which JSON-protocol / X-Amz-Target
+/// callers send). Previously only RFC3339 was accepted, so an epoch-second
+/// timestamp was silently dropped or rejected.
+pub(crate) fn parse_input_timestamp(s: &str) -> Option<DateTime<Utc>> {
+    let s = s.trim();
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    // Epoch seconds (optionally fractional).
+    if let Ok(secs) = s.parse::<f64>() {
+        if secs.is_finite() {
+            let whole = secs.trunc() as i64;
+            let nanos = (secs.fract().abs() * 1_000_000_000.0).round() as u32;
+            return DateTime::<Utc>::from_timestamp(whole, nanos);
+        }
+    }
+    None
+}
+
 /// Per-datapoint aggregation summary covering both the simple `Value` form
 /// and the `StatisticValues` form so callers don't lose the count or
 /// min/max baked into a `StatisticSet`.
@@ -743,15 +763,19 @@ pub(crate) fn percentile(sorted: &[f64], p: f64) -> Option<f64> {
 /// individual `value` samples (used for percentiles — distributions published
 /// as `StatisticValues` don't retain their raw values so they don't
 /// contribute), and the bucket's unit when consistent.
-struct MetricBucket {
+pub(crate) struct MetricBucket {
     agg: DatumStats,
-    samples: Vec<f64>,
+    pub(crate) samples: Vec<f64>,
     unit: Option<String>,
 }
 
 /// Resolve a single statistic (simple, e.g. `Sum`, or percentile, e.g. `p99`)
 /// for one bucket. `samples` must be sorted ascending.
-fn resolve_stat(stat: &str, bucket: &MetricBucket, samples_sorted: &[f64]) -> Option<f64> {
+pub(crate) fn resolve_stat(
+    stat: &str,
+    bucket: &MetricBucket,
+    samples_sorted: &[f64],
+) -> Option<f64> {
     if let Some(p) = parse_percentile(stat) {
         return percentile(samples_sorted, p);
     }
@@ -763,7 +787,7 @@ fn resolve_stat(stat: &str, bucket: &MetricBucket, samples_sorted: &[f64]) -> Op
 /// each distinct dimension combination as its own metric) and, when a unit
 /// filter is set, only datapoints published with that unit.
 #[allow(clippy::too_many_arguments)]
-fn collect_metric_buckets(
+pub(crate) fn collect_metric_buckets(
     data: &[MetricDatum],
     metric_name: &str,
     dim_filter: &BTreeMap<String, String>,
@@ -863,8 +887,7 @@ impl CloudWatchService {
                 .map_err(|_| invalid_param("Value must be a valid number"))?;
             let timestamp = member
                 .get("Timestamp")
-                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                .map(|d| d.with_timezone(&Utc))
+                .and_then(|s| parse_input_timestamp(s))
                 .unwrap_or(now);
             let unit = member.get("Unit").cloned();
             let storage_resolution = member
@@ -1010,12 +1033,10 @@ impl CloudWatchService {
         if period <= 0 {
             return Err(invalid_param("Period must be positive"));
         }
-        let start_ts = DateTime::parse_from_rfc3339(&start)
-            .map_err(|_| invalid_param("StartTime must be ISO 8601"))?
-            .with_timezone(&Utc);
-        let end_ts = DateTime::parse_from_rfc3339(&end)
-            .map_err(|_| invalid_param("EndTime must be ISO 8601"))?
-            .with_timezone(&Utc);
+        let start_ts = parse_input_timestamp(&start)
+            .ok_or_else(|| invalid_param("StartTime must be ISO 8601 or epoch seconds"))?;
+        let end_ts = parse_input_timestamp(&end)
+            .ok_or_else(|| invalid_param("EndTime must be ISO 8601 or epoch seconds"))?;
 
         let mut statistics: Vec<String> = Vec::new();
         let mut extended_statistics: Vec<String> = Vec::new();
@@ -1122,12 +1143,10 @@ impl CloudWatchService {
         )?;
         let start = required_query_param(req, "StartTime")?;
         let end = required_query_param(req, "EndTime")?;
-        let start_ts = DateTime::parse_from_rfc3339(&start)
-            .map_err(|_| invalid_param("StartTime must be ISO 8601"))?
-            .with_timezone(&Utc);
-        let end_ts = DateTime::parse_from_rfc3339(&end)
-            .map_err(|_| invalid_param("EndTime must be ISO 8601"))?
-            .with_timezone(&Utc);
+        let start_ts = parse_input_timestamp(&start)
+            .ok_or_else(|| invalid_param("StartTime must be ISO 8601 or epoch seconds"))?;
+        let end_ts = parse_input_timestamp(&end)
+            .ok_or_else(|| invalid_param("EndTime must be ISO 8601 or epoch seconds"))?;
 
         // Default ScanBy is TimestampDescending (newest first); callers read
         // Values[0] as the latest datapoint. The bucket map is ascending, so
@@ -1487,7 +1506,13 @@ impl CloudWatchService {
             true
         };
 
-        let state = self.state.read();
+        // Recompute alarm states from the metric data (and composite rules)
+        // before rendering, so a PutMetricData that crosses a threshold is
+        // reflected here and a composite alarm mirrors its children.
+        let mut state = self.state.write();
+        if let Some(acct) = state.accounts.get_mut(&req.account_id) {
+            crate::alarm_eval::evaluate_alarms(acct, &req.region, Utc::now());
+        }
         let mut combined: Vec<(bool, String)> = Vec::new();
         if let Some(acct) = state.get(&req.account_id) {
             if let Some(alarms) = acct.alarms_in(&req.region) {
@@ -1668,20 +1693,34 @@ impl CloudWatchService {
         let new_state = AlarmState::parse(&state_value)
             .ok_or_else(|| invalid_param("StateValue must be OK | ALARM | INSUFFICIENT_DATA"))?;
 
+        let now = Utc::now();
         let mut state = self.state.write();
         let acct = state.get_or_create(&req.account_id);
-        let alarms = acct.alarms_in_mut(&req.region);
-        let alarm = alarms.get_mut(&alarm_name).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "ResourceNotFound",
-                format!("Alarm {alarm_name} not found"),
-            )
-        })?;
-        let old_state = alarm.state_value.as_str().to_string();
-        alarm.state_value = new_state;
-        alarm.state_reason = state_reason.clone();
-        alarm.state_updated_timestamp = Utc::now();
+        // SetAlarmState can target a metric alarm or a composite alarm; look up
+        // the metric store first, then fall back to the composite store.
+        let (old_state, alarm_type) =
+            if let Some(alarm) = acct.alarms_in_mut(&req.region).get_mut(&alarm_name) {
+                let old = alarm.state_value.as_str().to_string();
+                alarm.state_value = new_state;
+                alarm.state_reason = state_reason.clone();
+                alarm.state_updated_timestamp = now;
+                (old, "MetricAlarm")
+            } else if let Some(composite) = acct
+                .composite_alarms_in_mut(&req.region)
+                .get_mut(&alarm_name)
+            {
+                let old = composite.state_value.as_str().to_string();
+                composite.state_value = new_state;
+                composite.state_reason = state_reason.clone();
+                composite.state_updated_timestamp = now;
+                (old, "CompositeAlarm")
+            } else {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFound",
+                    format!("Alarm {alarm_name} not found"),
+                ));
+            };
 
         let new_state_str = new_state.as_str().to_string();
         let summary = format!("Alarm updated from {old_state} to {new_state_str}");
@@ -1693,7 +1732,7 @@ impl CloudWatchService {
             acct,
             &req.region,
             &alarm_name,
-            "MetricAlarm",
+            alarm_type,
             "StateUpdate",
             summary,
             history_data,
@@ -1724,12 +1763,9 @@ impl CloudWatchService {
         )?;
         let alarm_filter = optional_query_param(req, "AlarmName");
         let type_filter = optional_query_param(req, "HistoryItemType");
-        let start_date = optional_query_param(req, "StartDate")
-            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
-            .map(|d| d.with_timezone(&Utc));
-        let end_date = optional_query_param(req, "EndDate")
-            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
-            .map(|d| d.with_timezone(&Utc));
+        let start_date =
+            optional_query_param(req, "StartDate").and_then(|s| parse_input_timestamp(&s));
+        let end_date = optional_query_param(req, "EndDate").and_then(|s| parse_input_timestamp(&s));
         // DescribeAlarmHistory defaults to TimestampDescending (newest first).
         let descending = req
             .query_params
@@ -1956,7 +1992,7 @@ impl CloudWatchService {
 /// Append an alarm-history record (newest appended last). Shared by
 /// PutMetricAlarm, SetAlarmState and DeleteAlarms so DescribeAlarmHistory
 /// reflects real lifecycle transitions.
-fn push_alarm_history(
+pub(crate) fn push_alarm_history(
     acct: &mut crate::state::CloudWatchState,
     region: &str,
     alarm_name: &str,

--- a/crates/fakecloud-cloudwatch/src/tests.rs
+++ b/crates/fakecloud-cloudwatch/src/tests.rs
@@ -247,6 +247,254 @@ async fn composite_alarm_in_describe_alarms() {
     assert!(!body_of(&after).contains("ALARM(x)"));
 }
 
+// H5: metric alarms are evaluated against PutMetricData on DescribeAlarms.
+#[tokio::test]
+async fn metric_alarm_evaluates_to_alarm_above_threshold() {
+    let svc = service();
+    call(
+        &svc,
+        "PutMetricAlarm",
+        &[
+            ("AlarmName", "cpu-alarm"),
+            ("Namespace", "Test/App"),
+            ("MetricName", "CPU"),
+            ("ComparisonOperator", "GreaterThanThreshold"),
+            ("Threshold", "50"),
+            ("EvaluationPeriods", "1"),
+            ("Period", "60"),
+            ("Statistic", "Average"),
+        ],
+    )
+    .await;
+    // Publish a datapoint above the threshold.
+    call(
+        &svc,
+        "PutMetricData",
+        &[
+            ("Namespace", "Test/App"),
+            ("MetricData.member.1.MetricName", "CPU"),
+            ("MetricData.member.1.Value", "100"),
+        ],
+    )
+    .await;
+    let desc = call(
+        &svc,
+        "DescribeAlarms",
+        &[("AlarmNames.member.1", "cpu-alarm")],
+    )
+    .await;
+    assert!(
+        body_of(&desc).contains("<StateValue>ALARM</StateValue>"),
+        "alarm above threshold should be ALARM: {}",
+        body_of(&desc)
+    );
+}
+
+#[tokio::test]
+async fn metric_alarm_evaluates_to_ok_below_threshold() {
+    let svc = service();
+    call(
+        &svc,
+        "PutMetricAlarm",
+        &[
+            ("AlarmName", "cpu-ok"),
+            ("Namespace", "Test/App2"),
+            ("MetricName", "CPU"),
+            ("ComparisonOperator", "GreaterThanThreshold"),
+            ("Threshold", "50"),
+            ("EvaluationPeriods", "1"),
+            ("Period", "60"),
+            ("Statistic", "Average"),
+        ],
+    )
+    .await;
+    call(
+        &svc,
+        "PutMetricData",
+        &[
+            ("Namespace", "Test/App2"),
+            ("MetricData.member.1.MetricName", "CPU"),
+            ("MetricData.member.1.Value", "10"),
+        ],
+    )
+    .await;
+    let desc = call(&svc, "DescribeAlarms", &[("AlarmNames.member.1", "cpu-ok")]).await;
+    assert!(
+        body_of(&desc).contains("<StateValue>OK</StateValue>"),
+        "alarm below threshold should be OK: {}",
+        body_of(&desc)
+    );
+}
+
+// A manually-set state must survive DescribeAlarms re-evaluation when the
+// watched metric has no datapoints (default treat-missing-data).
+#[tokio::test]
+async fn set_alarm_state_survives_evaluation_without_data() {
+    let svc = service();
+    call(
+        &svc,
+        "PutMetricAlarm",
+        &[
+            ("AlarmName", "manual"),
+            ("Namespace", "Test/None"),
+            ("MetricName", "M"),
+            ("ComparisonOperator", "GreaterThanThreshold"),
+            ("Threshold", "1"),
+            ("EvaluationPeriods", "1"),
+            ("Statistic", "Sum"),
+        ],
+    )
+    .await;
+    call(
+        &svc,
+        "SetAlarmState",
+        &[
+            ("AlarmName", "manual"),
+            ("StateValue", "ALARM"),
+            ("StateReason", "manual"),
+        ],
+    )
+    .await;
+    let desc = call(&svc, "DescribeAlarms", &[("AlarmNames.member.1", "manual")]).await;
+    assert!(body_of(&desc).contains("<StateValue>ALARM</StateValue>"));
+}
+
+// H3: a composite alarm reflects ALARM when its rule is satisfied by children.
+#[tokio::test]
+async fn composite_alarm_reflects_children_states() {
+    let svc = service();
+    for name in ["child-a", "child-b"] {
+        call(
+            &svc,
+            "PutMetricAlarm",
+            &[
+                ("AlarmName", name),
+                ("Namespace", "Test/C"),
+                ("MetricName", "M"),
+                ("ComparisonOperator", "GreaterThanThreshold"),
+                ("Threshold", "1"),
+                ("EvaluationPeriods", "1"),
+                ("Statistic", "Sum"),
+            ],
+        )
+        .await;
+        call(
+            &svc,
+            "SetAlarmState",
+            &[
+                ("AlarmName", name),
+                ("StateValue", "ALARM"),
+                ("StateReason", "x"),
+            ],
+        )
+        .await;
+    }
+    call(
+        &svc,
+        "PutCompositeAlarm",
+        &[
+            ("AlarmName", "comp2"),
+            ("AlarmRule", "ALARM(child-a) AND ALARM(child-b)"),
+        ],
+    )
+    .await;
+    let desc = call(&svc, "DescribeAlarms", &[("AlarmNames.member.1", "comp2")]).await;
+    let b = body_of(&desc);
+    assert!(
+        b.contains("<CompositeAlarms>") && b.contains("<StateValue>ALARM</StateValue>"),
+        "composite should be ALARM when both children ALARM: {b}"
+    );
+
+    // Flip one child OK -> composite should evaluate back to OK.
+    call(
+        &svc,
+        "SetAlarmState",
+        &[
+            ("AlarmName", "child-a"),
+            ("StateValue", "OK"),
+            ("StateReason", "x"),
+        ],
+    )
+    .await;
+    let desc = call(&svc, "DescribeAlarms", &[("AlarmNames.member.1", "comp2")]).await;
+    assert!(body_of(&desc).contains("<StateValue>OK</StateValue>"));
+}
+
+// H4: SetAlarmState can target a composite alarm.
+#[tokio::test]
+async fn set_alarm_state_targets_composite_alarm() {
+    let svc = service();
+    call(
+        &svc,
+        "PutCompositeAlarm",
+        &[("AlarmName", "comp3"), ("AlarmRule", "ALARM(x)")],
+    )
+    .await;
+    // Previously this returned ResourceNotFound (only metric alarms checked).
+    call(
+        &svc,
+        "SetAlarmState",
+        &[
+            ("AlarmName", "comp3"),
+            ("StateValue", "ALARM"),
+            ("StateReason", "manual"),
+        ],
+    )
+    .await;
+    // Verify directly against state (DescribeAlarms would re-evaluate the rule).
+    let state = svc.state.read();
+    let sv = state
+        .get(ACCT)
+        .and_then(|a| a.composite_alarms_in(REGION))
+        .and_then(|c| c.get("comp3"))
+        .map(|c| c.state_value)
+        .unwrap();
+    assert_eq!(sv, crate::state::AlarmState::Alarm);
+}
+
+// H3: PutCompositeAlarm rejects a malformed AlarmRule.
+#[tokio::test]
+async fn put_composite_alarm_rejects_malformed_rule() {
+    let svc = service();
+    let err = call_err(
+        &svc,
+        "PutCompositeAlarm",
+        &[("AlarmName", "bad"), ("AlarmRule", "ALARM(")],
+    )
+    .await;
+    assert_eq!(err.code(), "ValidationError");
+}
+
+// M1: JSON-protocol epoch-second timestamps are accepted on PutMetricData.
+#[tokio::test]
+async fn put_metric_data_accepts_epoch_second_timestamp() {
+    let svc = service();
+    let now = chrono::Utc::now().timestamp();
+    call(
+        &svc,
+        "PutMetricData",
+        &[
+            ("Namespace", "Test/Epoch"),
+            ("MetricData.member.1.MetricName", "M"),
+            ("MetricData.member.1.Value", "5"),
+            ("MetricData.member.1.Timestamp", &now.to_string()),
+        ],
+    )
+    .await;
+    // Read it back over a window that includes `now`; an epoch-second timestamp
+    // that was dropped would have defaulted to ingestion time (still now), so
+    // instead assert the stored datum carries the exact epoch we sent.
+    let state = svc.state.read();
+    let datum_ts = state
+        .get(ACCT)
+        .and_then(|a| a.metrics_in(REGION))
+        .and_then(|m| m.get("Test/Epoch"))
+        .and_then(|v| v.first())
+        .map(|d| d.timestamp.timestamp())
+        .unwrap();
+    assert_eq!(datum_ts, now);
+}
+
 #[tokio::test]
 async fn mute_rule_lifecycle() {
     let svc = service();

--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -1115,10 +1115,12 @@ pub(crate) fn deliver_to_logs(
             events: Vec::new(),
         });
 
+    let next_seq = stream.events.iter().map(|e| e.seq).max().unwrap_or(0) + 1;
     stream.events.push(fakecloud_logs::LogEvent {
         timestamp: ts_millis,
         message: payload.to_string(),
         ingestion_time: ts_millis,
+        seq: next_seq,
     });
     stream.last_event_timestamp = Some(ts_millis);
     stream.last_ingestion_time = Some(ts_millis);

--- a/crates/fakecloud-logs/src/filter_pattern.rs
+++ b/crates/fakecloud-logs/src/filter_pattern.rs
@@ -162,18 +162,22 @@ fn eval_atom(condition: &str, json: &Value) -> bool {
 
     let ops = ["!=", ">=", "<=", "=", ">", "<"];
     let mut found: Option<(&str, usize)> = None;
-    let bytes = condition.as_bytes();
+    // Iterate by character index so a multi-byte character (e.g. `é`) never
+    // leaves the cursor on a UTF-8 continuation byte, which would panic when
+    // slicing `condition[i..]`. The operator tokens are all ASCII.
     let mut in_quotes = false;
-    let mut i = 0usize;
-    while i < bytes.len() {
-        let c = bytes[i];
-        if c == b'\\' && i + 1 < bytes.len() {
-            i += 2;
+    let mut escaped = false;
+    for (i, c) in condition.char_indices() {
+        if escaped {
+            escaped = false;
             continue;
         }
-        if c == b'"' {
+        if c == '\\' {
+            escaped = true;
+            continue;
+        }
+        if c == '"' {
             in_quotes = !in_quotes;
-            i += 1;
             continue;
         }
         if !in_quotes {
@@ -186,7 +190,6 @@ fn eval_atom(condition: &str, json: &Value) -> bool {
                 break;
             }
         }
-        i += 1;
     }
 
     let Some((op, pos)) = found else {
@@ -525,6 +528,17 @@ mod tests {
     fn resolve_metric_value_json_path_extracts_field() {
         let v = resolve_metric_value("$.bytes", None, r#"{"bytes": 1024}"#);
         assert_eq!(v, 1024.0);
+    }
+
+    #[test]
+    fn multibyte_json_pattern_does_not_panic() {
+        // A multi-byte character in the JSON condition must not panic the
+        // byte-index scan (regression: non-char-boundary slice).
+        assert!(!matches("{ café }", r#"{"statusCode": 500}"#));
+        assert!(!matches("{ $.café = 1 }", r#"{"statusCode": 500}"#));
+        assert!(matches("{ $.café = 1 }", r#"{"café": 1}"#));
+        // Multi-byte inside a quoted value must also be safe.
+        assert!(matches("{ $.name = \"café\" }", r#"{"name": "café"}"#));
     }
 
     #[test]

--- a/crates/fakecloud-logs/src/ingest.rs
+++ b/crates/fakecloud-logs/src/ingest.rs
@@ -73,7 +73,8 @@ pub fn append_events(
             events: Vec::new(),
         });
 
-    for e in events {
+    let base_seq = stream.events.iter().map(|e| e.seq).max().unwrap_or(0);
+    for (i, e) in events.iter().enumerate() {
         if stream.first_event_timestamp.is_none() {
             stream.first_event_timestamp = Some(e.timestamp_ms);
         }
@@ -89,6 +90,8 @@ pub fn append_events(
             timestamp: e.timestamp_ms,
             message: e.message.clone(),
             ingestion_time: now,
+            // Stable, monotonically-increasing per-stream sequence number.
+            seq: base_seq + 1 + i as u64,
         });
     }
 }

--- a/crates/fakecloud-logs/src/query.rs
+++ b/crates/fakecloud-logs/src/query.rs
@@ -36,8 +36,14 @@ pub enum FilterClause {
     Equals { field: String, value: String },
     /// `filter field != "value"`
     NotEquals { field: String, value: String },
-    /// `filter field like /pattern/` or `filter field like "substring"`
-    Like { field: String, pattern: String },
+    /// `filter field like /pattern/` (regex) or `filter field like "substring"`
+    /// (plain substring). `is_regex` records which form was written so the
+    /// `/.../` form is matched as a compiled regular expression.
+    Like {
+        field: String,
+        pattern: String,
+        is_regex: bool,
+    },
 }
 
 /// A `parse` directive: glob `pattern` applied to `source`, binding each `*`
@@ -87,7 +93,11 @@ fn parse_field_list(s: &str) -> Vec<String> {
 }
 
 /// Parse a CWLI query string into a structured pipeline.
-pub fn parse_query(query: &str) -> ParsedQuery {
+///
+/// Returns an `Err` describing the problem for a malformed query (e.g. an
+/// unterminated regex or string literal) so the caller can surface a
+/// `MalformedQueryException` instead of proceeding with a broken pipeline.
+pub fn parse_query(query: &str) -> Result<ParsedQuery, String> {
     let mut parsed = ParsedQuery::default();
 
     for raw in query.split('|') {
@@ -105,7 +115,7 @@ pub fn parse_query(query: &str) -> ParsedQuery {
                 .commands
                 .push(Command::Display(parse_field_list(rest)));
         } else if let Some(rest) = strip_keyword(cmd, "filter") {
-            if let Some(clause) = parse_filter_clause(rest.trim()) {
+            if let Some(clause) = parse_filter_clause(rest.trim())? {
                 parsed.commands.push(Command::Filter(clause));
             }
         } else if let Some(rest) = strip_keyword(cmd, "stats") {
@@ -131,35 +141,61 @@ pub fn parse_query(query: &str) -> ParsedQuery {
         }
     }
 
-    parsed
+    Ok(parsed)
 }
 
-fn parse_filter_clause(s: &str) -> Option<FilterClause> {
+fn parse_filter_clause(s: &str) -> Result<Option<FilterClause>, String> {
     // Try: field like /pattern/ or field like "substring"
     if let Some(like_pos) = s.find(" like ") {
         let field = s[..like_pos].trim().to_string();
         let pattern_str = s[like_pos + 6..].trim();
-        let pattern = if pattern_str.starts_with('/') && pattern_str.ends_with('/') {
-            pattern_str[1..pattern_str.len() - 1].to_string()
+        let (pattern, is_regex) = if pattern_str.starts_with('/') {
+            // A `/.../` regex literal needs a closing delimiter and at least
+            // one character between the slashes; a lone `/` is malformed and
+            // must not slice out of bounds.
+            if pattern_str.len() < 2 || !pattern_str.ends_with('/') {
+                return Err(format!("malformed regex in filter: {pattern_str}"));
+            }
+            (pattern_str[1..pattern_str.len() - 1].to_string(), true)
         } else {
-            unquote(pattern_str)
+            (parse_string_literal(pattern_str)?, false)
         };
-        return Some(FilterClause::Like { field, pattern });
+        return Ok(Some(FilterClause::Like {
+            field,
+            pattern,
+            is_regex,
+        }));
     }
 
     if let Some(ne_pos) = s.find(" != ") {
         let field = s[..ne_pos].trim().to_string();
-        let value = unquote(s[ne_pos + 4..].trim());
-        return Some(FilterClause::NotEquals { field, value });
+        let value = parse_string_literal(s[ne_pos + 4..].trim())?;
+        return Ok(Some(FilterClause::NotEquals { field, value }));
     }
 
     if let Some(eq_pos) = s.find(" = ") {
         let field = s[..eq_pos].trim().to_string();
-        let value = unquote(s[eq_pos + 3..].trim());
-        return Some(FilterClause::Equals { field, value });
+        let value = parse_string_literal(s[eq_pos + 3..].trim())?;
+        return Ok(Some(FilterClause::Equals { field, value }));
     }
 
-    None
+    Ok(None)
+}
+
+/// Parse a filter right-hand side. A value wrapped in single or double quotes
+/// must be properly closed (guarding against a lone `"` slicing out of
+/// bounds); an unquoted value is taken literally.
+fn parse_string_literal(s: &str) -> Result<String, String> {
+    let bytes = s.as_bytes();
+    if let Some(&first) = bytes.first() {
+        if first == b'"' || first == b'\'' {
+            if s.len() >= 2 && bytes[s.len() - 1] == first {
+                return Ok(s[1..s.len() - 1].to_string());
+            }
+            return Err(format!("unterminated string literal in filter: {s}"));
+        }
+    }
+    Ok(s.to_string())
 }
 
 /// Parse a `stats` command body (the text after `stats`).
@@ -262,14 +298,6 @@ fn parse_parse(rest: &str) -> Option<ParseSpec> {
     })
 }
 
-fn unquote(s: &str) -> String {
-    if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
-        s[1..s.len() - 1].to_string()
-    } else {
-        s.to_string()
-    }
-}
-
 /// A materialized query row: ordered (field, value) pairs. Insertion order is
 /// preserved so output column ordering is stable.
 #[derive(Clone, Default)]
@@ -364,8 +392,24 @@ fn record_matches_filter(r: &Record, clause: &FilterClause) -> bool {
         FilterClause::NotEquals { field, value } => {
             record_field(r, field).map(|v| v != *value).unwrap_or(true)
         }
-        FilterClause::Like { field, pattern } => record_field(r, field)
-            .map(|v| matches_pattern(&v, pattern))
+        FilterClause::Like {
+            field,
+            pattern,
+            is_regex,
+        } => record_field(r, field)
+            .map(|v| {
+                if *is_regex {
+                    // A `like /regex/` clause matches the compiled regular
+                    // expression. An uncompilable pattern matches nothing
+                    // (rather than falling back to substring, which would
+                    // silently mis-match).
+                    regex::Regex::new(pattern)
+                        .map(|re| re.is_match(&v))
+                        .unwrap_or(false)
+                } else {
+                    matches_pattern(&v, pattern)
+                }
+            })
             .unwrap_or(false),
     }
 }
@@ -629,12 +673,13 @@ mod tests {
             timestamp: ts,
             message: msg.to_string(),
             ingestion_time: ts,
+            seq: 0,
         }
     }
 
     #[test]
     fn parse_fields_and_limit() {
-        let q = parse_query("fields @timestamp, @message | limit 5");
+        let q = parse_query("fields @timestamp, @message | limit 5").unwrap();
         assert_eq!(q.commands.len(), 2);
         match &q.commands[0] {
             Command::Fields(f) => assert_eq!(f, &vec!["@timestamp", "@message"]),
@@ -656,7 +701,7 @@ mod tests {
                 ev(3000000, "ERROR: again"),
             ],
         )];
-        let q = parse_query("filter @message like /ERROR/ | limit 10");
+        let q = parse_query("filter @message like /ERROR/ | limit 10").unwrap();
         let r = execute_query(&q, &streams, 0, 10000);
         assert_eq!(r.len(), 2);
     }
@@ -670,7 +715,7 @@ mod tests {
                 ev(2000000, r#"{"level":"INFO","msg":"ok"}"#),
             ],
         )];
-        let q = parse_query(r#"filter level = "ERROR""#);
+        let q = parse_query(r#"filter level = "ERROR""#).unwrap();
         let r = execute_query(&q, &streams, 0, 10000);
         assert_eq!(r.len(), 1);
     }
@@ -684,7 +729,7 @@ mod tests {
                 ev(2000000, r#"{"level":"INFO"}"#),
             ],
         )];
-        let q = parse_query(r#"filter level != "ERROR""#);
+        let q = parse_query(r#"filter level != "ERROR""#).unwrap();
         let r = execute_query(&q, &streams, 0, 10000);
         assert_eq!(r.len(), 1);
     }
@@ -700,7 +745,7 @@ mod tests {
                 ev(4000000, r#"{"level":"ERROR"}"#),
             ],
         )];
-        let q = parse_query("stats count(*) by level");
+        let q = parse_query("stats count(*) by level").unwrap();
         let rows = execute_query(&q, &streams, 0, 10000);
         assert_eq!(rows.len(), 2);
         let error_row = rows
@@ -730,7 +775,7 @@ mod tests {
                 ev(2000000, r#"{"svc":"a","latency":30}"#),
             ],
         )];
-        let q = parse_query("stats sum(latency) as total, avg(latency) as mean by svc");
+        let q = parse_query("stats sum(latency) as total, avg(latency) as mean by svc").unwrap();
         let rows = execute_query(&q, &streams, 0, 10000);
         assert_eq!(rows.len(), 1);
         let row = rows[0].as_array().unwrap();
@@ -744,7 +789,7 @@ mod tests {
     fn ptr_is_base64_group_stream_index() {
         use base64::Engine;
         let streams = vec![stream("s1", vec![ev(1000000, "hello")])];
-        let q = parse_query("fields @message");
+        let q = parse_query("fields @message").unwrap();
         let rows = execute_query(&q, &streams, 0, 10000);
         let row = rows[0].as_array().unwrap();
         let ptr = row.iter().find(|f| f["field"] == "@ptr").unwrap();
@@ -758,7 +803,8 @@ mod tests {
     fn parse_glob_extracts_fields() {
         let streams = vec![stream("s1", vec![ev(1000000, "GET /api 200")])];
         let q =
-            parse_query("parse @message \"* * *\" as method, path, code | filter code = \"200\"");
+            parse_query("parse @message \"* * *\" as method, path, code | filter code = \"200\"")
+                .unwrap();
         let rows = execute_query(&q, &streams, 0, 10000);
         assert_eq!(rows.len(), 1);
     }
@@ -773,7 +819,7 @@ mod tests {
                 ev(3000000, r#"{"level":"INFO"}"#),
             ],
         )];
-        let q = parse_query("dedup level");
+        let q = parse_query("dedup level").unwrap();
         let rows = execute_query(&q, &streams, 0, 10000);
         assert_eq!(rows.len(), 2);
     }
@@ -788,10 +834,51 @@ mod tests {
                 ev(2000000, "second"),
             ],
         )];
-        let q = parse_query("sort @timestamp desc");
+        let q = parse_query("sort @timestamp desc").unwrap();
         let rows = execute_query(&q, &streams, 0, 10000);
         let first = rows[0].as_array().unwrap();
         let msg = first.iter().find(|f| f["field"] == "@message").unwrap();
         assert_eq!(msg["value"], "third");
+    }
+
+    #[test]
+    fn malformed_filter_queries_error_not_panic() {
+        // Degenerate delimiters that previously sliced out of bounds now
+        // surface an error instead of panicking.
+        assert!(parse_query("filter x like /").is_err());
+        assert!(parse_query("filter x = \"").is_err());
+        assert!(parse_query("filter x != '").is_err());
+        // A well-formed regex / string still parses.
+        assert!(parse_query("filter x like /err.*/").is_ok());
+        assert!(parse_query(r#"filter x = "ok""#).is_ok());
+    }
+
+    #[test]
+    fn like_regex_matches_as_regex_not_substring() {
+        let streams = vec![stream(
+            "s1",
+            vec![
+                ev(1000000, "status=404 not found"),
+                ev(2000000, "status=200 ok"),
+                ev(3000000, "status=503 down"),
+            ],
+        )];
+        // `5..` should match 503 but not 404/200 as a regex anchored digit
+        // class — a substring match of `5[0-9][0-9]` would match nothing.
+        let q = parse_query("filter @message like /status=5[0-9][0-9]/").unwrap();
+        let rows = execute_query(&q, &streams, 0, 10000);
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn like_plain_string_is_substring() {
+        let streams = vec![stream(
+            "s1",
+            vec![ev(1000000, "the [0-9] literal"), ev(2000000, "nope")],
+        )];
+        // A quoted substring is matched literally, not as a regex.
+        let q = parse_query(r#"filter @message like "[0-9]""#).unwrap();
+        let rows = execute_query(&q, &streams, 0, 10000);
+        assert_eq!(rows.len(), 1);
     }
 }

--- a/crates/fakecloud-logs/src/service/exports.rs
+++ b/crates/fakecloud-logs/src/service/exports.rs
@@ -273,9 +273,23 @@ impl LogsService {
             })
             .collect();
 
+        // Apply the `limit` (AWS caps DescribeExportTasks at 50 per page) and
+        // round-trip a `nextToken` — previously both were validated then
+        // ignored, so every task was returned on one page.
+        let (page, next_token) = super::paginate_offset(
+            &tasks,
+            body["limit"].as_i64(),
+            50,
+            body["nextToken"].as_str(),
+        );
+        let mut result = json!({ "exportTasks": page });
+        if let Some(token) = next_token {
+            result["nextToken"] = json!(token);
+        }
+
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({ "exportTasks": tasks })).unwrap(),
+            serde_json::to_string(&result).unwrap(),
         ))
     }
 
@@ -873,6 +887,42 @@ mod tests {
         let data = entries[0]["data"].as_str().unwrap();
         assert!(data.contains("web event"));
         assert!(!data.contains("api event"));
+    }
+
+    #[test]
+    fn describe_export_tasks_applies_limit_and_next_token() {
+        let svc = make_service();
+        create_group(&svc, "/export/paged");
+        let now = chrono::Utc::now().timestamp_millis();
+        for i in 0..3 {
+            let req = make_request(
+                "CreateExportTask",
+                json!({
+                    "logGroupName": "/export/paged",
+                    "from": now - 1000,
+                    "to": now + 10000,
+                    "destination": format!("bucket-{i}"),
+                }),
+            );
+            svc.create_export_task(&req).unwrap();
+        }
+
+        // Page 1: limit 2 -> two tasks plus a nextToken.
+        let req = make_request("DescribeExportTasks", json!({ "limit": 2 }));
+        let resp = svc.describe_export_tasks(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["exportTasks"].as_array().unwrap().len(), 2);
+        let token = body["nextToken"].as_str().unwrap().to_string();
+
+        // Page 2: the remaining task, no further token.
+        let req = make_request(
+            "DescribeExportTasks",
+            json!({ "limit": 2, "nextToken": token }),
+        );
+        let resp = svc.describe_export_tasks(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["exportTasks"].as_array().unwrap().len(), 1);
+        assert!(body["nextToken"].as_str().is_none());
     }
 
     #[test]

--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -529,6 +529,49 @@ pub(crate) fn extract_log_group_from_arn(arn: &str) -> Option<String> {
     }
 }
 
+/// Encode a pagination offset into an opaque base64 `nextToken`.
+pub(crate) fn encode_offset_token(offset: usize) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(format!("offset:{offset}").as_bytes())
+}
+
+/// Decode a `nextToken` produced by [`encode_offset_token`]. An absent or
+/// unparseable token resolves to the first page (offset 0).
+pub(crate) fn decode_offset_token(token: Option<&str>) -> usize {
+    use base64::Engine;
+    token
+        .and_then(|t| base64::engine::general_purpose::STANDARD.decode(t).ok())
+        .and_then(|b| String::from_utf8(b).ok())
+        .and_then(|s| {
+            s.strip_prefix("offset:")
+                .and_then(|n| n.parse::<usize>().ok())
+        })
+        .unwrap_or(0)
+}
+
+/// Apply an offset+limit page to `items`, returning the page slice together
+/// with the `nextToken` for the following page (if any). `limit` values <= 0
+/// fall back to `default_limit`.
+pub(crate) fn paginate_offset<T: Clone>(
+    items: &[T],
+    limit: Option<i64>,
+    default_limit: usize,
+    next_token: Option<&str>,
+) -> (Vec<T>, Option<String>) {
+    let limit = limit
+        .filter(|n| *n > 0)
+        .map(|n| n as usize)
+        .unwrap_or(default_limit);
+    let offset = decode_offset_token(next_token);
+    let page: Vec<T> = items.iter().skip(offset).take(limit).cloned().collect();
+    let next = if offset + limit < items.len() {
+        Some(encode_offset_token(offset + limit))
+    } else {
+        None
+    };
+    (page, next)
+}
+
 /// CloudWatch Logs filter pattern matching.
 ///
 /// Rules:

--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -52,6 +52,17 @@ impl LogsService {
         }
         validate_optional_string_length("queryString", Some(&query_string), 0, 10000)?;
 
+        // Reject a malformed query up front (AWS surfaces MalformedQueryException
+        // from StartQuery) so a broken query string is never stored to later
+        // trip up GetQueryResults.
+        if let Err(e) = query::parse_query(&query_string) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MalformedQueryException",
+                e,
+            ));
+        }
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
@@ -131,8 +142,11 @@ impl LogsService {
             )
         })?;
 
-        // Parse the query string
-        let parsed = query::parse_query(&query_info.query_string);
+        // Parse the query string. StartQuery already rejected malformed
+        // queries; treat any residual parse failure as an empty pipeline so a
+        // stored-then-corrupted query can never panic or return an undeclared
+        // error here (GetQueryResults does not declare MalformedQueryException).
+        let parsed = query::parse_query(&query_info.query_string).unwrap_or_default();
 
         // Collect events by stream from every group/identifier the query
         // referenced, not just the legacy single `log_group_name`. ARNs are
@@ -267,9 +281,20 @@ impl LogsService {
             })
             .collect();
 
+        let (page, next_token) = super::paginate_offset(
+            &queries,
+            body["maxResults"].as_i64(),
+            1000,
+            body["nextToken"].as_str(),
+        );
+        let mut result = json!({ "queries": page });
+        if let Some(token) = next_token {
+            result["nextToken"] = json!(token);
+        }
+
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({ "queries": queries })).unwrap(),
+            serde_json::to_string(&result).unwrap(),
         ))
     }
 
@@ -391,9 +416,20 @@ impl LogsService {
             })
             .collect();
 
+        let (page, next_token) = super::paginate_offset(
+            &defs,
+            body["maxResults"].as_i64(),
+            1000,
+            body["nextToken"].as_str(),
+        );
+        let mut result = json!({ "queryDefinitions": page });
+        if let Some(token) = next_token {
+            result["nextToken"] = json!(token);
+        }
+
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({ "queryDefinitions": defs })).unwrap(),
+            serde_json::to_string(&result).unwrap(),
         ))
     }
 
@@ -633,6 +669,56 @@ mod tests {
             }),
         );
         assert!(svc.start_query(&req).is_err());
+    }
+
+    #[test]
+    fn start_query_malformed_query_string_errors() {
+        let svc = make_service();
+        create_group(&svc, "app");
+        // A lone regex delimiter previously panicked when GetQueryResults parsed
+        // it; StartQuery now rejects it with MalformedQueryException.
+        let req = make_request(
+            "StartQuery",
+            json!({
+                "logGroupName": "app",
+                "startTime": 0,
+                "endTime": 0,
+                "queryString": "filter @message like /"
+            }),
+        );
+        match svc.start_query(&req) {
+            Err(e) => assert_eq!(e.code(), "MalformedQueryException"),
+            Ok(_) => panic!("expected MalformedQueryException"),
+        }
+    }
+
+    #[test]
+    fn get_query_results_does_not_panic_on_bad_stored_query() {
+        // Even if a malformed query slips into storage, GetQueryResults must
+        // return (empty) results rather than panic.
+        let svc = make_service();
+        create_group(&svc, "app");
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("123456789012");
+            state.queries.insert(
+                "q-bad".to_string(),
+                crate::state::QueryInfo {
+                    query_id: "q-bad".to_string(),
+                    log_group_name: "app".to_string(),
+                    log_group_identifiers: vec!["app".to_string()],
+                    query_string: "filter x = \"".to_string(),
+                    start_time: 0,
+                    end_time: 0,
+                    status: "Complete".to_string(),
+                    create_time: 0,
+                },
+            );
+        }
+        let get = make_request("GetQueryResults", json!({"queryId": "q-bad"}));
+        let resp = svc.get_query_results(&get).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["results"].is_array());
     }
 
     #[test]

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -332,6 +332,33 @@ impl LogsService {
             )
         })?;
 
+        // A PutLogEvents batch must contain at least one event, and every event
+        // must carry both a timestamp and a message (AWS rejects a batch that
+        // omits either rather than silently defaulting them).
+        if log_events.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "logEvents must contain at least one log event",
+            ));
+        }
+        for e in log_events.iter() {
+            if !e["timestamp"].is_i64() && !e["timestamp"].is_u64() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "each log event requires an integer timestamp",
+                ));
+            }
+            if !e["message"].is_string() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "each log event requires a message",
+                ));
+            }
+        }
+
         let now = Utc::now().timestamp_millis();
 
         // Check chronological order
@@ -381,6 +408,9 @@ impl LogsService {
                 timestamp: ts,
                 message: e["message"].as_str().unwrap_or("").to_string(),
                 ingestion_time: now,
+                // Assigned from the stream's counter once the stream is
+                // resolved below.
+                seq: 0,
             });
         }
 
@@ -419,6 +449,14 @@ impl LogsService {
                 "The specified log stream does not exist.",
             )
         })?;
+
+        // Assign each new event a stable, monotonically-increasing per-stream
+        // sequence number so a FilterLogEvents pagination cursor stays valid
+        // even after the stream is re-sorted by timestamp.
+        let base_seq = stream.events.iter().map(|e| e.seq).max().unwrap_or(0);
+        for (i, event) in new_events.iter_mut().enumerate() {
+            event.seq = base_seq + 1 + i as u64;
+        }
 
         // Update stream metadata
         for event in &new_events {
@@ -1036,7 +1074,7 @@ impl LogsService {
         };
 
         for (_, stream) in streams {
-            for (idx, event) in stream.events.iter().enumerate() {
+            for event in stream.events.iter() {
                 if let Some(cutoff) = retention_cutoff {
                     if event.timestamp < cutoff {
                         continue;
@@ -1062,11 +1100,12 @@ impl LogsService {
                     continue;
                 }
 
-                // Include the per-stream event index so two events with the
-                // same millisecond timestamp get distinct eventIds; otherwise a
-                // nextToken whose cursor is a shared eventId resumes at the
-                // first of the group and re-delivers the rest.
-                let event_id = format!("{}-{}-{}", stream.name, event.timestamp, idx);
+                // Build the eventId from the event's stable per-stream sequence
+                // number rather than its array index. The index shifts whenever
+                // an earlier event is inserted and the stream is re-sorted,
+                // which would break a nextToken cursor and silently drop the
+                // remaining page; the sequence number never shifts.
+                let event_id = format!("{}-{}-{}", stream.name, event.timestamp, event.seq);
 
                 filtered_events.push(json!({
                     "logStreamName": stream.name,
@@ -1393,6 +1432,102 @@ mod tests {
             vec!["a", "b", "c"],
             "same-timestamp events must each be delivered exactly once across pages"
         );
+    }
+
+    #[test]
+    fn filter_log_events_pagination_survives_concurrent_earlier_insert() {
+        // Regression: an index-based eventId cursor dropped the remaining page
+        // when an earlier-timestamped event was inserted between paginated
+        // calls (it shifted every subsequent array index). A stable per-event
+        // sequence number keeps the cursor valid.
+        let svc = make_service();
+        create_group(&svc, "reorder");
+        create_stream(&svc, "reorder", "s1");
+        let base = chrono::Utc::now().timestamp_millis();
+
+        let put = |ts: i64, msg: &str| {
+            svc.put_log_events(&make_request(
+                "PutLogEvents",
+                json!({
+                    "logGroupName": "reorder",
+                    "logStreamName": "s1",
+                    "logEvents": [{"timestamp": ts, "message": msg}],
+                }),
+            ))
+            .unwrap();
+        };
+
+        put(base + 1000, "first");
+        put(base + 2000, "second");
+
+        // Page 1: fetch a single event and a cursor.
+        let resp = svc
+            .filter_log_events(&make_request(
+                "FilterLogEvents",
+                json!({"logGroupName": "reorder", "limit": 1}),
+            ))
+            .unwrap();
+        let page1: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(page1["events"][0]["message"], "first");
+        let token = page1["nextToken"].as_str().unwrap().to_string();
+
+        // Insert an event with an EARLIER timestamp, forcing a re-sort that
+        // would shift array indices.
+        put(base + 500, "earlier");
+
+        // Page 2 must still deliver "second" rather than an empty page.
+        let resp = svc
+            .filter_log_events(&make_request(
+                "FilterLogEvents",
+                json!({"logGroupName": "reorder", "limit": 10, "nextToken": token}),
+            ))
+            .unwrap();
+        let page2: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let msgs: Vec<&str> = page2["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["message"].as_str().unwrap())
+            .collect();
+        assert!(
+            msgs.contains(&"second"),
+            "page 2 must still contain the later event after a reorder, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn put_log_events_rejects_empty_and_malformed_batch() {
+        let svc = make_service();
+        create_group(&svc, "val");
+        create_stream(&svc, "val", "s1");
+        let ts = chrono::Utc::now().timestamp_millis();
+
+        // Empty logEvents.
+        let empty = svc.put_log_events(&make_request(
+            "PutLogEvents",
+            json!({"logGroupName": "val", "logStreamName": "s1", "logEvents": []}),
+        ));
+        assert!(empty.is_err());
+
+        // Missing timestamp.
+        let no_ts = svc.put_log_events(&make_request(
+            "PutLogEvents",
+            json!({
+                "logGroupName": "val", "logStreamName": "s1",
+                "logEvents": [{"message": "hi"}]
+            }),
+        ));
+        assert!(no_ts.is_err());
+
+        // Missing message.
+        let no_msg = svc.put_log_events(&make_request(
+            "PutLogEvents",
+            json!({
+                "logGroupName": "val", "logStreamName": "s1",
+                "logEvents": [{"timestamp": ts}]
+            }),
+        ));
+        assert!(no_msg.is_err());
     }
 
     // ---- FilterLogEvents pattern matching tests ----

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -201,6 +201,13 @@ pub struct LogEvent {
     pub timestamp: i64,
     pub message: String,
     pub ingestion_time: i64,
+    /// A stable, monotonically-increasing per-stream identifier assigned at
+    /// ingestion. Unlike an array index it never shifts when an earlier event
+    /// is inserted, so a `FilterLogEvents` pagination cursor built from it
+    /// resumes correctly even after the stream is re-sorted. Defaults to 0 for
+    /// events restored from snapshots that predate this field.
+    #[serde(default)]
+    pub seq: u64,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Summary
Behavioral hardening of CloudWatch + Logs — two reachable request-path panics (DoS), an entirely-stubbed alarm-evaluation subsystem, and list-pagination gaps the conformance probe can't see.

**Panics (DoS):**
- C1 Logs Insights query parser sliced out of range on a malformed stored query (`filter x like /`, `filter x = "`) — now length-guarded, returns a validation error.
- C2 Logs filter-pattern engine sliced on a non-char boundary for any non-ASCII JSON pattern (`{ café }`); one bad stored PutMetricFilter panicked every subsequent JSON PutLogEvents. Now iterates on char boundaries.

**Alarm evaluation (was entirely stubbed — no-stub rule):**
- H5 metric alarms are now evaluated from stored datapoints over `evaluationPeriods` × `period` applying comparison/threshold/datapointsToAlarm/statistic/treatMissingData (new `alarm_eval.rs`).
- H3 composite `AlarmRule` is parsed (ALARM/OK/INSUFFICIENT_DATA, AND/OR/NOT, parens) and evaluated against child alarms; malformed rules rejected.
- H4 SetAlarmState can now target composite alarms.

**Correctness:** M1 accept epoch-second timestamps on JSON-protocol input; M2 Insights `like /regex/` compiles a real regex; M3 stable pagination cursor (new `LogEvent.seq`, not array index — all cross-crate ctors updated); M4 apply maxResults + emit nextToken across list ops; L4 reject empty/malformed InputLogEvents; metric_math recursion depth guard.

## Test plan
- `cargo test -p fakecloud-cloudwatch -p fakecloud-logs` — 52 + 308 pass, incl. new tests: malformed-query/non-ASCII-pattern no-panic, metric-alarm ALARM/OK transitions, composite-rule evaluation, epoch timestamps, regex `like`, stable pagination.
- `cargo build --workspace` clean (new `LogEvent.seq` field propagated to every ctor incl. the eventbridge→logs delivery path). CI runs full clippy + conformance + e2e.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened CloudWatch and Logs to prevent crashes, add real alarm evaluation, and make pagination and timestamps consistent. This improves correctness under malformed input and keeps queries and listings stable.

- **New Features**
  - CloudWatch: evaluate metric alarms from stored datapoints and composite `AlarmRule` expressions; states update during `DescribeAlarms`; `SetAlarmState` now works for composite alarms.
  - Logs: `like /regex/` compiles and matches real regex; list endpoints apply `maxResults` and return `nextToken` (`DescribeExportTasks`, `ListQueries`, `ListQueryDefinitions`).
  - Inputs: accept epoch-second timestamps in JSON/X-Amz-Target requests (e.g., `PutMetricData`, time filters).

- **Bug Fixes**
  - Prevented two panics: Insights parser now errors on malformed `filter` (e.g., `like /`, unterminated quotes), and filter-pattern scanning uses char boundaries (no non-ASCII slice panic).
  - Query safety: `StartQuery` rejects malformed queries with `MalformedQueryException`; `GetQueryResults` handles stored bad queries without panicking.
  - Pagination and validation: `FilterLogEvents` cursors are stable using per-stream sequence ids; `PutLogEvents` rejects empty batches and events missing `timestamp` or `message`; metric math parser has a recursion-depth guard.

<sup>Written for commit 369fdfc21b1c8c4b55995dd49eec582a22d2bbca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

