### PR TITLE
fix(secretsmanager): enforce single AWSPREVIOUS/AWSCURRENT, validate inputs, expire deletions

### DIFF
--- a/crates/fakecloud-secretsmanager/src/rotation.rs
+++ b/crates/fakecloud-secretsmanager/src/rotation.rs
@@ -99,14 +99,10 @@ pub async fn check_and_rotate(
                     };
                     secret.versions.insert(version_id.clone(), version);
                 } else {
-                    // Without Lambda: simple rotation
+                    // Without Lambda: simple rotation. Demote the outgoing
+                    // AWSCURRENT to AWSPREVIOUS, keeping AWSPREVIOUS unique.
                     if let Some(old_vid) = secret.current_version_id.clone() {
-                        if let Some(old_v) = secret.versions.get_mut(&old_vid) {
-                            old_v.stages.retain(|s| s != "AWSCURRENT");
-                            if !old_v.stages.contains(&"AWSPREVIOUS".to_string()) {
-                                old_v.stages.push("AWSPREVIOUS".to_string());
-                            }
-                        }
+                        crate::service::demote_current_to_previous(&mut secret.versions, &old_vid);
                     }
                     let version = SecretVersion {
                         version_id: version_id.clone(),

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -488,7 +488,7 @@ impl SecretsManagerService {
         validate_optional_string_length("secretString", body["SecretString"].as_str(), 1, 65536)?;
 
         let secret_string = body["SecretString"].as_str().map(|s| s.to_string());
-        let secret_binary = body["SecretBinary"].as_str().and_then(base64_decode);
+        let secret_binary = parse_secret_binary(&body)?;
 
         // Validate that either SecretString or SecretBinary is provided
         if secret_string.is_none() && secret_binary.is_none() {
@@ -584,18 +584,7 @@ impl SecretsManagerService {
         // Move AWSCURRENT from old version to AWSPREVIOUS if new version has AWSCURRENT
         if version_stages.contains(&"AWSCURRENT".to_string()) {
             if let Some(ref old_vid) = secret.current_version_id.clone() {
-                if let Some(old_version) = secret.versions.get_mut(old_vid) {
-                    old_version.stages.retain(|s| s != "AWSCURRENT");
-                    if !old_version.stages.contains(&"AWSPREVIOUS".to_string()) {
-                        old_version.stages.push("AWSPREVIOUS".to_string());
-                    }
-                }
-                // Remove AWSPREVIOUS from any other version
-                for (id, v) in secret.versions.iter_mut() {
-                    if id != old_vid {
-                        v.stages.retain(|s| s != "AWSPREVIOUS");
-                    }
-                }
+                demote_current_to_previous(&mut secret.versions, old_vid);
             }
             secret.current_version_id = Some(version_id.clone());
         }
@@ -686,7 +675,7 @@ impl SecretsManagerService {
 
         // If SecretString or SecretBinary is provided, create a new version
         let secret_string = body["SecretString"].as_str().map(|s| s.to_string());
-        let secret_binary = body["SecretBinary"].as_str().and_then(base64_decode);
+        let secret_binary = parse_secret_binary(&body)?;
 
         let version_id = if secret_string.is_some() || secret_binary.is_some() {
             let vid = body["ClientRequestToken"]
@@ -731,14 +720,10 @@ impl SecretsManagerService {
 
             let now = Utc::now();
 
-            // Move AWSCURRENT -> AWSPREVIOUS on old version
+            // Move AWSCURRENT -> AWSPREVIOUS on old version, keeping AWSPREVIOUS
+            // unique across versions.
             if let Some(ref old_vid) = secret.current_version_id.clone() {
-                if let Some(old_v) = secret.versions.get_mut(old_vid) {
-                    old_v.stages.retain(|s| s != "AWSCURRENT");
-                    if !old_v.stages.contains(&"AWSPREVIOUS".to_string()) {
-                        old_v.stages.push("AWSPREVIOUS".to_string());
-                    }
-                }
+                demote_current_to_previous(&mut secret.versions, old_vid);
             }
 
             let version = SecretVersion {
@@ -1320,6 +1305,20 @@ impl SecretsManagerService {
 
         // Use simple random generation
         if require_each {
+            // Each required class (plus space, when included) consumes one
+            // guaranteed slot. If the requested length can't hold one of each,
+            // AWS rejects the request rather than silently dropping a class.
+            let mut required_count = required_chars.len();
+            if include_space && !exclude_chars.contains(' ') {
+                required_count += 1;
+            }
+            if length < required_count {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "PasswordLength is too short to include one of each required character type.",
+                ));
+            }
             // First, ensure at least one character from each required category
             for category in &required_chars {
                 let chars: Vec<char> = category.chars().collect();
@@ -1456,7 +1455,6 @@ impl SecretsManagerService {
         //   Secrets Manager). LastRotatedDate is only set on an actual rotation.
         let mut invocation = None;
         if rotate_immediately {
-            secret.last_rotated_at = Some(now);
             if let Some(current_vid) = secret.current_version_id.clone() {
                 let current_value = secret.versions.get(&current_vid).cloned();
 
@@ -1483,14 +1481,9 @@ impl SecretsManagerService {
                             });
                         }
                     } else {
-                        // Without Lambda: simple rotation - new version becomes AWSCURRENT
-                        // Move old version to AWSPREVIOUS
-                        if let Some(old_v) = secret.versions.get_mut(&current_vid) {
-                            old_v.stages.retain(|s| s != "AWSCURRENT");
-                            if !old_v.stages.contains(&"AWSPREVIOUS".to_string()) {
-                                old_v.stages.push("AWSPREVIOUS".to_string());
-                            }
-                        }
+                        // Without Lambda: simple rotation - new version becomes AWSCURRENT.
+                        // Move old version to AWSPREVIOUS (kept unique across versions).
+                        demote_current_to_previous(&mut secret.versions, &current_vid);
                         let version = SecretVersion {
                             version_id: version_id.clone(),
                             secret_string: cv.secret_string.clone(),
@@ -1500,6 +1493,11 @@ impl SecretsManagerService {
                         };
                         secret.versions.insert(version_id.clone(), version);
                         secret.current_version_id = Some(version_id.clone());
+                        // The value has now actually rotated (synchronously), so
+                        // this is the point where LastRotatedDate is stamped. The
+                        // Lambda path does not claim completion here because the
+                        // rotation runs asynchronously and may not succeed.
+                        secret.last_rotated_at = Some(now);
                     }
                 }
             }
@@ -1640,38 +1638,48 @@ impl SecretsManagerService {
             }
         }
 
-        // Remove stage from specified version
-        if let Some(ref remove_vid) = remove_from {
-            if let Some(version) = secret.versions.get_mut(remove_vid) {
-                version.stages.retain(|s| s != &version_stage);
-                // If moving AWSCURRENT away, add AWSPREVIOUS and remove from others
-                if version_stage == "AWSCURRENT" {
-                    // Remove AWSPREVIOUS from all other versions first
-                    for (id, v) in secret.versions.iter_mut() {
-                        if id != remove_vid {
-                            v.stages.retain(|s| s != "AWSPREVIOUS");
-                        }
-                    }
-                    // Now add AWSPREVIOUS to the version losing AWSCURRENT
-                    if let Some(v) = secret.versions.get_mut(remove_vid) {
-                        if !v.stages.contains(&"AWSPREVIOUS".to_string()) {
-                            v.stages.push("AWSPREVIOUS".to_string());
-                        }
+        // Moving the AWSCURRENT label needs the single-AWSCURRENT invariant. A
+        // caller-supplied RemoveFromVersionId that does not actually hold
+        // AWSCURRENT must not leave two versions labelled AWSCURRENT: demote
+        // whichever version really holds it today.
+        if version_stage == "AWSCURRENT" {
+            if let Some(ref move_vid) = move_to {
+                let current_holder = secret
+                    .versions
+                    .iter()
+                    .find(|(id, v)| {
+                        id.as_str() != move_vid.as_str()
+                            && v.stages.contains(&"AWSCURRENT".to_string())
+                    })
+                    .map(|(id, _)| id.clone());
+                if let Some(holder) = current_holder {
+                    demote_current_to_previous(&mut secret.versions, &holder);
+                }
+                if let Some(version) = secret.versions.get_mut(move_vid) {
+                    version.stages.retain(|s| s != "AWSPREVIOUS");
+                    if !version.stages.contains(&version_stage) {
+                        version.stages.push(version_stage.clone());
                     }
                 }
-            }
-        }
-
-        // Add stage to specified version
-        if let Some(ref move_vid) = move_to {
-            if let Some(version) = secret.versions.get_mut(move_vid) {
-                if !version.stages.contains(&version_stage) {
-                    version.stages.push(version_stage.clone());
-                }
-            }
-            // Update current_version_id if we moved AWSCURRENT
-            if version_stage == "AWSCURRENT" {
                 secret.current_version_id = Some(move_vid.clone());
+            } else if let Some(ref remove_vid) = remove_from {
+                // Remove-only: demote the named version, keeping it the sole
+                // AWSPREVIOUS.
+                demote_current_to_previous(&mut secret.versions, remove_vid);
+            }
+        } else {
+            // Generic (custom / AWSPENDING) stage move.
+            if let Some(ref remove_vid) = remove_from {
+                if let Some(version) = secret.versions.get_mut(remove_vid) {
+                    version.stages.retain(|s| s != &version_stage);
+                }
+            }
+            if let Some(ref move_vid) = move_to {
+                if let Some(version) = secret.versions.get_mut(move_vid) {
+                    if !version.stages.contains(&version_stage) {
+                        version.stages.push(version_stage.clone());
+                    }
+                }
             }
         }
 
@@ -2054,29 +2062,34 @@ impl SecretsManagerService {
         state: &crate::state::SecretsManagerState,
         secret_id: &str,
     ) -> Result<String, AwsServiceError> {
-        if state.secrets.contains_key(secret_id) {
-            return Ok(secret_id.to_string());
-        }
+        let key = if state.secrets.contains_key(secret_id) {
+            Some(secret_id.to_string())
+        } else if let Some(secret) = state.secrets.values().find(|s| s.arn == secret_id) {
+            Some(secret.name.clone())
+        } else if secret_id.starts_with("arn:aws:secretsmanager:") {
+            state
+                .secrets
+                .values()
+                .find(|s| s.arn.starts_with(secret_id))
+                .map(|s| s.name.clone())
+        } else {
+            None
+        };
 
-        for secret in state.secrets.values() {
-            if secret.arn == secret_id {
-                return Ok(secret.name.clone());
+        match key {
+            // A secret whose recovery window has elapsed is treated as gone.
+            Some(key)
+                if state
+                    .secrets
+                    .get(&key)
+                    .map(|s| secret_recovery_window_elapsed(s, Utc::now()))
+                    .unwrap_or(false) =>
+            {
+                Err(secret_not_found())
             }
+            Some(key) => Ok(key),
+            None => Err(secret_not_found()),
         }
-
-        if secret_id.starts_with("arn:aws:secretsmanager:") {
-            for secret in state.secrets.values() {
-                if secret.arn.starts_with(secret_id) {
-                    return Ok(secret.name.clone());
-                }
-            }
-        }
-
-        Err(AwsServiceError::aws_error(
-            StatusCode::NOT_FOUND,
-            "ResourceNotFoundException",
-            "Secrets Manager can't find the specified secret.",
-        ))
     }
 
     /// Find a secret by name, full ARN, or partial ARN (immutable).
@@ -2085,32 +2098,39 @@ impl SecretsManagerService {
         state: &'a crate::state::SecretsManagerState,
         secret_id: &str,
     ) -> Result<&'a Secret, AwsServiceError> {
-        if let Some(secret) = state.secrets.get(secret_id) {
-            return Ok(secret);
-        }
-
-        // Search by full ARN
-        for secret in state.secrets.values() {
-            if secret.arn == secret_id {
-                return Ok(secret);
-            }
-        }
-
-        // Search by partial ARN
-        if secret_id.starts_with("arn:aws:secretsmanager:") {
-            for secret in state.secrets.values() {
-                if secret.arn.starts_with(secret_id) {
-                    return Ok(secret);
+        let secret = state
+            .secrets
+            .get(secret_id)
+            .or_else(|| state.secrets.values().find(|s| s.arn == secret_id))
+            .or_else(|| {
+                if secret_id.starts_with("arn:aws:secretsmanager:") {
+                    state
+                        .secrets
+                        .values()
+                        .find(|s| s.arn.starts_with(secret_id))
+                } else {
+                    None
                 }
-            }
-        }
+            });
 
-        Err(AwsServiceError::aws_error(
-            StatusCode::NOT_FOUND,
-            "ResourceNotFoundException",
-            "Secrets Manager can't find the specified secret.",
-        ))
+        match secret {
+            // A secret whose recovery window has elapsed is treated as gone.
+            Some(secret) if secret_recovery_window_elapsed(secret, Utc::now()) => {
+                Err(secret_not_found())
+            }
+            Some(secret) => Ok(secret),
+            None => Err(secret_not_found()),
+        }
     }
+}
+
+/// The standard "secret can't be found" error, shared by the resolution helpers.
+fn secret_not_found() -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::NOT_FOUND,
+        "ResourceNotFoundException",
+        "Secrets Manager can't find the specified secret.",
+    )
 }
 
 /// Persist the current Secrets Manager state as a snapshot. Offloads the
@@ -2175,6 +2195,7 @@ impl CreateSecretInput {
             })?
             .to_string();
         validate_string_length("name", &name, 1, 512)?;
+        validate_secret_name_charset(&name)?;
         validate_optional_string_length(
             "clientRequestToken",
             body["ClientRequestToken"].as_str(),
@@ -2191,7 +2212,7 @@ impl CreateSecretInput {
             description: body["Description"].as_str().map(|s| s.to_string()),
             kms_key_id: body["KmsKeyId"].as_str().map(|s| s.to_string()),
             secret_string: body["SecretString"].as_str().map(|s| s.to_string()),
-            secret_binary: body["SecretBinary"].as_str().and_then(base64_decode),
+            secret_binary: parse_secret_binary(body)?,
             tags: parse_tags(&body["Tags"]),
             add_replica_regions: body["AddReplicaRegions"]
                 .as_array()

--- a/crates/fakecloud-secretsmanager/src/service_helpers.rs
+++ b/crates/fakecloud-secretsmanager/src/service_helpers.rs
@@ -25,6 +25,78 @@ pub(crate) fn check_secret_version_idempotency(
     }
 }
 
+/// Demote the version currently holding `AWSCURRENT` to `AWSPREVIOUS`, enforcing
+/// the single-`AWSPREVIOUS` invariant: strip `AWSPREVIOUS` from every other
+/// version so exactly one version ever carries it.
+///
+/// AWS keeps at most one `AWSPREVIOUS` staging label per secret. The naive
+/// "remove AWSCURRENT, add AWSPREVIOUS to the old version" logic leaves the
+/// previously-previous version still tagged `AWSPREVIOUS`, so two versions end
+/// up with the label and `GetSecretValue(AWSPREVIOUS)` returns an arbitrary one.
+/// This helper centralizes the correct behaviour already used by
+/// `PutSecretValue` / `UpdateSecretVersionStage` so `UpdateSecret`,
+/// `RotateSecret` and scheduled rotation share it.
+pub(crate) fn demote_current_to_previous(
+    versions: &mut BTreeMap<String, SecretVersion>,
+    old_vid: &str,
+) {
+    // Strip AWSPREVIOUS from any other version first so `old_vid` becomes the
+    // sole holder.
+    for (id, v) in versions.iter_mut() {
+        if id != old_vid {
+            v.stages.retain(|s| s != "AWSPREVIOUS");
+        }
+    }
+    if let Some(old_v) = versions.get_mut(old_vid) {
+        old_v.stages.retain(|s| s != "AWSCURRENT");
+        if !old_v.stages.contains(&"AWSPREVIOUS".to_string()) {
+            old_v.stages.push("AWSPREVIOUS".to_string());
+        }
+    }
+}
+
+/// Decode the optional `SecretBinary` field. Returns an error when the field is
+/// present but not valid base64, matching AWS which rejects an undecodable
+/// `SecretBinary` rather than silently dropping it (which would let a caller
+/// think binary was stored when it was not).
+pub(crate) fn parse_secret_binary(body: &Value) -> Result<Option<Vec<u8>>, AwsServiceError> {
+    match body["SecretBinary"].as_str() {
+        None => Ok(None),
+        Some(s) => base64_decode(s).map(Some).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "Invalid base64: the value of the SecretBinary field could not be decoded.",
+            )
+        }),
+    }
+}
+
+/// Whether a secret scheduled for deletion has passed its recovery window and
+/// should be treated as permanently gone. AWS purges a secret once the recovery
+/// window elapses; a lazy check on read reproduces that without a background
+/// reaper.
+pub(crate) fn secret_recovery_window_elapsed(secret: &Secret, now: chrono::DateTime<Utc>) -> bool {
+    secret.deleted && secret.deletion_date.map(|d| now >= d).unwrap_or(false)
+}
+
+/// Reject secret names outside the AWS-permitted charset. AWS allows only
+/// `[A-Za-z0-9/_+=.@-]` in a secret name.
+pub(crate) fn validate_secret_name_charset(name: &str) -> Result<(), AwsServiceError> {
+    if name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || "/_+=.@-".contains(c))
+    {
+        Ok(())
+    } else {
+        Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterException",
+            "Invalid name. Name must contain only alphanumeric characters or the characters /_+=.@-",
+        ))
+    }
+}
+
 /// Actions that mutate Secrets Manager state.
 pub(crate) fn is_mutating_action(action: &str) -> bool {
     matches!(

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -450,7 +450,11 @@ async fn test_rotate_secret_stores_rotation_config() {
         secret.rotation_lambda_arn.as_deref(),
         Some("arn:aws:lambda:us-east-1:123456789012:function:my-rotator")
     );
-    assert!(secret.last_rotated_at.is_some());
+    // A Lambda-driven rotation runs asynchronously and, with no delivery bus
+    // wired up, never completes. LastRotatedDate must therefore stay unset --
+    // RotateSecret must not falsely claim the value rotated before the Lambda
+    // finished (the simple, no-Lambda path is covered separately).
+    assert!(secret.last_rotated_at.is_none());
     let rules = secret.rotation_rules.as_ref().unwrap();
     assert_eq!(rules.automatically_after_days, Some(30));
 
@@ -2748,4 +2752,295 @@ async fn test_create_secret_with_add_replica_regions() {
         .collect();
     assert!(dregions.contains(&"us-west-2"));
     assert!(dregions.contains(&"eu-west-1"));
+}
+
+// ---------------------------------------------------------------------------
+// Hardening: single AWSPREVIOUS / AWSCURRENT, input validation, expiry.
+// ---------------------------------------------------------------------------
+
+/// Count how many versions of a secret carry a given staging label.
+fn stage_count(state: &SharedSecretsManagerState, name: &str, stage: &str) -> usize {
+    let accts = state.read();
+    accts.default_ref().secrets[name]
+        .versions
+        .values()
+        .filter(|v| v.stages.iter().any(|s| s == stage))
+        .count()
+}
+
+#[tokio::test]
+async fn test_update_secret_keeps_single_awsprevious() {
+    // Repeated UpdateSecret must leave exactly one AWSPREVIOUS version, and it
+    // must be the immediately-previous value -- not accumulate across updates.
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    let req = make_request("CreateSecret", r#"{"Name": "prev", "SecretString": "v1"}"#);
+    svc.handle(req).await.unwrap();
+    let req = make_request(
+        "UpdateSecret",
+        r#"{"SecretId": "prev", "SecretString": "v2"}"#,
+    );
+    svc.handle(req).await.unwrap();
+    let req = make_request(
+        "UpdateSecret",
+        r#"{"SecretId": "prev", "SecretString": "v3"}"#,
+    );
+    svc.handle(req).await.unwrap();
+
+    assert_eq!(
+        stage_count(&state, "prev", "AWSPREVIOUS"),
+        1,
+        "exactly one version must hold AWSPREVIOUS"
+    );
+    assert_eq!(stage_count(&state, "prev", "AWSCURRENT"), 1);
+
+    // AWSPREVIOUS resolves to the immediately-previous value, deterministically.
+    let req = make_request(
+        "GetSecretValue",
+        r#"{"SecretId": "prev", "VersionStage": "AWSPREVIOUS"}"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["SecretString"], "v2");
+}
+
+#[tokio::test]
+async fn test_rotate_secret_simple_keeps_single_awsprevious() {
+    // The no-Lambda rotation path must also keep AWSPREVIOUS unique across
+    // repeated rotations.
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    let req = make_request("CreateSecret", r#"{"Name": "rot", "SecretString": "v1"}"#);
+    svc.handle(req).await.unwrap();
+
+    for _ in 0..3 {
+        let req = make_request("RotateSecret", r#"{"SecretId": "rot"}"#);
+        svc.handle(req).await.unwrap();
+    }
+
+    assert_eq!(stage_count(&state, "rot", "AWSPREVIOUS"), 1);
+    assert_eq!(stage_count(&state, "rot", "AWSCURRENT"), 1);
+}
+
+#[tokio::test]
+async fn test_update_version_stage_wrong_remove_from_no_double_current() {
+    // Moving AWSCURRENT with a RemoveFromVersionId that does NOT hold AWSCURRENT
+    // must still leave exactly one AWSCURRENT (the demotion targets the real
+    // holder, not the caller-supplied id).
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    let v1 = "11111111-1111-1111-1111-111111111111";
+    let v2 = "22222222-2222-2222-2222-222222222222";
+
+    let body = serde_json::json!({
+        "Name": "stage", "SecretString": "v1", "ClientRequestToken": v1,
+    });
+    svc.handle(make_request("CreateSecret", &body.to_string()))
+        .await
+        .unwrap();
+
+    // Stage a second version as AWSPENDING.
+    let body = serde_json::json!({
+        "SecretId": "stage", "SecretString": "v2",
+        "ClientRequestToken": v2, "VersionStages": ["AWSPENDING"],
+    });
+    svc.handle(make_request("PutSecretValue", &body.to_string()))
+        .await
+        .unwrap();
+
+    // Move AWSCURRENT to v2 but pass v2 (wrong) as RemoveFromVersionId.
+    let body = serde_json::json!({
+        "SecretId": "stage", "VersionStage": "AWSCURRENT",
+        "MoveToVersionId": v2, "RemoveFromVersionId": v2,
+    });
+    svc.handle(make_request("UpdateSecretVersionStage", &body.to_string()))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        stage_count(&state, "stage", "AWSCURRENT"),
+        1,
+        "there must be exactly one AWSCURRENT"
+    );
+    // And it must be v2.
+    let req = make_request("GetSecretValue", r#"{"SecretId": "stage"}"#);
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["SecretString"], "v2");
+}
+
+#[tokio::test]
+async fn test_create_secret_invalid_binary_rejected() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    let req = make_request(
+        "CreateSecret",
+        r#"{"Name": "badbin", "SecretBinary": "!!!not_base64!!!"}"#,
+    );
+    let err = expect_err(svc.handle(req).await);
+    assert!(err.to_string().contains("InvalidParameterException"));
+}
+
+#[tokio::test]
+async fn test_put_secret_value_invalid_binary_rejected() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "bin2", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+
+    let req = make_request(
+        "PutSecretValue",
+        r#"{"SecretId": "bin2", "SecretBinary": "!!!not_base64!!!"}"#,
+    );
+    let err = expect_err(svc.handle(req).await);
+    assert!(err.to_string().contains("InvalidParameterException"));
+}
+
+#[tokio::test]
+async fn test_create_secret_invalid_name_charset_rejected() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    let req = make_request(
+        "CreateSecret",
+        r#"{"Name": "bad$name", "SecretString": "v"}"#,
+    );
+    let err = expect_err(svc.handle(req).await);
+    assert!(err.to_string().contains("InvalidParameterException"));
+
+    // A name using every allowed special character is accepted.
+    let req = make_request(
+        "CreateSecret",
+        r#"{"Name": "ok/name_+=.@-1", "SecretString": "v"}"#,
+    );
+    assert_eq!(svc.handle(req).await.unwrap().status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_get_random_password_short_length_includes_each_type() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    // Minimum length with all four required classes: each class must survive.
+    let req = make_request("GetRandomPassword", r#"{"PasswordLength": 4}"#);
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let pw = body["RandomPassword"].as_str().unwrap();
+    assert_eq!(pw.chars().count(), 4);
+    assert!(pw.chars().any(|c| c.is_ascii_lowercase()), "pw={pw}");
+    assert!(pw.chars().any(|c| c.is_ascii_uppercase()), "pw={pw}");
+    assert!(pw.chars().any(|c| c.is_ascii_digit()), "pw={pw}");
+    assert!(
+        pw.chars().any(|c| !c.is_ascii_alphanumeric()),
+        "pw={pw} must contain punctuation"
+    );
+}
+
+#[tokio::test]
+async fn test_get_random_password_length_too_short_for_required_types() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    // Length 4 can't hold all four classes plus a required space.
+    let req = make_request(
+        "GetRandomPassword",
+        r#"{"PasswordLength": 4, "IncludeSpace": true}"#,
+    );
+    let err = expect_err(svc.handle(req).await);
+    assert!(err.to_string().contains("InvalidParameterException"));
+}
+
+#[tokio::test]
+async fn test_rotate_secret_simple_path_stamps_last_rotated() {
+    // The no-Lambda simple rotation completes synchronously, so LastRotatedDate
+    // is stamped.
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "rotstamp", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+
+    svc.handle(make_request("RotateSecret", r#"{"SecretId": "rotstamp"}"#))
+        .await
+        .unwrap();
+
+    let accts = state.read();
+    let secret = &accts.default_ref().secrets["rotstamp"];
+    assert!(
+        secret.last_rotated_at.is_some(),
+        "synchronous rotation must stamp LastRotatedDate"
+    );
+}
+
+#[tokio::test]
+async fn test_scheduled_deletion_expires_on_read() {
+    // Once the recovery window elapses, the secret is treated as gone.
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "expiring", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+    svc.handle(make_request("DeleteSecret", r#"{"SecretId": "expiring"}"#))
+        .await
+        .unwrap();
+
+    // Force the recovery window to have already elapsed.
+    {
+        let mut accts = state.write();
+        accts
+            .default_mut()
+            .secrets
+            .get_mut("expiring")
+            .unwrap()
+            .deletion_date = Some(Utc::now() - chrono::Duration::days(1));
+    }
+
+    let err = expect_err(
+        svc.handle(make_request(
+            "GetSecretValue",
+            r#"{"SecretId": "expiring"}"#,
+        ))
+        .await,
+    );
+    assert!(err.to_string().contains("ResourceNotFoundException"));
+
+    // A still-within-window deletion is NOT treated as gone (it reports the
+    // marked-for-deletion error instead of not-found).
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "pending-del", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+    svc.handle(make_request(
+        "DeleteSecret",
+        r#"{"SecretId": "pending-del"}"#,
+    ))
+    .await
+    .unwrap();
+    let err = expect_err(
+        svc.handle(make_request(
+            "GetSecretValue",
+            r#"{"SecretId": "pending-del"}"#,
+        ))
+        .await,
+    );
+    assert!(err.to_string().contains("marked for deletion"));
 }


### PR DESCRIPTION
## Summary
Behavioral hardening of Secrets Manager — version-stage invariant violations + validation gaps the conformance probe can't see (it runs each op once with clean input, never chains two writes then reads a stage).

- **M1** `AWSPREVIOUS` accumulated across repeated `UpdateSecret` / no-Lambda `RotateSecret` / scheduled rotation — two versions ended up both labelled `AWSPREVIOUS`, so `GetSecretValue(VersionStage=AWSPREVIOUS)` returned an arbitrary one by key order. Now strips `AWSPREVIOUS` from the prior holder in all three paths (matching the existing correct logic in PutSecretValue/UpdateSecretVersionStage).
- **M2** `UpdateSecretVersionStage` moving `AWSCURRENT` with a stale `RemoveFromVersionId` could leave two `AWSCURRENT`; it now strips the stage from whatever version actually holds it.
- **L1** undecodable `SecretBinary` was silently dropped → now rejected. **L2** secret-name charset validated. **L3** `GetRandomPassword` keeps each `RequireEachIncludedType` class at short lengths. **L4** `LastRotatedDate` only stamped on real completion. **L5** scheduled-deletion secrets expire (`ResourceNotFoundException`) after the recovery window (lazy check on read).

## Test plan
- `cargo test -p fakecloud-secretsmanager` — 129 pass, incl. new tests: two updates → exactly one AWSPREVIOUS, AWSCURRENT move strips prior, invalid SecretBinary rejected, name charset, short-length password classes, deletion expiry.
- Persistence unchanged. CI runs full clippy + conformance + e2e.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Secrets Manager behavior: enforces single AWSCURRENT/AWSPREVIOUS, validates inputs, and expires scheduled deletions to prevent nondeterministic reads and hidden errors.

- **Bug Fixes**
  - Keep exactly one AWSPREVIOUS across UpdateSecret, no-Lambda RotateSecret, and scheduled rotation; GetSecretValue(AWSPREVIOUS) is now deterministic.
  - Ensure a single AWSCURRENT when moving stages, even with a stale RemoveFromVersionId (demotes the real current holder).
  - Input validation: reject invalid base64 in SecretBinary and enforce secret name charset [A-Za-z0-9/_+=.@-].
  - GetRandomPassword now errors when length can’t include one of each required type (including space when requested).
  - State correctness: LastRotatedDate is set only on real completion (stamped for simple rotation; Lambda path waits), and secrets scheduled for deletion return ResourceNotFound after the recovery window.

<sup>Written for commit 345c141472f073dae594314fb1a614460c6303fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

