### PR TITLE
fix(rds): apply DB rename + port/endpoint consistency, tighten modify validation

### DIFF
--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -560,6 +560,7 @@ impl RdsService {
             optional_query_param(request, "RotateMasterUserPassword").as_deref(),
         )?;
 
+        let new_db_instance_identifier = optional_query_param(request, "NewDBInstanceIdentifier");
         let db_instance_class = optional_query_param(request, "DBInstanceClass");
         let master_user_password = optional_query_param(request, "MasterUserPassword");
         let engine_version = optional_query_param(request, "EngineVersion");
@@ -671,13 +672,44 @@ impl RdsService {
             || domain_auth_secret_arn.is_some()
             || domain_dns_ips.is_some()
             || disable_domain.is_some()
-            || rotate_master_user_password.is_some();
+            || rotate_master_user_password.is_some()
+            || new_db_instance_identifier
+                .as_deref()
+                .is_some_and(|new_id| new_id != db_instance_identifier);
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
         let instance = state
             .instances
             .get_mut(&db_instance_identifier)
             .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
+
+        // Reject storage shrink / engine-version downgrade before mutating
+        // anything. Real AWS surfaces these as InvalidParameterCombination;
+        // silently accepting them corrupts the reported size/version.
+        if let Some(new_storage) = allocated_storage {
+            if new_storage < instance.allocated_storage {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterCombination",
+                    format!(
+                        "Invalid storage size for engine name {}: new allocated storage of {} is smaller than the current value of {}.",
+                        instance.engine, new_storage, instance.allocated_storage
+                    ),
+                ));
+            }
+        }
+        if let Some(ref new_version) = engine_version {
+            if is_version_downgrade(&instance.engine_version, new_version) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterCombination",
+                    format!(
+                        "Cannot downgrade the DB engine version of instance {} from {} to {}.",
+                        db_instance_identifier, instance.engine_version, new_version
+                    ),
+                ));
+            }
+        }
 
         // Smithy declares no `InvalidParameterCombination` shape on
         // ModifyDBInstance, so "no fields to mutate" treats as a no-op
@@ -813,7 +845,19 @@ impl RdsService {
                 instance.tde_credential_arn = Some(arn);
             }
             if let Some(p) = db_port_number {
-                instance.port = p;
+                // The reachable endpoint port is the container's published
+                // `host_port`; we can't re-publish a live container on a new
+                // port, so advertising an arbitrary DBPortNumber would point
+                // the endpoint at a port nothing listens on. Keep the
+                // advertised port equal to the reachable one whenever a
+                // container backs the instance; honor the requested port only
+                // when there's no live container (offline / no-backend mode),
+                // where the endpoint is suppressed anyway.
+                instance.port = if instance.host_port != 0 {
+                    i32::from(instance.host_port)
+                } else {
+                    p
+                };
             }
             if let Some(retention) = backup_retention_period {
                 instance.backup_retention_period = retention;
@@ -910,6 +954,50 @@ impl RdsService {
                 }
             }
         }
+
+        // NewDBInstanceIdentifier: rename the instance key + ARN + endpoint
+        // host. AWS applies the rename immediately when ApplyImmediately is
+        // set (otherwise at the next maintenance window); we apply it in
+        // place, mirroring the cluster rename path. Reject when the target
+        // already names another instance (or one mid-creation) so the rename
+        // can't silently clobber real data. The `&mut instance` borrow above
+        // has ended, so we can move the row inside `state.instances`.
+        let final_identifier = match new_db_instance_identifier {
+            Some(ref new_id) if *new_id != db_instance_identifier => {
+                if state.instances.contains_key(new_id)
+                    || state.in_progress_instance_ids.contains(new_id)
+                {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "DBInstanceAlreadyExists",
+                        format!("DBInstance {new_id} already exists."),
+                    ));
+                }
+                let new_arn = state.db_instance_arn(new_id);
+                let mut moved = state
+                    .instances
+                    .remove(&db_instance_identifier)
+                    .expect("instance present after modify");
+                // Keep the advertised endpoint host consistent if it embedded
+                // the old identifier (real endpoints are `<id>.<...>`); the
+                // local 127.0.0.1 endpoint is unaffected.
+                if moved.endpoint_address.contains(&db_instance_identifier) {
+                    moved.endpoint_address = moved
+                        .endpoint_address
+                        .replace(&db_instance_identifier, new_id);
+                }
+                moved.db_instance_identifier = new_id.clone();
+                moved.db_instance_arn = new_arn;
+                state.instances.insert(new_id.clone(), moved);
+                new_id.clone()
+            }
+            _ => db_instance_identifier.clone(),
+        };
+
+        let instance = state
+            .instances
+            .get(&final_identifier)
+            .expect("instance present after modify");
         let instance_arn = instance.db_instance_arn.clone();
         let xml = query_response_xml(
             "ModifyDBInstance",
@@ -924,7 +1012,7 @@ impl RdsService {
 
         self.emit_event(
             RdsSourceType::DbInstance,
-            &db_instance_identifier,
+            &final_identifier,
             &instance_arn,
             "RDS-EVENT-0014",
             &["configuration change"],

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -169,8 +169,13 @@ pub(crate) fn parse_vpc_security_group_ids(req: &AwsRequest) -> Vec<String> {
         }
     }
 
-    // If no security groups provided, return a default one
-    vec!["sg-default".to_string()]
+    // No VPC security groups supplied. Don't fabricate a synthetic
+    // `sg-default` — real AWS attaches the VPC's actual default security
+    // group and ModifyDBInstance leaves the membership untouched (None)
+    // when the parameter is absent. Returning an empty list keeps Create
+    // consistent with Modify rather than reporting a group that doesn't
+    // exist in the account.
+    Vec::new()
 }
 
 pub(crate) fn query_param_prefix_exists(req: &AwsRequest, prefix: &str) -> bool {
@@ -196,6 +201,52 @@ pub(crate) fn parse_string_member_list(req: &AwsRequest, base: &str) -> Vec<Stri
 /// emitted on Create/Modify/Restore paths.
 pub(crate) fn parse_cloudwatch_logs_exports(req: &AwsRequest, base: &str) -> Vec<String> {
     parse_string_member_list(req, base)
+}
+
+/// Parse the leading dotted-numeric components of an engine version
+/// (e.g. `16.4` -> `[16, 4]`, `8.0.mysql_aurora.3.04.0` -> `[8, 0]`).
+/// Stops at the first non-numeric component so Aurora-style versions with
+/// embedded engine tokens don't get mis-compared. Returns `None` when the
+/// string has no leading numeric component.
+fn numeric_version_prefix(version: &str) -> Option<Vec<u64>> {
+    let parts: Vec<u64> = version
+        .split('.')
+        .map_while(|c| c.parse::<u64>().ok())
+        .collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts)
+    }
+}
+
+/// True when `candidate` is a strictly-lower engine version than
+/// `current`, comparing dotted-numeric prefixes component-by-component.
+/// Conservative: when either version has no numeric prefix (unusual
+/// engine strings) we return `false` so a legitimate change isn't
+/// rejected as a downgrade.
+pub(crate) fn is_version_downgrade(current: &str, candidate: &str) -> bool {
+    match (
+        numeric_version_prefix(current),
+        numeric_version_prefix(candidate),
+    ) {
+        (Some(cur), Some(cand)) => {
+            // Compare only the components both versions share so a caller
+            // who supplies a shorter-but-equal prefix (e.g. "16" vs
+            // "16.3") isn't rejected. A downgrade is the first differing
+            // shared component being lower on the candidate side.
+            for (c, n) in cur.iter().zip(cand.iter()) {
+                if n < c {
+                    return true;
+                }
+                if n > c {
+                    return false;
+                }
+            }
+            false
+        }
+        _ => false,
+    }
 }
 
 pub(crate) fn parse_optional_i32(value: Option<&str>) -> Result<Option<i32>, AwsServiceError> {

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -1927,6 +1927,258 @@ fn modify_db_instance_no_fields_against_missing_instance_returns_not_found() {
     assert_code(svc.modify_db_instance(&req), "DBInstanceNotFound");
 }
 
+// ── M1: NewDBInstanceIdentifier rename ───────────────────────────
+
+#[test]
+fn modify_db_instance_renames_instance_and_arn() {
+    let svc = make_service();
+    seed_instance(&svc, "db-old");
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db-old"),
+            ("NewDBInstanceIdentifier", "db-new"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    svc.modify_db_instance(&req).unwrap();
+
+    let __a = svc.state.read();
+    let state = __a.default_ref();
+    assert!(
+        !state.instances.contains_key("db-old"),
+        "old identifier must no longer resolve after rename"
+    );
+    let renamed = state
+        .instances
+        .get("db-new")
+        .expect("instance now lives under the new identifier");
+    assert_eq!(renamed.db_instance_identifier, "db-new");
+    assert_eq!(
+        renamed.db_instance_arn, "arn:aws:rds:us-east-1:123456789012:db:db-new",
+        "ARN must track the renamed identifier"
+    );
+}
+
+#[test]
+fn modify_db_instance_rename_rejects_existing_target() {
+    let svc = make_service();
+    seed_instance(&svc, "db-a");
+    seed_instance(&svc, "db-b");
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db-a"),
+            ("NewDBInstanceIdentifier", "db-b"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    assert_code(svc.modify_db_instance(&req), "DBInstanceAlreadyExists");
+    // Both instances must still be intact — no silent clobber.
+    let __a = svc.state.read();
+    let state = __a.default_ref();
+    assert!(state.instances.contains_key("db-a"));
+    assert!(state.instances.contains_key("db-b"));
+}
+
+#[test]
+fn modify_db_instance_rename_updates_endpoint_host() {
+    let svc = make_service();
+    seed_instance(&svc, "db-old");
+    {
+        // Simulate an AWS-style endpoint host embedding the identifier.
+        let mut accounts = svc.state.write();
+        let state = accounts.default_mut();
+        state.instances.get_mut("db-old").unwrap().endpoint_address =
+            "db-old.abc123.us-east-1.rds.amazonaws.com".to_string();
+    }
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db-old"),
+            ("NewDBInstanceIdentifier", "db-new"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    svc.modify_db_instance(&req).unwrap();
+    let __a = svc.state.read();
+    let state = __a.default_ref();
+    assert_eq!(
+        state.instances.get("db-new").unwrap().endpoint_address,
+        "db-new.abc123.us-east-1.rds.amazonaws.com",
+        "endpoint host must follow the rename"
+    );
+}
+
+// ── M2: DBPortNumber must not break the reachable endpoint ────────
+
+#[test]
+fn modify_db_instance_port_number_keeps_endpoint_reachable() {
+    let svc = make_service();
+    // seed_instance sets host_port == port == 15432 (consistent).
+    seed_instance(&svc, "db1");
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db1"),
+            ("DBPortNumber", "5433"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    svc.modify_db_instance(&req).unwrap();
+    let __a = svc.state.read();
+    let state = __a.default_ref();
+    let inst = state.instances.get("db1").unwrap();
+    assert_eq!(
+        inst.port,
+        i32::from(inst.host_port),
+        "advertised endpoint port must stay equal to the reachable host_port"
+    );
+    assert_eq!(inst.port, 15432);
+}
+
+#[test]
+fn modify_db_instance_port_number_honored_when_no_container() {
+    let svc = make_service();
+    seed_instance(&svc, "db1");
+    {
+        // Offline / no-backend instance: no live container to re-publish.
+        let mut accounts = svc.state.write();
+        let state = accounts.default_mut();
+        let inst = state.instances.get_mut("db1").unwrap();
+        inst.host_port = 0;
+        inst.port = 0;
+        inst.endpoint_address = String::new();
+    }
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db1"),
+            ("DBPortNumber", "5433"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    svc.modify_db_instance(&req).unwrap();
+    let __a = svc.state.read();
+    let state = __a.default_ref();
+    assert_eq!(state.instances.get("db1").unwrap().port, 5433);
+}
+
+// ── L2: reject storage shrink / engine-version downgrade ──────────
+
+#[test]
+fn modify_db_instance_rejects_storage_shrink() {
+    let svc = make_service();
+    seed_instance(&svc, "db1"); // allocated_storage == 20
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db1"),
+            ("AllocatedStorage", "10"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    assert_code(svc.modify_db_instance(&req), "InvalidParameterCombination");
+    // Unchanged.
+    let __a = svc.state.read();
+    assert_eq!(
+        __a.default_ref()
+            .instances
+            .get("db1")
+            .unwrap()
+            .allocated_storage,
+        20
+    );
+}
+
+#[test]
+fn modify_db_instance_allows_storage_grow() {
+    let svc = make_service();
+    seed_instance(&svc, "db1");
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db1"),
+            ("AllocatedStorage", "100"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    svc.modify_db_instance(&req).unwrap();
+    let __a = svc.state.read();
+    assert_eq!(
+        __a.default_ref()
+            .instances
+            .get("db1")
+            .unwrap()
+            .allocated_storage,
+        100
+    );
+}
+
+#[test]
+fn modify_db_instance_rejects_version_downgrade() {
+    let svc = make_service();
+    seed_instance(&svc, "db1"); // engine_version == 16.3
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db1"),
+            ("EngineVersion", "15.4"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    assert_code(svc.modify_db_instance(&req), "InvalidParameterCombination");
+    let __a = svc.state.read();
+    assert_eq!(
+        __a.default_ref()
+            .instances
+            .get("db1")
+            .unwrap()
+            .engine_version,
+        "16.3"
+    );
+}
+
+// ── L3: no synthetic sg-default fabricated on create ──────────────
+
+#[test]
+fn create_db_instance_does_not_fabricate_sg_default() {
+    // parse_vpc_security_group_ids backs Create/Restore/RestoreFromSnapshot.
+    // With no VpcSecurityGroupIds supplied it must yield an empty list, not
+    // a synthetic `sg-default` that doesn't exist in the account.
+    let req = request("CreateDBInstance", &[("DBInstanceIdentifier", "db1")]);
+    assert!(
+        super::parse_vpc_security_group_ids(&req).is_empty(),
+        "absent VpcSecurityGroupIds must not synthesize sg-default"
+    );
+
+    let req_with = request(
+        "CreateDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db1"),
+            ("VpcSecurityGroupIds.VpcSecurityGroupId.1", "sg-abc"),
+        ],
+    );
+    assert_eq!(
+        super::parse_vpc_security_group_ids(&req_with),
+        vec!["sg-abc".to_string()]
+    );
+}
+
+#[test]
+fn is_version_downgrade_detects_lower_versions() {
+    use super::is_version_downgrade;
+    assert!(is_version_downgrade("16.3", "15.4"));
+    assert!(is_version_downgrade("16.3", "16.2"));
+    assert!(!is_version_downgrade("16.3", "16.4"));
+    assert!(!is_version_downgrade("16.3", "17.1"));
+    assert!(!is_version_downgrade("16.3", "16.3"));
+    // Shorter-but-equal prefix isn't a downgrade.
+    assert!(!is_version_downgrade("16.3", "16"));
+    // Non-numeric engine strings are treated conservatively (not a downgrade).
+    assert!(!is_version_downgrade("aurora", "aurora"));
+}
+
 #[tokio::test]
 async fn reboot_db_instance_not_found() {
     let svc = make_service();

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2748,30 +2748,18 @@ async fn main() {
                                     "loaded rds persistence snapshot (migrated from v1)",
                                 );
                             }
-                            // Drop any `creating` placeholder rows the snapshot
-                            // captured mid-CreateDBInstance. The background
-                            // container-start task didn't survive the restart,
-                            // so the placeholder would otherwise be stuck in
-                            // `creating` forever. Dropping them is safe — the
-                            // user can retry CreateDBInstance.
+                            // Keep any `creating` placeholder rows the snapshot
+                            // captured mid-CreateDBInstance. CreateDBInstance
+                            // already acknowledged them to the client, so
+                            // DescribeDBInstances must not lose them on restart.
+                            // `recover_persisted_containers` (below) re-drives
+                            // `creating` rows through `ensure_*` to a live
+                            // container — dropping them here would make that
+                            // recovery branch dead code and silently vanish an
+                            // acknowledged instance.
                             {
                                 let mut mas = rds_state.write();
                                 for (_, state) in mas.iter_mut() {
-                                    let stuck: Vec<String> = state
-                                        .instances
-                                        .iter()
-                                        .filter(|(_, inst)| inst.db_instance_status == "creating")
-                                        .map(|(id, _)| id.clone())
-                                        .collect();
-                                    for id in &stuck {
-                                        state.instances.remove(id);
-                                    }
-                                    if !stuck.is_empty() {
-                                        tracing::warn!(
-                                            count = stuck.len(),
-                                            "dropped stuck `creating` rds instances after persistence load",
-                                        );
-                                    }
                                     // Clear any in-flight identifier reservations a
                                     // restore/replica op left in the snapshot. The
                                     // task that held them is dead, so a leftover


### PR DESCRIPTION
Hardens the RDS `ModifyDBInstance` / `CreateDBInstance` state machine. Five confirmed behavioral bugs, each with in-crate tests.

## M1 — ModifyDBInstance dropped `NewDBInstanceIdentifier` (rename no-op)
Instance renames were silently ignored (clusters already handled `NewDBClusterIdentifier`; instances didn't). Now the instance is moved under the new identifier, the ARN is rewritten, and an endpoint host embedding the old id is rewritten too. Renaming onto an existing (or mid-creation) identifier is rejected with `DBInstanceAlreadyExists` instead of clobbering data. The lifecycle event now reports the final identifier.

## M2 — `DBPortNumber` corrupted the advertised endpoint
The immediate path set `instance.port` (rendered as `Endpoint.Port`) to the requested port, but the container's reachable published port is `host_port` (unchanged) — so the endpoint advertised a dead port. The advertised port now stays equal to the reachable `host_port` when a container backs the instance; the requested port is honored only when there is no live container (offline mode, where the endpoint is suppressed anyway).

## L1 — CreateDBInstance could vanish on restart
The persistence loader deleted every `creating` row *before* `recover_persisted_containers` ran, making the recovery branch that resumes `creating` rows dead code — an acknowledged instance silently disappeared. The loader no longer drops `creating` rows (it still clears stale in-flight identifier reservations); recovery re-drives them to a live container.

## L2 — ModifyDBInstance too lenient on storage/version
Storage shrink (`AllocatedStorage` below current) and engine-version downgrades are now rejected with `InvalidParameterCombination` before any mutation. Version comparison is conservative (dotted-numeric prefix only; unusual engine strings and shorter-but-equal prefixes are not flagged).

## L3 — CreateDBInstance fabricated a synthetic `sg-default`
`parse_vpc_security_group_ids` injected a non-existent `sg-default` membership when none was supplied, diverging from the Modify path (which correctly uses none). It now returns an empty list, matching Modify.

## Tests
10 new in-crate unit tests cover rename (+ collision + endpoint-host rewrite), port/endpoint consistency (container and offline), storage shrink/grow, version downgrade, no-sg-default, and the version-comparison helper. `cargo test -p fakecloud-rds` green (237 passed); `cargo clippy --workspace --all-targets -D warnings` clean; `cargo fmt` applied.

L1 (server loader) is verified by reasoning; the RDS conformance suite needs Docker/a live server and is left to CI.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens RDS instance modify/create behavior: renames now apply correctly, endpoints stay reachable after port changes, “creating” instances survive restarts, and unsafe storage/version changes are rejected.

- **Bug Fixes**
  - Apply instance rename via `NewDBInstanceIdentifier`; update ARN and endpoint host; reject collisions with `DBInstanceAlreadyExists`; lifecycle events use the final id.
  - Keep advertised endpoint port equal to the container `host_port`; honor `DBPortNumber` only when no container is running.
  - Preserve `creating` instances on server restart and re-drive them to a live container; still clear stale in-flight id reservations.
  - Reject storage shrink and engine-version downgrades in Modify with `InvalidParameterCombination`; compare versions by dotted-numeric prefix.
  - Stop fabricating `sg-default` when `VpcSecurityGroupIds` is absent in Create; return an empty list to match Modify.

<sup>Written for commit 444136a8a50d6ce82b04c4762a4cb9870fdc5edb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

